### PR TITLE
Change diagnostic callables to operations

### DIFF
--- a/library/std/diagnostics.qs
+++ b/library/std/diagnostics.qs
@@ -4,7 +4,7 @@
 namespace Microsoft.Quantum.Diagnostics {
     open QIR.Intrinsic;
 
-    operation DumpMachine() : Unit {
+    function DumpMachine() : Unit {
         body intrinsic;
     }
 

--- a/library/std/diagnostics.qs
+++ b/library/std/diagnostics.qs
@@ -4,15 +4,15 @@
 namespace Microsoft.Quantum.Diagnostics {
     open QIR.Intrinsic;
 
-    function DumpMachine() : Unit {
+    operation DumpMachine() : Unit {
         body intrinsic;
     }
 
-    function CheckZero(qubit : Qubit) : Bool {
+    operation CheckZero(qubit : Qubit) : Bool {
         body intrinsic;
     }
 
-    function CheckAllZero(qubits : Qubit[]) : Bool {
+    operation CheckAllZero(qubits : Qubit[]) : Bool {
         for q in qubits {
             if not CheckZero(q) {
                 return false;


### PR DESCRIPTION
Some diagnostic callables were written as functions when they are not pure functions, so should instead be operations.