### PR TITLE
Use standard scoping for all blocks

### DIFF
--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -1675,47 +1675,6 @@ fn repeat_until_fixup_expr() {
 }
 
 #[test]
-fn repeat_until_fixup_scoping_expr() {
-    check_expr(
-        "",
-        indoc! {"{
-            mutable x = 0;
-            repeat {
-                let increment = 2;
-            }
-            until x >= 3 * increment
-            fixup {
-                set x = x + increment;
-            }
-            x
-        }"},
-        &expect!["6"],
-    );
-}
-
-#[test]
-fn repeat_until_fixup_shadowing_expr() {
-    check_expr(
-        "",
-        indoc! {"{
-            mutable x = 0;
-            mutable y = 0;
-            repeat {
-                let increment = 2;
-            }
-            until x >= 3 * increment
-            fixup {
-                set x = x + increment;
-                set y = 1;
-                let y = 2;
-            }
-            y
-        }"},
-        &expect!["1"],
-    );
-}
-
-#[test]
 fn return_expr() {
     check_expr("", "return 4", &expect!["4"]);
 }

--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -340,7 +340,7 @@ impl AstVisitor<'_> for With<'_> {
                 ast_visit::walk_qubit_init(self, init);
                 self.resolver.bind_pat(pat);
                 if let Some(block) = block {
-                    ast_visit::walk_block(self, block);
+                    self.visit_block(block);
                 }
             }
             ast::StmtKind::Empty | ast::StmtKind::Expr(_) | ast::StmtKind::Semi(_) => {
@@ -354,18 +354,6 @@ impl AstVisitor<'_> for With<'_> {
             ast::ExprKind::For(pat, iter, block) => {
                 self.visit_expr(iter);
                 self.with_pat(ScopeKind::Block, pat, |visitor| visitor.visit_block(block));
-            }
-            ast::ExprKind::Repeat(repeat, cond, fixup) => {
-                self.with_scope(ScopeKind::Block, |visitor| {
-                    repeat
-                        .stmts
-                        .iter()
-                        .for_each(|stmt| visitor.visit_stmt(stmt));
-                    visitor.visit_expr(cond);
-                    if let Some(block) = fixup.as_ref() {
-                        block.stmts.iter().for_each(|stmt| visitor.visit_stmt(stmt));
-                    }
-                });
             }
             ast::ExprKind::Lambda(_, input, output) => {
                 self.with_pat(ScopeKind::Block, input, |visitor| {


### PR DESCRIPTION
Following exceptional scoping for repeat loops causes errors in block handling, where normal scoping for all blocks allows for consistent behavior that properly supports all features.

Fixes #352
Fixes #354