### PR TITLE
Clean-up todos, add `newtype` validation errors

### DIFF
--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -59,7 +59,7 @@ impl Display for Value {
             }
             Value::BigInt(v) => write!(f, "{v}"),
             Value::Bool(v) => write!(f, "{v}"),
-            Value::Closure => todo!(),
+            Value::Closure => todo!("https://github.com/microsoft/qsharp/issues/151"),
             Value::Double(v) => {
                 if (v.floor() - v.ceil()).abs() < f64::EPSILON {
                     // The value is a whole number, which by convention is displayed with one decimal point
@@ -105,7 +105,7 @@ impl Display for Value {
                 }
                 write!(f, ")")
             }
-            Value::Udt => todo!(),
+            Value::Udt => todo!("https://github.com/microsoft/qsharp/issues/148"),
         }
     }
 }

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -214,9 +214,9 @@ impl<'a> Context<'a> {
             ExprKind::BinOp(op, lhs, rhs) => term.then(self.infer_binop(expr.span, *op, lhs, rhs)),
             ExprKind::Block(block) => term.then(self.infer_block(block)),
             ExprKind::Call(callee, input) => {
-                // TODO: Require that the callee has functors needed for generated specializations.
                 // TODO: Handle partial application. (It's probably easier to turn them into lambdas
                 // before type inference.)
+                // https://github.com/microsoft/qsharp/issues/151
                 let callee_ty = term.then(self.infer_expr(callee));
                 let input_ty = term.then(self.infer_expr(input));
                 let output_ty = self.inferrer.fresh();
@@ -295,6 +295,7 @@ impl<'a> Context<'a> {
             }
             ExprKind::Lambda(kind, input, body) => {
                 // TODO: Infer the supported functors or require that they are explicitly listed.
+                // https://github.com/microsoft/qsharp/issues/151
                 let input = self.infer_pat(input);
                 let body = term.then(self.infer_expr(body));
                 Ty::Arrow(*kind, Box::new(input), Box::new(body), HashSet::new())

--- a/compiler/qsc_frontend/src/validate/tests.rs
+++ b/compiler/qsc_frontend/src/validate/tests.rs
@@ -129,3 +129,43 @@ fn test_unrecognized_attr() {
         "#]],
     );
 }
+
+#[test]
+fn test_newtype_syntax_not_supported() {
+    check(
+        indoc! {"
+            namespace input {
+                newtype Bar = Baz : Int;
+                operation Foo(a : Bar) : Unit {
+                    let x = a!;
+                    let y = a::Baz;
+                }
+            }
+        "},
+        &expect![[r#"
+            [
+                NotCurrentlySupported(
+                    "newtype",
+                    Span {
+                        lo: 22,
+                        hi: 46,
+                    },
+                ),
+                NotCurrentlySupported(
+                    "unwrap operator",
+                    Span {
+                        lo: 99,
+                        hi: 101,
+                    },
+                ),
+                NotCurrentlySupported(
+                    "field access",
+                    Span {
+                        lo: 119,
+                        hi: 125,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}

--- a/compiler/qsc_wasm/src/lib.rs
+++ b/compiler/qsc_wasm/src/lib.rs
@@ -16,9 +16,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Write;
 use wasm_bindgen::prelude::*;
 
-// TODO: Below is an example of how to return typed structures from Rust via Wasm
-// to the consuming JavaScript/TypeScript code. To be replaced with the implementation.
-
 // These definitions match the values expected by VS Code and Monaco.
 enum CompletionKind {
     Method = 1,
@@ -309,6 +306,8 @@ where
     let mut out = CallbackReceiver { event_cb };
     let context = compile_execution_context(true, expr, [code.to_string()]);
     if let Err(err) = context {
+        // TODO: handle multiple errors
+        // https://github.com/microsoft/qsharp/issues/149
         let e = err.0[0].clone();
         let diag: VSDiagnostic = (&e).into();
         let msg = format!(
@@ -326,6 +325,7 @@ where
             Ok(value) => format!(r#""{value}""#),
             Err(err) => {
                 // TODO: handle multiple errors
+                // https://github.com/microsoft/qsharp/issues/149
                 let e = err.0[0].clone();
                 success = false;
                 let diag: VSDiagnostic = (&e).into();


### PR DESCRIPTION
This change adds URLs for matching issues to a number of TODO comments in the code. In addition, it includes `newtype` in the unsupported features flagged by validation. It also removes the `HasFunctorsIfOp` type class and related infrastructure since functor support for calls in generated specializations will be validated by specialization generation instead of type checking.