### PR TITLE
Added HeadAndRest, MostAndTail

### DIFF
--- a/library/std/arrays.qs
+++ b/library/std/arrays.qs
@@ -487,6 +487,23 @@ namespace Microsoft.Quantum.Arrays {
     }
 
     /// # Summary
+    /// Returns a tuple of first and all remaining elements of the array.
+    ///
+    /// # Type Parameters
+    /// ## 'A
+    /// The type of the array elements.
+    ///
+    /// # Input
+    /// ## array
+    /// An array with at least one element.
+    ///
+    /// # Output
+    /// A tuple of first and all remaining elements of the array.
+    function HeadAndRest<'A>(array : 'A[]) : ('A, 'A[]) {
+        return (Head(array), Rest(array));
+    }
+
+    /// # Summary
     /// Returns the first index of the first element in an array that satisfies
     /// a given predicate. If no such element exists, returns -1.
     ///
@@ -828,6 +845,23 @@ namespace Microsoft.Quantum.Arrays {
     /// An array containing the elements `array[0..Length(array) - 2]`.
     function Most<'T> (array : 'T[]) : 'T[] {
         array[... Length(array) - 2]
+    }
+
+    /// # Summary
+    /// Returns a tuple of all but one and the last element of the array.
+    ///
+    /// # Type Parameters
+    /// ## 'A
+    /// The type of the array elements.
+    ///
+    /// # Input
+    /// ## array
+    /// An array with at least one element.
+    ///
+    /// # Output
+    /// A tuple of all but one and the last element of the array.
+    function MostAndTail<'A>(array : 'A[]) : ('A[], 'A) {
+        return (Most(array), Tail(array));
     }
 
     /// # Summary

--- a/library/std/arrays.qs
+++ b/library/std/arrays.qs
@@ -500,7 +500,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Output
     /// A tuple of first and all remaining elements of the array.
     function HeadAndRest<'A>(array : 'A[]) : ('A, 'A[]) {
-        return (Head(array), Rest(array));
+        (Head(array), Rest(array))
     }
 
     /// # Summary

--- a/library/std/arrays.qs
+++ b/library/std/arrays.qs
@@ -861,7 +861,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Output
     /// A tuple of all but one and the last element of the array.
     function MostAndTail<'A>(array : 'A[]) : ('A[], 'A) {
-        return (Most(array), Tail(array));
+        (Most(array), Tail(array))
     }
 
     /// # Summary

--- a/library/tests/src/test_arrays.rs
+++ b/library/tests/src/test_arrays.rs
@@ -318,6 +318,20 @@ fn check_head() {
 }
 
 #[test]
+fn check_head_and_rest() {
+    test_expression(
+        "Microsoft.Quantum.Arrays.HeadAndRest([5,6,7,8])",
+        &Value::Tuple(
+            vec![
+                Value::Int(5),
+                Value::Array(vec![Value::Int(6), Value::Int(7), Value::Int(8)].into()),
+            ]
+            .into(),
+        ),
+    );
+}
+
+#[test]
 fn check_index_of() {
     test_expression(
         "Microsoft.Quantum.Arrays.IndexOf(x -> x % 2 != 0, [10, 8, 6, 5, 4])",
@@ -500,6 +514,20 @@ fn check_most() {
     test_expression(
         "Microsoft.Quantum.Arrays.Most([5, 6, 7, 8])",
         &Value::Array(vec![Value::Int(5), Value::Int(6), Value::Int(7)].into()),
+    );
+}
+
+#[test]
+fn check_most_and_tail() {
+    test_expression(
+        "Microsoft.Quantum.Arrays.MostAndTail([5, 6, 7, 8])",
+        &Value::Tuple(
+            vec![
+                Value::Array(vec![Value::Int(5), Value::Int(6), Value::Int(7)].into()),
+                Value::Int(8),
+            ]
+            .into(),
+        ),
     );
 }
 


### PR DESCRIPTION
Ported function HeadAndRest and MostAndTail. The following explanation is for HeadAndRest, the other one is similar. 

Although they seem redundant because the following two lines are equivalent:

```
let (h, r) = (Head(a), Rest(a));
let (h, r) = HeadAndRest(a);
```

This doesn't work efficiently where a is computed in the expression. Such as

`let (h, r) = HeadAndRest(a[..2^(n-1)..2^(n+1)];`

In this case separate Head() and Rest() would require lengthier expressions.

Implementation uses library functions Head() and Rest() rather than inline implementation as the function name really calls for them.