### PR TITLE
Turn off no-explicit-any ESLint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,4 +17,7 @@ module.exports = {
     browser: true,
     node: true,
   },
+  rules: {
+    "@typescript-eslint/no-explicit-any": "off",
+  },
 };

--- a/npm/src/cancellation.ts
+++ b/npm/src/cancellation.ts
@@ -6,7 +6,6 @@ export interface CancellationToken {
   readonly isCancellationRequested: boolean;
 
   //  An event which fires when cancellation is requested.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly onCancellationRequested: (listener: (e: any) => any) => void;
 }
 
@@ -18,7 +17,6 @@ class InternalToken implements CancellationToken {
     this.eventTarget = new EventTarget();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onCancellationRequested(listener: (e: any) => any) {
     this.eventTarget.addEventListener("cancelled", listener);
   }

--- a/npm/src/compiler.ts
+++ b/npm/src/compiler.ts
@@ -34,7 +34,6 @@ export interface ICompiler {
 // WebWorker also support being explicitly terminated to tear down the worker thread
 export type ICompilerWorker = ICompiler & { terminate: () => void };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function errToDiagnostic(err: any): VSDiagnostic {
   if (
     err &&
@@ -118,7 +117,7 @@ export class Compiler implements ICompiler {
     eventHandler: IQscEventTarget
   ): Promise<boolean> {
     let success = false;
-    let err: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let err: any = null;
     try {
       if (this.onstatechange) this.onstatechange("busy");
       success = this.wasm.run_kata_exercise(

--- a/npm/src/log.ts
+++ b/npm/src/log.ts
@@ -43,7 +43,6 @@ export const log = {
   getLogLevel(): number {
     return globalThis.qscLogLevel || 0;
   },
-  /* eslint-disable @typescript-eslint/no-explicit-any */
   error(...args: any) {
     if (qscLogLevel >= 1) console.error(...args);
   },
@@ -60,7 +59,6 @@ export const log = {
     // console.trace in JavaScript just writes a stack trace at info level, so use 'debug'
     if (qscLogLevel >= 5) console.debug(...args);
   },
-  /* eslint-enable @typescript-eslint/no-explicit-any */
   never(val: never) {
     // Utility function to ensure exhaustive type checking. See https://stackoverflow.com/a/39419171
     log.error("Exhaustive type checking didn't account for: %o", val);

--- a/npm/src/worker-common.ts
+++ b/npm/src/worker-common.ts
@@ -22,7 +22,6 @@ invoked. When the response is received this is used to resolve the promise and
 complete the request.
 */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 type RequestState = {
   type: string;
   args: any[];
@@ -31,7 +30,6 @@ type RequestState = {
   evtTarget?: IQscEventTarget;
   cancellationToken?: CancellationToken;
 };
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 /**
  * @param postMessage A function to post messages to the worker
@@ -56,7 +54,7 @@ export function createWorkerProxy(
 
   function queueRequest(
     type: string,
-    args: any[], // eslint-disable-line @typescript-eslint/no-explicit-any
+    args: any[],
     evtTarget?: IQscEventTarget,
     cancellationToken?: CancellationToken
   ): Promise<RespResultTypes> {
@@ -329,7 +327,7 @@ type CompilerRespMsg =
   | { type: "getCompletions-result"; result: ICompletionList }
   | { type: "run-result"; result: void }
   | { type: "runKata-result"; result: boolean }
-  | { type: "error-result"; result: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
+  | { type: "error-result"; result: any };
 
 // Get the possible 'result' types from a compiler response
 type ExtractResult<T> = T extends { result: infer R } ? R : never;
@@ -339,6 +337,6 @@ type CompilerEventMsg =
   | { type: "message-event"; event: MessageMsg }
   | { type: "dumpMachine-event"; event: DumpMsg }
   | { type: "success-event"; event: string }
-  | { type: "failure-event"; event: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
+  | { type: "failure-event"; event: any };
 
 export type ResponseMsgType = CompilerRespMsg | CompilerEventMsg;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1759,7 +1759,8 @@
     },
     "vscode": {
       "name": "qsharp-vscode",
-      "version": "0.0.1",
+      "version": "0.0.0",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "engines": {
         "vscode": "^1.77.0"
       }

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -28,7 +28,6 @@ export type ActiveTab = "results-tab" | "hir-tab" | "logs-tab";
 const logLevelUri = new URLSearchParams(window.location.search).get("logLevel");
 if (logLevelUri) log.setLogLevel(logLevelUri as LogLevel);
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const basePath = (window as any).qscBasePath || "";
 const monacoPath = basePath + "libs/monaco/vs";
 const modulePath = basePath + "libs/qsharp/qsc_wasm_bg.wasm";


### PR DESCRIPTION
Turning off this linter rule. Not very useful in practice and we have a lot of suppression comments for it.