### PR TITLE
Add Step Next/In/Out to Debugger

### DIFF
--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -8,4 +8,5 @@ pub mod stateless;
 pub use qsc_eval::{
     output::{self, GenericReceiver},
     val::Value,
+    StepAction, StepResult,
 };

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -508,8 +508,8 @@ impl Interpreter {
                     name,
                     functor,
                     path,
-                    lo: frame.span.lo,
-                    hi: frame.span.hi,
+                    lo: frame.span.lo - source.offset,
+                    hi: frame.span.hi - source.offset,
                 }
             })
             .collect();

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -241,7 +241,7 @@ impl Interpreter {
         &mut self,
         receiver: &mut impl Receiver,
         breakpoints: &[StmtId],
-        step: &StepAction,
+        step: StepAction,
     ) -> Result<StepResult, Vec<Error>> {
         let globals = Lookup {
             fir_store: &self.fir_store,

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -12,16 +12,18 @@ use crate::{
     error::WithSource,
 };
 use miette::Diagnostic;
+use num_bigint::BigUint;
+use num_complex::Complex;
 use qsc_data_structures::index_map::IndexMap;
+use qsc_eval::backend::Backend;
 use qsc_eval::{
     backend::SparseSim,
     debug::{map_fir_package_to_hir, map_hir_package_to_fir, Frame},
     eval_stmt,
     output::Receiver,
     val::{GlobalId, Value},
-    Env, Global, NodeLookup, State, StepAction, StepResult,
+    Env, Global, NodeLookup, State, StepAction, StepResult, VariableInfo,
 };
-
 use qsc_fir::{
     fir::{
         Block, BlockId, CallableDecl, Expr, ExprId, LocalItemId, Package, PackageId, Pat, PatId,
@@ -504,6 +506,10 @@ impl Interpreter {
         stack_frames
     }
 
+    pub fn capture_quantum_state(&mut self) -> (Vec<(BigUint, Complex<f64>)>, usize) {
+        self.sim.capture_quantum_state()
+    }
+
     #[must_use]
     pub fn get_breakpoints(&self, path: &str) -> Vec<BreakpointSpan> {
         let unit = self
@@ -532,6 +538,11 @@ impl Interpreter {
         } else {
             Vec::new()
         }
+    }
+
+    #[must_use]
+    pub fn get_locals(&self) -> Vec<VariableInfo> {
+        self.env.get_variables_in_top_frame()
     }
 }
 

--- a/compiler/qsc/src/interpret/stateful/stepping_tests.rs
+++ b/compiler/qsc/src/interpret/stateful/stepping_tests.rs
@@ -141,7 +141,7 @@ fn step_in(
     Result<StepResult, Vec<crate::interpret::stateful::Error>>,
     String,
 ) {
-    step(interpreter, breakpoints, &qsc_eval::StepAction::In)
+    step(interpreter, breakpoints, qsc_eval::StepAction::In)
 }
 
 fn step_next(
@@ -151,7 +151,7 @@ fn step_next(
     Result<StepResult, Vec<crate::interpret::stateful::Error>>,
     String,
 ) {
-    step(interpreter, breakpoints, &qsc_eval::StepAction::Next)
+    step(interpreter, breakpoints, qsc_eval::StepAction::Next)
 }
 
 fn step_out(
@@ -161,13 +161,13 @@ fn step_out(
     Result<StepResult, Vec<crate::interpret::stateful::Error>>,
     String,
 ) {
-    step(interpreter, breakpoints, &qsc_eval::StepAction::Out)
+    step(interpreter, breakpoints, qsc_eval::StepAction::Out)
 }
 
 fn step(
     interpreter: &mut Interpreter,
     breakpoints: &[StmtId],
-    step: &StepAction,
+    step: StepAction,
 ) -> (
     Result<StepResult, Vec<crate::interpret::stateful::Error>>,
     String,

--- a/compiler/qsc/src/interpret/stateful/stepping_tests.rs
+++ b/compiler/qsc/src/interpret/stateful/stepping_tests.rs
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::interpret::stateful::Interpreter;
+use qsc_eval::{output::CursorReceiver, StepAction, StepResult};
+use qsc_fir::fir::StmtId;
+use qsc_frontend::compile::SourceMap;
+use qsc_passes::PackageType;
+use std::io::Cursor;
+
+#[cfg(test)]
+mod given_interpreter_with_sources {
+    use super::*;
+
+    static STEPPING_SOURCE: &str = r#"
+        namespace Test {
+            @EntryPoint()
+            operation A() : Int {
+                let d = B();
+                let e = d / 1;
+                e
+            }
+            operation B() : Int {
+                let g = 10;
+                let h = 20;
+                let l = C(g, h);
+                42
+            }
+            operation C(m: Int, n: Int) : Int {
+                let o = 42 - (m + n);
+                let p = (m + n) + o;
+                p
+            }
+        }"#;
+    #[cfg(test)]
+    mod step {
+        use super::*;
+
+        #[test]
+        fn in_one_level_operation_works() -> Result<(), Vec<crate::interpret::stateful::Error>> {
+            let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
+            let mut interpreter = Interpreter::new(true, sources, PackageType::Exe)?;
+            interpreter.set_entry()?;
+            let ids = get_breakpoint_ids(&interpreter, "test");
+            let expected_id = ids[0];
+            expect_bp(&mut interpreter, &ids, expected_id);
+            expect_in(&mut interpreter);
+            expect_next(&mut interpreter);
+            expect_next(&mut interpreter);
+            expect_next(&mut interpreter);
+            let expected = "42";
+            expect_return(interpreter, expected);
+            Ok(())
+        }
+
+        #[test]
+        fn next_crosses_operation_works() -> Result<(), Vec<crate::interpret::stateful::Error>> {
+            let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
+            let mut interpreter = Interpreter::new(true, sources, PackageType::Exe)?;
+            interpreter.set_entry()?;
+            let ids = get_breakpoint_ids(&interpreter, "test");
+            let expected_id = ids[0];
+            expect_bp(&mut interpreter, &ids, expected_id);
+            expect_next(&mut interpreter);
+            expect_next(&mut interpreter);
+            let expected = "42";
+            expect_return(interpreter, expected);
+            Ok(())
+        }
+
+        #[test]
+        fn in_multiple_operations_works() -> Result<(), Vec<crate::interpret::stateful::Error>> {
+            let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
+            let mut interpreter = Interpreter::new(true, sources, PackageType::Exe)?;
+            interpreter.set_entry()?;
+            let ids = get_breakpoint_ids(&interpreter, "test");
+            let expected_id = ids[0];
+            expect_bp(&mut interpreter, &ids, expected_id);
+            expect_in(&mut interpreter);
+            expect_next(&mut interpreter);
+            expect_next(&mut interpreter);
+            expect_in(&mut interpreter);
+            expect_next(&mut interpreter);
+            expect_next(&mut interpreter);
+            let expected = "42";
+            expect_return(interpreter, expected);
+            Ok(())
+        }
+
+        #[test]
+        fn out_multiple_operations_works() -> Result<(), Vec<crate::interpret::stateful::Error>> {
+            let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
+            let mut interpreter = Interpreter::new(true, sources, PackageType::Exe)?;
+            interpreter.set_entry()?;
+            let ids = get_breakpoint_ids(&interpreter, "test");
+            let expected_id = ids[0];
+            expect_bp(&mut interpreter, &ids, expected_id);
+            expect_in(&mut interpreter);
+            expect_next(&mut interpreter);
+            expect_next(&mut interpreter);
+            expect_in(&mut interpreter);
+            expect_out(&mut interpreter);
+            expect_out(&mut interpreter);
+            expect_next(&mut interpreter);
+            let expected = "42";
+            expect_return(interpreter, expected);
+            Ok(())
+        }
+    }
+}
+
+fn get_breakpoint_ids(interpreter: &Interpreter, path: &str) -> Vec<StmtId> {
+    let mut bps = interpreter.get_breakpoints(path);
+    bps.sort_by_key(|f| f.id);
+    let ids = bps.iter().map(|f| f.id.into()).collect::<Vec<_>>();
+    ids
+}
+
+fn expect_return(mut interpreter: Interpreter, expected: &str) {
+    let r = step_next(&mut interpreter, &[]);
+    match r.0 {
+        Ok(StepResult::Return(value)) => assert_eq!(value.to_string(), expected),
+        Ok(v) => panic!("Expected Return, got {v:?}"),
+        Err(e) => panic!("Expected Return, got {e:?}"),
+    }
+}
+
+fn expect_bp(interpreter: &mut Interpreter, ids: &[StmtId], expected_id: StmtId) {
+    let r = step_next(interpreter, ids);
+    match r.0 {
+        Ok(StepResult::BreakpointHit(actual_id)) => assert!(actual_id == expected_id),
+        Ok(v) => panic!("Expected BP, got {v:?}"),
+        Err(e) => panic!("Expected BP, got {e:?}"),
+    }
+}
+
+fn step_in(
+    interpreter: &mut Interpreter,
+    breakpoints: &[StmtId],
+) -> (
+    Result<StepResult, Vec<crate::interpret::stateful::Error>>,
+    String,
+) {
+    step(interpreter, breakpoints, &qsc_eval::StepAction::In)
+}
+
+fn step_next(
+    interpreter: &mut Interpreter,
+    breakpoints: &[StmtId],
+) -> (
+    Result<StepResult, Vec<crate::interpret::stateful::Error>>,
+    String,
+) {
+    step(interpreter, breakpoints, &qsc_eval::StepAction::Next)
+}
+
+fn step_out(
+    interpreter: &mut Interpreter,
+    breakpoints: &[StmtId],
+) -> (
+    Result<StepResult, Vec<crate::interpret::stateful::Error>>,
+    String,
+) {
+    step(interpreter, breakpoints, &qsc_eval::StepAction::Out)
+}
+
+fn step(
+    interpreter: &mut Interpreter,
+    breakpoints: &[StmtId],
+    step: &StepAction,
+) -> (
+    Result<StepResult, Vec<crate::interpret::stateful::Error>>,
+    String,
+) {
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    let mut receiver = CursorReceiver::new(&mut cursor);
+    (
+        interpreter.eval_step(&mut receiver, breakpoints, step),
+        receiver.dump(),
+    )
+}
+
+fn expect_next(interpreter: &mut Interpreter) {
+    let result = step_next(interpreter, &[]);
+    match result.0 {
+        Ok(StepResult::Next) => (),
+        Ok(v) => panic!("Expected Next, got {v:?}"),
+        Err(e) => panic!("Expected Next, got {e:?}"),
+    }
+}
+
+fn expect_in(interpreter: &mut Interpreter) {
+    let result = step_in(interpreter, &[]);
+    match result.0 {
+        Ok(StepResult::StepIn) => (),
+        Ok(v) => panic!("Expected StepIn, got {v:?}"),
+        Err(e) => panic!("Expected StepIn, got {e:?}"),
+    }
+}
+
+fn expect_out(interpreter: &mut Interpreter) {
+    let result = step_out(interpreter, &[]);
+    match result.0 {
+        Ok(StepResult::StepOut) => (),
+        Ok(v) => panic!("Expected StepOut, got {v:?}"),
+        Err(e) => panic!("Expected StepOut, got {e:?}"),
+    }
+}

--- a/compiler/qsc_eval/src/debug.rs
+++ b/compiler/qsc_eval/src/debug.rs
@@ -28,6 +28,11 @@ impl CallStack {
     }
 
     #[must_use]
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    #[must_use]
     pub fn into_frames(self) -> Vec<Frame> {
         self.frames
     }

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -530,13 +530,13 @@ impl State {
                         StepResult::BreakpointHit(*bp)
                     } else {
                         // no breakpoint, but we may stop here
-                        if matches!(step, StepAction::In) {
+                        if step == StepAction::In {
                             StepResult::StepIn
-                        } else if matches!(step, StepAction::Next)
+                        } else if step == StepAction::Next
                             && current_frame == self.call_stack.len()
                         {
                             StepResult::Next
-                        } else if matches!(step, StepAction::Out)
+                        } else if step == StepAction::Out
                             && current_frame > self.call_stack.len()
                         {
                             StepResult::StepOut

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -169,6 +169,7 @@ pub fn eval_stmt(
 }
 
 /// The type of step action to take during evaluation
+#[derive(PartialEq)]
 pub enum StepAction {
     Next,
     In,

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -336,7 +336,6 @@ pub struct State {
     package: PackageId,
     call_stack: CallStack,
     current_span: Span,
-    source_package: PackageId,
 }
 
 impl State {
@@ -348,7 +347,6 @@ impl State {
             package,
             call_stack: CallStack::default(),
             current_span: Span::default(),
-            source_package: package,
         }
     }
 
@@ -494,13 +492,7 @@ impl State {
                 panic!("unexpected return");
             }
 
-            // If we are in the source package, we are done.
-            // If we are in another package, we are in core or std
-            // rather than make the user step through all of that,
-            // we just return when running user code.
-            if self.package == self.source_package {
-                return Ok(res);
-            }
+            return Ok(res);
         }
 
         Ok(StepResult::Return(self.get_result()))

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -144,6 +144,7 @@ pub fn eval_stmt(
         _ => unreachable!("eval_stmt should always return a value"),
     }
 }
+
 pub enum StepAction {
     Next,
     In,

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -30,7 +30,7 @@ pub(super) fn eval_expr(
     let mut env = Env::with_empty_scope();
     let mut sim = SparseSim::new();
     state.push_expr(expr);
-    let res = state.resume(globals, &mut env, &mut sim, out, &[], &StepAction::Continue)?;
+    let res = state.eval(globals, &mut env, &mut sim, out, &[], &StepAction::Continue)?;
     match res {
         StepResult::Return(value) => Ok(value),
         _ => unreachable!("eval_expr should always return a value"),

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{
     debug::{map_hir_package_to_fir, Frame},
     output::{GenericReceiver, Receiver},
     val::GlobalId,
-    Env, Error, Global, NodeLookup, State, Value,
+    Env, Error, Global, NodeLookup, State, StepAction, StepResult, Value,
 };
 use expect_test::{expect, Expect};
 use indoc::indoc;
@@ -30,8 +30,11 @@ pub(super) fn eval_expr(
     let mut env = Env::with_empty_scope();
     let mut sim = SparseSim::new();
     state.push_expr(expr);
-    state.resume(globals, &mut env, &mut sim, out, &[])?;
-    Ok(state.pop_val())
+    let res = state.resume(globals, &mut env, &mut sim, out, &[], &StepAction::Continue)?;
+    match res {
+        StepResult::Return(value) => Ok(value),
+        _ => unreachable!("eval_expr should always return a value"),
+    }
 }
 
 struct Lookup<'a> {

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -30,11 +30,10 @@ pub(super) fn eval_expr(
     let mut env = Env::with_empty_scope();
     let mut sim = SparseSim::new();
     state.push_expr(expr);
-    let res = state.eval(globals, &mut env, &mut sim, out, &[], &StepAction::Continue)?;
-    match res {
-        StepResult::Return(value) => Ok(value),
-        _ => unreachable!("eval_expr should always return a value"),
-    }
+    let StepResult::Return(value) = state.eval(globals, &mut env, &mut sim, out, &[], StepAction::Continue)? else{
+        unreachable!("eval_expr should always return a value");
+    };
+    Ok(value)
 }
 
 struct Lookup<'a> {

--- a/npm/src/browser.ts
+++ b/npm/src/browser.ts
@@ -82,6 +82,13 @@ async function instantiateWasm() {
   log.onLevelChanged = (level) => wasm.setLogLevel(level);
 }
 
+export async function provideTextDocumentContent(
+  path: string
+): Promise<string | undefined> {
+  await instantiateWasm();
+  return wasm.provide_text_document_content(path);
+}
+
 export async function getDebugService(): Promise<IDebugService> {
   await instantiateWasm();
   return new QSharpDebugService(wasm);

--- a/npm/src/browser.ts
+++ b/npm/src/browser.ts
@@ -82,11 +82,11 @@ async function instantiateWasm() {
   log.onLevelChanged = (level) => wasm.setLogLevel(level);
 }
 
-export async function provideTextDocumentContent(
+export async function getLibrarySourceContent(
   path: string
 ): Promise<string | undefined> {
   await instantiateWasm();
-  return wasm.provide_text_document_content(path);
+  return wasm.get_library_source_content(path);
 }
 
 export async function getDebugService(): Promise<IDebugService> {

--- a/npm/src/browser.ts
+++ b/npm/src/browser.ts
@@ -213,4 +213,5 @@ export type { ICompilerWorker, ICompiler };
 export type { ILanguageServiceWorker, ILanguageService };
 export type { IDebugServiceWorker, IDebugService };
 export type { IBreakpointSpan, IStackFrame } from "../lib/web/qsc_wasm.js";
+export { type IStructStepResult, StepResultId } from "../lib/web/qsc_wasm.js";
 export { type LanguageServiceEvent } from "./language-service/language-service.js";

--- a/npm/src/debug-service/debug-service.ts
+++ b/npm/src/debug-service/debug-service.ts
@@ -69,7 +69,7 @@ export class QSharpDebugService implements IDebugService {
       stack_frame_list.frames.map(async (frame: IStackFrame) => {
         // get any missing sources if possible
         if (!(frame.path in this.code)) {
-          const content = await this.wasm.provide_text_document_content(
+          const content = await this.wasm.get_library_source_content(
             frame.path
           );
           if (content) {

--- a/npm/src/debug-service/worker-node.ts
+++ b/npm/src/debug-service/worker-node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// This module supports running the qsharp compiler in a Node.js worker thread. It should be
+// This module supports running the qsharp debugger in a Node.js worker thread. It should be
 // used in a Node.js module in a manner similar to the below to create it with the right log level:
 //
 //     const worker = new Worker(join(thisDir,"worker-node.js"), {

--- a/npm/src/debug-service/worker-proxy.ts
+++ b/npm/src/debug-service/worker-proxy.ts
@@ -17,6 +17,9 @@ const requests: MethodMap<IDebugService> = {
   getBreakpoints: "request",
   getStackFrames: "request",
   evalContinue: "requestWithProgress",
+  evalNext: "requestWithProgress",
+  evalStepIn: "requestWithProgress",
+  evalStepOut: "requestWithProgress",
   dispose: "request",
 };
 

--- a/npm/src/debug-service/worker-proxy.ts
+++ b/npm/src/debug-service/worker-proxy.ts
@@ -15,6 +15,8 @@ import { IDebugService } from "./debug-service.js";
 const requests: MethodMap<IDebugService> = {
   loadSource: "request",
   getBreakpoints: "request",
+  getLocalVariables: "request",
+  captureQuantumState: "request",
   getStackFrames: "request",
   evalContinue: "requestWithProgress",
   evalNext: "requestWithProgress",

--- a/npm/src/main.ts
+++ b/npm/src/main.ts
@@ -31,6 +31,15 @@ type Wasm = typeof import("../lib/node/qsc_wasm.cjs");
 let wasm: Wasm | null = null;
 const require = createRequire(import.meta.url);
 
+export async function provideTextDocumentContent(
+  path: string
+): Promise<string | undefined> {
+  if (!wasm) {
+    wasm = require("../lib/node/qsc_wasm.cjs") as Wasm;
+    return wasm.provide_text_document_content(path);
+  }
+}
+
 export function getCompiler(): ICompiler {
   if (!wasm) {
     wasm = require("../lib/node/qsc_wasm.cjs") as Wasm;

--- a/npm/src/main.ts
+++ b/npm/src/main.ts
@@ -31,12 +31,12 @@ type Wasm = typeof import("../lib/node/qsc_wasm.cjs");
 let wasm: Wasm | null = null;
 const require = createRequire(import.meta.url);
 
-export async function provideTextDocumentContent(
+export async function getLibrarySourceContent(
   path: string
 ): Promise<string | undefined> {
   if (!wasm) {
     wasm = require("../lib/node/qsc_wasm.cjs") as Wasm;
-    return wasm.provide_text_document_content(path);
+    return wasm.get_library_source_content(path);
   }
 }
 

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -576,7 +576,7 @@ test("debug service getting breakpoints after loaded source succeeds when file n
     );
     assert.equal(true, result);
     const bps = await debugService.getBreakpoints("test.qs");
-    assert.equal(bps.length, 8);
+    assert.equal(bps.length, 5);
   } finally {
     debugService.terminate();
   }

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -3,7 +3,7 @@
 
 export const qsharpLanguageId = "qsharp";
 export const qsharpExtensionId = "qsharp-vscode";
-export const QsLibraryUriScheme = "qsharp-source-request";
+export const qsharpLibraryUriScheme = "qsharp-library-source";
 
 export interface FileAccessor {
   readFile(uri: string): Promise<Uint8Array>;

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -3,6 +3,7 @@
 
 export const qsharpLanguageId = "qsharp";
 export const qsharpExtensionId = "qsharp-vscode";
+export const QsLibraryUriScheme = "qsharp-source-request";
 
 export interface FileAccessor {
   readFile(uri: string): Promise<Uint8Array>;

--- a/vscode/src/debugger/output.ts
+++ b/vscode/src/debugger/output.ts
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as vscode from "vscode";
-
 import { QscEventTarget } from "qsharp";
 
-export function createDebugConsoleEventTarget() {
+export function createDebugConsoleEventTarget(out: (message: string) => void) {
   const eventTarget = new QscEventTarget(false);
 
   eventTarget.addEventListener("Message", (evt) => {
-    vscode.debug.activeDebugConsole.appendLine(`Message: ${evt.detail}`);
+    out(`Message: ${evt.detail}`);
   });
 
   eventTarget.addEventListener("DumpMachine", (evt) => {
@@ -27,34 +25,30 @@ export function createDebugConsoleEventTarget() {
     }
 
     const dump = evt.detail;
-    vscode.debug.activeDebugConsole.appendLine("");
-    vscode.debug.activeDebugConsole.appendLine("DumpMachine:");
-    vscode.debug.activeDebugConsole.appendLine("");
-    vscode.debug.activeDebugConsole.appendLine(
-      "  Basis | Amplitude     | Probability   | Phase"
-    );
-    vscode.debug.activeDebugConsole.appendLine(
-      "  ---------------------------------------------"
-    );
+    out("");
+    out("DumpMachine:");
+    out("");
+    out("  Basis | Amplitude     | Probability   | Phase");
+    out("  ---------------------------------------------");
     Object.keys(dump).map((basis) => {
       const [real, imag] = dump[basis];
       const complex = formatComplex(real, imag);
       const probabilityPercent = probability(real, imag) * 100;
       const phase = Math.atan2(imag, real);
 
-      vscode.debug.activeDebugConsole.appendLine(
+      out(
         `  ${basis}  | ${complex} | ${probabilityPercent.toFixed(
           4
         )}%     | ${phase.toFixed(4)}`
       );
     });
-    vscode.debug.activeDebugConsole.appendLine("");
-    vscode.debug.activeDebugConsole.appendLine("");
+    out("");
+    out("");
   });
 
   eventTarget.addEventListener("Result", (evt) => {
     const resultJson = JSON.stringify(evt.detail.value, null, 2);
-    vscode.debug.activeDebugConsole.appendLine(`Result: ${resultJson}`);
+    out(`Result: ${resultJson}`);
   });
   return eventTarget;
 }

--- a/vscode/src/debugger/session.ts
+++ b/vscode/src/debugger/session.ts
@@ -52,7 +52,7 @@ export class QscDebugSession extends LoggingDebugSession {
   private failed: boolean;
   private program: string;
   private eventTarget: QscEventTarget;
-  private supportsVariableType: boolean = false;
+  private supportsVariableType = false;
 
   public constructor(
     private fileAccessor: FileAccessor,
@@ -659,7 +659,7 @@ export class QscDebugSession extends LoggingDebugSession {
     if (handle === "locals") {
       const locals = await this.debugService.getLocalVariables();
       const variables = locals.map((local) => {
-        let variable: DebugProtocol.Variable = {
+        const variable: DebugProtocol.Variable = {
           name: local.name,
           value: local.value,
           variablesReference: 0,

--- a/vscode/src/debugger/session.ts
+++ b/vscode/src/debugger/session.ts
@@ -577,7 +577,7 @@ export class QscDebugSession extends LoggingDebugSession {
               // There is a custom content provider subscribed to this scheme.
               // Opening the text document by that uri will use the content
               // provider to look for the source code.
-              const uri = vscode.Uri.parse(QsLibraryUriScheme + ":" + f.path);
+              const uri = vscode.Uri.from({ scheme: qsharpLibraryUriScheme, path: f.path });
               const file = await vscode.workspace.openTextDocument(uri);
               const start_pos = file.positionAt(f.lo);
               const end_pos = file.positionAt(f.hi);

--- a/vscode/src/debugger/session.ts
+++ b/vscode/src/debugger/session.ts
@@ -22,7 +22,7 @@ import {
   Scope,
 } from "@vscode/debugadapter";
 
-import { FileAccessor, QsLibraryUriScheme } from "../common";
+import { FileAccessor, qsharpLibraryUriScheme } from "../common";
 import { DebugProtocol } from "@vscode/debugprotocol";
 import {
   IBreakpointSpan,
@@ -279,8 +279,8 @@ export class QscDebugSession extends LoggingDebugSession {
 
   private async endSession(message: string, exitCode: number): Promise<void> {
     log.trace(message);
-    this.writeToStdOut("");
-    this.writeToStdOut(SimulationCompleted);
+    this.writeToDebugConsole("");
+    this.writeToDebugConsole(SimulationCompleted);
     this.sendEvent(new TerminatedEvent());
     this.sendEvent(new ExitedEvent(exitCode));
   }
@@ -577,7 +577,10 @@ export class QscDebugSession extends LoggingDebugSession {
               // There is a custom content provider subscribed to this scheme.
               // Opening the text document by that uri will use the content
               // provider to look for the source code.
-              const uri = vscode.Uri.from({ scheme: qsharpLibraryUriScheme, path: f.path });
+              const uri = vscode.Uri.from({
+                scheme: qsharpLibraryUriScheme,
+                path: f.path,
+              });
               const file = await vscode.workspace.openTextDocument(uri);
               const start_pos = file.positionAt(f.lo);
               const end_pos = file.positionAt(f.hi);

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -6,10 +6,10 @@ import {
   getLanguageService,
   loadWasmModule,
   log,
-  provideTextDocumentContent,
+  getLibrarySourceContent,
 } from "qsharp";
 import * as vscode from "vscode";
-import { QsLibraryUriScheme } from "./common";
+import { qsharpLibraryUriScheme } from "./common";
 import { createCompletionItemProvider } from "./completion.js";
 import { createDefinitionProvider } from "./definition.js";
 import { startCheckingQSharp } from "./diagnostics.js";
@@ -22,7 +22,7 @@ export async function activate(context: vscode.ExtensionContext) {
   log.info("Q# extension activating.");
 
   vscode.workspace.registerTextDocumentContentProvider(
-    QsLibraryUriScheme,
+    qsharpLibraryUriScheme,
     new QsTextDocumentContentProvider()
   );
 
@@ -159,6 +159,6 @@ export class QsTextDocumentContentProvider
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     token: vscode.CancellationToken
   ): vscode.ProviderResult<string> {
-    return provideTextDocumentContent(uri.path);
+    return getLibrarySourceContent(uri.path);
   }
 }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -158,11 +158,6 @@ export class QsTextDocumentContentProvider
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     token: vscode.CancellationToken
   ): vscode.ProviderResult<string> {
-    const contents = provideTextDocumentContent(uri.path);
-    if (contents) {
-      return contents;
-    } else {
-      return Promise.reject();
-    }
+    return provideTextDocumentContent(uri.path);
   }
 }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -9,6 +9,7 @@ import {
   provideTextDocumentContent,
 } from "qsharp";
 import * as vscode from "vscode";
+import { QsLibraryUriScheme } from "./common";
 import { createCompletionItemProvider } from "./completion.js";
 import { createDefinitionProvider } from "./definition.js";
 import { startCheckingQSharp } from "./diagnostics.js";
@@ -21,7 +22,7 @@ export async function activate(context: vscode.ExtensionContext) {
   log.info("Q# extension activating.");
 
   vscode.workspace.registerTextDocumentContentProvider(
-    "qsharp-source-request",
+    QsLibraryUriScheme,
     new QsTextDocumentContentProvider()
   );
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -155,6 +155,7 @@ export class QsTextDocumentContentProvider
   onDidChange?: vscode.Event<vscode.Uri> | undefined;
   provideTextDocumentContent(
     uri: vscode.Uri,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     token: vscode.CancellationToken
   ): vscode.ProviderResult<string> {
     const contents = provideTextDocumentContent(uri.path);

--- a/wasm/src/debug_service.rs
+++ b/wasm/src/debug_service.rs
@@ -193,10 +193,6 @@ impl From<StepResult> for StructStepResult {
                 id: StepResultId::StepOut.into(),
                 value: 0,
             },
-            StepResult::Continue => StructStepResult {
-                id: StepResultId::Continue.into(),
-                value: 0,
-            },
             StepResult::Return(_) => StructStepResult {
                 id: StepResultId::Return.into(),
                 value: 0,
@@ -212,8 +208,7 @@ pub enum StepResultId {
     Next = 1,
     StepIn = 2,
     StepOut = 3,
-    Continue = 4,
-    Return = 5,
+    Return = 4,
 }
 
 impl From<StepResultId> for usize {

--- a/wasm/src/debug_service.rs
+++ b/wasm/src/debug_service.rs
@@ -72,7 +72,7 @@ impl DebugService {
         event_cb: &js_sys::Function,
         ids: &[u32],
     ) -> Result<JsValue, JsValue> {
-        self.eval(event_cb, ids, &StepAction::Next)
+        self.eval(event_cb, ids, StepAction::Next)
     }
 
     pub fn eval_continue(
@@ -80,7 +80,7 @@ impl DebugService {
         event_cb: &js_sys::Function,
         ids: &[u32],
     ) -> Result<JsValue, JsValue> {
-        self.eval(event_cb, ids, &StepAction::Continue)
+        self.eval(event_cb, ids, StepAction::Continue)
     }
 
     pub fn eval_step_in(
@@ -88,7 +88,7 @@ impl DebugService {
         event_cb: &js_sys::Function,
         ids: &[u32],
     ) -> Result<JsValue, JsValue> {
-        self.eval(event_cb, ids, &StepAction::In)
+        self.eval(event_cb, ids, StepAction::In)
     }
 
     pub fn eval_step_out(
@@ -96,14 +96,14 @@ impl DebugService {
         event_cb: &js_sys::Function,
         ids: &[u32],
     ) -> Result<JsValue, JsValue> {
-        self.eval(event_cb, ids, &StepAction::Out)
+        self.eval(event_cb, ids, StepAction::Out)
     }
 
     fn eval(
         &mut self,
         event_cb: &js_sys::Function,
         ids: &[u32],
-        step: &StepAction,
+        step: StepAction,
     ) -> Result<JsValue, JsValue> {
         if !event_cb.is_function() {
             return Err(JsError::new("Events callback function must be provided").into());
@@ -129,7 +129,7 @@ impl DebugService {
         &mut self,
         event_cb: F,
         bps: &[StmtId],
-        step: &StepAction,
+        step: StepAction,
     ) -> Result<StepResult, Vec<stateful::Error>>
     where
         F: Fn(&str),


### PR DESCRIPTION
Debug stepping ~has introduced enough overhead that it~ may be worthwhile to split eval_continue into two calls. There is a lot going on in the eval for debugging. We will probably want to take a look after scopes support is added. Step granularity on expressions may also introduce noticeable overhead, but that is speculation at the moment.

```
Teleport evaluation     time:   [103.03 µs 103.08 µs 103.14 µs]
                        change: [+0.3841% +0.6847% +0.9592%] (p = 0.00 < 0.05)
                        Change within noise threshold.

Deutsch-Jozsa evaluation
                        time:   [22.510 ms 22.517 ms 22.525 ms]
                        change: [+0.6672% +0.8058% +0.8961%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```