### PR TITLE
added Fact check for Head/Tail

### DIFF
--- a/library/std/arrays.qs
+++ b/library/std/arrays.qs
@@ -155,7 +155,7 @@ namespace Microsoft.Quantum.Arrays {
     ///
     /// # Example
     /// ```qsharp
-    ///  let evensCount = Count(x -> x % 2 == 0, [1, 3, 6, 7, 9]); 
+    ///  let evensCount = Count(x -> x % 2 == 0, [1, 3, 6, 7, 9]);
     /// // evensCount is 1.
     /// ```
     function Count<'T>(predicate : ('T -> Bool), array : 'T[]) : Int {
@@ -371,7 +371,7 @@ namespace Microsoft.Quantum.Arrays {
     function FlatMapped<'TInput, 'TOutput>(mapper : ('TInput -> 'TOutput[]), array : 'TInput[]) : 'TOutput[] {
         mutable output = [];
         for element in array {
-            set output += mapper(element); 
+            set output += mapper(element);
         }
         output
     }
@@ -482,6 +482,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Output
     /// The first element of the array.
     function Head<'A> (array : 'A[]) : 'A {
+        Fact(Length(array) > 0, "Array must have at least 1 element");
         array[0]
     }
 
@@ -1041,7 +1042,7 @@ namespace Microsoft.Quantum.Arrays {
     /// ```qsharp
     /// let sortedArray = Sorted(LessThanOrEqualI, [3, 17, 11, -201, -11]);
     /// ```
-    /// 
+    ///
     /// # Remarks
     /// The function `comparison` is assumed to be transitive, such that
     /// if `comparison(a, b)` and `comparison(b, c)`, then `comparison(a, c)`
@@ -1059,7 +1060,7 @@ namespace Microsoft.Quantum.Arrays {
         // Sort each sublist, then merge them back into a single combined
         // list and return.
         SortedMerged(
-            comparison, 
+            comparison,
             Sorted(comparison, left),
             Sorted(comparison, right)
         )
@@ -1093,7 +1094,7 @@ namespace Microsoft.Quantum.Arrays {
     /// array that match the given locations.
     ///
     /// # Remarks
-    /// If `locations` contains repeated elements, the corresponding elements 
+    /// If `locations` contains repeated elements, the corresponding elements
     /// of `array` will likewise be repeated.
     ///
     /// # Type Parameters
@@ -1109,9 +1110,9 @@ namespace Microsoft.Quantum.Arrays {
     /// # Output
     /// An array `out` of elements whose locations correspond to the subarray,
     /// such that `out[index] == array[locations[index]]`.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```qsharp
     /// let array = [1, 2, 3, 4];
     /// let permutation = Subarray([3, 0, 2, 1], array); // [4, 1, 3, 2]
@@ -1210,7 +1211,9 @@ namespace Microsoft.Quantum.Arrays {
     /// # Output
     /// The last element of the array.
     function Tail<'A> (array : 'A[]) : 'A {
-        array[Length(array) - 1]
+        let size = Length(array);
+        Fact(size > 0, "Array must have at least 1 element");
+        array[size - 1]
     }
 
     /// # Summary


### PR DESCRIPTION
Added a fact check for Head/Tail array functions, which improves a bit the feedback.

```
let foo : Int[] = [];
let bar = Head(foo);
```
current error: `ERROR: runtime error: index out of range: 0`
new error: `ERROR: runtime error: program failed: Array must have at least 1 element`

```
let foo : Int[] = [];
let bar = Tail(foo);
```
current error: `ERROR: runtime error: value cannot be used as an index: -1`
new error: `ERROR: runtime error: program failed: Array must have at least 1 element`

---

Regarding for the trailing whitespace changes - VS Code cleaned it up "on its own" due to `"editor.formatOnType": true` setting - but I kept them because they seem anyway to be consistent with the rest of the codebase.
