### PR TITLE
Adding main def in package.json

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -13,6 +13,7 @@
     "Notebooks"
   ],
   "browser": "./out/extension.js",
+  "main": "./out/extension.js",
   "virtualWorkspaces": true,
   "activationEvents": [
     "onNotebook:jupyter",


### PR DESCRIPTION
Extension wasn't loading when installing locally without `"main"` entry defined.