### PR TITLE
Don't report errors in library files or notebook cells

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -1,7 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { DocumentFilter } from "vscode";
+
 export const qsharpLanguageId = "qsharp";
+// Matches all Q# documents, including unsaved files, notebook cells, etc.
+export const qsharpDocumentFilter: DocumentFilter = {
+  language: qsharpLanguageId,
+};
+// Matches only Q# notebook cell documents.
+export const qsharpNotebookCellDocumentFilter: DocumentFilter = {
+  language: qsharpLanguageId,
+  notebookType: "jupyter-notebook",
+};
 export const qsharpExtensionId = "qsharp-vscode";
 export const qsharpLibraryUriScheme = "qsharp-library-source";
 

--- a/vscode/src/debugger/activate.ts
+++ b/vscode/src/debugger/activate.ts
@@ -5,7 +5,11 @@
 
 import * as vscode from "vscode";
 import { IDebugServiceWorker, getDebugServiceWorker } from "qsharp";
-import { FileAccessor, qsharpExtensionId } from "../common";
+import {
+  FileAccessor,
+  qsharpExtensionId,
+  qsharpDocumentFilter,
+} from "../common";
 import { QscDebugSession } from "./session";
 
 let debugServiceWorkerFactory: () => IDebugServiceWorker;
@@ -93,7 +97,10 @@ class QsDebugConfigProvider implements vscode.DebugConfigurationProvider {
     // if launch.json is missing or empty
     if (!config.type && !config.request && !config.name) {
       const editor = vscode.window.activeTextEditor;
-      if (editor && editor.document.languageId === "qsharp") {
+      if (
+        editor &&
+        vscode.languages.match(qsharpDocumentFilter, editor.document)
+      ) {
         config.type = "qsharp";
         config.name = "Launch";
         config.request = "launch";

--- a/vscode/src/diagnostics.ts
+++ b/vscode/src/diagnostics.ts
@@ -3,7 +3,7 @@
 
 import { ILanguageService, VSDiagnostic } from "qsharp";
 import * as vscode from "vscode";
-import { qsharpLanguageId } from "./common.js";
+import { qsharpLanguageId, qsharpLibraryUriScheme } from "./common.js";
 
 export function startCheckingQSharp(languageService: ILanguageService) {
   const diagCollection =
@@ -17,6 +17,12 @@ export function startCheckingQSharp(languageService: ILanguageService) {
     };
   }) {
     const diagnostics = evt.detail;
+    const uri = vscode.Uri.parse(diagnostics.uri);
+
+    if (uri.scheme === qsharpLibraryUriScheme) {
+      // Don't report diagnostics for library files.
+      return;
+    }
 
     const getPosition = (offset: number) => {
       // We need the document here to be able to map offsets to line/column positions.
@@ -30,7 +36,7 @@ export function startCheckingQSharp(languageService: ILanguageService) {
     };
 
     diagCollection.set(
-      vscode.Uri.parse(evt.detail.uri),
+      uri,
       diagnostics.diagnostics.map((d) => {
         let severity;
         switch (d.severity) {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -16,6 +16,10 @@ import { startCheckingQSharp } from "./diagnostics.js";
 import { createHoverProvider } from "./hover.js";
 import { registerQSharpNotebookHandlers } from "./notebook.js";
 import { activateDebugger } from "./debugger/activate.js";
+import {
+  qsharpDocumentFilter,
+  qsharpNotebookCellDocumentFilter,
+} from "./common.js";
 
 export async function activate(context: vscode.ExtensionContext) {
   initializeLogger();
@@ -39,7 +43,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // completions
   context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
-      "qsharp",
+      qsharpDocumentFilter,
       createCompletionItemProvider(languageService),
       "."
     )
@@ -48,7 +52,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // hover
   context.subscriptions.push(
     vscode.languages.registerHoverProvider(
-      "qsharp",
+      qsharpDocumentFilter,
       createHoverProvider(languageService)
     )
   );
@@ -120,14 +124,22 @@ function registerDocumentUpdateHandlers(languageService: ILanguageService) {
 
   subscriptions.push(
     vscode.workspace.onDidCloseTextDocument((document) => {
-      if (vscode.languages.match("qsharp", document)) {
+      if (
+        vscode.languages.match(qsharpDocumentFilter, document) &&
+        !vscode.languages.match(qsharpNotebookCellDocumentFilter, document)
+      ) {
+        // Notebook cells don't currently support the language service.
         languageService.closeDocument(document.uri.toString());
       }
     })
   );
 
   function updateIfQsharpDocument(document: vscode.TextDocument) {
-    if (vscode.languages.match("qsharp", document)) {
+    if (
+      vscode.languages.match(qsharpDocumentFilter, document) &&
+      !vscode.languages.match(qsharpNotebookCellDocumentFilter, document)
+    ) {
+      // Notebook cells don't currently support the language service.
       languageService.updateDocument(
         document.uri.toString(),
         document.version,

--- a/vscode/src/notebook.ts
+++ b/vscode/src/notebook.ts
@@ -11,6 +11,12 @@ export function registerQSharpNotebookHandlers() {
   const qsharpCellMagic = "%%qsharp";
   const jupyterNotebookType = "jupyter-notebook";
 
+  vscode.workspace.notebookDocuments.forEach((notebookDocument) => {
+    if (notebookDocument.notebookType === jupyterNotebookType) {
+      updateQSharpCellLanguages(notebookDocument.getCells());
+    }
+  });
+
   const subscriptions = [];
   subscriptions.push(
     vscode.workspace.onDidOpenNotebookDocument((notebookDocument) => {


### PR DESCRIPTION
- For now, exclude notebook cells altogether until we have proper language service support. (`%%qsharp` magic and top-level statements just don't play well with the parser at the moment).
- For stdlib/corelib files, hide diagnostics but allow other language service features.