### PR TITLE
Set `NodeId` during transformation passes

### DIFF
--- a/compiler/qsc_passes/src/common.rs
+++ b/compiler/qsc_passes/src/common.rs
@@ -3,6 +3,7 @@
 
 use qsc_data_structures::span::Span;
 use qsc_hir::{
+    assigner::Assigner,
     global::Table,
     hir::{
         Expr, ExprKind, Field, Ident, Mutability, NodeId, Pat, PatKind, PrimField, Res, Stmt,
@@ -12,6 +13,7 @@ use qsc_hir::{
 };
 use std::rc::Rc;
 
+#[derive(Debug, Clone)]
 pub(crate) struct IdentTemplate {
     pub id: NodeId,
     pub span: Span,
@@ -20,18 +22,18 @@ pub(crate) struct IdentTemplate {
 }
 
 impl IdentTemplate {
-    pub fn gen_local_ref(&self) -> Expr {
+    pub fn gen_local_ref(&self, assigner: &mut Assigner) -> Expr {
         Expr {
-            id: NodeId::default(),
+            id: assigner.next_node(),
             span: self.span,
             ty: self.ty.clone(),
             kind: ExprKind::Var(Res::Local(self.id), Vec::new()),
         }
     }
 
-    fn gen_pat(&self) -> Pat {
+    fn gen_pat(&self, assigner: &mut Assigner) -> Pat {
         Pat {
-            id: NodeId::default(),
+            id: assigner.next_node(),
             span: self.span,
             ty: self.ty.clone(),
             kind: PatKind::Bind(Ident {
@@ -42,20 +44,20 @@ impl IdentTemplate {
         }
     }
 
-    pub fn gen_field_access(&self, field: PrimField) -> Expr {
+    pub fn gen_field_access(&self, field: PrimField, assigner: &mut Assigner) -> Expr {
         Expr {
-            id: NodeId::default(),
+            id: assigner.next_node(),
             span: self.span,
             ty: Ty::Prim(Prim::Int),
-            kind: ExprKind::Field(Box::new(self.gen_local_ref()), Field::Prim(field)),
+            kind: ExprKind::Field(Box::new(self.gen_local_ref(assigner)), Field::Prim(field)),
         }
     }
 
-    pub fn gen_id_init(&self, mutability: Mutability, expr: Expr) -> Stmt {
+    pub fn gen_id_init(&self, mutability: Mutability, expr: Expr, assigner: &mut Assigner) -> Stmt {
         Stmt {
-            id: NodeId::default(),
+            id: assigner.next_node(),
             span: self.span,
-            kind: StmtKind::Local(mutability, self.gen_pat(), expr),
+            kind: StmtKind::Local(mutability, self.gen_pat(assigner), expr),
         }
     }
 }

--- a/compiler/qsc_passes/src/conjugate_invert/tests.rs
+++ b/compiler/qsc_passes/src/conjugate_invert/tests.rs
@@ -66,33 +66,33 @@ fn conjugate_invert() {
                         functors: empty set
                         body: SpecDecl 9 [63-216]: Impl:
                             Block 10 [84-216] [Type Unit]:
-                                Stmt 11 [94-210]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block _id_ [0-0] [Type Unit]:
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 13 [101-148] [Type Unit]:
+                                Stmt 11 [94-210]: Expr: Expr 54 [0-0] [Type Unit]: Expr Block: Block 47 [0-0] [Type Unit]:
+                                    Stmt 48 [0-0]: Expr: Expr 49 [0-0] [Type Unit]: Expr Block: Block 13 [101-148] [Type Unit]:
                                         Stmt 14 [115-120]: Semi: Expr 15 [115-119] [Type Unit]: Call:
                                             Expr 16 [115-116] [Type (Int => Unit is Adj)]: Var: Item 1
                                             Expr 17 [117-118] [Type Int]: Lit: Int(1)
                                         Stmt 18 [133-138]: Semi: Expr 19 [133-137] [Type Unit]: Call:
                                             Expr 20 [133-134] [Type (Int => Unit is Adj)]: Var: Item 1
                                             Expr 21 [135-136] [Type Int]: Lit: Int(2)
-                                    Stmt 33 [0-0]: Local (Immutable):
-                                        Pat 34 [0-0] [Type Unit]: Bind: Ident 32 [0-0] "apply_res"
-                                        Expr _id_ [0-0] [Type Unit]: Expr Block: Block 22 [163-210] [Type Unit]:
+                                    Stmt 44 [0-0]: Local (Immutable):
+                                        Pat 45 [0-0] [Type Unit]: Bind: Ident 43 [0-0] "apply_res"
+                                        Expr 46 [0-0] [Type Unit]: Expr Block: Block 22 [163-210] [Type Unit]:
                                             Stmt 23 [177-182]: Semi: Expr 24 [177-181] [Type Unit]: Call:
                                                 Expr 25 [177-178] [Type (Int => Unit is Adj)]: Var: Item 1
                                                 Expr 26 [179-180] [Type Int]: Lit: Int(3)
                                             Stmt 27 [195-200]: Semi: Expr 28 [195-199] [Type Unit]: Call:
                                                 Expr 29 [195-196] [Type (Int => Unit is Adj)]: Var: Item 1
                                                 Expr 30 [197-198] [Type Int]: Lit: Int(4)
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 13 [101-148] [Type Unit]:
-                                        Stmt 18 [133-138]: Semi: Expr 19 [133-137] [Type Unit]: Call:
-                                            Expr _id_ [133-134] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 20 [133-134] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 21 [135-136] [Type Int]: Lit: Int(2)
-                                        Stmt 14 [115-120]: Semi: Expr 15 [115-119] [Type Unit]: Call:
-                                            Expr _id_ [115-116] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 16 [115-116] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 17 [117-118] [Type Int]: Lit: Int(1)
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Var: Local 32
+                                    Stmt 50 [0-0]: Expr: Expr 51 [0-0] [Type Unit]: Expr Block: Block 32 [101-148] [Type Unit]:
+                                        Stmt 33 [133-138]: Semi: Expr 34 [133-137] [Type Unit]: Call:
+                                            Expr 35 [133-134] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 36 [133-134] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 37 [135-136] [Type Int]: Lit: Int(2)
+                                        Stmt 38 [115-120]: Semi: Expr 39 [115-119] [Type Unit]: Call:
+                                            Expr 40 [115-116] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 41 [115-116] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 42 [117-118] [Type Int]: Lit: Int(1)
+                                    Stmt 52 [0-0]: Expr: Expr 53 [0-0] [Type Unit]: Var: Local 43
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -146,17 +146,17 @@ fn conjugate_invert_with_output() {
                             Block 10 [83-252] [Type Int]:
                                 Stmt 11 [93-234]: Local (Immutable):
                                     Pat 12 [97-100] [Type Int]: Bind: Ident 13 [97-100] "val"
-                                    Expr _id_ [0-0] [Type Int]: Expr Block: Block _id_ [0-0] [Type Int]:
-                                        Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 15 [110-157] [Type Unit]:
+                                    Expr 60 [0-0] [Type Int]: Expr Block: Block 53 [0-0] [Type Int]:
+                                        Stmt 54 [0-0]: Expr: Expr 55 [0-0] [Type Unit]: Expr Block: Block 15 [110-157] [Type Unit]:
                                             Stmt 16 [124-129]: Semi: Expr 17 [124-128] [Type Unit]: Call:
                                                 Expr 18 [124-125] [Type (Int => Unit is Adj)]: Var: Item 1
                                                 Expr 19 [126-127] [Type Int]: Lit: Int(1)
                                             Stmt 20 [142-147]: Semi: Expr 21 [142-146] [Type Unit]: Call:
                                                 Expr 22 [142-143] [Type (Int => Unit is Adj)]: Var: Item 1
                                                 Expr 23 [144-145] [Type Int]: Lit: Int(2)
-                                        Stmt 39 [0-0]: Local (Immutable):
-                                            Pat 40 [0-0] [Type Int]: Bind: Ident 38 [0-0] "apply_res"
-                                            Expr _id_ [0-0] [Type Int]: Expr Block: Block 24 [172-233] [Type Int]:
+                                        Stmt 50 [0-0]: Local (Immutable):
+                                            Pat 51 [0-0] [Type Int]: Bind: Ident 49 [0-0] "apply_res"
+                                            Expr 52 [0-0] [Type Int]: Expr Block: Block 24 [172-233] [Type Int]:
                                                 Stmt 25 [186-191]: Semi: Expr 26 [186-190] [Type Unit]: Call:
                                                     Expr 27 [186-187] [Type (Int => Unit is Adj)]: Var: Item 1
                                                     Expr 28 [188-189] [Type Int]: Lit: Int(3)
@@ -164,16 +164,16 @@ fn conjugate_invert_with_output() {
                                                     Expr 31 [204-205] [Type (Int => Unit is Adj)]: Var: Item 1
                                                     Expr 32 [206-207] [Type Int]: Lit: Int(4)
                                                 Stmt 33 [222-223]: Expr: Expr 34 [222-223] [Type Int]: Lit: Int(7)
-                                        Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 15 [110-157] [Type Unit]:
-                                            Stmt 20 [142-147]: Semi: Expr 21 [142-146] [Type Unit]: Call:
-                                                Expr _id_ [142-143] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                    Expr 22 [142-143] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 23 [144-145] [Type Int]: Lit: Int(2)
-                                            Stmt 16 [124-129]: Semi: Expr 17 [124-128] [Type Unit]: Call:
-                                                Expr _id_ [124-125] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                    Expr 18 [124-125] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 19 [126-127] [Type Int]: Lit: Int(1)
-                                        Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Int]: Var: Local 38
+                                        Stmt 56 [0-0]: Expr: Expr 57 [0-0] [Type Unit]: Expr Block: Block 38 [110-157] [Type Unit]:
+                                            Stmt 39 [142-147]: Semi: Expr 40 [142-146] [Type Unit]: Call:
+                                                Expr 41 [142-143] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                    Expr 42 [142-143] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 43 [144-145] [Type Int]: Lit: Int(2)
+                                            Stmt 44 [124-129]: Semi: Expr 45 [124-128] [Type Unit]: Call:
+                                                Expr 46 [124-125] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                    Expr 47 [124-125] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 48 [126-127] [Type Int]: Lit: Int(1)
+                                        Stmt 58 [0-0]: Expr: Expr 59 [0-0] [Type Int]: Var: Local 49
                                 Stmt 35 [243-246]: Expr: Expr 36 [243-246] [Type Int]: Var: Local 13
                         adj: <none>
                         ctl: <none>
@@ -231,82 +231,82 @@ fn nested_conjugate_invert() {
                         functors: empty set
                         body: SpecDecl 9 [63-355]: Impl:
                             Block 10 [84-355] [Type Unit]:
-                                Stmt 11 [94-349]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block _id_ [0-0] [Type Unit]:
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 13 [101-287] [Type Unit]:
+                                Stmt 11 [94-349]: Expr: Expr 87 [0-0] [Type Unit]: Expr Block: Block 80 [0-0] [Type Unit]:
+                                    Stmt 81 [0-0]: Expr: Expr 82 [0-0] [Type Unit]: Expr Block: Block 13 [101-287] [Type Unit]:
                                         Stmt 14 [115-120]: Semi: Expr 15 [115-119] [Type Unit]: Call:
                                             Expr 16 [115-116] [Type (Int => Unit is Adj)]: Var: Item 1
                                             Expr 17 [117-118] [Type Int]: Lit: Int(0)
-                                        Stmt 18 [133-277]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block _id_ [0-0] [Type Unit]:
-                                            Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 20 [140-199] [Type Unit]:
+                                        Stmt 18 [133-277]: Expr: Expr 110 [0-0] [Type Unit]: Expr Block: Block 103 [0-0] [Type Unit]:
+                                            Stmt 104 [0-0]: Expr: Expr 105 [0-0] [Type Unit]: Expr Block: Block 20 [140-199] [Type Unit]:
                                                 Stmt 21 [158-163]: Semi: Expr 22 [158-162] [Type Unit]: Call:
                                                     Expr 23 [158-159] [Type (Int => Unit is Adj)]: Var: Item 1
                                                     Expr 24 [160-161] [Type Int]: Lit: Int(1)
                                                 Stmt 25 [180-185]: Semi: Expr 26 [180-184] [Type Unit]: Call:
                                                     Expr 27 [180-181] [Type (Int => Unit is Adj)]: Var: Item 1
                                                     Expr 28 [182-183] [Type Int]: Lit: Int(2)
-                                            Stmt 52 [0-0]: Local (Immutable):
-                                                Pat 53 [0-0] [Type Unit]: Bind: Ident 51 [0-0] "apply_res"
-                                                Expr _id_ [0-0] [Type Unit]: Expr Block: Block 29 [218-277] [Type Unit]:
+                                            Stmt 100 [0-0]: Local (Immutable):
+                                                Pat 101 [0-0] [Type Unit]: Bind: Ident 99 [0-0] "apply_res"
+                                                Expr 102 [0-0] [Type Unit]: Expr Block: Block 29 [218-277] [Type Unit]:
                                                     Stmt 30 [236-241]: Semi: Expr 31 [236-240] [Type Unit]: Call:
                                                         Expr 32 [236-237] [Type (Int => Unit is Adj)]: Var: Item 1
                                                         Expr 33 [238-239] [Type Int]: Lit: Int(3)
                                                     Stmt 34 [258-263]: Semi: Expr 35 [258-262] [Type Unit]: Call:
                                                         Expr 36 [258-259] [Type (Int => Unit is Adj)]: Var: Item 1
                                                         Expr 37 [260-261] [Type Int]: Lit: Int(4)
-                                            Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 20 [140-199] [Type Unit]:
-                                                Stmt 25 [180-185]: Semi: Expr 26 [180-184] [Type Unit]: Call:
-                                                    Expr _id_ [180-181] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                        Expr 27 [180-181] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                    Expr 28 [182-183] [Type Int]: Lit: Int(2)
-                                                Stmt 21 [158-163]: Semi: Expr 22 [158-162] [Type Unit]: Call:
-                                                    Expr _id_ [158-159] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                        Expr 23 [158-159] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                    Expr 24 [160-161] [Type Int]: Lit: Int(1)
-                                            Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Var: Local 51
-                                    Stmt 49 [0-0]: Local (Immutable):
-                                        Pat 50 [0-0] [Type Unit]: Bind: Ident 48 [0-0] "apply_res"
-                                        Expr _id_ [0-0] [Type Unit]: Expr Block: Block 38 [302-349] [Type Unit]:
+                                            Stmt 106 [0-0]: Expr: Expr 107 [0-0] [Type Unit]: Expr Block: Block 88 [140-199] [Type Unit]:
+                                                Stmt 89 [180-185]: Semi: Expr 90 [180-184] [Type Unit]: Call:
+                                                    Expr 91 [180-181] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                        Expr 92 [180-181] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                    Expr 93 [182-183] [Type Int]: Lit: Int(2)
+                                                Stmt 94 [158-163]: Semi: Expr 95 [158-162] [Type Unit]: Call:
+                                                    Expr 96 [158-159] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                        Expr 97 [158-159] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                    Expr 98 [160-161] [Type Int]: Lit: Int(1)
+                                            Stmt 108 [0-0]: Expr: Expr 109 [0-0] [Type Unit]: Var: Local 99
+                                    Stmt 77 [0-0]: Local (Immutable):
+                                        Pat 78 [0-0] [Type Unit]: Bind: Ident 76 [0-0] "apply_res"
+                                        Expr 79 [0-0] [Type Unit]: Expr Block: Block 38 [302-349] [Type Unit]:
                                             Stmt 39 [316-321]: Semi: Expr 40 [316-320] [Type Unit]: Call:
                                                 Expr 41 [316-317] [Type (Int => Unit is Adj)]: Var: Item 1
                                                 Expr 42 [318-319] [Type Int]: Lit: Int(5)
                                             Stmt 43 [334-339]: Semi: Expr 44 [334-338] [Type Unit]: Call:
                                                 Expr 45 [334-335] [Type (Int => Unit is Adj)]: Var: Item 1
                                                 Expr 46 [336-337] [Type Int]: Lit: Int(6)
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 13 [101-287] [Type Unit]:
-                                        Stmt 18 [133-277]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block _id_ [0-0] [Type Unit]:
-                                            Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 20 [140-199] [Type Unit]:
-                                                Stmt 21 [158-163]: Semi: Expr 22 [158-162] [Type Unit]: Call:
-                                                    Expr 23 [158-159] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                    Expr 24 [160-161] [Type Int]: Lit: Int(1)
-                                                Stmt 25 [180-185]: Semi: Expr 26 [180-184] [Type Unit]: Call:
-                                                    Expr 27 [180-181] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                    Expr 28 [182-183] [Type Int]: Lit: Int(2)
-                                            Stmt 55 [0-0]: Local (Immutable):
-                                                Pat 56 [0-0] [Type Unit]: Bind: Ident 54 [0-0] "apply_res"
-                                                Expr _id_ [0-0] [Type Unit]: Expr Block: Block 29 [218-277] [Type Unit]:
-                                                    Stmt 34 [258-263]: Semi: Expr 35 [258-262] [Type Unit]: Call:
-                                                        Expr _id_ [258-259] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                            Expr 36 [258-259] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                        Expr 37 [260-261] [Type Int]: Lit: Int(4)
-                                                    Stmt 30 [236-241]: Semi: Expr 31 [236-240] [Type Unit]: Call:
-                                                        Expr _id_ [236-237] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                            Expr 32 [236-237] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                        Expr 33 [238-239] [Type Int]: Lit: Int(3)
-                                            Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 20 [140-199] [Type Unit]:
-                                                Stmt 25 [180-185]: Semi: Expr 26 [180-184] [Type Unit]: Call:
-                                                    Expr _id_ [180-181] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                        Expr 27 [180-181] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                    Expr 28 [182-183] [Type Int]: Lit: Int(2)
-                                                Stmt 21 [158-163]: Semi: Expr 22 [158-162] [Type Unit]: Call:
-                                                    Expr _id_ [158-159] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                        Expr 23 [158-159] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                    Expr 24 [160-161] [Type Int]: Lit: Int(1)
-                                            Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Var: Local 54
-                                        Stmt 14 [115-120]: Semi: Expr 15 [115-119] [Type Unit]: Call:
-                                            Expr _id_ [115-116] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 16 [115-116] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 17 [117-118] [Type Int]: Lit: Int(0)
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Var: Local 48
+                                    Stmt 83 [0-0]: Expr: Expr 84 [0-0] [Type Unit]: Expr Block: Block 48 [101-287] [Type Unit]:
+                                        Stmt 49 [133-277]: Expr: Expr 133 [0-0] [Type Unit]: Expr Block: Block 126 [0-0] [Type Unit]:
+                                            Stmt 127 [0-0]: Expr: Expr 128 [0-0] [Type Unit]: Expr Block: Block 51 [140-199] [Type Unit]:
+                                                Stmt 52 [158-163]: Semi: Expr 53 [158-162] [Type Unit]: Call:
+                                                    Expr 54 [158-159] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                    Expr 55 [160-161] [Type Int]: Lit: Int(1)
+                                                Stmt 56 [180-185]: Semi: Expr 57 [180-184] [Type Unit]: Call:
+                                                    Expr 58 [180-181] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                    Expr 59 [182-183] [Type Int]: Lit: Int(2)
+                                            Stmt 123 [0-0]: Local (Immutable):
+                                                Pat 124 [0-0] [Type Unit]: Bind: Ident 122 [0-0] "apply_res"
+                                                Expr 125 [0-0] [Type Unit]: Expr Block: Block 60 [218-277] [Type Unit]:
+                                                    Stmt 61 [258-263]: Semi: Expr 62 [258-262] [Type Unit]: Call:
+                                                        Expr 63 [258-259] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                            Expr 64 [258-259] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                        Expr 65 [260-261] [Type Int]: Lit: Int(4)
+                                                    Stmt 66 [236-241]: Semi: Expr 67 [236-240] [Type Unit]: Call:
+                                                        Expr 68 [236-237] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                            Expr 69 [236-237] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                        Expr 70 [238-239] [Type Int]: Lit: Int(3)
+                                            Stmt 129 [0-0]: Expr: Expr 130 [0-0] [Type Unit]: Expr Block: Block 111 [140-199] [Type Unit]:
+                                                Stmt 112 [180-185]: Semi: Expr 113 [180-184] [Type Unit]: Call:
+                                                    Expr 114 [180-181] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                        Expr 115 [180-181] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                    Expr 116 [182-183] [Type Int]: Lit: Int(2)
+                                                Stmt 117 [158-163]: Semi: Expr 118 [158-162] [Type Unit]: Call:
+                                                    Expr 119 [158-159] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                        Expr 120 [158-159] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                    Expr 121 [160-161] [Type Int]: Lit: Int(1)
+                                            Stmt 131 [0-0]: Expr: Expr 132 [0-0] [Type Unit]: Var: Local 122
+                                        Stmt 71 [115-120]: Semi: Expr 72 [115-119] [Type Unit]: Call:
+                                            Expr 73 [115-116] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 74 [115-116] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 75 [117-118] [Type Int]: Lit: Int(0)
+                                    Stmt 85 [0-0]: Expr: Expr 86 [0-0] [Type Unit]: Var: Local 76
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -464,6 +464,7 @@ fn conjugate_mutable_correct_use_succeeds() {
                         let x = a;
                         B(1);
                         B(2);
+                        let y = x;
                     }
                     apply {
                         mutable b = a;
@@ -476,8 +477,8 @@ fn conjugate_mutable_correct_use_succeeds() {
         "},
         &expect![[r#"
             Package:
-                Item 0 [0-314] (Public):
-                    Namespace (Ident 47 [10-14] "Test"): Item 1, Item 2
+                Item 0 [0-337] (Public):
+                    Namespace (Ident 51 [10-14] "Test"): Item 1, Item 2
                 Item 1 [21-58] (Public):
                     Parent: 0
                     Callable 0 [21-58] (operation):
@@ -490,20 +491,20 @@ fn conjugate_mutable_correct_use_succeeds() {
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>
-                Item 2 [63-312] (Public):
+                Item 2 [63-335] (Public):
                     Parent: 0
-                    Callable 6 [63-312] (operation):
+                    Callable 6 [63-335] (operation):
                         name: Ident 7 [73-74] "A"
                         input: Pat 8 [74-76] [Type Unit]: Unit
                         output: Unit
                         functors: empty set
-                        body: SpecDecl 9 [63-312]: Impl:
-                            Block 10 [84-312] [Type Unit]:
+                        body: SpecDecl 9 [63-335]: Impl:
+                            Block 10 [84-335] [Type Unit]:
                                 Stmt 11 [94-108]: Local (Mutable):
                                     Pat 12 [102-103] [Type Int]: Bind: Ident 13 [102-103] "a"
                                     Expr 14 [106-107] [Type Int]: Lit: Int(1)
-                                Stmt 15 [117-306]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block _id_ [0-0] [Type Unit]:
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 17 [124-194] [Type Unit]:
+                                Stmt 15 [117-329]: Expr: Expr 82 [0-0] [Type Unit]: Expr Block: Block 75 [0-0] [Type Unit]:
+                                    Stmt 76 [0-0]: Expr: Expr 77 [0-0] [Type Unit]: Expr Block: Block 17 [124-217] [Type Unit]:
                                         Stmt 18 [138-148]: Local (Immutable):
                                             Pat 19 [142-143] [Type Int]: Bind: Ident 20 [142-143] "x"
                                             Expr 21 [146-147] [Type Int]: Var: Local 13
@@ -513,34 +514,40 @@ fn conjugate_mutable_correct_use_succeeds() {
                                         Stmt 26 [179-184]: Semi: Expr 27 [179-183] [Type Unit]: Call:
                                             Expr 28 [179-180] [Type (Int => Unit is Adj)]: Var: Item 1
                                             Expr 29 [181-182] [Type Int]: Lit: Int(2)
-                                    Stmt 49 [0-0]: Local (Immutable):
-                                        Pat 50 [0-0] [Type Unit]: Bind: Ident 48 [0-0] "apply_res"
-                                        Expr _id_ [0-0] [Type Unit]: Expr Block: Block 30 [209-306] [Type Unit]:
-                                            Stmt 31 [223-237]: Local (Mutable):
-                                                Pat 32 [231-232] [Type Int]: Bind: Ident 33 [231-232] "b"
-                                                Expr 34 [235-236] [Type Int]: Var: Local 13
-                                            Stmt 35 [250-260]: Semi: Expr 36 [250-259] [Type Unit]: Assign:
-                                                Expr 37 [254-255] [Type Int]: Var: Local 33
-                                                Expr 38 [258-259] [Type Int]: Lit: Int(0)
-                                            Stmt 39 [273-278]: Semi: Expr 40 [273-277] [Type Unit]: Call:
-                                                Expr 41 [273-274] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 42 [275-276] [Type Int]: Lit: Int(3)
-                                            Stmt 43 [291-296]: Semi: Expr 44 [291-295] [Type Unit]: Call:
-                                                Expr 45 [291-292] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 46 [293-294] [Type Int]: Lit: Int(4)
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block 17 [124-194] [Type Unit]:
-                                        Stmt 18 [138-148]: Local (Immutable):
-                                            Pat 19 [142-143] [Type Int]: Bind: Ident 20 [142-143] "x"
-                                            Expr 21 [146-147] [Type Int]: Var: Local 13
-                                        Stmt 26 [179-184]: Semi: Expr 27 [179-183] [Type Unit]: Call:
-                                            Expr _id_ [179-180] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 28 [179-180] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 29 [181-182] [Type Int]: Lit: Int(2)
-                                        Stmt 22 [161-166]: Semi: Expr 23 [161-165] [Type Unit]: Call:
-                                            Expr _id_ [161-162] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 24 [161-162] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 25 [163-164] [Type Int]: Lit: Int(1)
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: Var: Local 48
+                                        Stmt 30 [197-207]: Local (Immutable):
+                                            Pat 31 [201-202] [Type Int]: Bind: Ident 32 [201-202] "y"
+                                            Expr 33 [205-206] [Type Int]: Var: Local 20
+                                    Stmt 72 [0-0]: Local (Immutable):
+                                        Pat 73 [0-0] [Type Unit]: Bind: Ident 71 [0-0] "apply_res"
+                                        Expr 74 [0-0] [Type Unit]: Expr Block: Block 34 [232-329] [Type Unit]:
+                                            Stmt 35 [246-260]: Local (Mutable):
+                                                Pat 36 [254-255] [Type Int]: Bind: Ident 37 [254-255] "b"
+                                                Expr 38 [258-259] [Type Int]: Var: Local 13
+                                            Stmt 39 [273-283]: Semi: Expr 40 [273-282] [Type Unit]: Assign:
+                                                Expr 41 [277-278] [Type Int]: Var: Local 37
+                                                Expr 42 [281-282] [Type Int]: Lit: Int(0)
+                                            Stmt 43 [296-301]: Semi: Expr 44 [296-300] [Type Unit]: Call:
+                                                Expr 45 [296-297] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 46 [298-299] [Type Int]: Lit: Int(3)
+                                            Stmt 47 [314-319]: Semi: Expr 48 [314-318] [Type Unit]: Call:
+                                                Expr 49 [314-315] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 50 [316-317] [Type Int]: Lit: Int(4)
+                                    Stmt 78 [0-0]: Expr: Expr 79 [0-0] [Type Unit]: Expr Block: Block 52 [124-217] [Type Unit]:
+                                        Stmt 53 [138-148]: Local (Immutable):
+                                            Pat 54 [142-143] [Type Int]: Bind: Ident 55 [142-143] "x"
+                                            Expr 56 [146-147] [Type Int]: Var: Local 13
+                                        Stmt 57 [197-207]: Local (Immutable):
+                                            Pat 58 [201-202] [Type Int]: Bind: Ident 59 [201-202] "y"
+                                            Expr 60 [205-206] [Type Int]: Var: Local 55
+                                        Stmt 61 [179-184]: Semi: Expr 62 [179-183] [Type Unit]: Call:
+                                            Expr 63 [179-180] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 64 [179-180] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 65 [181-182] [Type Int]: Lit: Int(2)
+                                        Stmt 66 [161-166]: Semi: Expr 67 [161-165] [Type Unit]: Call:
+                                            Expr 68 [161-162] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 69 [161-162] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 70 [163-164] [Type Int]: Lit: Int(1)
+                                    Stmt 80 [0-0]: Expr: Expr 81 [0-0] [Type Unit]: Var: Local 71
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -4,22 +4,25 @@
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_frontend::compile::{self, compile, PackageStore, SourceMap};
-use qsc_hir::hir::{Expr, Package};
+use qsc_hir::{
+    assigner::Assigner,
+    hir::{Expr, Package},
+};
 
 /// Extracts a single entry point callable declaration, if found.
 /// # Errors
 /// Returns an error if a single entry point with no parameters cannot be found.
-fn extract_entry(package: &Package) -> Result<Expr, Vec<crate::Error>> {
+fn extract_entry(assigner: &mut Assigner, package: &Package) -> Result<Expr, Vec<crate::Error>> {
     let callables = super::get_callables(package);
-    super::create_entry_from_callables(callables)
+    super::create_entry_from_callables(assigner, callables)
 }
 
 fn check(file: &str, expr: &str, expect: &Expect) {
     let sources = SourceMap::new([("test".into(), file.into())], Some(expr.into()));
-    let unit = compile(&PackageStore::new(compile::core()), &[], sources);
+    let mut unit = compile(&PackageStore::new(compile::core()), &[], sources);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 
-    match extract_entry(&unit.package) {
+    match extract_entry(&mut unit.assigner, &unit.package) {
         Ok(entry) => expect.assert_eq(&entry.to_string()),
         Err(errors) => expect.assert_debug_eq(&errors),
     }
@@ -35,9 +38,9 @@ fn test_entry_point_attr_to_expr() {
             }"},
         "",
         &expect![[r#"
-            Expr _id_ [39-72] [Type Int]: Call:
-                Expr _id_ [39-72] [Type Int]: Var: Item 1
-                Expr _id_ [39-72] [Type Unit]: Unit"#]],
+            Expr 12 [39-72] [Type Int]: Call:
+                Expr 11 [39-72] [Type Int]: Var: Item 1
+                Expr 10 [39-72] [Type Unit]: Unit"#]],
     );
 }
 

--- a/compiler/qsc_passes/src/id_update.rs
+++ b/compiler/qsc_passes/src/id_update.rs
@@ -75,16 +75,12 @@ impl MutVisitor for NodeIdRefresher<'_> {
 
         match &mut expr.kind {
             ExprKind::Closure(captures, _) => {
-                *captures = captures.iter_mut().map(|id| self.freshen_id(*id)).collect();
+                *captures = captures.iter_mut().map(|id| self.replace_id(*id)).collect();
             }
             ExprKind::Var(Res::Local(id), _) => {
                 *id = self.replace_id(*id);
             }
             _ => {}
-        }
-
-        if let ExprKind::Closure(captures, _) = &mut expr.kind {
-            *captures = captures.iter_mut().map(|id| self.freshen_id(*id)).collect();
         }
 
         walk_expr(self, expr);

--- a/compiler/qsc_passes/src/id_update.rs
+++ b/compiler/qsc_passes/src/id_update.rs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::{hash_map::Entry, HashMap};
+
+use qsc_hir::{
+    assigner::Assigner,
+    hir::{
+        Block, CallableDecl, Expr, ExprKind, Ident, NodeId, Pat, QubitInit, Res, SpecDecl, Stmt,
+    },
+    mut_visit::{
+        walk_block, walk_callable_decl, walk_expr, walk_ident, walk_pat, walk_qubit_init,
+        walk_spec_decl, walk_stmt, MutVisitor,
+    },
+};
+
+pub(crate) struct NodeIdRefresher<'a> {
+    assigner: &'a mut Assigner,
+    replacements: HashMap<NodeId, NodeId>,
+}
+
+impl<'a> NodeIdRefresher<'a> {
+    pub(crate) fn new(assigner: &'a mut Assigner) -> Self {
+        Self {
+            assigner,
+            replacements: HashMap::new(),
+        }
+    }
+
+    fn freshen_id(&mut self, id: NodeId) -> NodeId {
+        if id.is_default() {
+            return self.assigner.next_node();
+        }
+        match self.replacements.entry(id) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let new_id = self.assigner.next_node();
+                entry.insert(new_id);
+                new_id
+            }
+        }
+    }
+
+    fn replace_id(&mut self, id: NodeId) -> NodeId {
+        match self.replacements.get(&id) {
+            Some(new_id) => *new_id,
+            None => id,
+        }
+    }
+}
+
+impl MutVisitor for NodeIdRefresher<'_> {
+    fn visit_callable_decl(&mut self, decl: &mut CallableDecl) {
+        decl.id = self.freshen_id(decl.id);
+        walk_callable_decl(self, decl);
+    }
+
+    fn visit_spec_decl(&mut self, decl: &mut SpecDecl) {
+        decl.id = self.freshen_id(decl.id);
+        walk_spec_decl(self, decl);
+    }
+
+    fn visit_block(&mut self, block: &mut Block) {
+        block.id = self.freshen_id(block.id);
+        walk_block(self, block);
+    }
+
+    fn visit_stmt(&mut self, stmt: &mut Stmt) {
+        stmt.id = self.freshen_id(stmt.id);
+        walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &mut Expr) {
+        expr.id = self.freshen_id(expr.id);
+
+        match &mut expr.kind {
+            ExprKind::Closure(captures, _) => {
+                *captures = captures.iter_mut().map(|id| self.freshen_id(*id)).collect();
+            }
+            ExprKind::Var(Res::Local(id), _) => {
+                *id = self.replace_id(*id);
+            }
+            _ => {}
+        }
+
+        if let ExprKind::Closure(captures, _) = &mut expr.kind {
+            *captures = captures.iter_mut().map(|id| self.freshen_id(*id)).collect();
+        }
+
+        walk_expr(self, expr);
+    }
+
+    fn visit_pat(&mut self, pat: &mut Pat) {
+        pat.id = self.freshen_id(pat.id);
+        walk_pat(self, pat);
+    }
+
+    fn visit_qubit_init(&mut self, init: &mut QubitInit) {
+        init.id = self.freshen_id(init.id);
+        walk_qubit_init(self, init);
+    }
+
+    fn visit_ident(&mut self, ident: &mut Ident) {
+        ident.id = self.freshen_id(ident.id);
+        walk_ident(self, ident);
+    }
+}

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -8,6 +8,7 @@ mod callable_limits;
 mod common;
 mod conjugate_invert;
 pub mod entry_point;
+mod id_update;
 mod invert_block;
 mod logic_sep;
 mod loop_unification;

--- a/compiler/qsc_passes/src/loop_unification/tests.rs
+++ b/compiler/qsc_passes/src/loop_unification/tests.rs
@@ -48,38 +48,38 @@ fn convert_for_array() {
                         functors: empty set
                         body: SpecDecl 4 [21-131]: Impl:
                             Block 5 [56-131] [Type Unit]:
-                                Stmt 6 [66-125]: Expr: Expr _id_ [66-125] [Type Unit]: Expr Block: Block _id_ [66-125] [Type Unit]:
-                                    Stmt _id_ [75-78]: Local (Immutable):
-                                        Pat _id_ [75-78] [Type (Int)[]]: Bind: Ident 17 [75-78] "array_id_17"
+                                Stmt 6 [66-125]: Expr: Expr 43 [66-125] [Type Unit]: Expr Block: Block 44 [66-125] [Type Unit]:
+                                    Stmt 18 [75-78]: Local (Immutable):
+                                        Pat 19 [75-78] [Type (Int)[]]: Bind: Ident 17 [75-78] "array_id_17"
                                         Expr 10 [75-78] [Type (Int)[]]: Var: Local 3
-                                    Stmt _id_ [75-78]: Local (Immutable):
-                                        Pat _id_ [75-78] [Type Int]: Bind: Ident 18 [75-78] "len_id_18"
-                                        Expr _id_ [75-78] [Type (Int)[]]: Call:
-                                            Expr _id_ [75-78] [Type ((Int)[] -> Int)]: Var:
+                                    Stmt 24 [75-78]: Local (Immutable):
+                                        Pat 25 [75-78] [Type Int]: Bind: Ident 21 [75-78] "len_id_21"
+                                        Expr 22 [75-78] [Type (Int)[]]: Call:
+                                            Expr 20 [75-78] [Type ((Int)[] -> Int)]: Var:
                                                 res: Item 1 (Package 0)
                                                 generics:
                                                     Int
-                                            Expr _id_ [75-78] [Type (Int)[]]: Var: Local 17
-                                    Stmt _id_ [75-78]: Local (Mutable):
-                                        Pat _id_ [75-78] [Type Int]: Bind: Ident 19 [75-78] "index_id_19"
-                                        Expr _id_ [75-78] [Type Int]: Lit: Int(0)
-                                    Stmt _id_ [66-125]: Expr: Expr _id_ [66-125] [Type Unit]: While:
-                                        Expr _id_ [75-78] [Type Bool]: BinOp (Lt):
-                                            Expr _id_ [75-78] [Type Int]: Var: Local 19
-                                            Expr _id_ [75-78] [Type Int]: Var: Local 18
+                                            Expr 23 [75-78] [Type (Int)[]]: Var: Local 17
+                                    Stmt 28 [75-78]: Local (Mutable):
+                                        Pat 29 [75-78] [Type Int]: Bind: Ident 26 [75-78] "index_id_26"
+                                        Expr 27 [75-78] [Type Int]: Lit: Int(0)
+                                    Stmt 41 [66-125]: Expr: Expr 42 [66-125] [Type Unit]: While:
+                                        Expr 38 [75-78] [Type Bool]: BinOp (Lt):
+                                            Expr 39 [75-78] [Type Int]: Var: Local 26
+                                            Expr 40 [75-78] [Type Int]: Var: Local 21
                                         Block 11 [79-125] [Type Unit]:
-                                            Stmt _id_ [66-125]: Local (Immutable):
+                                            Stmt 30 [66-125]: Local (Immutable):
                                                 Pat 8 [70-71] [Type Int]: Bind: Ident 9 [70-71] "i"
-                                                Expr _id_ [75-78] [Type Int]: Index:
-                                                    Expr _id_ [75-78] [Type (Int)[]]: Var: Local 17
-                                                    Expr _id_ [75-78] [Type Int]: Var: Local 19
+                                                Expr 31 [75-78] [Type Int]: Index:
+                                                    Expr 32 [75-78] [Type (Int)[]]: Var: Local 17
+                                                    Expr 33 [75-78] [Type Int]: Var: Local 26
                                             Stmt 12 [93-115]: Local (Immutable):
                                                 Pat 13 [97-98] [Type String]: Bind: Ident 14 [97-98] "x"
                                                 Expr 15 [101-114] [Type String]: String:
                                                     Lit: "Hello World"
-                                            Stmt _id_ [75-78]: Semi: Expr _id_ [75-78] [Type Unit]: AssignOp (Add):
-                                                Expr _id_ [75-78] [Type Int]: Var: Local 19
-                                                Expr _id_ [75-78] [Type Int]: Lit: Int(1)
+                                            Stmt 35 [75-78]: Semi: Expr 36 [75-78] [Type Unit]: AssignOp (Add):
+                                                Expr 37 [75-78] [Type Int]: Var: Local 26
+                                                Expr 34 [75-78] [Type Int]: Lit: Int(1)
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -111,40 +111,40 @@ fn convert_for_array_deconstruct() {
                         functors: empty set
                         body: SpecDecl 4 [21-146]: Impl:
                             Block 5 [66-146] [Type Unit]:
-                                Stmt 6 [76-140]: Expr: Expr _id_ [76-140] [Type Unit]: Expr Block: Block _id_ [76-140] [Type Unit]:
-                                    Stmt _id_ [90-93]: Local (Immutable):
-                                        Pat _id_ [90-93] [Type ((Int, Double))[]]: Bind: Ident 20 [90-93] "array_id_20"
+                                Stmt 6 [76-140]: Expr: Expr 46 [76-140] [Type Unit]: Expr Block: Block 47 [76-140] [Type Unit]:
+                                    Stmt 21 [90-93]: Local (Immutable):
+                                        Pat 22 [90-93] [Type ((Int, Double))[]]: Bind: Ident 20 [90-93] "array_id_20"
                                         Expr 13 [90-93] [Type ((Int, Double))[]]: Var: Local 3
-                                    Stmt _id_ [90-93]: Local (Immutable):
-                                        Pat _id_ [90-93] [Type Int]: Bind: Ident 21 [90-93] "len_id_21"
-                                        Expr _id_ [90-93] [Type ((Int, Double))[]]: Call:
-                                            Expr _id_ [90-93] [Type (((Int, Double))[] -> Int)]: Var:
+                                    Stmt 27 [90-93]: Local (Immutable):
+                                        Pat 28 [90-93] [Type Int]: Bind: Ident 24 [90-93] "len_id_24"
+                                        Expr 25 [90-93] [Type ((Int, Double))[]]: Call:
+                                            Expr 23 [90-93] [Type (((Int, Double))[] -> Int)]: Var:
                                                 res: Item 1 (Package 0)
                                                 generics:
                                                     (Int, Double)
-                                            Expr _id_ [90-93] [Type ((Int, Double))[]]: Var: Local 20
-                                    Stmt _id_ [90-93]: Local (Mutable):
-                                        Pat _id_ [90-93] [Type Int]: Bind: Ident 22 [90-93] "index_id_22"
-                                        Expr _id_ [90-93] [Type Int]: Lit: Int(0)
-                                    Stmt _id_ [76-140]: Expr: Expr _id_ [76-140] [Type Unit]: While:
-                                        Expr _id_ [90-93] [Type Bool]: BinOp (Lt):
-                                            Expr _id_ [90-93] [Type Int]: Var: Local 22
-                                            Expr _id_ [90-93] [Type Int]: Var: Local 21
+                                            Expr 26 [90-93] [Type ((Int, Double))[]]: Var: Local 20
+                                    Stmt 31 [90-93]: Local (Mutable):
+                                        Pat 32 [90-93] [Type Int]: Bind: Ident 29 [90-93] "index_id_29"
+                                        Expr 30 [90-93] [Type Int]: Lit: Int(0)
+                                    Stmt 44 [76-140]: Expr: Expr 45 [76-140] [Type Unit]: While:
+                                        Expr 41 [90-93] [Type Bool]: BinOp (Lt):
+                                            Expr 42 [90-93] [Type Int]: Var: Local 29
+                                            Expr 43 [90-93] [Type Int]: Var: Local 24
                                         Block 14 [94-140] [Type Unit]:
-                                            Stmt _id_ [76-140]: Local (Immutable):
+                                            Stmt 33 [76-140]: Local (Immutable):
                                                 Pat 8 [80-86] [Type (Int, Double)]: Tuple:
                                                     Pat 9 [81-82] [Type Int]: Bind: Ident 10 [81-82] "i"
                                                     Pat 11 [84-85] [Type Double]: Bind: Ident 12 [84-85] "d"
-                                                Expr _id_ [90-93] [Type (Int, Double)]: Index:
-                                                    Expr _id_ [90-93] [Type ((Int, Double))[]]: Var: Local 20
-                                                    Expr _id_ [90-93] [Type Int]: Var: Local 22
+                                                Expr 34 [90-93] [Type (Int, Double)]: Index:
+                                                    Expr 35 [90-93] [Type ((Int, Double))[]]: Var: Local 20
+                                                    Expr 36 [90-93] [Type Int]: Var: Local 29
                                             Stmt 15 [108-130]: Local (Immutable):
                                                 Pat 16 [112-113] [Type String]: Bind: Ident 17 [112-113] "x"
                                                 Expr 18 [116-129] [Type String]: String:
                                                     Lit: "Hello World"
-                                            Stmt _id_ [90-93]: Semi: Expr _id_ [90-93] [Type Unit]: AssignOp (Add):
-                                                Expr _id_ [90-93] [Type Int]: Var: Local 22
-                                                Expr _id_ [90-93] [Type Int]: Lit: Int(1)
+                                            Stmt 38 [90-93]: Semi: Expr 39 [90-93] [Type Unit]: AssignOp (Add):
+                                                Expr 40 [90-93] [Type Int]: Var: Local 29
+                                                Expr 37 [90-93] [Type Int]: Lit: Int(1)
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -176,9 +176,9 @@ fn convert_for_slice() {
                         functors: empty set
                         body: SpecDecl 4 [21-141]: Impl:
                             Block 5 [56-141] [Type Unit]:
-                                Stmt 6 [66-135]: Expr: Expr _id_ [66-135] [Type Unit]: Expr Block: Block _id_ [66-135] [Type Unit]:
-                                    Stmt _id_ [75-88]: Local (Immutable):
-                                        Pat _id_ [75-88] [Type (Int)[]]: Bind: Ident 23 [75-88] "array_id_23"
+                                Stmt 6 [66-135]: Expr: Expr 49 [66-135] [Type Unit]: Expr Block: Block 50 [66-135] [Type Unit]:
+                                    Stmt 24 [75-88]: Local (Immutable):
+                                        Pat 25 [75-88] [Type (Int)[]]: Bind: Ident 23 [75-88] "array_id_23"
                                         Expr 10 [75-88] [Type (Int)[]]: Index:
                                             Expr 11 [75-78] [Type (Int)[]]: Var: Local 3
                                             Expr 12 [79-87] [Type Range]: Range:
@@ -186,34 +186,34 @@ fn convert_for_slice() {
                                                 Expr 14 [82-84] [Type Int]: UnOp (Neg):
                                                     Expr 15 [83-84] [Type Int]: Lit: Int(2)
                                                 Expr 16 [86-87] [Type Int]: Lit: Int(2)
-                                    Stmt _id_ [75-88]: Local (Immutable):
-                                        Pat _id_ [75-88] [Type Int]: Bind: Ident 24 [75-88] "len_id_24"
-                                        Expr _id_ [75-88] [Type (Int)[]]: Call:
-                                            Expr _id_ [75-88] [Type ((Int)[] -> Int)]: Var:
+                                    Stmt 30 [75-88]: Local (Immutable):
+                                        Pat 31 [75-88] [Type Int]: Bind: Ident 27 [75-88] "len_id_27"
+                                        Expr 28 [75-88] [Type (Int)[]]: Call:
+                                            Expr 26 [75-88] [Type ((Int)[] -> Int)]: Var:
                                                 res: Item 1 (Package 0)
                                                 generics:
                                                     Int
-                                            Expr _id_ [75-88] [Type (Int)[]]: Var: Local 23
-                                    Stmt _id_ [75-88]: Local (Mutable):
-                                        Pat _id_ [75-88] [Type Int]: Bind: Ident 25 [75-88] "index_id_25"
-                                        Expr _id_ [75-88] [Type Int]: Lit: Int(0)
-                                    Stmt _id_ [66-135]: Expr: Expr _id_ [66-135] [Type Unit]: While:
-                                        Expr _id_ [75-88] [Type Bool]: BinOp (Lt):
-                                            Expr _id_ [75-88] [Type Int]: Var: Local 25
-                                            Expr _id_ [75-88] [Type Int]: Var: Local 24
+                                            Expr 29 [75-88] [Type (Int)[]]: Var: Local 23
+                                    Stmt 34 [75-88]: Local (Mutable):
+                                        Pat 35 [75-88] [Type Int]: Bind: Ident 32 [75-88] "index_id_32"
+                                        Expr 33 [75-88] [Type Int]: Lit: Int(0)
+                                    Stmt 47 [66-135]: Expr: Expr 48 [66-135] [Type Unit]: While:
+                                        Expr 44 [75-88] [Type Bool]: BinOp (Lt):
+                                            Expr 45 [75-88] [Type Int]: Var: Local 32
+                                            Expr 46 [75-88] [Type Int]: Var: Local 27
                                         Block 17 [89-135] [Type Unit]:
-                                            Stmt _id_ [66-135]: Local (Immutable):
+                                            Stmt 36 [66-135]: Local (Immutable):
                                                 Pat 8 [70-71] [Type Int]: Bind: Ident 9 [70-71] "i"
-                                                Expr _id_ [75-88] [Type Int]: Index:
-                                                    Expr _id_ [75-88] [Type (Int)[]]: Var: Local 23
-                                                    Expr _id_ [75-88] [Type Int]: Var: Local 25
+                                                Expr 37 [75-88] [Type Int]: Index:
+                                                    Expr 38 [75-88] [Type (Int)[]]: Var: Local 23
+                                                    Expr 39 [75-88] [Type Int]: Var: Local 32
                                             Stmt 18 [103-125]: Local (Immutable):
                                                 Pat 19 [107-108] [Type String]: Bind: Ident 20 [107-108] "x"
                                                 Expr 21 [111-124] [Type String]: String:
                                                     Lit: "Hello World"
-                                            Stmt _id_ [75-88]: Semi: Expr _id_ [75-88] [Type Unit]: AssignOp (Add):
-                                                Expr _id_ [75-88] [Type Int]: Var: Local 25
-                                                Expr _id_ [75-88] [Type Int]: Lit: Int(1)
+                                            Stmt 41 [75-88]: Semi: Expr 42 [75-88] [Type Unit]: AssignOp (Add):
+                                                Expr 43 [75-88] [Type Int]: Var: Local 32
+                                                Expr 40 [75-88] [Type Int]: Lit: Int(1)
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -245,55 +245,55 @@ fn convert_for_range() {
                         functors: empty set
                         body: SpecDecl 3 [21-121]: Impl:
                             Block 4 [45-121] [Type Unit]:
-                                Stmt 5 [55-115]: Expr: Expr _id_ [55-115] [Type Unit]: Expr Block: Block _id_ [55-115] [Type Unit]:
-                                    Stmt _id_ [64-68]: Local (Immutable):
-                                        Pat _id_ [64-68] [Type Range]: Bind: Ident 18 [64-68] "range_id_18"
+                                Stmt 5 [55-115]: Expr: Expr 59 [55-115] [Type Unit]: Expr Block: Block 60 [55-115] [Type Unit]:
+                                    Stmt 19 [64-68]: Local (Immutable):
+                                        Pat 20 [64-68] [Type Range]: Bind: Ident 18 [64-68] "range_id_18"
                                         Expr 9 [64-68] [Type Range]: Range:
                                             Expr 10 [64-65] [Type Int]: Lit: Int(0)
                                             <no step>
                                             Expr 11 [67-68] [Type Int]: Lit: Int(4)
-                                    Stmt _id_ [64-68]: Local (Mutable):
-                                        Pat _id_ [64-68] [Type Int]: Bind: Ident 19 [64-68] "index_id_19"
-                                        Expr _id_ [64-68] [Type Int]: Field:
-                                            Expr _id_ [64-68] [Type Range]: Var: Local 18
+                                    Stmt 24 [64-68]: Local (Mutable):
+                                        Pat 25 [64-68] [Type Int]: Bind: Ident 21 [64-68] "index_id_21"
+                                        Expr 22 [64-68] [Type Int]: Field:
+                                            Expr 23 [64-68] [Type Range]: Var: Local 18
                                             Prim(Start)
-                                    Stmt _id_ [64-68]: Local (Immutable):
-                                        Pat _id_ [64-68] [Type Int]: Bind: Ident 20 [64-68] "step_id_20"
-                                        Expr _id_ [64-68] [Type Int]: Field:
-                                            Expr _id_ [64-68] [Type Range]: Var: Local 18
+                                    Stmt 29 [64-68]: Local (Immutable):
+                                        Pat 30 [64-68] [Type Int]: Bind: Ident 26 [64-68] "step_id_26"
+                                        Expr 27 [64-68] [Type Int]: Field:
+                                            Expr 28 [64-68] [Type Range]: Var: Local 18
                                             Prim(Step)
-                                    Stmt _id_ [64-68]: Local (Immutable):
-                                        Pat _id_ [64-68] [Type Int]: Bind: Ident 21 [64-68] "end_id_21"
-                                        Expr _id_ [64-68] [Type Int]: Field:
-                                            Expr _id_ [64-68] [Type Range]: Var: Local 18
+                                    Stmt 34 [64-68]: Local (Immutable):
+                                        Pat 35 [64-68] [Type Int]: Bind: Ident 31 [64-68] "end_id_31"
+                                        Expr 32 [64-68] [Type Int]: Field:
+                                            Expr 33 [64-68] [Type Range]: Var: Local 18
                                             Prim(End)
-                                    Stmt _id_ [55-115]: Expr: Expr _id_ [55-115] [Type Unit]: While:
-                                        Expr _id_ [64-68] [Type Bool]: BinOp (OrL):
-                                            Expr _id_ [64-68] [Type Bool]: BinOp (AndL):
-                                                Expr _id_ [64-68] [Type Bool]: BinOp (Gt):
-                                                    Expr _id_ [64-68] [Type Int]: Var: Local 20
-                                                    Expr _id_ [64-68] [Type Int]: Lit: Int(0)
-                                                Expr _id_ [64-68] [Type Bool]: BinOp (Lte):
-                                                    Expr _id_ [64-68] [Type Int]: Var: Local 19
-                                                    Expr _id_ [64-68] [Type Int]: Var: Local 21
-                                            Expr _id_ [64-68] [Type Bool]: BinOp (AndL):
-                                                Expr _id_ [64-68] [Type Bool]: BinOp (Lt):
-                                                    Expr _id_ [64-68] [Type Int]: Var: Local 20
-                                                    Expr _id_ [64-68] [Type Int]: Lit: Int(0)
-                                                Expr _id_ [64-68] [Type Bool]: BinOp (Gte):
-                                                    Expr _id_ [64-68] [Type Int]: Var: Local 19
-                                                    Expr _id_ [64-68] [Type Int]: Var: Local 21
+                                    Stmt 57 [55-115]: Expr: Expr 58 [55-115] [Type Unit]: While:
+                                        Expr 42 [64-68] [Type Bool]: BinOp (OrL):
+                                            Expr 43 [64-68] [Type Bool]: BinOp (AndL):
+                                                Expr 44 [64-68] [Type Bool]: BinOp (Gt):
+                                                    Expr 45 [64-68] [Type Int]: Var: Local 26
+                                                    Expr 46 [64-68] [Type Int]: Lit: Int(0)
+                                                Expr 47 [64-68] [Type Bool]: BinOp (Lte):
+                                                    Expr 48 [64-68] [Type Int]: Var: Local 21
+                                                    Expr 49 [64-68] [Type Int]: Var: Local 31
+                                            Expr 50 [64-68] [Type Bool]: BinOp (AndL):
+                                                Expr 51 [64-68] [Type Bool]: BinOp (Lt):
+                                                    Expr 52 [64-68] [Type Int]: Var: Local 26
+                                                    Expr 53 [64-68] [Type Int]: Lit: Int(0)
+                                                Expr 54 [64-68] [Type Bool]: BinOp (Gte):
+                                                    Expr 55 [64-68] [Type Int]: Var: Local 21
+                                                    Expr 56 [64-68] [Type Int]: Var: Local 31
                                         Block 12 [69-115] [Type Unit]:
-                                            Stmt _id_ [55-115]: Local (Immutable):
+                                            Stmt 36 [55-115]: Local (Immutable):
                                                 Pat 7 [59-60] [Type Int]: Bind: Ident 8 [59-60] "i"
-                                                Expr _id_ [64-68] [Type Int]: Var: Local 19
+                                                Expr 37 [64-68] [Type Int]: Var: Local 21
                                             Stmt 13 [83-105]: Local (Immutable):
                                                 Pat 14 [87-88] [Type String]: Bind: Ident 15 [87-88] "x"
                                                 Expr 16 [91-104] [Type String]: String:
                                                     Lit: "Hello World"
-                                            Stmt _id_ [64-68]: Semi: Expr _id_ [64-68] [Type Unit]: AssignOp (Add):
-                                                Expr _id_ [64-68] [Type Int]: Var: Local 19
-                                                Expr _id_ [64-68] [Type Int]: Var: Local 20
+                                            Stmt 39 [64-68]: Semi: Expr 40 [64-68] [Type Unit]: AssignOp (Add):
+                                                Expr 41 [64-68] [Type Int]: Var: Local 21
+                                                Expr 38 [64-68] [Type Int]: Var: Local 26
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -325,56 +325,56 @@ fn convert_for_reverse_range() {
                         functors: empty set
                         body: SpecDecl 3 [21-125]: Impl:
                             Block 4 [45-125] [Type Unit]:
-                                Stmt 5 [55-119]: Expr: Expr _id_ [55-119] [Type Unit]: Expr Block: Block _id_ [55-119] [Type Unit]:
-                                    Stmt _id_ [64-72]: Local (Immutable):
-                                        Pat _id_ [64-72] [Type Range]: Bind: Ident 20 [64-72] "range_id_20"
+                                Stmt 5 [55-119]: Expr: Expr 61 [55-119] [Type Unit]: Expr Block: Block 62 [55-119] [Type Unit]:
+                                    Stmt 21 [64-72]: Local (Immutable):
+                                        Pat 22 [64-72] [Type Range]: Bind: Ident 20 [64-72] "range_id_20"
                                         Expr 9 [64-72] [Type Range]: Range:
                                             Expr 10 [64-65] [Type Int]: Lit: Int(4)
                                             Expr 11 [67-69] [Type Int]: UnOp (Neg):
                                                 Expr 12 [68-69] [Type Int]: Lit: Int(1)
                                             Expr 13 [71-72] [Type Int]: Lit: Int(0)
-                                    Stmt _id_ [64-72]: Local (Mutable):
-                                        Pat _id_ [64-72] [Type Int]: Bind: Ident 21 [64-72] "index_id_21"
-                                        Expr _id_ [64-72] [Type Int]: Field:
-                                            Expr _id_ [64-72] [Type Range]: Var: Local 20
+                                    Stmt 26 [64-72]: Local (Mutable):
+                                        Pat 27 [64-72] [Type Int]: Bind: Ident 23 [64-72] "index_id_23"
+                                        Expr 24 [64-72] [Type Int]: Field:
+                                            Expr 25 [64-72] [Type Range]: Var: Local 20
                                             Prim(Start)
-                                    Stmt _id_ [64-72]: Local (Immutable):
-                                        Pat _id_ [64-72] [Type Int]: Bind: Ident 22 [64-72] "step_id_22"
-                                        Expr _id_ [64-72] [Type Int]: Field:
-                                            Expr _id_ [64-72] [Type Range]: Var: Local 20
+                                    Stmt 31 [64-72]: Local (Immutable):
+                                        Pat 32 [64-72] [Type Int]: Bind: Ident 28 [64-72] "step_id_28"
+                                        Expr 29 [64-72] [Type Int]: Field:
+                                            Expr 30 [64-72] [Type Range]: Var: Local 20
                                             Prim(Step)
-                                    Stmt _id_ [64-72]: Local (Immutable):
-                                        Pat _id_ [64-72] [Type Int]: Bind: Ident 23 [64-72] "end_id_23"
-                                        Expr _id_ [64-72] [Type Int]: Field:
-                                            Expr _id_ [64-72] [Type Range]: Var: Local 20
+                                    Stmt 36 [64-72]: Local (Immutable):
+                                        Pat 37 [64-72] [Type Int]: Bind: Ident 33 [64-72] "end_id_33"
+                                        Expr 34 [64-72] [Type Int]: Field:
+                                            Expr 35 [64-72] [Type Range]: Var: Local 20
                                             Prim(End)
-                                    Stmt _id_ [55-119]: Expr: Expr _id_ [55-119] [Type Unit]: While:
-                                        Expr _id_ [64-72] [Type Bool]: BinOp (OrL):
-                                            Expr _id_ [64-72] [Type Bool]: BinOp (AndL):
-                                                Expr _id_ [64-72] [Type Bool]: BinOp (Gt):
-                                                    Expr _id_ [64-72] [Type Int]: Var: Local 22
-                                                    Expr _id_ [64-72] [Type Int]: Lit: Int(0)
-                                                Expr _id_ [64-72] [Type Bool]: BinOp (Lte):
-                                                    Expr _id_ [64-72] [Type Int]: Var: Local 21
-                                                    Expr _id_ [64-72] [Type Int]: Var: Local 23
-                                            Expr _id_ [64-72] [Type Bool]: BinOp (AndL):
-                                                Expr _id_ [64-72] [Type Bool]: BinOp (Lt):
-                                                    Expr _id_ [64-72] [Type Int]: Var: Local 22
-                                                    Expr _id_ [64-72] [Type Int]: Lit: Int(0)
-                                                Expr _id_ [64-72] [Type Bool]: BinOp (Gte):
-                                                    Expr _id_ [64-72] [Type Int]: Var: Local 21
-                                                    Expr _id_ [64-72] [Type Int]: Var: Local 23
+                                    Stmt 59 [55-119]: Expr: Expr 60 [55-119] [Type Unit]: While:
+                                        Expr 44 [64-72] [Type Bool]: BinOp (OrL):
+                                            Expr 45 [64-72] [Type Bool]: BinOp (AndL):
+                                                Expr 46 [64-72] [Type Bool]: BinOp (Gt):
+                                                    Expr 47 [64-72] [Type Int]: Var: Local 28
+                                                    Expr 48 [64-72] [Type Int]: Lit: Int(0)
+                                                Expr 49 [64-72] [Type Bool]: BinOp (Lte):
+                                                    Expr 50 [64-72] [Type Int]: Var: Local 23
+                                                    Expr 51 [64-72] [Type Int]: Var: Local 33
+                                            Expr 52 [64-72] [Type Bool]: BinOp (AndL):
+                                                Expr 53 [64-72] [Type Bool]: BinOp (Lt):
+                                                    Expr 54 [64-72] [Type Int]: Var: Local 28
+                                                    Expr 55 [64-72] [Type Int]: Lit: Int(0)
+                                                Expr 56 [64-72] [Type Bool]: BinOp (Gte):
+                                                    Expr 57 [64-72] [Type Int]: Var: Local 23
+                                                    Expr 58 [64-72] [Type Int]: Var: Local 33
                                         Block 14 [73-119] [Type Unit]:
-                                            Stmt _id_ [55-119]: Local (Immutable):
+                                            Stmt 38 [55-119]: Local (Immutable):
                                                 Pat 7 [59-60] [Type Int]: Bind: Ident 8 [59-60] "i"
-                                                Expr _id_ [64-72] [Type Int]: Var: Local 21
+                                                Expr 39 [64-72] [Type Int]: Var: Local 23
                                             Stmt 15 [87-109]: Local (Immutable):
                                                 Pat 16 [91-92] [Type String]: Bind: Ident 17 [91-92] "x"
                                                 Expr 18 [95-108] [Type String]: String:
                                                     Lit: "Hello World"
-                                            Stmt _id_ [64-72]: Semi: Expr _id_ [64-72] [Type Unit]: AssignOp (Add):
-                                                Expr _id_ [64-72] [Type Int]: Var: Local 21
-                                                Expr _id_ [64-72] [Type Int]: Var: Local 22
+                                            Stmt 41 [64-72]: Semi: Expr 42 [64-72] [Type Unit]: AssignOp (Add):
+                                                Expr 43 [64-72] [Type Int]: Var: Local 23
+                                                Expr 40 [64-72] [Type Int]: Var: Local 28
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -406,20 +406,20 @@ fn convert_repeat() {
                         functors: empty set
                         body: SpecDecl 3 [21-126]: Impl:
                             Block 4 [45-126] [Type Unit]:
-                                Stmt 5 [55-120]: Semi: Expr _id_ [55-119] [Type Unit]: Expr Block: Block _id_ [55-119] [Type Unit]:
-                                    Stmt _id_ [115-119]: Local (Mutable):
-                                        Pat _id_ [115-119] [Type Bool]: Bind: Ident 14 [115-119] "continue_cond_14"
-                                        Expr _id_ [115-119] [Type Bool]: Lit: Bool(true)
-                                    Stmt _id_ [55-119]: Expr: Expr _id_ [55-119] [Type Unit]: While:
-                                        Expr _id_ [115-119] [Type Bool]: Var: Local 14
+                                Stmt 5 [55-120]: Semi: Expr 26 [55-119] [Type Unit]: Expr Block: Block 22 [55-119] [Type Unit]:
+                                    Stmt 16 [115-119]: Local (Mutable):
+                                        Pat 17 [115-119] [Type Bool]: Bind: Ident 14 [115-119] "continue_cond_14"
+                                        Expr 15 [115-119] [Type Bool]: Lit: Bool(true)
+                                    Stmt 23 [55-119]: Expr: Expr 24 [55-119] [Type Unit]: While:
+                                        Expr 25 [115-119] [Type Bool]: Var: Local 14
                                         Block 7 [62-108] [Type Unit]:
                                             Stmt 8 [76-98]: Local (Immutable):
                                                 Pat 9 [80-81] [Type String]: Bind: Ident 10 [80-81] "x"
                                                 Expr 11 [84-97] [Type String]: String:
                                                     Lit: "Hello World"
-                                            Stmt _id_ [115-119]: Semi: Expr _id_ [115-119] [Type Unit]: Assign:
-                                                Expr _id_ [115-119] [Type Bool]: Var: Local 14
-                                                Expr _id_ [115-119] [Type Bool]: UnOp (NotL):
+                                            Stmt 18 [115-119]: Semi: Expr 19 [115-119] [Type Unit]: Assign:
+                                                Expr 20 [115-119] [Type Bool]: Var: Local 14
+                                                Expr 21 [115-119] [Type Bool]: UnOp (NotL):
                                                     Expr 12 [115-119] [Type Bool]: Lit: Bool(true)
                         adj: <none>
                         ctl: <none>
@@ -455,24 +455,24 @@ fn convert_repeat_fixup() {
                         functors: empty set
                         body: SpecDecl 3 [21-180]: Impl:
                             Block 4 [45-180] [Type Unit]:
-                                Stmt 5 [55-174]: Expr: Expr _id_ [55-174] [Type Unit]: Expr Block: Block _id_ [55-174] [Type Unit]:
-                                    Stmt _id_ [115-119]: Local (Mutable):
-                                        Pat _id_ [115-119] [Type Bool]: Bind: Ident 19 [115-119] "continue_cond_19"
-                                        Expr _id_ [115-119] [Type Bool]: Lit: Bool(true)
-                                    Stmt _id_ [55-174]: Expr: Expr _id_ [55-174] [Type Unit]: While:
-                                        Expr _id_ [115-119] [Type Bool]: Var: Local 19
+                                Stmt 5 [55-174]: Expr: Expr 35 [55-174] [Type Unit]: Expr Block: Block 31 [55-174] [Type Unit]:
+                                    Stmt 21 [115-119]: Local (Mutable):
+                                        Pat 22 [115-119] [Type Bool]: Bind: Ident 19 [115-119] "continue_cond_19"
+                                        Expr 20 [115-119] [Type Bool]: Lit: Bool(true)
+                                    Stmt 32 [55-174]: Expr: Expr 33 [55-174] [Type Unit]: While:
+                                        Expr 34 [115-119] [Type Bool]: Var: Local 19
                                         Block 7 [62-108] [Type Unit]:
                                             Stmt 8 [76-98]: Local (Immutable):
                                                 Pat 9 [80-81] [Type String]: Bind: Ident 10 [80-81] "x"
                                                 Expr 11 [84-97] [Type String]: String:
                                                     Lit: "Hello World"
-                                            Stmt _id_ [115-119]: Semi: Expr _id_ [115-119] [Type Unit]: Assign:
-                                                Expr _id_ [115-119] [Type Bool]: Var: Local 19
-                                                Expr _id_ [115-119] [Type Bool]: UnOp (NotL):
+                                            Stmt 23 [115-119]: Semi: Expr 24 [115-119] [Type Unit]: Assign:
+                                                Expr 25 [115-119] [Type Bool]: Var: Local 19
+                                                Expr 26 [115-119] [Type Bool]: UnOp (NotL):
                                                     Expr 12 [115-119] [Type Bool]: Lit: Bool(true)
-                                            Stmt _id_ [134-174]: Expr: Expr _id_ [134-174] [Type Unit]: If:
-                                                Expr _id_ [115-119] [Type Bool]: Var: Local 19
-                                                Expr _id_ [134-174] [Type Unit]: Expr Block: Block 13 [134-174] [Type Unit]:
+                                            Stmt 27 [134-174]: Expr: Expr 28 [134-174] [Type Unit]: If:
+                                                Expr 29 [115-119] [Type Bool]: Var: Local 19
+                                                Expr 30 [134-174] [Type Unit]: Expr Block: Block 13 [134-174] [Type Unit]:
                                                     Stmt 14 [148-164]: Local (Immutable):
                                                         Pat 15 [152-153] [Type String]: Bind: Ident 16 [152-153] "y"
                                                         Expr 17 [156-163] [Type String]: String:
@@ -530,56 +530,56 @@ fn convert_repeat_nested() {
                                 Stmt 13 [100-113]: Local (Immutable):
                                     Pat 14 [104-105] [Type Bool]: Bind: Ident 15 [104-105] "c"
                                     Expr 16 [108-112] [Type Bool]: Lit: Bool(true)
-                                Stmt 17 [122-395]: Expr: Expr _id_ [122-395] [Type Unit]: Expr Block: Block _id_ [122-395] [Type Unit]:
-                                    Stmt _id_ [291-292]: Local (Mutable):
-                                        Pat _id_ [291-292] [Type Bool]: Bind: Ident 46 [291-292] "continue_cond_46"
-                                        Expr _id_ [291-292] [Type Bool]: Lit: Bool(true)
-                                    Stmt _id_ [122-395]: Expr: Expr _id_ [122-395] [Type Unit]: While:
-                                        Expr _id_ [291-292] [Type Bool]: Var: Local 46
+                                Stmt 17 [122-395]: Expr: Expr 90 [122-395] [Type Unit]: Expr Block: Block 86 [122-395] [Type Unit]:
+                                    Stmt 76 [291-292]: Local (Mutable):
+                                        Pat 77 [291-292] [Type Bool]: Bind: Ident 74 [291-292] "continue_cond_74"
+                                        Expr 75 [291-292] [Type Bool]: Lit: Bool(true)
+                                    Stmt 87 [122-395]: Expr: Expr 88 [122-395] [Type Unit]: While:
+                                        Expr 89 [291-292] [Type Bool]: Var: Local 74
                                         Block 19 [129-284] [Type Unit]:
-                                            Stmt 20 [143-274]: Expr: Expr _id_ [143-274] [Type Unit]: Expr Block: Block _id_ [143-274] [Type Unit]:
-                                                Stmt _id_ [205-206]: Local (Mutable):
-                                                    Pat _id_ [205-206] [Type Bool]: Bind: Ident 44 [205-206] "continue_cond_44"
-                                                    Expr _id_ [205-206] [Type Bool]: Lit: Bool(true)
-                                                Stmt _id_ [143-274]: Expr: Expr _id_ [143-274] [Type Unit]: While:
-                                                    Expr _id_ [205-206] [Type Bool]: Var: Local 44
+                                            Stmt 20 [143-274]: Expr: Expr 60 [143-274] [Type Unit]: Expr Block: Block 56 [143-274] [Type Unit]:
+                                                Stmt 46 [205-206]: Local (Mutable):
+                                                    Pat 47 [205-206] [Type Bool]: Bind: Ident 44 [205-206] "continue_cond_44"
+                                                    Expr 45 [205-206] [Type Bool]: Lit: Bool(true)
+                                                Stmt 57 [143-274]: Expr: Expr 58 [143-274] [Type Unit]: While:
+                                                    Expr 59 [205-206] [Type Bool]: Var: Local 44
                                                     Block 22 [150-198] [Type Unit]:
                                                         Stmt 23 [168-184]: Local (Immutable):
                                                             Pat 24 [172-173] [Type String]: Bind: Ident 25 [172-173] "x"
                                                             Expr 26 [176-183] [Type String]: String:
                                                                 Lit: "First"
-                                                        Stmt _id_ [205-206]: Semi: Expr _id_ [205-206] [Type Unit]: Assign:
-                                                            Expr _id_ [205-206] [Type Bool]: Var: Local 44
-                                                            Expr _id_ [205-206] [Type Bool]: UnOp (NotL):
+                                                        Stmt 48 [205-206]: Semi: Expr 49 [205-206] [Type Unit]: Assign:
+                                                            Expr 50 [205-206] [Type Bool]: Var: Local 44
+                                                            Expr 51 [205-206] [Type Bool]: UnOp (NotL):
                                                                 Expr 27 [205-206] [Type Bool]: Var: Local 7
-                                                        Stmt _id_ [225-274]: Expr: Expr _id_ [225-274] [Type Unit]: If:
-                                                            Expr _id_ [205-206] [Type Bool]: Var: Local 44
-                                                            Expr _id_ [225-274] [Type Unit]: Expr Block: Block 28 [225-274] [Type Unit]:
+                                                        Stmt 52 [225-274]: Expr: Expr 53 [225-274] [Type Unit]: If:
+                                                            Expr 54 [205-206] [Type Bool]: Var: Local 44
+                                                            Expr 55 [225-274] [Type Unit]: Expr Block: Block 28 [225-274] [Type Unit]:
                                                                 Stmt 29 [243-260]: Local (Immutable):
                                                                     Pat 30 [247-248] [Type String]: Bind: Ident 31 [247-248] "y"
                                                                     Expr 32 [251-259] [Type String]: String:
                                                                         Lit: "Second"
-                                            Stmt _id_ [291-292]: Semi: Expr _id_ [291-292] [Type Unit]: Assign:
-                                                Expr _id_ [291-292] [Type Bool]: Var: Local 46
-                                                Expr _id_ [291-292] [Type Bool]: UnOp (NotL):
+                                            Stmt 78 [291-292]: Semi: Expr 79 [291-292] [Type Unit]: Assign:
+                                                Expr 80 [291-292] [Type Bool]: Var: Local 74
+                                                Expr 81 [291-292] [Type Bool]: UnOp (NotL):
                                                     Expr 33 [291-292] [Type Bool]: Var: Local 11
-                                            Stmt _id_ [307-395]: Expr: Expr _id_ [307-395] [Type Unit]: If:
-                                                Expr _id_ [291-292] [Type Bool]: Var: Local 46
-                                                Expr _id_ [307-395] [Type Unit]: Expr Block: Block 34 [307-395] [Type Unit]:
-                                                    Stmt 35 [321-385]: Semi: Expr _id_ [321-384] [Type Unit]: Expr Block: Block _id_ [321-384] [Type Unit]:
-                                                        Stmt _id_ [383-384]: Local (Mutable):
-                                                            Pat _id_ [383-384] [Type Bool]: Bind: Ident 45 [383-384] "continue_cond_45"
-                                                            Expr _id_ [383-384] [Type Bool]: Lit: Bool(true)
-                                                        Stmt _id_ [321-384]: Expr: Expr _id_ [321-384] [Type Unit]: While:
-                                                            Expr _id_ [383-384] [Type Bool]: Var: Local 45
+                                            Stmt 82 [307-395]: Expr: Expr 83 [307-395] [Type Unit]: If:
+                                                Expr 84 [291-292] [Type Bool]: Var: Local 74
+                                                Expr 85 [307-395] [Type Unit]: Expr Block: Block 34 [307-395] [Type Unit]:
+                                                    Stmt 35 [321-385]: Semi: Expr 73 [321-384] [Type Unit]: Expr Block: Block 69 [321-384] [Type Unit]:
+                                                        Stmt 63 [383-384]: Local (Mutable):
+                                                            Pat 64 [383-384] [Type Bool]: Bind: Ident 61 [383-384] "continue_cond_61"
+                                                            Expr 62 [383-384] [Type Bool]: Lit: Bool(true)
+                                                        Stmt 70 [321-384]: Expr: Expr 71 [321-384] [Type Unit]: While:
+                                                            Expr 72 [383-384] [Type Bool]: Var: Local 61
                                                             Block 37 [328-376] [Type Unit]:
                                                                 Stmt 38 [346-362]: Local (Immutable):
                                                                     Pat 39 [350-351] [Type String]: Bind: Ident 40 [350-351] "z"
                                                                     Expr 41 [354-361] [Type String]: String:
                                                                         Lit: "Third"
-                                                                Stmt _id_ [383-384]: Semi: Expr _id_ [383-384] [Type Unit]: Assign:
-                                                                    Expr _id_ [383-384] [Type Bool]: Var: Local 45
-                                                                    Expr _id_ [383-384] [Type Bool]: UnOp (NotL):
+                                                                Stmt 65 [383-384]: Semi: Expr 66 [383-384] [Type Unit]: Assign:
+                                                                    Expr 67 [383-384] [Type Bool]: Var: Local 61
+                                                                    Expr 68 [383-384] [Type Bool]: UnOp (NotL):
                                                                         Expr 42 [383-384] [Type Bool]: Var: Local 15
                         adj: <none>
                         ctl: <none>

--- a/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
@@ -38,17 +38,17 @@ fn test_single_qubit() {
                         functors: empty set
                         body: SpecDecl 3 [22-96]: Impl:
                             Block 4 [45-96] [Type Unit]:
-                                Stmt _id_ [59-60]: Local (Immutable):
-                                    Pat _id_ [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "q"
-                                    Expr _id_ [59-60] [Type Qubit]: Call:
-                                        Expr _id_ [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [59-60] [Type Unit]: Unit
+                                Stmt 17 [59-60]: Local (Immutable):
+                                    Pat 18 [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "q"
+                                    Expr 15 [59-60] [Type Qubit]: Call:
+                                        Expr 14 [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 16 [59-60] [Type Unit]: Unit
                                 Stmt 9 [80-90]: Local (Immutable):
                                     Pat 10 [84-85] [Type Int]: Bind: Ident 11 [84-85] "x"
                                     Expr 12 [88-89] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [59-60]: Semi: Expr _id_ [59-60] [Type Unit]: Call:
-                                    Expr _id_ [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [59-60] [Type Qubit]: Var: Local 7
+                                Stmt 20 [59-60]: Semi: Expr 21 [59-60] [Type Unit]: Call:
+                                    Expr 19 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 22 [59-60] [Type Qubit]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -77,17 +77,17 @@ fn test_qubit_array() {
                         functors: empty set
                         body: SpecDecl 3 [22-97]: Impl:
                             Block 4 [45-97] [Type Unit]:
-                                Stmt _id_ [59-60]: Local (Immutable):
-                                    Pat _id_ [59-60] [Type (Qubit)[]]: Bind: Ident 7 [59-60] "q"
-                                    Expr _id_ [59-60] [Type Qubit]: Call:
-                                        Expr _id_ [59-60] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
+                                Stmt 18 [59-60]: Local (Immutable):
+                                    Pat 19 [59-60] [Type (Qubit)[]]: Bind: Ident 7 [59-60] "q"
+                                    Expr 16 [59-60] [Type Qubit]: Call:
+                                        Expr 15 [59-60] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
                                         Expr 9 [69-70] [Type Int]: Lit: Int(3)
                                 Stmt 10 [81-91]: Local (Immutable):
                                     Pat 11 [85-86] [Type Int]: Bind: Ident 12 [85-86] "x"
                                     Expr 13 [89-90] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [59-60]: Semi: Expr _id_ [59-60] [Type Unit]: Call:
-                                    Expr _id_ [59-60] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
-                                    Expr _id_ [59-60] [Type (Qubit)[]]: Var: Local 7
+                                Stmt 21 [59-60]: Semi: Expr 22 [59-60] [Type Unit]: Call:
+                                    Expr 20 [59-60] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
+                                    Expr 23 [59-60] [Type (Qubit)[]]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -116,30 +116,30 @@ fn test_qubit_tuple() {
                         functors: empty set
                         body: SpecDecl 3 [22-107]: Impl:
                             Block 4 [45-107] [Type Unit]:
-                                Stmt _id_ [64-71]: Local (Immutable):
-                                    Pat _id_ [64-71] [Type Qubit]: Bind: Ident 16 [64-71] "generated_ident_16"
-                                    Expr _id_ [64-71] [Type Qubit]: Call:
-                                        Expr _id_ [64-71] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [64-71] [Type Unit]: Unit
-                                Stmt _id_ [73-80]: Local (Immutable):
-                                    Pat _id_ [73-80] [Type Qubit]: Bind: Ident 17 [73-80] "generated_ident_17"
-                                    Expr _id_ [73-80] [Type Qubit]: Call:
-                                        Expr _id_ [73-80] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [73-80] [Type Unit]: Unit
-                                Stmt _id_ [55-82]: Local (Immutable):
+                                Stmt 24 [64-71]: Local (Immutable):
+                                    Pat 25 [64-71] [Type Qubit]: Bind: Ident 16 [64-71] "generated_ident_16"
+                                    Expr 22 [64-71] [Type Qubit]: Call:
+                                        Expr 21 [64-71] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 23 [64-71] [Type Unit]: Unit
+                                Stmt 29 [73-80]: Local (Immutable):
+                                    Pat 30 [73-80] [Type Qubit]: Bind: Ident 18 [73-80] "generated_ident_18"
+                                    Expr 27 [73-80] [Type Qubit]: Call:
+                                        Expr 26 [73-80] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 28 [73-80] [Type Unit]: Unit
+                                Stmt 31 [55-82]: Local (Immutable):
                                     Pat 6 [59-60] [Type (Qubit, Qubit)]: Bind: Ident 7 [59-60] "q"
-                                    Expr _id_ [63-81] [Type (Qubit, Qubit)]: Tuple:
-                                        Expr _id_ [64-71] [Type Qubit]: Var: Local 16
-                                        Expr _id_ [73-80] [Type Qubit]: Var: Local 17
+                                    Expr 20 [63-81] [Type (Qubit, Qubit)]: Tuple:
+                                        Expr 17 [64-71] [Type Qubit]: Var: Local 16
+                                        Expr 19 [73-80] [Type Qubit]: Var: Local 18
                                 Stmt 11 [91-101]: Local (Immutable):
                                     Pat 12 [95-96] [Type Int]: Bind: Ident 13 [95-96] "x"
                                     Expr 14 [99-100] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [73-80]: Semi: Expr _id_ [73-80] [Type Unit]: Call:
-                                    Expr _id_ [73-80] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [73-80] [Type Qubit]: Var: Local 17
-                                Stmt _id_ [64-71]: Semi: Expr _id_ [64-71] [Type Unit]: Call:
-                                    Expr _id_ [64-71] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [64-71] [Type Qubit]: Var: Local 16
+                                Stmt 33 [73-80]: Semi: Expr 34 [73-80] [Type Unit]: Call:
+                                    Expr 32 [73-80] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 35 [73-80] [Type Qubit]: Var: Local 18
+                                Stmt 37 [64-71]: Semi: Expr 38 [64-71] [Type Unit]: Call:
+                                    Expr 36 [64-71] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 39 [64-71] [Type Qubit]: Var: Local 16
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -168,32 +168,32 @@ fn test_multiple_qubits_tuple() {
                         functors: empty set
                         body: SpecDecl 3 [22-113]: Impl:
                             Block 4 [45-113] [Type Unit]:
-                                Stmt _id_ [69-76]: Local (Immutable):
-                                    Pat _id_ [69-76] [Type Qubit]: Bind: Ident 20 [69-76] "generated_ident_20"
-                                    Expr _id_ [69-76] [Type Qubit]: Call:
-                                        Expr _id_ [69-76] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [69-76] [Type Unit]: Unit
-                                Stmt _id_ [78-86]: Local (Immutable):
-                                    Pat _id_ [78-86] [Type (Qubit)[]]: Bind: Ident 21 [78-86] "generated_ident_21"
-                                    Expr _id_ [78-86] [Type Qubit]: Call:
-                                        Expr _id_ [78-86] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
+                                Stmt 28 [69-76]: Local (Immutable):
+                                    Pat 29 [69-76] [Type Qubit]: Bind: Ident 20 [69-76] "generated_ident_20"
+                                    Expr 26 [69-76] [Type Qubit]: Call:
+                                        Expr 25 [69-76] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 27 [69-76] [Type Unit]: Unit
+                                Stmt 33 [78-86]: Local (Immutable):
+                                    Pat 34 [78-86] [Type (Qubit)[]]: Bind: Ident 22 [78-86] "generated_ident_22"
+                                    Expr 31 [78-86] [Type Qubit]: Call:
+                                        Expr 30 [78-86] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
                                         Expr 14 [84-85] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [55-88]: Local (Immutable):
+                                Stmt 35 [55-88]: Local (Immutable):
                                     Pat 6 [59-65] [Type (Qubit, (Qubit)[])]: Tuple:
                                         Pat 7 [60-61] [Type Qubit]: Bind: Ident 8 [60-61] "a"
                                         Pat 9 [63-64] [Type (Qubit)[]]: Bind: Ident 10 [63-64] "b"
-                                    Expr _id_ [68-87] [Type (Qubit, (Qubit)[])]: Tuple:
-                                        Expr _id_ [69-76] [Type Qubit]: Var: Local 20
-                                        Expr _id_ [78-86] [Type (Qubit)[]]: Var: Local 21
+                                    Expr 24 [68-87] [Type (Qubit, (Qubit)[])]: Tuple:
+                                        Expr 21 [69-76] [Type Qubit]: Var: Local 20
+                                        Expr 23 [78-86] [Type (Qubit)[]]: Var: Local 22
                                 Stmt 15 [97-107]: Local (Immutable):
                                     Pat 16 [101-102] [Type Int]: Bind: Ident 17 [101-102] "x"
                                     Expr 18 [105-106] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [78-86]: Semi: Expr _id_ [78-86] [Type Unit]: Call:
-                                    Expr _id_ [78-86] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
-                                    Expr _id_ [78-86] [Type (Qubit)[]]: Var: Local 21
-                                Stmt _id_ [69-76]: Semi: Expr _id_ [69-76] [Type Unit]: Call:
-                                    Expr _id_ [69-76] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [69-76] [Type Qubit]: Var: Local 20
+                                Stmt 37 [78-86]: Semi: Expr 38 [78-86] [Type Unit]: Call:
+                                    Expr 36 [78-86] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
+                                    Expr 39 [78-86] [Type (Qubit)[]]: Var: Local 22
+                                Stmt 41 [69-76]: Semi: Expr 42 [69-76] [Type Unit]: Call:
+                                    Expr 40 [69-76] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 43 [69-76] [Type Qubit]: Var: Local 20
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -227,32 +227,32 @@ fn test_multiple_callables() {
                         functors: empty set
                         body: SpecDecl 3 [22-112]: Impl:
                             Block 4 [45-112] [Type Unit]:
-                                Stmt _id_ [69-76]: Local (Immutable):
-                                    Pat _id_ [69-76] [Type Qubit]: Bind: Ident 37 [69-76] "generated_ident_37"
-                                    Expr _id_ [69-76] [Type Qubit]: Call:
-                                        Expr _id_ [69-76] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [69-76] [Type Unit]: Unit
-                                Stmt _id_ [78-85]: Local (Immutable):
-                                    Pat _id_ [78-85] [Type Qubit]: Bind: Ident 38 [78-85] "generated_ident_38"
-                                    Expr _id_ [78-85] [Type Qubit]: Call:
-                                        Expr _id_ [78-85] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [78-85] [Type Unit]: Unit
-                                Stmt _id_ [55-87]: Local (Immutable):
+                                Stmt 45 [69-76]: Local (Immutable):
+                                    Pat 46 [69-76] [Type Qubit]: Bind: Ident 37 [69-76] "generated_ident_37"
+                                    Expr 43 [69-76] [Type Qubit]: Call:
+                                        Expr 42 [69-76] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 44 [69-76] [Type Unit]: Unit
+                                Stmt 50 [78-85]: Local (Immutable):
+                                    Pat 51 [78-85] [Type Qubit]: Bind: Ident 39 [78-85] "generated_ident_39"
+                                    Expr 48 [78-85] [Type Qubit]: Call:
+                                        Expr 47 [78-85] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 49 [78-85] [Type Unit]: Unit
+                                Stmt 52 [55-87]: Local (Immutable):
                                     Pat 6 [59-65] [Type (Qubit, Qubit)]: Tuple:
                                         Pat 7 [60-61] [Type Qubit]: Bind: Ident 8 [60-61] "a"
                                         Pat 9 [63-64] [Type Qubit]: Bind: Ident 10 [63-64] "b"
-                                    Expr _id_ [68-86] [Type (Qubit, Qubit)]: Tuple:
-                                        Expr _id_ [69-76] [Type Qubit]: Var: Local 37
-                                        Expr _id_ [78-85] [Type Qubit]: Var: Local 38
+                                    Expr 41 [68-86] [Type (Qubit, Qubit)]: Tuple:
+                                        Expr 38 [69-76] [Type Qubit]: Var: Local 37
+                                        Expr 40 [78-85] [Type Qubit]: Var: Local 39
                                 Stmt 14 [96-106]: Local (Immutable):
                                     Pat 15 [100-101] [Type Int]: Bind: Ident 16 [100-101] "x"
                                     Expr 17 [104-105] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [78-85]: Semi: Expr _id_ [78-85] [Type Unit]: Call:
-                                    Expr _id_ [78-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [78-85] [Type Qubit]: Var: Local 38
-                                Stmt _id_ [69-76]: Semi: Expr _id_ [69-76] [Type Unit]: Call:
-                                    Expr _id_ [69-76] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [69-76] [Type Qubit]: Var: Local 37
+                                Stmt 54 [78-85]: Semi: Expr 55 [78-85] [Type Unit]: Call:
+                                    Expr 53 [78-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 56 [78-85] [Type Qubit]: Var: Local 39
+                                Stmt 58 [69-76]: Semi: Expr 59 [69-76] [Type Unit]: Call:
+                                    Expr 57 [69-76] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 60 [69-76] [Type Qubit]: Var: Local 37
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>
@@ -265,32 +265,32 @@ fn test_multiple_callables() {
                         functors: empty set
                         body: SpecDecl 21 [122-212]: Impl:
                             Block 22 [145-212] [Type Unit]:
-                                Stmt _id_ [169-176]: Local (Immutable):
-                                    Pat _id_ [169-176] [Type Qubit]: Bind: Ident 39 [169-176] "generated_ident_39"
-                                    Expr _id_ [169-176] [Type Qubit]: Call:
-                                        Expr _id_ [169-176] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [169-176] [Type Unit]: Unit
-                                Stmt _id_ [178-185]: Local (Immutable):
-                                    Pat _id_ [178-185] [Type Qubit]: Bind: Ident 40 [178-185] "generated_ident_40"
-                                    Expr _id_ [178-185] [Type Qubit]: Call:
-                                        Expr _id_ [178-185] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [178-185] [Type Unit]: Unit
-                                Stmt _id_ [155-187]: Local (Immutable):
+                                Stmt 69 [169-176]: Local (Immutable):
+                                    Pat 70 [169-176] [Type Qubit]: Bind: Ident 61 [169-176] "generated_ident_61"
+                                    Expr 67 [169-176] [Type Qubit]: Call:
+                                        Expr 66 [169-176] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 68 [169-176] [Type Unit]: Unit
+                                Stmt 74 [178-185]: Local (Immutable):
+                                    Pat 75 [178-185] [Type Qubit]: Bind: Ident 63 [178-185] "generated_ident_63"
+                                    Expr 72 [178-185] [Type Qubit]: Call:
+                                        Expr 71 [178-185] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 73 [178-185] [Type Unit]: Unit
+                                Stmt 76 [155-187]: Local (Immutable):
                                     Pat 24 [159-165] [Type (Qubit, Qubit)]: Tuple:
                                         Pat 25 [160-161] [Type Qubit]: Bind: Ident 26 [160-161] "c"
                                         Pat 27 [163-164] [Type Qubit]: Bind: Ident 28 [163-164] "d"
-                                    Expr _id_ [168-186] [Type (Qubit, Qubit)]: Tuple:
-                                        Expr _id_ [169-176] [Type Qubit]: Var: Local 39
-                                        Expr _id_ [178-185] [Type Qubit]: Var: Local 40
+                                    Expr 65 [168-186] [Type (Qubit, Qubit)]: Tuple:
+                                        Expr 62 [169-176] [Type Qubit]: Var: Local 61
+                                        Expr 64 [178-185] [Type Qubit]: Var: Local 63
                                 Stmt 32 [196-206]: Local (Immutable):
                                     Pat 33 [200-201] [Type Int]: Bind: Ident 34 [200-201] "x"
                                     Expr 35 [204-205] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [178-185]: Semi: Expr _id_ [178-185] [Type Unit]: Call:
-                                    Expr _id_ [178-185] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [178-185] [Type Qubit]: Var: Local 40
-                                Stmt _id_ [169-176]: Semi: Expr _id_ [169-176] [Type Unit]: Call:
-                                    Expr _id_ [169-176] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [169-176] [Type Qubit]: Var: Local 39
+                                Stmt 78 [178-185]: Semi: Expr 79 [178-185] [Type Unit]: Call:
+                                    Expr 77 [178-185] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 80 [178-185] [Type Qubit]: Var: Local 63
+                                Stmt 82 [169-176]: Semi: Expr 83 [169-176] [Type Unit]: Call:
+                                    Expr 81 [169-176] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 84 [169-176] [Type Qubit]: Var: Local 61
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -323,44 +323,44 @@ fn test_qubit_block() {
                         functors: empty set
                         body: SpecDecl 3 [22-198]: Impl:
                             Block 4 [45-198] [Type Unit]:
-                                Stmt _id_ [55-173]: Expr: Expr _id_ [55-173] [Type Unit]: Expr Block: Block 14 [87-173] [Type Unit]:
-                                    Stmt _id_ [69-76]: Local (Immutable):
-                                        Pat _id_ [69-76] [Type Qubit]: Bind: Ident 32 [69-76] "generated_ident_32"
-                                        Expr _id_ [69-76] [Type Qubit]: Call:
-                                            Expr _id_ [69-76] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr _id_ [69-76] [Type Unit]: Unit
-                                    Stmt _id_ [78-85]: Local (Immutable):
-                                        Pat _id_ [78-85] [Type Qubit]: Bind: Ident 33 [78-85] "generated_ident_33"
-                                        Expr _id_ [78-85] [Type Qubit]: Call:
-                                            Expr _id_ [78-85] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr _id_ [78-85] [Type Unit]: Unit
-                                    Stmt _id_ [55-173]: Local (Immutable):
+                                Stmt 65 [55-173]: Expr: Expr 66 [55-173] [Type Unit]: Expr Block: Block 14 [87-173] [Type Unit]:
+                                    Stmt 40 [69-76]: Local (Immutable):
+                                        Pat 41 [69-76] [Type Qubit]: Bind: Ident 32 [69-76] "generated_ident_32"
+                                        Expr 38 [69-76] [Type Qubit]: Call:
+                                            Expr 37 [69-76] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 39 [69-76] [Type Unit]: Unit
+                                    Stmt 45 [78-85]: Local (Immutable):
+                                        Pat 46 [78-85] [Type Qubit]: Bind: Ident 34 [78-85] "generated_ident_34"
+                                        Expr 43 [78-85] [Type Qubit]: Call:
+                                            Expr 42 [78-85] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 44 [78-85] [Type Unit]: Unit
+                                    Stmt 47 [55-173]: Local (Immutable):
                                         Pat 6 [59-65] [Type (Qubit, Qubit)]: Tuple:
                                             Pat 7 [60-61] [Type Qubit]: Bind: Ident 8 [60-61] "a"
                                             Pat 9 [63-64] [Type Qubit]: Bind: Ident 10 [63-64] "b"
-                                        Expr _id_ [68-86] [Type (Qubit, Qubit)]: Tuple:
-                                            Expr _id_ [69-76] [Type Qubit]: Var: Local 32
-                                            Expr _id_ [78-85] [Type Qubit]: Var: Local 33
+                                        Expr 36 [68-86] [Type (Qubit, Qubit)]: Tuple:
+                                            Expr 33 [69-76] [Type Qubit]: Var: Local 32
+                                            Expr 35 [78-85] [Type Qubit]: Var: Local 34
                                     Stmt 15 [101-111]: Local (Immutable):
                                         Pat 16 [105-106] [Type Int]: Bind: Ident 17 [105-106] "x"
                                         Expr 18 [109-110] [Type Int]: Lit: Int(3)
-                                    Stmt _id_ [128-129]: Local (Immutable):
-                                        Pat _id_ [128-129] [Type Qubit]: Bind: Ident 21 [128-129] "c"
-                                        Expr _id_ [128-129] [Type Qubit]: Call:
-                                            Expr _id_ [128-129] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr _id_ [128-129] [Type Unit]: Unit
+                                    Stmt 51 [128-129]: Local (Immutable):
+                                        Pat 52 [128-129] [Type Qubit]: Bind: Ident 21 [128-129] "c"
+                                        Expr 49 [128-129] [Type Qubit]: Call:
+                                            Expr 48 [128-129] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 50 [128-129] [Type Unit]: Unit
                                     Stmt 23 [153-163]: Local (Immutable):
                                         Pat 24 [157-158] [Type Int]: Bind: Ident 25 [157-158] "y"
                                         Expr 26 [161-162] [Type Int]: Lit: Int(3)
-                                    Stmt _id_ [128-129]: Semi: Expr _id_ [128-129] [Type Unit]: Call:
-                                        Expr _id_ [128-129] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr _id_ [128-129] [Type Qubit]: Var: Local 21
-                                    Stmt _id_ [78-85]: Semi: Expr _id_ [78-85] [Type Unit]: Call:
-                                        Expr _id_ [78-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr _id_ [78-85] [Type Qubit]: Var: Local 33
-                                    Stmt _id_ [69-76]: Semi: Expr _id_ [69-76] [Type Unit]: Call:
-                                        Expr _id_ [69-76] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr _id_ [69-76] [Type Qubit]: Var: Local 32
+                                    Stmt 54 [128-129]: Semi: Expr 55 [128-129] [Type Unit]: Call:
+                                        Expr 53 [128-129] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 56 [128-129] [Type Qubit]: Var: Local 21
+                                    Stmt 58 [78-85]: Semi: Expr 59 [78-85] [Type Unit]: Call:
+                                        Expr 57 [78-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 60 [78-85] [Type Qubit]: Var: Local 34
+                                    Stmt 62 [69-76]: Semi: Expr 63 [69-76] [Type Unit]: Call:
+                                        Expr 61 [69-76] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 64 [69-76] [Type Qubit]: Var: Local 32
                                 Stmt 27 [182-192]: Local (Immutable):
                                     Pat 28 [186-187] [Type Int]: Bind: Ident 29 [186-187] "z"
                                     Expr 30 [190-191] [Type Int]: Lit: Int(3)
@@ -395,29 +395,29 @@ fn test_qubit_nested_block() {
                         functors: empty set
                         body: SpecDecl 3 [22-155]: Impl:
                             Block 4 [45-155] [Type Unit]:
-                                Stmt _id_ [59-60]: Local (Immutable):
-                                    Pat _id_ [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "a"
-                                    Expr _id_ [59-60] [Type Qubit]: Call:
-                                        Expr _id_ [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [59-60] [Type Unit]: Unit
-                                Stmt _id_ [80-130]: Expr: Expr _id_ [80-130] [Type Unit]: Expr Block: Block 13 [96-130] [Type Unit]:
-                                    Stmt _id_ [84-85]: Local (Immutable):
-                                        Pat _id_ [84-85] [Type Qubit]: Bind: Ident 11 [84-85] "b"
-                                        Expr _id_ [84-85] [Type Qubit]: Call:
-                                            Expr _id_ [84-85] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr _id_ [84-85] [Type Unit]: Unit
+                                Stmt 26 [59-60]: Local (Immutable):
+                                    Pat 27 [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "a"
+                                    Expr 24 [59-60] [Type Qubit]: Call:
+                                        Expr 23 [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 25 [59-60] [Type Unit]: Unit
+                                Stmt 37 [80-130]: Expr: Expr 38 [80-130] [Type Unit]: Expr Block: Block 13 [96-130] [Type Unit]:
+                                    Stmt 31 [84-85]: Local (Immutable):
+                                        Pat 32 [84-85] [Type Qubit]: Bind: Ident 11 [84-85] "b"
+                                        Expr 29 [84-85] [Type Qubit]: Call:
+                                            Expr 28 [84-85] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 30 [84-85] [Type Unit]: Unit
                                     Stmt 14 [110-120]: Local (Immutable):
                                         Pat 15 [114-115] [Type Int]: Bind: Ident 16 [114-115] "x"
                                         Expr 17 [118-119] [Type Int]: Lit: Int(3)
-                                    Stmt _id_ [84-85]: Semi: Expr _id_ [84-85] [Type Unit]: Call:
-                                        Expr _id_ [84-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr _id_ [84-85] [Type Qubit]: Var: Local 11
+                                    Stmt 34 [84-85]: Semi: Expr 35 [84-85] [Type Unit]: Call:
+                                        Expr 33 [84-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 36 [84-85] [Type Qubit]: Var: Local 11
                                 Stmt 18 [139-149]: Local (Immutable):
                                     Pat 19 [143-144] [Type Int]: Bind: Ident 20 [143-144] "y"
                                     Expr 21 [147-148] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [59-60]: Semi: Expr _id_ [59-60] [Type Unit]: Call:
-                                    Expr _id_ [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [59-60] [Type Qubit]: Var: Local 7
+                                Stmt 40 [59-60]: Semi: Expr 41 [59-60] [Type Unit]: Call:
+                                    Expr 39 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 42 [59-60] [Type Qubit]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -462,11 +462,11 @@ fn test_qubit_multiple_nested_blocks() {
                                 Stmt 5 [55-66]: Local (Immutable):
                                     Pat 6 [59-61] [Type Int]: Bind: Ident 7 [59-61] "x1"
                                     Expr 8 [64-65] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [79-80]: Local (Immutable):
-                                    Pat _id_ [79-80] [Type Qubit]: Bind: Ident 11 [79-80] "a"
-                                    Expr _id_ [79-80] [Type Qubit]: Call:
-                                        Expr _id_ [79-80] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [79-80] [Type Unit]: Unit
+                                Stmt 59 [79-80]: Local (Immutable):
+                                    Pat 60 [79-80] [Type Qubit]: Bind: Ident 11 [79-80] "a"
+                                    Expr 57 [79-80] [Type Qubit]: Call:
+                                        Expr 56 [79-80] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 58 [79-80] [Type Unit]: Unit
                                 Stmt 13 [100-111]: Local (Immutable):
                                     Pat 14 [104-106] [Type Int]: Bind: Ident 15 [104-106] "x2"
                                     Expr 16 [109-110] [Type Int]: Lit: Int(3)
@@ -474,17 +474,17 @@ fn test_qubit_multiple_nested_blocks() {
                                     Stmt 20 [134-145]: Local (Immutable):
                                         Pat 21 [138-140] [Type Int]: Bind: Ident 22 [138-140] "y1"
                                         Expr 23 [143-144] [Type Int]: Lit: Int(3)
-                                    Stmt _id_ [162-163]: Local (Immutable):
-                                        Pat _id_ [162-163] [Type Qubit]: Bind: Ident 26 [162-163] "b"
-                                        Expr _id_ [162-163] [Type Qubit]: Call:
-                                            Expr _id_ [162-163] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr _id_ [162-163] [Type Unit]: Unit
+                                    Stmt 64 [162-163]: Local (Immutable):
+                                        Pat 65 [162-163] [Type Qubit]: Bind: Ident 26 [162-163] "b"
+                                        Expr 62 [162-163] [Type Qubit]: Call:
+                                            Expr 61 [162-163] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 63 [162-163] [Type Unit]: Unit
                                     Stmt 28 [187-198]: Local (Immutable):
                                         Pat 29 [191-193] [Type Int]: Bind: Ident 30 [191-193] "y2"
                                         Expr 31 [196-197] [Type Int]: Lit: Int(3)
-                                    Stmt _id_ [162-163]: Semi: Expr _id_ [162-163] [Type Unit]: Call:
-                                        Expr _id_ [162-163] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr _id_ [162-163] [Type Qubit]: Var: Local 26
+                                    Stmt 67 [162-163]: Semi: Expr 68 [162-163] [Type Unit]: Call:
+                                        Expr 66 [162-163] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 69 [162-163] [Type Qubit]: Var: Local 26
                                 Stmt 32 [217-228]: Local (Immutable):
                                     Pat 33 [221-223] [Type Int]: Bind: Ident 34 [221-223] "x3"
                                     Expr 35 [226-227] [Type Int]: Lit: Int(3)
@@ -492,23 +492,23 @@ fn test_qubit_multiple_nested_blocks() {
                                     Stmt 39 [251-262]: Local (Immutable):
                                         Pat 40 [255-257] [Type Int]: Bind: Ident 41 [255-257] "z1"
                                         Expr 42 [260-261] [Type Int]: Lit: Int(3)
-                                    Stmt _id_ [279-280]: Local (Immutable):
-                                        Pat _id_ [279-280] [Type Qubit]: Bind: Ident 45 [279-280] "c"
-                                        Expr _id_ [279-280] [Type Qubit]: Call:
-                                            Expr _id_ [279-280] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr _id_ [279-280] [Type Unit]: Unit
+                                    Stmt 73 [279-280]: Local (Immutable):
+                                        Pat 74 [279-280] [Type Qubit]: Bind: Ident 45 [279-280] "c"
+                                        Expr 71 [279-280] [Type Qubit]: Call:
+                                            Expr 70 [279-280] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 72 [279-280] [Type Unit]: Unit
                                     Stmt 47 [304-315]: Local (Immutable):
                                         Pat 48 [308-310] [Type Int]: Bind: Ident 49 [308-310] "z2"
                                         Expr 50 [313-314] [Type Int]: Lit: Int(3)
-                                    Stmt _id_ [279-280]: Semi: Expr _id_ [279-280] [Type Unit]: Call:
-                                        Expr _id_ [279-280] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr _id_ [279-280] [Type Qubit]: Var: Local 45
+                                    Stmt 76 [279-280]: Semi: Expr 77 [279-280] [Type Unit]: Call:
+                                        Expr 75 [279-280] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 78 [279-280] [Type Qubit]: Var: Local 45
                                 Stmt 51 [334-345]: Local (Immutable):
                                     Pat 52 [338-340] [Type Int]: Bind: Ident 53 [338-340] "x4"
                                     Expr 54 [343-344] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [79-80]: Semi: Expr _id_ [79-80] [Type Unit]: Call:
-                                    Expr _id_ [79-80] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [79-80] [Type Qubit]: Var: Local 11
+                                Stmt 80 [79-80]: Semi: Expr 81 [79-80] [Type Unit]: Call:
+                                    Expr 79 [79-80] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 82 [79-80] [Type Qubit]: Var: Local 11
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -545,61 +545,61 @@ fn test_early_returns() {
                         functors: empty set
                         body: SpecDecl 3 [22-239]: Impl:
                             Block 4 [45-239] [Type Unit]:
-                                Stmt _id_ [59-60]: Local (Immutable):
-                                    Pat _id_ [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "a"
-                                    Expr _id_ [59-60] [Type Qubit]: Call:
-                                        Expr _id_ [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [59-60] [Type Unit]: Unit
+                                Stmt 37 [59-60]: Local (Immutable):
+                                    Pat 38 [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "a"
+                                    Expr 35 [59-60] [Type Qubit]: Call:
+                                        Expr 34 [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 36 [59-60] [Type Unit]: Unit
                                 Stmt 9 [80-151]: Expr: Expr 10 [80-151] [Type Unit]: If:
                                     Expr 11 [83-87] [Type Bool]: Lit: Bool(true)
                                     Expr 12 [88-151] [Type Unit]: Expr Block: Block 13 [88-151] [Type Unit]:
-                                        Stmt _id_ [106-107]: Local (Immutable):
-                                            Pat _id_ [106-107] [Type Qubit]: Bind: Ident 16 [106-107] "b"
-                                            Expr _id_ [106-107] [Type Qubit]: Call:
-                                                Expr _id_ [106-107] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                Expr _id_ [106-107] [Type Unit]: Unit
-                                        Stmt 18 [131-141]: Semi: Expr _id_ [131-140] [Type ?2]: Expr Block: Block _id_ [131-140] [Type ?2]:
-                                            Stmt _id_ [138-140]: Local (Immutable):
-                                                Pat _id_ [138-140] [Type Unit]: Bind: Ident 34 [138-140] "generated_ident_34"
+                                        Stmt 42 [106-107]: Local (Immutable):
+                                            Pat 43 [106-107] [Type Qubit]: Bind: Ident 16 [106-107] "b"
+                                            Expr 40 [106-107] [Type Qubit]: Call:
+                                                Expr 39 [106-107] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                Expr 41 [106-107] [Type Unit]: Unit
+                                        Stmt 18 [131-141]: Semi: Expr 58 [131-140] [Type ?2]: Expr Block: Block 59 [131-140] [Type ?2]:
+                                            Stmt 45 [138-140]: Local (Immutable):
+                                                Pat 46 [138-140] [Type Unit]: Bind: Ident 44 [138-140] "generated_ident_44"
                                                 Expr 20 [138-140] [Type Unit]: Unit
-                                            Stmt _id_ [106-107]: Semi: Expr _id_ [106-107] [Type Unit]: Call:
-                                                Expr _id_ [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr _id_ [106-107] [Type Qubit]: Var: Local 16
-                                            Stmt _id_ [59-60]: Semi: Expr _id_ [59-60] [Type Unit]: Call:
-                                                Expr _id_ [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr _id_ [59-60] [Type Qubit]: Var: Local 7
-                                            Stmt _id_ [131-140]: Semi: Expr _id_ [131-140] [Type ?2]: Return: Expr _id_ [138-140] [Type Unit]: Var: Local 34
-                                        Stmt _id_ [106-107]: Semi: Expr _id_ [106-107] [Type Unit]: Call:
-                                            Expr _id_ [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                            Expr _id_ [106-107] [Type Qubit]: Var: Local 16
-                                Stmt _id_ [161-233]: Local (Immutable):
-                                    Pat _id_ [161-233] [Type Unit]: Bind: Ident 36 [161-233] "generated_ident_36"
+                                            Stmt 48 [106-107]: Semi: Expr 49 [106-107] [Type Unit]: Call:
+                                                Expr 47 [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 50 [106-107] [Type Qubit]: Var: Local 16
+                                            Stmt 52 [59-60]: Semi: Expr 53 [59-60] [Type Unit]: Call:
+                                                Expr 51 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 54 [59-60] [Type Qubit]: Var: Local 7
+                                            Stmt 55 [131-140]: Semi: Expr 56 [131-140] [Type ?2]: Return: Expr 57 [138-140] [Type Unit]: Var: Local 44
+                                        Stmt 61 [106-107]: Semi: Expr 62 [106-107] [Type Unit]: Call:
+                                            Expr 60 [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                            Expr 63 [106-107] [Type Qubit]: Var: Local 16
+                                Stmt 90 [161-233]: Local (Immutable):
+                                    Pat 91 [161-233] [Type Unit]: Bind: Ident 89 [161-233] "generated_ident_89"
                                     Expr 22 [161-233] [Type Unit]: If:
                                         Expr 23 [164-169] [Type Bool]: Lit: Bool(false)
                                         Expr 24 [170-233] [Type Unit]: Expr Block: Block 25 [170-233] [Type Unit]:
-                                            Stmt _id_ [188-189]: Local (Immutable):
-                                                Pat _id_ [188-189] [Type Qubit]: Bind: Ident 28 [188-189] "c"
-                                                Expr _id_ [188-189] [Type Qubit]: Call:
-                                                    Expr _id_ [188-189] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                    Expr _id_ [188-189] [Type Unit]: Unit
-                                            Stmt 30 [213-223]: Semi: Expr _id_ [213-222] [Type ?5]: Expr Block: Block _id_ [213-222] [Type ?5]:
-                                                Stmt _id_ [220-222]: Local (Immutable):
-                                                    Pat _id_ [220-222] [Type Unit]: Bind: Ident 35 [220-222] "generated_ident_35"
+                                            Stmt 67 [188-189]: Local (Immutable):
+                                                Pat 68 [188-189] [Type Qubit]: Bind: Ident 28 [188-189] "c"
+                                                Expr 65 [188-189] [Type Qubit]: Call:
+                                                    Expr 64 [188-189] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                    Expr 66 [188-189] [Type Unit]: Unit
+                                            Stmt 30 [213-223]: Semi: Expr 83 [213-222] [Type ?5]: Expr Block: Block 84 [213-222] [Type ?5]:
+                                                Stmt 70 [220-222]: Local (Immutable):
+                                                    Pat 71 [220-222] [Type Unit]: Bind: Ident 69 [220-222] "generated_ident_69"
                                                     Expr 32 [220-222] [Type Unit]: Unit
-                                                Stmt _id_ [188-189]: Semi: Expr _id_ [188-189] [Type Unit]: Call:
-                                                    Expr _id_ [188-189] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                    Expr _id_ [188-189] [Type Qubit]: Var: Local 28
-                                                Stmt _id_ [59-60]: Semi: Expr _id_ [59-60] [Type Unit]: Call:
-                                                    Expr _id_ [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                    Expr _id_ [59-60] [Type Qubit]: Var: Local 7
-                                                Stmt _id_ [213-222]: Semi: Expr _id_ [213-222] [Type ?5]: Return: Expr _id_ [220-222] [Type Unit]: Var: Local 35
-                                            Stmt _id_ [188-189]: Semi: Expr _id_ [188-189] [Type Unit]: Call:
-                                                Expr _id_ [188-189] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr _id_ [188-189] [Type Qubit]: Var: Local 28
-                                Stmt _id_ [59-60]: Semi: Expr _id_ [59-60] [Type Unit]: Call:
-                                    Expr _id_ [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [59-60] [Type Qubit]: Var: Local 7
-                                Stmt _id_ [161-233]: Expr: Expr _id_ [161-233] [Type Unit]: Var: Local 36
+                                                Stmt 73 [188-189]: Semi: Expr 74 [188-189] [Type Unit]: Call:
+                                                    Expr 72 [188-189] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                    Expr 75 [188-189] [Type Qubit]: Var: Local 28
+                                                Stmt 77 [59-60]: Semi: Expr 78 [59-60] [Type Unit]: Call:
+                                                    Expr 76 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                    Expr 79 [59-60] [Type Qubit]: Var: Local 7
+                                                Stmt 80 [213-222]: Semi: Expr 81 [213-222] [Type ?5]: Return: Expr 82 [220-222] [Type Unit]: Var: Local 69
+                                            Stmt 86 [188-189]: Semi: Expr 87 [188-189] [Type Unit]: Call:
+                                                Expr 85 [188-189] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 88 [188-189] [Type Qubit]: Var: Local 28
+                                Stmt 95 [59-60]: Semi: Expr 96 [59-60] [Type Unit]: Call:
+                                    Expr 94 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 97 [59-60] [Type Qubit]: Var: Local 7
+                                Stmt 92 [161-233]: Expr: Expr 93 [161-233] [Type Unit]: Var: Local 89
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -632,11 +632,11 @@ fn test_end_exprs() {
                         functors: empty set
                         body: SpecDecl 3 [22-170]: Impl:
                             Block 4 [45-170] [Type Unit]:
-                                Stmt _id_ [59-60]: Local (Immutable):
-                                    Pat _id_ [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "a"
-                                    Expr _id_ [59-60] [Type Qubit]: Call:
-                                        Expr _id_ [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [59-60] [Type Unit]: Unit
+                                Stmt 31 [59-60]: Local (Immutable):
+                                    Pat 32 [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "a"
+                                    Expr 29 [59-60] [Type Qubit]: Call:
+                                        Expr 28 [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 30 [59-60] [Type Unit]: Unit
                                 Stmt 9 [80-92]: Local (Immutable):
                                     Pat 10 [84-85] [Type Int]: Bind: Ident 11 [84-85] "x"
                                     Expr 12 [88-91] [Type Int]: Expr Block: Block 13 [88-91] [Type Int]:
@@ -644,21 +644,21 @@ fn test_end_exprs() {
                                 Stmt 16 [101-164]: Local (Immutable):
                                     Pat 17 [105-106] [Type Int]: Bind: Ident 18 [105-106] "y"
                                     Expr 19 [109-163] [Type Int]: Expr Block: Block 20 [109-163] [Type Int]:
-                                        Stmt _id_ [127-128]: Local (Immutable):
-                                            Pat _id_ [127-128] [Type Qubit]: Bind: Ident 23 [127-128] "b"
-                                            Expr _id_ [127-128] [Type Qubit]: Call:
-                                                Expr _id_ [127-128] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                Expr _id_ [127-128] [Type Unit]: Unit
-                                        Stmt _id_ [152-153]: Local (Immutable):
-                                            Pat _id_ [152-153] [Type Int]: Bind: Ident 28 [152-153] "generated_ident_28"
+                                        Stmt 36 [127-128]: Local (Immutable):
+                                            Pat 37 [127-128] [Type Qubit]: Bind: Ident 23 [127-128] "b"
+                                            Expr 34 [127-128] [Type Qubit]: Call:
+                                                Expr 33 [127-128] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                Expr 35 [127-128] [Type Unit]: Unit
+                                        Stmt 39 [152-153]: Local (Immutable):
+                                            Pat 40 [152-153] [Type Int]: Bind: Ident 38 [152-153] "generated_ident_38"
                                             Expr 26 [152-153] [Type Int]: Lit: Int(3)
-                                        Stmt _id_ [127-128]: Semi: Expr _id_ [127-128] [Type Unit]: Call:
-                                            Expr _id_ [127-128] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                            Expr _id_ [127-128] [Type Qubit]: Var: Local 23
-                                        Stmt _id_ [152-153]: Expr: Expr _id_ [152-153] [Type Int]: Var: Local 28
-                                Stmt _id_ [59-60]: Semi: Expr _id_ [59-60] [Type Unit]: Call:
-                                    Expr _id_ [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [59-60] [Type Qubit]: Var: Local 7
+                                        Stmt 44 [127-128]: Semi: Expr 45 [127-128] [Type Unit]: Call:
+                                            Expr 43 [127-128] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                            Expr 46 [127-128] [Type Qubit]: Var: Local 23
+                                        Stmt 41 [152-153]: Expr: Expr 42 [152-153] [Type Int]: Var: Local 38
+                                Stmt 48 [59-60]: Semi: Expr 49 [59-60] [Type Unit]: Call:
+                                    Expr 47 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 50 [59-60] [Type Qubit]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -690,29 +690,29 @@ fn test_array_expr() {
                         functors: empty set
                         body: SpecDecl 3 [22-150]: Impl:
                             Block 4 [45-150] [Type Unit]:
-                                Stmt _id_ [59-60]: Local (Immutable):
-                                    Pat _id_ [59-60] [Type (Qubit)[]]: Bind: Ident 7 [59-60] "a"
-                                    Expr _id_ [59-60] [Type Qubit]: Call:
-                                        Expr _id_ [59-60] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
+                                Stmt 39 [59-60]: Local (Immutable):
+                                    Pat 40 [59-60] [Type (Qubit)[]]: Bind: Ident 7 [59-60] "a"
+                                    Expr 37 [59-60] [Type Qubit]: Call:
+                                        Expr 36 [59-60] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
                                         Expr 9 [69-123] [Type Int]: Expr Block: Block 10 [69-123] [Type Int]:
-                                            Stmt _id_ [87-88]: Local (Immutable):
-                                                Pat _id_ [87-88] [Type Qubit]: Bind: Ident 13 [87-88] "b"
-                                                Expr _id_ [87-88] [Type Qubit]: Call:
-                                                    Expr _id_ [87-88] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                    Expr _id_ [87-88] [Type Unit]: Unit
-                                            Stmt _id_ [112-113]: Local (Immutable):
-                                                Pat _id_ [112-113] [Type Int]: Bind: Ident 22 [112-113] "generated_ident_22"
+                                            Stmt 25 [87-88]: Local (Immutable):
+                                                Pat 26 [87-88] [Type Qubit]: Bind: Ident 13 [87-88] "b"
+                                                Expr 23 [87-88] [Type Qubit]: Call:
+                                                    Expr 22 [87-88] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                    Expr 24 [87-88] [Type Unit]: Unit
+                                            Stmt 28 [112-113]: Local (Immutable):
+                                                Pat 29 [112-113] [Type Int]: Bind: Ident 27 [112-113] "generated_ident_27"
                                                 Expr 16 [112-113] [Type Int]: Lit: Int(3)
-                                            Stmt _id_ [87-88]: Semi: Expr _id_ [87-88] [Type Unit]: Call:
-                                                Expr _id_ [87-88] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr _id_ [87-88] [Type Qubit]: Var: Local 13
-                                            Stmt _id_ [112-113]: Expr: Expr _id_ [112-113] [Type Int]: Var: Local 22
+                                            Stmt 33 [87-88]: Semi: Expr 34 [87-88] [Type Unit]: Call:
+                                                Expr 32 [87-88] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 35 [87-88] [Type Qubit]: Var: Local 13
+                                            Stmt 30 [112-113]: Expr: Expr 31 [112-113] [Type Int]: Var: Local 27
                                 Stmt 17 [134-144]: Local (Immutable):
                                     Pat 18 [138-139] [Type Int]: Bind: Ident 19 [138-139] "x"
                                     Expr 20 [142-143] [Type Int]: Lit: Int(3)
-                                Stmt _id_ [59-60]: Semi: Expr _id_ [59-60] [Type Unit]: Call:
-                                    Expr _id_ [59-60] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
-                                    Expr _id_ [59-60] [Type (Qubit)[]]: Var: Local 7
+                                Stmt 42 [59-60]: Semi: Expr 43 [59-60] [Type Unit]: Call:
+                                    Expr 41 [59-60] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
+                                    Expr 44 [59-60] [Type (Qubit)[]]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -744,34 +744,34 @@ fn test_rtrn_expr() {
                         functors: empty set
                         body: SpecDecl 3 [22-147]: Impl:
                             Block 4 [44-147] [Type Int]:
-                                Stmt _id_ [58-59]: Local (Immutable):
-                                    Pat _id_ [58-59] [Type Qubit]: Bind: Ident 7 [58-59] "a"
-                                    Expr _id_ [58-59] [Type Qubit]: Call:
-                                        Expr _id_ [58-59] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr _id_ [58-59] [Type Unit]: Unit
-                                Stmt 9 [79-141]: Semi: Expr _id_ [79-140] [Type ?2]: Expr Block: Block _id_ [79-140] [Type ?2]:
-                                    Stmt _id_ [86-140]: Local (Immutable):
-                                        Pat _id_ [86-140] [Type Int]: Bind: Ident 20 [86-140] "generated_ident_20"
+                                Stmt 23 [58-59]: Local (Immutable):
+                                    Pat 24 [58-59] [Type Qubit]: Bind: Ident 7 [58-59] "a"
+                                    Expr 21 [58-59] [Type Qubit]: Call:
+                                        Expr 20 [58-59] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 22 [58-59] [Type Unit]: Unit
+                                Stmt 9 [79-141]: Semi: Expr 49 [79-140] [Type ?2]: Expr Block: Block 50 [79-140] [Type ?2]:
+                                    Stmt 40 [86-140]: Local (Immutable):
+                                        Pat 41 [86-140] [Type Int]: Bind: Ident 25 [86-140] "generated_ident_25"
                                         Expr 11 [86-140] [Type Int]: Expr Block: Block 12 [86-140] [Type Int]:
-                                            Stmt _id_ [104-105]: Local (Immutable):
-                                                Pat _id_ [104-105] [Type Qubit]: Bind: Ident 15 [104-105] "b"
-                                                Expr _id_ [104-105] [Type Qubit]: Call:
-                                                    Expr _id_ [104-105] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                    Expr _id_ [104-105] [Type Unit]: Unit
-                                            Stmt _id_ [129-130]: Local (Immutable):
-                                                Pat _id_ [129-130] [Type Int]: Bind: Ident 21 [129-130] "generated_ident_21"
+                                            Stmt 29 [104-105]: Local (Immutable):
+                                                Pat 30 [104-105] [Type Qubit]: Bind: Ident 15 [104-105] "b"
+                                                Expr 27 [104-105] [Type Qubit]: Call:
+                                                    Expr 26 [104-105] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                    Expr 28 [104-105] [Type Unit]: Unit
+                                            Stmt 32 [129-130]: Local (Immutable):
+                                                Pat 33 [129-130] [Type Int]: Bind: Ident 31 [129-130] "generated_ident_31"
                                                 Expr 18 [129-130] [Type Int]: Lit: Int(3)
-                                            Stmt _id_ [104-105]: Semi: Expr _id_ [104-105] [Type Unit]: Call:
-                                                Expr _id_ [104-105] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr _id_ [104-105] [Type Qubit]: Var: Local 15
-                                            Stmt _id_ [129-130]: Expr: Expr _id_ [129-130] [Type Int]: Var: Local 21
-                                    Stmt _id_ [58-59]: Semi: Expr _id_ [58-59] [Type Unit]: Call:
-                                        Expr _id_ [58-59] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr _id_ [58-59] [Type Qubit]: Var: Local 7
-                                    Stmt _id_ [79-140]: Semi: Expr _id_ [79-140] [Type ?2]: Return: Expr _id_ [86-140] [Type Int]: Var: Local 20
-                                Stmt _id_ [58-59]: Semi: Expr _id_ [58-59] [Type Unit]: Call:
-                                    Expr _id_ [58-59] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr _id_ [58-59] [Type Qubit]: Var: Local 7
+                                            Stmt 37 [104-105]: Semi: Expr 38 [104-105] [Type Unit]: Call:
+                                                Expr 36 [104-105] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 39 [104-105] [Type Qubit]: Var: Local 15
+                                            Stmt 34 [129-130]: Expr: Expr 35 [129-130] [Type Int]: Var: Local 31
+                                    Stmt 43 [58-59]: Semi: Expr 44 [58-59] [Type Unit]: Call:
+                                        Expr 42 [58-59] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 45 [58-59] [Type Qubit]: Var: Local 7
+                                    Stmt 46 [79-140]: Semi: Expr 47 [79-140] [Type ?2]: Return: Expr 48 [86-140] [Type Int]: Var: Local 25
+                                Stmt 52 [58-59]: Semi: Expr 53 [58-59] [Type Unit]: Call:
+                                    Expr 51 [58-59] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 54 [58-59] [Type Qubit]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],

--- a/compiler/qsc_passes/src/spec_gen/ctl_gen.rs
+++ b/compiler/qsc_passes/src/spec_gen/ctl_gen.rs
@@ -35,6 +35,7 @@ impl MutVisitor for CtlDistrib {
 
                         if functors.contains(&Functor::Ctl) {
                             op.kind = ExprKind::UnOp(UnOp::Functor(Functor::Ctl), op.clone());
+                            op.id = NodeId::default();
                             op.ty = Ty::Arrow(Box::new(Arrow {
                                 kind: CallableKind::Operation,
                                 input: Box::new(Ty::Tuple(vec![
@@ -58,6 +59,7 @@ impl MutVisitor for CtlDistrib {
                                 Ty::Array(Box::new(Ty::Prim(Prim::Qubit))),
                                 Ty::clone(&args.ty),
                             ]);
+                            args.id = NodeId::default();
                         } else {
                             self.errors.push(Error::MissingCtlFunctor(op.span));
                         }

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -96,10 +96,10 @@ fn generate_ctl() {
                             Block 25 [161-182] [Type Unit]:
                                 Stmt 26 [171-176]: Semi: Expr 27 [171-175] [Type Unit]: Call:
                                     Expr 28 [171-172] [Type (((Qubit)[], Qubit) => Unit is Ctl)]: UnOp (Functor Ctl):
-                                        Expr 28 [171-172] [Type (Qubit => Unit is Ctl)]: Var: Item 1
-                                    Expr 29 [173-174] [Type ((Qubit)[], Qubit)]: Tuple:
-                                        Expr 30 [173-174] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 29 [173-174] [Type Qubit]: Var: Local 13
+                                        Expr 29 [171-172] [Type (Qubit => Unit is Ctl)]: Var: Item 1
+                                    Expr 30 [173-174] [Type ((Qubit)[], Qubit)]: Tuple:
+                                        Expr 31 [173-174] [Type (Qubit)[]]: Var: Local 24
+                                        Expr 32 [173-174] [Type Qubit]: Var: Local 13
                         ctl-adj: <none>"#]],
     );
 }
@@ -157,10 +157,10 @@ fn generate_ctl_auto() {
                             Block 26 [180-209] [Type Unit]:
                                 Stmt 27 [194-199]: Semi: Expr 28 [194-198] [Type Unit]: Call:
                                     Expr 29 [194-195] [Type (((Qubit)[], Qubit) => Unit is Ctl)]: UnOp (Functor Ctl):
-                                        Expr 29 [194-195] [Type (Qubit => Unit is Ctl)]: Var: Item 1
-                                    Expr 30 [196-197] [Type ((Qubit)[], Qubit)]: Tuple:
-                                        Expr 31 [196-197] [Type (Qubit)[]]: Var: Local 25
-                                        Expr 30 [196-197] [Type Qubit]: Var: Local 13
+                                        Expr 30 [194-195] [Type (Qubit => Unit is Ctl)]: Var: Item 1
+                                    Expr 31 [196-197] [Type ((Qubit)[], Qubit)]: Tuple:
+                                        Expr 32 [196-197] [Type (Qubit)[]]: Var: Local 25
+                                        Expr 33 [196-197] [Type Qubit]: Var: Local 13
                         ctl-adj: <none>"#]],
     );
 }
@@ -229,20 +229,20 @@ fn generate_ctladj_distrib() {
                             Block 39 [215-244] [Type Unit]:
                                 Stmt 40 [229-234]: Semi: Expr 41 [229-233] [Type Unit]: Call:
                                     Expr 42 [229-230] [Type (((Qubit)[], Qubit) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 42 [229-230] [Type (Qubit => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 43 [231-232] [Type ((Qubit)[], Qubit)]: Tuple:
-                                        Expr 44 [231-232] [Type (Qubit)[]]: Var: Local 38
-                                        Expr 43 [231-232] [Type Qubit]: Var: Local 15
-                        ctl-adj: SpecDecl 46 [153-308]: Impl:
-                            Pat 47 [153-308] [Type (Qubit)[]]: Bind: Ident 48 [153-308] "ctls"
-                            Block 49 [265-302] [Type Unit]:
-                                Stmt 50 [279-292]: Semi: Expr 51 [279-291] [Type Unit]: Call:
-                                    Expr 52 [279-288] [Type (((Qubit)[], Qubit) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 52 [279-288] [Type (Qubit => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 53 [287-288] [Type (Qubit => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 54 [289-290] [Type ((Qubit)[], Qubit)]: Tuple:
-                                        Expr 55 [289-290] [Type (Qubit)[]]: Var: Local 48
-                                        Expr 54 [289-290] [Type Qubit]: Var: Local 15"#]],
+                                        Expr 43 [229-230] [Type (Qubit => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 44 [231-232] [Type ((Qubit)[], Qubit)]: Tuple:
+                                        Expr 45 [231-232] [Type (Qubit)[]]: Var: Local 38
+                                        Expr 46 [231-232] [Type Qubit]: Var: Local 15
+                        ctl-adj: SpecDecl 48 [153-308]: Impl:
+                            Pat 49 [153-308] [Type (Qubit)[]]: Bind: Ident 50 [153-308] "ctls"
+                            Block 51 [265-302] [Type Unit]:
+                                Stmt 52 [279-292]: Semi: Expr 53 [279-291] [Type Unit]: Call:
+                                    Expr 54 [279-288] [Type (((Qubit)[], Qubit) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 55 [279-288] [Type (Qubit => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 56 [287-288] [Type (Qubit => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 57 [289-290] [Type ((Qubit)[], Qubit)]: Tuple:
+                                        Expr 58 [289-290] [Type (Qubit)[]]: Var: Local 50
+                                        Expr 59 [289-290] [Type Qubit]: Var: Local 15"#]],
     );
 }
 
@@ -313,10 +313,10 @@ fn generate_ctl_skip_conjugate_apply_block() {
                                     Block 41 [222-251] [Type Unit]:
                                         Stmt 42 [236-241]: Semi: Expr 43 [236-240] [Type Unit]: Call:
                                             Expr 44 [236-237] [Type (((Qubit)[], Qubit) => Unit is Ctl)]: UnOp (Functor Ctl):
-                                                Expr 44 [236-237] [Type (Qubit => Unit is Ctl)]: Var: Item 1
-                                            Expr 45 [238-239] [Type ((Qubit)[], Qubit)]: Tuple:
-                                                Expr 46 [238-239] [Type (Qubit)[]]: Var: Local 32
-                                                Expr 45 [238-239] [Type Qubit]: Var: Local 13
+                                                Expr 45 [236-237] [Type (Qubit => Unit is Ctl)]: Var: Item 1
+                                            Expr 46 [238-239] [Type ((Qubit)[], Qubit)]: Tuple:
+                                                Expr 47 [238-239] [Type (Qubit)[]]: Var: Local 32
+                                                Expr 48 [238-239] [Type Qubit]: Var: Local 13
                         ctl-adj: <none>"#]],
     );
 }
@@ -415,10 +415,10 @@ fn generate_ctl_with_function_calls() {
                                     Expr 37 [126-128] [Type Unit]: Unit
                                 Stmt 38 [138-142]: Semi: Expr 39 [138-141] [Type Unit]: Call:
                                     Expr 40 [138-139] [Type (((Qubit)[], Unit) => Unit is Ctl)]: UnOp (Functor Ctl):
-                                        Expr 40 [138-139] [Type (Unit => Unit is Ctl)]: Var: Item 2
-                                    Expr 41 [139-141] [Type ((Qubit)[], Unit)]: Tuple:
-                                        Expr 42 [139-141] [Type (Qubit)[]]: Var: Local 32
-                                        Expr 41 [139-141] [Type Unit]: Unit
+                                        Expr 41 [138-139] [Type (Unit => Unit is Ctl)]: Var: Item 2
+                                    Expr 42 [139-141] [Type ((Qubit)[], Unit)]: Tuple:
+                                        Expr 43 [139-141] [Type (Qubit)[]]: Var: Local 32
+                                        Expr 44 [139-141] [Type Unit]: Unit
                         ctl-adj: <none>"#]],
     );
 }
@@ -528,44 +528,44 @@ fn generate_ctladj_self() {
                                 Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
                                     Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl 49 [159-172]: Impl:
-                            Block 50 [135-150] [Type Unit]:
-                                Stmt 51 [137-142]: Semi: Expr 52 [137-141] [Type Unit]: Call:
-                                    Expr 53 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 54 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 55 [143-148]: Semi: Expr 56 [143-147] [Type Unit]: Call:
-                                    Expr 57 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 58 [145-146] [Type Int]: Lit: Int(2)
+                        adj: SpecDecl 53 [159-172]: Impl:
+                            Block 54 [135-150] [Type Unit]:
+                                Stmt 55 [137-142]: Semi: Expr 56 [137-141] [Type Unit]: Call:
+                                    Expr 57 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 58 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 59 [143-148]: Semi: Expr 60 [143-147] [Type Unit]: Call:
+                                    Expr 61 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 62 [145-146] [Type Int]: Lit: Int(2)
                         ctl: SpecDecl 35 [73-178]: Impl:
                             Pat 36 [73-178] [Type (Qubit)[]]: Bind: Ident 37 [73-178] "ctls"
                             Block 38 [135-150] [Type Unit]:
                                 Stmt 39 [137-142]: Semi: Expr 40 [137-141] [Type Unit]: Call:
                                     Expr 41 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 41 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 42 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 43 [139-140] [Type (Qubit)[]]: Var: Local 37
-                                        Expr 42 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 44 [143-148]: Semi: Expr 45 [143-147] [Type Unit]: Call:
-                                    Expr 46 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 46 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 47 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 48 [145-146] [Type (Qubit)[]]: Var: Local 37
-                                        Expr 47 [145-146] [Type Int]: Lit: Int(2)
-                        ctl-adj: SpecDecl 59 [73-178]: Impl:
-                            Pat 60 [73-178] [Type (Qubit)[]]: Bind: Ident 61 [73-178] "ctls"
-                            Block 62 [135-150] [Type Unit]:
-                                Stmt 63 [137-142]: Semi: Expr 64 [137-141] [Type Unit]: Call:
-                                    Expr 65 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 65 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 66 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 67 [139-140] [Type (Qubit)[]]: Var: Local 61
-                                        Expr 66 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 68 [143-148]: Semi: Expr 69 [143-147] [Type Unit]: Call:
-                                    Expr 70 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 70 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 71 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 72 [145-146] [Type (Qubit)[]]: Var: Local 61
-                                        Expr 71 [145-146] [Type Int]: Lit: Int(2)"#]],
+                                        Expr 42 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 43 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 44 [139-140] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 45 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 46 [143-148]: Semi: Expr 47 [143-147] [Type Unit]: Call:
+                                    Expr 48 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 49 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 50 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 51 [145-146] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 52 [145-146] [Type Int]: Lit: Int(2)
+                        ctl-adj: SpecDecl 63 [73-178]: Impl:
+                            Pat 64 [73-178] [Type (Qubit)[]]: Bind: Ident 65 [73-178] "ctls"
+                            Block 66 [135-150] [Type Unit]:
+                                Stmt 67 [137-142]: Semi: Expr 68 [137-141] [Type Unit]: Call:
+                                    Expr 69 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 70 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 71 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 72 [139-140] [Type (Qubit)[]]: Var: Local 65
+                                        Expr 73 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 74 [143-148]: Semi: Expr 75 [143-147] [Type Unit]: Call:
+                                    Expr 76 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 77 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 78 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 79 [145-146] [Type (Qubit)[]]: Var: Local 65
+                                        Expr 80 [145-146] [Type Int]: Lit: Int(2)"#]],
     );
 }
 
@@ -1298,48 +1298,48 @@ fn generate_ctladj_distribute() {
                                 Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
                                     Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl 48 [73-156]: Impl:
-                            Block 49 [135-150] [Type Unit]:
-                                Stmt 50 [143-148]: Semi: Expr 51 [143-147] [Type Unit]: Call:
-                                    Expr 52 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 53 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 54 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 55 [137-142]: Semi: Expr 56 [137-141] [Type Unit]: Call:
-                                    Expr 57 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 58 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 59 [139-140] [Type Int]: Lit: Int(1)
+                        adj: SpecDecl 52 [73-156]: Impl:
+                            Block 53 [135-150] [Type Unit]:
+                                Stmt 54 [143-148]: Semi: Expr 55 [143-147] [Type Unit]: Call:
+                                    Expr 56 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 57 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 58 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 59 [137-142]: Semi: Expr 60 [137-141] [Type Unit]: Call:
+                                    Expr 61 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 62 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 63 [139-140] [Type Int]: Lit: Int(1)
                         ctl: SpecDecl 34 [73-156]: Impl:
                             Pat 35 [73-156] [Type (Qubit)[]]: Bind: Ident 36 [73-156] "ctls"
                             Block 37 [135-150] [Type Unit]:
                                 Stmt 38 [137-142]: Semi: Expr 39 [137-141] [Type Unit]: Call:
                                     Expr 40 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 40 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 41 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 42 [139-140] [Type (Qubit)[]]: Var: Local 36
-                                        Expr 41 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 43 [143-148]: Semi: Expr 44 [143-147] [Type Unit]: Call:
-                                    Expr 45 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 45 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 46 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 47 [145-146] [Type (Qubit)[]]: Var: Local 36
-                                        Expr 46 [145-146] [Type Int]: Lit: Int(2)
-                        ctl-adj: SpecDecl 61 [73-156]: Impl:
-                            Pat 62 [73-156] [Type (Qubit)[]]: Bind: Ident 63 [73-156] "ctls"
-                            Block 64 [135-150] [Type Unit]:
-                                Stmt 65 [143-148]: Semi: Expr 66 [143-147] [Type Unit]: Call:
-                                    Expr 67 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 67 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 68 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 69 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 70 [145-146] [Type (Qubit)[]]: Var: Local 63
-                                        Expr 69 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 71 [137-142]: Semi: Expr 72 [137-141] [Type Unit]: Call:
-                                    Expr 73 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 73 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 74 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 75 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 76 [139-140] [Type (Qubit)[]]: Var: Local 63
-                                        Expr 75 [139-140] [Type Int]: Lit: Int(1)"#]],
+                                        Expr 41 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 42 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 43 [139-140] [Type (Qubit)[]]: Var: Local 36
+                                        Expr 44 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 45 [143-148]: Semi: Expr 46 [143-147] [Type Unit]: Call:
+                                    Expr 47 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 48 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 49 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 50 [145-146] [Type (Qubit)[]]: Var: Local 36
+                                        Expr 51 [145-146] [Type Int]: Lit: Int(2)
+                        ctl-adj: SpecDecl 65 [73-156]: Impl:
+                            Pat 66 [73-156] [Type (Qubit)[]]: Bind: Ident 67 [73-156] "ctls"
+                            Block 68 [135-150] [Type Unit]:
+                                Stmt 69 [143-148]: Semi: Expr 70 [143-147] [Type Unit]: Call:
+                                    Expr 71 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 72 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 73 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 74 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 75 [145-146] [Type (Qubit)[]]: Var: Local 67
+                                        Expr 76 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 77 [137-142]: Semi: Expr 78 [137-141] [Type Unit]: Call:
+                                    Expr 79 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 80 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 81 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 82 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 83 [139-140] [Type (Qubit)[]]: Var: Local 67
+                                        Expr 84 [139-140] [Type Int]: Lit: Int(1)"#]],
     );
 }
 
@@ -1391,48 +1391,48 @@ fn generate_ctladj_auto_to_distribute() {
                                 Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
                                     Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl 49 [73-189]: Impl:
-                            Block 50 [135-150] [Type Unit]:
-                                Stmt 51 [143-148]: Semi: Expr 52 [143-147] [Type Unit]: Call:
-                                    Expr 53 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 54 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 55 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 56 [137-142]: Semi: Expr 57 [137-141] [Type Unit]: Call:
-                                    Expr 58 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 59 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 60 [139-140] [Type Int]: Lit: Int(1)
+                        adj: SpecDecl 53 [73-189]: Impl:
+                            Block 54 [135-150] [Type Unit]:
+                                Stmt 55 [143-148]: Semi: Expr 56 [143-147] [Type Unit]: Call:
+                                    Expr 57 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 58 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 59 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 60 [137-142]: Semi: Expr 61 [137-141] [Type Unit]: Call:
+                                    Expr 62 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 63 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 64 [139-140] [Type Int]: Lit: Int(1)
                         ctl: SpecDecl 35 [73-189]: Impl:
                             Pat 36 [73-189] [Type (Qubit)[]]: Bind: Ident 37 [73-189] "ctls"
                             Block 38 [135-150] [Type Unit]:
                                 Stmt 39 [137-142]: Semi: Expr 40 [137-141] [Type Unit]: Call:
                                     Expr 41 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 41 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 42 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 43 [139-140] [Type (Qubit)[]]: Var: Local 37
-                                        Expr 42 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 44 [143-148]: Semi: Expr 45 [143-147] [Type Unit]: Call:
-                                    Expr 46 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 46 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 47 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 48 [145-146] [Type (Qubit)[]]: Var: Local 37
-                                        Expr 47 [145-146] [Type Int]: Lit: Int(2)
-                        ctl-adj: SpecDecl 62 [73-189]: Impl:
-                            Pat 63 [73-189] [Type (Qubit)[]]: Bind: Ident 64 [73-189] "ctls"
-                            Block 65 [135-150] [Type Unit]:
-                                Stmt 66 [143-148]: Semi: Expr 67 [143-147] [Type Unit]: Call:
-                                    Expr 68 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 68 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 69 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 70 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 71 [145-146] [Type (Qubit)[]]: Var: Local 64
-                                        Expr 70 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 72 [137-142]: Semi: Expr 73 [137-141] [Type Unit]: Call:
-                                    Expr 74 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 74 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 75 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 76 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 77 [139-140] [Type (Qubit)[]]: Var: Local 64
-                                        Expr 76 [139-140] [Type Int]: Lit: Int(1)"#]],
+                                        Expr 42 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 43 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 44 [139-140] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 45 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 46 [143-148]: Semi: Expr 47 [143-147] [Type Unit]: Call:
+                                    Expr 48 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 49 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 50 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 51 [145-146] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 52 [145-146] [Type Int]: Lit: Int(2)
+                        ctl-adj: SpecDecl 66 [73-189]: Impl:
+                            Pat 67 [73-189] [Type (Qubit)[]]: Bind: Ident 68 [73-189] "ctls"
+                            Block 69 [135-150] [Type Unit]:
+                                Stmt 70 [143-148]: Semi: Expr 71 [143-147] [Type Unit]: Call:
+                                    Expr 72 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 73 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 74 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 75 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 76 [145-146] [Type (Qubit)[]]: Var: Local 68
+                                        Expr 77 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 78 [137-142]: Semi: Expr 79 [137-141] [Type Unit]: Call:
+                                    Expr 80 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 81 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 82 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 83 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 84 [139-140] [Type (Qubit)[]]: Var: Local 68
+                                        Expr 85 [139-140] [Type Int]: Lit: Int(1)"#]],
     );
 }
 
@@ -1578,48 +1578,48 @@ fn generate_ctladj_invert() {
                                 Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
                                     Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl 49 [73-191]: Impl:
-                            Block 50 [135-150] [Type Unit]:
-                                Stmt 51 [143-148]: Semi: Expr 52 [143-147] [Type Unit]: Call:
-                                    Expr 53 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 54 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 55 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 56 [137-142]: Semi: Expr 57 [137-141] [Type Unit]: Call:
-                                    Expr 58 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 59 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 60 [139-140] [Type Int]: Lit: Int(1)
+                        adj: SpecDecl 53 [73-191]: Impl:
+                            Block 54 [135-150] [Type Unit]:
+                                Stmt 55 [143-148]: Semi: Expr 56 [143-147] [Type Unit]: Call:
+                                    Expr 57 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 58 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 59 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 60 [137-142]: Semi: Expr 61 [137-141] [Type Unit]: Call:
+                                    Expr 62 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 63 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 64 [139-140] [Type Int]: Lit: Int(1)
                         ctl: SpecDecl 35 [73-191]: Impl:
                             Pat 36 [73-191] [Type (Qubit)[]]: Bind: Ident 37 [73-191] "ctls"
                             Block 38 [135-150] [Type Unit]:
                                 Stmt 39 [137-142]: Semi: Expr 40 [137-141] [Type Unit]: Call:
                                     Expr 41 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 41 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 42 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 43 [139-140] [Type (Qubit)[]]: Var: Local 37
-                                        Expr 42 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 44 [143-148]: Semi: Expr 45 [143-147] [Type Unit]: Call:
-                                    Expr 46 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 46 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 47 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 48 [145-146] [Type (Qubit)[]]: Var: Local 37
-                                        Expr 47 [145-146] [Type Int]: Lit: Int(2)
-                        ctl-adj: SpecDecl 61 [159-185]: Impl:
-                            Pat 62 [73-191] [Type (Qubit)[]]: Bind: Ident 63 [73-191] "ctls"
-                            Block 64 [135-150] [Type Unit]:
-                                Stmt 65 [143-148]: Semi: Expr 66 [143-147] [Type Unit]: Call:
-                                    Expr 67 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 68 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                            Expr 68 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 69 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 70 [145-146] [Type (Qubit)[]]: Var: Local 63
-                                        Expr 69 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 71 [137-142]: Semi: Expr 72 [137-141] [Type Unit]: Call:
-                                    Expr 73 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 74 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                            Expr 74 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 75 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 76 [139-140] [Type (Qubit)[]]: Var: Local 63
-                                        Expr 75 [139-140] [Type Int]: Lit: Int(1)"#]],
+                                        Expr 42 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 43 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 44 [139-140] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 45 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 46 [143-148]: Semi: Expr 47 [143-147] [Type Unit]: Call:
+                                    Expr 48 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 49 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 50 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 51 [145-146] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 52 [145-146] [Type Int]: Lit: Int(2)
+                        ctl-adj: SpecDecl 65 [159-185]: Impl:
+                            Pat 66 [73-191] [Type (Qubit)[]]: Bind: Ident 67 [73-191] "ctls"
+                            Block 68 [135-150] [Type Unit]:
+                                Stmt 69 [143-148]: Semi: Expr 70 [143-147] [Type Unit]: Call:
+                                    Expr 71 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 72 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                            Expr 73 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 74 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 75 [145-146] [Type (Qubit)[]]: Var: Local 67
+                                        Expr 76 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 77 [137-142]: Semi: Expr 78 [137-141] [Type Unit]: Call:
+                                    Expr 79 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 80 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                            Expr 81 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 82 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 83 [139-140] [Type (Qubit)[]]: Var: Local 67
+                                        Expr 84 [139-140] [Type Int]: Lit: Int(1)"#]],
     );
 }
 

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -91,15 +91,15 @@ fn generate_ctl() {
                                     Expr 18 [171-172] [Type (Qubit => Unit is Ctl)]: Var: Item 1
                                     Expr 19 [173-174] [Type Qubit]: Var: Local 13
                         adj: <none>
-                        ctl: SpecDecl _id_ [124-182]: Impl:
-                            Pat _id_ [124-182] [Type (Qubit)[]]: Bind: Ident 21 [124-182] "ctls"
-                            Block 15 [161-182] [Type Unit]:
-                                Stmt 16 [171-176]: Semi: Expr 17 [171-175] [Type Unit]: Call:
-                                    Expr 18 [171-172] [Type (((Qubit)[], Qubit) => Unit is Ctl)]: UnOp (Functor Ctl):
-                                        Expr 18 [171-172] [Type (Qubit => Unit is Ctl)]: Var: Item 1
-                                    Expr 19 [173-174] [Type ((Qubit)[], Qubit)]: Tuple:
-                                        Expr _id_ [173-174] [Type (Qubit)[]]: Var: Local 21
-                                        Expr 19 [173-174] [Type Qubit]: Var: Local 13
+                        ctl: SpecDecl 22 [124-182]: Impl:
+                            Pat 23 [124-182] [Type (Qubit)[]]: Bind: Ident 24 [124-182] "ctls"
+                            Block 25 [161-182] [Type Unit]:
+                                Stmt 26 [171-176]: Semi: Expr 27 [171-175] [Type Unit]: Call:
+                                    Expr 28 [171-172] [Type (((Qubit)[], Qubit) => Unit is Ctl)]: UnOp (Functor Ctl):
+                                        Expr 28 [171-172] [Type (Qubit => Unit is Ctl)]: Var: Item 1
+                                    Expr 29 [173-174] [Type ((Qubit)[], Qubit)]: Tuple:
+                                        Expr 30 [173-174] [Type (Qubit)[]]: Var: Local 24
+                                        Expr 29 [173-174] [Type Qubit]: Var: Local 13
                         ctl-adj: <none>"#]],
     );
 }
@@ -152,15 +152,15 @@ fn generate_ctl_auto() {
                                     Expr 18 [194-195] [Type (Qubit => Unit is Ctl)]: Var: Item 1
                                     Expr 19 [196-197] [Type Qubit]: Var: Local 13
                         adj: <none>
-                        ctl: SpecDecl 20 [218-234]: Impl:
-                            Pat _id_ [218-234] [Type (Qubit)[]]: Bind: Ident 22 [218-234] "ctls"
-                            Block 15 [180-209] [Type Unit]:
-                                Stmt 16 [194-199]: Semi: Expr 17 [194-198] [Type Unit]: Call:
-                                    Expr 18 [194-195] [Type (((Qubit)[], Qubit) => Unit is Ctl)]: UnOp (Functor Ctl):
-                                        Expr 18 [194-195] [Type (Qubit => Unit is Ctl)]: Var: Item 1
-                                    Expr 19 [196-197] [Type ((Qubit)[], Qubit)]: Tuple:
-                                        Expr _id_ [196-197] [Type (Qubit)[]]: Var: Local 22
-                                        Expr 19 [196-197] [Type Qubit]: Var: Local 13
+                        ctl: SpecDecl 23 [218-234]: Impl:
+                            Pat 24 [218-234] [Type (Qubit)[]]: Bind: Ident 25 [218-234] "ctls"
+                            Block 26 [180-209] [Type Unit]:
+                                Stmt 27 [194-199]: Semi: Expr 28 [194-198] [Type Unit]: Call:
+                                    Expr 29 [194-195] [Type (((Qubit)[], Qubit) => Unit is Ctl)]: UnOp (Functor Ctl):
+                                        Expr 29 [194-195] [Type (Qubit => Unit is Ctl)]: Var: Item 1
+                                    Expr 30 [196-197] [Type ((Qubit)[], Qubit)]: Tuple:
+                                        Expr 31 [196-197] [Type (Qubit)[]]: Var: Local 25
+                                        Expr 30 [196-197] [Type Qubit]: Var: Local 13
                         ctl-adj: <none>"#]],
     );
 }
@@ -203,9 +203,9 @@ fn generate_ctladj_distrib() {
                         ctl: SpecDecl 8 [117-142]: Impl:
                             Pat 9 [129-133] [Type (Qubit)[]]: Bind: Ident 10 [129-133] "ctls"
                             Block 11 [140-142]: <empty>
-                        ctl-adj: SpecDecl _id_ [21-148]: Impl:
-                            Pat _id_ [21-148] [Type (Qubit)[]]: Bind: Ident 30 [21-148] "ctls"
-                            Block 7 [106-108]: <empty>
+                        ctl-adj: SpecDecl 31 [21-148]: Impl:
+                            Pat 32 [21-148] [Type (Qubit)[]]: Bind: Ident 33 [21-148] "ctls"
+                            Block 34 [106-108]: <empty>
                 Item 2 [153-308] (Public):
                     Parent: 0
                     Callable 12 [153-308] (operation):
@@ -224,25 +224,25 @@ fn generate_ctladj_distrib() {
                                     Expr 26 [279-288] [Type (Qubit => Unit is Adj + Ctl)]: UnOp (Functor Adj):
                                         Expr 27 [287-288] [Type (Qubit => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 28 [289-290] [Type Qubit]: Var: Local 15
-                        ctl: SpecDecl _id_ [153-308]: Impl:
-                            Pat _id_ [153-308] [Type (Qubit)[]]: Bind: Ident 31 [153-308] "ctls"
-                            Block 17 [215-244] [Type Unit]:
-                                Stmt 18 [229-234]: Semi: Expr 19 [229-233] [Type Unit]: Call:
-                                    Expr 20 [229-230] [Type (((Qubit)[], Qubit) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 20 [229-230] [Type (Qubit => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 21 [231-232] [Type ((Qubit)[], Qubit)]: Tuple:
-                                        Expr _id_ [231-232] [Type (Qubit)[]]: Var: Local 31
-                                        Expr 21 [231-232] [Type Qubit]: Var: Local 15
-                        ctl-adj: SpecDecl _id_ [153-308]: Impl:
-                            Pat _id_ [153-308] [Type (Qubit)[]]: Bind: Ident 32 [153-308] "ctls"
-                            Block 23 [265-302] [Type Unit]:
-                                Stmt 24 [279-292]: Semi: Expr 25 [279-291] [Type Unit]: Call:
-                                    Expr 26 [279-288] [Type (((Qubit)[], Qubit) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 26 [279-288] [Type (Qubit => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 27 [287-288] [Type (Qubit => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 28 [289-290] [Type ((Qubit)[], Qubit)]: Tuple:
-                                        Expr _id_ [289-290] [Type (Qubit)[]]: Var: Local 32
-                                        Expr 28 [289-290] [Type Qubit]: Var: Local 15"#]],
+                        ctl: SpecDecl 36 [153-308]: Impl:
+                            Pat 37 [153-308] [Type (Qubit)[]]: Bind: Ident 38 [153-308] "ctls"
+                            Block 39 [215-244] [Type Unit]:
+                                Stmt 40 [229-234]: Semi: Expr 41 [229-233] [Type Unit]: Call:
+                                    Expr 42 [229-230] [Type (((Qubit)[], Qubit) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 42 [229-230] [Type (Qubit => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 43 [231-232] [Type ((Qubit)[], Qubit)]: Tuple:
+                                        Expr 44 [231-232] [Type (Qubit)[]]: Var: Local 38
+                                        Expr 43 [231-232] [Type Qubit]: Var: Local 15
+                        ctl-adj: SpecDecl 46 [153-308]: Impl:
+                            Pat 47 [153-308] [Type (Qubit)[]]: Bind: Ident 48 [153-308] "ctls"
+                            Block 49 [265-302] [Type Unit]:
+                                Stmt 50 [279-292]: Semi: Expr 51 [279-291] [Type Unit]: Call:
+                                    Expr 52 [279-288] [Type (((Qubit)[], Qubit) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 52 [279-288] [Type (Qubit => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 53 [287-288] [Type (Qubit => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 54 [289-290] [Type ((Qubit)[], Qubit)]: Tuple:
+                                        Expr 55 [289-290] [Type (Qubit)[]]: Var: Local 48
+                                        Expr 54 [289-290] [Type Qubit]: Var: Local 15"#]],
     );
 }
 
@@ -302,21 +302,21 @@ fn generate_ctl_skip_conjugate_apply_block() {
                                             Expr 26 [236-237] [Type (Qubit => Unit is Ctl)]: Var: Item 1
                                             Expr 27 [238-239] [Type Qubit]: Var: Local 13
                         adj: <none>
-                        ctl: SpecDecl _id_ [124-257]: Impl:
-                            Pat _id_ [124-257] [Type (Qubit)[]]: Bind: Ident 29 [124-257] "ctls"
-                            Block 15 [161-257] [Type Unit]:
-                                Stmt 16 [171-251]: Expr: Expr 17 [171-251] [Type Unit]: Conjugate:
-                                    Block 18 [178-207] [Type Unit]:
-                                        Stmt 19 [192-197]: Semi: Expr 20 [192-196] [Type Unit]: Call:
-                                            Expr 21 [192-193] [Type (Qubit => Unit is Ctl)]: Var: Item 1
-                                            Expr 22 [194-195] [Type Qubit]: Var: Local 13
-                                    Block 23 [222-251] [Type Unit]:
-                                        Stmt 24 [236-241]: Semi: Expr 25 [236-240] [Type Unit]: Call:
-                                            Expr 26 [236-237] [Type (((Qubit)[], Qubit) => Unit is Ctl)]: UnOp (Functor Ctl):
-                                                Expr 26 [236-237] [Type (Qubit => Unit is Ctl)]: Var: Item 1
-                                            Expr 27 [238-239] [Type ((Qubit)[], Qubit)]: Tuple:
-                                                Expr _id_ [238-239] [Type (Qubit)[]]: Var: Local 29
-                                                Expr 27 [238-239] [Type Qubit]: Var: Local 13
+                        ctl: SpecDecl 30 [124-257]: Impl:
+                            Pat 31 [124-257] [Type (Qubit)[]]: Bind: Ident 32 [124-257] "ctls"
+                            Block 33 [161-257] [Type Unit]:
+                                Stmt 34 [171-251]: Expr: Expr 35 [171-251] [Type Unit]: Conjugate:
+                                    Block 36 [178-207] [Type Unit]:
+                                        Stmt 37 [192-197]: Semi: Expr 38 [192-196] [Type Unit]: Call:
+                                            Expr 39 [192-193] [Type (Qubit => Unit is Ctl)]: Var: Item 1
+                                            Expr 40 [194-195] [Type Qubit]: Var: Local 13
+                                    Block 41 [222-251] [Type Unit]:
+                                        Stmt 42 [236-241]: Semi: Expr 43 [236-240] [Type Unit]: Call:
+                                            Expr 44 [236-237] [Type (((Qubit)[], Qubit) => Unit is Ctl)]: UnOp (Functor Ctl):
+                                                Expr 44 [236-237] [Type (Qubit => Unit is Ctl)]: Var: Item 1
+                                            Expr 45 [238-239] [Type ((Qubit)[], Qubit)]: Tuple:
+                                                Expr 46 [238-239] [Type (Qubit)[]]: Var: Local 32
+                                                Expr 45 [238-239] [Type Qubit]: Var: Local 13
                         ctl-adj: <none>"#]],
     );
 }
@@ -387,9 +387,9 @@ fn generate_ctl_with_function_calls() {
                         body: SpecDecl 8 [50-80]: Impl:
                             Block 9 [78-80]: <empty>
                         adj: <none>
-                        ctl: SpecDecl _id_ [50-80]: Impl:
-                            Pat _id_ [50-80] [Type (Qubit)[]]: Bind: Ident 24 [50-80] "ctls"
-                            Block 9 [78-80]: <empty>
+                        ctl: SpecDecl 25 [50-80]: Impl:
+                            Pat 26 [50-80] [Type (Qubit)[]]: Bind: Ident 27 [50-80] "ctls"
+                            Block 28 [78-80]: <empty>
                         ctl-adj: <none>
                 Item 3 [85-148] (Public):
                     Parent: 0
@@ -407,18 +407,18 @@ fn generate_ctl_with_function_calls() {
                                     Expr 21 [138-139] [Type (Unit => Unit is Ctl)]: Var: Item 2
                                     Expr 22 [139-141] [Type Unit]: Unit
                         adj: <none>
-                        ctl: SpecDecl _id_ [85-148]: Impl:
-                            Pat _id_ [85-148] [Type (Qubit)[]]: Bind: Ident 25 [85-148] "ctls"
-                            Block 14 [113-148] [Type Unit]:
-                                Stmt 15 [123-129]: Semi: Expr 16 [123-128] [Type Unit]: Call:
-                                    Expr 17 [123-126] [Type (Unit -> Unit)]: Var: Item 1
-                                    Expr 18 [126-128] [Type Unit]: Unit
-                                Stmt 19 [138-142]: Semi: Expr 20 [138-141] [Type Unit]: Call:
-                                    Expr 21 [138-139] [Type (((Qubit)[], Unit) => Unit is Ctl)]: UnOp (Functor Ctl):
-                                        Expr 21 [138-139] [Type (Unit => Unit is Ctl)]: Var: Item 2
-                                    Expr 22 [139-141] [Type ((Qubit)[], Unit)]: Tuple:
-                                        Expr _id_ [139-141] [Type (Qubit)[]]: Var: Local 25
-                                        Expr 22 [139-141] [Type Unit]: Unit
+                        ctl: SpecDecl 30 [85-148]: Impl:
+                            Pat 31 [85-148] [Type (Qubit)[]]: Bind: Ident 32 [85-148] "ctls"
+                            Block 33 [113-148] [Type Unit]:
+                                Stmt 34 [123-129]: Semi: Expr 35 [123-128] [Type Unit]: Call:
+                                    Expr 36 [123-126] [Type (Unit -> Unit)]: Var: Item 1
+                                    Expr 37 [126-128] [Type Unit]: Unit
+                                Stmt 38 [138-142]: Semi: Expr 39 [138-141] [Type Unit]: Call:
+                                    Expr 40 [138-139] [Type (((Qubit)[], Unit) => Unit is Ctl)]: UnOp (Functor Ctl):
+                                        Expr 40 [138-139] [Type (Unit => Unit is Ctl)]: Var: Item 2
+                                    Expr 41 [139-141] [Type ((Qubit)[], Unit)]: Tuple:
+                                        Expr 42 [139-141] [Type (Qubit)[]]: Var: Local 32
+                                        Expr 41 [139-141] [Type Unit]: Unit
                         ctl-adj: <none>"#]],
     );
 }
@@ -448,8 +448,8 @@ fn generate_adj_self() {
                         functors: Adj
                         body: SpecDecl 4 [21-62]: Impl:
                             Block 5 [60-62]: <empty>
-                        adj: SpecDecl _id_ [21-62]: Impl:
-                            Block 5 [60-62]: <empty>
+                        adj: SpecDecl 22 [21-62]: Impl:
+                            Block 23 [60-62]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 2 [67-166] (Public):
@@ -467,14 +467,14 @@ fn generate_adj_self() {
                                 Stmt 16 [131-136]: Semi: Expr 17 [131-135] [Type Unit]: Call:
                                     Expr 18 [131-132] [Type (Int => Unit is Adj)]: Var: Item 1
                                     Expr 19 [133-134] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl 20 [147-160]: Impl:
-                            Block 11 [123-138] [Type Unit]:
-                                Stmt 12 [125-130]: Semi: Expr 13 [125-129] [Type Unit]: Call:
-                                    Expr 14 [125-126] [Type (Int => Unit is Adj)]: Var: Item 1
-                                    Expr 15 [127-128] [Type Int]: Lit: Int(1)
-                                Stmt 16 [131-136]: Semi: Expr 17 [131-135] [Type Unit]: Call:
-                                    Expr 18 [131-132] [Type (Int => Unit is Adj)]: Var: Item 1
-                                    Expr 19 [133-134] [Type Int]: Lit: Int(2)
+                        adj: SpecDecl 24 [147-160]: Impl:
+                            Block 25 [123-138] [Type Unit]:
+                                Stmt 26 [125-130]: Semi: Expr 27 [125-129] [Type Unit]: Call:
+                                    Expr 28 [125-126] [Type (Int => Unit is Adj)]: Var: Item 1
+                                    Expr 29 [127-128] [Type Int]: Lit: Int(1)
+                                Stmt 30 [131-136]: Semi: Expr 31 [131-135] [Type Unit]: Call:
+                                    Expr 32 [131-132] [Type (Int => Unit is Adj)]: Var: Item 1
+                                    Expr 33 [133-134] [Type Int]: Lit: Int(2)
                         ctl: <none>
                         ctl-adj: <none>"#]],
     );
@@ -505,14 +505,14 @@ fn generate_ctladj_self() {
                         functors: Adj + Ctl
                         body: SpecDecl 4 [21-68]: Impl:
                             Block 5 [66-68]: <empty>
-                        adj: SpecDecl _id_ [21-68]: Impl:
-                            Block 5 [66-68]: <empty>
-                        ctl: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 22 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
-                        ctl-adj: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 23 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
+                        adj: SpecDecl 27 [21-68]: Impl:
+                            Block 28 [66-68]: <empty>
+                        ctl: SpecDecl 23 [21-68]: Impl:
+                            Pat 24 [21-68] [Type (Qubit)[]]: Bind: Ident 25 [21-68] "ctls"
+                            Block 26 [66-68]: <empty>
+                        ctl-adj: SpecDecl 30 [21-68]: Impl:
+                            Pat 31 [21-68] [Type (Qubit)[]]: Bind: Ident 32 [21-68] "ctls"
+                            Block 33 [66-68]: <empty>
                 Item 2 [73-178] (Public):
                     Parent: 0
                     Callable 6 [73-178] (operation):
@@ -528,44 +528,44 @@ fn generate_ctladj_self() {
                                 Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
                                     Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl 20 [159-172]: Impl:
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        ctl: SpecDecl _id_ [73-178]: Impl:
-                            Pat _id_ [73-178] [Type (Qubit)[]]: Bind: Ident 24 [73-178] "ctls"
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr 14 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [139-140] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 15 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr 18 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [145-146] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        ctl-adj: SpecDecl _id_ [73-178]: Impl:
-                            Pat _id_ [73-178] [Type (Qubit)[]]: Bind: Ident 24 [73-178] "ctls"
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr 14 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [139-140] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 15 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr 18 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [145-146] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 19 [145-146] [Type Int]: Lit: Int(2)"#]],
+                        adj: SpecDecl 49 [159-172]: Impl:
+                            Block 50 [135-150] [Type Unit]:
+                                Stmt 51 [137-142]: Semi: Expr 52 [137-141] [Type Unit]: Call:
+                                    Expr 53 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 54 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 55 [143-148]: Semi: Expr 56 [143-147] [Type Unit]: Call:
+                                    Expr 57 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 58 [145-146] [Type Int]: Lit: Int(2)
+                        ctl: SpecDecl 35 [73-178]: Impl:
+                            Pat 36 [73-178] [Type (Qubit)[]]: Bind: Ident 37 [73-178] "ctls"
+                            Block 38 [135-150] [Type Unit]:
+                                Stmt 39 [137-142]: Semi: Expr 40 [137-141] [Type Unit]: Call:
+                                    Expr 41 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 41 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 42 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 43 [139-140] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 42 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 44 [143-148]: Semi: Expr 45 [143-147] [Type Unit]: Call:
+                                    Expr 46 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 46 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 47 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 48 [145-146] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 47 [145-146] [Type Int]: Lit: Int(2)
+                        ctl-adj: SpecDecl 59 [73-178]: Impl:
+                            Pat 60 [73-178] [Type (Qubit)[]]: Bind: Ident 61 [73-178] "ctls"
+                            Block 62 [135-150] [Type Unit]:
+                                Stmt 63 [137-142]: Semi: Expr 64 [137-141] [Type Unit]: Call:
+                                    Expr 65 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 65 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 66 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 67 [139-140] [Type (Qubit)[]]: Var: Local 61
+                                        Expr 66 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 68 [143-148]: Semi: Expr 69 [143-147] [Type Unit]: Call:
+                                    Expr 70 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 70 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 71 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 72 [145-146] [Type (Qubit)[]]: Var: Local 61
+                                        Expr 71 [145-146] [Type Int]: Lit: Int(2)"#]],
     );
 }
 
@@ -594,8 +594,8 @@ fn generate_adj_invert() {
                         functors: Adj
                         body: SpecDecl 4 [21-62]: Impl:
                             Block 5 [60-62]: <empty>
-                        adj: SpecDecl _id_ [21-62]: Impl:
-                            Block 5 [60-62]: <empty>
+                        adj: SpecDecl 21 [21-62]: Impl:
+                            Block 22 [60-62]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 2 [67-139] (Public):
@@ -613,16 +613,16 @@ fn generate_adj_invert() {
                                 Stmt 16 [128-133]: Semi: Expr 17 [128-132] [Type Unit]: Call:
                                     Expr 18 [128-129] [Type (Int => Unit is Adj)]: Var: Item 1
                                     Expr 19 [130-131] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl _id_ [67-139]: Impl:
-                            Block 11 [104-139] [Type Unit]:
-                                Stmt 16 [128-133]: Semi: Expr 17 [128-132] [Type Unit]: Call:
-                                    Expr _id_ [128-129] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                        Expr 18 [128-129] [Type (Int => Unit is Adj)]: Var: Item 1
-                                    Expr 19 [130-131] [Type Int]: Lit: Int(2)
-                                Stmt 12 [114-119]: Semi: Expr 13 [114-118] [Type Unit]: Call:
-                                    Expr _id_ [114-115] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                        Expr 14 [114-115] [Type (Int => Unit is Adj)]: Var: Item 1
-                                    Expr 15 [116-117] [Type Int]: Lit: Int(1)
+                        adj: SpecDecl 23 [67-139]: Impl:
+                            Block 24 [104-139] [Type Unit]:
+                                Stmt 25 [128-133]: Semi: Expr 26 [128-132] [Type Unit]: Call:
+                                    Expr 27 [128-129] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                        Expr 28 [128-129] [Type (Int => Unit is Adj)]: Var: Item 1
+                                    Expr 29 [130-131] [Type Int]: Lit: Int(2)
+                                Stmt 30 [114-119]: Semi: Expr 31 [114-118] [Type Unit]: Call:
+                                    Expr 32 [114-115] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                        Expr 33 [114-115] [Type (Int => Unit is Adj)]: Var: Item 1
+                                    Expr 34 [116-117] [Type Int]: Lit: Int(1)
                         ctl: <none>
                         ctl-adj: <none>"#]],
     );
@@ -656,8 +656,8 @@ fn generate_adj_auto() {
                         functors: Adj
                         body: SpecDecl 4 [21-62]: Impl:
                             Block 5 [60-62]: <empty>
-                        adj: SpecDecl _id_ [21-62]: Impl:
-                            Block 5 [60-62]: <empty>
+                        adj: SpecDecl 22 [21-62]: Impl:
+                            Block 23 [60-62]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 2 [67-198] (Public):
@@ -675,16 +675,16 @@ fn generate_adj_auto() {
                                 Stmt 16 [155-160]: Semi: Expr 17 [155-159] [Type Unit]: Call:
                                     Expr 18 [155-156] [Type (Int => Unit is Adj)]: Var: Item 1
                                     Expr 19 [157-158] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl 20 [179-192]: Impl:
-                            Block 11 [123-170] [Type Unit]:
-                                Stmt 16 [155-160]: Semi: Expr 17 [155-159] [Type Unit]: Call:
-                                    Expr _id_ [155-156] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                        Expr 18 [155-156] [Type (Int => Unit is Adj)]: Var: Item 1
-                                    Expr 19 [157-158] [Type Int]: Lit: Int(2)
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr _id_ [137-138] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj)]: Var: Item 1
-                                    Expr 15 [139-140] [Type Int]: Lit: Int(1)
+                        adj: SpecDecl 24 [179-192]: Impl:
+                            Block 25 [123-170] [Type Unit]:
+                                Stmt 26 [155-160]: Semi: Expr 27 [155-159] [Type Unit]: Call:
+                                    Expr 28 [155-156] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                        Expr 29 [155-156] [Type (Int => Unit is Adj)]: Var: Item 1
+                                    Expr 30 [157-158] [Type Int]: Lit: Int(2)
+                                Stmt 31 [137-142]: Semi: Expr 32 [137-141] [Type Unit]: Call:
+                                    Expr 33 [137-138] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                        Expr 34 [137-138] [Type (Int => Unit is Adj)]: Var: Item 1
+                                    Expr 35 [139-140] [Type Int]: Lit: Int(1)
                         ctl: <none>
                         ctl-adj: <none>"#]],
     );
@@ -721,8 +721,8 @@ fn generate_adj_invert_skips_within_block() {
                         functors: Adj
                         body: SpecDecl 4 [21-62]: Impl:
                             Block 5 [60-62]: <empty>
-                        adj: SpecDecl _id_ [21-62]: Impl:
-                            Block 5 [60-62]: <empty>
+                        adj: SpecDecl 33 [21-62]: Impl:
+                            Block 34 [60-62]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 2 [67-236] (Public):
@@ -749,25 +749,25 @@ fn generate_adj_invert_skips_within_block() {
                                         Stmt 28 [215-220]: Semi: Expr 29 [215-219] [Type Unit]: Call:
                                             Expr 30 [215-216] [Type (Int => Unit is Adj)]: Var: Item 1
                                             Expr 31 [217-218] [Type Int]: Lit: Int(4)
-                        adj: SpecDecl _id_ [67-236]: Impl:
-                            Block 11 [104-236] [Type Unit]:
-                                Stmt 12 [114-230]: Expr: Expr 13 [114-230] [Type Unit]: Conjugate:
-                                    Block 14 [121-168] [Type Unit]:
-                                        Stmt 15 [135-140]: Semi: Expr 16 [135-139] [Type Unit]: Call:
-                                            Expr 17 [135-136] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 18 [137-138] [Type Int]: Lit: Int(1)
-                                        Stmt 19 [153-158]: Semi: Expr 20 [153-157] [Type Unit]: Call:
-                                            Expr 21 [153-154] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 22 [155-156] [Type Int]: Lit: Int(2)
-                                    Block 23 [183-230] [Type Unit]:
-                                        Stmt 28 [215-220]: Semi: Expr 29 [215-219] [Type Unit]: Call:
-                                            Expr _id_ [215-216] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 30 [215-216] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 31 [217-218] [Type Int]: Lit: Int(4)
-                                        Stmt 24 [197-202]: Semi: Expr 25 [197-201] [Type Unit]: Call:
-                                            Expr _id_ [197-198] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 26 [197-198] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 27 [199-200] [Type Int]: Lit: Int(3)
+                        adj: SpecDecl 35 [67-236]: Impl:
+                            Block 36 [104-236] [Type Unit]:
+                                Stmt 37 [114-230]: Expr: Expr 38 [114-230] [Type Unit]: Conjugate:
+                                    Block 39 [121-168] [Type Unit]:
+                                        Stmt 40 [135-140]: Semi: Expr 41 [135-139] [Type Unit]: Call:
+                                            Expr 42 [135-136] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 43 [137-138] [Type Int]: Lit: Int(1)
+                                        Stmt 44 [153-158]: Semi: Expr 45 [153-157] [Type Unit]: Call:
+                                            Expr 46 [153-154] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 47 [155-156] [Type Int]: Lit: Int(2)
+                                    Block 48 [183-230] [Type Unit]:
+                                        Stmt 49 [215-220]: Semi: Expr 50 [215-219] [Type Unit]: Call:
+                                            Expr 51 [215-216] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 52 [215-216] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 53 [217-218] [Type Int]: Lit: Int(4)
+                                        Stmt 54 [197-202]: Semi: Expr 55 [197-201] [Type Unit]: Call:
+                                            Expr 56 [197-198] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 57 [197-198] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 58 [199-200] [Type Int]: Lit: Int(3)
                         ctl: <none>
                         ctl-adj: <none>"#]],
     );
@@ -801,8 +801,8 @@ fn generate_adj_invert_with_if_exprs() {
                         functors: Adj
                         body: SpecDecl 4 [21-62]: Impl:
                             Block 5 [60-62]: <empty>
-                        adj: SpecDecl _id_ [21-62]: Impl:
-                            Block 5 [60-62]: <empty>
+                        adj: SpecDecl 65 [21-62]: Impl:
+                            Block 66 [60-62]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 2 [67-266] (Public):
@@ -850,51 +850,51 @@ fn generate_adj_invert_with_if_exprs() {
                                 Stmt 60 [255-260]: Semi: Expr 61 [255-259] [Type Unit]: Call:
                                     Expr 62 [255-256] [Type (Int => Unit is Adj)]: Var: Item 1
                                     Expr 63 [257-258] [Type Int]: Lit: Int(7)
-                        adj: SpecDecl _id_ [67-266]: Impl:
-                            Block 11 [104-266] [Type Unit]:
-                                Stmt 16 [128-166]: Local (Immutable):
-                                    Pat 17 [132-135] [Type Bool]: Bind: Ident 18 [132-135] "val"
-                                    Expr 19 [138-165] [Type Bool]: If:
-                                        Expr 20 [141-145] [Type Bool]: Lit: Bool(true)
-                                        Expr 21 [146-153] [Type Bool]: Expr Block: Block 22 [146-153] [Type Bool]:
-                                            Stmt 23 [147-152]: Expr: Expr 24 [147-152] [Type Bool]: Lit: Bool(false)
-                                        Expr 25 [154-165] [Type Bool]: Expr Block: Block 26 [159-165] [Type Bool]:
-                                            Stmt 27 [160-164]: Expr: Expr 28 [160-164] [Type Bool]: Lit: Bool(true)
-                                Stmt 60 [255-260]: Semi: Expr 61 [255-259] [Type Unit]: Call:
-                                    Expr _id_ [255-256] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                        Expr 62 [255-256] [Type (Int => Unit is Adj)]: Var: Item 1
-                                    Expr 63 [257-258] [Type Int]: Lit: Int(7)
-                                Stmt 33 [189-246]: Expr: Expr 34 [189-246] [Type Unit]: If:
-                                    Expr 35 [192-197] [Type Bool]: Lit: Bool(false)
-                                    Expr 36 [198-211] [Type Unit]: Expr Block: Block 37 [198-211] [Type Unit]:
-                                        Stmt 42 [205-210]: Semi: Expr 43 [205-209] [Type Unit]: Call:
-                                            Expr _id_ [205-206] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 44 [205-206] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 45 [207-208] [Type Int]: Lit: Int(4)
-                                        Stmt 38 [199-204]: Semi: Expr 39 [199-203] [Type Unit]: Call:
-                                            Expr _id_ [199-200] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 40 [199-200] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 41 [201-202] [Type Int]: Lit: Int(3)
-                                    Expr 46 [212-246] [Type Unit]: Expr Block: Block 47 [217-246] [Type Unit]:
-                                        Stmt 52 [224-239]: Local (Immutable):
-                                            Pat 53 [228-231] [Type Bool]: Bind: Ident 54 [228-231] "val"
-                                            Expr 55 [234-238] [Type Bool]: Lit: Bool(true)
-                                        Stmt 56 [240-245]: Semi: Expr 57 [240-244] [Type Unit]: Call:
-                                            Expr _id_ [240-241] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 58 [240-241] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 59 [242-243] [Type Int]: Lit: Int(6)
-                                        Stmt 48 [218-223]: Semi: Expr 49 [218-222] [Type Unit]: Call:
-                                            Expr _id_ [218-219] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                Expr 50 [218-219] [Type (Int => Unit is Adj)]: Var: Item 1
-                                            Expr 51 [220-221] [Type Int]: Lit: Int(5)
-                                Stmt 29 [175-180]: Semi: Expr 30 [175-179] [Type Unit]: Call:
-                                    Expr _id_ [175-176] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                        Expr 31 [175-176] [Type (Int => Unit is Adj)]: Var: Item 1
-                                    Expr 32 [177-178] [Type Int]: Lit: Int(2)
-                                Stmt 12 [114-119]: Semi: Expr 13 [114-118] [Type Unit]: Call:
-                                    Expr _id_ [114-115] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                        Expr 14 [114-115] [Type (Int => Unit is Adj)]: Var: Item 1
-                                    Expr 15 [116-117] [Type Int]: Lit: Int(1)
+                        adj: SpecDecl 67 [67-266]: Impl:
+                            Block 68 [104-266] [Type Unit]:
+                                Stmt 69 [128-166]: Local (Immutable):
+                                    Pat 70 [132-135] [Type Bool]: Bind: Ident 71 [132-135] "val"
+                                    Expr 72 [138-165] [Type Bool]: If:
+                                        Expr 73 [141-145] [Type Bool]: Lit: Bool(true)
+                                        Expr 74 [146-153] [Type Bool]: Expr Block: Block 75 [146-153] [Type Bool]:
+                                            Stmt 76 [147-152]: Expr: Expr 77 [147-152] [Type Bool]: Lit: Bool(false)
+                                        Expr 78 [154-165] [Type Bool]: Expr Block: Block 79 [159-165] [Type Bool]:
+                                            Stmt 80 [160-164]: Expr: Expr 81 [160-164] [Type Bool]: Lit: Bool(true)
+                                Stmt 82 [255-260]: Semi: Expr 83 [255-259] [Type Unit]: Call:
+                                    Expr 84 [255-256] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                        Expr 85 [255-256] [Type (Int => Unit is Adj)]: Var: Item 1
+                                    Expr 86 [257-258] [Type Int]: Lit: Int(7)
+                                Stmt 87 [189-246]: Expr: Expr 88 [189-246] [Type Unit]: If:
+                                    Expr 89 [192-197] [Type Bool]: Lit: Bool(false)
+                                    Expr 90 [198-211] [Type Unit]: Expr Block: Block 91 [198-211] [Type Unit]:
+                                        Stmt 92 [205-210]: Semi: Expr 93 [205-209] [Type Unit]: Call:
+                                            Expr 94 [205-206] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 95 [205-206] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 96 [207-208] [Type Int]: Lit: Int(4)
+                                        Stmt 97 [199-204]: Semi: Expr 98 [199-203] [Type Unit]: Call:
+                                            Expr 99 [199-200] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 100 [199-200] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 101 [201-202] [Type Int]: Lit: Int(3)
+                                    Expr 102 [212-246] [Type Unit]: Expr Block: Block 103 [217-246] [Type Unit]:
+                                        Stmt 104 [224-239]: Local (Immutable):
+                                            Pat 105 [228-231] [Type Bool]: Bind: Ident 106 [228-231] "val"
+                                            Expr 107 [234-238] [Type Bool]: Lit: Bool(true)
+                                        Stmt 108 [240-245]: Semi: Expr 109 [240-244] [Type Unit]: Call:
+                                            Expr 110 [240-241] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 111 [240-241] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 112 [242-243] [Type Int]: Lit: Int(6)
+                                        Stmt 113 [218-223]: Semi: Expr 114 [218-222] [Type Unit]: Call:
+                                            Expr 115 [218-219] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                Expr 116 [218-219] [Type (Int => Unit is Adj)]: Var: Item 1
+                                            Expr 117 [220-221] [Type Int]: Lit: Int(5)
+                                Stmt 118 [175-180]: Semi: Expr 119 [175-179] [Type Unit]: Call:
+                                    Expr 120 [175-176] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                        Expr 121 [175-176] [Type (Int => Unit is Adj)]: Var: Item 1
+                                    Expr 122 [177-178] [Type Int]: Lit: Int(2)
+                                Stmt 123 [114-119]: Semi: Expr 124 [114-118] [Type Unit]: Call:
+                                    Expr 125 [114-115] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                        Expr 126 [114-115] [Type (Int => Unit is Adj)]: Var: Item 1
+                                    Expr 127 [116-117] [Type Int]: Lit: Int(1)
                         ctl: <none>
                         ctl-adj: <none>"#]],
     );
@@ -927,8 +927,8 @@ fn generate_adj_invert_with_range_loop() {
                         functors: Adj
                         body: SpecDecl 4 [21-62]: Impl:
                             Block 5 [60-62]: <empty>
-                        adj: SpecDecl _id_ [21-62]: Impl:
-                            Block 5 [60-62]: <empty>
+                        adj: SpecDecl 29 [21-62]: Impl:
+                            Block 30 [60-62]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 2 [67-181] (Public):
@@ -953,53 +953,53 @@ fn generate_adj_invert_with_range_loop() {
                                         Stmt 24 [160-165]: Semi: Expr 25 [160-164] [Type Unit]: Call:
                                             Expr 26 [160-161] [Type (Int => Unit is Adj)]: Var: Item 1
                                             Expr 27 [162-163] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl _id_ [67-181]: Impl:
-                            Block 11 [104-181] [Type Unit]:
-                                Stmt 12 [114-175]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block _id_ [0-0] [Type Unit]:
-                                    Stmt _id_ [0-0]: Local (Immutable):
-                                        Pat _id_ [0-0] [Type Range]: Bind: Ident 29 [0-0] "generated_range"
-                                        Expr 16 [123-127] [Type Range]: Range:
-                                            Expr 17 [123-124] [Type Int]: Lit: Int(0)
+                        adj: SpecDecl 32 [67-181]: Impl:
+                            Block 33 [104-181] [Type Unit]:
+                                Stmt 34 [114-175]: Expr: Expr 35 [0-0] [Type Unit]: Expr Block: Block 36 [0-0] [Type Unit]:
+                                    Stmt 37 [0-0]: Local (Immutable):
+                                        Pat 38 [0-0] [Type Range]: Bind: Ident 39 [0-0] "generated_range"
+                                        Expr 40 [123-127] [Type Range]: Range:
+                                            Expr 41 [123-124] [Type Int]: Lit: Int(0)
                                             <no step>
-                                            Expr 18 [126-127] [Type Int]: Lit: Int(5)
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: For:
-                                        Pat 14 [118-119] [Type Int]: Bind: Ident 15 [118-119] "i"
-                                        Expr _id_ [0-0] [Type Range]: Range:
-                                            Expr _id_ [0-0] [Type Int]: BinOp (Add):
-                                                Expr _id_ [0-0] [Type Int]: Field:
-                                                    Expr _id_ [0-0] [Type Range]: Var: Local 29
+                                            Expr 42 [126-127] [Type Int]: Lit: Int(5)
+                                    Stmt 43 [0-0]: Expr: Expr 44 [0-0] [Type Unit]: For:
+                                        Pat 45 [118-119] [Type Int]: Bind: Ident 46 [118-119] "i"
+                                        Expr 47 [0-0] [Type Range]: Range:
+                                            Expr 48 [0-0] [Type Int]: BinOp (Add):
+                                                Expr 49 [0-0] [Type Int]: Field:
+                                                    Expr 50 [0-0] [Type Range]: Var: Local 39
                                                     Prim(Start)
-                                                Expr _id_ [0-0] [Type Int]: BinOp (Mul):
-                                                    Expr _id_ [0-0] [Type Int]: BinOp (Div):
-                                                        Expr _id_ [0-0] [Type Int]: BinOp (Sub):
-                                                            Expr _id_ [0-0] [Type Int]: Field:
-                                                                Expr _id_ [0-0] [Type Range]: Var: Local 29
+                                                Expr 51 [0-0] [Type Int]: BinOp (Mul):
+                                                    Expr 52 [0-0] [Type Int]: BinOp (Div):
+                                                        Expr 53 [0-0] [Type Int]: BinOp (Sub):
+                                                            Expr 54 [0-0] [Type Int]: Field:
+                                                                Expr 55 [0-0] [Type Range]: Var: Local 39
                                                                 Prim(End)
-                                                            Expr _id_ [0-0] [Type Int]: Field:
-                                                                Expr _id_ [0-0] [Type Range]: Var: Local 29
+                                                            Expr 56 [0-0] [Type Int]: Field:
+                                                                Expr 57 [0-0] [Type Range]: Var: Local 39
                                                                 Prim(Start)
-                                                        Expr _id_ [0-0] [Type Int]: Field:
-                                                            Expr _id_ [0-0] [Type Range]: Var: Local 29
+                                                        Expr 58 [0-0] [Type Int]: Field:
+                                                            Expr 59 [0-0] [Type Range]: Var: Local 39
                                                             Prim(Step)
-                                                    Expr _id_ [0-0] [Type Int]: Field:
-                                                        Expr _id_ [0-0] [Type Range]: Var: Local 29
+                                                    Expr 60 [0-0] [Type Int]: Field:
+                                                        Expr 61 [0-0] [Type Range]: Var: Local 39
                                                         Prim(Step)
-                                            Expr _id_ [0-0] [Type Int]: UnOp (Neg):
-                                                Expr _id_ [0-0] [Type Int]: Field:
-                                                    Expr _id_ [0-0] [Type Range]: Var: Local 29
+                                            Expr 62 [0-0] [Type Int]: UnOp (Neg):
+                                                Expr 63 [0-0] [Type Int]: Field:
+                                                    Expr 64 [0-0] [Type Range]: Var: Local 39
                                                     Prim(Step)
-                                            Expr _id_ [0-0] [Type Int]: Field:
-                                                Expr _id_ [0-0] [Type Range]: Var: Local 29
+                                            Expr 65 [0-0] [Type Int]: Field:
+                                                Expr 66 [0-0] [Type Range]: Var: Local 39
                                                 Prim(Start)
-                                        Block 19 [128-175] [Type Unit]:
-                                            Stmt 24 [160-165]: Semi: Expr 25 [160-164] [Type Unit]: Call:
-                                                Expr _id_ [160-161] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                    Expr 26 [160-161] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 27 [162-163] [Type Int]: Lit: Int(2)
-                                            Stmt 20 [142-147]: Semi: Expr 21 [142-146] [Type Unit]: Call:
-                                                Expr _id_ [142-143] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                    Expr 22 [142-143] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 23 [144-145] [Type Int]: Lit: Int(1)
+                                        Block 67 [128-175] [Type Unit]:
+                                            Stmt 68 [160-165]: Semi: Expr 69 [160-164] [Type Unit]: Call:
+                                                Expr 70 [160-161] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                    Expr 71 [160-161] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 72 [162-163] [Type Int]: Lit: Int(2)
+                                            Stmt 73 [142-147]: Semi: Expr 74 [142-146] [Type Unit]: Call:
+                                                Expr 75 [142-143] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                    Expr 76 [142-143] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 77 [144-145] [Type Int]: Lit: Int(1)
                         ctl: <none>
                         ctl-adj: <none>"#]],
     );
@@ -1032,8 +1032,8 @@ fn generate_adj_invert_with_array_loop() {
                         functors: Adj
                         body: SpecDecl 4 [21-62]: Impl:
                             Block 5 [60-62]: <empty>
-                        adj: SpecDecl _id_ [21-62]: Impl:
-                            Block 5 [60-62]: <empty>
+                        adj: SpecDecl 30 [21-62]: Impl:
+                            Block 31 [60-62]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 2 [67-188] (Public):
@@ -1058,42 +1058,42 @@ fn generate_adj_invert_with_array_loop() {
                                         Stmt 25 [167-172]: Semi: Expr 26 [167-171] [Type Unit]: Call:
                                             Expr 27 [167-168] [Type (Int => Unit is Adj)]: Var: Item 1
                                             Expr 28 [169-170] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl _id_ [67-188]: Impl:
-                            Block 11 [104-188] [Type Unit]:
-                                Stmt 12 [114-182]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block _id_ [0-0] [Type Unit]:
-                                    Stmt _id_ [0-0]: Local (Immutable):
-                                        Pat _id_ [0-0] [Type (Int)[]]: Bind: Ident 30 [0-0] "generated_array"
-                                        Expr 16 [125-134] [Type (Int)[]]: Array:
-                                            Expr 17 [126-127] [Type Int]: Lit: Int(0)
-                                            Expr 18 [129-130] [Type Int]: Lit: Int(1)
-                                            Expr 19 [132-133] [Type Int]: Lit: Int(2)
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: For:
-                                        Pat _id_ [0-0] [Type Int]: Bind: Ident 31 [0-0] "generated_index"
-                                        Expr _id_ [0-0] [Type Range]: Range:
-                                            Expr _id_ [0-0] [Type Int]: BinOp (Sub):
-                                                Expr _id_ [0-0] [Type Int]: Call:
-                                                    Expr _id_ [0-0] [Type ((Int)[] -> Int)]: Var:
+                        adj: SpecDecl 34 [67-188]: Impl:
+                            Block 35 [104-188] [Type Unit]:
+                                Stmt 36 [114-182]: Expr: Expr 37 [0-0] [Type Unit]: Expr Block: Block 38 [0-0] [Type Unit]:
+                                    Stmt 39 [0-0]: Local (Immutable):
+                                        Pat 40 [0-0] [Type (Int)[]]: Bind: Ident 41 [0-0] "generated_array"
+                                        Expr 42 [125-134] [Type (Int)[]]: Array:
+                                            Expr 43 [126-127] [Type Int]: Lit: Int(0)
+                                            Expr 44 [129-130] [Type Int]: Lit: Int(1)
+                                            Expr 45 [132-133] [Type Int]: Lit: Int(2)
+                                    Stmt 46 [0-0]: Expr: Expr 47 [0-0] [Type Unit]: For:
+                                        Pat 48 [0-0] [Type Int]: Bind: Ident 49 [0-0] "generated_index"
+                                        Expr 50 [0-0] [Type Range]: Range:
+                                            Expr 51 [0-0] [Type Int]: BinOp (Sub):
+                                                Expr 52 [0-0] [Type Int]: Call:
+                                                    Expr 53 [0-0] [Type ((Int)[] -> Int)]: Var:
                                                         res: Item 1 (Package 0)
                                                         generics:
                                                             Int
-                                                    Expr _id_ [0-0] [Type (Int)[]]: Var: Local 30
-                                                Expr _id_ [0-0] [Type Int]: Lit: Int(1)
-                                            Expr _id_ [0-0] [Type Int]: Lit: Int(-1)
-                                            Expr _id_ [0-0] [Type Int]: Lit: Int(0)
-                                        Block 20 [135-182] [Type Unit]:
-                                            Stmt _id_ [0-0]: Local (Immutable):
-                                                Pat 14 [118-121] [Type Int]: Bind: Ident 15 [118-121] "val"
-                                                Expr _id_ [0-0] [Type Int]: Index:
-                                                    Expr _id_ [0-0] [Type (Int)[]]: Var: Local 30
-                                                    Expr _id_ [0-0] [Type Int]: Var: Local 31
-                                            Stmt 25 [167-172]: Semi: Expr 26 [167-171] [Type Unit]: Call:
-                                                Expr _id_ [167-168] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                    Expr 27 [167-168] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 28 [169-170] [Type Int]: Lit: Int(2)
-                                            Stmt 21 [149-154]: Semi: Expr 22 [149-153] [Type Unit]: Call:
-                                                Expr _id_ [149-150] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                    Expr 23 [149-150] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 24 [151-152] [Type Int]: Lit: Int(1)
+                                                    Expr 54 [0-0] [Type (Int)[]]: Var: Local 41
+                                                Expr 55 [0-0] [Type Int]: Lit: Int(1)
+                                            Expr 56 [0-0] [Type Int]: Lit: Int(-1)
+                                            Expr 57 [0-0] [Type Int]: Lit: Int(0)
+                                        Block 58 [135-182] [Type Unit]:
+                                            Stmt 59 [0-0]: Local (Immutable):
+                                                Pat 60 [118-121] [Type Int]: Bind: Ident 61 [118-121] "val"
+                                                Expr 62 [0-0] [Type Int]: Index:
+                                                    Expr 63 [0-0] [Type (Int)[]]: Var: Local 41
+                                                    Expr 64 [0-0] [Type Int]: Var: Local 49
+                                            Stmt 65 [167-172]: Semi: Expr 66 [167-171] [Type Unit]: Call:
+                                                Expr 67 [167-168] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                    Expr 68 [167-168] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 69 [169-170] [Type Int]: Lit: Int(2)
+                                            Stmt 70 [149-154]: Semi: Expr 71 [149-153] [Type Unit]: Call:
+                                                Expr 72 [149-150] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                    Expr 73 [149-150] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 74 [151-152] [Type Int]: Lit: Int(1)
                         ctl: <none>
                         ctl-adj: <none>"#]],
     );
@@ -1131,8 +1131,8 @@ fn generate_adj_invert_with_nested_loops() {
                         functors: Adj
                         body: SpecDecl 4 [21-62]: Impl:
                             Block 5 [60-62]: <empty>
-                        adj: SpecDecl _id_ [21-62]: Impl:
-                            Block 5 [60-62]: <empty>
+                        adj: SpecDecl 51 [21-62]: Impl:
+                            Block 52 [60-62]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 2 [67-318] (Public):
@@ -1173,79 +1173,79 @@ fn generate_adj_invert_with_nested_loops() {
                                         Stmt 46 [297-302]: Semi: Expr 47 [297-301] [Type Unit]: Call:
                                             Expr 48 [297-298] [Type (Int => Unit is Adj)]: Var: Item 1
                                             Expr 49 [299-300] [Type Int]: Lit: Int(4)
-                        adj: SpecDecl _id_ [67-318]: Impl:
-                            Block 11 [104-318] [Type Unit]:
-                                Stmt 12 [114-312]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block _id_ [0-0] [Type Unit]:
-                                    Stmt _id_ [0-0]: Local (Immutable):
-                                        Pat _id_ [0-0] [Type (Int)[]]: Bind: Ident 53 [0-0] "generated_array"
-                                        Expr 16 [125-134] [Type (Int)[]]: Array:
-                                            Expr 17 [126-127] [Type Int]: Lit: Int(0)
-                                            Expr 18 [129-130] [Type Int]: Lit: Int(1)
-                                            Expr 19 [132-133] [Type Int]: Lit: Int(2)
-                                    Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: For:
-                                        Pat _id_ [0-0] [Type Int]: Bind: Ident 54 [0-0] "generated_index"
-                                        Expr _id_ [0-0] [Type Range]: Range:
-                                            Expr _id_ [0-0] [Type Int]: BinOp (Sub):
-                                                Expr _id_ [0-0] [Type Int]: Call:
-                                                    Expr _id_ [0-0] [Type ((Int)[] -> Int)]: Var:
+                        adj: SpecDecl 57 [67-318]: Impl:
+                            Block 58 [104-318] [Type Unit]:
+                                Stmt 59 [114-312]: Expr: Expr 60 [0-0] [Type Unit]: Expr Block: Block 61 [0-0] [Type Unit]:
+                                    Stmt 62 [0-0]: Local (Immutable):
+                                        Pat 63 [0-0] [Type (Int)[]]: Bind: Ident 64 [0-0] "generated_array"
+                                        Expr 65 [125-134] [Type (Int)[]]: Array:
+                                            Expr 66 [126-127] [Type Int]: Lit: Int(0)
+                                            Expr 67 [129-130] [Type Int]: Lit: Int(1)
+                                            Expr 68 [132-133] [Type Int]: Lit: Int(2)
+                                    Stmt 69 [0-0]: Expr: Expr 70 [0-0] [Type Unit]: For:
+                                        Pat 71 [0-0] [Type Int]: Bind: Ident 72 [0-0] "generated_index"
+                                        Expr 73 [0-0] [Type Range]: Range:
+                                            Expr 74 [0-0] [Type Int]: BinOp (Sub):
+                                                Expr 75 [0-0] [Type Int]: Call:
+                                                    Expr 76 [0-0] [Type ((Int)[] -> Int)]: Var:
                                                         res: Item 1 (Package 0)
                                                         generics:
                                                             Int
-                                                    Expr _id_ [0-0] [Type (Int)[]]: Var: Local 53
-                                                Expr _id_ [0-0] [Type Int]: Lit: Int(1)
-                                            Expr _id_ [0-0] [Type Int]: Lit: Int(-1)
-                                            Expr _id_ [0-0] [Type Int]: Lit: Int(0)
-                                        Block 20 [135-312] [Type Unit]:
-                                            Stmt _id_ [0-0]: Local (Immutable):
-                                                Pat 14 [118-121] [Type Int]: Bind: Ident 15 [118-121] "val"
-                                                Expr _id_ [0-0] [Type Int]: Index:
-                                                    Expr _id_ [0-0] [Type (Int)[]]: Var: Local 53
-                                                    Expr _id_ [0-0] [Type Int]: Var: Local 54
-                                            Stmt 25 [167-197]: Local (Immutable):
-                                                Pat 26 [171-174] [Type (Bool)[]]: Bind: Ident 27 [171-174] "arr"
-                                                Expr 28 [177-196] [Type (Bool)[]]: Array:
-                                                    Expr 29 [178-182] [Type Bool]: Lit: Bool(true)
-                                                    Expr 30 [184-189] [Type Bool]: Lit: Bool(false)
-                                                    Expr 31 [191-195] [Type Bool]: Lit: Bool(true)
-                                            Stmt 46 [297-302]: Semi: Expr 47 [297-301] [Type Unit]: Call:
-                                                Expr _id_ [297-298] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                    Expr 48 [297-298] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 49 [299-300] [Type Int]: Lit: Int(4)
-                                            Stmt 32 [210-284]: Expr: Expr _id_ [0-0] [Type Unit]: Expr Block: Block _id_ [0-0] [Type Unit]:
-                                                Stmt _id_ [0-0]: Local (Immutable):
-                                                    Pat _id_ [0-0] [Type (Bool)[]]: Bind: Ident 51 [0-0] "generated_array"
-                                                    Expr 36 [221-224] [Type (Bool)[]]: Var: Local 27
-                                                Stmt _id_ [0-0]: Expr: Expr _id_ [0-0] [Type Unit]: For:
-                                                    Pat _id_ [0-0] [Type Int]: Bind: Ident 52 [0-0] "generated_index"
-                                                    Expr _id_ [0-0] [Type Range]: Range:
-                                                        Expr _id_ [0-0] [Type Int]: BinOp (Sub):
-                                                            Expr _id_ [0-0] [Type Int]: Call:
-                                                                Expr _id_ [0-0] [Type ((Bool)[] -> Int)]: Var:
+                                                    Expr 77 [0-0] [Type (Int)[]]: Var: Local 64
+                                                Expr 78 [0-0] [Type Int]: Lit: Int(1)
+                                            Expr 79 [0-0] [Type Int]: Lit: Int(-1)
+                                            Expr 80 [0-0] [Type Int]: Lit: Int(0)
+                                        Block 81 [135-312] [Type Unit]:
+                                            Stmt 82 [0-0]: Local (Immutable):
+                                                Pat 83 [118-121] [Type Int]: Bind: Ident 84 [118-121] "val"
+                                                Expr 85 [0-0] [Type Int]: Index:
+                                                    Expr 86 [0-0] [Type (Int)[]]: Var: Local 64
+                                                    Expr 87 [0-0] [Type Int]: Var: Local 72
+                                            Stmt 88 [167-197]: Local (Immutable):
+                                                Pat 89 [171-174] [Type (Bool)[]]: Bind: Ident 90 [171-174] "arr"
+                                                Expr 91 [177-196] [Type (Bool)[]]: Array:
+                                                    Expr 92 [178-182] [Type Bool]: Lit: Bool(true)
+                                                    Expr 93 [184-189] [Type Bool]: Lit: Bool(false)
+                                                    Expr 94 [191-195] [Type Bool]: Lit: Bool(true)
+                                            Stmt 95 [297-302]: Semi: Expr 96 [297-301] [Type Unit]: Call:
+                                                Expr 97 [297-298] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                    Expr 98 [297-298] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 99 [299-300] [Type Int]: Lit: Int(4)
+                                            Stmt 100 [210-284]: Expr: Expr 101 [0-0] [Type Unit]: Expr Block: Block 102 [0-0] [Type Unit]:
+                                                Stmt 103 [0-0]: Local (Immutable):
+                                                    Pat 104 [0-0] [Type (Bool)[]]: Bind: Ident 105 [0-0] "generated_array"
+                                                    Expr 106 [221-224] [Type (Bool)[]]: Var: Local 90
+                                                Stmt 107 [0-0]: Expr: Expr 108 [0-0] [Type Unit]: For:
+                                                    Pat 109 [0-0] [Type Int]: Bind: Ident 110 [0-0] "generated_index"
+                                                    Expr 111 [0-0] [Type Range]: Range:
+                                                        Expr 112 [0-0] [Type Int]: BinOp (Sub):
+                                                            Expr 113 [0-0] [Type Int]: Call:
+                                                                Expr 114 [0-0] [Type ((Bool)[] -> Int)]: Var:
                                                                     res: Item 1 (Package 0)
                                                                     generics:
                                                                         Bool
-                                                                Expr _id_ [0-0] [Type (Bool)[]]: Var: Local 51
-                                                            Expr _id_ [0-0] [Type Int]: Lit: Int(1)
-                                                        Expr _id_ [0-0] [Type Int]: Lit: Int(-1)
-                                                        Expr _id_ [0-0] [Type Int]: Lit: Int(0)
-                                                    Block 37 [225-284] [Type Unit]:
-                                                        Stmt _id_ [0-0]: Local (Immutable):
-                                                            Pat 34 [214-217] [Type Bool]: Bind: Ident 35 [214-217] "val"
-                                                            Expr _id_ [0-0] [Type Bool]: Index:
-                                                                Expr _id_ [0-0] [Type (Bool)[]]: Var: Local 51
-                                                                Expr _id_ [0-0] [Type Int]: Var: Local 52
-                                                        Stmt 42 [265-270]: Semi: Expr 43 [265-269] [Type Unit]: Call:
-                                                            Expr _id_ [265-266] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                                Expr 44 [265-266] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                            Expr 45 [267-268] [Type Int]: Lit: Int(3)
-                                                        Stmt 38 [243-248]: Semi: Expr 39 [243-247] [Type Unit]: Call:
-                                                            Expr _id_ [243-244] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                                Expr 40 [243-244] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                            Expr 41 [245-246] [Type Int]: Lit: Int(2)
-                                            Stmt 21 [149-154]: Semi: Expr 22 [149-153] [Type Unit]: Call:
-                                                Expr _id_ [149-150] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
-                                                    Expr 23 [149-150] [Type (Int => Unit is Adj)]: Var: Item 1
-                                                Expr 24 [151-152] [Type Int]: Lit: Int(1)
+                                                                Expr 115 [0-0] [Type (Bool)[]]: Var: Local 105
+                                                            Expr 116 [0-0] [Type Int]: Lit: Int(1)
+                                                        Expr 117 [0-0] [Type Int]: Lit: Int(-1)
+                                                        Expr 118 [0-0] [Type Int]: Lit: Int(0)
+                                                    Block 119 [225-284] [Type Unit]:
+                                                        Stmt 120 [0-0]: Local (Immutable):
+                                                            Pat 121 [214-217] [Type Bool]: Bind: Ident 122 [214-217] "val"
+                                                            Expr 123 [0-0] [Type Bool]: Index:
+                                                                Expr 124 [0-0] [Type (Bool)[]]: Var: Local 105
+                                                                Expr 125 [0-0] [Type Int]: Var: Local 110
+                                                        Stmt 126 [265-270]: Semi: Expr 127 [265-269] [Type Unit]: Call:
+                                                            Expr 128 [265-266] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                                Expr 129 [265-266] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                            Expr 130 [267-268] [Type Int]: Lit: Int(3)
+                                                        Stmt 131 [243-248]: Semi: Expr 132 [243-247] [Type Unit]: Call:
+                                                            Expr 133 [243-244] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                                Expr 134 [243-244] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                            Expr 135 [245-246] [Type Int]: Lit: Int(2)
+                                            Stmt 136 [149-154]: Semi: Expr 137 [149-153] [Type Unit]: Call:
+                                                Expr 138 [149-150] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
+                                                    Expr 139 [149-150] [Type (Int => Unit is Adj)]: Var: Item 1
+                                                Expr 140 [151-152] [Type Int]: Lit: Int(1)
                         ctl: <none>
                         ctl-adj: <none>"#]],
     );
@@ -1275,14 +1275,14 @@ fn generate_ctladj_distribute() {
                         functors: Adj + Ctl
                         body: SpecDecl 4 [21-68]: Impl:
                             Block 5 [66-68]: <empty>
-                        adj: SpecDecl _id_ [21-68]: Impl:
-                            Block 5 [66-68]: <empty>
-                        ctl: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 21 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
-                        ctl-adj: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 22 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
+                        adj: SpecDecl 26 [21-68]: Impl:
+                            Block 27 [66-68]: <empty>
+                        ctl: SpecDecl 22 [21-68]: Impl:
+                            Pat 23 [21-68] [Type (Qubit)[]]: Bind: Ident 24 [21-68] "ctls"
+                            Block 25 [66-68]: <empty>
+                        ctl-adj: SpecDecl 29 [21-68]: Impl:
+                            Pat 30 [21-68] [Type (Qubit)[]]: Bind: Ident 31 [21-68] "ctls"
+                            Block 32 [66-68]: <empty>
                 Item 2 [73-156] (Public):
                     Parent: 0
                     Callable 6 [73-156] (operation):
@@ -1298,48 +1298,48 @@ fn generate_ctladj_distribute() {
                                 Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
                                     Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl _id_ [73-156]: Impl:
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr _id_ [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr _id_ [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type Int]: Lit: Int(1)
-                        ctl: SpecDecl _id_ [73-156]: Impl:
-                            Pat _id_ [73-156] [Type (Qubit)[]]: Bind: Ident 23 [73-156] "ctls"
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr 14 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [139-140] [Type (Qubit)[]]: Var: Local 23
-                                        Expr 15 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr 18 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [145-146] [Type (Qubit)[]]: Var: Local 23
-                                        Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        ctl-adj: SpecDecl _id_ [73-156]: Impl:
-                            Pat _id_ [73-156] [Type (Qubit)[]]: Bind: Ident 24 [73-156] "ctls"
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr _id_ [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr _id_ [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [145-146] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr _id_ [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr _id_ [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [139-140] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 15 [139-140] [Type Int]: Lit: Int(1)"#]],
+                        adj: SpecDecl 48 [73-156]: Impl:
+                            Block 49 [135-150] [Type Unit]:
+                                Stmt 50 [143-148]: Semi: Expr 51 [143-147] [Type Unit]: Call:
+                                    Expr 52 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 53 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 54 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 55 [137-142]: Semi: Expr 56 [137-141] [Type Unit]: Call:
+                                    Expr 57 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 58 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 59 [139-140] [Type Int]: Lit: Int(1)
+                        ctl: SpecDecl 34 [73-156]: Impl:
+                            Pat 35 [73-156] [Type (Qubit)[]]: Bind: Ident 36 [73-156] "ctls"
+                            Block 37 [135-150] [Type Unit]:
+                                Stmt 38 [137-142]: Semi: Expr 39 [137-141] [Type Unit]: Call:
+                                    Expr 40 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 40 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 41 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 42 [139-140] [Type (Qubit)[]]: Var: Local 36
+                                        Expr 41 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 43 [143-148]: Semi: Expr 44 [143-147] [Type Unit]: Call:
+                                    Expr 45 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 45 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 46 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 47 [145-146] [Type (Qubit)[]]: Var: Local 36
+                                        Expr 46 [145-146] [Type Int]: Lit: Int(2)
+                        ctl-adj: SpecDecl 61 [73-156]: Impl:
+                            Pat 62 [73-156] [Type (Qubit)[]]: Bind: Ident 63 [73-156] "ctls"
+                            Block 64 [135-150] [Type Unit]:
+                                Stmt 65 [143-148]: Semi: Expr 66 [143-147] [Type Unit]: Call:
+                                    Expr 67 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 67 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 68 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 69 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 70 [145-146] [Type (Qubit)[]]: Var: Local 63
+                                        Expr 69 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 71 [137-142]: Semi: Expr 72 [137-141] [Type Unit]: Call:
+                                    Expr 73 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 73 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 74 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 75 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 76 [139-140] [Type (Qubit)[]]: Var: Local 63
+                                        Expr 75 [139-140] [Type Int]: Lit: Int(1)"#]],
     );
 }
 
@@ -1368,14 +1368,14 @@ fn generate_ctladj_auto_to_distribute() {
                         functors: Adj + Ctl
                         body: SpecDecl 4 [21-68]: Impl:
                             Block 5 [66-68]: <empty>
-                        adj: SpecDecl _id_ [21-68]: Impl:
-                            Block 5 [66-68]: <empty>
-                        ctl: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 22 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
-                        ctl-adj: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 23 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
+                        adj: SpecDecl 27 [21-68]: Impl:
+                            Block 28 [66-68]: <empty>
+                        ctl: SpecDecl 23 [21-68]: Impl:
+                            Pat 24 [21-68] [Type (Qubit)[]]: Bind: Ident 25 [21-68] "ctls"
+                            Block 26 [66-68]: <empty>
+                        ctl-adj: SpecDecl 30 [21-68]: Impl:
+                            Pat 31 [21-68] [Type (Qubit)[]]: Bind: Ident 32 [21-68] "ctls"
+                            Block 33 [66-68]: <empty>
                 Item 2 [73-189] (Public):
                     Parent: 0
                     Callable 6 [73-189] (operation):
@@ -1391,48 +1391,48 @@ fn generate_ctladj_auto_to_distribute() {
                                 Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
                                     Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl _id_ [73-189]: Impl:
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr _id_ [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr _id_ [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type Int]: Lit: Int(1)
-                        ctl: SpecDecl _id_ [73-189]: Impl:
-                            Pat _id_ [73-189] [Type (Qubit)[]]: Bind: Ident 24 [73-189] "ctls"
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr 14 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [139-140] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 15 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr 18 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [145-146] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        ctl-adj: SpecDecl _id_ [73-189]: Impl:
-                            Pat _id_ [73-189] [Type (Qubit)[]]: Bind: Ident 25 [73-189] "ctls"
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr _id_ [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr _id_ [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [145-146] [Type (Qubit)[]]: Var: Local 25
-                                        Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr _id_ [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr _id_ [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                            Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [139-140] [Type (Qubit)[]]: Var: Local 25
-                                        Expr 15 [139-140] [Type Int]: Lit: Int(1)"#]],
+                        adj: SpecDecl 49 [73-189]: Impl:
+                            Block 50 [135-150] [Type Unit]:
+                                Stmt 51 [143-148]: Semi: Expr 52 [143-147] [Type Unit]: Call:
+                                    Expr 53 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 54 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 55 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 56 [137-142]: Semi: Expr 57 [137-141] [Type Unit]: Call:
+                                    Expr 58 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 59 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 60 [139-140] [Type Int]: Lit: Int(1)
+                        ctl: SpecDecl 35 [73-189]: Impl:
+                            Pat 36 [73-189] [Type (Qubit)[]]: Bind: Ident 37 [73-189] "ctls"
+                            Block 38 [135-150] [Type Unit]:
+                                Stmt 39 [137-142]: Semi: Expr 40 [137-141] [Type Unit]: Call:
+                                    Expr 41 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 41 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 42 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 43 [139-140] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 42 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 44 [143-148]: Semi: Expr 45 [143-147] [Type Unit]: Call:
+                                    Expr 46 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 46 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 47 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 48 [145-146] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 47 [145-146] [Type Int]: Lit: Int(2)
+                        ctl-adj: SpecDecl 62 [73-189]: Impl:
+                            Pat 63 [73-189] [Type (Qubit)[]]: Bind: Ident 64 [73-189] "ctls"
+                            Block 65 [135-150] [Type Unit]:
+                                Stmt 66 [143-148]: Semi: Expr 67 [143-147] [Type Unit]: Call:
+                                    Expr 68 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 68 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 69 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 70 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 71 [145-146] [Type (Qubit)[]]: Var: Local 64
+                                        Expr 70 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 72 [137-142]: Semi: Expr 73 [137-141] [Type Unit]: Call:
+                                    Expr 74 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 74 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                            Expr 75 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 76 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 77 [139-140] [Type (Qubit)[]]: Var: Local 64
+                                        Expr 76 [139-140] [Type Int]: Lit: Int(1)"#]],
     );
 }
 
@@ -1462,14 +1462,14 @@ fn generate_ctladj_auto_to_invert() {
                         functors: Adj + Ctl
                         body: SpecDecl 4 [21-68]: Impl:
                             Block 5 [66-68]: <empty>
-                        adj: SpecDecl _id_ [21-68]: Impl:
-                            Block 5 [66-68]: <empty>
-                        ctl: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 40 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
-                        ctl-adj: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 41 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
+                        adj: SpecDecl 45 [21-68]: Impl:
+                            Block 46 [66-68]: <empty>
+                        ctl: SpecDecl 41 [21-68]: Impl:
+                            Pat 42 [21-68] [Type (Qubit)[]]: Bind: Ident 43 [21-68] "ctls"
+                            Block 44 [66-68]: <empty>
+                        ctl-adj: SpecDecl 48 [21-68]: Impl:
+                            Pat 49 [21-68] [Type (Qubit)[]]: Bind: Ident 50 [21-68] "ctls"
+                            Block 51 [66-68]: <empty>
                 Item 2 [73-270] (Public):
                     Parent: 0
                     Callable 6 [73-270] (operation):
@@ -1485,16 +1485,16 @@ fn generate_ctladj_auto_to_invert() {
                                 Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
                                     Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl _id_ [73-270]: Impl:
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr _id_ [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr _id_ [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type Int]: Lit: Int(1)
+                        adj: SpecDecl 52 [73-270]: Impl:
+                            Block 53 [135-150] [Type Unit]:
+                                Stmt 54 [143-148]: Semi: Expr 55 [143-147] [Type Unit]: Call:
+                                    Expr 56 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 57 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 58 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 59 [137-142]: Semi: Expr 60 [137-141] [Type Unit]: Call:
+                                    Expr 61 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 62 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 63 [139-140] [Type Int]: Lit: Int(1)
                         ctl: SpecDecl 20 [159-231]: Impl:
                             Pat 21 [171-175] [Type (Qubit)[]]: Bind: Ident 22 [171-175] "ctls"
                             Block 23 [182-231] [Type Unit]:
@@ -1510,23 +1510,23 @@ fn generate_ctladj_auto_to_invert() {
                                     Expr 35 [219-228] [Type ((Qubit)[], Int)]: Tuple:
                                         Expr 36 [220-224] [Type (Qubit)[]]: Var: Local 22
                                         Expr 37 [226-227] [Type Int]: Lit: Int(2)
-                        ctl-adj: SpecDecl _id_ [73-270]: Impl:
-                            Pat 21 [171-175] [Type (Qubit)[]]: Bind: Ident 22 [171-175] "ctls"
-                            Block 23 [182-231] [Type Unit]:
-                                Stmt 31 [207-229]: Semi: Expr 32 [207-228] [Type Unit]: Call:
-                                    Expr _id_ [207-219] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 33 [207-219] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                            Expr 34 [218-219] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 35 [219-228] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 36 [220-224] [Type (Qubit)[]]: Var: Local 22
-                                        Expr 37 [226-227] [Type Int]: Lit: Int(2)
-                                Stmt 24 [184-206]: Semi: Expr 25 [184-205] [Type Unit]: Call:
-                                    Expr _id_ [184-196] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 26 [184-196] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                            Expr 27 [195-196] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 28 [196-205] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr 29 [197-201] [Type (Qubit)[]]: Var: Local 22
-                                        Expr 30 [203-204] [Type Int]: Lit: Int(1)"#]],
+                        ctl-adj: SpecDecl 64 [73-270]: Impl:
+                            Pat 65 [171-175] [Type (Qubit)[]]: Bind: Ident 66 [171-175] "ctls"
+                            Block 67 [182-231] [Type Unit]:
+                                Stmt 68 [207-229]: Semi: Expr 69 [207-228] [Type Unit]: Call:
+                                    Expr 70 [207-219] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 71 [207-219] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                            Expr 72 [218-219] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 73 [219-228] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 74 [220-224] [Type (Qubit)[]]: Var: Local 66
+                                        Expr 75 [226-227] [Type Int]: Lit: Int(2)
+                                Stmt 76 [184-206]: Semi: Expr 77 [184-205] [Type Unit]: Call:
+                                    Expr 78 [184-196] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 79 [184-196] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                            Expr 80 [195-196] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 81 [196-205] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 82 [197-201] [Type (Qubit)[]]: Var: Local 66
+                                        Expr 83 [203-204] [Type Int]: Lit: Int(1)"#]],
     );
 }
 
@@ -1555,14 +1555,14 @@ fn generate_ctladj_invert() {
                         functors: Adj + Ctl
                         body: SpecDecl 4 [21-68]: Impl:
                             Block 5 [66-68]: <empty>
-                        adj: SpecDecl _id_ [21-68]: Impl:
-                            Block 5 [66-68]: <empty>
-                        ctl: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 22 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
-                        ctl-adj: SpecDecl _id_ [21-68]: Impl:
-                            Pat _id_ [21-68] [Type (Qubit)[]]: Bind: Ident 23 [21-68] "ctls"
-                            Block 5 [66-68]: <empty>
+                        adj: SpecDecl 27 [21-68]: Impl:
+                            Block 28 [66-68]: <empty>
+                        ctl: SpecDecl 23 [21-68]: Impl:
+                            Pat 24 [21-68] [Type (Qubit)[]]: Bind: Ident 25 [21-68] "ctls"
+                            Block 26 [66-68]: <empty>
+                        ctl-adj: SpecDecl 30 [21-68]: Impl:
+                            Pat 31 [21-68] [Type (Qubit)[]]: Bind: Ident 32 [21-68] "ctls"
+                            Block 33 [66-68]: <empty>
                 Item 2 [73-191] (Public):
                     Parent: 0
                     Callable 6 [73-191] (operation):
@@ -1578,48 +1578,48 @@ fn generate_ctladj_invert() {
                                 Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
                                     Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
                                     Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        adj: SpecDecl _id_ [73-191]: Impl:
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr _id_ [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr _id_ [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type Int]: Lit: Int(1)
-                        ctl: SpecDecl _id_ [73-191]: Impl:
-                            Pat _id_ [73-191] [Type (Qubit)[]]: Bind: Ident 24 [73-191] "ctls"
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr 14 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [139-140] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 15 [139-140] [Type Int]: Lit: Int(1)
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr 18 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                        Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [145-146] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                        ctl-adj: SpecDecl 20 [159-185]: Impl:
-                            Pat _id_ [73-191] [Type (Qubit)[]]: Bind: Ident 24 [73-191] "ctls"
-                            Block 11 [135-150] [Type Unit]:
-                                Stmt 16 [143-148]: Semi: Expr 17 [143-147] [Type Unit]: Call:
-                                    Expr _id_ [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 18 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                            Expr 18 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 19 [145-146] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [145-146] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 19 [145-146] [Type Int]: Lit: Int(2)
-                                Stmt 12 [137-142]: Semi: Expr 13 [137-141] [Type Unit]: Call:
-                                    Expr _id_ [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
-                                        Expr 14 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
-                                            Expr 14 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
-                                    Expr 15 [139-140] [Type ((Qubit)[], Int)]: Tuple:
-                                        Expr _id_ [139-140] [Type (Qubit)[]]: Var: Local 24
-                                        Expr 15 [139-140] [Type Int]: Lit: Int(1)"#]],
+                        adj: SpecDecl 49 [73-191]: Impl:
+                            Block 50 [135-150] [Type Unit]:
+                                Stmt 51 [143-148]: Semi: Expr 52 [143-147] [Type Unit]: Call:
+                                    Expr 53 [143-144] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 54 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 55 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 56 [137-142]: Semi: Expr 57 [137-141] [Type Unit]: Call:
+                                    Expr 58 [137-138] [Type (Int => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 59 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 60 [139-140] [Type Int]: Lit: Int(1)
+                        ctl: SpecDecl 35 [73-191]: Impl:
+                            Pat 36 [73-191] [Type (Qubit)[]]: Bind: Ident 37 [73-191] "ctls"
+                            Block 38 [135-150] [Type Unit]:
+                                Stmt 39 [137-142]: Semi: Expr 40 [137-141] [Type Unit]: Call:
+                                    Expr 41 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 41 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 42 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 43 [139-140] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 42 [139-140] [Type Int]: Lit: Int(1)
+                                Stmt 44 [143-148]: Semi: Expr 45 [143-147] [Type Unit]: Call:
+                                    Expr 46 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                        Expr 46 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 47 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 48 [145-146] [Type (Qubit)[]]: Var: Local 37
+                                        Expr 47 [145-146] [Type Int]: Lit: Int(2)
+                        ctl-adj: SpecDecl 61 [159-185]: Impl:
+                            Pat 62 [73-191] [Type (Qubit)[]]: Bind: Ident 63 [73-191] "ctls"
+                            Block 64 [135-150] [Type Unit]:
+                                Stmt 65 [143-148]: Semi: Expr 66 [143-147] [Type Unit]: Call:
+                                    Expr 67 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 68 [143-144] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                            Expr 68 [143-144] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 69 [145-146] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 70 [145-146] [Type (Qubit)[]]: Var: Local 63
+                                        Expr 69 [145-146] [Type Int]: Lit: Int(2)
+                                Stmt 71 [137-142]: Semi: Expr 72 [137-141] [Type Unit]: Call:
+                                    Expr 73 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Adj):
+                                        Expr 74 [137-138] [Type (((Qubit)[], Int) => Unit is Adj + Ctl)]: UnOp (Functor Ctl):
+                                            Expr 74 [137-138] [Type (Int => Unit is Adj + Ctl)]: Var: Item 1
+                                    Expr 75 [139-140] [Type ((Qubit)[], Int)]: Tuple:
+                                        Expr 76 [139-140] [Type (Qubit)[]]: Var: Local 63
+                                        Expr 75 [139-140] [Type Int]: Lit: Int(1)"#]],
     );
 }
 
@@ -1646,8 +1646,8 @@ fn lambda_adj_calls_adj() {
                         functors: Adj
                         body: SpecDecl 4 [18-55]: Impl:
                             Block 5 [53-55]: <empty>
-                        adj: SpecDecl _id_ [18-55]: Impl:
-                            Block 5 [53-55]: <empty>
+                        adj: SpecDecl 33 [18-55]: Impl:
+                            Block 34 [53-55]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 2 [60-106] (Public):
@@ -1695,12 +1695,12 @@ fn lambda_adj_calls_adj() {
                                 Stmt 31 [143-147]: Expr: Expr 23 [143-147] [Type Unit]: Call:
                                     Expr 24 [143-144] [Type (Qubit => Unit is Adj)]: Var: Item 1
                                     Expr 25 [145-146] [Type Qubit]: Var: Local 22
-                        adj: SpecDecl _id_ [138-147]: Impl:
-                            Block 30 [143-147] [Type Unit]:
-                                Stmt 31 [143-147]: Expr: Expr 23 [143-147] [Type Unit]: Call:
-                                    Expr _id_ [143-144] [Type (Qubit => Unit is Adj)]: UnOp (Functor Adj):
-                                        Expr 24 [143-144] [Type (Qubit => Unit is Adj)]: Var: Item 1
-                                    Expr 25 [145-146] [Type Qubit]: Var: Local 22
+                        adj: SpecDecl 35 [138-147]: Impl:
+                            Block 36 [143-147] [Type Unit]:
+                                Stmt 37 [143-147]: Expr: Expr 38 [143-147] [Type Unit]: Call:
+                                    Expr 39 [143-144] [Type (Qubit => Unit is Adj)]: UnOp (Functor Adj):
+                                        Expr 40 [143-144] [Type (Qubit => Unit is Adj)]: Var: Item 1
+                                    Expr 41 [145-146] [Type Qubit]: Var: Local 22
                         ctl: <none>
                         ctl-adj: <none>"#]],
     );
@@ -1769,8 +1769,8 @@ fn op_array_forget_functors_with_lambdas() {
                         functors: Adj
                         body: SpecDecl 10 [92-131]: Impl:
                             Block 11 [129-131]: <empty>
-                        adj: SpecDecl _id_ [92-131]: Impl:
-                            Block 11 [129-131]: <empty>
+                        adj: SpecDecl 53 [92-131]: Impl:
+                            Block 54 [129-131]: <empty>
                         ctl: <none>
                         ctl-adj: <none>
                 Item 3 [148-193] (Public):
@@ -1782,14 +1782,14 @@ fn op_array_forget_functors_with_lambdas() {
                         functors: Adj + Ctl
                         body: SpecDecl 16 [148-193]: Impl:
                             Block 17 [191-193]: <empty>
-                        adj: SpecDecl _id_ [148-193]: Impl:
-                            Block 17 [191-193]: <empty>
-                        ctl: SpecDecl _id_ [148-193]: Impl:
-                            Pat _id_ [148-193] [Type (Qubit)[]]: Bind: Ident 53 [148-193] "ctls"
-                            Block 17 [191-193]: <empty>
-                        ctl-adj: SpecDecl _id_ [148-193]: Impl:
-                            Pat _id_ [148-193] [Type (Qubit)[]]: Bind: Ident 54 [148-193] "ctls"
-                            Block 17 [191-193]: <empty>
+                        adj: SpecDecl 60 [148-193]: Impl:
+                            Block 61 [191-193]: <empty>
+                        ctl: SpecDecl 56 [148-193]: Impl:
+                            Pat 57 [148-193] [Type (Qubit)[]]: Bind: Ident 58 [148-193] "ctls"
+                            Block 59 [191-193]: <empty>
+                        ctl-adj: SpecDecl 63 [148-193]: Impl:
+                            Pat 64 [148-193] [Type (Qubit)[]]: Bind: Ident 65 [148-193] "ctls"
+                            Block 66 [191-193]: <empty>
                 Item 4 [210-314] (Public):
                     Parent: 0
                     Callable 18 [210-314] (operation):


### PR DESCRIPTION
This change updates the transformation passes to include refreshing node ids for cloned blocks as well as reducing use of `NodeId::default()` in the code. As a result, transformed code should now correctly include valid, non-duplicate node ids throughout.

Fixes #453