### PR TITLE
Fix operator precedence for functors and calls

### DIFF
--- a/compiler/qsc_frontend/src/parse/expr.rs
+++ b/compiler/qsc_frontend/src/parse/expr.rs
@@ -243,11 +243,11 @@ fn prefix_op(name: OpName) -> Option<PrefixOp> {
         }),
         OpName::Keyword(Keyword::AdjointUpper) => Some(PrefixOp {
             kind: UnOp::Functor(Functor::Adj),
-            precedence: 13,
+            precedence: 14,
         }),
         OpName::Keyword(Keyword::ControlledUpper) => Some(PrefixOp {
             kind: UnOp::Functor(Functor::Ctl),
-            precedence: 13,
+            precedence: 14,
         }),
         _ => None,
     }
@@ -348,21 +348,21 @@ fn mixfix_op(name: OpName) -> Option<MixfixOp> {
             kind: OpKind::Binary(BinOp::Exp, Assoc::Right),
             precedence: 12,
         }),
+        OpName::Token(TokenKind::Open(Delim::Paren)) => Some(MixfixOp {
+            kind: OpKind::Rich(call_op),
+            precedence: 13,
+        }),
         OpName::Token(TokenKind::Bang) => Some(MixfixOp {
             kind: OpKind::Postfix(UnOp::Unwrap),
-            precedence: 14,
+            precedence: 15,
         }),
         OpName::Token(TokenKind::ColonColon) => Some(MixfixOp {
             kind: OpKind::Rich(field_op),
-            precedence: 14,
+            precedence: 15,
         }),
         OpName::Token(TokenKind::Open(Delim::Bracket)) => Some(MixfixOp {
             kind: OpKind::Rich(index_op),
-            precedence: 14,
-        }),
-        OpName::Token(TokenKind::Open(Delim::Paren)) => Some(MixfixOp {
-            kind: OpKind::Rich(call_op),
-            precedence: 14,
+            precedence: 15,
         }),
         _ => None,
     }

--- a/compiler/qsc_frontend/src/parse/expr/tests.rs
+++ b/compiler/qsc_frontend/src/parse/expr/tests.rs
@@ -5707,6 +5707,268 @@ fn adjoint_op() {
 }
 
 #[test]
+fn adjoint_call_ops() {
+    check(
+        expr,
+        "Adjoint X(q)",
+        &expect![[r#"
+            Ok(
+                Expr {
+                    id: NodeId(
+                        4294967295,
+                    ),
+                    span: Span {
+                        lo: 0,
+                        hi: 12,
+                    },
+                    kind: Call(
+                        Expr {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 0,
+                                hi: 9,
+                            },
+                            kind: UnOp(
+                                Functor(
+                                    Adj,
+                                ),
+                                Expr {
+                                    id: NodeId(
+                                        4294967295,
+                                    ),
+                                    span: Span {
+                                        lo: 8,
+                                        hi: 9,
+                                    },
+                                    kind: Path(
+                                        Path {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 8,
+                                                hi: 9,
+                                            },
+                                            namespace: None,
+                                            name: Ident {
+                                                id: NodeId(
+                                                    4294967295,
+                                                ),
+                                                span: Span {
+                                                    lo: 8,
+                                                    hi: 9,
+                                                },
+                                                name: "X",
+                                            },
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                        Expr {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 9,
+                                hi: 12,
+                            },
+                            kind: Paren(
+                                Expr {
+                                    id: NodeId(
+                                        4294967295,
+                                    ),
+                                    span: Span {
+                                        lo: 10,
+                                        hi: 11,
+                                    },
+                                    kind: Path(
+                                        Path {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 10,
+                                                hi: 11,
+                                            },
+                                            namespace: None,
+                                            name: Ident {
+                                                id: NodeId(
+                                                    4294967295,
+                                                ),
+                                                span: Span {
+                                                    lo: 10,
+                                                    hi: 11,
+                                                },
+                                                name: "q",
+                                            },
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn adjoint_index_call_ops() {
+    check(
+        expr,
+        "Adjoint ops[i](q)",
+        &expect![[r#"
+            Ok(
+                Expr {
+                    id: NodeId(
+                        4294967295,
+                    ),
+                    span: Span {
+                        lo: 0,
+                        hi: 17,
+                    },
+                    kind: Call(
+                        Expr {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 0,
+                                hi: 14,
+                            },
+                            kind: UnOp(
+                                Functor(
+                                    Adj,
+                                ),
+                                Expr {
+                                    id: NodeId(
+                                        4294967295,
+                                    ),
+                                    span: Span {
+                                        lo: 8,
+                                        hi: 14,
+                                    },
+                                    kind: Index(
+                                        Expr {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 8,
+                                                hi: 11,
+                                            },
+                                            kind: Path(
+                                                Path {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 8,
+                                                        hi: 11,
+                                                    },
+                                                    namespace: None,
+                                                    name: Ident {
+                                                        id: NodeId(
+                                                            4294967295,
+                                                        ),
+                                                        span: Span {
+                                                            lo: 8,
+                                                            hi: 11,
+                                                        },
+                                                        name: "ops",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                        Expr {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 12,
+                                                hi: 13,
+                                            },
+                                            kind: Path(
+                                                Path {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 12,
+                                                        hi: 13,
+                                                    },
+                                                    namespace: None,
+                                                    name: Ident {
+                                                        id: NodeId(
+                                                            4294967295,
+                                                        ),
+                                                        span: Span {
+                                                            lo: 12,
+                                                            hi: 13,
+                                                        },
+                                                        name: "i",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                        Expr {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 14,
+                                hi: 17,
+                            },
+                            kind: Paren(
+                                Expr {
+                                    id: NodeId(
+                                        4294967295,
+                                    ),
+                                    span: Span {
+                                        lo: 15,
+                                        hi: 16,
+                                    },
+                                    kind: Path(
+                                        Path {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 15,
+                                                hi: 16,
+                                            },
+                                            namespace: None,
+                                            name: Ident {
+                                                id: NodeId(
+                                                    4294967295,
+                                                ),
+                                                span: Span {
+                                                    lo: 15,
+                                                    hi: 16,
+                                                },
+                                                name: "q",
+                                            },
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            )
+        "#]],
+    );
+}
+
+#[test]
 fn controlled_op() {
     check(
         expr,
@@ -5754,6 +6016,360 @@ fn controlled_op() {
                                         name: "x",
                                     },
                                 },
+                            ),
+                        },
+                    ),
+                },
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn controlled_call_ops() {
+    check(
+        expr,
+        "Controlled X([q1], q2)",
+        &expect![[r#"
+            Ok(
+                Expr {
+                    id: NodeId(
+                        4294967295,
+                    ),
+                    span: Span {
+                        lo: 0,
+                        hi: 22,
+                    },
+                    kind: Call(
+                        Expr {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 0,
+                                hi: 12,
+                            },
+                            kind: UnOp(
+                                Functor(
+                                    Ctl,
+                                ),
+                                Expr {
+                                    id: NodeId(
+                                        4294967295,
+                                    ),
+                                    span: Span {
+                                        lo: 11,
+                                        hi: 12,
+                                    },
+                                    kind: Path(
+                                        Path {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 11,
+                                                hi: 12,
+                                            },
+                                            namespace: None,
+                                            name: Ident {
+                                                id: NodeId(
+                                                    4294967295,
+                                                ),
+                                                span: Span {
+                                                    lo: 11,
+                                                    hi: 12,
+                                                },
+                                                name: "X",
+                                            },
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                        Expr {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 12,
+                                hi: 22,
+                            },
+                            kind: Tuple(
+                                [
+                                    Expr {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 13,
+                                            hi: 17,
+                                        },
+                                        kind: Array(
+                                            [
+                                                Expr {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 14,
+                                                        hi: 16,
+                                                    },
+                                                    kind: Path(
+                                                        Path {
+                                                            id: NodeId(
+                                                                4294967295,
+                                                            ),
+                                                            span: Span {
+                                                                lo: 14,
+                                                                hi: 16,
+                                                            },
+                                                            namespace: None,
+                                                            name: Ident {
+                                                                id: NodeId(
+                                                                    4294967295,
+                                                                ),
+                                                                span: Span {
+                                                                    lo: 14,
+                                                                    hi: 16,
+                                                                },
+                                                                name: "q1",
+                                                            },
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        ),
+                                    },
+                                    Expr {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 19,
+                                            hi: 21,
+                                        },
+                                        kind: Path(
+                                            Path {
+                                                id: NodeId(
+                                                    4294967295,
+                                                ),
+                                                span: Span {
+                                                    lo: 19,
+                                                    hi: 21,
+                                                },
+                                                namespace: None,
+                                                name: Ident {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 19,
+                                                        hi: 21,
+                                                    },
+                                                    name: "q2",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
+                            ),
+                        },
+                    ),
+                },
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn controlled_index_call_ops() {
+    check(
+        expr,
+        "Controlled ops[i]([q1], q2)",
+        &expect![[r#"
+            Ok(
+                Expr {
+                    id: NodeId(
+                        4294967295,
+                    ),
+                    span: Span {
+                        lo: 0,
+                        hi: 27,
+                    },
+                    kind: Call(
+                        Expr {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 0,
+                                hi: 17,
+                            },
+                            kind: UnOp(
+                                Functor(
+                                    Ctl,
+                                ),
+                                Expr {
+                                    id: NodeId(
+                                        4294967295,
+                                    ),
+                                    span: Span {
+                                        lo: 11,
+                                        hi: 17,
+                                    },
+                                    kind: Index(
+                                        Expr {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 11,
+                                                hi: 14,
+                                            },
+                                            kind: Path(
+                                                Path {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 11,
+                                                        hi: 14,
+                                                    },
+                                                    namespace: None,
+                                                    name: Ident {
+                                                        id: NodeId(
+                                                            4294967295,
+                                                        ),
+                                                        span: Span {
+                                                            lo: 11,
+                                                            hi: 14,
+                                                        },
+                                                        name: "ops",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                        Expr {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 15,
+                                                hi: 16,
+                                            },
+                                            kind: Path(
+                                                Path {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 15,
+                                                        hi: 16,
+                                                    },
+                                                    namespace: None,
+                                                    name: Ident {
+                                                        id: NodeId(
+                                                            4294967295,
+                                                        ),
+                                                        span: Span {
+                                                            lo: 15,
+                                                            hi: 16,
+                                                        },
+                                                        name: "i",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                        Expr {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 17,
+                                hi: 27,
+                            },
+                            kind: Tuple(
+                                [
+                                    Expr {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 18,
+                                            hi: 22,
+                                        },
+                                        kind: Array(
+                                            [
+                                                Expr {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 19,
+                                                        hi: 21,
+                                                    },
+                                                    kind: Path(
+                                                        Path {
+                                                            id: NodeId(
+                                                                4294967295,
+                                                            ),
+                                                            span: Span {
+                                                                lo: 19,
+                                                                hi: 21,
+                                                            },
+                                                            namespace: None,
+                                                            name: Ident {
+                                                                id: NodeId(
+                                                                    4294967295,
+                                                                ),
+                                                                span: Span {
+                                                                    lo: 19,
+                                                                    hi: 21,
+                                                                },
+                                                                name: "q1",
+                                                            },
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        ),
+                                    },
+                                    Expr {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 24,
+                                            hi: 26,
+                                        },
+                                        kind: Path(
+                                            Path {
+                                                id: NodeId(
+                                                    4294967295,
+                                                ),
+                                                span: Span {
+                                                    lo: 24,
+                                                    hi: 26,
+                                                },
+                                                namespace: None,
+                                                name: Ident {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 24,
+                                                        hi: 26,
+                                                    },
+                                                    name: "q2",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ],
                             ),
                         },
                     ),


### PR DESCRIPTION
To parse `Adjoint X(q)` as the expected `(Adjoint X)(q)`, the precedence for functors needs to be higher than the precedence for calls.