### PR TITLE
Add QIR base profile validation pass

### DIFF
--- a/compiler/qsc_passes/src/baseprofck.rs
+++ b/compiler/qsc_passes/src/baseprofck.rs
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashSet;
+
+use miette::Diagnostic;
+use qsc_data_structures::span::Span;
+use qsc_frontend::compile::PackageStore;
+use qsc_hir::{
+    hir::{
+        BinOp, CallableKind, Expr, ExprKind, Item, ItemId, ItemKind, Lit, Package, PackageId, Res,
+        SpecBody, SpecGen,
+    },
+    ty::{Prim, Ty},
+    visit::{walk_expr, walk_item, Visitor},
+};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Diagnostic, Error)]
+pub enum Error {
+    #[error("cannot compare measurement results")]
+    #[diagnostic(help(
+        "comparing measurement results is not supported when performing base profile QIR generation"
+    ))]
+    #[diagnostic(code("Qsc.BaseProfCk.ResultComparison"))]
+    ResultComparison(#[label] Span),
+
+    #[error("result literals are not supported")]
+    #[diagnostic(help(
+        "result literals `One` and `Zero` are not supported when performing base profile QIR generation"
+    ))]
+    #[diagnostic(code("Qsc.BaseProfCk.ResultLiteral"))]
+    ResultLiteral(#[label] Span),
+
+    #[error("non-Result return type in entry expression")]
+    #[diagnostic(help(
+        "returning types other than Result from the entry expression is not supported when performing base profile QIR generation"
+    ))]
+    #[diagnostic(code("Qsc.BaseProfCk.ReturnNonResult"))]
+    ReturnNonResult(#[label] Span),
+
+    #[error("intrinsic operations that return types other than Result or Unit are not supported")]
+    #[diagnostic(help(
+        "intrinsic operations that return values other than Result or Unit are not supported when performing base profile QIR generation"
+    ))]
+    #[diagnostic(code("Qsc.BaseProfCk.UnsupportedIntrinsic"))]
+    UnsupportedIntrinsic(#[label] Span),
+}
+
+#[must_use]
+pub fn check_base_profile_compliance(store: &PackageStore, package: &Package) -> Vec<Error> {
+    let mut checker = Checker {
+        current_package: None,
+        pending: Vec::new(),
+        processed: HashSet::new(),
+        errors: Vec::new(),
+    };
+    if let Some(entry) = &package.entry {
+        if any_non_result_ty(&entry.ty) {
+            checker.errors.push(Error::ReturnNonResult(entry.span));
+        }
+    }
+    checker.visit_package(package);
+
+    while let Some(item_id) = checker.pending.pop() {
+        if !checker.processed.insert(item_id) {
+            continue;
+        }
+
+        let item = store
+            .get(item_id.package.expect("package id should be set"))
+            .expect("package should be present in store")
+            .package
+            .items
+            .get(item_id.item)
+            .expect("item should be present in package");
+        checker.current_package = item_id.package;
+        checker.visit_item(item);
+    }
+
+    checker.errors
+}
+
+struct Checker {
+    current_package: Option<PackageId>,
+    pending: Vec<ItemId>,
+    processed: HashSet<ItemId>,
+    errors: Vec<Error>,
+}
+
+impl<'a> Visitor<'a> for Checker {
+    fn visit_item(&mut self, item: &'a Item) {
+        match &item.kind {
+            ItemKind::Callable(callable)
+                if callable.kind == CallableKind::Operation
+                    && callable.body.body == SpecBody::Gen(SpecGen::Intrinsic)
+                    && callable.output != Ty::Prim(Prim::Result)
+                    && callable.output != Ty::Prim(Prim::Qubit)
+                    && callable.output != Ty::UNIT =>
+            {
+                self.errors
+                    .push(Error::UnsupportedIntrinsic(callable.name.span));
+            }
+            _ => {}
+        }
+
+        walk_item(self, item);
+    }
+
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        match &expr.kind {
+            ExprKind::BinOp(BinOp::Eq | BinOp::Neq, lhs, _) if any_result_ty(&lhs.ty) => {
+                self.errors.push(Error::ResultComparison(expr.span));
+            }
+            ExprKind::Lit(Lit::Result(_)) => {
+                self.errors.push(Error::ResultLiteral(expr.span));
+            }
+            ExprKind::Var(Res::Item(item_id), _) => {
+                if item_id.package.is_some() && !self.processed.contains(item_id) {
+                    self.pending.push(*item_id);
+                } else if self.current_package.is_some() {
+                    self.pending.push(ItemId {
+                        package: self.current_package,
+                        item: item_id.item,
+                    });
+                }
+            }
+            _ => {}
+        }
+        walk_expr(self, expr);
+    }
+}
+
+fn any_result_ty(ty: &Ty) -> bool {
+    match ty {
+        Ty::Array(ty) => any_result_ty(ty),
+        Ty::Prim(Prim::Result) => true,
+        Ty::Tuple(tys) => tys.iter().any(any_result_ty),
+        _ => false,
+    }
+}
+
+fn any_non_result_ty(ty: &Ty) -> bool {
+    match ty {
+        Ty::Array(ty) => any_non_result_ty(ty),
+        Ty::Prim(Prim::Result) => false,
+        Ty::Tuple(tys) => tys.iter().any(any_non_result_ty),
+        _ => true,
+    }
+}

--- a/compiler/qsc_passes/src/baseprofck/tests.rs
+++ b/compiler/qsc_passes/src/baseprofck/tests.rs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use expect_test::{expect, Expect};
+use indoc::indoc;
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap};
+
+use crate::baseprofck::check_base_profile_compliance;
+
+fn check(expr: &str, expect: &Expect) {
+    let mut store = PackageStore::new(compile::core());
+    let std = store.insert(compile::std(&store));
+    let lib_src = SourceMap::new(
+        [(
+            "lib".into(),
+            indoc! {"
+        namespace Lib {
+            operation Foo() : Unit {
+                body intrinsic;
+            }
+            operation Bar() : Result {
+                body intrinsic;
+            }
+            operation Baz() : Int {
+                body intrinsic;
+            }
+            operation MeasAreEq(q1 : Qubit, q2 : Qubit) : Bool {
+                M(q1) == M(q2)
+            }
+        }
+    "}
+            .into(),
+        )],
+        None,
+    );
+    let lib_unit = compile(&store, &[std], lib_src);
+    assert!(lib_unit.errors.is_empty(), "{:?}", lib_unit.errors);
+    let lib = store.insert(lib_unit);
+    let sources = SourceMap::new([("test".into(), "".into())], Some(expr.into()));
+    let unit = compile(&store, &[std, lib], sources);
+    assert!(unit.errors.is_empty(), "{:?}", unit.errors);
+
+    let errors = check_base_profile_compliance(&store, &unit.package);
+    expect.assert_debug_eq(&errors);
+}
+
+#[test]
+fn simple_program_is_valid() {
+    check(
+        indoc! {"{
+            use q = Qubit();
+            H(q);
+            M(q)
+        }"},
+        &expect![[r#"
+            []
+        "#]],
+    );
+}
+
+#[test]
+fn intrinsic_lib_calls_with_supported_returns_are_valid() {
+    check(
+        indoc! {"{
+            Lib.Foo();
+            Lib.Bar()
+        }"},
+        &expect![[r#"
+            []
+        "#]],
+    );
+}
+
+#[test]
+fn intrinsic_lib_calls_with_unsupported_returns_are_invalid() {
+    check(
+        indoc! {"{
+            Lib.Baz()
+        }"},
+        &expect![[r#"
+            [
+                ReturnNonResult(
+                    Span {
+                        lo: 0,
+                        hi: 17,
+                    },
+                ),
+                UnsupportedIntrinsic(
+                    Span {
+                        lo: 150,
+                        hi: 153,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn result_comparison_error() {
+    check(
+        indoc! {"{
+            use q = Qubit();
+            H(q);
+            if (M(q) == M(q)) {
+                X(q);
+            }
+        }"},
+        &expect![[r#"
+            [
+                ResultComparison(
+                    Span {
+                        lo: 41,
+                        hi: 53,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn result_comparison_in_lib_error() {
+    check(
+        indoc! {"{
+            use q = Qubit();
+            Lib.MeasAreEq(q, q);
+        }"},
+        &expect![[r#"
+            [
+                ResultComparison(
+                    Span {
+                        lo: 259,
+                        hi: 273,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn result_literal_error() {
+    check(
+        indoc! {"(One, Zero)"},
+        &expect![[r#"
+            [
+                ResultLiteral(
+                    Span {
+                        lo: 1,
+                        hi: 4,
+                    },
+                ),
+                ResultLiteral(
+                    Span {
+                        lo: 6,
+                        hi: 10,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn non_result_return_error() {
+    check(
+        indoc! {"{
+            use q = Qubit();
+            H(q);
+            M(q);
+            3 + 1
+        }"},
+        &expect![[r#"
+            [
+                ReturnNonResult(
+                    Span {
+                        lo: 0,
+                        hi: 54,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn unsupported_intrsinsic_error() {
+    check(
+        indoc! {"{
+            operation Rand() : Int {
+                body intrinsic;
+            }
+        }"},
+        &expect![[r#"
+            [
+                UnsupportedIntrinsic(
+                    Span {
+                        lo: 16,
+                        hi: 20,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
 
+pub mod baseprofck;
 mod borrowck;
 mod callable_limits;
 mod common;
@@ -35,6 +36,7 @@ use thiserror::Error;
 #[diagnostic(transparent)]
 #[error(transparent)]
 pub enum Error {
+    BaseProfCk(baseprofck::Error),
     BorrowCk(borrowck::Error),
     CallableLimits(callable_limits::Error),
     ConjInvert(conjugate_invert::Error),


### PR DESCRIPTION
This change adds an analysis pass that will check whether a given program conforms to the QIR base profile. Specifically, this disallows:

 - Comparison of `Result` values
 - `Result` literals
 - Operation intrinsics that don't return Result or Unit
 - Entry point callables or expressions that return types other than `Result` or aggregates of `Result`

The logic for the pass with validate the entire package provided, but then only validate callables from dependent packages that are called somewhere in the given package. This allows for use of a subset of the standard library without producing extraneous errors.

The new pass is not run by default, but will be triggered if the compiler is invoked with qir emission, ie: `qsc <file> --emit qir`.