### PR TITLE
Fix bug when generating controlled adjoint self

### DIFF
--- a/compiler/qsc_passes/src/spec_gen.rs
+++ b/compiler/qsc_passes/src/spec_gen.rs
@@ -280,16 +280,14 @@ impl<'a> MutVisitor for SpecImplPass<'a> {
             }
 
             if let (Some(ctladj), Some(adj), Some(ctl)) = (ctladj.as_mut(), &adj, &ctl) {
-                if ctladj.body != SpecBody::Gen(SpecGen::Invert) {
-                    match &ctladj.body {
-                        SpecBody::Gen(SpecGen::Auto | SpecGen::Distribute) => {
-                            if let SpecBody::Impl(_, adj_block) = &adj.body {
-                                self.ctl_distrib(ctladj, adj_block);
-                            }
+                match &ctladj.body {
+                    SpecBody::Gen(SpecGen::Auto | SpecGen::Distribute) => {
+                        if let SpecBody::Impl(_, adj_block) = &adj.body {
+                            self.ctl_distrib(ctladj, adj_block);
                         }
-                        SpecBody::Gen(SpecGen::Slf) => ctladj.body = ctl.body.clone(),
-                        _ => {}
                     }
+                    SpecBody::Gen(SpecGen::Slf) => ctladj.body = ctl.body.clone(),
+                    _ => {}
                 }
             };
 

--- a/compiler/qsc_passes/src/spec_gen/test.rs
+++ b/compiler/qsc_passes/src/spec_gen/test.rs
@@ -489,7 +489,7 @@ fn generate_ctladj_self() {
         indoc! {r#"
             namespace test {
                 operation B(input : Int) : Unit is Ctl + Adj {}
-                operation A(q : Qubit) : Unit is Ctl+ Adj {
+                operation A(q : Qubit) : Unit is Ctl + Adj {
                     body ... { B(1); B(2); }
                     adjoint self;
                 }
@@ -497,7 +497,7 @@ fn generate_ctladj_self() {
         "#},
         &expect![[r#"
             Package 0:
-                Namespace 1 [0-179] (Ident 2 [10-14] "test"):
+                Namespace 1 [0-180] (Ident 2 [10-14] "test"):
                     Item 3 [21-68]:
                         Callable 4 [21-68] (Operation):
                             name: Ident 5 [31-32] "B"
@@ -519,69 +519,69 @@ fn generate_ctladj_self() {
                                         Pat 55 [21-68]: Elided
                                     Block 14 [66-68]: <empty>
                                 SpecDecl 48 [21-68] (CtlAdj): Gen: Distribute
-                    Item 15 [73-177]:
-                        Callable 16 [73-177] (Operation):
+                    Item 15 [73-178]:
+                        Callable 16 [73-178] (Operation):
                             name: Ident 17 [83-84] "A"
                             input: Pat 18 [84-95]: Paren:
                                 Pat 19 [85-94]: Bind:
                                     Ident 20 [85-86] "q"
                                     Type 21 [89-94]: Prim (Qubit)
                             output: Type 22 [98-102]: Unit
-                            functors: Functor Expr 23 [106-114]: BinOp Union: (Functor Expr 24 [106-109]: Ctl) (Functor Expr 25 [111-114]: Adj)
+                            functors: Functor Expr 23 [106-115]: BinOp Union: (Functor Expr 24 [106-109]: Ctl) (Functor Expr 25 [112-115]: Adj)
                             body: Specializations:
-                                SpecDecl 26 [125-149] (Body): Impl:
-                                    Pat 27 [130-133]: Elided
-                                    Block 28 [134-149]:
-                                        Stmt 29 [136-141]: Semi: Expr 30 [136-140]: Call:
-                                            Expr 31 [136-137]: Path: Path 32 [136-137] (Ident 33 [136-137] "B")
-                                            Expr 34 [137-140]: Paren: Expr 35 [138-139]: Lit: Int(1)
-                                        Stmt 36 [142-147]: Semi: Expr 37 [142-146]: Call:
-                                            Expr 38 [142-143]: Path: Path 39 [142-143] (Ident 40 [142-143] "B")
-                                            Expr 41 [143-146]: Paren: Expr 42 [144-145]: Lit: Int(2)
-                                SpecDecl 43 [158-171] (Adj): Impl:
-                                    Pat 27 [130-133]: Elided
-                                    Block 28 [134-149]:
-                                        Stmt 29 [136-141]: Semi: Expr 30 [136-140]: Call:
-                                            Expr 31 [136-137]: Path: Path 32 [136-137] (Ident 33 [136-137] "B")
-                                            Expr 34 [137-140]: Paren: Expr 35 [138-139]: Lit: Int(1)
-                                        Stmt 36 [142-147]: Semi: Expr 37 [142-146]: Call:
-                                            Expr 38 [142-143]: Path: Path 39 [142-143] (Ident 40 [142-143] "B")
-                                            Expr 41 [143-146]: Paren: Expr 42 [144-145]: Lit: Int(2)
-                                SpecDecl 49 [73-177] (Ctl): Impl:
-                                    Pat 64 [73-177]: Tuple:
-                                        Pat 65 [73-177]: Bind:
-                                            Ident 57 [73-177] "ctls"
-                                        Pat 66 [73-177]: Elided
-                                    Block 28 [134-149]:
-                                        Stmt 29 [136-141]: Semi: Expr 30 [136-140]: Call:
-                                            Expr 58 [136-137]: UnOp (Functor Ctl):
-                                                Expr 31 [136-137]: Path: Path 32 [136-137] (Ident 33 [136-137] "B")
-                                            Expr 59 [137-140]: Tuple:
-                                                Expr 60 [137-140]: Path: Path 56 [73-177] (Ident 57 [73-177] "ctls")
-                                                Expr 34 [137-140]: Paren: Expr 35 [138-139]: Lit: Int(1)
-                                        Stmt 36 [142-147]: Semi: Expr 37 [142-146]: Call:
-                                            Expr 61 [142-143]: UnOp (Functor Ctl):
-                                                Expr 38 [142-143]: Path: Path 39 [142-143] (Ident 40 [142-143] "B")
-                                            Expr 62 [143-146]: Tuple:
-                                                Expr 63 [143-146]: Path: Path 56 [73-177] (Ident 57 [73-177] "ctls")
-                                                Expr 41 [143-146]: Paren: Expr 42 [144-145]: Lit: Int(2)
-                                SpecDecl 50 [73-177] (CtlAdj): Impl:
-                                    Pat 64 [73-177]: Tuple:
-                                        Pat 65 [73-177]: Bind:
-                                            Ident 57 [73-177] "ctls"
-                                        Pat 66 [73-177]: Elided
-                                    Block 28 [134-149]:
-                                        Stmt 29 [136-141]: Semi: Expr 30 [136-140]: Call:
-                                            Expr 58 [136-137]: UnOp (Functor Ctl):
-                                                Expr 31 [136-137]: Path: Path 32 [136-137] (Ident 33 [136-137] "B")
-                                            Expr 59 [137-140]: Tuple:
-                                                Expr 60 [137-140]: Path: Path 56 [73-177] (Ident 57 [73-177] "ctls")
-                                                Expr 34 [137-140]: Paren: Expr 35 [138-139]: Lit: Int(1)
-                                        Stmt 36 [142-147]: Semi: Expr 37 [142-146]: Call:
-                                            Expr 61 [142-143]: UnOp (Functor Ctl):
-                                                Expr 38 [142-143]: Path: Path 39 [142-143] (Ident 40 [142-143] "B")
-                                            Expr 62 [143-146]: Tuple:
-                                                Expr 63 [143-146]: Path: Path 56 [73-177] (Ident 57 [73-177] "ctls")
-                                                Expr 41 [143-146]: Paren: Expr 42 [144-145]: Lit: Int(2)"#]],
+                                SpecDecl 26 [126-150] (Body): Impl:
+                                    Pat 27 [131-134]: Elided
+                                    Block 28 [135-150]:
+                                        Stmt 29 [137-142]: Semi: Expr 30 [137-141]: Call:
+                                            Expr 31 [137-138]: Path: Path 32 [137-138] (Ident 33 [137-138] "B")
+                                            Expr 34 [138-141]: Paren: Expr 35 [139-140]: Lit: Int(1)
+                                        Stmt 36 [143-148]: Semi: Expr 37 [143-147]: Call:
+                                            Expr 38 [143-144]: Path: Path 39 [143-144] (Ident 40 [143-144] "B")
+                                            Expr 41 [144-147]: Paren: Expr 42 [145-146]: Lit: Int(2)
+                                SpecDecl 43 [159-172] (Adj): Impl:
+                                    Pat 27 [131-134]: Elided
+                                    Block 28 [135-150]:
+                                        Stmt 29 [137-142]: Semi: Expr 30 [137-141]: Call:
+                                            Expr 31 [137-138]: Path: Path 32 [137-138] (Ident 33 [137-138] "B")
+                                            Expr 34 [138-141]: Paren: Expr 35 [139-140]: Lit: Int(1)
+                                        Stmt 36 [143-148]: Semi: Expr 37 [143-147]: Call:
+                                            Expr 38 [143-144]: Path: Path 39 [143-144] (Ident 40 [143-144] "B")
+                                            Expr 41 [144-147]: Paren: Expr 42 [145-146]: Lit: Int(2)
+                                SpecDecl 49 [73-178] (Ctl): Impl:
+                                    Pat 64 [73-178]: Tuple:
+                                        Pat 65 [73-178]: Bind:
+                                            Ident 57 [73-178] "ctls"
+                                        Pat 66 [73-178]: Elided
+                                    Block 28 [135-150]:
+                                        Stmt 29 [137-142]: Semi: Expr 30 [137-141]: Call:
+                                            Expr 58 [137-138]: UnOp (Functor Ctl):
+                                                Expr 31 [137-138]: Path: Path 32 [137-138] (Ident 33 [137-138] "B")
+                                            Expr 59 [138-141]: Tuple:
+                                                Expr 60 [138-141]: Path: Path 56 [73-178] (Ident 57 [73-178] "ctls")
+                                                Expr 34 [138-141]: Paren: Expr 35 [139-140]: Lit: Int(1)
+                                        Stmt 36 [143-148]: Semi: Expr 37 [143-147]: Call:
+                                            Expr 61 [143-144]: UnOp (Functor Ctl):
+                                                Expr 38 [143-144]: Path: Path 39 [143-144] (Ident 40 [143-144] "B")
+                                            Expr 62 [144-147]: Tuple:
+                                                Expr 63 [144-147]: Path: Path 56 [73-178] (Ident 57 [73-178] "ctls")
+                                                Expr 41 [144-147]: Paren: Expr 42 [145-146]: Lit: Int(2)
+                                SpecDecl 50 [73-178] (CtlAdj): Impl:
+                                    Pat 64 [73-178]: Tuple:
+                                        Pat 65 [73-178]: Bind:
+                                            Ident 57 [73-178] "ctls"
+                                        Pat 66 [73-178]: Elided
+                                    Block 28 [135-150]:
+                                        Stmt 29 [137-142]: Semi: Expr 30 [137-141]: Call:
+                                            Expr 58 [137-138]: UnOp (Functor Ctl):
+                                                Expr 31 [137-138]: Path: Path 32 [137-138] (Ident 33 [137-138] "B")
+                                            Expr 59 [138-141]: Tuple:
+                                                Expr 60 [138-141]: Path: Path 56 [73-178] (Ident 57 [73-178] "ctls")
+                                                Expr 34 [138-141]: Paren: Expr 35 [139-140]: Lit: Int(1)
+                                        Stmt 36 [143-148]: Semi: Expr 37 [143-147]: Call:
+                                            Expr 61 [143-144]: UnOp (Functor Ctl):
+                                                Expr 38 [143-144]: Path: Path 39 [143-144] (Ident 40 [143-144] "B")
+                                            Expr 62 [144-147]: Tuple:
+                                                Expr 63 [144-147]: Path: Path 56 [73-178] (Ident 57 [73-178] "ctls")
+                                                Expr 41 [144-147]: Paren: Expr 42 [145-146]: Lit: Int(2)"#]],
     );
 }


### PR DESCRIPTION
If the adjoint generator was `self` then the placeholder for controlled adjoint was also `self`, but that generator was not properly handled by the code, leaving  behind an unimplement specialization. This corrects the issue by cloning the controlled block (after any generation) such that an implementation is present.