### PR TITLE
Fix instantiation of type schemes with duplicate parameter names

### DIFF
--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -312,7 +312,7 @@ fn insert_core_call() {
                 .expect("qubit allocation should be in core");
             let allocate_ty = allocate
                 .scheme
-                .instantiate([])
+                .instantiate(&[])
                 .expect("qubit allocation scheme should instantiate");
             let callee = Expr {
                 id: NodeId::default(),

--- a/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/compiler/qsc_frontend/src/typeck/infer.rs
@@ -333,7 +333,7 @@ impl Inferrer {
 
     /// Instantiates the type scheme.
     pub(super) fn instantiate(&mut self, scheme: &Scheme, span: Span) -> (Arrow, Vec<GenericArg>) {
-        let args = scheme
+        let args: Vec<_> = scheme
             .params()
             .iter()
             .map(|param| match param.kind {

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -3172,3 +3172,17 @@ fn duplicate_type_decls_inferred_and_ignored() {
         "##]],
     );
 }
+
+#[test]
+fn instantiate_duplicate_ty_param_names() {
+    check(
+        "namespace Test { function Foo<'T, 'T>() : () { let f = Foo; } }",
+        "",
+        &expect![[r##"
+            #8 37-39 "()" : Unit
+            #10 45-61 "{ let f = Foo; }" : Unit
+            #12 51-52 "f" : (Unit -> Unit)
+            #14 55-58 "Foo" : (Unit -> Unit)
+        "##]],
+    );
+}

--- a/compiler/qsc_hir/src/ty.rs
+++ b/compiler/qsc_hir/src/ty.rs
@@ -93,12 +93,9 @@ impl Scheme {
     /// # Errors
     ///
     /// Returns an error if the given arguments do not match the scheme parameters.
-    pub fn instantiate<'a>(
-        &self,
-        args: impl IntoIterator<Item = &'a GenericArg>,
-    ) -> Result<Arrow, InstantiationError> {
-        let args: HashMap<_, _> = self.params.iter().map(|p| &p.name).zip(args).collect();
+    pub fn instantiate(&self, args: &[GenericArg]) -> Result<Arrow, InstantiationError> {
         if args.len() == self.params.len() {
+            let args: HashMap<_, _> = self.params.iter().map(|p| &p.name).zip(args).collect();
             instantiate_arrow_ty(|name| args.get(name).copied(), &self.ty)
         } else {
             Err(InstantiationError::Arity)


### PR DESCRIPTION
The root cause here is that callables with duplicate type parameter names are allowed to be declared (#195). Fixing that is a bigger change. In the meantime, I don't think it's fair for `Scheme::instantiate` to complain about an arity mismatch when the caller did actually provide the right number of arguments (it's only the constructed hash map that is smaller). Check the arity based on the original input list instead of the hash map.

Fixes #381.