### PR TITLE
Update fixed argument handling for lambda

### DIFF
--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -788,12 +788,6 @@ impl<'a, G: GlobalLookup<'a>> State<'a, G> {
             _ => panic!("value is not callable"),
         };
 
-        let arg = if let Some(fixed_args) = fixed_args {
-            Value::Tuple(fixed_args.iter().cloned().chain(iter::once(arg)).collect())
-        } else {
-            arg
-        };
-
         let callee = match self.globals.get(callee_id) {
             Some(Global::Callable(callable)) => callable,
             Some(Global::Udt) => {
@@ -816,7 +810,14 @@ impl<'a, G: GlobalLookup<'a>> State<'a, G> {
         .body;
         match block_body {
             SpecBody::Impl(input, body_block) => {
-                bind_args_for_spec(self.env, &callee.input, input, arg, functor.controlled);
+                bind_args_for_spec(
+                    self.env,
+                    &callee.input,
+                    input,
+                    arg,
+                    functor.controlled,
+                    fixed_args,
+                );
                 self.push_block(body_block);
                 Ok(())
             }
@@ -998,6 +999,14 @@ impl<'a, G: GlobalLookup<'a>> State<'a, G> {
     }
 }
 
+fn merge_fixed_args(fixed_args: Option<Rc<[Value]>>, arg: Value) -> Value {
+    if let Some(fixed_args) = fixed_args {
+        Value::Tuple(fixed_args.iter().cloned().chain(iter::once(arg)).collect())
+    } else {
+        arg
+    }
+}
+
 fn bind_value(env: &mut Env, pat: &Pat, val: Value, mutability: Mutability) {
     match &pat.kind {
         PatKind::Bind(variable) => {
@@ -1061,6 +1070,7 @@ fn bind_args_for_spec(
     spec_pat: &Option<Pat>,
     args_val: Value,
     ctl_count: u8,
+    fixed_args: Option<Rc<[Value]>>,
 ) {
     match spec_pat {
         Some(spec_pat) => {
@@ -1085,9 +1095,19 @@ fn bind_args_for_spec(
                 Value::Array(ctls.into()),
                 Mutability::Immutable,
             );
-            bind_value(env, decl_pat, tup, Mutability::Immutable);
+            bind_value(
+                env,
+                decl_pat,
+                merge_fixed_args(fixed_args, tup),
+                Mutability::Immutable,
+            );
         }
-        None => bind_value(env, decl_pat, args_val, Mutability::Immutable),
+        None => bind_value(
+            env,
+            decl_pat,
+            merge_fixed_args(fixed_args, args_val),
+            Mutability::Immutable,
+        ),
     }
 }
 

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -2679,6 +2679,63 @@ fn lambda_operation_closure() {
 }
 
 #[test]
+fn lambda_operation_controlled() {
+    check_expr(
+        "
+            namespace A {
+                open Microsoft.Quantum.Measurement;
+                operation Foo(op : Qubit => Unit is Adj + Ctl, q : Qubit) : Unit is Adj + Ctl { op(q) }
+                operation Bar() : Result[] {
+                    mutable output = [];
+                    use (ctls, q) = (Qubit[1], Qubit());
+                    let op = q => X(q);
+                    Foo(op, q);
+                    set output += [MResetZ(q)];
+                    Controlled Foo(ctls, (op, q));
+                    set output += [MResetZ(q)];
+                    X(ctls[0]);
+                    Controlled Foo(ctls, (op, q));
+                    set output += [MResetZ(q)];
+                    ResetAll(ctls);
+                    output
+                }
+            }
+        ",
+        "A.Bar()",
+        &expect!["[One, Zero, One]"],
+    );
+}
+
+#[test]
+fn lambda_operation_controlled_controlled() {
+    check_expr(
+        "
+            namespace A {
+                open Microsoft.Quantum.Measurement;
+                operation Foo(op : Qubit => Unit is Adj + Ctl, q : Qubit) : Unit is Adj + Ctl { op(q) }
+                operation Bar() : Result[] {
+                    mutable output = [];
+                    use (ctls1, ctls2, q) = (Qubit[1], Qubit[1], Qubit());
+                    let op = q => X(q);
+                    Foo(op, q);
+                    set output += [MResetZ(q)];
+                    Controlled Controlled Foo(ctls1, (ctls2, (op, q)));
+                    set output += [MResetZ(q)];
+                    X(ctls1[0]);
+                    X(ctls2[0]);
+                    Controlled Controlled Foo(ctls1, (ctls2, (op, q)));
+                    set output += [MResetZ(q)];
+                    ResetAll(ctls1 + ctls2);
+                    output
+                }
+            }
+        ",
+        "A.Bar()",
+        &expect!["[One, Zero, One]"],
+    );
+}
+
+#[test]
 fn partial_app_all_holes() {
     check_expr(
         "",


### PR DESCRIPTION
This change updates the way fixed arguments are handled for lambdas to properly interact with controlled invocations, where the argument tuple that must be modified is an inner tuple.

Fixes #459