### PR TITLE
Add vscode/out/ to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,4 +14,5 @@ pip/src/**/*.html
 playground/public/libs/
 samples/
 target/
+vscode/out/
 wasm/


### PR DESCRIPTION
CI didn't catch this omission since prettier runs before the build.