### PR TITLE
Use `@` to identify and ignore generated locals

### DIFF
--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -543,7 +543,11 @@ impl Interpreter {
 
     #[must_use]
     pub fn get_locals(&self) -> Vec<VariableInfo> {
-        self.env.get_variables_in_top_frame()
+        self.env
+            .get_variables_in_top_frame()
+            .into_iter()
+            .filter(|v| !v.name.starts_with('@'))
+            .collect()
     }
 }
 

--- a/compiler/qsc_passes/src/common.rs
+++ b/compiler/qsc_passes/src/common.rs
@@ -13,6 +13,10 @@ use qsc_hir::{
 };
 use std::rc::Rc;
 
+pub(crate) fn generated_name(name: &str) -> Rc<str> {
+    Rc::from(format!("@{name}"))
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct IdentTemplate {
     pub id: NodeId,

--- a/compiler/qsc_passes/src/conjugate_invert.rs
+++ b/compiler/qsc_passes/src/conjugate_invert.rs
@@ -23,6 +23,7 @@ use qsc_hir::{
 use thiserror::Error;
 
 use crate::{
+    common::generated_name,
     id_update::NodeIdRefresher,
     invert_block::adj_invert_block,
     spec_gen::adj_gen::{self, AdjDistrib},
@@ -192,7 +193,7 @@ impl ConjugateElim<'_> {
                         kind: PatKind::Bind(Ident {
                             id: bind_id,
                             span: Span::default(),
-                            name: "apply_res".into(),
+                            name: generated_name("apply_res"),
                         }),
                     },
                     self.block_as_expr(block, ty),

--- a/compiler/qsc_passes/src/conjugate_invert/tests.rs
+++ b/compiler/qsc_passes/src/conjugate_invert/tests.rs
@@ -77,7 +77,7 @@ fn conjugate_invert() {
                                             Expr 20 [133-134] [Type (Int => Unit is Adj)]: Var: Item 1
                                             Expr 21 [135-136] [Type Int]: Lit: Int(2)
                                     Stmt 44 [0-0]: Local (Immutable):
-                                        Pat 45 [0-0] [Type Unit]: Bind: Ident 43 [0-0] "apply_res"
+                                        Pat 45 [0-0] [Type Unit]: Bind: Ident 43 [0-0] "@apply_res"
                                         Expr 46 [0-0] [Type Unit]: Expr Block: Block 22 [163-210] [Type Unit]:
                                             Stmt 23 [177-182]: Semi: Expr 24 [177-181] [Type Unit]: Call:
                                                 Expr 25 [177-178] [Type (Int => Unit is Adj)]: Var: Item 1
@@ -157,7 +157,7 @@ fn conjugate_invert_with_output() {
                                                 Expr 22 [142-143] [Type (Int => Unit is Adj)]: Var: Item 1
                                                 Expr 23 [144-145] [Type Int]: Lit: Int(2)
                                         Stmt 50 [0-0]: Local (Immutable):
-                                            Pat 51 [0-0] [Type Int]: Bind: Ident 49 [0-0] "apply_res"
+                                            Pat 51 [0-0] [Type Int]: Bind: Ident 49 [0-0] "@apply_res"
                                             Expr 52 [0-0] [Type Int]: Expr Block: Block 24 [172-233] [Type Int]:
                                                 Stmt 25 [186-191]: Semi: Expr 26 [186-190] [Type Unit]: Call:
                                                     Expr 27 [186-187] [Type (Int => Unit is Adj)]: Var: Item 1
@@ -247,7 +247,7 @@ fn nested_conjugate_invert() {
                                                     Expr 27 [180-181] [Type (Int => Unit is Adj)]: Var: Item 1
                                                     Expr 28 [182-183] [Type Int]: Lit: Int(2)
                                             Stmt 100 [0-0]: Local (Immutable):
-                                                Pat 101 [0-0] [Type Unit]: Bind: Ident 99 [0-0] "apply_res"
+                                                Pat 101 [0-0] [Type Unit]: Bind: Ident 99 [0-0] "@apply_res"
                                                 Expr 102 [0-0] [Type Unit]: Expr Block: Block 29 [218-277] [Type Unit]:
                                                     Stmt 30 [236-241]: Semi: Expr 31 [236-240] [Type Unit]: Call:
                                                         Expr 32 [236-237] [Type (Int => Unit is Adj)]: Var: Item 1
@@ -266,7 +266,7 @@ fn nested_conjugate_invert() {
                                                     Expr 98 [160-161] [Type Int]: Lit: Int(1)
                                             Stmt 108 [0-0]: Expr: Expr 109 [0-0] [Type Unit]: Var: Local 99
                                     Stmt 77 [0-0]: Local (Immutable):
-                                        Pat 78 [0-0] [Type Unit]: Bind: Ident 76 [0-0] "apply_res"
+                                        Pat 78 [0-0] [Type Unit]: Bind: Ident 76 [0-0] "@apply_res"
                                         Expr 79 [0-0] [Type Unit]: Expr Block: Block 38 [302-349] [Type Unit]:
                                             Stmt 39 [316-321]: Semi: Expr 40 [316-320] [Type Unit]: Call:
                                                 Expr 41 [316-317] [Type (Int => Unit is Adj)]: Var: Item 1
@@ -284,7 +284,7 @@ fn nested_conjugate_invert() {
                                                     Expr 58 [180-181] [Type (Int => Unit is Adj)]: Var: Item 1
                                                     Expr 59 [182-183] [Type Int]: Lit: Int(2)
                                             Stmt 123 [0-0]: Local (Immutable):
-                                                Pat 124 [0-0] [Type Unit]: Bind: Ident 122 [0-0] "apply_res"
+                                                Pat 124 [0-0] [Type Unit]: Bind: Ident 122 [0-0] "@apply_res"
                                                 Expr 125 [0-0] [Type Unit]: Expr Block: Block 60 [218-277] [Type Unit]:
                                                     Stmt 61 [258-263]: Semi: Expr 62 [258-262] [Type Unit]: Call:
                                                         Expr 63 [258-259] [Type (Int => Unit is Adj)]: UnOp (Functor Adj):
@@ -520,7 +520,7 @@ fn conjugate_mutable_correct_use_succeeds() {
                                             Pat 31 [201-202] [Type Int]: Bind: Ident 32 [201-202] "y"
                                             Expr 33 [205-206] [Type Int]: Var: Local 20
                                     Stmt 72 [0-0]: Local (Immutable):
-                                        Pat 73 [0-0] [Type Unit]: Bind: Ident 71 [0-0] "apply_res"
+                                        Pat 73 [0-0] [Type Unit]: Bind: Ident 71 [0-0] "@apply_res"
                                         Expr 74 [0-0] [Type Unit]: Expr Block: Block 34 [232-329] [Type Unit]:
                                             Stmt 35 [246-260]: Local (Mutable):
                                                 Pat 36 [254-255] [Type Int]: Bind: Ident 37 [254-255] "b"

--- a/compiler/qsc_passes/src/invert_block.rs
+++ b/compiler/qsc_passes/src/invert_block.rs
@@ -16,7 +16,7 @@ use qsc_hir::{
 };
 
 use crate::{
-    common::create_gen_core_ref,
+    common::{create_gen_core_ref, generated_name},
     logic_sep::{find_quantum_stmts, Error},
 };
 
@@ -134,7 +134,7 @@ impl<'a> BlockInverter<'a> {
                     kind: PatKind::Bind(Ident {
                         id: new_arr_id,
                         span: Span::default(),
-                        name: "generated_array".into(),
+                        name: generated_name("array"),
                     }),
                 },
                 iterable,
@@ -150,7 +150,7 @@ impl<'a> BlockInverter<'a> {
             kind: PatKind::Bind(Ident {
                 id: index_id,
                 span: Span::default(),
-                name: "generated_index".into(),
+                name: generated_name("index"),
             }),
         };
 
@@ -228,7 +228,7 @@ impl<'a> BlockInverter<'a> {
                     kind: PatKind::Bind(Ident {
                         id: new_range_id,
                         span: Span::default(),
-                        name: "generated_range".into(),
+                        name: generated_name("range"),
                     }),
                 },
                 iterable.clone(),

--- a/compiler/qsc_passes/src/loop_unification.rs
+++ b/compiler/qsc_passes/src/loop_unification.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use core::panic;
-use std::{mem::take, rc::Rc};
+use std::mem::take;
 
 use qsc_data_structures::span::Span;
 use qsc_hir::{
@@ -13,7 +13,7 @@ use qsc_hir::{
     ty::{GenericArg, Prim, Ty},
 };
 
-use crate::common::{create_gen_core_ref, IdentTemplate};
+use crate::common::{create_gen_core_ref, generated_name, IdentTemplate};
 
 #[cfg(test)]
 mod tests;
@@ -312,7 +312,7 @@ impl LoopUni<'_> {
             id,
             span,
             ty,
-            name: Rc::from(format!("{label}_{id}")),
+            name: generated_name(&format!("{label}_{id}")),
         }
     }
 }

--- a/compiler/qsc_passes/src/loop_unification/tests.rs
+++ b/compiler/qsc_passes/src/loop_unification/tests.rs
@@ -51,10 +51,10 @@ fn convert_for_array() {
                             Block 5 [56-131] [Type Unit]:
                                 Stmt 6 [66-125]: Expr: Expr 43 [66-125] [Type Unit]: Expr Block: Block 44 [66-125] [Type Unit]:
                                     Stmt 18 [75-78]: Local (Immutable):
-                                        Pat 19 [75-78] [Type (Int)[]]: Bind: Ident 17 [75-78] "array_id_17"
+                                        Pat 19 [75-78] [Type (Int)[]]: Bind: Ident 17 [75-78] "@array_id_17"
                                         Expr 10 [75-78] [Type (Int)[]]: Var: Local 3
                                     Stmt 24 [75-78]: Local (Immutable):
-                                        Pat 25 [75-78] [Type Int]: Bind: Ident 21 [75-78] "len_id_21"
+                                        Pat 25 [75-78] [Type Int]: Bind: Ident 21 [75-78] "@len_id_21"
                                         Expr 22 [75-78] [Type (Int)[]]: Call:
                                             Expr 20 [75-78] [Type ((Int)[] -> Int)]: Var:
                                                 res: Item 1 (Package 0)
@@ -62,7 +62,7 @@ fn convert_for_array() {
                                                     Int
                                             Expr 23 [75-78] [Type (Int)[]]: Var: Local 17
                                     Stmt 28 [75-78]: Local (Mutable):
-                                        Pat 29 [75-78] [Type Int]: Bind: Ident 26 [75-78] "index_id_26"
+                                        Pat 29 [75-78] [Type Int]: Bind: Ident 26 [75-78] "@index_id_26"
                                         Expr 27 [75-78] [Type Int]: Lit: Int(0)
                                     Stmt 41 [66-125]: Expr: Expr 42 [66-125] [Type Unit]: While:
                                         Expr 38 [75-78] [Type Bool]: BinOp (Lt):
@@ -114,10 +114,10 @@ fn convert_for_array_deconstruct() {
                             Block 5 [66-146] [Type Unit]:
                                 Stmt 6 [76-140]: Expr: Expr 46 [76-140] [Type Unit]: Expr Block: Block 47 [76-140] [Type Unit]:
                                     Stmt 21 [90-93]: Local (Immutable):
-                                        Pat 22 [90-93] [Type ((Int, Double))[]]: Bind: Ident 20 [90-93] "array_id_20"
+                                        Pat 22 [90-93] [Type ((Int, Double))[]]: Bind: Ident 20 [90-93] "@array_id_20"
                                         Expr 13 [90-93] [Type ((Int, Double))[]]: Var: Local 3
                                     Stmt 27 [90-93]: Local (Immutable):
-                                        Pat 28 [90-93] [Type Int]: Bind: Ident 24 [90-93] "len_id_24"
+                                        Pat 28 [90-93] [Type Int]: Bind: Ident 24 [90-93] "@len_id_24"
                                         Expr 25 [90-93] [Type ((Int, Double))[]]: Call:
                                             Expr 23 [90-93] [Type (((Int, Double))[] -> Int)]: Var:
                                                 res: Item 1 (Package 0)
@@ -125,7 +125,7 @@ fn convert_for_array_deconstruct() {
                                                     (Int, Double)
                                             Expr 26 [90-93] [Type ((Int, Double))[]]: Var: Local 20
                                     Stmt 31 [90-93]: Local (Mutable):
-                                        Pat 32 [90-93] [Type Int]: Bind: Ident 29 [90-93] "index_id_29"
+                                        Pat 32 [90-93] [Type Int]: Bind: Ident 29 [90-93] "@index_id_29"
                                         Expr 30 [90-93] [Type Int]: Lit: Int(0)
                                     Stmt 44 [76-140]: Expr: Expr 45 [76-140] [Type Unit]: While:
                                         Expr 41 [90-93] [Type Bool]: BinOp (Lt):
@@ -179,7 +179,7 @@ fn convert_for_slice() {
                             Block 5 [56-141] [Type Unit]:
                                 Stmt 6 [66-135]: Expr: Expr 49 [66-135] [Type Unit]: Expr Block: Block 50 [66-135] [Type Unit]:
                                     Stmt 24 [75-88]: Local (Immutable):
-                                        Pat 25 [75-88] [Type (Int)[]]: Bind: Ident 23 [75-88] "array_id_23"
+                                        Pat 25 [75-88] [Type (Int)[]]: Bind: Ident 23 [75-88] "@array_id_23"
                                         Expr 10 [75-88] [Type (Int)[]]: Index:
                                             Expr 11 [75-78] [Type (Int)[]]: Var: Local 3
                                             Expr 12 [79-87] [Type Range]: Range:
@@ -188,7 +188,7 @@ fn convert_for_slice() {
                                                     Expr 15 [83-84] [Type Int]: Lit: Int(2)
                                                 Expr 16 [86-87] [Type Int]: Lit: Int(2)
                                     Stmt 30 [75-88]: Local (Immutable):
-                                        Pat 31 [75-88] [Type Int]: Bind: Ident 27 [75-88] "len_id_27"
+                                        Pat 31 [75-88] [Type Int]: Bind: Ident 27 [75-88] "@len_id_27"
                                         Expr 28 [75-88] [Type (Int)[]]: Call:
                                             Expr 26 [75-88] [Type ((Int)[] -> Int)]: Var:
                                                 res: Item 1 (Package 0)
@@ -196,7 +196,7 @@ fn convert_for_slice() {
                                                     Int
                                             Expr 29 [75-88] [Type (Int)[]]: Var: Local 23
                                     Stmt 34 [75-88]: Local (Mutable):
-                                        Pat 35 [75-88] [Type Int]: Bind: Ident 32 [75-88] "index_id_32"
+                                        Pat 35 [75-88] [Type Int]: Bind: Ident 32 [75-88] "@index_id_32"
                                         Expr 33 [75-88] [Type Int]: Lit: Int(0)
                                     Stmt 47 [66-135]: Expr: Expr 48 [66-135] [Type Unit]: While:
                                         Expr 44 [75-88] [Type Bool]: BinOp (Lt):
@@ -248,23 +248,23 @@ fn convert_for_range() {
                             Block 4 [45-121] [Type Unit]:
                                 Stmt 5 [55-115]: Expr: Expr 59 [55-115] [Type Unit]: Expr Block: Block 60 [55-115] [Type Unit]:
                                     Stmt 19 [64-68]: Local (Immutable):
-                                        Pat 20 [64-68] [Type Range]: Bind: Ident 18 [64-68] "range_id_18"
+                                        Pat 20 [64-68] [Type Range]: Bind: Ident 18 [64-68] "@range_id_18"
                                         Expr 9 [64-68] [Type Range]: Range:
                                             Expr 10 [64-65] [Type Int]: Lit: Int(0)
                                             <no step>
                                             Expr 11 [67-68] [Type Int]: Lit: Int(4)
                                     Stmt 24 [64-68]: Local (Mutable):
-                                        Pat 25 [64-68] [Type Int]: Bind: Ident 21 [64-68] "index_id_21"
+                                        Pat 25 [64-68] [Type Int]: Bind: Ident 21 [64-68] "@index_id_21"
                                         Expr 22 [64-68] [Type Int]: Field:
                                             Expr 23 [64-68] [Type Range]: Var: Local 18
                                             Prim(Start)
                                     Stmt 29 [64-68]: Local (Immutable):
-                                        Pat 30 [64-68] [Type Int]: Bind: Ident 26 [64-68] "step_id_26"
+                                        Pat 30 [64-68] [Type Int]: Bind: Ident 26 [64-68] "@step_id_26"
                                         Expr 27 [64-68] [Type Int]: Field:
                                             Expr 28 [64-68] [Type Range]: Var: Local 18
                                             Prim(Step)
                                     Stmt 34 [64-68]: Local (Immutable):
-                                        Pat 35 [64-68] [Type Int]: Bind: Ident 31 [64-68] "end_id_31"
+                                        Pat 35 [64-68] [Type Int]: Bind: Ident 31 [64-68] "@end_id_31"
                                         Expr 32 [64-68] [Type Int]: Field:
                                             Expr 33 [64-68] [Type Range]: Var: Local 18
                                             Prim(End)
@@ -328,24 +328,24 @@ fn convert_for_reverse_range() {
                             Block 4 [45-125] [Type Unit]:
                                 Stmt 5 [55-119]: Expr: Expr 61 [55-119] [Type Unit]: Expr Block: Block 62 [55-119] [Type Unit]:
                                     Stmt 21 [64-72]: Local (Immutable):
-                                        Pat 22 [64-72] [Type Range]: Bind: Ident 20 [64-72] "range_id_20"
+                                        Pat 22 [64-72] [Type Range]: Bind: Ident 20 [64-72] "@range_id_20"
                                         Expr 9 [64-72] [Type Range]: Range:
                                             Expr 10 [64-65] [Type Int]: Lit: Int(4)
                                             Expr 11 [67-69] [Type Int]: UnOp (Neg):
                                                 Expr 12 [68-69] [Type Int]: Lit: Int(1)
                                             Expr 13 [71-72] [Type Int]: Lit: Int(0)
                                     Stmt 26 [64-72]: Local (Mutable):
-                                        Pat 27 [64-72] [Type Int]: Bind: Ident 23 [64-72] "index_id_23"
+                                        Pat 27 [64-72] [Type Int]: Bind: Ident 23 [64-72] "@index_id_23"
                                         Expr 24 [64-72] [Type Int]: Field:
                                             Expr 25 [64-72] [Type Range]: Var: Local 20
                                             Prim(Start)
                                     Stmt 31 [64-72]: Local (Immutable):
-                                        Pat 32 [64-72] [Type Int]: Bind: Ident 28 [64-72] "step_id_28"
+                                        Pat 32 [64-72] [Type Int]: Bind: Ident 28 [64-72] "@step_id_28"
                                         Expr 29 [64-72] [Type Int]: Field:
                                             Expr 30 [64-72] [Type Range]: Var: Local 20
                                             Prim(Step)
                                     Stmt 36 [64-72]: Local (Immutable):
-                                        Pat 37 [64-72] [Type Int]: Bind: Ident 33 [64-72] "end_id_33"
+                                        Pat 37 [64-72] [Type Int]: Bind: Ident 33 [64-72] "@end_id_33"
                                         Expr 34 [64-72] [Type Int]: Field:
                                             Expr 35 [64-72] [Type Range]: Var: Local 20
                                             Prim(End)
@@ -409,7 +409,7 @@ fn convert_repeat() {
                             Block 4 [45-126] [Type Unit]:
                                 Stmt 5 [55-120]: Semi: Expr 26 [55-119] [Type Unit]: Expr Block: Block 22 [55-119] [Type Unit]:
                                     Stmt 16 [115-119]: Local (Mutable):
-                                        Pat 17 [115-119] [Type Bool]: Bind: Ident 14 [115-119] "continue_cond_14"
+                                        Pat 17 [115-119] [Type Bool]: Bind: Ident 14 [115-119] "@continue_cond_14"
                                         Expr 15 [115-119] [Type Bool]: Lit: Bool(true)
                                     Stmt 23 [55-119]: Expr: Expr 24 [55-119] [Type Unit]: While:
                                         Expr 25 [115-119] [Type Bool]: Var: Local 14
@@ -458,7 +458,7 @@ fn convert_repeat_fixup() {
                             Block 4 [45-180] [Type Unit]:
                                 Stmt 5 [55-174]: Expr: Expr 35 [55-174] [Type Unit]: Expr Block: Block 31 [55-174] [Type Unit]:
                                     Stmt 21 [115-119]: Local (Mutable):
-                                        Pat 22 [115-119] [Type Bool]: Bind: Ident 19 [115-119] "continue_cond_19"
+                                        Pat 22 [115-119] [Type Bool]: Bind: Ident 19 [115-119] "@continue_cond_19"
                                         Expr 20 [115-119] [Type Bool]: Lit: Bool(true)
                                     Stmt 32 [55-174]: Expr: Expr 33 [55-174] [Type Unit]: While:
                                         Expr 34 [115-119] [Type Bool]: Var: Local 19
@@ -533,14 +533,14 @@ fn convert_repeat_nested() {
                                     Expr 16 [108-112] [Type Bool]: Lit: Bool(true)
                                 Stmt 17 [122-395]: Expr: Expr 90 [122-395] [Type Unit]: Expr Block: Block 86 [122-395] [Type Unit]:
                                     Stmt 76 [291-292]: Local (Mutable):
-                                        Pat 77 [291-292] [Type Bool]: Bind: Ident 74 [291-292] "continue_cond_74"
+                                        Pat 77 [291-292] [Type Bool]: Bind: Ident 74 [291-292] "@continue_cond_74"
                                         Expr 75 [291-292] [Type Bool]: Lit: Bool(true)
                                     Stmt 87 [122-395]: Expr: Expr 88 [122-395] [Type Unit]: While:
                                         Expr 89 [291-292] [Type Bool]: Var: Local 74
                                         Block 19 [129-284] [Type Unit]:
                                             Stmt 20 [143-274]: Expr: Expr 60 [143-274] [Type Unit]: Expr Block: Block 56 [143-274] [Type Unit]:
                                                 Stmt 46 [205-206]: Local (Mutable):
-                                                    Pat 47 [205-206] [Type Bool]: Bind: Ident 44 [205-206] "continue_cond_44"
+                                                    Pat 47 [205-206] [Type Bool]: Bind: Ident 44 [205-206] "@continue_cond_44"
                                                     Expr 45 [205-206] [Type Bool]: Lit: Bool(true)
                                                 Stmt 57 [143-274]: Expr: Expr 58 [143-274] [Type Unit]: While:
                                                     Expr 59 [205-206] [Type Bool]: Var: Local 44
@@ -569,7 +569,7 @@ fn convert_repeat_nested() {
                                                 Expr 85 [307-395] [Type Unit]: Expr Block: Block 34 [307-395] [Type Unit]:
                                                     Stmt 35 [321-385]: Semi: Expr 73 [321-384] [Type Unit]: Expr Block: Block 69 [321-384] [Type Unit]:
                                                         Stmt 63 [383-384]: Local (Mutable):
-                                                            Pat 64 [383-384] [Type Bool]: Bind: Ident 61 [383-384] "continue_cond_61"
+                                                            Pat 64 [383-384] [Type Bool]: Bind: Ident 61 [383-384] "@continue_cond_61"
                                                             Expr 62 [383-384] [Type Bool]: Lit: Bool(true)
                                                         Stmt 70 [321-384]: Expr: Expr 71 [321-384] [Type Unit]: While:
                                                             Expr 72 [383-384] [Type Bool]: Var: Local 61

--- a/compiler/qsc_passes/src/replace_qubit_allocation.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation.rs
@@ -14,9 +14,9 @@ use qsc_hir::{
     mut_visit::{walk_expr, walk_stmt, MutVisitor},
     ty::{Prim, Ty},
 };
-use std::{mem::take, rc::Rc};
+use std::mem::take;
 
-use crate::common::{create_gen_core_ref, IdentTemplate};
+use crate::common::{create_gen_core_ref, generated_name, IdentTemplate};
 
 #[derive(Debug, Clone)]
 struct QubitIdent {
@@ -186,7 +186,7 @@ impl<'a> ReplaceQubitAllocation<'a> {
         IdentTemplate {
             id,
             span,
-            name: Rc::from(format!("generated_ident_{id}")),
+            name: generated_name(&format!("generated_ident_{id}")),
             ty,
         }
     }

--- a/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
@@ -118,12 +118,12 @@ fn test_qubit_tuple() {
                         body: SpecDecl 3 [22-107]: Impl:
                             Block 4 [45-107] [Type Unit]:
                                 Stmt 24 [64-71]: Local (Immutable):
-                                    Pat 25 [64-71] [Type Qubit]: Bind: Ident 16 [64-71] "generated_ident_16"
+                                    Pat 25 [64-71] [Type Qubit]: Bind: Ident 16 [64-71] "@generated_ident_16"
                                     Expr 22 [64-71] [Type Qubit]: Call:
                                         Expr 21 [64-71] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                         Expr 23 [64-71] [Type Unit]: Unit
                                 Stmt 29 [73-80]: Local (Immutable):
-                                    Pat 30 [73-80] [Type Qubit]: Bind: Ident 18 [73-80] "generated_ident_18"
+                                    Pat 30 [73-80] [Type Qubit]: Bind: Ident 18 [73-80] "@generated_ident_18"
                                     Expr 27 [73-80] [Type Qubit]: Call:
                                         Expr 26 [73-80] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                         Expr 28 [73-80] [Type Unit]: Unit
@@ -170,12 +170,12 @@ fn test_multiple_qubits_tuple() {
                         body: SpecDecl 3 [22-113]: Impl:
                             Block 4 [45-113] [Type Unit]:
                                 Stmt 28 [69-76]: Local (Immutable):
-                                    Pat 29 [69-76] [Type Qubit]: Bind: Ident 20 [69-76] "generated_ident_20"
+                                    Pat 29 [69-76] [Type Qubit]: Bind: Ident 20 [69-76] "@generated_ident_20"
                                     Expr 26 [69-76] [Type Qubit]: Call:
                                         Expr 25 [69-76] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                         Expr 27 [69-76] [Type Unit]: Unit
                                 Stmt 33 [78-86]: Local (Immutable):
-                                    Pat 34 [78-86] [Type (Qubit)[]]: Bind: Ident 22 [78-86] "generated_ident_22"
+                                    Pat 34 [78-86] [Type (Qubit)[]]: Bind: Ident 22 [78-86] "@generated_ident_22"
                                     Expr 31 [78-86] [Type Qubit]: Call:
                                         Expr 30 [78-86] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
                                         Expr 14 [84-85] [Type Int]: Lit: Int(3)
@@ -229,12 +229,12 @@ fn test_multiple_callables() {
                         body: SpecDecl 3 [22-112]: Impl:
                             Block 4 [45-112] [Type Unit]:
                                 Stmt 45 [69-76]: Local (Immutable):
-                                    Pat 46 [69-76] [Type Qubit]: Bind: Ident 37 [69-76] "generated_ident_37"
+                                    Pat 46 [69-76] [Type Qubit]: Bind: Ident 37 [69-76] "@generated_ident_37"
                                     Expr 43 [69-76] [Type Qubit]: Call:
                                         Expr 42 [69-76] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                         Expr 44 [69-76] [Type Unit]: Unit
                                 Stmt 50 [78-85]: Local (Immutable):
-                                    Pat 51 [78-85] [Type Qubit]: Bind: Ident 39 [78-85] "generated_ident_39"
+                                    Pat 51 [78-85] [Type Qubit]: Bind: Ident 39 [78-85] "@generated_ident_39"
                                     Expr 48 [78-85] [Type Qubit]: Call:
                                         Expr 47 [78-85] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                         Expr 49 [78-85] [Type Unit]: Unit
@@ -267,12 +267,12 @@ fn test_multiple_callables() {
                         body: SpecDecl 21 [118-208]: Impl:
                             Block 22 [141-208] [Type Unit]:
                                 Stmt 69 [165-172]: Local (Immutable):
-                                    Pat 70 [165-172] [Type Qubit]: Bind: Ident 61 [165-172] "generated_ident_61"
+                                    Pat 70 [165-172] [Type Qubit]: Bind: Ident 61 [165-172] "@generated_ident_61"
                                     Expr 67 [165-172] [Type Qubit]: Call:
                                         Expr 66 [165-172] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                         Expr 68 [165-172] [Type Unit]: Unit
                                 Stmt 74 [174-181]: Local (Immutable):
-                                    Pat 75 [174-181] [Type Qubit]: Bind: Ident 63 [174-181] "generated_ident_63"
+                                    Pat 75 [174-181] [Type Qubit]: Bind: Ident 63 [174-181] "@generated_ident_63"
                                     Expr 72 [174-181] [Type Qubit]: Call:
                                         Expr 71 [174-181] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                         Expr 73 [174-181] [Type Unit]: Unit
@@ -326,12 +326,12 @@ fn test_qubit_block() {
                             Block 4 [45-198] [Type Unit]:
                                 Stmt 65 [55-173]: Expr: Expr 66 [55-173] [Type Unit]: Expr Block: Block 14 [87-173] [Type Unit]:
                                     Stmt 40 [69-76]: Local (Immutable):
-                                        Pat 41 [69-76] [Type Qubit]: Bind: Ident 32 [69-76] "generated_ident_32"
+                                        Pat 41 [69-76] [Type Qubit]: Bind: Ident 32 [69-76] "@generated_ident_32"
                                         Expr 38 [69-76] [Type Qubit]: Call:
                                             Expr 37 [69-76] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                             Expr 39 [69-76] [Type Unit]: Unit
                                     Stmt 45 [78-85]: Local (Immutable):
-                                        Pat 46 [78-85] [Type Qubit]: Bind: Ident 34 [78-85] "generated_ident_34"
+                                        Pat 46 [78-85] [Type Qubit]: Bind: Ident 34 [78-85] "@generated_ident_34"
                                         Expr 43 [78-85] [Type Qubit]: Call:
                                             Expr 42 [78-85] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                             Expr 44 [78-85] [Type Unit]: Unit
@@ -561,7 +561,7 @@ fn test_early_returns() {
                                                 Expr 41 [106-107] [Type Unit]: Unit
                                         Stmt 18 [131-141]: Semi: Expr 58 [131-140] [Type Unit]: Expr Block: Block 59 [131-140] [Type Unit]:
                                             Stmt 45 [138-140]: Local (Immutable):
-                                                Pat 46 [138-140] [Type Unit]: Bind: Ident 44 [138-140] "generated_ident_44"
+                                                Pat 46 [138-140] [Type Unit]: Bind: Ident 44 [138-140] "@generated_ident_44"
                                                 Expr 20 [138-140] [Type Unit]: Unit
                                             Stmt 48 [106-107]: Semi: Expr 49 [106-107] [Type Unit]: Call:
                                                 Expr 47 [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
@@ -574,7 +574,7 @@ fn test_early_returns() {
                                             Expr 60 [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                             Expr 63 [106-107] [Type Qubit]: Var: Local 16
                                 Stmt 90 [161-233]: Local (Immutable):
-                                    Pat 91 [161-233] [Type Unit]: Bind: Ident 89 [161-233] "generated_ident_89"
+                                    Pat 91 [161-233] [Type Unit]: Bind: Ident 89 [161-233] "@generated_ident_89"
                                     Expr 22 [161-233] [Type Unit]: If:
                                         Expr 23 [164-169] [Type Bool]: Lit: Bool(false)
                                         Expr 24 [170-233] [Type Unit]: Expr Block: Block 25 [170-233] [Type Unit]:
@@ -585,7 +585,7 @@ fn test_early_returns() {
                                                     Expr 66 [188-189] [Type Unit]: Unit
                                             Stmt 30 [213-223]: Semi: Expr 83 [213-222] [Type Unit]: Expr Block: Block 84 [213-222] [Type Unit]:
                                                 Stmt 70 [220-222]: Local (Immutable):
-                                                    Pat 71 [220-222] [Type Unit]: Bind: Ident 69 [220-222] "generated_ident_69"
+                                                    Pat 71 [220-222] [Type Unit]: Bind: Ident 69 [220-222] "@generated_ident_69"
                                                     Expr 32 [220-222] [Type Unit]: Unit
                                                 Stmt 73 [188-189]: Semi: Expr 74 [188-189] [Type Unit]: Call:
                                                     Expr 72 [188-189] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
@@ -651,7 +651,7 @@ fn test_end_exprs() {
                                                 Expr 33 [127-128] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                                 Expr 35 [127-128] [Type Unit]: Unit
                                         Stmt 39 [152-153]: Local (Immutable):
-                                            Pat 40 [152-153] [Type Int]: Bind: Ident 38 [152-153] "generated_ident_38"
+                                            Pat 40 [152-153] [Type Int]: Bind: Ident 38 [152-153] "@generated_ident_38"
                                             Expr 26 [152-153] [Type Int]: Lit: Int(3)
                                         Stmt 44 [127-128]: Semi: Expr 45 [127-128] [Type Unit]: Call:
                                             Expr 43 [127-128] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
@@ -702,7 +702,7 @@ fn test_array_expr() {
                                                     Expr 22 [87-88] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                                     Expr 24 [87-88] [Type Unit]: Unit
                                             Stmt 28 [112-113]: Local (Immutable):
-                                                Pat 29 [112-113] [Type Int]: Bind: Ident 27 [112-113] "generated_ident_27"
+                                                Pat 29 [112-113] [Type Int]: Bind: Ident 27 [112-113] "@generated_ident_27"
                                                 Expr 16 [112-113] [Type Int]: Lit: Int(3)
                                             Stmt 33 [87-88]: Semi: Expr 34 [87-88] [Type Unit]: Call:
                                                 Expr 32 [87-88] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
@@ -752,7 +752,7 @@ fn test_rtrn_expr() {
                                         Expr 22 [58-59] [Type Unit]: Unit
                                 Stmt 9 [79-141]: Semi: Expr 49 [79-140] [Type Unit]: Expr Block: Block 50 [79-140] [Type Unit]:
                                     Stmt 40 [86-140]: Local (Immutable):
-                                        Pat 41 [86-140] [Type Int]: Bind: Ident 25 [86-140] "generated_ident_25"
+                                        Pat 41 [86-140] [Type Int]: Bind: Ident 25 [86-140] "@generated_ident_25"
                                         Expr 11 [86-140] [Type Int]: Expr Block: Block 12 [86-140] [Type Int]:
                                             Stmt 29 [104-105]: Local (Immutable):
                                                 Pat 30 [104-105] [Type Qubit]: Bind: Ident 15 [104-105] "b"
@@ -760,7 +760,7 @@ fn test_rtrn_expr() {
                                                     Expr 26 [104-105] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                                     Expr 28 [104-105] [Type Unit]: Unit
                                             Stmt 32 [129-130]: Local (Immutable):
-                                                Pat 33 [129-130] [Type Int]: Bind: Ident 31 [129-130] "generated_ident_31"
+                                                Pat 33 [129-130] [Type Int]: Bind: Ident 31 [129-130] "@generated_ident_31"
                                                 Expr 18 [129-130] [Type Int]: Lit: Int(3)
                                             Stmt 37 [104-105]: Semi: Expr 38 [104-105] [Type Unit]: Call:
                                                 Expr 36 [104-105] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -959,7 +959,7 @@ fn generate_adj_invert_with_range_loop() {
                             Block 35 [104-181] [Type Unit]:
                                 Stmt 36 [114-175]: Expr: Expr 37 [0-0] [Type Unit]: Expr Block: Block 38 [0-0] [Type Unit]:
                                     Stmt 39 [0-0]: Local (Immutable):
-                                        Pat 40 [0-0] [Type Range]: Bind: Ident 41 [0-0] "generated_range"
+                                        Pat 40 [0-0] [Type Range]: Bind: Ident 41 [0-0] "@range"
                                         Expr 42 [123-127] [Type Range]: Range:
                                             Expr 43 [123-124] [Type Int]: Lit: Int(0)
                                             <no step>
@@ -1064,13 +1064,13 @@ fn generate_adj_invert_with_array_loop() {
                             Block 37 [104-188] [Type Unit]:
                                 Stmt 38 [114-182]: Expr: Expr 39 [0-0] [Type Unit]: Expr Block: Block 40 [0-0] [Type Unit]:
                                     Stmt 41 [0-0]: Local (Immutable):
-                                        Pat 42 [0-0] [Type (Int)[]]: Bind: Ident 43 [0-0] "generated_array"
+                                        Pat 42 [0-0] [Type (Int)[]]: Bind: Ident 43 [0-0] "@array"
                                         Expr 44 [125-134] [Type (Int)[]]: Array:
                                             Expr 45 [126-127] [Type Int]: Lit: Int(0)
                                             Expr 46 [129-130] [Type Int]: Lit: Int(1)
                                             Expr 47 [132-133] [Type Int]: Lit: Int(2)
                                     Stmt 48 [0-0]: Expr: Expr 49 [0-0] [Type Unit]: For:
-                                        Pat 50 [0-0] [Type Int]: Bind: Ident 51 [0-0] "generated_index"
+                                        Pat 50 [0-0] [Type Int]: Bind: Ident 51 [0-0] "@index"
                                         Expr 52 [0-0] [Type Range]: Range:
                                             Expr 53 [0-0] [Type Int]: BinOp (Sub):
                                                 Expr 54 [0-0] [Type Int]: Call:
@@ -1179,13 +1179,13 @@ fn generate_adj_invert_with_nested_loops() {
                             Block 60 [104-318] [Type Unit]:
                                 Stmt 61 [114-312]: Expr: Expr 62 [0-0] [Type Unit]: Expr Block: Block 63 [0-0] [Type Unit]:
                                     Stmt 64 [0-0]: Local (Immutable):
-                                        Pat 65 [0-0] [Type (Int)[]]: Bind: Ident 66 [0-0] "generated_array"
+                                        Pat 65 [0-0] [Type (Int)[]]: Bind: Ident 66 [0-0] "@array"
                                         Expr 67 [125-134] [Type (Int)[]]: Array:
                                             Expr 68 [126-127] [Type Int]: Lit: Int(0)
                                             Expr 69 [129-130] [Type Int]: Lit: Int(1)
                                             Expr 70 [132-133] [Type Int]: Lit: Int(2)
                                     Stmt 71 [0-0]: Expr: Expr 72 [0-0] [Type Unit]: For:
-                                        Pat 73 [0-0] [Type Int]: Bind: Ident 74 [0-0] "generated_index"
+                                        Pat 73 [0-0] [Type Int]: Bind: Ident 74 [0-0] "@index"
                                         Expr 75 [0-0] [Type Range]: Range:
                                             Expr 76 [0-0] [Type Int]: BinOp (Sub):
                                                 Expr 77 [0-0] [Type Int]: Call:
@@ -1215,10 +1215,10 @@ fn generate_adj_invert_with_nested_loops() {
                                                 Expr 101 [299-300] [Type Int]: Lit: Int(4)
                                             Stmt 102 [210-284]: Expr: Expr 103 [0-0] [Type Unit]: Expr Block: Block 104 [0-0] [Type Unit]:
                                                 Stmt 105 [0-0]: Local (Immutable):
-                                                    Pat 106 [0-0] [Type (Bool)[]]: Bind: Ident 107 [0-0] "generated_array"
+                                                    Pat 106 [0-0] [Type (Bool)[]]: Bind: Ident 107 [0-0] "@array"
                                                     Expr 108 [221-224] [Type (Bool)[]]: Var: Local 92
                                                 Stmt 109 [0-0]: Expr: Expr 110 [0-0] [Type Unit]: For:
-                                                    Pat 111 [0-0] [Type Int]: Bind: Ident 112 [0-0] "generated_index"
+                                                    Pat 111 [0-0] [Type Int]: Bind: Ident 112 [0-0] "@index"
                                                     Expr 113 [0-0] [Type Range]: Range:
                                                         Expr 114 [0-0] [Type Int]: BinOp (Sub):
                                                             Expr 115 [0-0] [Type Int]: Call:


### PR DESCRIPTION
For passes that create new local bindings added to the code, we use `generated_name` to include an `@` symbol that differentiates them from normal Q# identifiers and lets the debugger successfully ignore them.