### PR TITLE
Include core package in incremental compilation

### DIFF
--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -40,6 +40,13 @@ mod given_interpreter {
         }
 
         #[test]
+        fn core_members_should_be_available() {
+            let mut interpreter = get_interpreter();
+            let (result, output) = line(&mut interpreter, "Length([1, 2, 3])");
+            is_only_value(&result, &output, &Value::Int(3));
+        }
+
+        #[test]
         fn let_bindings_update_interpreter() {
             let mut interpreter = get_interpreter();
             line(&mut interpreter, "let y = 7;")

--- a/compiler/qsc_frontend/src/incremental.rs
+++ b/compiler/qsc_frontend/src/incremental.rs
@@ -51,6 +51,11 @@ impl Compiler {
     pub fn new(store: &PackageStore, dependencies: impl IntoIterator<Item = PackageId>) -> Self {
         let mut resolve_globals = resolve::GlobalTable::new();
         let mut typeck_globals = typeck::GlobalTable::new();
+        if let Some(unit) = store.get(PackageId::CORE) {
+            resolve_globals.add_external_package(PackageId::CORE, &unit.package);
+            typeck_globals.add_external_package(PackageId::CORE, &unit.package);
+        }
+
         for id in dependencies {
             let unit = store
                 .get(id)


### PR DESCRIPTION
This fixes an oversight where the incremental compiler did not include the core library in the set of globals, meaning callables like `Length` were not available. Also adds a test to confirm availability of those callables.