### PR TITLE
Simplify intrinsic macro

### DIFF
--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -136,30 +136,30 @@ fn invoke_quantum_intrinsic(
     args_span: Span,
 ) -> ControlFlow<Reason, Value> {
     macro_rules! match_intrinsic {
-        ($chosen_op:ident, $chosen_op_span:ident, $(($(1, $op1:ident, $args1:ident, $args_span1:ident),* $(2, $op2:ident, $args2:ident, $args_span2:ident),* $(3, $op3:ident, $args3:ident, $args_span3:ident),*)),* ) => {
+        ($chosen_op:ident, $chosen_op_span:ident, $(($(1, $op1:ident),* $(2, $op2:ident),* $(3, $op3:ident),*)),* ) => {
             match $chosen_op {
                 $($(stringify!($op1) => {
-                    $op1($args1.try_into().with_span($args_span1)?);
+                    $op1(args.try_into().with_span(args_span)?);
                     ControlFlow::Continue(Value::UNIT)
                 })*
                 $(stringify!($op2) => {
-                    let mut args = $args2.try_into_tuple().with_span($args_span2)?;
+                    let mut args = args.try_into_tuple().with_span(args_span)?;
                     if args.len() == 2 {
                         let (a2, a1) = (
                             args.pop().expect("tuple should have 2 entries"),
                             args.pop().expect("tuple should have 2 entries"),
                         );
                         $op2(
-                            a1.try_into().with_span($args_span2)?,
-                            a2.try_into().with_span($args_span2)?,
+                            a1.try_into().with_span(args_span)?,
+                            a2.try_into().with_span(args_span)?,
                         );
                         ControlFlow::Continue(Value::UNIT)
                     } else {
-                        ControlFlow::Break(Reason::Error(Error::TupleArity(2, args.len(), $args_span2)))
+                        ControlFlow::Break(Reason::Error(Error::TupleArity(2, args.len(), args_span)))
                     }
                 })*
                 $(stringify!($op3) => {
-                    let mut args = $args3.try_into_tuple().with_span($args_span3)?;
+                    let mut args = args.try_into_tuple().with_span(args_span)?;
                     if args.len() == 3 {
                         let (a3, a2, a1) = (
                             args.pop().expect("tuple should have 3 entries"),
@@ -167,13 +167,13 @@ fn invoke_quantum_intrinsic(
                             args.pop().expect("tuple should have 3 entries"),
                         );
                         $op3(
-                            a1.try_into().with_span($args_span3)?,
-                            a2.try_into().with_span($args_span3)?,
-                            a3.try_into().with_span($args_span3)?,
+                            a1.try_into().with_span(args_span)?,
+                            a2.try_into().with_span(args_span)?,
+                            a3.try_into().with_span(args_span)?,
                         );
                         ControlFlow::Continue(Value::UNIT)
                     } else {
-                        ControlFlow::Break(Reason::Error(Error::TupleArity(3, args.len(), $args_span3)))
+                        ControlFlow::Break(Reason::Error(Error::TupleArity(3, args.len(), args_span)))
                     }
                 })*)*
 
@@ -201,25 +201,25 @@ fn invoke_quantum_intrinsic(
     match_intrinsic!(
         name,
         name_span,
-        (3, __quantum__qis__ccx__body, args, args_span),
-        (2, __quantum__qis__cx__body, args, args_span),
-        (2, __quantum__qis__cy__body, args, args_span),
-        (2, __quantum__qis__cz__body, args, args_span),
-        (2, __quantum__qis__rx__body, args, args_span),
-        (3, __quantum__qis__rxx__body, args, args_span),
-        (2, __quantum__qis__ry__body, args, args_span),
-        (3, __quantum__qis__ryy__body, args, args_span),
-        (2, __quantum__qis__rz__body, args, args_span),
-        (3, __quantum__qis__rzz__body, args, args_span),
-        (1, __quantum__qis__h__body, args, args_span),
-        (1, __quantum__qis__s__body, args, args_span),
-        (1, __quantum__qis__s__adj, args, args_span),
-        (1, __quantum__qis__t__body, args, args_span),
-        (1, __quantum__qis__t__adj, args, args_span),
-        (1, __quantum__qis__x__body, args, args_span),
-        (1, __quantum__qis__y__body, args, args_span),
-        (1, __quantum__qis__z__body, args, args_span),
-        (2, __quantum__qis__swap__body, args, args_span),
-        (1, __quantum__qis__reset__body, args, args_span)
+        (3, __quantum__qis__ccx__body),
+        (2, __quantum__qis__cx__body),
+        (2, __quantum__qis__cy__body),
+        (2, __quantum__qis__cz__body),
+        (2, __quantum__qis__rx__body),
+        (3, __quantum__qis__rxx__body),
+        (2, __quantum__qis__ry__body),
+        (3, __quantum__qis__ryy__body),
+        (2, __quantum__qis__rz__body),
+        (3, __quantum__qis__rzz__body),
+        (1, __quantum__qis__h__body),
+        (1, __quantum__qis__s__body),
+        (1, __quantum__qis__s__adj),
+        (1, __quantum__qis__t__body),
+        (1, __quantum__qis__t__adj),
+        (1, __quantum__qis__x__body),
+        (1, __quantum__qis__y__body),
+        (1, __quantum__qis__z__body),
+        (2, __quantum__qis__swap__body),
+        (1, __quantum__qis__reset__body)
     )
 }

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -781,3 +781,24 @@ fn unknown_intrinsic() {
         "#]],
     );
 }
+
+#[test]
+fn single_arg_for_tuple() {
+    check_intrinsic_result(
+        "",
+        indoc! {r#"{
+            use q = Qubit();
+            Ry(q);
+        }"#},
+        &expect![[r#"
+            Type(
+                "Tuple",
+                "Qubit",
+                Span {
+                    lo: 29,
+                    hi: 32,
+                },
+            )
+        "#]],
+    );
+}


### PR DESCRIPTION
This simplifies the big macro used for quantum intrinsic invocation, and confirms error handling with a couple test cases.