### PR TITLE
Random numbers kata tutorial

### DIFF
--- a/katas/content/random_numbers/common.qs
+++ b/katas/content/random_numbers/common.qs
@@ -1,0 +1,26 @@
+﻿    // ------------------------------------------------------
+    /// # Summary
+    /// Helper operation to rerun test operation several times
+    /// (a single run can fail with non-negligible probability even for a correct solution).
+    /// # Input
+    /// ## testingHarness
+    /// Test operation which verifies the user's solution.
+    operation RetryTestOperation (testingHarness : (Unit => Bool)) : Unit {
+        let numRetries = 3;
+        mutable sufficientlyRandom = false;
+        mutable attemptNum = 1;
+        repeat {
+            set sufficientlyRandom = testingHarness();
+            set attemptNum += 1;
+        } until (sufficientlyRandom or attemptNum > numRetries);
+
+        if not sufficientlyRandom {
+            fail $"Failed to generate sufficiently random integer";
+        }
+    }
+
+    operation CheckRandomCalls () : Unit {
+        Fact(GetOracleCallsCount(DrawRandomInt) == 0, "You are not allowed to call DrawRandomInt() in this task");
+        Fact(GetOracleCallsCount(DrawRandomDouble) == 0, "You are not allowed to call DrawRandomDouble() in this task");
+        ResetOracleCallsCount();
+    }

--- a/katas/content/random_numbers/index.md
+++ b/katas/content/random_numbers/index.md
@@ -1,0 +1,176 @@
+﻿# Quantum Random Number Generation Tutorial
+
+True random number generation is a notoriously difficult problem. Many "random" generators today are actually pseudo-random, using a starting seed to spawning seemingly-random numbers that are actually a repeatable function of that seed. Most true random number generations are based on measurements of some natural phenomenon, such as atmospheric noise or atomic decay. 
+(You can read more about it [here]( https://en.wikipedia.org/wiki/Random_number_generation).) 
+
+Quantum random number generators (QRNGs) are truly random. The quantum algorithm for random number generation is one of the simplest applications of quantum computing principles, requiring very few qubits to run.
+
+**In this tutorial you will:**
+* learn about quantum random number generation and the principles behind it,
+* implement a variety of QRNGs with equal probability of any given number,
+* implement a single-bit QRNG with weighted probabilities of generated bits.
+
+**What you should know for this workbook**
+
+You should be familiar with the following concepts before tackling the Quantum Random Number Generation Tutorial (and this workbook):
+
+1. The concept of qubit and measurement
+2. Single-qubit gates
+
+Let's go!
+
+## Introduction
+
+Recall from the [Qubit](../Qubit/Qubit.ipynb) tutorial that a qubit state $|\psi\rangle$ is defined via the basis states $|0\rangle$ and $|1\rangle$ as:
+
+$$|\psi\rangle = \begin{bmatrix} \alpha \\ \beta \end{bmatrix} = \alpha|0\rangle + \beta|1\rangle\text{, where }|\alpha|^2 + |\beta|^2 = 1$$
+
+We call $\alpha$ and $\beta$ the **amplitudes** of states $|0\rangle$ and $|1\rangle$, respectively. 
+When $|\psi\rangle$ is measured in the $\{|0\rangle, |1\rangle\}$ basis (the computational basis), the probabilities of the outcomes are defined based on the state amplitudes: there is a $|\alpha|^2$ probability that the measurement result will be $0$, and a $|\beta|^2$ probability that the measurement result will be $1$.
+
+> For example, a qubit in state $\begin{bmatrix} \frac{1}{\sqrt{2}} \\ \frac{1}{\sqrt{2}} \end{bmatrix}$ will yield measurement results $0$ or $1$ with equal probability, while a qubit in state $\begin{bmatrix} \frac{1}{2} \\ \frac{\sqrt3}{2} \end{bmatrix}$ will yield measurement result $0$ only 25% of the time, and $1$ 75% of the time.
+
+This is sufficient to implement a simple random number generator!
+
+> Remember that you can refer to the [Single Qubit Gates tutorial](../SingleQubitGates/SingleQubitGates.ipynb) if you need a refresher on the various quantum gates and their usage in Q#.
+
+## <span style="color:blue">Exercise 1</span>: Generate a single random bit
+
+**Input:** None.
+
+**Goal:** Generate a $0$ or $1$ with equal probability.
+
+<details>
+    <summary><strong>Need a hint? Click here</strong></summary>
+    Use the allocated qubit, apply a quantum gate to it, measure it and use the result to return a $0$ or $1$.
+</details>
+
+**Stretch goal:** Can you find a different way to implement this operation?
+
+<details>
+    <summary><strong>Need a hint? Click here</strong></summary>
+    What are the different quantum states that produce $0$ and $1$ measurement results with the same probability? How would measuring the qubit in a different basis change the result? 
+</details>
+
+@[exercise]({
+"id": "random_bit",
+"codeDependenciesPaths": [
+"../KatasLibrary.qs",
+"./Common.qs"
+],
+"verificationSourcePath": "./random_bit/verification.qs",
+"placeholderSourcePath": "./random_bit/placeholder.qs",
+"solutionSourcePath": "./random_bit/solution.qs",
+"solutionDescriptionPath": "./random_bit/solution.md"
+})
+
+## <span style="color:blue">Exercise 2</span>: Generate a random two-bit number
+
+Now that you can generate a single random bit, you can use that logic to create random multi-bit numbers. Let's try first to make a two-bit number by combining two randomly generated bits.
+
+**Input:** None.
+
+**Goal:** Generate a random number in the range $[0, 3]$ with an equal probability of getting each of the four numbers.
+
+**Stretch goal:** Can you do this without allocating qubits in this operation?
+
+<details>
+    <summary><strong>Need a hint? Click here</strong></summary>
+    Remember that you can use the previously defined operations.
+</details>
+
+@[exercise]({
+"id": "random_two_bits",
+"codeDependenciesPaths": [
+"../KatasLibrary.qs",
+"./Common.qs"
+],
+"verificationSourcePath": "./random_two_bits/verification.qs",
+"placeholderSourcePath": "./random_two_bits/placeholder.qs",
+"solutionSourcePath": "./random_two_bits/solution.qs",
+"solutionDescriptionPath": "./random_two_bits/solution.md"
+})
+
+## <span style="color:blue">Exercise 3</span>: Generate a number of arbitrary size
+
+Let's take it a step further and generate an $N$-bit number. 
+
+> Remember that you can use previously defined operations in your solution.
+
+**Input:** An integer $N$ ($1 \le N \le 10$).
+
+**Goal:** Generate a random number in the range $[0, 2^N - 1]$ with an equal probability of getting each of the numbers in this range.
+
+> Useful Q# documentation: 
+> * [`for` loops](https://docs.microsoft.com/azure/quantum/user-guide/language/statements/iterations), 
+> * [mutable variables](https://docs.microsoft.com/azure/quantum/user-guide/language/typesystem/immutability), 
+> * [exponents](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math.powi).
+
+@[exercise]({
+"id": "random_n_bits",
+"codeDependenciesPaths": [
+"../KatasLibrary.qs",
+"./Common.qs"
+],
+"verificationSourcePath": "./random_n_bits/verification.qs",
+"placeholderSourcePath": "./random_n_bits/placeholder.qs",
+"solutionSourcePath": "./random_n_bits/solution.qs",
+"solutionDescriptionPath": "./random_n_bits/solution.md"
+})
+
+## <span style="color:blue">Exercise 4</span>: Generate a weighted bit!
+
+In each of the above exercises, all generated numbers were equally likely. Now let's create an operation that will return a random bit with different probabilities of outcomes. 
+
+> Remember that by setting amplitudes of basis states $\alpha$ and $\beta$, we can control the probability of getting measurement outcomes $0$ and $1$ when the qubit is measured.
+
+**Input:** 
+A floating-point number $x$, $0 \le x \le 1$. 
+
+**Goal:** Generate $0$ or $1$ with probability of $0$ equal to $x$ and probability of $1$ equal to $1 - x$.
+
+> Useful Q# documentation: 
+> * [`Math` namespace](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math)
+> * [`ArcCos` function](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math.arccos)
+> * [`Sqrt` function](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math.sqrt)
+
+@[exercise]({
+"id": "weighted_random_bit",
+"codeDependenciesPaths": [
+"../KatasLibrary.qs",
+"./Common.qs"
+],
+"verificationSourcePath": "./weighted_random_bit/verification.qs",
+"placeholderSourcePath": "./weighted_random_bit/placeholder.qs",
+"solutionSourcePath": "./weighted_random_bit/solution.qs",
+"solutionDescriptionPath": "./weighted_random_bit/solution.md"
+})
+
+## <span style="color:blue">Exercise 5</span>: Generate a random number between min and max
+
+In exercise 3, we generated numbers in the range $[0, 2^N-1]$ $(1 \leq N \leq 10)$. Now let's create an operation that will return a random number in the range $[min, max]$. 
+
+**Input:** 
+Two integers $min$ and $max$ ($0 \leq min \leq max \leq 2^{10}-1$).
+
+**Goal:** Generate a random number in the range $[min, max]$ with an equal probability of getting each of the numbers in this range.
+
+> Useful Q# documentation: 
+> * [`BitSizeI` function](https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.math.bitsizei)
+
+@[exercise]({
+"id": "random_number",
+"codeDependenciesPaths": [
+"../KatasLibrary.qs",
+"./Common.qs"
+],
+"verificationSourcePath": "./random_number/verification.qs",
+"placeholderSourcePath": "./random_number/placeholder.qs",
+"solutionSourcePath": "./random_number/solution.qs",
+"solutionDescriptionPath": "./random_number/solution.md"
+})
+
+## What's Next?
+We hope you enjoyed this tutorial on quantum random number generation! If you're looking to learn more about quantum computing and Q#, here are some suggestions:
+* The [Quantum Katas](https://github.com/microsoft/QuantumKatas/) are sets of programming exercises on quantum computing that can be solved using Q#. They cover a variety of topics, from the basics like the concepts of superposition and measurements to more interesting algorithms like Grover's search.
+* For another look at quantum random number generation, you can check out the [Microsoft Learn module "Create your first Q# program by using the Quantum Development Kit"](https://docs.microsoft.com/learn/modules/qsharp-create-first-quantum-development-kit/1-introduction).

--- a/katas/content/random_numbers/random_bit/placeholder.qs
+++ b/katas/content/random_numbers/random_bit/placeholder.qs
@@ -1,0 +1,10 @@
+﻿namespace Quantum.Kata {
+
+    // Exercise 1.
+    operation RandomBit () : Int {
+        use q = Qubit();
+        // ...
+        return -1;
+    }
+
+}

--- a/katas/content/random_numbers/random_bit/solution.md
+++ b/katas/content/random_numbers/random_bit/solution.md
@@ -1,0 +1,31 @@
+﻿### Solution
+
+The state of single qubit can be represented as a two-dimensional column vector $\begin{bmatrix} \alpha\\ \beta \end{bmatrix}$, where $\alpha$ and $\beta$ are complex numbers that satisfy $|\alpha|^2 + |\beta|^2 = 1$. When we measure the qubit, we get either 0 with probability $|\alpha|^2$ or 1 with probability $|\beta|^2$. Essentially we can control probablity of measurement outcome by setting the right amplitudes of basis states. 
+
+When we allocate the qubit in Q#, amplitudes $\alpha$ and $\beta$ are 1 and 0, respectively. Now our goal is set equal amplitudes for $\alpha$ and $\beta$ for absolute randomness. We can achieve that by simply applying Hadamard gate to the initial state $|0\rangle$:
+
+$$
+H|0\rangle=
+\frac{1}{\sqrt{2}}\begin{bmatrix}
+   1 & 1 \\
+   1 & -1
+  \end{bmatrix}
+ \begin{bmatrix}
+   1\\
+   0\\
+  \end{bmatrix}
+=
+\frac{1}{\sqrt{2}}\begin{bmatrix}
+   1 \cdot 1 + 1 \cdot 0 \\
+   1 \cdot 1 + (-1) \cdot 0
+  \end{bmatrix}
+=
+  \frac{1}{\sqrt{2}}\begin{bmatrix}
+   1\\
+   1
+  \end{bmatrix}
+$$
+
+Now, both 0 and 1 measurement outcomes occur with equal probablity of $|\frac{1}{\sqrt{2}}|^2 = \frac{1}{2}$.
+
+> Note: Since probablity is the square of the absolute value of amplitude, we will get the same randomness by applying Hadamard gate on base state $|1\rangle$. Try it out as an exercise!

--- a/katas/content/random_numbers/random_bit/solution.qs
+++ b/katas/content/random_numbers/random_bit/solution.qs
@@ -1,0 +1,15 @@
+﻿namespace Quantum.Kata.Reference {
+
+    // Exercise 1.
+    operation RandomBit () : Int {
+        // Allocate single qubit
+        use q = Qubit();
+        
+        // Set qubit in superposition state
+        H(q);
+        
+        // Measuring state of qubit and return integer value of result
+        return (M(q) == Zero) ? 0 | 1;
+    }
+
+}

--- a/katas/content/random_numbers/random_bit/verification.qs
+++ b/katas/content/random_numbers/random_bit/verification.qs
@@ -1,0 +1,15 @@
+﻿namespace Quantum.Kata.Reference {
+
+    // ------------------------------------------------------
+    // Exercise 1.
+    @EntryPoint()
+    operation T1_RandomBit () : Unit {
+        Message("Testing one random bit generation...");
+        let solution = RandomBit;
+        // Delay() converts CheckUniformDistribution to a parameterless operation
+        let testingHarness = Delay(CheckUniformDistribution, (solution, 0, 1, 1000), _);
+        RetryTestOperation(testingHarness);
+        Message("Test passed");
+    }
+
+}

--- a/katas/content/random_numbers/random_n_bits/placeholder.qs
+++ b/katas/content/random_numbers/random_n_bits/placeholder.qs
@@ -1,0 +1,9 @@
+﻿namespace Quantum.Kata {
+
+    // Exercise 3.
+    operation RandomNBits (N : Int) : Int {
+        // ...
+        return -1;
+    }
+
+}

--- a/katas/content/random_numbers/random_n_bits/solution.md
+++ b/katas/content/random_numbers/random_n_bits/solution.md
@@ -1,0 +1,5 @@
+﻿### Solution
+
+Let's reuse `RandomBit` operation from [Exercise 1](#Exercise-1:-Generate-a-single-random-bit) again.
+We'll generate N random bits by calling `RandomBit` operation N times, and treat the result as a binary notation to convert it into an integer.
+Since the maximum value of the number written with N bits is $2^N - 1$, we don't need to do any extra checks to ensure that the result is within the given range.

--- a/katas/content/random_numbers/random_n_bits/solution.qs
+++ b/katas/content/random_numbers/random_n_bits/solution.qs
@@ -1,0 +1,12 @@
+﻿namespace Quantum.Kata.Reference {
+    
+    // Exercise 3.
+    operation RandomNBits_Reference (N: Int) : Int {
+        mutable result = 0;
+        for i in 0..(N - 1) {
+            set result = result * 2 + RandomBit_Reference();
+        }
+        return result;
+    }
+
+}

--- a/katas/content/random_numbers/random_n_bits/verification.qs
+++ b/katas/content/random_numbers/random_n_bits/verification.qs
@@ -1,0 +1,82 @@
+﻿namespace Quantum.Kata.Reference {
+
+    // ------------------------------------------------------
+    // Exercise 3.
+    @EntryPoint()
+    operation T3_RandomNBits () : Unit {
+        // Test random number generation for 1, 2, 3, 10 bits
+        for N in [1, 2, 3, 10] {
+            Message($"Testing N = {N}...");
+            let max = (1 <<< N) - 1;
+            let solution = Delay(RandomNBits, N, _);
+            let testingHarness = Delay(CheckUniformDistribution, (solution, 0, max, 1000), _);
+            RetryTestOperation(testingHarness);
+            Message($"Test passed for N = {N}");
+	    }
+    }
+
+    // ------------------------------------------------------
+    /// # Summary
+    /// Helper operation that checks that the given RNG operation generates a uniform distribution.
+    /// # Input
+    /// ## op
+    /// Random number generation operation to be tested.
+    /// The parameters to this operation are provided by the caller using Delay().
+    /// ## min, max
+    /// Minimal and maximal numbers in the range to be generated, inclusive.
+    /// ## nRuns
+    /// The number of random numbers to generate for test.
+    operation CheckUniformDistribution (op : (Unit => Int), min : Int, max : Int, nRuns : Int) : Bool {
+        let idealMean = 0.5 * IntAsDouble(max + min) ;
+        let rangeDividedByTwo = 0.5 * IntAsDouble(max - min);
+        // Variance = a*(a+1)/3, where a = (max-min)/2
+        // For sample population : divide it by nRuns
+        let varianceInSamplePopulation = (rangeDividedByTwo * (rangeDividedByTwo + 1.0)) / IntAsDouble(3 * nRuns);
+        let standardDeviation = Sqrt(varianceInSamplePopulation);
+
+        // lowRange : The lower bound of the median and average for generated dataset
+        // highRange : The upper bound of the median and average for generated dataset
+        // Set them with 3 units of std deviation for 99% accuracy.
+        let lowRange = idealMean - 3.0 * standardDeviation;
+        let highRange = idealMean + 3.0 * standardDeviation;
+
+        let idealCopiesGenerated = IntAsDouble(nRuns) / IntAsDouble(max-min+1);
+        let minimumCopiesGenerated = (0.8 * idealCopiesGenerated > 40.0) ? 0.8 * idealCopiesGenerated | 0.0;
+
+        mutable counts = [0, size = max + 1];
+        mutable average = 0.0;
+
+        ResetOracleCallsCount();
+        for i in 1..nRuns {
+            let val = op();
+            if (val < min or val > max) {
+                Message($"Unexpected number generated. Expected values from {min} to {max}, generated {val}");
+                return false;
+            }
+            set average += IntAsDouble(val);
+            set counts w/= val <- counts[val] + 1;
+        }
+        CheckRandomCalls();
+
+        set average = average / IntAsDouble(nRuns);
+        if (average < lowRange or average > highRange) {
+            Message($"Unexpected average of generated numbers. Expected between {lowRange} and {highRange}, got {average}");
+            return false;
+        }
+
+        let median = FindMedian (counts, max+1, nRuns);
+        if (median < Floor(lowRange) or median > Ceiling(highRange)) {
+            Message($"Unexpected median of generated numbers. Expected between {Floor(lowRange)} and {Ceiling(highRange)}, got {median}.");
+            return false;
+        }
+
+        for i in min..max {
+            if counts[i] < Floor(minimumCopiesGenerated) {
+                Message($"Unexpectedly low number of {i}'s generated. Only {counts[i]} out of {nRuns} were {i}");
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/katas/content/random_numbers/random_number/placeholder.qs
+++ b/katas/content/random_numbers/random_number/placeholder.qs
@@ -1,0 +1,9 @@
+﻿namespace Quantum.Kata {
+    
+    // Exercise 5.
+    operation RandomNumberInRange (min : Int, max : Int) : Int {
+        // ...
+        return -1;
+    }
+
+}

--- a/katas/content/random_numbers/random_number/solution.md
+++ b/katas/content/random_numbers/random_number/solution.md
@@ -1,0 +1,5 @@
+﻿### Solution
+
+We can reuse `RandomNBits` operation from [Exercise 3](#Exercise-3:-Generate-a-number-of-arbitrary-size).
+
+We'll generate an N-bit random number by calling `RandomNBits` operation, where N is the bitsize of $max - min$. We can repeat this process until the result is less than or equal than $max - min$, and return that number plus $min$.

--- a/katas/content/random_numbers/random_number/solution.qs
+++ b/katas/content/random_numbers/random_number/solution.qs
@@ -1,0 +1,13 @@
+﻿namespace Quantum.Kata.Reference {
+    
+    // Exercise 5.
+    operation RandomNumberInRange_Reference (min : Int, max : Int) : Int {
+        let nBits = BitSizeI(max - min);
+        mutable output = 0; 
+        repeat {
+            set output = RandomNBits_Reference(nBits); 
+        } until output <= max - min;
+        return output + min;
+    }
+
+}

--- a/katas/content/random_numbers/random_number/verification.qs
+++ b/katas/content/random_numbers/random_number/verification.qs
@@ -1,0 +1,22 @@
+﻿namespace Quantum.Kata.Reference {
+
+    // ------------------------------------------------------
+    // Exercise 5.
+    @EntryPoint()
+    operation T5_RandomNumberInRange () : Unit {
+        for (min, max) in [(1, 3), (27, 312), (0, 3), (0, 1023)] {
+            Message($"Testing for min = {min} and max = {max}...");
+            let solution = Delay(RandomNumberInRange, (min,max), _);
+            let testingHarness = Delay(CheckUniformDistribution, (solution, min, max, 1000), _);
+            RetryTestOperation(testingHarness);
+            Message($"Test passed for min = {min} and max = {max}");
+	    }
+    }
+
+    operation CheckRandomCalls () : Unit {
+        Fact(GetOracleCallsCount(DrawRandomInt) == 0, "You are not allowed to call DrawRandomInt() in this task");
+        Fact(GetOracleCallsCount(DrawRandomDouble) == 0, "You are not allowed to call DrawRandomDouble() in this task");
+        ResetOracleCallsCount();
+    }
+
+}

--- a/katas/content/random_numbers/random_two_bits/placeholder.qs
+++ b/katas/content/random_numbers/random_two_bits/placeholder.qs
@@ -1,0 +1,9 @@
+﻿namespace Quantum.Kata {
+    
+    // Exercise 2. 
+    operation RandomTwoBits () : Int {
+        // ...
+        return -1;
+    }
+
+}

--- a/katas/content/random_numbers/random_two_bits/solution.md
+++ b/katas/content/random_numbers/random_two_bits/solution.md
@@ -1,0 +1,4 @@
+﻿### Solution
+
+Let's reuse `RandomBit` operation from [Exercise 1](#Exercise-1:-Generate-a-single-random-bit).
+We can generate two random bits by calling `RandomBit` operation twice, multiply the most significant bit by 2 and add the second random bit to generate a random two-bit number.

--- a/katas/content/random_numbers/random_two_bits/solution.qs
+++ b/katas/content/random_numbers/random_two_bits/solution.qs
@@ -1,0 +1,8 @@
+﻿namespace Quantum.Kata.Reference {
+
+    // Exercise 2. 
+    operation RandomTwoBits_Reference () : Int {
+        return 2 * RandomBit_Reference() + RandomBit_Reference();
+    }
+
+}

--- a/katas/content/random_numbers/random_two_bits/verification.qs
+++ b/katas/content/random_numbers/random_two_bits/verification.qs
@@ -1,0 +1,15 @@
+﻿namespace Quantum.Kata.Reference {
+
+    // ------------------------------------------------------
+    // Exercise 2.
+    @EntryPoint()
+    operation T2_RandomTwoBits () : Unit {
+        Message("Testing two random bits generation...");
+        let solution = RandomTwoBits;
+        // Delay() converts CheckUniformDistribution to a parameterless operation
+        let testingHarness = Delay(CheckUniformDistribution, (solution, 0, 3, 1000), _);
+        RetryTestOperation(testingHarness);
+        Message("Test passed");
+    }
+
+}

--- a/katas/content/random_numbers/weighted_random_bit/placeholder.qs
+++ b/katas/content/random_numbers/weighted_random_bit/placeholder.qs
@@ -1,0 +1,9 @@
+﻿namespace Quantum.Kata {
+    
+    // Exercise 4.
+    operation WeightedRandomBit (x : Double) : Int {
+        // ...
+        return -1;
+    }
+
+}

--- a/katas/content/random_numbers/weighted_random_bit/solution.md
+++ b/katas/content/random_numbers/weighted_random_bit/solution.md
@@ -1,0 +1,31 @@
+﻿### Solution
+
+We already learnt how to generate random bit with equal probability in exercise 1, in this exercise we need to generate random bit with weighted probability.
+
+An arbitrary single-qubit state can be written as:
+
+$$
+|\psi\rangle =
+    \cos \frac{\theta}{2} |0 \rangle \, + \, e^{i\phi}  \sin \frac{\theta}{2} |1\rangle
+$$
+
+Here $\theta$ is angle between state vector and $Z$-axis, and $\phi$ is longitude angle with respect to $X$-axis on the Bloch sphere.
+
+Our goal is to generate 0 or 1 with probability of 0 equal to $x$ and probability of 1 equal to $1 - x$, which means the qubit state should look like
+
+$$
+|\psi\rangle =
+    \sqrt x |0 \rangle + \sqrt{1 - x} |1\rangle
+$$
+
+By comparing the amplitudes of the state $|0 \rangle$ on both equations we get
+
+$$
+\sqrt x = \cos \frac{\theta}{2} \Rightarrow \theta = 2 \arccos\sqrt x
+$$
+
+Since $\theta$ is angle between state vector and the $Z$-axis, we need to apply the [Ry](https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.ry) gate with caculated $\theta$ to the starting state $|0 \rangle$ to get the desired qubit state.
+
+Ry operation applies a given rotation about $Y$-axis (i.e., in the $ZX$-plane), hence $\phi$ (longitude angle with respect to $X$-axis) is always equal to $0^{\circ}$, which means that the relative phase $e^{i\phi}$ doesn't have any impact on resulting qubit state.
+
+> We can also calculate ${\theta}$ by comparing the amplitudes of the state $|1 \rangle$ on both equations, which is $2 \arcsin\sqrt{1.0 - x}$

--- a/katas/content/random_numbers/weighted_random_bit/solution.qs
+++ b/katas/content/random_numbers/weighted_random_bit/solution.qs
@@ -1,0 +1,20 @@
+﻿namespace Quantum.Kata.Reference {
+
+    open Microsoft.Quantum.Math;
+
+    // Exercise 4. 
+    operation WeightedRandomBit (x : Double) : Int {
+        // Calculate theta value
+        let theta = 2.0 *  ArcCos(Sqrt(x));  // (or) 2.0 * ArcSin(Sqrt(1.0 - x));
+
+        // Allocate single qubit
+        use q = Qubit();
+
+        // Set qubit in superposition state which aligns with given probabilities
+        Ry(theta, q);
+
+        // Measuring state of qubit and return integer value of result
+        return M(q) == Zero ? 0 | 1;
+    }
+
+}

--- a/katas/content/random_numbers/weighted_random_bit/verification.qs
+++ b/katas/content/random_numbers/weighted_random_bit/verification.qs
@@ -1,0 +1,60 @@
+﻿namespace Quantum.Kata.Reference {
+
+    // ------------------------------------------------------
+    // Exercise 4.
+    @EntryPoint()
+    operation T4_WeightedRandomBit () : Unit {
+        ResetOracleCallsCount();
+        for x in [0.0, 0.25, 0.5, 0.75, 1.0] {
+            Message($"Testing generating zero with {x*100.0}% probability...");
+            let solution = Delay(WeightedRandomBit, x, _);
+            let testingHarness = Delay(CheckXPercentZero, (solution, x), _);
+            RetryTestOperation(testingHarness);
+            Message($"Test passed for generating zero with {x*100.0}% probability");
+        }
+        CheckRandomCalls();
+    }
+
+    // ------------------------------------------------------
+    /// # Summary
+    /// Helper operation that checks that the given RNG operation generates zero with x percent probability
+    /// # Input
+    /// ## op
+    /// Random number generation operation to be tested.
+    /// ## x
+    /// Probability of generating zero
+    operation CheckXPercentZero (op : (Unit => Int), x : Double) : Bool {
+        mutable oneCount = 0;
+        let nRuns = 1000;
+        ResetOracleCallsCount();
+        for N in 1..nRuns {
+            let val = op();
+            if (val < 0 or val > 1) {
+                Message($"Unexpected number generated. Expected 0 or 1, instead generated {val}");
+                return false;
+            }
+            set oneCount += val;
+        }
+        CheckRandomCalls();
+
+        let zeroCount = nRuns - oneCount;
+        let goalZeroCount = (x == 0.0) ? 0 | (x == 1.0) ? nRuns | Floor(x * IntAsDouble(nRuns));
+        // We don't have tests with probabilities near 0.0 or 1.0, so for those the matching has to be exact
+        if (goalZeroCount == 0 or goalZeroCount == nRuns) {
+            if zeroCount != goalZeroCount {
+                Message($"Expected {x * 100.0}% 0's, instead got {zeroCount} 0's out of {nRuns}");
+                return false;
+            }
+        } else {
+            if zeroCount < goalZeroCount - 4 * nRuns / 100 {
+                Message($"Unexpectedly low number of 0's generated: expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
+                return false;
+            } elif zeroCount > goalZeroCount + 4 * nRuns / 100 {
+                Message($"Unexpectedly high number of 0's generated: expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
+                return false;
+            }
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
Based on [Quantum Random Number Generation Tutorial](https://github.com/microsoft/QuantumKatas/tree/main/tutorials/RandomNumberGeneration)
This has all content of the RandomNumberGeneration in place: Information, examples, solutions, verification code. The tutorial is a single file with @[exercise] and @[example] macros.

This is a draft PR because:

The infrastructure to hook it up isn't yet ready (coming any day now).
The verify functions aren't implemented as expected - need working infrastructure to make sure they interact properly.
The code not yet run.
Hyperlinks to Kata content (and some other content) aren't correct.