### PR TITLE
Explicitly set rev-parse short length.

### DIFF
--- a/compiler/qsc/build.rs
+++ b/compiler/qsc/build.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 fn main() {
     let git_hash = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short=8", "HEAD"])
         .output()
         .map_or_else(
             |_| "unknown".to_string(),

--- a/wasm/build.rs
+++ b/wasm/build.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 fn main() {
     let git_hash = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short=8", "HEAD"])
         .output()
         .map_or_else(
             |_| "unknown".to_string(),


### PR DESCRIPTION
rev-parse can return different lengths based on user config, repo config, and OS config. This explicitly sets the short length to avoid inconsistencies.