### PR TITLE
Don't print unit values in REPL

### DIFF
--- a/compiler/qsc/src/bin/qsi.rs
+++ b/compiler/qsc/src/bin/qsi.rs
@@ -165,6 +165,7 @@ fn print_prompt(continuation: bool) {
 
 fn print_interpret_result(line: &str, result: Result<Value, Vec<LineError>>) {
     match result {
+        Ok(Value::Tuple(items)) if items.is_empty() => {}
         Ok(value) => println!("{value}"),
         Err(errors) => {
             let source: Arc<str> = line.into();


### PR DESCRIPTION
Printing "()" after every statement is too noisy; it matches the behavior of other REPLs like Python and Haskell to simply print nothing in this case.