### PR TITLE
Add pass context for incremental compilation

### DIFF
--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -23,7 +23,7 @@ use qsc_frontend::{
     incremental::{self, Compiler, Fragment},
 };
 use qsc_hir::hir::{CallableDecl, ItemKind, LocalItemId, PackageId, Stmt};
-use qsc_passes::{run_default_passes_for_fragment, PackageType};
+use qsc_passes::{PackageType, PassContext};
 use std::{collections::HashSet, sync::Arc};
 use thiserror::Error;
 
@@ -81,6 +81,7 @@ pub struct Interpreter {
     compiler: Compiler,
     udts: HashSet<LocalItemId>,
     callables: IndexMap<LocalItemId, CallableDecl>,
+    passes: PassContext,
     env: Env,
     sim: SparseSim,
 }
@@ -113,6 +114,7 @@ impl Interpreter {
             compiler,
             udts: HashSet::new(),
             callables: IndexMap::new(),
+            passes: PassContext::default(),
             env: Env::with_empty_scope(),
             sim: SparseSim::new(),
         })
@@ -140,7 +142,7 @@ impl Interpreter {
         let pass_errors = fragments
             .iter_mut()
             .flat_map(|fragment| {
-                run_default_passes_for_fragment(
+                self.passes.run_default_passes_for_fragment(
                     self.store.core(),
                     self.compiler.assigner_mut(),
                     fragment,

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -142,11 +142,8 @@ impl Interpreter {
         let pass_errors = fragments
             .iter_mut()
             .flat_map(|fragment| {
-                self.passes.run_default_passes_for_fragment(
-                    self.store.core(),
-                    self.compiler.assigner_mut(),
-                    fragment,
-                )
+                self.passes
+                    .run(self.store.core(), self.compiler.assigner_mut(), fragment)
             })
             .collect::<Vec<_>>();
         if !pass_errors.is_empty() {

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -275,6 +275,28 @@ mod given_interpreter {
             let (result, output) = line(&mut interpreter, "f(1)");
             is_only_value(&result, &output, &Value::Int(2));
         }
+
+        #[test]
+        fn mutability_persists_across_stmts() {
+            let mut interpreter = get_interpreter();
+            let (result, output) = line(
+                &mut interpreter,
+                "mutable x : Int[] = []; let y : Int[] = [];",
+            );
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "set x += [0];");
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "set y += [0];");
+            is_only_error(&result, &output, "cannot update immutable variable");
+            let (result, output) = line(&mut interpreter, "let lam = () -> y + [0];");
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "let lam = () -> x + [0];");
+            is_only_error(
+                &result,
+                &output,
+                "lambdas cannot close over mutable variables",
+            );
+        }
     }
 
     #[cfg(test)]

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -48,6 +48,11 @@ pub enum PackageType {
     Lib,
 }
 
+#[derive(Default)]
+pub struct PassContext {
+    borrow_check: borrowck::Checker,
+}
+
 /// Run the default set of passes required for evaluation.
 pub fn run_default_passes(
     core: &Table,
@@ -115,58 +120,56 @@ pub fn run_core_passes(core: &mut CompileUnit) -> Vec<Error> {
     borrow_errors.into_iter().map(Error::BorrowCk).collect()
 }
 
-pub fn run_default_passes_for_fragment(
-    core: &Table,
-    assigner: &mut Assigner,
-    fragment: &mut Fragment,
-) -> Vec<Error> {
-    let mut errors = Vec::new();
+impl PassContext {
+    pub fn run_default_passes_for_fragment(
+        &mut self,
+        core: &Table,
+        assigner: &mut Assigner,
+        fragment: &mut Fragment,
+    ) -> Vec<Error> {
+        let mut errors = Vec::new();
 
-    match fragment {
-        Fragment::Stmt(stmt) => {
-            // TODO: This creates a branch new borrow checker for every statement, when it really
-            // should have a context that tracks mutability across all statements that are part of
-            // incremental compilation. This is realted thematically to https://github.com/microsoft/qsharp/issues/205,
-            // which has been updated to note the connection.
-            let mut borrow_check = borrowck::Checker::default();
-            borrow_check.visit_stmt(stmt);
-            errors.extend(borrow_check.errors.into_iter().map(Error::BorrowCk));
+        match fragment {
+            Fragment::Stmt(stmt) => {
+                self.borrow_check.visit_stmt(stmt);
+                errors.extend(self.borrow_check.errors.drain(..).map(Error::BorrowCk));
 
-            errors.extend(
-                conjugate_invert::invert_conjugate_exprs_for_stmt(core, assigner, stmt)
-                    .into_iter()
-                    .map(Error::ConjInvert),
-            );
-            LoopUni { core, assigner }.visit_stmt(stmt);
-            ReplaceQubitAllocation::new(core, assigner).visit_stmt(stmt);
+                errors.extend(
+                    conjugate_invert::invert_conjugate_exprs_for_stmt(core, assigner, stmt)
+                        .into_iter()
+                        .map(Error::ConjInvert),
+                );
+                LoopUni { core, assigner }.visit_stmt(stmt);
+                ReplaceQubitAllocation::new(core, assigner).visit_stmt(stmt);
+            }
+            Fragment::Item(Item {
+                kind: ItemKind::Callable(decl),
+                ..
+            }) => {
+                let mut call_limits = CallableLimits::default();
+                call_limits.visit_callable_decl(decl);
+                errors.extend(call_limits.errors.into_iter().map(Error::CallableLimits));
+
+                let mut borrow_check = borrowck::Checker::default();
+                borrow_check.visit_callable_decl(decl);
+                errors.extend(borrow_check.errors.into_iter().map(Error::BorrowCk));
+
+                errors.extend(
+                    spec_gen::generate_specs_for_callable(core, assigner, decl)
+                        .into_iter()
+                        .map(Error::SpecGen),
+                );
+                errors.extend(
+                    conjugate_invert::invert_conjugate_exprs_for_callable(core, assigner, decl)
+                        .into_iter()
+                        .map(Error::ConjInvert),
+                );
+                LoopUni { core, assigner }.visit_callable_decl(decl);
+                ReplaceQubitAllocation::new(core, assigner).visit_callable_decl(decl);
+            }
+            Fragment::Item(_) => {}
         }
-        Fragment::Item(Item {
-            kind: ItemKind::Callable(decl),
-            ..
-        }) => {
-            let mut call_limits = CallableLimits::default();
-            call_limits.visit_callable_decl(decl);
-            errors.extend(call_limits.errors.into_iter().map(Error::CallableLimits));
 
-            let mut borrow_check = borrowck::Checker::default();
-            borrow_check.visit_callable_decl(decl);
-            errors.extend(borrow_check.errors.into_iter().map(Error::BorrowCk));
-
-            errors.extend(
-                spec_gen::generate_specs_for_callable(core, assigner, decl)
-                    .into_iter()
-                    .map(Error::SpecGen),
-            );
-            errors.extend(
-                conjugate_invert::invert_conjugate_exprs_for_callable(core, assigner, decl)
-                    .into_iter()
-                    .map(Error::ConjInvert),
-            );
-            LoopUni { core, assigner }.visit_callable_decl(decl);
-            ReplaceQubitAllocation::new(core, assigner).visit_callable_decl(decl);
-        }
-        Fragment::Item(_) => {}
+        errors
     }
-
-    errors
 }

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -121,7 +121,7 @@ pub fn run_core_passes(core: &mut CompileUnit) -> Vec<Error> {
 }
 
 impl PassContext {
-    pub fn run_default_passes_for_fragment(
+    pub fn run(
         &mut self,
         core: &Table,
         assigner: &mut Assigner,


### PR DESCRIPTION
This adds a context for passes that can be persisted in incremental compilation. For now, the only pass with context that must persist is the borrow checker that verifies mutability rules are followed. Future passes can include context in the struct when/if needed.

Fixes #398