### PR TITLE
Check missing semicolons in callable body block

### DIFF
--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2212,7 +2212,7 @@ fn local_function_last_stmt_is_unit_block() {
         indoc! {"
             namespace A {
                 function Foo() : Int {
-                    Bar()
+                    Bar();
                     function Bar() : Int { 4 }
                 }
             }
@@ -2220,14 +2220,14 @@ fn local_function_last_stmt_is_unit_block() {
         "",
         &expect![[r##"
             #6 30-32 "()" : Unit
-            #10 39-95 "{\n        Bar()\n        function Bar() : Int { 4 }\n    }" : Unit
+            #10 39-96 "{\n        Bar();\n        function Bar() : Int { 4 }\n    }" : Unit
             #12 49-54 "Bar()" : Int
             #13 49-52 "Bar" : (Unit -> Int)
             #16 52-54 "()" : Unit
-            #21 75-77 "()" : Unit
-            #25 84-89 "{ 4 }" : Int
-            #27 86-87 "4" : Int
-            Error(Type(Error(TyMismatch(Prim(Int), Tuple([]), Span { lo: 63, hi: 89 }))))
+            #21 76-78 "()" : Unit
+            #25 85-90 "{ 4 }" : Int
+            #27 87-88 "4" : Int
+            Error(Type(Error(TyMismatch(Prim(Int), Tuple([]), Span { lo: 64, hi: 90 }))))
         "##]],
     );
 }

--- a/compiler/qsc_parse/src/item.rs
+++ b/compiler/qsc_parse/src/item.rs
@@ -16,6 +16,7 @@ use super::{
 use crate::{
     lex::{Delim, TokenKind},
     prim::{barrier, recovering, recovering_token, shorten},
+    stmt::check_semis,
     ErrorKind,
 };
 use qsc_ast::ast::{
@@ -275,6 +276,7 @@ fn parse_callable_body(s: &mut Scanner) -> Result<CallableBody> {
         let specs = many(s, parse_spec_decl)?;
         if specs.is_empty() {
             let stmts = stmt::parse_many(s)?;
+            check_semis(&stmts)?;
             recovering_token(s, TokenKind::Close(Delim::Brace))?;
             Ok(CallableBody::Block(Box::new(Block {
                 id: NodeId::default(),

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -445,6 +445,24 @@ fn function_single_impl() {
 }
 
 #[test]
+fn function_body_missing_semi_between_stmts() {
+    check(
+        parse,
+        "function Foo() : () { f(x) g(y) }",
+        &expect![[r#"
+            Error(
+                MissingSemi(
+                    Span {
+                        lo: 26,
+                        hi: 26,
+                    },
+                ),
+            )
+        "#]],
+    );
+}
+
+#[test]
 fn operation_body_impl() {
     check(
         parse,

--- a/compiler/qsc_parse/src/stmt.rs
+++ b/compiler/qsc_parse/src/stmt.rs
@@ -163,7 +163,7 @@ fn parse_qubit_init(s: &mut Scanner) -> Result<Box<QubitInit>> {
     }))
 }
 
-fn check_semis(stmts: &[Box<Stmt>]) -> Result<()> {
+pub(super) fn check_semis(stmts: &[Box<Stmt>]) -> Result<()> {
     let leading_stmts = stmts.split_last().map_or([].as_slice(), |s| s.1);
     for stmt in leading_stmts {
         if matches!(&*stmt.kind, StmtKind::Expr(expr) if !expr::is_stmt_final(&expr.kind)) {


### PR DESCRIPTION
I forgot about this when I was adding the semicolon check to the block parser. Callable bodies aren't parsed in the same way as other blocks, since they may contain either specializations or statements. Add the semicolon check to callable body blocks, too.