### PR TITLE
added ResultAsBool and BoolAsResult to std

### DIFF
--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Convert {
     /// # Output
     /// A `Bool` representing the `input`.
     function ResultAsBool(input : Result) : Bool {
-        return input == One;
+        input == One
     }
 
     /// # Summary

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -136,7 +136,7 @@ namespace Microsoft.Quantum.Convert {
     function ResultArrayAsBoolArray(input : Result[]) : Bool[] {
         mutable output = [];
         for r in input {
-            set output += [ResultAsBool(r)];
+            set output += [r == One];
         }
 
         output
@@ -155,7 +155,7 @@ namespace Microsoft.Quantum.Convert {
     function BoolArrayAsResultArray(input : Bool[]) : Result[] {
         mutable output = [];
         for b in input {
-            set output += [BoolAsResult(b)];
+            set output += [if b {One} else {Zero}];
         }
 
         output

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -41,7 +41,7 @@ namespace Microsoft.Quantum.Convert {
     /// # Output
     /// A `Result` representing the `input`.
     function BoolAsResult(input : Bool) : Result {
-        return input ? One | Zero;
+        if input {One} else {Zero}
     }
 
     /// # Summary

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -17,6 +17,34 @@ namespace Microsoft.Quantum.Convert {
     }
 
     /// # Summary
+    /// Converts a `Result` type to a `Bool` type, where `One` is mapped to
+    /// `true` and `Zero` is mapped to `false`.
+    ///
+    /// # Input
+    /// ## input
+    /// `Result` to be converted.
+    ///
+    /// # Output
+    /// A `Bool` representing the `input`.
+    function ResultAsBool(input : Result) : Bool {
+        return input == One;
+    }
+
+    /// # Summary
+    /// Converts a `Bool` type to a `Result` type, where `true` is mapped to
+    /// `One` and `false` is mapped to `Zero`.
+    ///
+    /// # Input
+    /// ## input
+    /// `Bool` to be converted.
+    ///
+    /// # Output
+    /// A `Result` representing the `input`.
+    function BoolAsResult(input : Bool) : Result {
+        return input ? One | Zero;
+    }
+
+    /// # Summary
     /// Produces a non-negative integer from a string of bits in little endian format.
     ///
     /// # Input
@@ -108,7 +136,7 @@ namespace Microsoft.Quantum.Convert {
     function ResultArrayAsBoolArray(input : Result[]) : Bool[] {
         mutable output = [];
         for r in input {
-            set output += [r == One];
+            set output += [ResultAsBool(r)];
         }
 
         output
@@ -127,7 +155,7 @@ namespace Microsoft.Quantum.Convert {
     function BoolArrayAsResultArray(input : Bool[]) : Result[] {
         mutable output = [];
         for b in input {
-            set output += [if b {One} else {Zero}];
+            set output += [BoolAsResult(b)];
         }
 
         output

--- a/library/tests/src/test_convert.rs
+++ b/library/tests/src/test_convert.rs
@@ -39,6 +39,22 @@ fn check_result_array_as_int() {
 }
 
 #[test]
+fn check_result_zero_as_bool() {
+    test_expression(
+        "Microsoft.Quantum.Convert.ResultAsBool(Zero)",
+        &Value::Bool(false),
+    );
+}
+
+#[test]
+fn check_result_one_as_bool() {
+    test_expression(
+        "Microsoft.Quantum.Convert.ResultAsBool(One)",
+        &Value::Bool(true),
+    );
+}
+
+#[test]
 fn check_result_array_as_bool_array() {
     test_expression(
         "Microsoft.Quantum.Convert.ResultArrayAsBoolArray([One, Zero, One, Zero])",
@@ -51,6 +67,22 @@ fn check_result_array_as_bool_array() {
             ]
             .into(),
         ),
+    );
+}
+
+#[test]
+fn check_bool_true_as_result() {
+    test_expression(
+        "Microsoft.Quantum.Convert.BoolAsResult(true)",
+        &Value::Result(true),
+    );
+}
+
+#[test]
+fn check_bool_false_as_result() {
+    test_expression(
+        "Microsoft.Quantum.Convert.BoolAsResult(false)",
+        &Value::Result(false),
     );
 }
 


### PR DESCRIPTION
As I was trying to run some of my code I realized `ResultAsBool` and `BoolAsResult` were missing and the code that used to compile with qsharp-compiler does not compile anymore.

I am not sure of what is the process for including functions (whether they were missed or omitted intentionally) but given that they are super simple and that there are already `ResultArrayAsBoolArray` and `BoolArrayAsResultArray` I think it makes sense to have them as they are quite commonly used.