### PR TITLE
Update Fuzz workflow to run on some merges to main

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,6 +15,17 @@ on:
   schedule:                                   # Production runs against default branch.
     - cron: '24 11 * * 0'                     # Run after 11:24 UTC (4:24am PDT/3:24am PST) on Sun.
   workflow_dispatch:                          # Manual runs.
+  push:
+    branches:
+      - main                                  # Development runs against main branch.
+    paths:
+      - 'fuzz/**'                             # Run if the fuzzing infra was changed.
+      - '.github/ISSUE_TEMPLATE/fuzz_bug_report.md'
+                                              # Run if the GitHub issue template was changed.
+      - '.github/workflows/fuzz.yml'          # Run if the workflow itself was changed.
+      - 'compiler/**'                         # Run if the compiler was changed.
+      - '!compiler/qsc_eval/**'               # Exclude the qsc_eval dir.
+      - '!compiler/qsc_codegen/**'            # Exclude the qsc_codegen dir.
 
 jobs:
   fuzz:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,11 +19,11 @@ on:
     branches:
       - main                                  # Development runs against main branch.
     paths:
+      - 'compiler/**'                         # Run if the compiler was changed.
       - 'fuzz/**'                             # Run if the fuzzing infra was changed.
       - '.github/ISSUE_TEMPLATE/fuzz_bug_report.md'
                                               # Run if the GitHub issue template was changed.
       - '.github/workflows/fuzz.yml'          # Run if the workflow itself was changed.
-      - 'compiler/**'                         # Run if the compiler was changed.
       - '!compiler/qsc_eval/**'               # Exclude the qsc_eval dir.
       - '!compiler/qsc_codegen/**'            # Exclude the qsc_codegen dir.
 


### PR DESCRIPTION
This updates the Fuzz workflow conditions to include running on merges to main as long as certain conditions are met, namely:
 - Any fuzzing infrastructure was changed
 - The reporting template was changed
 - The workflow itself was changed
 - The compiler was changed (excluding the evaluator and codegen)