### PR TITLE
Rename interpret() to eval() in Python module

### DIFF
--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from ._qsharp import interpret, interpret_file
+from ._qsharp import eval, eval_file
 
 from ._native import Result, Pauli, QSharpError
 
@@ -16,4 +16,4 @@ except NameError:
     pass
 
 
-__all__ = ["interpret", "interpret_file", "Result", "Pauli", "QSharpError"]
+__all__ = ["eval", "eval_file", "Result", "Pauli", "QSharpError"]

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -7,30 +7,30 @@ from ._native import Interpreter
 _interpreter = Interpreter()
 
 
-def interpret(input):
+def eval(source):
     """
-    Interprets Q# source code.
+    Evaluates Q# source code.
 
     Output is printed to console.
 
-    :param input: The Q# source code to interpret.
+    :param input: The Q# source code to evaluate.
     :returns value: The value returned by the last statement in the input.
-    :raises QSharpError: If there is an error interpreting the input.
+    :raises QSharpError: If there is an error evaluating the input.
     """
 
     def callback(output):
         print(output)
 
-    return _interpreter.interpret(input, callback)
+    return _interpreter.interpret(source, callback)
 
 
-def interpret_file(path) -> None:
+def eval_file(path) -> None:
     """
-    Reads Q# source code from a file and interprets it.
+    Reads Q# source code from a file and evaluates it.
 
     :param path: The path to the Q# source file.
     :returns: The value returned by the last statement in the line.
     :raises: QSharpError
     """
     f = open(path, mode="r", encoding="utf-8")
-    return interpret(f.read())
+    return eval(f.read())

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -13,9 +13,9 @@ def eval(source):
 
     Output is printed to console.
 
-    :param input: The Q# source code to evaluate.
-    :returns value: The value returned by the last statement in the input.
-    :raises QSharpError: If there is an error evaluating the input.
+    :param source: The Q# source code to evaluate.
+    :returns value: The value returned by the last statement in the source code.
+    :raises QSharpError: If there is an error evaluating the source code.
     """
 
     def callback(output):
@@ -29,7 +29,7 @@ def eval_file(path) -> None:
     Reads Q# source code from a file and evaluates it.
 
     :param path: The path to the Q# source file.
-    :returns: The value returned by the last statement in the line.
+    :returns: The value returned by the last statement in the file.
     :raises: QSharpError
     """
     f = open(path, mode="r", encoding="utf-8")

--- a/pip/samples/sample.ipynb
+++ b/pip/samples/sample.ipynb
@@ -12,10 +12,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1e8e4faa",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": "// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT License.\n\n// This file provides CodeMirror syntax highlighting for Q# magic cells\n// in classic Jupyter Notebooks. It does nothing in other (Jupyter Notebook 7,\n// VS Code, Azure Notebooks, etc.) environments.\n\n// Detect the prerequisites and do nothing if they don't exist.\nif (window.require && window.CodeMirror && window.Jupyter) {\n  // The simple mode plugin for CodeMirror is not loaded by default, so require it.\n  window.require([\"codemirror/addon/mode/simple\"], function defineMode() {\n    let rules = [\n      {\n        token: \"comment\",\n        regex: /(\\/\\/).*/,\n        beginWord: false,\n      },\n      {\n        token: \"string\",\n        regex: String.raw`^\\\"(?:[^\\\"\\\\]|\\\\[\\s\\S])*(?:\\\"|$)`,\n        beginWord: false,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(namespace|open|as|operation|function|body|adjoint|newtype|controlled|internal)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(let|set|w\\/|new|not|and|or|use|borrow|using|borrowing|newtype|mutable)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"meta\",\n        regex: String.raw`(Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"atom\",\n        regex: String.raw`(true|false|Pauli(I|X|Y|Z)|One|Zero)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"builtin\",\n        regex: String.raw`(X|Y|Z|H|HY|S|T|SWAP|CNOT|CCNOT|MultiX|R|RFrac|Rx|Ry|Rz|R1|R1Frac|Exp|ExpFrac|Measure|M|MultiM)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"builtin\",\n        regex: String.raw`(Message|Length|Assert|AssertProb|AssertEqual)\\b`,\n        beginWord: true,\n      },\n    ];\n    let simpleRules = [];\n    for (let rule of rules) {\n      simpleRules.push({\n        token: rule.token,\n        regex: new RegExp(rule.regex, \"g\"),\n        sol: rule.beginWord,\n      });\n      if (rule.beginWord) {\n        // Need an additional rule due to the fact that CodeMirror simple mode doesn't work with ^ token\n        simpleRules.push({\n          token: rule.token,\n          regex: new RegExp(String.raw`\\W` + rule.regex, \"g\"),\n          sol: false,\n        });\n      }\n    }\n\n    // Register the mode defined above with CodeMirror\n    window.CodeMirror.defineSimpleMode(\"qsharp\", { start: simpleRules });\n    window.CodeMirror.defineMIME(\"text/x-qsharp\", \"qsharp\");\n\n    // Tell Jupyter to associate %%qsharp magic cells with the qsharp mode\n    window.Jupyter.CodeCell.options_default.highlight_modes[\"qsharp\"] = {\n      reg: [/^%%qsharp/],\n    };\n\n    // Force re-highlighting of all cells the first time this code runs\n    for (const cell of window.Jupyter.notebook.get_cells()) {\n      cell.auto_highlight();\n    }\n  });\n}\n",
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import qsharp"
    ]
@@ -32,10 +41,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "9df62352",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+       "      <th style=\"text-align: left\">Amplitude</th>\n",
+       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">|1⟩</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <progress max=\"100\" value=\"100\"></progress>\n",
+       "    <span style=\"display: inline-block\">100.0000%</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">0.0000</span>\n",
+       "  </td>\n",
+       "</tr>\n",
+       "\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "STATE:\n",
+       "|1⟩: 1.0000+0.0000𝑖"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p>The result of the measurement is One</p>"
+      ],
+      "text/plain": [
+       "The result of the measurement is One"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Result.One"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%qsharp\n",
     "\n",
@@ -64,12 +137,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "7d0995bf",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "STATE:\n",
+      "|1⟩: 1.0000+0.0000𝑖\n",
+      "The result of the measurement is One\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Result.One"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "qsharp.eval(\"Main()\")"
    ]
@@ -84,10 +177,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "50383f8a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result: 3 (type: int)\n"
+     ]
+    }
+   ],
    "source": [
     "result = qsharp.eval(\"1 + 2\")\n",
     "\n",
@@ -106,10 +207,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "33fd3c4d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mQsc.Resolve.NotFound\u001b[0m\n",
+      "\n",
+      "  \u001b[31m×\u001b[0m name error\n",
+      "\u001b[31m  ╰─▶ \u001b[0m`Bar` not found\n",
+      "   ╭─[2:1]\n",
+      " \u001b[2m2\u001b[0m │ operation Foo() : Unit {\n",
+      " \u001b[2m3\u001b[0m │     Bar();\n",
+      "   · \u001b[35;1m    ───\u001b[0m\n",
+      " \u001b[2m4\u001b[0m │     Baz();\n",
+      "   ╰────\n",
+      "\u001b[31mQsc.Resolve.NotFound\u001b[0m\n",
+      "\n",
+      "  \u001b[31m×\u001b[0m name error\n",
+      "\u001b[31m  ╰─▶ \u001b[0m`Baz` not found\n",
+      "   ╭─[3:1]\n",
+      " \u001b[2m3\u001b[0m │     Bar();\n",
+      " \u001b[2m4\u001b[0m │     Baz();\n",
+      "   · \u001b[35;1m    ───\u001b[0m\n",
+      " \u001b[2m5\u001b[0m │ }\n",
+      "   ╰────\n",
+      "\u001b[31mQsc.TypeCk.AmbiguousTy\u001b[0m\n",
+      "\n",
+      "  \u001b[31m×\u001b[0m type error\n",
+      "\u001b[31m  ╰─▶ \u001b[0minsufficient type information to infer type\n",
+      "   ╭─[2:1]\n",
+      " \u001b[2m2\u001b[0m │ operation Foo() : Unit {\n",
+      " \u001b[2m3\u001b[0m │     Bar();\n",
+      "   · \u001b[35;1m    ─────\u001b[0m\n",
+      " \u001b[2m4\u001b[0m │     Baz();\n",
+      "   ╰────\n",
+      "\u001b[36m  help: \u001b[0mprovide a type annotation\n",
+      "\u001b[31mQsc.TypeCk.AmbiguousTy\u001b[0m\n",
+      "\n",
+      "  \u001b[31m×\u001b[0m type error\n",
+      "\u001b[31m  ╰─▶ \u001b[0minsufficient type information to infer type\n",
+      "   ╭─[3:1]\n",
+      " \u001b[2m3\u001b[0m │     Bar();\n",
+      " \u001b[2m4\u001b[0m │     Baz();\n",
+      "   · \u001b[35;1m    ─────\u001b[0m\n",
+      " \u001b[2m5\u001b[0m │ }\n",
+      "   ╰────\n",
+      "\u001b[36m  help: \u001b[0mprovide a type annotation\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "from qsharp import QSharpError\n",
     "\n",
@@ -136,10 +287,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "e70a95d9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Error: Qubit2 released while not in |0⟩ state\n",
+      "Call stack:\n",
+      "    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n",
+      "    at Foo in <expression>\n",
+      "\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n",
+      "\n",
+      "  \u001b[31m×\u001b[0m runtime error\n",
+      "\u001b[31m  ╰─▶ \u001b[0mQubit2 released while not in |0⟩ state\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    qsharp.eval(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")\n",
@@ -157,10 +324,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "d40d86cb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "QSharpError",
+     "evalue": "Error: Qubit3 released while not in |0⟩ state\nCall stack:\n    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n    at Foo in <expression>\n\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n\n  \u001b[31m×\u001b[0m runtime error\n\u001b[31m  ╰─▶ \u001b[0mQubit3 released while not in |0⟩ state\n",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mQSharpError\u001b[0m                               Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[9], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m qsharp\u001b[39m.\u001b[39;49meval(\u001b[39m\"\u001b[39;49m\u001b[39moperation Foo() : Unit \u001b[39;49m\u001b[39m{\u001b[39;49m\u001b[39m use q = Qubit(); X(q) } Foo()\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n",
+      "File \u001b[1;32mc:\\src\\qsharp\\.venv\\Lib\\site-packages\\qsharp\\_qsharp.py:24\u001b[0m, in \u001b[0;36meval\u001b[1;34m(source)\u001b[0m\n\u001b[0;32m     21\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcallback\u001b[39m(output):\n\u001b[0;32m     22\u001b[0m     \u001b[39mprint\u001b[39m(output)\n\u001b[1;32m---> 24\u001b[0m \u001b[39mreturn\u001b[39;00m _interpreter\u001b[39m.\u001b[39;49minterpret(source, callback)\n",
+      "\u001b[1;31mQSharpError\u001b[0m: Error: Qubit3 released while not in |0⟩ state\nCall stack:\n    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n    at Foo in <expression>\n\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n\n  \u001b[31m×\u001b[0m runtime error\n\u001b[31m  ╰─▶ \u001b[0mQubit3 released while not in |0⟩ state\n"
+     ]
+    }
+   ],
    "source": [
     "qsharp.eval(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")"
    ]
@@ -175,12 +355,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "1b55e53c",
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+       "      <th style=\"text-align: left\">Amplitude</th>\n",
+       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">|01111⟩</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <progress max=\"100\" value=\"100\"></progress>\n",
+       "    <span style=\"display: inline-block\">100.0000%</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">0.0000</span>\n",
+       "  </td>\n",
+       "</tr>\n",
+       "\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "STATE:\n",
+       "|01111⟩: 1.0000+0.0000𝑖"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Error: Qubit4 released while not in |0⟩ state\n",
+       "Call stack:\n",
+       "    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n",
+       "    at Bar in <expression>\n",
+       "\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n",
+       "\n",
+       "  \u001b[31m×\u001b[0m runtime error\n",
+       "\u001b[31m  ╰─▶ \u001b[0mQubit4 released while not in |0⟩ state\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%qsharp\n",
     "\n",
@@ -203,10 +441,288 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "bd25ae87",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p>Generating random bit... </p>"
+      ],
+      "text/plain": [
+       "Generating random bit... "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+       "      <th style=\"text-align: left\">Amplitude</th>\n",
+       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">|011111⟩</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <progress max=\"100\" value=\"100\"></progress>\n",
+       "    <span style=\"display: inline-block\">100.0000%</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">0.0000</span>\n",
+       "  </td>\n",
+       "</tr>\n",
+       "\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "STATE:\n",
+       "|011111⟩: 1.0000+0.0000𝑖"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p>Result: Zero</p>"
+      ],
+      "text/plain": [
+       "Result: Zero"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+       "      <th style=\"text-align: left\">Amplitude</th>\n",
+       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">|111111⟩</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <progress max=\"100\" value=\"100\"></progress>\n",
+       "    <span style=\"display: inline-block\">100.0000%</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">0.0000</span>\n",
+       "  </td>\n",
+       "</tr>\n",
+       "\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "STATE:\n",
+       "|111111⟩: 1.0000+0.0000𝑖"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p>Result: One</p>"
+      ],
+      "text/plain": [
+       "Result: One"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+       "      <th style=\"text-align: left\">Amplitude</th>\n",
+       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">|111111⟩</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <progress max=\"100\" value=\"100\"></progress>\n",
+       "    <span style=\"display: inline-block\">100.0000%</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">0.0000</span>\n",
+       "  </td>\n",
+       "</tr>\n",
+       "\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "STATE:\n",
+       "|111111⟩: 1.0000+0.0000𝑖"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p>Result: One</p>"
+      ],
+      "text/plain": [
+       "Result: One"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+       "      <th style=\"text-align: left\">Amplitude</th>\n",
+       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">|011111⟩</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <progress max=\"100\" value=\"100\"></progress>\n",
+       "    <span style=\"display: inline-block\">100.0000%</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">0.0000</span>\n",
+       "  </td>\n",
+       "</tr>\n",
+       "\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "STATE:\n",
+       "|011111⟩: 1.0000+0.0000𝑖"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p>Result: Zero</p>"
+      ],
+      "text/plain": [
+       "Result: Zero"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+       "      <th style=\"text-align: left\">Amplitude</th>\n",
+       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">|111111⟩</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <progress max=\"100\" value=\"100\"></progress>\n",
+       "    <span style=\"display: inline-block\">100.0000%</span>\n",
+       "  </td>\n",
+       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+       "  <td style=\"text-align: left\">\n",
+       "    <span style=\"display: inline-block\">0.0000</span>\n",
+       "  </td>\n",
+       "</tr>\n",
+       "\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "STATE:\n",
+       "|111111⟩: 1.0000+0.0000𝑖"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p>Result: One</p>"
+      ],
+      "text/plain": [
+       "Result: One"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%qsharp\n",
     "\n",

--- a/pip/samples/sample.ipynb
+++ b/pip/samples/sample.ipynb
@@ -12,116 +12,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "1e8e4faa",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "// Copyright (c) Microsoft Corporation.\n",
-       "// Licensed under the MIT License.\n",
-       "\n",
-       "\n",
-       "// This file provides CodeMirror syntax highlighting for Q# magic cells\n",
-       "// in classic Jupyter Notebooks. It does nothing in other (Jupyter Notebook 7, \n",
-       "// VS Code, Azure Notebooks, etc.) environments.\n",
-       "\n",
-       "\n",
-       "// Detect the prerequisites and do nothing if they don't exist.\n",
-       "if (window.require && window.CodeMirror && window.Jupyter) {\n",
-       "\n",
-       "    // The simple mode plugin for CodeMirror is not loaded by default, so require it.\n",
-       "    window.require(['codemirror/addon/mode/simple'], function defineMode() {\n",
-       "        let rules = [\n",
-       "            {\n",
-       "                token: \"comment\",\n",
-       "                regex: /(\\/\\/).*/,\n",
-       "                beginWord: false,\n",
-       "            },\n",
-       "            {\n",
-       "                token: \"string\",\n",
-       "                regex: String.raw`^\\\"(?:[^\\\"\\\\]|\\\\[\\s\\S])*(?:\\\"|$)`,\n",
-       "                beginWord: false,\n",
-       "            },\n",
-       "            {\n",
-       "                token: \"keyword\",\n",
-       "                regex: String.raw`(namespace|open|as|operation|function|body|adjoint|newtype|controlled|internal)\\b`,\n",
-       "                beginWord: true,\n",
-       "            },\n",
-       "            {\n",
-       "                token: \"keyword\",\n",
-       "                regex: String.raw`(if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\\b`,\n",
-       "                beginWord: true,\n",
-       "            },\n",
-       "            {\n",
-       "                token: \"keyword\",\n",
-       "                regex: String.raw`(Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\\b`,\n",
-       "                beginWord: true,\n",
-       "            },\n",
-       "            {\n",
-       "                token: \"keyword\",\n",
-       "                regex: String.raw`(let|set|w\\/|new|not|and|or|use|borrow|using|borrowing|newtype|mutable)\\b`,\n",
-       "                beginWord: true,\n",
-       "            },\n",
-       "            {\n",
-       "                token: \"meta\",\n",
-       "                regex: String.raw`(Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\\b`,\n",
-       "                beginWord: true,\n",
-       "            },\n",
-       "            {\n",
-       "                token: \"atom\",\n",
-       "                regex: String.raw`(true|false|Pauli(I|X|Y|Z)|One|Zero)\\b`,\n",
-       "                beginWord: true,\n",
-       "            },\n",
-       "            {\n",
-       "                token: \"builtin\",\n",
-       "                regex: String.raw`(X|Y|Z|H|HY|S|T|SWAP|CNOT|CCNOT|MultiX|R|RFrac|Rx|Ry|Rz|R1|R1Frac|Exp|ExpFrac|Measure|M|MultiM)\\b`,\n",
-       "                beginWord: true,\n",
-       "            },\n",
-       "            {\n",
-       "                token: \"builtin\",\n",
-       "                regex: String.raw`(Message|Length|Assert|AssertProb|AssertEqual)\\b`,\n",
-       "                beginWord: true,\n",
-       "            }\n",
-       "        ];\n",
-       "        let simpleRules = [];\n",
-       "        for (let rule of rules) {\n",
-       "            simpleRules.push({\n",
-       "                \"token\": rule.token,\n",
-       "                \"regex\": new RegExp(rule.regex, \"g\"),\n",
-       "                \"sol\": rule.beginWord\n",
-       "            });\n",
-       "            if (rule.beginWord) {\n",
-       "                // Need an additional rule due to the fact that CodeMirror simple mode doesn't work with ^ token\n",
-       "                simpleRules.push({\n",
-       "                    \"token\": rule.token,\n",
-       "                    \"regex\": new RegExp(String.raw`\\W` + rule.regex, \"g\"),\n",
-       "                    \"sol\": false\n",
-       "                });\n",
-       "            }\n",
-       "        }\n",
-       "\n",
-       "        // Register the mode defined above with CodeMirror\n",
-       "        window.CodeMirror.defineSimpleMode('qsharp', { start: simpleRules });\n",
-       "        window.CodeMirror.defineMIME(\"text/x-qsharp\", \"qsharp\");\n",
-       "\n",
-       "        // Tell Jupyter to associate %%qsharp magic cells with the qsharp mode\n",
-       "        window.Jupyter.CodeCell.options_default.highlight_modes['qsharp'] = { 'reg': [/^%%qsharp/] }\n",
-       "\n",
-       "        // Force re-highlighting of all cells the first time this code runs\n",
-       "        for (const cell of window.Jupyter.notebook.get_cells()) {\n",
-       "            cell.auto_highlight();\n",
-       "        }\n",
-       "    });\n",
-       "}\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import qsharp"
    ]
@@ -138,65 +32,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "9df62352",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "    <thead><tr>\n",
-       "      <th style=\"text-align: left;\">Basis State<br/>(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left;\">Amplitude</th>\n",
-       "      <th style=\"text-align: left;\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left;\" colspan=\"2\">Phase</th>\n",
-       "    </tr></thead>\n",
-       "    <tbody><tr>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">|1⟩</span></td>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">1.0000+0.0000𝑖</span></td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <progress max=\"100\" value=\"100\"></progress>\n",
-       "        <span style=\"display: inline-block;\">100.0000%</span>\n",
-       "    </td>\n",
-       "    <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <span style=\"display: inline-block;\">0.0000</span>\n",
-       "    </td>\n",
-       "</tr></tbody>\n",
-       " </table>"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|1⟩: 1.0000+0.0000i"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>The result of the measurement is One</p>"
-      ],
-      "text/plain": [
-       "The result of the measurement is One"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Result.One"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%qsharp\n",
     "\n",
@@ -218,41 +57,21 @@
    "id": "4584c494",
    "metadata": {},
    "source": [
-    "`qsharp.interpret()` does the same thing as the `%%qsharp` magic.\n",
+    "`qsharp.eval()` does the same thing as the `%%qsharp` magic.\n",
     "\n",
     "`DumpMachine()` and `Message()` print to stdout and get displayed in the notebook as plain text"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "7d0995bf",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "STATE:\n",
-      "|1⟩: 1.0000+0.0000i\n",
-      "The result of the measurement is One\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Result.One"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "qsharp.interpret(\"Main()\")"
+    "qsharp.eval(\"Main()\")"
    ]
   },
   {
@@ -265,20 +84,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "50383f8a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result: 3 (type: int)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "result = qsharp.interpret(\"1 + 2\")\n",
+    "result = qsharp.eval(\"1 + 2\")\n",
     "\n",
     "print(f\"Result: {result} (type: {type(result).__name__})\")"
    ]
@@ -295,41 +106,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "33fd3c4d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  \u001b[31m×\u001b[0m name error\n",
-      "\u001b[31m  ╰─▶ \u001b[0m`Bar` not found in this scope\n",
-      "   ╭─[2:1]\n",
-      " \u001b[2m2\u001b[0m │ operation Foo() : Unit {\n",
-      " \u001b[2m3\u001b[0m │     Bar();\n",
-      "   · \u001b[35;1m    ───\u001b[0m\n",
-      " \u001b[2m4\u001b[0m │     Baz();\n",
-      "   ╰────\n",
-      "\n",
-      "  \u001b[31m×\u001b[0m name error\n",
-      "\u001b[31m  ╰─▶ \u001b[0m`Baz` not found in this scope\n",
-      "   ╭─[3:1]\n",
-      " \u001b[2m3\u001b[0m │     Bar();\n",
-      " \u001b[2m4\u001b[0m │     Baz();\n",
-      "   · \u001b[35;1m    ───\u001b[0m\n",
-      " \u001b[2m5\u001b[0m │ }\n",
-      "   ╰────\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qsharp import QSharpError\n",
     "\n",
     "try:\n",
-    "    qsharp.interpret(\n",
+    "    qsharp.eval(\n",
     "        \"\"\"\n",
     "operation Foo() : Unit {\n",
     "    Bar();\n",
@@ -351,31 +136,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "e70a95d9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Error: Qubit0 released while not in |0⟩ state\n",
-      "Call stack:\n",
-      "    at Foo in <expression>\n",
-      "\n",
-      "  \u001b[31m×\u001b[0m runtime error\n",
-      "\u001b[31m  ╰─▶ \u001b[0mQubit0 released while not in |0⟩ state\n",
-      "   ╭────\n",
-      " \u001b[2m1\u001b[0m │ operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\n",
-      "   · \u001b[35;1m                                 ───────\u001b[0m\n",
-      "   ╰────\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "try:\n",
-    "    qsharp.interpret(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")\n",
+    "    qsharp.eval(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")\n",
     "except QSharpError as ex:\n",
     "    print(ex)"
    ]
@@ -390,25 +157,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "d40d86cb",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "QSharpError",
-     "evalue": "Error: Qubit1 released while not in |0⟩ state\nCall stack:\n    at Foo in <expression>\n\n  \u001b[31m×\u001b[0m runtime error\n\u001b[31m  ╰─▶ \u001b[0mQubit1 released while not in |0⟩ state\n   ╭────\n \u001b[2m1\u001b[0m │ operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\n   · \u001b[35;1m                                 ───────\u001b[0m\n   ╰────\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mQSharpError\u001b[0m                               Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m qsharp\u001b[38;5;241m.\u001b[39minterpret(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124moperation Foo() : Unit \u001b[39m\u001b[38;5;124m{\u001b[39m\u001b[38;5;124m use q = Qubit(); X(q) } Foo()\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "File \u001b[0;32m~/src/qsharp/pip/qsharp/_qsharp.py:23\u001b[0m, in \u001b[0;36minterpret\u001b[0;34m(line)\u001b[0m\n\u001b[1;32m     20\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcallback\u001b[39m(output):\n\u001b[1;32m     21\u001b[0m     \u001b[38;5;28mprint\u001b[39m(output)\n\u001b[0;32m---> 23\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m _interpreter\u001b[38;5;241m.\u001b[39minterpret(line, callback)\n",
-      "\u001b[0;31mQSharpError\u001b[0m: Error: Qubit1 released while not in |0⟩ state\nCall stack:\n    at Foo in <expression>\n\n  \u001b[31m×\u001b[0m runtime error\n\u001b[31m  ╰─▶ \u001b[0mQubit1 released while not in |0⟩ state\n   ╭────\n \u001b[2m1\u001b[0m │ operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\n   · \u001b[35;1m                                 ───────\u001b[0m\n   ╰────\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "qsharp.interpret(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")"
+    "qsharp.eval(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")"
    ]
   },
   {
@@ -421,65 +175,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "1b55e53c",
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "    <thead><tr>\n",
-       "      <th style=\"text-align: left;\">Basis State<br/>(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left;\">Amplitude</th>\n",
-       "      <th style=\"text-align: left;\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left;\" colspan=\"2\">Phase</th>\n",
-       "    </tr></thead>\n",
-       "    <tbody><tr>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">|011⟩</span></td>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">1.0000+0.0000𝑖</span></td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <progress max=\"100\" value=\"100\"></progress>\n",
-       "        <span style=\"display: inline-block;\">100.0000%</span>\n",
-       "    </td>\n",
-       "    <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <span style=\"display: inline-block;\">0.0000</span>\n",
-       "    </td>\n",
-       "</tr></tbody>\n",
-       " </table>"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|011⟩: 1.0000+0.0000i"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Error: Qubit2 released while not in |0⟩ state\n",
-       "Call stack:\n",
-       "    at Bar in <expression>\n",
-       "\n",
-       "  \u001b[31m×\u001b[0m runtime error\n",
-       "\u001b[31m  ╰─▶ \u001b[0mQubit2 released while not in |0⟩ state\n",
-       "   ╭─[2:1]\n",
-       " \u001b[2m2\u001b[0m │ operation Bar() : Unit {\n",
-       " \u001b[2m3\u001b[0m │     use q = Qubit(); \n",
-       "   · \u001b[35;1m            ───────\u001b[0m\n",
-       " \u001b[2m4\u001b[0m │     Microsoft.Quantum.Diagnostics.DumpMachine(); \n",
-       "   ╰────\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%qsharp\n",
     "\n",
@@ -502,243 +203,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "bd25ae87",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<p>Generating random bit... </p>"
-      ],
-      "text/plain": [
-       "Generating random bit... "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "    <thead><tr>\n",
-       "      <th style=\"text-align: left;\">Basis State<br/>(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left;\">Amplitude</th>\n",
-       "      <th style=\"text-align: left;\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left;\" colspan=\"2\">Phase</th>\n",
-       "    </tr></thead>\n",
-       "    <tbody><tr>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">|0111⟩</span></td>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">1.0000+0.0000𝑖</span></td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <progress max=\"100\" value=\"100\"></progress>\n",
-       "        <span style=\"display: inline-block;\">100.0000%</span>\n",
-       "    </td>\n",
-       "    <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <span style=\"display: inline-block;\">0.0000</span>\n",
-       "    </td>\n",
-       "</tr></tbody>\n",
-       " </table>"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|0111⟩: 1.0000+0.0000i"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: Zero</p>"
-      ],
-      "text/plain": [
-       "Result: Zero"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "    <thead><tr>\n",
-       "      <th style=\"text-align: left;\">Basis State<br/>(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left;\">Amplitude</th>\n",
-       "      <th style=\"text-align: left;\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left;\" colspan=\"2\">Phase</th>\n",
-       "    </tr></thead>\n",
-       "    <tbody><tr>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">|0111⟩</span></td>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">1.0000+0.0000𝑖</span></td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <progress max=\"100\" value=\"100\"></progress>\n",
-       "        <span style=\"display: inline-block;\">100.0000%</span>\n",
-       "    </td>\n",
-       "    <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <span style=\"display: inline-block;\">0.0000</span>\n",
-       "    </td>\n",
-       "</tr></tbody>\n",
-       " </table>"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|0111⟩: 1.0000+0.0000i"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: Zero</p>"
-      ],
-      "text/plain": [
-       "Result: Zero"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "    <thead><tr>\n",
-       "      <th style=\"text-align: left;\">Basis State<br/>(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left;\">Amplitude</th>\n",
-       "      <th style=\"text-align: left;\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left;\" colspan=\"2\">Phase</th>\n",
-       "    </tr></thead>\n",
-       "    <tbody><tr>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">|0111⟩</span></td>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">1.0000+0.0000𝑖</span></td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <progress max=\"100\" value=\"100\"></progress>\n",
-       "        <span style=\"display: inline-block;\">100.0000%</span>\n",
-       "    </td>\n",
-       "    <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <span style=\"display: inline-block;\">0.0000</span>\n",
-       "    </td>\n",
-       "</tr></tbody>\n",
-       " </table>"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|0111⟩: 1.0000+0.0000i"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: Zero</p>"
-      ],
-      "text/plain": [
-       "Result: Zero"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "    <thead><tr>\n",
-       "      <th style=\"text-align: left;\">Basis State<br/>(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left;\">Amplitude</th>\n",
-       "      <th style=\"text-align: left;\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left;\" colspan=\"2\">Phase</th>\n",
-       "    </tr></thead>\n",
-       "    <tbody><tr>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">|0111⟩</span></td>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">1.0000+0.0000𝑖</span></td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <progress max=\"100\" value=\"100\"></progress>\n",
-       "        <span style=\"display: inline-block;\">100.0000%</span>\n",
-       "    </td>\n",
-       "    <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <span style=\"display: inline-block;\">0.0000</span>\n",
-       "    </td>\n",
-       "</tr></tbody>\n",
-       " </table>"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|0111⟩: 1.0000+0.0000i"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: Zero</p>"
-      ],
-      "text/plain": [
-       "Result: Zero"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "    <thead><tr>\n",
-       "      <th style=\"text-align: left;\">Basis State<br/>(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left;\">Amplitude</th>\n",
-       "      <th style=\"text-align: left;\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left;\" colspan=\"2\">Phase</th>\n",
-       "    </tr></thead>\n",
-       "    <tbody><tr>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">|0111⟩</span></td>\n",
-       "    <td style=\"text-align: left;\"><span style=\"display: inline-block;\">1.0000+0.0000𝑖</span></td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <progress max=\"100\" value=\"100\"></progress>\n",
-       "        <span style=\"display: inline-block;\">100.0000%</span>\n",
-       "    </td>\n",
-       "    <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "    <td style=\"text-align: left;\">\n",
-       "        <span style=\"display: inline-block;\">0.0000</span>\n",
-       "    </td>\n",
-       "</tr></tbody>\n",
-       " </table>"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|0111⟩: 1.0000+0.0000i"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: Zero</p>"
-      ],
-      "text/plain": [
-       "Result: Zero"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%qsharp\n",
     "\n",
@@ -778,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -12,7 +12,7 @@ import io
 def test_stdout() -> None:
     f = io.StringIO()
     with redirect_stdout(f):
-        result = qsharp.interpret('Message("Hello, world!")')
+        result = qsharp.eval('Message("Hello, world!")')
 
     assert result is None
     assert f.getvalue() == "Hello, world!\n"
@@ -21,7 +21,7 @@ def test_stdout() -> None:
 def test_stdout_multiple_lines() -> None:
     f = io.StringIO()
     with redirect_stdout(f):
-        qsharp.interpret(
+        qsharp.eval(
             """
         use q = Qubit();
         Microsoft.Quantum.Diagnostics.DumpMachine();


### PR DESCRIPTION
A while back during the spec review we decided that `eval()` would be a more user-friendly name (echoing Python's `eval()`).

Dropping the name "interpret" from all user-facing contexts. We continue to use "interpreter" in the implementation though.