### PR TITLE
Fix lifting for items defined in entry expr

### DIFF
--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -2703,16 +2703,12 @@ fn nested_interpolated_string_with_exprs() {
 #[test]
 fn udt_unwrap() {
     check_expr(
-        indoc! {"
-            namespace A {
-                newtype Foo = (Int, Bool);
-            }
-        "},
-        indoc! {"{
-            open A;
+        "",
+        "{
+            newtype Foo = (Int, Bool);
             let foo = Foo(1, true);
             foo!
-        }"},
+        }",
         &expect!["(1, true)"],
     );
 }
@@ -2720,16 +2716,12 @@ fn udt_unwrap() {
 #[test]
 fn udt_fields() {
     check_expr(
-        indoc! {"
-            namespace A {
-                newtype Point = (X : Int, Y : Int);
-            }
-        "},
-        indoc! {"{
-            open A;
+        "",
+        "{
+            newtype Point = (X : Int, Y : Int);
             let p = Point(1, 2);
             (p::X, p::Y)
-        }"},
+        }",
         &expect!["(1, 2)"],
     );
 }
@@ -2737,46 +2729,26 @@ fn udt_fields() {
 #[test]
 fn udt_field_nested() {
     check_expr(
-        indoc! {"
-            namespace A {
-                newtype Point = (X : Int, (Y : Int, Z : Int));
-            }
-        "},
-        indoc! {"{
-            open A;
+        "",
+        "{
+            newtype Point = (X : Int, (Y : Int, Z : Int));
             let p = Point(1, (2, 3));
             (p::Y, p::Z)
-        }"},
+        }",
         &expect!["(2, 3)"],
     );
 }
 
 #[test]
 fn lambda_function_empty_closure() {
-    check_expr(
-        indoc! {"
-            namespace A {
-                function Foo() : Int {
-                    let f = x -> x + 1;
-                    f(1)
-                }
-            }
-        "},
-        "A.Foo()",
-        &expect!["2"],
-    );
+    check_expr("", "{ let f = x -> x + 1; f(1) }", &expect!["2"]);
 }
 
 #[test]
 fn lambda_function_empty_closure_passed() {
     check_expr(
-        indoc! {"
-            namespace A {
-                function Foo(f : Int -> Int) : Int { f(2) }
-                function Bar() : Int { Foo(x -> x + 1) }
-            }
-        "},
-        "A.Bar()",
+        "",
+        "{ function Foo(f : Int -> Int) : Int { f(2) }; Foo(x -> x + 1) }",
         &expect!["3"],
     );
 }
@@ -2784,16 +2756,8 @@ fn lambda_function_empty_closure_passed() {
 #[test]
 fn lambda_function_closure() {
     check_expr(
-        indoc! {"
-            namespace A {
-                function Foo() : (Int, Int) {
-                    let x = 5;
-                    let f = y -> (x, y);
-                    f(2)
-                }
-            }
-        "},
-        "A.Foo()",
+        "",
+        "{ let x = 5; let f = y -> (x, y); f(2) }",
         &expect!["(5, 2)"],
     );
 }
@@ -2801,16 +2765,8 @@ fn lambda_function_closure() {
 #[test]
 fn lambda_function_closure_passed() {
     check_expr(
-        indoc! {"
-            namespace A {
-                function Foo(f : Int -> (Int, Int)) : (Int, Int) { f(2) }
-                function Bar() : (Int, Int) {
-                    let x = 5;
-                    Foo(y -> (x, y))
-                }
-            }
-        "},
-        "A.Bar()",
+        "",
+        "{ function Foo(f : Int -> (Int, Int)) : (Int, Int) { f(2) }; let x = 5; Foo(y -> (x, y)) }",
         &expect!["(5, 2)"],
     );
 }
@@ -2818,7 +2774,7 @@ fn lambda_function_closure_passed() {
 #[test]
 fn lambda_function_nested_closure() {
     check_expr(
-        indoc! {"
+        "
             namespace A {
                 function Foo(f : Int -> Int -> (Int, Int, Int, Int)) : (Int, Int, Int, Int) {
                     f(2)(3)
@@ -2832,7 +2788,7 @@ fn lambda_function_nested_closure() {
                     })
                 }
             }
-        "},
+        ",
         "A.Bar()",
         &expect!["(5, 2, 1, 3)"],
     );
@@ -2841,7 +2797,7 @@ fn lambda_function_nested_closure() {
 #[test]
 fn lambda_operation_empty_closure() {
     check_expr(
-        indoc! {"
+        "
             namespace A {
                 open Microsoft.Quantum.Measurement;
 
@@ -2853,7 +2809,7 @@ fn lambda_operation_empty_closure() {
 
                 operation Bar() : Result { Foo(q => X(q)) }
             }
-        "},
+        ",
         "A.Bar()",
         &expect!["One"],
     );
@@ -2862,7 +2818,7 @@ fn lambda_operation_empty_closure() {
 #[test]
 fn lambda_operation_closure() {
     check_expr(
-        indoc! {"
+        "
             namespace A {
                 open Microsoft.Quantum.Measurement;
                 operation Foo(op : () => Result) : Result { op() }
@@ -2872,7 +2828,7 @@ fn lambda_operation_closure() {
                     Foo(() => MResetZ(q))
                 }
             }
-        "},
+        ",
         "A.Bar()",
         &expect!["One"],
     );

--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -96,8 +96,8 @@ impl With<'_> {
             self.lower_namespace(namespace);
         }
 
-        let items = self.lowerer.items.drain(..).map(|i| (i.id, i)).collect();
         let entry = package.entry.as_ref().map(|e| self.lower_expr(e));
+        let items = self.lowerer.items.drain(..).map(|i| (i.id, i)).collect();
         hir::Package { items, entry }
     }
 

--- a/library/tests/src/lib.rs
+++ b/library/tests/src/lib.rs
@@ -31,26 +31,3 @@ pub fn test_expression(expr: &str, expected: &Value) {
 
     assert_eq!(expected, &result);
 }
-
-/// # Panics
-///
-/// Will panic if compilation fails or the result is not the same as expected.
-pub fn test_operation(operation: &str, expected: &Value) {
-    let mut stdout = vec![];
-    let mut out = GenericReceiver::new(&mut stdout);
-    let mut operation_in_namespace = String::from("namespace Test {");
-    operation_in_namespace.push_str(operation);
-    operation_in_namespace.push('}');
-
-    let sources = SourceMap::new(
-        [("test".into(), operation_in_namespace.into())],
-        Some("Test.Test()".into()),
-    );
-
-    let context = stateless::Context::new(true, sources).expect("test should compile");
-    let result = context
-        .eval(&mut out)
-        .expect("test should run successfully");
-
-    assert_eq!(expected, &result);
-}

--- a/library/tests/src/test_arrays.rs
+++ b/library/tests/src/test_arrays.rs
@@ -1,51 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::{test_expression, test_operation};
+use crate::test_expression;
 use qsc::interpret::Value;
 
 // Tests for Microsoft.Quantum.Arrays namespace
 
 #[test]
 fn check_all() {
-    test_operation(
-        r#"operation Test() : Bool {
-            Microsoft.Quantum.Arrays.All(x -> x != 0, [1, 2, 3, 4, 5])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.All(x -> x != 0, [1, 2, 3, 4, 5])",
         &Value::Bool(true),
     );
-    test_operation(
-        r#"operation Test() : Bool {
-            Microsoft.Quantum.Arrays.All(x -> x != 0, [1, 2, 0, 4, 5])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.All(x -> x != 0, [1, 2, 0, 4, 5])",
         &Value::Bool(false),
     );
-    test_operation(
-        r#"operation Test() : Bool {
-            Microsoft.Quantum.Arrays.All(x -> x == One, [One, One, One])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.All(x -> x == One, [One, One, One])",
         &Value::Bool(true),
     );
-    test_operation(
-        r#"operation Test() : Bool {
-            Microsoft.Quantum.Arrays.All(x -> x == One, [One, One, Zero])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.All(x -> x == One, [One, One, Zero])",
         &Value::Bool(false),
     );
 }
 
 #[test]
 fn check_any() {
-    test_operation(
-        r#"operation Test() : Bool {
-            Microsoft.Quantum.Arrays.Any(x -> x % 2 == 0, [1, 3, 6, 7, 9])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.Any(x -> x % 2 == 0, [1, 3, 6, 7, 9])",
         &Value::Bool(true),
     );
-    test_operation(
-        r#"operation Test() : Bool {
-            Microsoft.Quantum.Arrays.Any(x -> x % 2 == 0, [1, 3, 5, 7, 9])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.Any(x -> x % 2 == 0, [1, 3, 5, 7, 9])",
         &Value::Bool(false),
     );
 }
@@ -140,16 +128,12 @@ fn check_column_at() {
 
 #[test]
 fn check_count() {
-    test_operation(
-        r#"operation Test() : Int {
-            Microsoft.Quantum.Arrays.Count(x -> x % 2 != 0, [1, 3, 6, 7, 9])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.Count(x -> x % 2 != 0, [1, 3, 6, 7, 9])",
         &Value::Int(4),
     );
-    test_operation(
-        r#"operation Test() : Int {
-            Microsoft.Quantum.Arrays.Count(x -> x % 2 == 0, [1, 3, 6, 7, 9])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.Count(x -> x % 2 == 0, [1, 3, 6, 7, 9])",
         &Value::Int(1),
     );
 }
@@ -180,13 +164,13 @@ fn check_diagnonal() {
 
 #[test]
 fn check_draw_many() {
-    test_operation(
-        r#"operation Test() : Result[] {
+    test_expression(
+        "{
             use qubit = Qubit();
             let results = Microsoft.Quantum.Arrays.DrawMany(q => {X(q); M(q)}, 3, qubit);
             Reset(qubit);
             results
-        }"#,
+        }",
         &Value::Array(
             vec![
                 Value::Result(true),
@@ -245,35 +229,29 @@ fn check_enumerated() {
 
 #[test]
 fn check_fold() {
-    test_operation(
-        r#"operation Test() : Int {
-            Microsoft.Quantum.Arrays.Fold((x, y) -> x + y, 0, [1, 2, 3, 4, 5])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.Fold((x, y) -> x + y, 0, [1, 2, 3, 4, 5])",
         &Value::Int(15),
     );
-    test_operation(
-        r#"operation Test() : Bool {
-            Microsoft.Quantum.Arrays.Fold((x, y) -> x or y, false, [true, false, true])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.Fold((x, y) -> x or y, false, [true, false, true])",
         &Value::Bool(true),
     );
-    test_operation(
-        r#"operation Test() : Bool {
-            Microsoft.Quantum.Arrays.Fold((x, y) -> x and y, true, [true, false, true])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.Fold((x, y) -> x and y, true, [true, false, true])",
         &Value::Bool(false),
     );
 }
 
 #[test]
 fn check_for_each() {
-    test_operation(
-        r#"operation Test() : Result[] {
+    test_expression(
+        "{
             use register = Qubit[3];
             Microsoft.Quantum.Arrays.ForEach
                 (q => {X(q); Microsoft.Quantum.Measurement.MResetZ(q)},
                 register)
-        }"#,
+        }",
         &Value::Array(
             vec![
                 Value::Result(true),
@@ -388,20 +366,16 @@ fn check_is_square_array() {
 
 #[test]
 fn check_mapped() {
-    test_operation(
-        r#"operation Test() : Int[] {
-            Microsoft.Quantum.Arrays.Mapped(i -> i * 2, [0, 1, 2])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.Mapped(i -> i * 2, [0, 1, 2])",
         &Value::Array(vec![Value::Int(0), Value::Int(2), Value::Int(4)].into()),
     );
 }
 
 #[test]
 fn check_mapped_by_index() {
-    test_operation(
-        r#"operation Test() : Bool[] {
-            Microsoft.Quantum.Arrays.MappedByIndex((index, element) -> index == element ,[0, -1, 2])
-        }"#,
+    test_expression(
+        "Microsoft.Quantum.Arrays.MappedByIndex((index, element) -> index == element ,[0, -1, 2])",
         &Value::Array(vec![Value::Bool(true), Value::Bool(false), Value::Bool(true)].into()),
     );
 }


### PR DESCRIPTION
This change fixes a minor bug that affected lifting of items from entry expressions. Additionally, updates tests that previously worked around this bug.

Fixes #340.