### PR TITLE
Added ApplyPauliFromInt, ApplyControlledOnInt, DrawRandomDouble

### DIFF
--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -68,6 +68,16 @@ pub(crate) fn call(
                 Ok(Value::Int(rand::thread_rng().gen_range(lo..=hi)))
             }
         }
+        "DrawRandomDouble" => {
+            let [lo, hi] = unwrap_tuple(arg);
+            let lo = lo.unwrap_double();
+            let hi = hi.unwrap_double();
+            if lo > hi {
+                Err(Error::EmptyRange(arg_span))
+            } else {
+                Ok(Value::Double(rand::thread_rng().gen_range(lo..=hi)))
+            }
+        }
         #[allow(clippy::cast_possible_truncation)]
         "Truncate" => Ok(Value::Int(arg.unwrap_double() as i64)),
         "__quantum__rt__qubit_allocate" => Ok(Value::Qubit(Qubit(sim.qubit_allocate()))),

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -280,6 +280,15 @@ fn draw_random_int() {
 }
 
 #[test]
+fn draw_random_double() {
+    check_intrinsic_value(
+        "",
+        "Microsoft.Quantum.Random.DrawRandomDouble(5.0,5.0)",
+        &Value::Double(5.0),
+    );
+}
+
+#[test]
 fn truncate() {
     check_intrinsic_value("", "Microsoft.Quantum.Math.Truncate(3.1)", &Value::Int(3));
     check_intrinsic_value("", "Microsoft.Quantum.Math.Truncate(3.9)", &Value::Int(3));

--- a/library/std/random.qs
+++ b/library/std/random.qs
@@ -27,4 +27,30 @@ namespace Microsoft.Quantum.Random {
     operation DrawRandomInt(min : Int, max : Int) : Int {
         body intrinsic;
     }
+
+    /// # Summary
+    /// Draws a random real number in a given inclusive interval.
+    ///
+    /// # Input
+    /// ## min
+    /// The smallest real number to be drawn.
+    /// ## max
+    /// The largest real number to be drawn.
+    ///
+    /// # Output
+    /// A random real number in the inclusive interval from `min` to `max` with
+    /// uniform probability.
+    ///
+    /// # Remarks
+    /// Fails if `max < min`.
+    ///
+    /// # Example
+    /// The following Q# snippet randomly draws an angle between $0$ and $2 \pi$:
+    /// ```qsharp
+    /// let angle = DrawRandomDouble(0.0, 2.0 * PI());
+    /// ```
+    operation DrawRandomDouble(min : Double, max : Double) : Double {
+        body intrinsic;
+    }
+
 }

--- a/library/tests/src/tests.rs
+++ b/library/tests/src/tests.rs
@@ -660,6 +660,51 @@ fn check_apply_pauli_from_bit_string() {
 }
 
 #[test]
+fn check_apply_pauli_from_int() {
+    test_expression(
+        {
+            "{
+            open Microsoft.Quantum.Measurement;
+            use q = Qubit[3];
+            ApplyPauliFromInt(PauliX, false, 5, q);
+            return MResetEachZ(q);
+        }"
+        },
+        &Value::Array(
+            vec![
+                Value::Result(false),
+                Value::Result(true),
+                Value::Result(false),
+            ]
+            .into(),
+        ),
+    );
+}
+
+#[test]
+fn check_apply_controlled_on_int() {
+    test_expression(
+        {
+            "{
+            open Microsoft.Quantum.Measurement;
+            use c = Qubit[3];
+            use t1 = Qubit();
+            use t2 = Qubit();
+            within {
+                X(c[0]);
+                X(c[2]);
+            } apply {
+                ApplyControlledOnInt(5, X, c, t1);
+            }
+            ApplyControlledOnInt(5, X, c, t2);
+            return [MResetZ(t1), M(t2)];
+        }"
+        },
+        &Value::Array(vec![Value::Result(true), Value::Result(false)].into()),
+    );
+}
+
+#[test]
 fn check_apply_cnot_chain_3a() {
     test_expression(
         {


### PR DESCRIPTION
Added library functions and basic tests.
Note that DrawRandomDouble documentations calls for inclusive bounds, but the code doesn't include the lower bound as underlying Rust function doesn't seem to allow inclusion of the lower bound. This may be OK because the probability of drawing exact number is very slim when the interval is reasonable.