### PR TITLE
Fix debugging on virtual file systems

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -13,7 +13,6 @@
     "Notebooks"
   ],
   "browser": "./out/extension.js",
-  "main": "./out/extension.js",
   "virtualWorkspaces": true,
   "activationEvents": [
     "onNotebook:jupyter",

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as vscode from "vscode";
-
 export const qsharpLanguageId = "qsharp";
 export const qsharpExtensionId = "qsharp-vscode";
 
 export interface FileAccessor {
-  readFile(uri: vscode.Uri): Promise<Uint8Array>;
-  readFileAsString(uri: vscode.Uri): Promise<string>;
-  writeFile(uri: vscode.Uri, contents: Uint8Array): Promise<void>;
+  readFile(uri: string): Promise<Uint8Array>;
+  readFileAsString(uri: string): Promise<string>;
+  writeFile(uri: string, contents: Uint8Array): Promise<void>;
 }

--- a/vscode/src/debugger/activate.ts
+++ b/vscode/src/debugger/activate.ts
@@ -49,7 +49,7 @@ function registerCommands(context: vscode.ExtensionContext) {
               type: "qsharp",
               name: "Run Q# File",
               request: "launch",
-              program: targetResource,
+              program: targetResource.toString(),
               shots: 1,
               stopOnEntry: false,
             },
@@ -71,7 +71,7 @@ function registerCommands(context: vscode.ExtensionContext) {
             type: "qsharp",
             name: "Debug Q# File",
             request: "launch",
-            program: targetResource,
+            program: targetResource.toString(),
             shots: 1,
             stopOnEntry: true,
           });
@@ -94,7 +94,7 @@ class QsDebugConfigProvider implements vscode.DebugConfigurationProvider {
         config.type = "qsharp";
         config.name = "Launch";
         config.request = "launch";
-        config.program = editor.document.uri;
+        config.program = editor.document.uri.toString();
         config.shots = 1;
         config.stopOnEntry = true;
         config.noDebug = "noDebug" in config ? config.noDebug : false;
@@ -115,15 +115,15 @@ class QsDebugConfigProvider implements vscode.DebugConfigurationProvider {
 }
 
 export const workspaceFileAccessor: FileAccessor = {
-  async readFile(uri: vscode.Uri): Promise<Uint8Array> {
-    return await vscode.workspace.fs.readFile(uri);
+  async readFile(uri: string): Promise<Uint8Array> {
+    return await vscode.workspace.fs.readFile(vscode.Uri.parse(uri));
   },
-  async readFileAsString(uri: vscode.Uri): Promise<string> {
+  async readFileAsString(uri: string): Promise<string> {
     const contents = await this.readFile(uri);
     return new TextDecoder().decode(contents);
   },
-  async writeFile(uri: vscode.Uri, contents: Uint8Array) {
-    await vscode.workspace.fs.writeFile(uri, contents);
+  async writeFile(uri: string, contents: Uint8Array) {
+    await vscode.workspace.fs.writeFile(vscode.Uri.parse(uri), contents);
   },
 };
 

--- a/vscode/src/debugger/types.ts
+++ b/vscode/src/debugger/types.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as vscode from "vscode";
-
 import { DebugProtocol } from "@vscode/debugprotocol";
 
 /**
@@ -14,7 +12,7 @@ import { DebugProtocol } from "@vscode/debugprotocol";
 export interface ILaunchRequestArguments
   extends DebugProtocol.LaunchRequestArguments {
   /** An absolute path to the "program" to debug. */
-  program: vscode.Uri;
+  program: string;
   /** Automatically stop target after launch at the entry expression */
   stopOnEntry?: boolean;
   /** Entry expression to execute overriding default entry behavior */


### PR DESCRIPTION
In testing the current run/debug experience on github.dev (which uses a virtual file system to the repo), the Play/Debug experience was broken.

This is as the code was trying to pass Uri objects across boundaries, however in getting serialized/deserialized it becomes just a regular object with the same data fields but none of the Uri methods, as shown below. VS Code would see this "Uri-like" object and try and call Uri methods on it (such as .with or .parse) which would then throw (e.g. `path.with is undefined`)

Basically, just pass data values across boundaries, not objects with methods on their prototype chain (which then get lost)

<img width="970" alt="image" src="https://github.com/microsoft/qsharp/assets/993909/736364b2-948e-4eb0-9baa-5c430746f9d4">

CC @idavis 