### PR TITLE
Test that Q# examples in katas build and run successfully

### DIFF
--- a/katas/content/multi_qubit_systems/examples/MultiQubitSystems.qs
+++ b/katas/content/multi_qubit_systems/examples/MultiQubitSystems.qs
@@ -1,5 +1,5 @@
-﻿namespace Kata {
-    open Microsoft.Quantum.Diagnostics;
+namespace Kata {
+open Microsoft.Quantum.Diagnostics;
 
     @EntryPoint()
     operation MultiQubitSystemsDemo () : Unit {
@@ -41,5 +41,4 @@
         // This returns the system into state |00⟩
         ResetAll(qs);
     }
-
 }

--- a/katas/content/multi_qubit_systems/examples/MultiQubitSystems.qs
+++ b/katas/content/multi_qubit_systems/examples/MultiQubitSystems.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Diagnostics;
 
     @EntryPoint()
     operation MultiQubitSystemsDemo () : Unit {

--- a/katas/content/multi_qubit_systems/index.md
+++ b/katas/content/multi_qubit_systems/index.md
@@ -245,7 +245,7 @@ If you aren't familiar with the output of this function for single qubits, you s
 When printing the state of multi-qubit systems, this function outputs the same information for each multi-qubit basis state.
 The qubit kata explains how `DumpMachine` works for multiple qubits in more detail.
 
-@[example]({"id": "multiqubit_system", "codePath": "./multiqubit_system.qs"})
+@[example]({"id": "multiqubit_system", "codePath": "./examples/MultiQubitSystems.qs"})
 
 > You might have noticed that we've been "resetting" the qubits at the end of our demos, i.e., returning them to $|0\rangle$ state. Q# requires you to return your qubits into the $|0\rangle$ state before releasing them at the end of the `using` block.
 > The reason for this is entanglement.

--- a/katas/content/single_qubit_measurements/implementing_measurement/example.qs
+++ b/katas/content/single_qubit_measurements/implementing_measurement/example.qs
@@ -18,5 +18,6 @@ namespace Kata {
         Message($"The measurement outcome is {outcome}.");
         Message("Post-measurement state of the qubit:");
         DumpMachine();
+        Reset(q);
     }
 }

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -252,8 +252,13 @@ async function validateKata(
 
   if (validateExamples) {
     const examples = await getAllKataExamples(kata);
-    console.log("Total examples");
-    console.log(examples.length);
+    for (const example of examples) {
+      const result = await runSingleShot(example.code, "", false);
+      assert(
+        result.success,
+        `Example "${example.id}" in "${kata.id}" kata failed to run`
+      );
+    }
   }
 }
 

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -149,6 +149,28 @@ async function runExerciseSolutionCheck(exercise, solution) {
   };
 }
 
+async function getAllKataExamples(kata) {
+  let examples = [];
+
+  // Get all the examples conatined in solution explanations.
+  const exerciseExamples = kata.sections
+    .filter((section) => section.type === "exercise")
+    .map((exercise) =>
+      exercise.explainedSolution.items.filter((item) => item.type === "example")
+    )
+    .flat();
+  examples = examples.concat(exerciseExamples);
+
+  // Get all the examples in lessons.
+  const lessonExamples = kata.sections
+    .filter((section) => section.type === "lesson")
+    .map((lesson) => lesson.items.filter((item) => item.type === "example"))
+    .flat();
+  examples = examples.concat(lessonExamples);
+
+  return examples;
+}
+
 async function validateExercise(
   exercise,
   validatePlaceholder,
@@ -212,6 +234,7 @@ async function validateExercise(
 
 async function validateKata(
   kata,
+  validateExamples,
   validateExercisePlaceholder,
   validateExerciseSolutions
 ) {
@@ -225,6 +248,12 @@ async function validateKata(
       validateExercisePlaceholder,
       validateExerciseSolutions
     );
+  }
+
+  if (validateExamples) {
+    const examples = await getAllKataExamples(kata);
+    console.log("Total examples");
+    console.log(examples.length);
   }
 }
 
@@ -241,42 +270,42 @@ test("all katas work", async () => {
 
 test("qubit kata is valid", async () => {
   const kata = await getKata("qubit");
-  await validateKata(kata, true, true);
+  await validateKata(kata, true, true, true);
 });
 
 test("single_qubit_gates kata is valid", async () => {
   const kata = await getKata("single_qubit_gates");
-  await validateKata(kata, true, true);
+  await validateKata(kata, false, true, true);
 });
 
 test("multi_qubit_systems kata is valid", async () => {
   const kata = await getKata("multi_qubit_systems");
-  await validateKata(kata, true, true);
+  await validateKata(kata, false, true, true);
 });
 
 test("multi_qubit_gates kata is valid", async () => {
   const kata = await getKata("multi_qubit_gates");
-  await validateKata(kata, true, true);
+  await validateKata(kata, false, true, true);
 });
 
 test("single_qubit_measurements is valid", async () => {
   const kata = await getKata("single_qubit_measurements");
-  await validateKata(kata, true, true);
+  await validateKata(kata, false, true, true);
 });
 
 test("multi_qubit_measurements is valid", async () => {
   const kata = await getKata("multi_qubit_measurements");
-  await validateKata(kata, true, true);
+  await validateKata(kata, false, true, true);
 });
 
 test("random_numbers kata is valid", async () => {
   const kata = await getKata("random_numbers");
-  await validateKata(kata, true, true);
+  await validateKata(kata, false, true, true);
 });
 
 test("oracles kata is valid", async () => {
   const kata = await getKata("oracles");
-  await validateKata(kata, true, true);
+  await validateKata(kata, false, true, true);
 });
 
 test("worker 100 shots", async () => {

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -257,13 +257,12 @@ async function validateKata(
         const result = await runSingleShot(example.code, "", false);
         assert(
           result.success,
-          `Example "${example.id}" in "${kata.id}" kata failed to run`
+          `Example "${example.id}" in "${kata.id}" kata failed to run.`
         );
       } catch (error) {
         assert(
           false,
-          `Example "${example.id}" in "${kata.id}" kata failed to run:\n` +
-            `${error}`
+          `Example "${example.id}" in "${kata.id}" kata failed to build:\n${error}`
         );
       }
     }

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -253,11 +253,19 @@ async function validateKata(
   if (validateExamples) {
     const examples = await getAllKataExamples(kata);
     for (const example of examples) {
-      const result = await runSingleShot(example.code, "", false);
-      assert(
-        result.success,
-        `Example "${example.id}" in "${kata.id}" kata failed to run`
-      );
+      try {
+        const result = await runSingleShot(example.code, "", false);
+        assert(
+          result.success,
+          `Example "${example.id}" in "${kata.id}" kata failed to run`
+        );
+      } catch (error) {
+        assert(
+          false,
+          `Example "${example.id}" in "${kata.id}" kata failed to run:\n` +
+            `${error}`
+        );
+      }
     }
   }
 }
@@ -280,12 +288,12 @@ test("qubit kata is valid", async () => {
 
 test("single_qubit_gates kata is valid", async () => {
   const kata = await getKata("single_qubit_gates");
-  await validateKata(kata, false, true, true);
+  await validateKata(kata, true, true, true);
 });
 
 test("multi_qubit_systems kata is valid", async () => {
   const kata = await getKata("multi_qubit_systems");
-  await validateKata(kata, false, true, true);
+  await validateKata(kata, true, true, true);
 });
 
 test("multi_qubit_gates kata is valid", async () => {

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -313,12 +313,12 @@ test("multi_qubit_measurements is valid", async () => {
 
 test("random_numbers kata is valid", async () => {
   const kata = await getKata("random_numbers");
-  await validateKata(kata, false, true, true);
+  await validateKata(kata, true, true, true);
 });
 
 test("oracles kata is valid", async () => {
   const kata = await getKata("oracles");
-  await validateKata(kata, false, true, true);
+  await validateKata(kata, true, true, true);
 });
 
 test("worker 100 shots", async () => {

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -298,17 +298,17 @@ test("multi_qubit_systems kata is valid", async () => {
 
 test("multi_qubit_gates kata is valid", async () => {
   const kata = await getKata("multi_qubit_gates");
-  await validateKata(kata, false, true, true);
+  await validateKata(kata, true, true, true);
 });
 
 test("single_qubit_measurements is valid", async () => {
   const kata = await getKata("single_qubit_measurements");
-  await validateKata(kata, false, true, true);
+  await validateKata(kata, true, true, true);
 });
 
 test("multi_qubit_measurements is valid", async () => {
   const kata = await getKata("multi_qubit_measurements");
-  await validateKata(kata, false, true, true);
+  await validateKata(kata, true, true, true);
 });
 
 test("random_numbers kata is valid", async () => {


### PR DESCRIPTION
This change adds validation for Q# examples that are part of katas.