### PR TITLE
Improve Hover Display

### DIFF
--- a/language_service/src/display.rs
+++ b/language_service/src/display.rs
@@ -88,7 +88,7 @@ struct IdentTy<'a> {
 
 impl<'a> Display for IdentTy<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}: {}", self.ident.name, Ty { ty: self.ty },)
+        write!(f, "{}: {}", self.ident.name, AstTy { ty: self.ty },)
     }
 }
 
@@ -144,15 +144,19 @@ impl Display for HirCallableDecl<'_, '_> {
             hir::CallableKind::Operation => ("operation", "=>"),
         };
 
+        write!(f, "{} {}", kind, self.decl.name.name)?;
+        let input = HirPat {
+            pat: &self.decl.input,
+            compilation: self.compilation,
+        };
+        if matches!(self.decl.input.kind, hir::PatKind::Tuple(_)) {
+            write!(f, "{input}")?;
+        } else {
+            write!(f, "({input})")?;
+        }
         write!(
             f,
-            "{} {} {} {} {}{}",
-            kind,
-            self.decl.name.name,
-            HirTy {
-                ty: &self.decl.input.ty,
-                compilation: self.compilation
-            },
+            " {} {}{}",
             arrow,
             HirTy {
                 ty: &self.decl.output,
@@ -180,21 +184,139 @@ impl<'a> Display for AstCallableDecl<'a> {
         let functors = ast_callable_functors(self.decl);
         let functors = FunctorSetValue { functors };
 
+        write!(f, "{} {}", kind, self.decl.name.name)?;
+        let input = AstPat {
+            pat: &self.decl.input,
+            compilation: self.compilation,
+        };
+        if matches!(*self.decl.input.kind, ast::PatKind::Tuple(_)) {
+            write!(f, "{input}")?;
+        } else {
+            write!(f, "({input})")?;
+        }
         write!(
             f,
-            "{} {} {} {} {}{}",
-            kind,
-            self.decl.name.name,
-            TyId {
-                ty_id: self.decl.input.id,
-                compilation: self.compilation
-            },
+            " {} {}{}",
             arrow,
-            Ty {
+            AstTy {
                 ty: &self.decl.output
             },
             functors,
         )
+    }
+}
+
+struct HirPat<'a> {
+    pat: &'a hir::Pat,
+    compilation: &'a Compilation,
+}
+
+impl<'a> Display for HirPat<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let ty = HirTy {
+            ty: &self.pat.ty,
+            compilation: self.compilation,
+        };
+        match &self.pat.kind {
+            hir::PatKind::Bind(name) => write!(f, "{}: {ty}", name.name),
+            hir::PatKind::Discard => write!(f, "_: {ty}"),
+            hir::PatKind::Tuple(items) => {
+                let mut elements = items.iter();
+                if let Some(elem) = elements.next() {
+                    write!(
+                        f,
+                        "({}",
+                        HirPat {
+                            pat: elem,
+                            compilation: self.compilation
+                        }
+                    )?;
+                    for elem in elements {
+                        write!(
+                            f,
+                            ", {}",
+                            HirPat {
+                                pat: elem,
+                                compilation: self.compilation
+                            }
+                        )?;
+                    }
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
+            }
+        }
+    }
+}
+
+struct AstPat<'a> {
+    pat: &'a ast::Pat,
+    compilation: &'a Compilation,
+}
+
+impl<'a> Display for AstPat<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match &*self.pat.kind {
+            ast::PatKind::Bind(ident, anno) => match anno {
+                Some(ty) => write!(f, "{}", IdentTy { ident, ty }),
+                None => write!(
+                    f,
+                    "{}",
+                    IdentTyId {
+                        compilation: self.compilation,
+                        ident,
+                        ty_id: self.pat.id
+                    }
+                ),
+            },
+            ast::PatKind::Discard(anno) => match anno {
+                Some(ty) => write!(f, "{}", AstTy { ty }),
+                None => write!(
+                    f,
+                    "_: {}",
+                    TyId {
+                        ty_id: self.pat.id,
+                        compilation: self.compilation
+                    }
+                ),
+            },
+            ast::PatKind::Elided => write!(f, "..."),
+            ast::PatKind::Paren(item) => write!(
+                f,
+                "{}",
+                AstPat {
+                    pat: item,
+                    compilation: self.compilation
+                }
+            ),
+            ast::PatKind::Tuple(items) => {
+                let mut elements = items.iter();
+                if let Some(elem) = elements.next() {
+                    write!(
+                        f,
+                        "({}",
+                        AstPat {
+                            pat: elem,
+                            compilation: self.compilation
+                        }
+                    )?;
+                    for elem in elements {
+                        write!(
+                            f,
+                            ", {}",
+                            AstPat {
+                                pat: elem,
+                                compilation: self.compilation
+                            }
+                        )?;
+                    }
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
+            }
+        }
     }
 }
 
@@ -435,14 +557,14 @@ impl<'a> Display for TyId<'a> {
     }
 }
 
-struct Ty<'a> {
+struct AstTy<'a> {
     ty: &'a ast::Ty,
 }
 
-impl<'a> Display for Ty<'a> {
+impl<'a> Display for AstTy<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self.ty.kind.as_ref() {
-            ast::TyKind::Array(ty) => write!(f, "{}[]", Ty { ty }),
+            ast::TyKind::Array(ty) => write!(f, "{}[]", AstTy { ty }),
             ast::TyKind::Arrow(kind, input, output, functors) => {
                 let arrow = match kind {
                     ast::CallableKind::Function => "->",
@@ -451,14 +573,14 @@ impl<'a> Display for Ty<'a> {
                 write!(
                     f,
                     "({} {} {}{})",
-                    Ty { ty: input },
+                    AstTy { ty: input },
                     arrow,
-                    Ty { ty: output },
+                    AstTy { ty: output },
                     FunctorExpr { functors }
                 )
             }
             ast::TyKind::Hole => write!(f, "_"),
-            ast::TyKind::Paren(ty) => write!(f, "{}", Ty { ty }),
+            ast::TyKind::Paren(ty) => write!(f, "{}", AstTy { ty }),
             ast::TyKind::Path(path) => write!(f, "{}", Path { path }),
             ast::TyKind::Param(id) => write!(f, "{}", id.name),
             ast::TyKind::Tuple(tys) => {
@@ -470,7 +592,7 @@ impl<'a> Display for Ty<'a> {
                         if count != 0 {
                             write!(f, ", ")?;
                         }
-                        write!(f, "{}", Ty { ty: def })?;
+                        write!(f, "{}", AstTy { ty: def })?;
                     }
                     write!(f, ")")
                 }
@@ -516,8 +638,8 @@ impl<'a> Display for TyDef<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self.def.kind.as_ref() {
             ast::TyDefKind::Field(name, ty) => match name {
-                Some(name) => write!(f, "{}: {}", name.name, Ty { ty }),
-                None => write!(f, "{}", Ty { ty }),
+                Some(name) => write!(f, "{}: {}", name.name, AstTy { ty }),
+                None => write!(f, "{}", AstTy { ty }),
             },
             ast::TyDefKind::Paren(def) => write!(f, "{}", TyDef { def }),
             ast::TyDefKind::Tuple(tys) => {

--- a/language_service/src/display.rs
+++ b/language_service/src/display.rs
@@ -139,9 +139,9 @@ struct HirCallableDecl<'a, 'b> {
 
 impl Display for HirCallableDecl<'_, '_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let (kind, arrow) = match self.decl.kind {
-            hir::CallableKind::Function => ("function", "->"),
-            hir::CallableKind::Operation => ("operation", "=>"),
+        let kind = match self.decl.kind {
+            hir::CallableKind::Function => "function",
+            hir::CallableKind::Operation => "operation",
         };
 
         write!(f, "{} {}", kind, self.decl.name.name)?;
@@ -156,8 +156,7 @@ impl Display for HirCallableDecl<'_, '_> {
         }
         write!(
             f,
-            " {} {}{}",
-            arrow,
+            " : {}{}",
             HirTy {
                 ty: &self.decl.output,
                 compilation: self.compilation
@@ -176,9 +175,9 @@ struct AstCallableDecl<'a> {
 
 impl<'a> Display for AstCallableDecl<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let (kind, arrow) = match self.decl.kind {
-            ast::CallableKind::Function => ("function", "->"),
-            ast::CallableKind::Operation => ("operation", "=>"),
+        let kind = match self.decl.kind {
+            ast::CallableKind::Function => "function",
+            ast::CallableKind::Operation => "operation",
         };
 
         let functors = ast_callable_functors(self.decl);
@@ -196,8 +195,7 @@ impl<'a> Display for AstCallableDecl<'a> {
         }
         write!(
             f,
-            " {} {}{}",
-            arrow,
+            " : {}{}",
             AstTy {
                 ty: &self.decl.output
             },

--- a/language_service/src/display.rs
+++ b/language_service/src/display.rs
@@ -327,7 +327,12 @@ struct IdentTyDef<'a> {
 
 impl<'a> Display for IdentTyDef<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{} = {}", self.ident.name, TyDef { def: self.def })
+        write!(
+            f,
+            "newtype {} = {}",
+            self.ident.name,
+            TyDef { def: self.def }
+        )
     }
 }
 
@@ -340,7 +345,7 @@ struct HirUdt<'a> {
 impl<'a> Display for HirUdt<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let udt_def = UdtDef::new(self.compilation, self.udt);
-        write!(f, "{} = {}", self.ident.name, udt_def)
+        write!(f, "newtype {} = {}", self.ident.name, udt_def)
     }
 }
 

--- a/language_service/src/hover.rs
+++ b/language_service/src/hover.rs
@@ -198,10 +198,10 @@ fn markdown_with_doc(doc: &Rc<str>, code: impl Display) -> String {
         markdown_fenced_block(code)
     } else {
         format!(
-            "{}
-{}",
+            "{}{}
+",
+            markdown_fenced_block(code),
             parsed_doc.summary,
-            markdown_fenced_block(code)
         )
     }
 }

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -46,7 +46,7 @@ fn hover_callable_unit_types() {
         }
     "#},
         &expect![[r#"
-            "Doc comment\nwith multiple lines!\n```qsharp\noperation Bar() => Unit\n```\n"
+            "```qsharp\noperation Bar() => Unit\n```\nDoc comment\nwith multiple lines!\n"
         "#]],
     );
 }
@@ -61,7 +61,7 @@ fn hover_callable_with_callable_types() {
         }
     "#},
         &expect![[r#"
-            "Doc comment!\n```qsharp\noperation Foo(x: (Int => Int)) => (Int => Int)\n```\n"
+            "```qsharp\noperation Foo(x: (Int => Int)) => (Int => Int)\n```\nDoc comment!\n"
         "#]],
     );
 }
@@ -92,7 +92,7 @@ fn hover_callable_unit_types_functors() {
         }
     "#},
         &expect![[r#"
-            "Doc comment!\n```qsharp\noperation Foo() => Unit is Ctl\n```\n"
+            "```qsharp\noperation Foo() => Unit is Ctl\n```\nDoc comment!\n"
         "#]],
     );
 }
@@ -107,7 +107,7 @@ fn hover_callable_with_callable_types_functors() {
         }
     "#},
         &expect![[r#"
-            "Doc comment!\n```qsharp\noperation Foo(x: (Int => Int is Adj + Ctl)) => (Int => Int is Adj) is Adj\n```\n"
+            "```qsharp\noperation Foo(x: (Int => Int is Adj + Ctl)) => (Int => Int is Adj) is Adj\n```\nDoc comment!\n"
         "#]],
     );
 }
@@ -547,7 +547,7 @@ fn hover_callable_summary() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
+            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -565,7 +565,7 @@ fn hover_callable_summary_stuff_before() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
+            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -584,7 +584,7 @@ fn hover_callable_summary_other_header_before() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
+            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -603,7 +603,7 @@ fn hover_callable_summary_other_header_after() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
+            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -624,7 +624,7 @@ fn hover_callable_summary_other_headers() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
+            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -641,9 +641,9 @@ fn hover_callable_headers_but_no_summary() {
             operation ◉F↘oo◉() : Unit {}
         }
     "#},
-        &expect![[r##"
-            "# Not The Summary\nThis stuff is not the summary.\n# Also Not The Summary\nThis stuff is also not the summary.\n```qsharp\noperation Foo() => Unit\n```\n"
-        "##]],
+        &expect![[r#"
+            "```qsharp\noperation Foo() => Unit\n```\n# Not The Summary\nThis stuff is not the summary.\n# Also Not The Summary\nThis stuff is also not the summary.\n"
+        "#]],
     );
 }
 
@@ -663,7 +663,7 @@ fn hover_callable_summary_only_header_matches() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line # Summary!\n```qsharp\noperation Foo() => Unit\n```\n"
+            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line # Summary!\n"
         "#]],
     );
 }
@@ -681,7 +681,7 @@ fn hover_callable_summary_successive_headers() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
+            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -46,7 +46,7 @@ fn hover_callable_unit_types() {
         }
     "#},
         &expect![[r#"
-            "Doc comment\nwith multiple lines!\n```qsharp\noperation Bar Unit => Unit\n```\n"
+            "Doc comment\nwith multiple lines!\n```qsharp\noperation Bar() => Unit\n```\n"
         "#]],
     );
 }
@@ -61,7 +61,7 @@ fn hover_callable_with_callable_types() {
         }
     "#},
         &expect![[r#"
-            "Doc comment!\n```qsharp\noperation Foo (Int => Int) => (Int => Int)\n```\n"
+            "Doc comment!\n```qsharp\noperation Foo(x: (Int => Int)) => (Int => Int)\n```\n"
         "#]],
     );
 }
@@ -77,7 +77,7 @@ fn hover_call() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Bar Unit => Unit\n```\n"
+            "```qsharp\noperation Bar() => Unit\n```\n"
         "#]],
     );
 }
@@ -92,7 +92,7 @@ fn hover_callable_unit_types_functors() {
         }
     "#},
         &expect![[r#"
-            "Doc comment!\n```qsharp\noperation Foo Unit => Unit is Ctl\n```\n"
+            "Doc comment!\n```qsharp\noperation Foo() => Unit is Ctl\n```\n"
         "#]],
     );
 }
@@ -107,7 +107,7 @@ fn hover_callable_with_callable_types_functors() {
         }
     "#},
         &expect![[r#"
-            "Doc comment!\n```qsharp\noperation Foo (Int => Int is Adj + Ctl) => (Int => Int is Adj) is Adj\n```\n"
+            "Doc comment!\n```qsharp\noperation Foo(x: (Int => Int is Adj + Ctl)) => (Int => Int is Adj) is Adj\n```\n"
         "#]],
     );
 }
@@ -123,7 +123,7 @@ fn hover_call_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Bar Unit => Unit is Adj\n```\n"
+            "```qsharp\noperation Bar() => Unit is Adj\n```\n"
         "#]],
     );
 }
@@ -496,7 +496,7 @@ fn hover_foreign_call() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Fake Unit => Unit\n```\n"
+            "```qsharp\noperation Fake() => Unit\n```\n"
         "#]],
     );
 }
@@ -513,7 +513,24 @@ fn hover_foreign_call_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation FakeCtlAdj Unit => Unit is Adj + Ctl\n```\n"
+            "```qsharp\noperation FakeCtlAdj() => Unit is Adj + Ctl\n```\n"
+        "#]],
+    );
+}
+
+#[test]
+fn hover_foreign_call_with_param() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            open FakeStdLib;
+            operation Foo() : Unit {
+                ◉FakeWi↘thParam◉(4);
+            }
+        }
+    "#},
+        &expect![[r#"
+            "```qsharp\noperation FakeWithParam(x: Int) => Unit\n```\n"
         "#]],
     );
 }
@@ -530,7 +547,7 @@ fn hover_callable_summary() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo Unit => Unit\n```\n"
+            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
         "#]],
     );
 }
@@ -548,7 +565,7 @@ fn hover_callable_summary_stuff_before() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo Unit => Unit\n```\n"
+            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
         "#]],
     );
 }
@@ -567,7 +584,7 @@ fn hover_callable_summary_other_header_before() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo Unit => Unit\n```\n"
+            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
         "#]],
     );
 }
@@ -586,7 +603,7 @@ fn hover_callable_summary_other_header_after() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo Unit => Unit\n```\n"
+            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
         "#]],
     );
 }
@@ -607,7 +624,7 @@ fn hover_callable_summary_other_headers() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo Unit => Unit\n```\n"
+            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
         "#]],
     );
 }
@@ -625,7 +642,7 @@ fn hover_callable_headers_but_no_summary() {
         }
     "#},
         &expect![[r##"
-            "# Not The Summary\nThis stuff is not the summary.\n# Also Not The Summary\nThis stuff is also not the summary.\n```qsharp\noperation Foo Unit => Unit\n```\n"
+            "# Not The Summary\nThis stuff is not the summary.\n# Also Not The Summary\nThis stuff is also not the summary.\n```qsharp\noperation Foo() => Unit\n```\n"
         "##]],
     );
 }
@@ -646,7 +663,7 @@ fn hover_callable_summary_only_header_matches() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line # Summary!\n```qsharp\noperation Foo Unit => Unit\n```\n"
+            "This is a\nmulti-line # Summary!\n```qsharp\noperation Foo() => Unit\n```\n"
         "#]],
     );
 }
@@ -664,7 +681,7 @@ fn hover_callable_summary_successive_headers() {
         }
     "#},
         &expect![[r#"
-            "This is a\nmulti-line summary!\n```qsharp\noperation Foo Unit => Unit\n```\n"
+            "This is a\nmulti-line summary!\n```qsharp\noperation Foo() => Unit\n```\n"
         "#]],
     );
 }
@@ -680,8 +697,8 @@ fn hover_callable_empty_summary() {
             operation ◉F↘oo◉() : Unit {}
         }
     "#},
-        &expect![[r##"
-            "```qsharp\noperation Foo Unit => Unit\n```\n"
-        "##]],
+        &expect![[r#"
+            "```qsharp\noperation Foo() => Unit\n```\n"
+        "#]],
     );
 }

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -46,7 +46,7 @@ fn hover_callable_unit_types() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Bar() => Unit\n```\nDoc comment\nwith multiple lines!\n"
+            "```qsharp\noperation Bar() : Unit\n```\nDoc comment\nwith multiple lines!\n"
         "#]],
     );
 }
@@ -61,7 +61,7 @@ fn hover_callable_with_callable_types() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo(x: (Int => Int)) => (Int => Int)\n```\nDoc comment!\n"
+            "```qsharp\noperation Foo(x: (Int => Int)) : (Int => Int)\n```\nDoc comment!\n"
         "#]],
     );
 }
@@ -77,7 +77,7 @@ fn hover_call() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Bar() => Unit\n```\n"
+            "```qsharp\noperation Bar() : Unit\n```\n"
         "#]],
     );
 }
@@ -92,7 +92,7 @@ fn hover_callable_unit_types_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit is Ctl\n```\nDoc comment!\n"
+            "```qsharp\noperation Foo() : Unit is Ctl\n```\nDoc comment!\n"
         "#]],
     );
 }
@@ -107,7 +107,7 @@ fn hover_callable_with_callable_types_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo(x: (Int => Int is Adj + Ctl)) => (Int => Int is Adj) is Adj\n```\nDoc comment!\n"
+            "```qsharp\noperation Foo(x: (Int => Int is Adj + Ctl)) : (Int => Int is Adj) is Adj\n```\nDoc comment!\n"
         "#]],
     );
 }
@@ -123,7 +123,7 @@ fn hover_call_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Bar() => Unit is Adj\n```\n"
+            "```qsharp\noperation Bar() : Unit is Adj\n```\n"
         "#]],
     );
 }
@@ -496,7 +496,7 @@ fn hover_foreign_call() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Fake() => Unit\n```\n"
+            "```qsharp\noperation Fake() : Unit\n```\n"
         "#]],
     );
 }
@@ -513,7 +513,7 @@ fn hover_foreign_call_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation FakeCtlAdj() => Unit is Adj + Ctl\n```\n"
+            "```qsharp\noperation FakeCtlAdj() : Unit is Adj + Ctl\n```\n"
         "#]],
     );
 }
@@ -530,7 +530,7 @@ fn hover_foreign_call_with_param() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation FakeWithParam(x: Int) => Unit\n```\n"
+            "```qsharp\noperation FakeWithParam(x: Int) : Unit\n```\n"
         "#]],
     );
 }
@@ -547,7 +547,7 @@ fn hover_callable_summary() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -565,7 +565,7 @@ fn hover_callable_summary_stuff_before() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -584,7 +584,7 @@ fn hover_callable_summary_other_header_before() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -603,7 +603,7 @@ fn hover_callable_summary_other_header_after() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -624,7 +624,7 @@ fn hover_callable_summary_other_headers() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -642,7 +642,7 @@ fn hover_callable_headers_but_no_summary() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit\n```\n# Not The Summary\nThis stuff is not the summary.\n# Also Not The Summary\nThis stuff is also not the summary.\n"
+            "```qsharp\noperation Foo() : Unit\n```\n# Not The Summary\nThis stuff is not the summary.\n# Also Not The Summary\nThis stuff is also not the summary.\n"
         "#]],
     );
 }
@@ -663,7 +663,7 @@ fn hover_callable_summary_only_header_matches() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line # Summary!\n"
+            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line # Summary!\n"
         "#]],
     );
 }
@@ -681,7 +681,7 @@ fn hover_callable_summary_successive_headers() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -698,7 +698,7 @@ fn hover_callable_empty_summary() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() => Unit\n```\n"
+            "```qsharp\noperation Foo() : Unit\n```\n"
         "#]],
     );
 }

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -365,7 +365,7 @@ fn hover_udt() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nPair = (Int, snd: Int)\n```\n"
+            "```qsharp\nnewtype Pair = (Int, snd: Int)\n```\n"
         "#]],
     );
 }
@@ -382,7 +382,7 @@ fn hover_udt_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nBar = (fst: Int, (snd: Int, Double, fourth: String), Double, sixth: Int)\n```\n"
+            "```qsharp\nnewtype Bar = (fst: Int, (snd: Int, Double, fourth: String), Double, sixth: Int)\n```\n"
         "#]],
     );
 }
@@ -400,7 +400,7 @@ fn hover_udt_ref_nested_udt() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nBar = (fst: Int, (snd: Int, Double, fourth: Pair), Double, sixth: Int)\n```\n"
+            "```qsharp\nnewtype Bar = (fst: Int, (snd: Int, Double, fourth: Pair), Double, sixth: Int)\n```\n"
         "#]],
     );
 }
@@ -417,7 +417,7 @@ fn hover_udt_anno_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nPair = (Int, snd: Int)\n```\n"
+            "```qsharp\nnewtype Pair = (Int, snd: Int)\n```\n"
         "#]],
     );
 }
@@ -434,7 +434,7 @@ fn hover_udt_constructor() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nPair = (Int, snd: Int)\n```\n"
+            "```qsharp\nnewtype Pair = (Int, snd: Int)\n```\n"
         "#]],
     );
 }

--- a/language_service/src/test_utils.rs
+++ b/language_service/src/test_utils.rs
@@ -36,6 +36,7 @@ pub(crate) fn compile_with_fake_stdlib(source_name: &str, source_contents: &str)
             "<std>".into(),
             "namespace FakeStdLib {
                 operation Fake() : Unit {}
+                operation FakeWithParam(x: Int) : Unit {}
                 operation FakeCtlAdj() : Unit is Ctl + Adj {}
             }"
             .into(),


### PR DESCRIPTION
Display parameter names when hovering over callables.
Preface UDT display with `newtype` to help indicate that it is a UDT.
Put doc strings below other information, as it can get lengthy and we don't want to burry the other info displayed.