### PR TITLE
Change Q# `ToString` to `AsString`

### DIFF
--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -57,7 +57,7 @@ pub(crate) fn invoke_intrinsic(
                 Err(_) => ControlFlow::Break(Reason::Error(Error::Output(name_span))),
             },
 
-            "ToString" => ControlFlow::Continue(Value::String(args.to_string())),
+            "AsString" => ControlFlow::Continue(Value::String(args.to_string())),
 
             "CheckZero" => ControlFlow::Continue(Value::Bool(qubit_is_zero(
                 args.try_into().with_span(args_span)?,

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -150,14 +150,14 @@ fn message() {
 
 #[test]
 fn to_string() {
-    check_intrinsic_result("", "ToString(One)", &expect![["One"]]);
+    check_intrinsic_result("", "AsString(One)", &expect![["One"]]);
 }
 
 #[test]
 fn to_string_message() {
     check_intrinsic_output(
         "",
-        r#"Message(ToString(PauliX))"#,
+        r#"Message(AsString(PauliX))"#,
         &expect![[r#"
             PauliX
         "#]],

--- a/library/core.qs
+++ b/library/core.qs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Core {
         body intrinsic;
     }
 
-    function ToString<'T>(v : 'T) : String {
+    function AsString<'T>(v : 'T) : String {
         body intrinsic;
     }
 


### PR DESCRIPTION
This is a name change only to bring the new API into better alignment with our existing Q# style. Most conversion functions are of the form <From>As<To>, such as `IntAsDouble`. This API is intended to function on any type, so the <From> part is eliminated, leaving `AsString`.