### PR TITLE
Removing unused default and fixing Run Q# file menu command

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -116,8 +116,7 @@
               },
               "shots": {
                 "type": "number",
-                "description": "Number of shots to execute.",
-                "default": 10
+                "description": "Number of shots to execute."
               },
               "trace": {
                 "type": "boolean",

--- a/vscode/src/debugger/activate.ts
+++ b/vscode/src/debugger/activate.ts
@@ -49,7 +49,7 @@ function registerCommands(context: vscode.ExtensionContext) {
               type: "qsharp",
               name: "Run Q# File",
               request: "launch",
-              program: targetResource.toString(),
+              program: targetResource,
               shots: 1,
               stopOnEntry: false,
             },


### PR DESCRIPTION
There is a type error on the program causing a hang when executing the `runEditorContents` command. This was missed in an earlier refactor.