### PR TITLE
FIR assigner

### DIFF
--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -410,42 +410,23 @@ impl Interpreter {
 
     fn lower_callable_decl(&mut self, callable: &qsc_hir::hir::CallableDecl) -> CallableDecl {
         let callable = self.lowerer.lower_callable_decl(callable);
-        self.update_fir();
+        self.update_fir_package();
         callable
     }
 
     fn lower_stmt(&mut self, stmt: &qsc_hir::hir::Stmt) -> StmtId {
         let stmt_id = self.lowerer.lower_stmt(stmt);
-        self.update_fir();
+        self.update_fir_package();
         stmt_id
     }
 
-    fn update_fir(&mut self) {
+    fn update_fir_package(&mut self) {
         let package = self
             .fir_store
             .get_mut(self.package)
             .expect("package should be in store");
 
-        for (id, value) in self.lowerer.blocks.drain() {
-            if !package.blocks.contains_key(id) {
-                package.blocks.insert(id, value.clone());
-            }
-        }
-        for (id, value) in self.lowerer.exprs.drain() {
-            if !package.exprs.contains_key(id) {
-                package.exprs.insert(id, value.clone());
-            }
-        }
-        for (id, value) in self.lowerer.pats.drain() {
-            if !package.pats.contains_key(id) {
-                package.pats.insert(id, value.clone());
-            }
-        }
-        for (id, value) in self.lowerer.stmts.drain() {
-            if !package.stmts.contains_key(id) {
-                package.stmts.insert(id, value.clone());
-            }
-        }
+        self.lowerer.update_package(package);
     }
 
     fn eval_stmt(

--- a/compiler/qsc_fir/src/assigner.rs
+++ b/compiler/qsc_fir/src/assigner.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::fir::{BlockId, ExprId, LocalItemId, NodeId, PatId, StmtId};
+use crate::fir::{BlockId, ExprId, NodeId, PatId, StmtId};
 
 #[derive(Debug)]
 pub struct Assigner {
@@ -10,7 +10,6 @@ pub struct Assigner {
     next_expr: ExprId,
     next_pat: PatId,
     next_stmt: StmtId,
-    next_item: LocalItemId,
 }
 
 impl Assigner {
@@ -18,11 +17,10 @@ impl Assigner {
     pub fn new() -> Self {
         Self {
             next_node: NodeId::FIRST,
-            next_block: BlockId::FIRST,
-            next_expr: ExprId::FIRST,
-            next_pat: PatId::FIRST,
-            next_stmt: StmtId::FIRST,
-            next_item: LocalItemId::default(),
+            next_block: BlockId::default(),
+            next_expr: ExprId::default(),
+            next_pat: PatId::default(),
+            next_stmt: StmtId::default(),
         }
     }
 
@@ -53,12 +51,6 @@ impl Assigner {
     pub fn next_stmt(&mut self) -> StmtId {
         let id = self.next_stmt;
         self.next_stmt = id.successor();
-        id
-    }
-
-    pub fn next_item(&mut self) -> LocalItemId {
-        let id = self.next_item;
-        self.next_item = id.successor();
         id
     }
 }

--- a/compiler/qsc_fir/src/assigner.rs
+++ b/compiler/qsc_fir/src/assigner.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::fir::{BlockId, ExprId, LocalItemId, NodeId, PatId, StmtId};
+
+#[derive(Debug)]
+pub struct Assigner {
+    next_node: NodeId,
+    next_block: BlockId,
+    next_expr: ExprId,
+    next_pat: PatId,
+    next_stmt: StmtId,
+    next_item: LocalItemId,
+}
+
+impl Assigner {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            next_node: NodeId::FIRST,
+            next_block: BlockId::FIRST,
+            next_expr: ExprId::FIRST,
+            next_pat: PatId::FIRST,
+            next_stmt: StmtId::FIRST,
+            next_item: LocalItemId::default(),
+        }
+    }
+
+    pub fn next_node(&mut self) -> NodeId {
+        let id = self.next_node;
+        self.next_node = id.successor();
+        id
+    }
+
+    pub fn next_block(&mut self) -> BlockId {
+        let id = self.next_block;
+        self.next_block = id.successor();
+        id
+    }
+
+    pub fn next_expr(&mut self) -> ExprId {
+        let id = self.next_expr;
+        self.next_expr = id.successor();
+        id
+    }
+
+    pub fn next_pat(&mut self) -> PatId {
+        let id = self.next_pat;
+        self.next_pat = id.successor();
+        id
+    }
+
+    pub fn next_stmt(&mut self) -> StmtId {
+        let id = self.next_stmt;
+        self.next_stmt = id.successor();
+        id
+    }
+
+    pub fn next_item(&mut self) -> LocalItemId {
+        let id = self.next_item;
+        self.next_item = id.successor();
+        id
+    }
+}
+
+impl Default for Assigner {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -139,6 +139,25 @@ macro_rules! fir_id {
         #[derive(Debug, Clone, Copy)]
         pub struct $id(pub u32);
 
+        impl $id {
+            const DEFAULT_VALUE: u32 = u32::MAX;
+
+            /// The ID of the first node.
+            pub const FIRST: Self = Self(0);
+
+            /// The successor of this ID.
+            #[must_use]
+            pub fn successor(self) -> Self {
+                Self(self.0 + 1)
+            }
+
+            /// True if this is the default ID.
+            #[must_use]
+            pub fn is_default(self) -> bool {
+                self.0 == Self::DEFAULT_VALUE
+            }
+        }
+
         impl From<NodeId> for $id {
             fn from(val: NodeId) -> Self {
                 $id(val.into())
@@ -566,7 +585,7 @@ impl Display for SpecBody {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Block {
     /// The node ID.
-    pub id: NodeId,
+    pub id: BlockId,
     /// The span.
     pub span: Span,
     /// The block type.
@@ -598,8 +617,8 @@ impl Display for Block {
 /// A statement.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Stmt {
-    /// The node ID.
-    pub id: NodeId,
+    /// The stmt ID.
+    pub id: StmtId,
     /// The span.
     pub span: Span,
     /// The statement kind.
@@ -657,8 +676,8 @@ impl Display for StmtKind {
 /// An expression.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Expr {
-    /// The node ID.
-    pub id: NodeId,
+    /// The expr ID.
+    pub id: ExprId,
     /// The span.
     pub span: Span,
     /// The expression type.
@@ -1034,7 +1053,7 @@ pub enum StringComponent {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Pat {
     /// The node ID.
-    pub id: NodeId,
+    pub id: PatId,
     /// The span.
     pub span: Span,
     /// The pattern type.

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -40,8 +40,6 @@ fn set_indentation<'a, 'b>(
 pub struct NodeId(u32);
 
 impl NodeId {
-    const DEFAULT_VALUE: u32 = u32::MAX;
-
     /// The ID of the first node.
     pub const FIRST: Self = Self(0);
 
@@ -50,33 +48,16 @@ impl NodeId {
     pub fn successor(self) -> Self {
         Self(self.0 + 1)
     }
-
-    /// True if this is the default ID.
-    #[must_use]
-    pub fn is_default(self) -> bool {
-        self.0 == Self::DEFAULT_VALUE
-    }
-}
-
-impl Default for NodeId {
-    fn default() -> Self {
-        Self(Self::DEFAULT_VALUE)
-    }
 }
 
 impl Display for NodeId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        if self.is_default() {
-            f.write_str("_id_")
-        } else {
-            Display::fmt(&self.0, f)
-        }
+        Display::fmt(&self.0, f)
     }
 }
 
 impl From<NodeId> for usize {
     fn from(value: NodeId) -> Self {
-        assert!(!value.is_default(), "default node ID should be replaced");
         value.0 as usize
     }
 }
@@ -93,7 +74,6 @@ impl From<usize> for NodeId {
 
 impl From<NodeId> for u32 {
     fn from(value: NodeId) -> Self {
-        assert!(!value.is_default(), "default node ID should be replaced");
         value.0
     }
 }
@@ -106,7 +86,6 @@ impl From<u32> for NodeId {
 
 impl PartialEq for NodeId {
     fn eq(&self, other: &Self) -> bool {
-        assert!(!self.is_default(), "default node ID should be replaced");
         self.0 == other.0
     }
 }
@@ -115,14 +94,12 @@ impl Eq for NodeId {}
 
 impl PartialOrd for NodeId {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        assert!(!self.is_default(), "default node ID should be replaced");
         self.0.partial_cmp(&other.0)
     }
 }
 
 impl Ord for NodeId {
     fn cmp(&self, other: &Self) -> Ordering {
-        assert!(!self.is_default(), "default node ID should be replaced");
         self.0.cmp(&other.0)
     }
 }
@@ -140,21 +117,16 @@ macro_rules! fir_id {
         pub struct $id(pub u32);
 
         impl $id {
-            const DEFAULT_VALUE: u32 = u32::MAX;
-
-            /// The ID of the first node.
-            pub const FIRST: Self = Self(0);
-
             /// The successor of this ID.
             #[must_use]
             pub fn successor(self) -> Self {
                 Self(self.0 + 1)
             }
+        }
 
-            /// True if this is the default ID.
-            #[must_use]
-            pub fn is_default(self) -> bool {
-                self.0 == Self::DEFAULT_VALUE
+        impl Default for $id {
+            fn default() -> Self {
+                Self(0)
             }
         }
 

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -313,6 +313,15 @@ impl Display for Res {
 }
 
 /// The root node of the FIR.
+/// ### Notes
+/// We maintain a dense map of ids within the package.
+/// `BlockId`, `ExprId`, `PatId`, `StmtId`, and `NodeId`s are all assigned
+/// from a type specific counter in the assigner.
+///
+/// `BlockId`, `ExprId`, `PatId`, `StmtId` ids don't leak and are only used
+/// within the containing node. Node ids are used to identify nodes within
+/// the package and require mapping from the HIR node id to the new FIR node id.
+/// `PackageId`s and `LocalItemId`s are 1:1 from the HIR and are not remapped.
 #[derive(Clone, Debug, Default)]
 pub struct Package {
     /// The items in the package.

--- a/compiler/qsc_fir/src/lib.rs
+++ b/compiler/qsc_fir/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
 
+pub mod assigner;
 pub mod fir;
 pub mod global;
 pub mod mut_visit;


### PR DESCRIPTION
Adds an assigner for FIR converting the sparse index maps into dense maps. Correctness is verified by the interpreter tests. Any missing entry mapping and the a "stmt/expr/block/pat should have been lowered" error will be emitted.