### PR TITLE
Panic if default node ID is used before assigned

### DIFF
--- a/compiler/qsc_ast/src/ast.rs
+++ b/compiler/qsc_ast/src/ast.rs
@@ -70,14 +70,14 @@ impl Display for NodeId {
 
 impl From<NodeId> for usize {
     fn from(value: NodeId) -> Self {
-        assert!(!value.is_default(), "default node ID should be assigned");
+        assert!(!value.is_default(), "default node ID should be replaced");
         value.0 as usize
     }
 }
 
 impl PartialEq for NodeId {
     fn eq(&self, other: &Self) -> bool {
-        assert!(!self.is_default(), "default node ID should be assigned");
+        assert!(!self.is_default(), "default node ID should be replaced");
         self.0 == other.0
     }
 }
@@ -86,14 +86,14 @@ impl Eq for NodeId {}
 
 impl PartialOrd for NodeId {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        assert!(!self.is_default(), "default node ID should be assigned");
+        assert!(!self.is_default(), "default node ID should be replaced");
         self.0.partial_cmp(&other.0)
     }
 }
 
 impl Ord for NodeId {
     fn cmp(&self, other: &Self) -> Ordering {
-        assert!(!self.is_default(), "default node ID should be assigned");
+        assert!(!self.is_default(), "default node ID should be replaced");
         self.0.cmp(&other.0)
     }
 }

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -73,14 +73,14 @@ impl Display for NodeId {
 
 impl From<NodeId> for usize {
     fn from(value: NodeId) -> Self {
-        assert!(!value.is_default(), "default node ID should be assigned");
+        assert!(!value.is_default(), "default node ID should be replaced");
         value.0 as usize
     }
 }
 
 impl PartialEq for NodeId {
     fn eq(&self, other: &Self) -> bool {
-        assert!(!self.is_default(), "default node ID should be assigned");
+        assert!(!self.is_default(), "default node ID should be replaced");
         self.0 == other.0
     }
 }
@@ -89,14 +89,14 @@ impl Eq for NodeId {}
 
 impl PartialOrd for NodeId {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        assert!(!self.is_default(), "default node ID should be assigned");
+        assert!(!self.is_default(), "default node ID should be replaced");
         self.0.partial_cmp(&other.0)
     }
 }
 
 impl Ord for NodeId {
     fn cmp(&self, other: &Self) -> Ordering {
-        assert!(!self.is_default(), "default node ID should be assigned");
+        assert!(!self.is_default(), "default node ID should be replaced");
         self.0.cmp(&other.0)
     }
 }


### PR DESCRIPTION
This makes it easier to figure out the problem when a default node ID is accidentally used. Things can get pretty weird if that happens without being checked (like an IndexMap trying to allocate a Vec with u32::MAX elements).