### PR TITLE
Support unicode in code sharing

### DIFF
--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -10,7 +10,7 @@ import {
 
 import { generateHistogramData, generateHistogramSvg, sampleData } from "./histogram.js";
 import { PopulateKatasList, RenderKatas } from "./katas.js";
-import { fromBinary, toBinary } from "./utils.js";
+import { base64ToCode, codeToBase64 } from "./utils.js";
 
 const sampleCode = `namespace Sample {
     open Microsoft.Quantum.Diagnostics;
@@ -75,7 +75,12 @@ async function loaded() {
     // If URL is a sharing link, populate the editor with the code from the link. 
     // Otherwise, populate with sample code.
     const params = new URLSearchParams(window.location.search);
-    const code = params.get("code") ? fromBinary(window.atob(params.get("code")!)) : sampleCode;
+
+    let code = sampleCode;
+    if (params.get("code")) {
+        const base64code = decodeURIComponent(params.get("code")!);
+        code = base64ToCode(base64code);
+    }
 
     let srcModel = monaco.editor.createModel(code, 'qsharp');
     editor.setModel(srcModel);
@@ -187,9 +192,11 @@ async function loaded() {
 
     shareButton.addEventListener('click', _ => {
         const code = srcModel.getValue();
-        const encodedCode = window.btoa(toBinary(code));
+        const encodedCode = codeToBase64(code);
+        const escapedCode = encodeURIComponent(encodedCode);
+
         // Get current URL without query parameters to use as the base URL
-        const newUrl = `${window.location.href.split('?')[0]}?code=${encodedCode}`;
+        const newUrl = `${window.location.href.split('?')[0]}?code=${escapedCode}`;
         // Copy link to clipboard and update url without reloading the page
         navigator.clipboard.writeText(newUrl);
         window.history.pushState({}, '', newUrl);

--- a/playground/src/utils.ts
+++ b/playground/src/utils.ts
@@ -1,41 +1,45 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// base64 functions to encode unicode
-// Per samples on https://developer.mozilla.org/en-US/docs/Web/API/btoa
+// Utility functions to convert source code to and from base64.
+//
+// The btoa function expects a string of bytes (i.e. in the range x00 - xFF), however
+// as the code may contain UTF-16 code units outside this range, it needs to be converted
+// first. If you just encodeUriComponent the whole string, it will blow up considerably as
+// all spaces and newlines (common chars in code) become %20 and %0A (so 4 spaces and a newline
+// and up being 15 chars) whereas base64 encoding those 5 chars in ASCII is just 'ICAgIAo' (i.e.
+// 7 bytes, or less then half the size).
+//
+// The below functions simply convert the source to utf-8 bytes first (and as most source code
+// is ASCII this is usually a one-to-one mapping), and then base64 encodes/decodes the utf-8
+// bytes. In testing this results in an encoding about half the size of other methods.
 
-// convert a Unicode string to a string in which
-// each 16-bit unit occupies only one byte
-// e.g.
-//   const myString = "☸☹☺☻☼☾☿";
-//   const converted = toBinary(myString);   // "8&9&:&;&<&>&?&"
-//   const encoded = window.btoa(converted); // "OCY5JjomOyY8Jj4mPyY="
-export function toBinary(string: string) {
-  const codeUnits = Uint16Array.from(
-    { length: string.length },
-    (element, index) => string.charCodeAt(index)
-  );
-  const charCodes = new Uint8Array(codeUnits.buffer);
+export function codeToBase64(code: string) : string {
+  // Convert to utf=8
+  const myencoder = new TextEncoder();
+  const buff = myencoder.encode(code);
 
-  let result = "";
-  charCodes.forEach((char) => {
-    result += String.fromCharCode(char);
-  });
-  return result;
+  // Create a string of the utf-8 code units (so each will be <= 0xFF)
+  let binStr = "";
+  for(const unit of buff) {
+    binStr += String.fromCharCode(unit);
+  }
+
+  // Convert that to base64
+  const base64String = window.btoa(binStr);
+  return base64String;
 }
 
-// Does the inverse of toBinary, e.g.
-//   const decoded = window.atob(encoded); // "8&9&:&;&<&>&?&"
-//   const original = fromBinary(decoded); // "☸☹☺☻☼☾☿"
-export function fromBinary(binary: string) {
-  const bytes = Uint8Array.from({ length: binary.length }, (element, index) =>
-    binary.charCodeAt(index)
-  );
-  const charCodes = new Uint16Array(bytes.buffer);
+export function base64ToCode(b64: string) : string {
+  // Get the binary string of utf-8 code units
+  const binStr = window.atob(b64);
 
-  let result = "";
-  charCodes.forEach((char) => {
-    result += String.fromCharCode(char);
-  });
-  return result;
+  // Create the Uint8Array from it
+  const byteArray = new Uint8Array(binStr.length);
+  for (let i = 0; i < binStr.length; ++i) byteArray[i] = binStr.charCodeAt(i);
+
+  // Decode the utf-8 bytes into a JavaScript string
+  const decoder = new TextDecoder();
+  const code = decoder.decode(byteArray);
+  return code;
 }


### PR DESCRIPTION
A simple fix to enable unicode chars in the code sharing feature. For example, try the below after loading the playground locally. CC @minestarks 

<http://localhost:5555/?code=Ly8g8J%2BYgAovLyBncmlubmluZyBmYWNlCi8vIFVuaWNvZGU6IFUrMUY2MDAsIFVURi04OiBGMCA5RiA5OCA4MAoKLy8g8J%2BHuvCfh7gKLy8gZmxhZyBvZiB0aGUgVW5pdGVkIFN0YXRlcwovLyBVbmljb2RlOiBVKzFGMUZBIFUrMUYxRjgsIFVURi04OiBGMCA5RiA4NyBCQSBGMCA5RiA4NyBCOAoKLy8g8J%2BkvOKAjeKZgO%2B4jwovLyB3b21lbiB3cmVzdGxpbgovLyBVbmljb2RlOiBVKzFGOTNDIFUrMjAwRCBVKzI2NDAgVStGRTBGLCBVVEYtODogRjAgOUYgQTQgQkMgRTIgODAgOEQgRTIgOTkgODAgRUYgQjggOEYKCm5hbWVzcGFjZSBTYW1wbGUgewogICAgb3BlbiBNaWNyb3NvZnQuUXVhbnR1bS5EaWFnbm9zdGljczsKCiAgICBARW50cnlQb2ludCgpCiAgICBvcGVyYXRpb24gTWFpbigpIDogUmVzdWx0W10gewogICAgICAgIHVzZSBxMSA9IFF1Yml0KCk7CiAgICAgICAgdXNlIHEyID0gUXViaXQoKTsKCiAgICAgICAgSChxMSk7CiAgICAgICAgQ05PVChxMSwgcTIpOwogICAgICAgIER1bXBNYWNoaW5lKCk7CgogICAgICAgIGxldCBtMSA9IE0ocTEpOwogICAgICAgIGxldCBtMiA9IE0ocTIpOwoKICAgICAgICByZXR1cm4gW20xLCBtMl07CiAgICB9Cn0K>