### PR TITLE
Namespace Info on Hover over Callables

### DIFF
--- a/language_service/src/display.rs
+++ b/language_service/src/display.rs
@@ -493,7 +493,7 @@ impl<'a> Display for HirTy<'a> {
             }
             hir::ty::Ty::Udt(res) => match res {
                 hir::Res::Item(item_id) => {
-                    if let Some((item, _)) = find_item(self.compilation, item_id) {
+                    if let (Some(item), _) = find_item(self.compilation, item_id) {
                         match &item.kind {
                             hir::ItemKind::Ty(ident, _) => write!(f, "{}", ident.name),
                             _ => panic!("UDT has invalid resolution."),

--- a/language_service/src/display.rs
+++ b/language_service/src/display.rs
@@ -493,7 +493,7 @@ impl<'a> Display for HirTy<'a> {
             }
             hir::ty::Ty::Udt(res) => match res {
                 hir::Res::Item(item_id) => {
-                    if let Some(item) = find_item(self.compilation, item_id) {
+                    if let Some((item, _)) = find_item(self.compilation, item_id) {
                         match &item.kind {
                             hir::ItemKind::Ty(ident, _) => write!(f, "{}", ident.name),
                             _ => panic!("UDT has invalid resolution."),

--- a/language_service/src/hover.rs
+++ b/language_service/src/hover.rs
@@ -228,7 +228,7 @@ fn markdown_with_doc(doc: &str, namespace: Option<Rc<str>>, code: impl Display) 
     if parsed_doc.summary.is_empty() {
         code
     } else {
-        format!("{}---\n{}", code, parsed_doc.summary,)
+        format!("{}---\n{}\n", code, parsed_doc.summary,)
     }
 }
 

--- a/language_service/src/hover.rs
+++ b/language_service/src/hover.rs
@@ -170,7 +170,17 @@ impl Visitor<'_> for HoverVisitor<'_> {
             if let Some(res) = res {
                 match &res {
                     resolve::Res::Item(item_id) => {
-                        if let Some((item, ns)) = find_item(self.compilation, item_id) {
+                        if let (Some(item), Some(package)) = find_item(self.compilation, item_id) {
+                            let ns = item
+                                .parent
+                                .and_then(|parent_id| package.items.get(parent_id))
+                                .and_then(|parent| match &parent.kind {
+                                    qsc::hir::ItemKind::Namespace(namespace, _) => {
+                                        Some(namespace.name.clone())
+                                    }
+                                    _ => None,
+                                });
+
                             self.contents = match &item.kind {
                                 hir::ItemKind::Callable(decl) => Some(markdown_with_doc(
                                     &item.doc,

--- a/language_service/src/hover.rs
+++ b/language_service/src/hover.rs
@@ -228,11 +228,7 @@ fn markdown_with_doc(doc: &str, namespace: Option<Rc<str>>, code: impl Display) 
     if parsed_doc.summary.is_empty() {
         code
     } else {
-        format!(
-            "{}{}
-",
-            code, parsed_doc.summary,
-        )
+        format!("{}---\n{}", code, parsed_doc.summary,)
     }
 }
 

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -50,6 +50,7 @@ fn hover_callable_unit_types() {
             Test
             operation Bar() : Unit
             ```
+            ---
             Doc comment
             with multiple lines!
         "#]],
@@ -70,6 +71,7 @@ fn hover_callable_with_callable_types() {
             Test
             operation Foo(x: (Int => Int)) : (Int => Int)
             ```
+            ---
             Doc comment!
         "#]],
     );
@@ -108,6 +110,7 @@ fn hover_callable_unit_types_functors() {
             Test
             operation Foo() : Unit is Ctl
             ```
+            ---
             Doc comment!
         "#]],
     );
@@ -127,6 +130,7 @@ fn hover_callable_with_callable_types_functors() {
             Test
             operation Foo(x: (Int => Int is Adj + Ctl)) : (Int => Int is Adj) is Adj
             ```
+            ---
             Doc comment!
         "#]],
     );
@@ -623,6 +627,7 @@ fn hover_callable_summary() {
             Test
             operation Foo() : Unit
             ```
+            ---
             This is a
             multi-line summary!
         "#]],
@@ -646,6 +651,7 @@ fn hover_callable_summary_stuff_before() {
             Test
             operation Foo() : Unit
             ```
+            ---
             This is a
             multi-line summary!
         "#]],
@@ -670,6 +676,7 @@ fn hover_callable_summary_other_header_before() {
             Test
             operation Foo() : Unit
             ```
+            ---
             This is a
             multi-line summary!
         "#]],
@@ -694,6 +701,7 @@ fn hover_callable_summary_other_header_after() {
             Test
             operation Foo() : Unit
             ```
+            ---
             This is a
             multi-line summary!
         "#]],
@@ -720,6 +728,7 @@ fn hover_callable_summary_other_headers() {
             Test
             operation Foo() : Unit
             ```
+            ---
             This is a
             multi-line summary!
         "#]],
@@ -743,6 +752,7 @@ fn hover_callable_headers_but_no_summary() {
             Test
             operation Foo() : Unit
             ```
+            ---
             # Not The Summary
             This stuff is not the summary.
             # Also Not The Summary
@@ -771,6 +781,7 @@ fn hover_callable_summary_only_header_matches() {
             Test
             operation Foo() : Unit
             ```
+            ---
             This is a
             multi-line # Summary!
         "#]],
@@ -794,6 +805,7 @@ fn hover_callable_summary_successive_headers() {
             Test
             operation Foo() : Unit
             ```
+            ---
             This is a
             multi-line summary!
         "#]],

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -24,7 +24,7 @@ fn check(source_with_markers: &str, expect: &Expect) {
             end: target_offsets[1],
         }
     );
-    expect.assert_debug_eq(&actual.contents);
+    expect.assert_eq(&actual.contents);
 }
 
 /// Asserts that there is no hover for the given test case.
@@ -46,7 +46,12 @@ fn hover_callable_unit_types() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Bar() : Unit\n```\nDoc comment\nwith multiple lines!\n"
+            ```qsharp
+            Test
+            operation Bar() : Unit
+            ```
+            Doc comment
+            with multiple lines!
         "#]],
     );
 }
@@ -61,7 +66,11 @@ fn hover_callable_with_callable_types() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo(x: (Int => Int)) : (Int => Int)\n```\nDoc comment!\n"
+            ```qsharp
+            Test
+            operation Foo(x: (Int => Int)) : (Int => Int)
+            ```
+            Doc comment!
         "#]],
     );
 }
@@ -77,7 +86,10 @@ fn hover_call() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Bar() : Unit\n```\n"
+            ```qsharp
+            Test
+            operation Bar() : Unit
+            ```
         "#]],
     );
 }
@@ -92,7 +104,11 @@ fn hover_callable_unit_types_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit is Ctl\n```\nDoc comment!\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit is Ctl
+            ```
+            Doc comment!
         "#]],
     );
 }
@@ -107,7 +123,11 @@ fn hover_callable_with_callable_types_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo(x: (Int => Int is Adj + Ctl)) : (Int => Int is Adj) is Adj\n```\nDoc comment!\n"
+            ```qsharp
+            Test
+            operation Foo(x: (Int => Int is Adj + Ctl)) : (Int => Int is Adj) is Adj
+            ```
+            Doc comment!
         "#]],
     );
 }
@@ -123,7 +143,10 @@ fn hover_call_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Bar() : Unit is Adj\n```\n"
+            ```qsharp
+            Test
+            operation Bar() : Unit is Adj
+            ```
         "#]],
     );
 }
@@ -139,7 +162,9 @@ fn hover_identifier() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nx: Int\n```\n"
+            ```qsharp
+            x: Int
+            ```
         "#]],
     );
 }
@@ -156,7 +181,9 @@ fn hover_identifier_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nx: Int\n```\n"
+            ```qsharp
+            x: Int
+            ```
         "#]],
     );
 }
@@ -172,7 +199,9 @@ fn hover_identifier_tuple() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\ny: Double\n```\n"
+            ```qsharp
+            y: Double
+            ```
         "#]],
     );
 }
@@ -189,7 +218,9 @@ fn hover_identifier_tuple_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\ny: Double\n```\n"
+            ```qsharp
+            y: Double
+            ```
         "#]],
     );
 }
@@ -207,7 +238,9 @@ fn hover_identifier_for_loop() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\ni: Int\n```\n"
+            ```qsharp
+            i: Int
+            ```
         "#]],
     );
 }
@@ -225,7 +258,9 @@ fn hover_identifier_for_loop_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\ni: Int\n```\n"
+            ```qsharp
+            i: Int
+            ```
         "#]],
     );
 }
@@ -244,7 +279,9 @@ fn hover_identifier_nested_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nx: Int\n```\n"
+            ```qsharp
+            x: Int
+            ```
         "#]],
     );
 }
@@ -262,7 +299,9 @@ fn hover_lambda() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nlambda: ((Double, String) => Int)\n```\n"
+            ```qsharp
+            lambda: ((Double, String) => Int)
+            ```
         "#]],
     );
 }
@@ -280,7 +319,9 @@ fn hover_lambda_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nlambda: ((Double, String) => Int)\n```\n"
+            ```qsharp
+            lambda: ((Double, String) => Int)
+            ```
         "#]],
     );
 }
@@ -298,7 +339,9 @@ fn hover_lambda_param() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\ny: String\n```\n"
+            ```qsharp
+            y: String
+            ```
         "#]],
     );
 }
@@ -315,7 +358,9 @@ fn hover_lambda_param_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\ny: String\n```\n"
+            ```qsharp
+            y: String
+            ```
         "#]],
     );
 }
@@ -333,7 +378,9 @@ fn hover_lambda_closure_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\na: Int\n```\n"
+            ```qsharp
+            a: Int
+            ```
         "#]],
     );
 }
@@ -351,7 +398,9 @@ fn hover_identifier_udt() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\na: Pair\n```\n"
+            ```qsharp
+            a: Pair
+            ```
         "#]],
     );
 }
@@ -365,7 +414,9 @@ fn hover_udt() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nnewtype Pair = (Int, snd: Int)\n```\n"
+            ```qsharp
+            newtype Pair = (Int, snd: Int)
+            ```
         "#]],
     );
 }
@@ -382,7 +433,9 @@ fn hover_udt_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nnewtype Bar = (fst: Int, (snd: Int, Double, fourth: String), Double, sixth: Int)\n```\n"
+            ```qsharp
+            newtype Bar = (fst: Int, (snd: Int, Double, fourth: String), Double, sixth: Int)
+            ```
         "#]],
     );
 }
@@ -400,7 +453,9 @@ fn hover_udt_ref_nested_udt() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nnewtype Bar = (fst: Int, (snd: Int, Double, fourth: Pair), Double, sixth: Int)\n```\n"
+            ```qsharp
+            newtype Bar = (fst: Int, (snd: Int, Double, fourth: Pair), Double, sixth: Int)
+            ```
         "#]],
     );
 }
@@ -417,7 +472,9 @@ fn hover_udt_anno_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nnewtype Pair = (Int, snd: Int)\n```\n"
+            ```qsharp
+            newtype Pair = (Int, snd: Int)
+            ```
         "#]],
     );
 }
@@ -434,7 +491,9 @@ fn hover_udt_constructor() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nnewtype Pair = (Int, snd: Int)\n```\n"
+            ```qsharp
+            newtype Pair = (Int, snd: Int)
+            ```
         "#]],
     );
 }
@@ -448,7 +507,9 @@ fn hover_udt_field() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nsnd: Int\n```\n"
+            ```qsharp
+            snd: Int
+            ```
         "#]],
     );
 }
@@ -466,7 +527,9 @@ fn hover_udt_field_ref() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nsnd: Int\n```\n"
+            ```qsharp
+            snd: Int
+            ```
         "#]],
     );
 }
@@ -496,7 +559,10 @@ fn hover_foreign_call() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nFakeStdLib\noperation Fake() : Unit\n```\n"
+            ```qsharp
+            FakeStdLib
+            operation Fake() : Unit
+            ```
         "#]],
     );
 }
@@ -513,7 +579,10 @@ fn hover_foreign_call_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nFakeStdLib\noperation FakeCtlAdj() : Unit is Adj + Ctl\n```\n"
+            ```qsharp
+            FakeStdLib
+            operation FakeCtlAdj() : Unit is Adj + Ctl
+            ```
         "#]],
     );
 }
@@ -530,7 +599,10 @@ fn hover_foreign_call_with_param() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nFakeStdLib\noperation FakeWithParam(x: Int) : Unit\n```\n"
+            ```qsharp
+            FakeStdLib
+            operation FakeWithParam(x: Int) : Unit
+            ```
         "#]],
     );
 }
@@ -547,7 +619,12 @@ fn hover_callable_summary() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit
+            ```
+            This is a
+            multi-line summary!
         "#]],
     );
 }
@@ -565,7 +642,12 @@ fn hover_callable_summary_stuff_before() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit
+            ```
+            This is a
+            multi-line summary!
         "#]],
     );
 }
@@ -584,7 +666,12 @@ fn hover_callable_summary_other_header_before() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit
+            ```
+            This is a
+            multi-line summary!
         "#]],
     );
 }
@@ -603,7 +690,12 @@ fn hover_callable_summary_other_header_after() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit
+            ```
+            This is a
+            multi-line summary!
         "#]],
     );
 }
@@ -624,7 +716,12 @@ fn hover_callable_summary_other_headers() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit
+            ```
+            This is a
+            multi-line summary!
         "#]],
     );
 }
@@ -642,7 +739,14 @@ fn hover_callable_headers_but_no_summary() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit\n```\n# Not The Summary\nThis stuff is not the summary.\n# Also Not The Summary\nThis stuff is also not the summary.\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit
+            ```
+            # Not The Summary
+            This stuff is not the summary.
+            # Also Not The Summary
+            This stuff is also not the summary.
         "#]],
     );
 }
@@ -663,7 +767,12 @@ fn hover_callable_summary_only_header_matches() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line # Summary!\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit
+            ```
+            This is a
+            multi-line # Summary!
         "#]],
     );
 }
@@ -681,7 +790,12 @@ fn hover_callable_summary_successive_headers() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit
+            ```
+            This is a
+            multi-line summary!
         "#]],
     );
 }
@@ -698,7 +812,10 @@ fn hover_callable_empty_summary() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\nTest\noperation Foo() : Unit\n```\n"
+            ```qsharp
+            Test
+            operation Foo() : Unit
+            ```
         "#]],
     );
 }

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -46,7 +46,7 @@ fn hover_callable_unit_types() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Bar() : Unit\n```\nDoc comment\nwith multiple lines!\n"
+            "```qsharp\nTest\noperation Bar() : Unit\n```\nDoc comment\nwith multiple lines!\n"
         "#]],
     );
 }
@@ -61,7 +61,7 @@ fn hover_callable_with_callable_types() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo(x: (Int => Int)) : (Int => Int)\n```\nDoc comment!\n"
+            "```qsharp\nTest\noperation Foo(x: (Int => Int)) : (Int => Int)\n```\nDoc comment!\n"
         "#]],
     );
 }
@@ -77,7 +77,7 @@ fn hover_call() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Bar() : Unit\n```\n"
+            "```qsharp\nTest\noperation Bar() : Unit\n```\n"
         "#]],
     );
 }
@@ -92,7 +92,7 @@ fn hover_callable_unit_types_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit is Ctl\n```\nDoc comment!\n"
+            "```qsharp\nTest\noperation Foo() : Unit is Ctl\n```\nDoc comment!\n"
         "#]],
     );
 }
@@ -107,7 +107,7 @@ fn hover_callable_with_callable_types_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo(x: (Int => Int is Adj + Ctl)) : (Int => Int is Adj) is Adj\n```\nDoc comment!\n"
+            "```qsharp\nTest\noperation Foo(x: (Int => Int is Adj + Ctl)) : (Int => Int is Adj) is Adj\n```\nDoc comment!\n"
         "#]],
     );
 }
@@ -123,7 +123,7 @@ fn hover_call_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Bar() : Unit is Adj\n```\n"
+            "```qsharp\nTest\noperation Bar() : Unit is Adj\n```\n"
         "#]],
     );
 }
@@ -496,7 +496,7 @@ fn hover_foreign_call() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Fake() : Unit\n```\n"
+            "```qsharp\nFakeStdLib\noperation Fake() : Unit\n```\n"
         "#]],
     );
 }
@@ -513,7 +513,7 @@ fn hover_foreign_call_functors() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation FakeCtlAdj() : Unit is Adj + Ctl\n```\n"
+            "```qsharp\nFakeStdLib\noperation FakeCtlAdj() : Unit is Adj + Ctl\n```\n"
         "#]],
     );
 }
@@ -530,7 +530,7 @@ fn hover_foreign_call_with_param() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation FakeWithParam(x: Int) : Unit\n```\n"
+            "```qsharp\nFakeStdLib\noperation FakeWithParam(x: Int) : Unit\n```\n"
         "#]],
     );
 }
@@ -547,7 +547,7 @@ fn hover_callable_summary() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -565,7 +565,7 @@ fn hover_callable_summary_stuff_before() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -584,7 +584,7 @@ fn hover_callable_summary_other_header_before() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -603,7 +603,7 @@ fn hover_callable_summary_other_header_after() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -624,7 +624,7 @@ fn hover_callable_summary_other_headers() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -642,7 +642,7 @@ fn hover_callable_headers_but_no_summary() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit\n```\n# Not The Summary\nThis stuff is not the summary.\n# Also Not The Summary\nThis stuff is also not the summary.\n"
+            "```qsharp\nTest\noperation Foo() : Unit\n```\n# Not The Summary\nThis stuff is not the summary.\n# Also Not The Summary\nThis stuff is also not the summary.\n"
         "#]],
     );
 }
@@ -663,7 +663,7 @@ fn hover_callable_summary_only_header_matches() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line # Summary!\n"
+            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line # Summary!\n"
         "#]],
     );
 }
@@ -681,7 +681,7 @@ fn hover_callable_summary_successive_headers() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
+            "```qsharp\nTest\noperation Foo() : Unit\n```\nThis is a\nmulti-line summary!\n"
         "#]],
     );
 }
@@ -698,7 +698,7 @@ fn hover_callable_empty_summary() {
         }
     "#},
         &expect![[r#"
-            "```qsharp\noperation Foo() : Unit\n```\n"
+            "```qsharp\nTest\noperation Foo() : Unit\n```\n"
         "#]],
     );
 }

--- a/language_service/src/qsc_utils.rs
+++ b/language_service/src/qsc_utils.rs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::rc::Rc;
-
 use qsc::{
     compile::{self, Error},
-    hir::{Item, ItemId, PackageId},
+    hir::{Item, ItemId, Package, PackageId},
     CompileUnit, PackageStore, PackageType, SourceMap, Span,
 };
 
@@ -50,14 +48,17 @@ pub(crate) fn map_offset(source_map: &SourceMap, source_name: &str, source_offse
         + source_offset
 }
 
-pub(crate) fn find_item<'a>(compilation: &'a Compilation, id: &ItemId) -> Option<&'a Item> {
+pub(crate) fn find_item<'a>(
+    compilation: &'a Compilation,
+    id: &ItemId,
+) -> (Option<&'a Item>, Option<&'a Package>) {
     let package = if let Some(package_id) = id.package {
         match compilation.package_store.get(package_id) {
             Some(compilation) => &compilation.package,
-            None => return None,
+            None => return (None, None),
         }
     } else {
         &compilation.unit.package
     };
-    package.items.get(id.item)
+    (package.items.get(id.item), Some(package))
 }

--- a/language_service/src/qsc_utils.rs
+++ b/language_service/src/qsc_utils.rs
@@ -50,29 +50,14 @@ pub(crate) fn map_offset(source_map: &SourceMap, source_name: &str, source_offse
         + source_offset
 }
 
-pub(crate) fn find_item<'a>(
-    compilation: &'a Compilation,
-    id: &ItemId,
-) -> Option<(&'a Item, Option<Rc<str>>)> {
+pub(crate) fn find_item<'a>(compilation: &'a Compilation, id: &ItemId) -> Option<&'a Item> {
     let package = if let Some(package_id) = id.package {
-        match &compilation.package_store.get(package_id) {
+        match compilation.package_store.get(package_id) {
             Some(compilation) => &compilation.package,
-            None => {
-                return None;
-            }
+            None => return None,
         }
     } else {
         &compilation.unit.package
     };
-    package.items.get(id.item).map(|item| {
-        (
-            item,
-            item.parent
-                .and_then(|parent_id| package.items.get(parent_id))
-                .and_then(|parent| match &parent.kind {
-                    qsc::hir::ItemKind::Namespace(namespace, _) => Some(namespace.name.clone()),
-                    _ => None,
-                }),
-        )
-    })
+    package.items.get(id.item)
 }


### PR DESCRIPTION
Adds what namespace a callable is in to the callable's hover info card.