### PR TITLE
Optimize parsing with ordered keyword matching

### DIFF
--- a/compiler/qsc_frontend/src/parse/keyword.rs
+++ b/compiler/qsc_frontend/src/parse/keyword.rs
@@ -138,6 +138,9 @@ impl Keyword {
 impl FromStr for Keyword {
     type Err = ();
 
+    // This is a hot function. Use a match expression so that the Rust compiler
+    // can optimize the string comparisons better, and order the cases by
+    // frequency in Q# so that fewer comparisons are needed on average.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "let" => Ok(Self::Let),


### PR DESCRIPTION
This PR has two components:
1. Replace `from_str` impl for `impl FromStr for Keyword` to use a match statement instead of search.
2. Reorder match statement based on keyword frequency analysis.

TLDR:
- standard library `1.6393 ms` to `994.67 µs` : `-39.287%`,
- NQueens `34.757 ms` to `18.806 ms` : `-45.893%`

Baseline:
```shell
qsharp/compiler/qsc❯ cargo bench -- --save-baseline main

Standard library        time:   [1.6377 ms 1.6393 ms 1.6408 ms]
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

NQueens large input file
                        time:   [34.705 ms 34.757 ms 34.812 ms]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```
Implementing first change and its results saved as `match`:
```shell
qsharp/compiler/qsc❯ cargo bench -- --load-baseline match --baseline main

Standard library        time:   [1.0084 ms 1.0107 ms 1.0135 ms]
                        change: [-38.503% -38.301% -38.096%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

NQueens large input file
                        time:   [19.384 ms 19.437 ms 19.491 ms]
                        change: [-44.259% -44.079% -43.896%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```
 Implementing second change for reordering (saved as `kworder`) and comparing it to `match`:
```shell
qsharp/compiler/qsc❯ cargo bench -- --load-baseline kworder --baseline match       

Standard library        time:   [992.05 µs 994.67 µs 997.77 µs]
                        change: [-4.3405% -3.8579% -3.1096%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) high mild
  12 (12.00%) high severe

NQueens large input file
                        time:   [18.748 ms 18.806 ms 18.867 ms]
                        change: [-8.8605% -8.4997% -8.1436%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

Total changes:
```shell
qsharp/compiler/qsc❯ cargo bench -- --load-baseline kworder --baseline main 

Standard library        time:   [992.06 µs 994.67 µs 997.84 µs]
                        change: [-39.586% -39.287% -38.815%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) high mild
  12 (12.00%) high severe

NQueens large input file
                        time:   [18.749 ms 18.806 ms 18.866 ms]
                        change: [-46.090% -45.893% -45.713%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

