### PR TITLE
Fixed bug in Padded function

### DIFF
--- a/library/std/arrays.qs
+++ b/library/std/arrays.qs
@@ -897,8 +897,8 @@ namespace Microsoft.Quantum.Arrays {
     function Padded<'T> (paddedLength : Int, defaultElement : 'T, inputArray : 'T[]) : 'T[] {
         let nElementsInitial = Length(inputArray);
         let nAbsElementsTotal = AbsI(paddedLength);
-        if nAbsElementsTotal <= nElementsInitial {
-            fail "Specified output array length must be longer than `inputArray` length.";
+        if nAbsElementsTotal < nElementsInitial {
+            fail "Specified output array length must be at least as long as `inputArray` length.";
         }
         let nElementsPad = nAbsElementsTotal - nElementsInitial;
         let padArray = Repeated(defaultElement, nElementsPad);

--- a/library/tests/src/test_arrays.rs
+++ b/library/tests/src/test_arrays.rs
@@ -583,6 +583,28 @@ fn check_padded() {
             .into(),
         ),
     );
+    test_expression(
+        "Microsoft.Quantum.Arrays.Padded(3, 2, [10, 11, 12])",
+        &Value::Array(
+            vec![
+                Value::Int(10),
+                Value::Int(11),
+                Value::Int(12),
+            ]
+            .into(),
+        ),
+    );
+    test_expression(
+        "Microsoft.Quantum.Arrays.Padded(-3, 2, [10, 11, 12])",
+        &Value::Array(
+            vec![
+                Value::Int(10),
+                Value::Int(11),
+                Value::Int(12),
+            ]
+            .into(),
+        ),
+    );
 }
 
 #[test]

--- a/library/tests/src/test_arrays.rs
+++ b/library/tests/src/test_arrays.rs
@@ -585,25 +585,11 @@ fn check_padded() {
     );
     test_expression(
         "Microsoft.Quantum.Arrays.Padded(3, 2, [10, 11, 12])",
-        &Value::Array(
-            vec![
-                Value::Int(10),
-                Value::Int(11),
-                Value::Int(12),
-            ]
-            .into(),
-        ),
+        &Value::Array(vec![Value::Int(10), Value::Int(11), Value::Int(12)].into()),
     );
     test_expression(
         "Microsoft.Quantum.Arrays.Padded(-3, 2, [10, 11, 12])",
-        &Value::Array(
-            vec![
-                Value::Int(10),
-                Value::Int(11),
-                Value::Int(12),
-            ]
-            .into(),
-        ),
+        &Value::Array(vec![Value::Int(10), Value::Int(11), Value::Int(12)].into()),
     );
 }
 


### PR DESCRIPTION
Padded function now allows user to ask for the length that is the same as current array length. This matches functionality of the QDK version.