### PR TITLE
Add incremental context for type inference

### DIFF
--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -238,6 +238,30 @@ mod given_interpreter {
             let (result, output) = line(&mut interpreter, "DumpMachine()");
             is_unit_with_output(&result, &output, "STATE:\n|0101⟩: 1+0i");
         }
+
+        #[test]
+        fn ambiguous_type_allowed_only_in_top_level_stmts() {
+            let mut interpreter = get_interpreter();
+            let (result, output) = line(&mut interpreter, "let x = [];");
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "function Foo() : Unit { let x = []; }");
+            is_only_error(
+                &result,
+                &output,
+                "type error: insufficient type information to infer type",
+            );
+        }
+
+        #[test]
+        fn resolved_type_persists_across_stmts() {
+            let mut interpreter = get_interpreter();
+            let (result, output) = line(&mut interpreter, "let x = [];");
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "let y = [0] + x;");
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "let z = [0.0] + x;");
+            is_only_error(&result, &output, "type error: expected Double, found Int");
+        }
     }
 
     #[cfg(test)]

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -266,6 +266,15 @@ mod given_interpreter {
             let (result, output) = line(&mut interpreter, "let z = [0.0] + x;");
             is_only_error(&result, &output, "type error: expected Double, found Int");
         }
+
+        #[test]
+        fn incremental_lambas_work() {
+            let mut interpreter = get_interpreter();
+            let (result, output) = line(&mut interpreter, "let x = 1; let f = (y) -> x + y;");
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "f(1)");
+            is_only_value(&result, &output, &Value::Int(2));
+        }
     }
 
     #[cfg(test)]

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -240,9 +240,15 @@ mod given_interpreter {
         }
 
         #[test]
-        fn ambiguous_type_allowed_only_in_top_level_stmts() {
+        fn ambiguous_type_error_in_top_level_stmts() {
             let mut interpreter = get_interpreter();
             let (result, output) = line(&mut interpreter, "let x = [];");
+            is_only_error(
+                &result,
+                &output,
+                "type error: insufficient type information to infer type",
+            );
+            let (result, output) = line(&mut interpreter, "let x = []; let y = [0] + x;");
             is_only_value(&result, &output, &Value::unit());
             let (result, output) = line(&mut interpreter, "function Foo() : Unit { let x = []; }");
             is_only_error(
@@ -255,9 +261,7 @@ mod given_interpreter {
         #[test]
         fn resolved_type_persists_across_stmts() {
             let mut interpreter = get_interpreter();
-            let (result, output) = line(&mut interpreter, "let x = [];");
-            is_only_value(&result, &output, &Value::unit());
-            let (result, output) = line(&mut interpreter, "let y = [0] + x;");
+            let (result, output) = line(&mut interpreter, "let x = []; let y = [0] + x;");
             is_only_value(&result, &output, &Value::unit());
             let (result, output) = line(&mut interpreter, "let z = [0.0] + x;");
             is_only_error(&result, &output, "type error: expected Double, found Int");

--- a/compiler/qsc_data_structures/src/index_map.rs
+++ b/compiler/qsc_data_structures/src/index_map.rs
@@ -39,6 +39,13 @@ impl<K, V> IndexMap<K, V> {
         }
     }
 
+    pub fn drain(&mut self) -> Drain<K, V> {
+        Drain {
+            _keys: PhantomData,
+            base: self.values.drain(..).enumerate(),
+        }
+    }
+
     #[must_use]
     pub fn values(&self) -> Values<V> {
         Values {
@@ -180,6 +187,23 @@ pub struct IntoIter<K, V> {
 }
 
 impl<K: From<usize>, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let (index, Some(value)) = self.base.next()? {
+                break Some((index.into(), value));
+            }
+        }
+    }
+}
+
+pub struct Drain<'a, K, V> {
+    _keys: PhantomData<K>,
+    base: Enumerate<vec::Drain<'a, Option<V>>>,
+}
+
+impl<K: From<usize>, V> Iterator for Drain<'_, K, V> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/compiler/qsc_frontend/src/incremental.rs
+++ b/compiler/qsc_frontend/src/incremental.rs
@@ -98,7 +98,7 @@ impl Compiler {
 
         let fragments = fragments
             .into_iter()
-            .flat_map(|f| self.compile_fragment(f))
+            .flat_map(|f| self.lower_fragment(f))
             .collect();
 
         let errors = self.drain_errors();
@@ -110,7 +110,7 @@ impl Compiler {
         }
     }
 
-    fn compile_fragment(&mut self, fragment: qsc_parse::Fragment) -> Vec<Fragment> {
+    fn lower_fragment(&mut self, fragment: qsc_parse::Fragment) -> Vec<Fragment> {
         let fragment = match fragment {
             qsc_parse::Fragment::Namespace(namespace) => {
                 self.lower_namespace(&namespace);

--- a/compiler/qsc_frontend/src/typeck/check.rs
+++ b/compiler/qsc_frontend/src/typeck/check.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use super::{
-    infer::{Inferrer, Solution},
+    infer::Inferrer,
     rules::{self, Context, SpecImpl},
     Error, ErrorKind, Table,
 };
@@ -59,7 +59,6 @@ pub(crate) struct Checker {
     globals: HashMap<ItemId, Scheme>,
     table: Table,
     inferrer: Inferrer,
-    solution: Solution,
     errors: Vec<Error>,
 }
 
@@ -73,7 +72,6 @@ impl Checker {
                 generics: IndexMap::new(),
             },
             inferrer: Inferrer::new(),
-            solution: Solution::default(),
             errors: globals.errors,
         }
     }
@@ -180,8 +178,7 @@ impl Checker {
 
     pub(crate) fn solve(&mut self, names: &Names) {
         let mut context = Context::new(names, &self.globals, &mut self.table, &mut self.inferrer);
-        self.errors
-            .append(&mut context.solve_fragment(&mut self.solution));
+        self.errors.append(&mut context.solve());
     }
 }
 

--- a/compiler/qsc_frontend/src/typeck/check.rs
+++ b/compiler/qsc_frontend/src/typeck/check.rs
@@ -3,7 +3,7 @@
 
 use super::{
     infer::{Inferrer, Solution},
-    rules::{self, SpecImpl},
+    rules::{self, Context, SpecImpl},
     Error, ErrorKind, Table,
 };
 use crate::{
@@ -169,14 +169,19 @@ impl Checker {
         ItemCollector::new(self, names).visit_stmt(stmt);
         ItemChecker::new(self, names).visit_stmt(stmt);
 
-        self.errors.append(&mut rules::stmt_fragment(
+        rules::stmt_fragment(
             names,
             &self.globals,
             &mut self.table,
             &mut self.inferrer,
-            &mut self.solution,
             stmt,
-        ));
+        );
+    }
+
+    pub(crate) fn solve(&mut self, names: &Names) {
+        let mut context = Context::new(names, &self.globals, &mut self.table, &mut self.inferrer);
+        self.errors
+            .append(&mut context.solve_fragment(&mut self.solution));
     }
 }
 

--- a/compiler/qsc_frontend/src/typeck/check.rs
+++ b/compiler/qsc_frontend/src/typeck/check.rs
@@ -3,7 +3,7 @@
 
 use super::{
     infer::Inferrer,
-    rules::{self, Context, SpecImpl},
+    rules::{self, SpecImpl},
     Error, ErrorKind, Table,
 };
 use crate::{
@@ -177,8 +177,12 @@ impl Checker {
     }
 
     pub(crate) fn solve(&mut self, names: &Names) {
-        let mut context = Context::new(names, &self.globals, &mut self.table, &mut self.inferrer);
-        self.errors.append(&mut context.solve());
+        self.errors.append(&mut rules::solve(
+            names,
+            &self.globals,
+            &mut self.table,
+            &mut self.inferrer,
+        ));
     }
 }
 

--- a/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/compiler/qsc_frontend/src/typeck/infer.rs
@@ -397,9 +397,10 @@ impl Inferrer {
             }
         }
         let unresolved_ty_errs = self.find_unresolved_types();
+        self.solver.default_functors(self.next_functor);
         self.solver
-            .drain_errors(self.next_functor)
-            .into_iter()
+            .errors
+            .drain(..)
             .chain(unresolved_ty_errs.into_iter())
             .collect()
     }
@@ -637,11 +638,6 @@ impl Solver {
 
             functor = functor.successor();
         }
-    }
-
-    fn drain_errors(&mut self, functor_end: InferFunctorId) -> Vec<Error> {
-        self.default_functors(functor_end);
-        self.errors.drain(..).collect()
     }
 }
 

--- a/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/compiler/qsc_frontend/src/typeck/infer.rs
@@ -392,7 +392,7 @@ impl Inferrer {
         &mut self,
         udts: &HashMap<ItemId, Udt>,
         solution: &mut Solution,
-    ) -> (Vec<Error>, Vec<Error>) {
+    ) -> Vec<Error> {
         let mut solver = Solver::new(udts, self.next_functor, solution);
         while let Some(constraint) = self.constraints.pop_front() {
             for constraint in solver.constrain(constraint).into_iter().rev() {
@@ -400,8 +400,11 @@ impl Inferrer {
             }
         }
         let unresolved_ty_errs = self.find_unresolved_types(&mut solver);
-        let errs = solver.into_errors();
-        (errs, unresolved_ty_errs)
+        solver
+            .into_errors()
+            .into_iter()
+            .chain(unresolved_ty_errs.into_iter())
+            .collect()
     }
 
     fn find_unresolved_types(&mut self, solver: &mut Solver) -> Vec<Error> {

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -50,6 +50,7 @@ impl<'a> Context<'a> {
         globals: &'a HashMap<ItemId, Scheme>,
         table: &'a mut Table,
         inferrer: &'a mut Inferrer,
+        new: Vec<NodeId>,
     ) -> Self {
         Self {
             names,
@@ -57,7 +58,7 @@ impl<'a> Context<'a> {
             table,
             return_ty: None,
             typed_holes: Vec::new(),
-            new: Vec::new(),
+            new,
             inferrer,
         }
     }
@@ -754,7 +755,7 @@ pub(super) fn spec(
     spec: SpecImpl,
 ) -> Vec<Error> {
     let mut inferrer = Inferrer::new();
-    let mut context = Context::new(names, globals, table, &mut inferrer);
+    let mut context = Context::new(names, globals, table, &mut inferrer, Vec::new());
     context.infer_spec(spec);
     context.solve()
 }
@@ -766,7 +767,7 @@ pub(super) fn expr(
     expr: &Expr,
 ) -> Vec<Error> {
     let mut inferrer = Inferrer::new();
-    let mut context = Context::new(names, globals, table, &mut inferrer);
+    let mut context = Context::new(names, globals, table, &mut inferrer, Vec::new());
     context.infer_expr(expr);
     context.solve()
 }
@@ -777,9 +778,10 @@ pub(super) fn stmt_fragment(
     table: &mut Table,
     inferrer: &mut Inferrer,
     stmt: &Stmt,
-) {
-    let mut context = Context::new(names, globals, table, inferrer);
+) -> Vec<NodeId> {
+    let mut context = Context::new(names, globals, table, inferrer, Vec::new());
     context.infer_stmt(stmt);
+    context.new
 }
 
 pub(super) fn solve(
@@ -787,8 +789,9 @@ pub(super) fn solve(
     globals: &HashMap<ItemId, Scheme>,
     table: &mut Table,
     inferrer: &mut Inferrer,
+    new_nodes: Vec<NodeId>,
 ) -> Vec<Error> {
-    let context = Context::new(names, globals, table, inferrer);
+    let context = Context::new(names, globals, table, inferrer, new_nodes);
     context.solve()
 }
 

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -711,7 +711,6 @@ impl<'a> Context<'a> {
     }
 
     fn solve(&mut self) -> Vec<Error> {
-        // For normal type inference, return the combined list of errors and ambiguous type errors.
         self.solve_fragment(&mut Solution::default())
     }
 
@@ -783,9 +782,6 @@ pub(super) fn stmt_fragment(
     inferrer: &mut Inferrer,
     stmt: &Stmt,
 ) {
-    // Because a fragment is a top-level statement in the interpreter, it has slightly different rules
-    // for how it is solved. In particular, it is allowed to have ambiguous types, since those can
-    // and should be resolved in later statements once the type has enough information to be inferred.
     let mut context = Context::new(names, globals, table, inferrer);
     context.infer_stmt(stmt);
 }

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -811,6 +811,9 @@ pub(super) fn stmt_fragment(
     solution: &mut Solution,
     stmt: &Stmt,
 ) -> Vec<Error> {
+    // Because a fragment is a top-level statement in the interpreter, it has slightly different rules
+    // for how it is solved. In particular, it is allowed to have ambiguous types, since those can
+    // and should be resolved in later statements once the type has enough information to be inferred.
     let mut context = Context::new(names, globals, table, inferrer);
     context.infer_stmt(stmt);
     context.solve_fragment(solution)

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2709,9 +2709,9 @@ fn typed_hole_error_ambiguous_type() {
             #2 0-1 "_" : ?0
             #3 1-4 "(3)" : Int
             #4 2-3 "3" : Int
-            Error(Type(Error(TyHole(Infer(InferTyId(0)), Span { lo: 0, hi: 1 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 1 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 4 }))))
+            Error(Type(Error(TyHole(Infer(InferTyId(0)), Span { lo: 0, hi: 1 }))))
         "##]],
     );
 }

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2709,9 +2709,9 @@ fn typed_hole_error_ambiguous_type() {
             #2 0-1 "_" : ?0
             #3 1-4 "(3)" : Int
             #4 2-3 "3" : Int
+            Error(Type(Error(TyHole(Infer(InferTyId(0)), Span { lo: 0, hi: 1 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 1 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 4 }))))
-            Error(Type(Error(TyHole(Infer(InferTyId(0)), Span { lo: 0, hi: 1 }))))
         "##]],
     );
 }

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -165,7 +165,7 @@ pub fn run_default_passes_for_fragment(
             LoopUni { core, assigner }.visit_callable_decl(decl);
             ReplaceQubitAllocation::new(core, assigner).visit_callable_decl(decl);
         }
-        Fragment::Item(_) | Fragment::Error(_) => {}
+        Fragment::Item(_) => {}
     }
 
     errors


### PR DESCRIPTION
This change adds the option for an persistent `Inferrer` and `Solution` struct used during type inference, allowing incremental compilation to remember types that are solved for in separate statements.

This fixes #205.