### PR TITLE
Avoiding extra work while parsing literals

### DIFF
--- a/compiler/qsc_frontend/src/parse/expr.rs
+++ b/compiler/qsc_frontend/src/parse/expr.rs
@@ -236,6 +236,7 @@ fn lit(s: &mut Scanner) -> Result<Lit> {
     }
 }
 
+#[allow(clippy::inline_always)]
 #[inline(always)]
 fn lit_token(lexeme: &str, kind: TokenKind) -> Option<Lit> {
     match kind {
@@ -262,6 +263,7 @@ fn lit_token(lexeme: &str, kind: TokenKind) -> Option<Lit> {
     }
 }
 
+#[allow(clippy::inline_always)]
 #[inline(always)]
 fn lit_keyword(lexeme: &str) -> Option<Lit> {
     match lexeme {


### PR DESCRIPTION
This PR reworks the literal parsing for better performance:

standard library 908.91 µs to 885.86 µs : -2.3%,
NQueens 17.336 ms to 16.536 ms : -4.6%

```shell
> cargo bench -- --save-baseline main

Standard library        time:   [908.63 µs 908.91 µs 909.21 µs]
                        change: [-44.755% -44.576% -44.318%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

NQueens large input file
                        time:   [17.314 ms 17.336 ms 17.372 ms]
                        change: [-50.231% -50.122% -49.983%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```

```shell
> cargo bench -- --save-baseline lit

Standard library        time:   [885.50 µs 885.86 µs 886.29 µs]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

NQueens large input file
                        time:   [16.523 ms 16.536 ms 16.551 ms]
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
```

```shell
> cargo bench -- --load-baseline lit --baseline main

Standard library        time:   [885.51 µs 885.86 µs 886.29 µs]
                        change: [-2.8040% -2.3221% -1.8254%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

NQueens large input file
                        time:   [16.523 ms 16.536 ms 16.551 ms]
                        change: [-4.8296% -4.6168% -4.4550%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
```