### PR TITLE
Fix output capture for katas tests

### DIFF
--- a/katas/src/tests.rs
+++ b/katas/src/tests.rs
@@ -33,7 +33,7 @@ fn validate_exercise(path: impl AsRef<Path>) {
 
     let placeholder =
         fs::read_to_string(path.join("placeholder.qs")).expect("file should be readable");
-    // TODO: Assert that running returns true. This isn't reliable until the controlled functor is supported.
+    // TODO: Assert that running returns false. This isn't reliable until the controlled functor is supported.
     run_kata([&placeholder, &verify]).expect("placeholder should succeed");
 }
 


### PR DESCRIPTION
This PR fixes the katas tests so they don't print things to the console when running `cargo test` without `--nocapture`. The output is still printed when the test fails.

The test code was unnecessarily long and confusing, so I cleaned it up to make it easier to fix the issue.