### PR TITLE
Fix entry point error checking

### DIFF
--- a/compiler/qsc/benches/large.rs
+++ b/compiler/qsc/benches/large.rs
@@ -4,6 +4,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use qsc::compile::{self, compile};
 use qsc_frontend::compile::{PackageStore, SourceMap};
+use qsc_passes::PackageType;
 
 const INPUT: &str = include_str!("./large.qs");
 
@@ -13,7 +14,7 @@ pub fn large_file(c: &mut Criterion) {
             let mut store = PackageStore::new(compile::core());
             let std = store.insert(compile::std(&store));
             let sources = SourceMap::new([("large.qs".into(), INPUT.into())], None);
-            let (_, reports) = compile(&store, &[std], sources, compile::PackageType::Exe);
+            let (_, reports) = compile(&store, &[std], sources, PackageType::Exe);
             assert!(reports.is_empty());
         })
     });

--- a/compiler/qsc/benches/large.rs
+++ b/compiler/qsc/benches/large.rs
@@ -13,7 +13,7 @@ pub fn large_file(c: &mut Criterion) {
             let mut store = PackageStore::new(compile::core());
             let std = store.insert(compile::std(&store));
             let sources = SourceMap::new([("large.qs".into(), INPUT.into())], None);
-            let (_, reports) = compile(&store, &[std], sources);
+            let (_, reports) = compile(&store, &[std], sources, compile::CheckEntry::Required);
             assert!(reports.is_empty());
         })
     });

--- a/compiler/qsc/benches/large.rs
+++ b/compiler/qsc/benches/large.rs
@@ -13,7 +13,7 @@ pub fn large_file(c: &mut Criterion) {
             let mut store = PackageStore::new(compile::core());
             let std = store.insert(compile::std(&store));
             let sources = SourceMap::new([("large.qs".into(), INPUT.into())], None);
-            let (_, reports) = compile(&store, &[std], sources, compile::CheckEntry::Required);
+            let (_, reports) = compile(&store, &[std], sources, compile::PackageType::Exe);
             assert!(reports.is_empty());
         })
     });

--- a/compiler/qsc/src/bin/qsc.rs
+++ b/compiler/qsc/src/bin/qsc.rs
@@ -6,7 +6,7 @@
 use clap::{crate_version, ArgGroup, Parser, ValueEnum};
 use log::info;
 use miette::{Context, IntoDiagnostic, Report};
-use qsc::compile::compile;
+use qsc::compile::{compile, CheckEntry};
 use qsc_frontend::compile::{PackageStore, SourceContents, SourceMap, SourceName};
 use qsc_hir::hir::Package;
 use std::{
@@ -68,7 +68,7 @@ fn main() -> miette::Result<ExitCode> {
 
     let entry = cli.entry.unwrap_or_default();
     let sources = SourceMap::new(sources, Some(entry.into()));
-    let (unit, errors) = compile(&store, &dependencies, sources);
+    let (unit, errors) = compile(&store, &dependencies, sources, CheckEntry::Optional);
 
     let out_dir = cli.out_dir.as_ref().map_or(".".as_ref(), PathBuf::as_path);
     for emit in &cli.emit {

--- a/compiler/qsc/src/bin/qsc.rs
+++ b/compiler/qsc/src/bin/qsc.rs
@@ -6,9 +6,10 @@
 use clap::{crate_version, ArgGroup, Parser, ValueEnum};
 use log::info;
 use miette::{Context, IntoDiagnostic, Report};
-use qsc::compile::{compile, PackageType};
+use qsc::compile::compile;
 use qsc_frontend::compile::{PackageStore, SourceContents, SourceMap, SourceName};
 use qsc_hir::hir::Package;
+use qsc_passes::PackageType;
 use std::{
     concat, fs,
     io::{self, Read},

--- a/compiler/qsc/src/bin/qsc.rs
+++ b/compiler/qsc/src/bin/qsc.rs
@@ -6,7 +6,7 @@
 use clap::{crate_version, ArgGroup, Parser, ValueEnum};
 use log::info;
 use miette::{Context, IntoDiagnostic, Report};
-use qsc::compile::{compile, CheckEntry};
+use qsc::compile::{compile, PackageType};
 use qsc_frontend::compile::{PackageStore, SourceContents, SourceMap, SourceName};
 use qsc_hir::hir::Package;
 use std::{
@@ -68,7 +68,7 @@ fn main() -> miette::Result<ExitCode> {
 
     let entry = cli.entry.unwrap_or_default();
     let sources = SourceMap::new(sources, Some(entry.into()));
-    let (unit, errors) = compile(&store, &dependencies, sources, CheckEntry::Optional);
+    let (unit, errors) = compile(&store, &dependencies, sources, PackageType::Lib);
 
     let out_dir = cli.out_dir.as_ref().map_or(".".as_ref(), PathBuf::as_path);
     for emit in &cli.emit {

--- a/compiler/qsc/src/compile.rs
+++ b/compiler/qsc/src/compile.rs
@@ -17,9 +17,9 @@ pub enum Error {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum CheckEntry {
-    Required,
-    Optional,
+pub enum PackageType {
+    Exe,
+    Lib,
 }
 
 #[must_use]
@@ -27,7 +27,7 @@ pub fn compile(
     store: &PackageStore,
     dependencies: &[PackageId],
     sources: SourceMap,
-    entry: CheckEntry,
+    package_type: PackageType,
 ) -> (CompileUnit, Vec<Error>) {
     let mut unit = qsc_frontend::compile::compile(store, dependencies, sources);
     let mut errors = Vec::new();
@@ -39,7 +39,7 @@ pub fn compile(
         for error in run_default_passes(store.core(), &mut unit) {
             errors.push(error.into());
         }
-        if entry == CheckEntry::Required {
+        if package_type == PackageType::Exe {
             for error in generate_entry_expr(&mut unit) {
                 errors.push(error.into());
             }

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -5,7 +5,7 @@
 mod tests;
 
 use crate::{
-    compile::{self, compile, CheckEntry},
+    compile::{self, compile, PackageType},
     error::WithSource,
 };
 use miette::Diagnostic;
@@ -96,7 +96,7 @@ impl Interpreter {
             dependencies.push(store.insert(compile::std(&store)));
         }
 
-        let (unit, errors) = compile(&store, &dependencies, sources, CheckEntry::Optional);
+        let (unit, errors) = compile(&store, &dependencies, sources, PackageType::Lib);
         if !errors.is_empty() {
             return Err(errors
                 .into_iter()

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -5,7 +5,7 @@
 mod tests;
 
 use crate::{
-    compile::{self, compile},
+    compile::{self, compile, CheckEntry},
     error::WithSource,
 };
 use miette::Diagnostic;
@@ -96,7 +96,7 @@ impl Interpreter {
             dependencies.push(store.insert(compile::std(&store)));
         }
 
-        let (unit, errors) = compile(&store, &dependencies, sources);
+        let (unit, errors) = compile(&store, &dependencies, sources, CheckEntry::Optional);
         if !errors.is_empty() {
             return Err(errors
                 .into_iter()

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -5,7 +5,7 @@
 mod tests;
 
 use crate::{
-    compile::{self, compile, PackageType},
+    compile::{self, compile},
     error::WithSource,
 };
 use miette::Diagnostic;
@@ -23,7 +23,7 @@ use qsc_frontend::{
     incremental::{self, Compiler, Fragment},
 };
 use qsc_hir::hir::{CallableDecl, ItemKind, LocalItemId, PackageId, Stmt};
-use qsc_passes::run_default_passes_for_fragment;
+use qsc_passes::{run_default_passes_for_fragment, PackageType};
 use std::{collections::HashSet, sync::Arc};
 use thiserror::Error;
 

--- a/compiler/qsc/src/interpret/stateless.rs
+++ b/compiler/qsc/src/interpret/stateless.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
-    compile::{self, compile, CheckEntry},
+    compile::{self, compile, PackageType},
     error::WithSource,
 };
 use miette::Diagnostic;
@@ -82,7 +82,7 @@ impl Interpreter {
             dependencies.push(store.insert(compile::std(&store)));
         }
 
-        let (unit, errors) = compile(&store, &dependencies, sources, CheckEntry::Required);
+        let (unit, errors) = compile(&store, &dependencies, sources, PackageType::Exe);
         if errors.is_empty() {
             let package = store.insert(unit);
             Ok(Self { store, package })

--- a/compiler/qsc/src/interpret/stateless.rs
+++ b/compiler/qsc/src/interpret/stateless.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
-    compile::{self, compile},
+    compile::{self, compile, CheckEntry},
     error::WithSource,
 };
 use miette::Diagnostic;
@@ -82,7 +82,7 @@ impl Interpreter {
             dependencies.push(store.insert(compile::std(&store)));
         }
 
-        let (unit, errors) = compile(&store, &dependencies, sources);
+        let (unit, errors) = compile(&store, &dependencies, sources, CheckEntry::Required);
         if errors.is_empty() {
             let package = store.insert(unit);
             Ok(Self { store, package })

--- a/compiler/qsc/src/interpret/stateless.rs
+++ b/compiler/qsc/src/interpret/stateless.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
-    compile::{self, compile, PackageType},
+    compile::{self, compile},
     error::WithSource,
 };
 use miette::Diagnostic;
@@ -16,6 +16,7 @@ use qsc_eval::{
 };
 use qsc_frontend::compile::{PackageStore, Source, SourceMap};
 use qsc_hir::hir::{Expr, ItemKind, PackageId};
+use qsc_passes::PackageType;
 use thiserror::Error;
 
 use super::debug::format_call_stack;

--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -22,3 +22,5 @@ pub mod ast {
 }
 
 pub use qsc_data_structures::span::Span;
+
+pub use qsc_passes::PackageType;

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -14,7 +14,7 @@ use expect_test::{expect, Expect};
 use indoc::indoc;
 use num_bigint::BigInt;
 use qsc_frontend::compile::{self, compile, PackageStore, SourceMap};
-use qsc_passes::{run_core_passes, run_default_passes};
+use qsc_passes::{run_core_passes, run_default_passes, PackageType};
 
 struct Lookup<'a> {
     store: &'a PackageStore,
@@ -32,13 +32,13 @@ fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Va
     let mut store = PackageStore::new(core);
     let mut std = compile::std(&store);
     assert!(std.errors.is_empty());
-    assert!(run_default_passes(store.core(), &mut std).is_empty());
+    assert!(run_default_passes(store.core(), &mut std, PackageType::Lib).is_empty());
 
     let std_id = store.insert(std);
     let sources = SourceMap::new([("test".into(), file.into())], Some(expr.into()));
     let mut unit = compile(&store, &[std_id], sources);
     assert!(unit.errors.is_empty());
-    assert!(run_default_passes(store.core(), &mut unit).is_empty());
+    assert!(run_default_passes(store.core(), &mut unit, PackageType::Lib).is_empty());
 
     let id = store.insert(unit);
     let entry = store

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -15,7 +15,7 @@ use qsc_hir::hir::Expr;
 use qsc_hir::hir::ItemKind;
 use qsc_hir::hir::PackageId;
 
-use qsc_passes::{run_core_passes, run_default_passes};
+use qsc_passes::{run_core_passes, run_default_passes, PackageType};
 /// Evaluates the given expression with the given context.
 /// Creates a new environment and simulator.
 /// # Errors
@@ -50,13 +50,13 @@ fn check_expr(file: &str, expr: &str, expect: &Expect) {
 
     let mut std = compile::std(&store);
     assert!(std.errors.is_empty());
-    assert!(run_default_passes(store.core(), &mut std).is_empty());
+    assert!(run_default_passes(store.core(), &mut std, PackageType::Lib).is_empty());
     let std_id = store.insert(std);
 
     let sources = SourceMap::new([("test".into(), file.into())], Some(expr.into()));
     let mut unit = compile(&store, &[std_id], sources);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
-    let pass_errors = run_default_passes(store.core(), &mut unit);
+    let pass_errors = run_default_passes(store.core(), &mut unit, PackageType::Lib);
     assert!(pass_errors.is_empty(), "{pass_errors:?}");
     let id = store.insert(unit);
 

--- a/compiler/qsc_passes/src/entry_point.rs
+++ b/compiler/qsc_passes/src/entry_point.rs
@@ -42,7 +42,6 @@ pub enum Error {
 
 // If no entry expression is provided, generate one from the entry point callable.
 // Only one callable should be annotated with the entry point attribute.
-// If more than one callable is annotated, or none are annotated, we skip this pass.
 pub fn generate_entry_expr(unit: &mut CompileUnit) -> Vec<super::Error> {
     if unit.package.entry.is_some() {
         return vec![];

--- a/compiler/qsc_passes/src/entry_point.rs
+++ b/compiler/qsc_passes/src/entry_point.rs
@@ -43,14 +43,11 @@ pub enum Error {
 // If no entry expression is provided, generate one from the entry point callable.
 // Only one callable should be annotated with the entry point attribute.
 // If more than one callable is annotated, or none are annotated, we skip this pass.
-pub(super) fn generate_entry_expr(unit: &mut CompileUnit) -> Vec<super::Error> {
+pub fn generate_entry_expr(unit: &mut CompileUnit) -> Vec<super::Error> {
     if unit.package.entry.is_some() {
         return vec![];
     }
     let callables = get_callables(&unit.package);
-    if callables.len() != 1 {
-        return vec![];
-    }
 
     match create_entry_from_callables(&mut unit.assigner, callables) {
         Ok(expr) => {

--- a/compiler/qsc_passes/src/entry_point.rs
+++ b/compiler/qsc_passes/src/entry_point.rs
@@ -42,7 +42,7 @@ pub enum Error {
 
 // If no entry expression is provided, generate one from the entry point callable.
 // Only one callable should be annotated with the entry point attribute.
-pub fn generate_entry_expr(unit: &mut CompileUnit) -> Vec<super::Error> {
+pub(super) fn generate_entry_expr(unit: &mut CompileUnit) -> Vec<super::Error> {
     if unit.package.entry.is_some() {
         return vec![];
     }

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -16,6 +16,7 @@ mod replace_qubit_allocation;
 mod spec_gen;
 
 use callable_limits::CallableLimits;
+use entry_point::generate_entry_expr;
 use loop_unification::LoopUni;
 use miette::Diagnostic;
 use qsc_frontend::{compile::CompileUnit, incremental::Fragment};
@@ -41,8 +42,18 @@ pub enum Error {
     SpecGen(spec_gen::Error),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PackageType {
+    Exe,
+    Lib,
+}
+
 /// Run the default set of passes required for evaluation.
-pub fn run_default_passes(core: &Table, unit: &mut CompileUnit) -> Vec<Error> {
+pub fn run_default_passes(
+    core: &Table,
+    unit: &mut CompileUnit,
+    package_type: PackageType,
+) -> Vec<Error> {
     let mut call_limits = CallableLimits::default();
     call_limits.visit_package(&unit.package);
     let callable_errors = call_limits.errors;
@@ -56,6 +67,14 @@ pub fn run_default_passes(core: &Table, unit: &mut CompileUnit) -> Vec<Error> {
 
     let conjugate_errors = conjugate_invert::invert_conjugate_exprs(core, unit);
     Validator::default().visit_package(&unit.package);
+
+    let entry_point_errors = if package_type == PackageType::Exe {
+        let entry_point_errors = generate_entry_expr(unit);
+        Validator::default().visit_package(&unit.package);
+        entry_point_errors
+    } else {
+        Vec::new()
+    };
 
     LoopUni {
         core,
@@ -73,6 +92,7 @@ pub fn run_default_passes(core: &Table, unit: &mut CompileUnit) -> Vec<Error> {
         .chain(borrow_errors.into_iter().map(Error::BorrowCk))
         .chain(spec_errors.into_iter().map(Error::SpecGen))
         .chain(conjugate_errors.into_iter().map(Error::ConjInvert))
+        .chain(entry_point_errors.into_iter())
         .collect()
 }
 

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -16,7 +16,6 @@ mod replace_qubit_allocation;
 mod spec_gen;
 
 use callable_limits::CallableLimits;
-use entry_point::generate_entry_expr;
 use loop_unification::LoopUni;
 use miette::Diagnostic;
 use qsc_frontend::{compile::CompileUnit, incremental::Fragment};
@@ -58,9 +57,6 @@ pub fn run_default_passes(core: &Table, unit: &mut CompileUnit) -> Vec<Error> {
     let conjugate_errors = conjugate_invert::invert_conjugate_exprs(core, unit);
     Validator::default().visit_package(&unit.package);
 
-    let entry_point_errors = generate_entry_expr(unit);
-    Validator::default().visit_package(&unit.package);
-
     LoopUni {
         core,
         assigner: &mut unit.assigner,
@@ -77,7 +73,6 @@ pub fn run_default_passes(core: &Table, unit: &mut CompileUnit) -> Vec<Error> {
         .chain(borrow_errors.into_iter().map(Error::BorrowCk))
         .chain(spec_errors.into_iter().map(Error::SpecGen))
         .chain(conjugate_errors.into_iter().map(Error::ConjInvert))
-        .chain(entry_point_errors.into_iter())
         .collect()
 }
 

--- a/fuzz/fuzz_targets/compile.rs
+++ b/fuzz/fuzz_targets/compile.rs
@@ -18,8 +18,7 @@ fn compile(data: &[u8]) {
         }
         let sources = SourceMap::new([("fuzzed_code".into(), fuzzed_code.into())], None);
         STORE_STD.with(|(store, std)| {
-            let mut _unit =
-                qsc::compile::compile(store, &[*std], sources, qsc::compile::PackageType::Lib);
+            let mut _unit = qsc::compile::compile(store, &[*std], sources, qsc::PackageType::Lib);
         });
     }
 }

--- a/fuzz/fuzz_targets/compile.rs
+++ b/fuzz/fuzz_targets/compile.rs
@@ -18,7 +18,8 @@ fn compile(data: &[u8]) {
         }
         let sources = SourceMap::new([("fuzzed_code".into(), fuzzed_code.into())], None);
         STORE_STD.with(|(store, std)| {
-            let mut _unit = qsc::compile::compile(store, &[*std], sources);
+            let mut _unit =
+                qsc::compile::compile(store, &[*std], sources, qsc::compile::CheckEntry::Optional);
         });
     }
 }

--- a/fuzz/fuzz_targets/compile.rs
+++ b/fuzz/fuzz_targets/compile.rs
@@ -19,7 +19,7 @@ fn compile(data: &[u8]) {
         let sources = SourceMap::new([("fuzzed_code".into(), fuzzed_code.into())], None);
         STORE_STD.with(|(store, std)| {
             let mut _unit =
-                qsc::compile::compile(store, &[*std], sources, qsc::compile::CheckEntry::Optional);
+                qsc::compile::compile(store, &[*std], sources, qsc::compile::PackageType::Lib);
         });
     }
 }

--- a/language_service/src/qsc_utils.rs
+++ b/language_service/src/qsc_utils.rs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use qsc::compile::PackageType;
-use qsc::hir::{Item, ItemId, PackageId};
 use qsc::{
     compile::{self, Error},
-    PackageStore, SourceMap,
+    hir::{Item, ItemId, PackageId},
+    CompileUnit, PackageStore, PackageType, SourceMap, Span,
 };
-use qsc::{CompileUnit, Span};
 
 /// Represents an immutable compilation state that can be used
 /// to implement language service features.

--- a/language_service/src/qsc_utils.rs
+++ b/language_service/src/qsc_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use qsc::compile::CheckEntry;
+use qsc::compile::PackageType;
 use qsc::hir::{Item, ItemId, PackageId};
 use qsc::{
     compile::{self, Error},
@@ -28,7 +28,7 @@ pub(crate) fn compile_document(source_name: &str, source_contents: &str) -> Comp
         &package_store,
         &[std_package_id],
         source_map,
-        CheckEntry::Required,
+        PackageType::Exe,
     );
     Compilation {
         package_store,

--- a/language_service/src/qsc_utils.rs
+++ b/language_service/src/qsc_utils.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use qsc::compile::CheckEntry;
 use qsc::hir::{Item, ItemId, PackageId};
 use qsc::{
     compile::{self, Error},
@@ -23,7 +24,12 @@ pub(crate) fn compile_document(source_name: &str, source_contents: &str) -> Comp
 
     // Source map only contains the current document.
     let source_map = SourceMap::new([(source_name.into(), source_contents.into())], None);
-    let (unit, errors) = compile::compile(&package_store, &[std_package_id], source_map);
+    let (unit, errors) = compile::compile(
+        &package_store,
+        &[std_package_id],
+        source_map,
+        CheckEntry::Required,
+    );
     Compilation {
         package_store,
         std_package_id,

--- a/language_service/src/test_utils.rs
+++ b/language_service/src/test_utils.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::qsc_utils::Compilation;
+use qsc::compile::CheckEntry;
 use qsc::hir::PackageId;
 use qsc::{compile, PackageStore, SourceMap};
 
@@ -42,12 +43,21 @@ pub(crate) fn compile_with_fake_stdlib(source_name: &str, source_contents: &str)
         )],
         None,
     );
-    let (std_compile_unit, std_errors) =
-        compile::compile(&package_store, &[PackageId::CORE], std_source_map);
+    let (std_compile_unit, std_errors) = compile::compile(
+        &package_store,
+        &[PackageId::CORE],
+        std_source_map,
+        CheckEntry::Optional,
+    );
     assert!(std_errors.is_empty());
     let std_package_id = package_store.insert(std_compile_unit);
     let source_map = SourceMap::new([(source_name.into(), source_contents.into())], None);
-    let (unit, errors) = compile::compile(&package_store, &[std_package_id], source_map);
+    let (unit, errors) = compile::compile(
+        &package_store,
+        &[std_package_id],
+        source_map,
+        CheckEntry::Required,
+    );
     Compilation {
         package_store,
         std_package_id,

--- a/language_service/src/test_utils.rs
+++ b/language_service/src/test_utils.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::qsc_utils::Compilation;
-use qsc::compile::CheckEntry;
+use qsc::compile::PackageType;
 use qsc::hir::PackageId;
 use qsc::{compile, PackageStore, SourceMap};
 
@@ -48,7 +48,7 @@ pub(crate) fn compile_with_fake_stdlib(source_name: &str, source_contents: &str)
         &package_store,
         &[PackageId::CORE],
         std_source_map,
-        CheckEntry::Optional,
+        PackageType::Lib,
     );
     assert!(std_errors.is_empty());
     let std_package_id = package_store.insert(std_compile_unit);
@@ -57,7 +57,7 @@ pub(crate) fn compile_with_fake_stdlib(source_name: &str, source_contents: &str)
         &package_store,
         &[std_package_id],
         source_map,
-        CheckEntry::Required,
+        PackageType::Exe,
     );
     Compilation {
         package_store,

--- a/language_service/src/test_utils.rs
+++ b/language_service/src/test_utils.rs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::qsc_utils::Compilation;
-use qsc::compile::PackageType;
-use qsc::hir::PackageId;
-use qsc::{compile, PackageStore, SourceMap};
+use qsc::{compile, hir::PackageId, PackageStore, PackageType, SourceMap};
 
 pub(crate) fn get_source_and_marker_offsets(
     source_with_markers: &str,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -6,7 +6,7 @@ use katas::check_solution;
 use num_bigint::BigUint;
 use num_complex::Complex64;
 use qsc::{
-    compile,
+    compile::{self, CheckEntry},
     hir::PackageId,
     interpret::{
         output::{self, Receiver},
@@ -44,7 +44,7 @@ fn compile(code: &str) -> (qsc::hir::Package, Vec<VSDiagnostic>) {
 
     STORE_STD.with(|(store, std)| {
         let sources = SourceMap::new([("code".into(), code.into())], None);
-        let (unit, errors) = compile::compile(store, &[*std], sources);
+        let (unit, errors) = compile::compile(store, &[*std], sources, CheckEntry::Required);
         (
             unit.package,
             errors.into_iter().map(|error| (&error).into()).collect(),
@@ -405,6 +405,6 @@ mod test {
             },
             1,
         );
-        assert!(result.is_ok());
+        assert!(result.is_err());
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -6,13 +6,13 @@ use katas::check_solution;
 use num_bigint::BigUint;
 use num_complex::Complex64;
 use qsc::{
-    compile::{self, PackageType},
+    compile::{self},
     hir::PackageId,
     interpret::{
         output::{self, Receiver},
         stateless,
     },
-    PackageStore, SourceContents, SourceMap, SourceName,
+    PackageStore, PackageType, SourceContents, SourceMap, SourceName,
 };
 use serde_json::json;
 use std::fmt::Write;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -6,7 +6,7 @@ use katas::check_solution;
 use num_bigint::BigUint;
 use num_complex::Complex64;
 use qsc::{
-    compile::{self, CheckEntry},
+    compile::{self, PackageType},
     hir::PackageId,
     interpret::{
         output::{self, Receiver},
@@ -44,7 +44,7 @@ fn compile(code: &str) -> (qsc::hir::Package, Vec<VSDiagnostic>) {
 
     STORE_STD.with(|(store, std)| {
         let sources = SourceMap::new([("code".into(), code.into())], None);
-        let (unit, errors) = compile::compile(store, &[*std], sources, CheckEntry::Required);
+        let (unit, errors) = compile::compile(store, &[*std], sources, PackageType::Exe);
         (
             unit.package,
             errors.into_iter().map(|error| (&error).into()).collect(),


### PR DESCRIPTION
This change updates the way entry point attributes and/or expressions are checked to ensure that the error messages get propageted as expected. Recent changes regressed the error cases, and this introduces a new parameter to compile that lets the caller decide whether an entry point attribute or expression should be treated as required. This is essentially the difference between a library compilation (no entry required) and and executable compilation (single entry required), so this code is a placeholder until we formalize the difference between library compilation and exe compilation.