### PR TITLE
Python `compile` for QIR codegen

### DIFF
--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -47,7 +47,7 @@ pub fn generate_qir(
     let unit = fir_store.get(package).expect("store should have package");
     let entry_expr = unit.entry.expect("package should have entry");
 
-    let mut stdout = vec![];
+    let mut stdout = std::io::sink();
     let mut out = GenericReceiver::new(&mut stdout);
     let result = eval_expr(
         &mut State::new(package),
@@ -80,7 +80,7 @@ pub fn generate_qir_for_stmt(
 ) -> std::result::Result<String, (Error, Vec<Frame>)> {
     let mut sim = BaseProfSim::default();
     sim.instrs.push_str(PREFIX);
-    let mut stdout = vec![];
+    let mut stdout = std::io::sink();
     let mut out = GenericReceiver::new(&mut stdout);
     match eval_stmt(stmt, globals, env, &mut sim, package, &mut out) {
         Ok(val) => {

--- a/compiler/qsc_codegen/src/qir_base/prefix.ll
+++ b/compiler/qsc_codegen/src/qir_base/prefix.ll
@@ -1,4 +1,4 @@
 %Result = type opaque
 %Qubit = type opaque
 
-define void @program__main() #0 {
+define void @ENTRYPOINT__main() #0 {

--- a/compiler/qsc_codegen/src/qir_base/tests.rs
+++ b/compiler/qsc_codegen/src/qir_base/tests.rs
@@ -57,7 +57,7 @@ fn simple_program_is_valid() {
             %Result = type opaque
             %Qubit = type opaque
 
-            define void @program__main() #0 {
+            define void @ENTRYPOINT__main() #0 {
               call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
               call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
               call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
@@ -112,7 +112,7 @@ fn output_recording_array() {
             %Result = type opaque
             %Qubit = type opaque
 
-            define void @program__main() #0 {
+            define void @ENTRYPOINT__main() #0 {
               call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
               call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 1 to %Result*)) #1
               call void @__quantum__rt__array_record_output(i64 2, i8* null)
@@ -169,7 +169,7 @@ fn output_recording_tuple() {
             %Result = type opaque
             %Qubit = type opaque
 
-            define void @program__main() #0 {
+            define void @ENTRYPOINT__main() #0 {
               call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
               call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 1 to %Result*)) #1
               call void @__quantum__rt__tuple_record_output(i64 2, i8* null)
@@ -250,7 +250,7 @@ fn verify_all_intrinsics() {
             %Result = type opaque
             %Qubit = type opaque
 
-            define void @program__main() #0 {
+            define void @ENTRYPOINT__main() #0 {
               call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__cy__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
@@ -351,7 +351,7 @@ fn complex_program_is_valid() {
             %Result = type opaque
             %Qubit = type opaque
 
-            define void @program__main() #0 {
+            define void @ENTRYPOINT__main() #0 {
               call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))

--- a/compiler/qsc_frontend/src/incremental.rs
+++ b/compiler/qsc_frontend/src/incremental.rs
@@ -76,6 +76,35 @@ impl Compiler {
         &mut self.hir_assigner
     }
 
+    /// Compile a string with a single fragment of Q# code that is an expression.
+    /// # Errors
+    /// Returns a vector of errors if the input fails compilation.
+    pub fn compile_expr(&mut self, input: &str) -> Result<Fragment, Vec<Error>> {
+        let (expr, errors) = qsc_parse::expr(input);
+        if !errors.is_empty() {
+            return Err(errors
+                .into_iter()
+                .map(|e| Error(ErrorKind::Parse(e)))
+                .collect());
+        }
+
+        let mut stmt = ast::Stmt {
+            id: ast::NodeId::default(),
+            span: expr.span,
+            kind: Box::new(ast::StmtKind::Expr(expr)),
+        };
+        self.check_stmt(&mut stmt);
+        self.checker.solve(self.resolver.names());
+
+        let fragment = self.lower_stmt(&stmt);
+        let errors = self.drain_errors();
+        if errors.is_empty() {
+            Ok(fragment.expect("lowering an expression should not produce None"))
+        } else {
+            Err(errors)
+        }
+    }
+
     /// Compile a string with one or more fragments of Q# code.
     /// # Errors
     /// Returns a vector of errors if any of the input fails compilation.

--- a/compiler/qsc_passes/src/baseprofck.rs
+++ b/compiler/qsc_passes/src/baseprofck.rs
@@ -9,7 +9,7 @@ use qsc_data_structures::span::Span;
 use qsc_hir::{
     hir::{
         BinOp, CallableDecl, CallableKind, Expr, ExprKind, Item, ItemKind, Lit, Package, SpecBody,
-        SpecGen, Stmt,
+        SpecGen, Stmt, StmtKind,
     },
     ty::{Prim, Ty},
     visit::{walk_expr, walk_item, Visitor},
@@ -64,6 +64,11 @@ pub fn check_base_profile_compliance(package: &Package) -> Vec<Error> {
 pub fn check_base_profile_compliance_for_stmt(stmt: &Stmt) -> Vec<Error> {
     let mut checker = Checker { errors: Vec::new() };
     checker.visit_stmt(stmt);
+    if let StmtKind::Expr(expr) = &stmt.kind {
+        if any_non_result_ty(&expr.ty) {
+            checker.errors.push(Error::ReturnNonResult(stmt.span));
+        }
+    }
 
     checker.errors
 }

--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from ._qsharp import eval, eval_file
+from ._qsharp import init, eval, eval_file, compile
 
-from ._native import Result, Pauli, QSharpError
+from ._native import Result, Pauli, QSharpError, Target
 
 # IPython notebook specific features
 try:
@@ -16,4 +16,13 @@ except NameError:
     pass
 
 
-__all__ = ["eval", "eval_file", "Result", "Pauli", "QSharpError"]
+__all__ = [
+    "init",
+    "eval",
+    "eval_file",
+    "compile",
+    "Result",
+    "Pauli",
+    "QSharpError",
+    "Target",
+]

--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -3,7 +3,7 @@
 
 from ._qsharp import init, eval, eval_file, compile
 
-from ._native import Result, Pauli, QSharpError, Target
+from ._native import Result, Pauli, QSharpError, TargetProfile
 
 # IPython notebook specific features
 try:
@@ -24,5 +24,5 @@ __all__ = [
     "Result",
     "Pauli",
     "QSharpError",
-    "Target",
+    "TargetProfile",
 ]

--- a/pip/qsharp/_ipython.py
+++ b/pip/qsharp/_ipython.py
@@ -4,7 +4,7 @@
 from IPython.display import display, Javascript, Pretty
 from IPython.core.magic import register_cell_magic
 from ._native import QSharpError
-from ._qsharp import _interpreter
+from ._qsharp import get_interpreter
 import pathlib
 
 
@@ -17,7 +17,7 @@ def register_magic():
             display(output)
 
         try:
-            return _interpreter.interpret(cell, callback)
+            return get_interpreter().interpret(cell, callback)
         except QSharpError as e:
             display(Pretty(str(e)))
 

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -2,21 +2,40 @@
 # Licensed under the MIT License.
 
 from enum import Enum
-from typing import Any, Callable
+from typing import Any, Callable, ClassVar
 
-class Target(Enum):
+class TargetProfile:
     """
-    A Q# target.
+    A Q# target profile.
+
+    The target is the hardware or simulator which will be used to run the Q# program.
+    The target profile is a description of a target's capabilities.
     """
 
-    Full: int
-    Base: int
+    Full: ClassVar[Any]
+    """
+    Describes the full set of capabilities required to run any Q# program.
+
+    This option maps to the Full Profile as defined by the QIR specification.
+    """
+
+    Base: ClassVar[Any]
+    """
+    Target supports the minimal set of capabilities required to run a quantum
+    program.
+
+    This option maps to the Base Profile as defined by the QIR specification.
+    """
 
 class Interpreter:
     """A Q# interpreter."""
 
-    def __init__(self, target: Target) -> None:
-        """Initializes a new Q# interpreter."""
+    def __init__(self, target_profile: TargetProfile) -> None:
+        """
+        Initializes the Q# interpreter.
+
+        :param target_profile: The target profile to use for the interpreter.
+        """
         ...
     def interpret(self, input: str, output_fn: Callable[[Output], None]) -> Any:
         """
@@ -32,7 +51,11 @@ class Interpreter:
         ...
     def qir(self, entry_expr: str) -> str:
         """
-        Generates QIR from the provided Q# source code.
+        Generates QIR from Q# source code.
+
+        :param entry_expr: The entry expression.
+
+        :returns qir: The QIR string.
         """
         ...
 

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -4,10 +4,18 @@
 from enum import Enum
 from typing import Any, Callable
 
+class Target(Enum):
+    """
+    A Q# target.
+    """
+
+    Full: int
+    Base: int
+
 class Interpreter:
     """A Q# interpreter."""
 
-    def __init__(self) -> None:
+    def __init__(self, target: Target) -> None:
         """Initializes a new Q# interpreter."""
         ...
     def interpret(self, input: str, output_fn: Callable[[Output], None]) -> Any:
@@ -20,6 +28,11 @@ class Interpreter:
         :returns value: The value returned by the last statement in the input.
 
         :raises QSharpError: If there is an error interpreting the input.
+        """
+        ...
+    def qir(self, entry_expr: str) -> str:
+        """
+        Generates QIR from the provided Q# source code.
         """
         ...
 

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -26,9 +26,7 @@ def get_interpreter() -> Interpreter:
     """
     global _interpreter
     if _interpreter is None:
-        raise RuntimeError(
-            "Q# interpreter not initialized. Call qsharp.init() with any desired configuration settings first."
-        )
+        init()
     return _interpreter
 
 

--- a/pip/samples/azure_submission.ipynb
+++ b/pip/samples/azure_submission.ipynb
@@ -43,7 +43,7 @@
    "source": [
     "import qsharp\n",
     "\n",
-    "qsharp.init(target=qsharp.Target.Base)"
+    "qsharp.init(target_profile=qsharp.TargetProfile.Base)"
    ]
   },
   {
@@ -149,7 +149,16 @@
    "source": [
     "Submit to Azure Quantum with a custom entry expression.\n",
     "\n",
-    "Make sure the `azure-quantum` package is installed (`pip install azure-quantum`)."
+    "Make sure the `azure-quantum` package is installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install azure-quantum"
    ]
   },
   {

--- a/pip/samples/azure_submission.ipynb
+++ b/pip/samples/azure_submission.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To connect to an Azure workspace replace the following variables with your own values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subscription_id = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'\n",
+    "resource_group = 'myresourcegroup'\n",
+    "workspace_name = 'myworkspace'\n",
+    "location = 'westus'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import the Q# package. Set the target profile to be the base profile."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": "// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT License.\n\n// This file provides CodeMirror syntax highlighting for Q# magic cells\n// in classic Jupyter Notebooks. It does nothing in other (Jupyter Notebook 7,\n// VS Code, Azure Notebooks, etc.) environments.\n\n// Detect the prerequisites and do nothing if they don't exist.\nif (window.require && window.CodeMirror && window.Jupyter) {\n  // The simple mode plugin for CodeMirror is not loaded by default, so require it.\n  window.require([\"codemirror/addon/mode/simple\"], function defineMode() {\n    let rules = [\n      {\n        token: \"comment\",\n        regex: /(\\/\\/).*/,\n        beginWord: false,\n      },\n      {\n        token: \"string\",\n        regex: String.raw`^\\\"(?:[^\\\"\\\\]|\\\\[\\s\\S])*(?:\\\"|$)`,\n        beginWord: false,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(namespace|open|as|operation|function|body|adjoint|newtype|controlled|internal)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(let|set|w\\/|new|not|and|or|use|borrow|using|borrowing|newtype|mutable)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"meta\",\n        regex: String.raw`(Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"atom\",\n        regex: String.raw`(true|false|Pauli(I|X|Y|Z)|One|Zero)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"builtin\",\n        regex: String.raw`(X|Y|Z|H|HY|S|T|SWAP|CNOT|CCNOT|MultiX|R|RFrac|Rx|Ry|Rz|R1|R1Frac|Exp|ExpFrac|Measure|M|MultiM)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"builtin\",\n        regex: String.raw`(Message|Length|Assert|AssertProb|AssertEqual)\\b`,\n        beginWord: true,\n      },\n    ];\n    let simpleRules = [];\n    for (let rule of rules) {\n      simpleRules.push({\n        token: rule.token,\n        regex: new RegExp(rule.regex, \"g\"),\n        sol: rule.beginWord,\n      });\n      if (rule.beginWord) {\n        // Need an additional rule due to the fact that CodeMirror simple mode doesn't work with ^ token\n        simpleRules.push({\n          token: rule.token,\n          regex: new RegExp(String.raw`\\W` + rule.regex, \"g\"),\n          sol: false,\n        });\n      }\n    }\n\n    // Register the mode defined above with CodeMirror\n    window.CodeMirror.defineSimpleMode(\"qsharp\", { start: simpleRules });\n    window.CodeMirror.defineMIME(\"text/x-qsharp\", \"qsharp\");\n\n    // Tell Jupyter to associate %%qsharp magic cells with the qsharp mode\n    window.Jupyter.CodeCell.options_default.highlight_modes[\"qsharp\"] = {\n      reg: [/^%%qsharp/],\n    };\n\n    // Force re-highlighting of all cells the first time this code runs\n    for (const cell of window.Jupyter.notebook.get_cells()) {\n      cell.auto_highlight();\n    }\n  });\n}\n",
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import qsharp\n",
+    "\n",
+    "qsharp.init(target=qsharp.Target.Base)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following will generate a compiler error because it uses a feature unsupported by the base profile."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "vscode": {
+     "languageId": "qsharp"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[31mQsc.BaseProfCk.ResultComparison\u001b[0m\n",
+       "\n",
+       "  \u001b[31m×\u001b[0m cannot compare measurement results\n",
+       "   ╭─[4:1]\n",
+       " \u001b[2m4\u001b[0m │     let result = M(q);\n",
+       " \u001b[2m5\u001b[0m │     if (result == Zero) {\n",
+       "   · \u001b[35;1m        ──────────────\u001b[0m\n",
+       " \u001b[2m6\u001b[0m │         Message(\"The result is Zero\");\n",
+       "   ╰────\n",
+       "\u001b[36m  help: \u001b[0mcomparing measurement results is not supported when performing base\n",
+       "        profile QIR generation\n",
+       "\u001b[31mQsc.BaseProfCk.ResultLiteral\u001b[0m\n",
+       "\n",
+       "  \u001b[31m×\u001b[0m result literals are not supported\n",
+       "   ╭─[4:1]\n",
+       " \u001b[2m4\u001b[0m │     let result = M(q);\n",
+       " \u001b[2m5\u001b[0m │     if (result == Zero) {\n",
+       "   · \u001b[35;1m                  ────\u001b[0m\n",
+       " \u001b[2m6\u001b[0m │         Message(\"The result is Zero\");\n",
+       "   ╰────\n",
+       "\u001b[36m  help: \u001b[0mresult literals `One` and `Zero` are not supported when performing\n",
+       "        base profile QIR generation\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%qsharp\n",
+    "\n",
+    "operation NotAllowed() : Unit {\n",
+    "    use q = Qubit();\n",
+    "    let result = M(q);\n",
+    "    if (result == Zero) {\n",
+    "        Message(\"The result is Zero\");\n",
+    "    }\n",
+    "    Reset(q);\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define some more Q# operations. This should compile without error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "vscode": {
+     "languageId": "qsharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%qsharp\n",
+    "\n",
+    "operation Random() : Result {\n",
+    "    use q = Qubit();\n",
+    "    H(q);\n",
+    "    let result = M(q);\n",
+    "    Reset(q);\n",
+    "    return result\n",
+    "}\n",
+    "\n",
+    "operation RandomNBits(N: Int): Result[] {\n",
+    "    mutable results = [];\n",
+    "    for i in 0 .. N - 1 {\n",
+    "        let r = Random();\n",
+    "        set results += [r];\n",
+    "    }\n",
+    "    return results\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Submit to Azure Quantum with a custom entry expression.\n",
+    "\n",
+    "Make sure the `azure-quantum` package is installed (`pip install azure-quantum`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import azure.quantum\n",
+    "\n",
+    "operation = qsharp.compile(\"RandomNBits(4)\")\n",
+    "\n",
+    "workspace = azure.quantum.Workspace(\n",
+    "    subscription_id=subscription_id,\n",
+    "    resource_group=resource_group,\n",
+    "    name=workspace_name,\n",
+    "    location=location,\n",
+    ")\n",
+    "target = workspace.get_targets(\"rigetti.sim.qvm\")\n",
+    "job = target.submit(operation, \"my-azure-quantum-job\", input_params={ \"count\": 100 })\n",
+    "job.get_results()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "qsharp",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.1"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pip/samples/sample.ipynb
+++ b/pip/samples/sample.ipynb
@@ -1,770 +1,782 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "a2f48f2b",
-   "metadata": {},
-   "source": [
-    "Import the Q# module.\n",
-    "\n",
-    "This enables the `%%qsharp` magic and initializes a Q# interpreter singleton."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "1e8e4faa",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "application/javascript": "// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT License.\n\n// This file provides CodeMirror syntax highlighting for Q# magic cells\n// in classic Jupyter Notebooks. It does nothing in other (Jupyter Notebook 7,\n// VS Code, Azure Notebooks, etc.) environments.\n\n// Detect the prerequisites and do nothing if they don't exist.\nif (window.require && window.CodeMirror && window.Jupyter) {\n  // The simple mode plugin for CodeMirror is not loaded by default, so require it.\n  window.require([\"codemirror/addon/mode/simple\"], function defineMode() {\n    let rules = [\n      {\n        token: \"comment\",\n        regex: /(\\/\\/).*/,\n        beginWord: false,\n      },\n      {\n        token: \"string\",\n        regex: String.raw`^\\\"(?:[^\\\"\\\\]|\\\\[\\s\\S])*(?:\\\"|$)`,\n        beginWord: false,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(namespace|open|as|operation|function|body|adjoint|newtype|controlled|internal)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(let|set|w\\/|new|not|and|or|use|borrow|using|borrowing|newtype|mutable)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"meta\",\n        regex: String.raw`(Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"atom\",\n        regex: String.raw`(true|false|Pauli(I|X|Y|Z)|One|Zero)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"builtin\",\n        regex: String.raw`(X|Y|Z|H|HY|S|T|SWAP|CNOT|CCNOT|MultiX|R|RFrac|Rx|Ry|Rz|R1|R1Frac|Exp|ExpFrac|Measure|M|MultiM)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"builtin\",\n        regex: String.raw`(Message|Length|Assert|AssertProb|AssertEqual)\\b`,\n        beginWord: true,\n      },\n    ];\n    let simpleRules = [];\n    for (let rule of rules) {\n      simpleRules.push({\n        token: rule.token,\n        regex: new RegExp(rule.regex, \"g\"),\n        sol: rule.beginWord,\n      });\n      if (rule.beginWord) {\n        // Need an additional rule due to the fact that CodeMirror simple mode doesn't work with ^ token\n        simpleRules.push({\n          token: rule.token,\n          regex: new RegExp(String.raw`\\W` + rule.regex, \"g\"),\n          sol: false,\n        });\n      }\n    }\n\n    // Register the mode defined above with CodeMirror\n    window.CodeMirror.defineSimpleMode(\"qsharp\", { start: simpleRules });\n    window.CodeMirror.defineMIME(\"text/x-qsharp\", \"qsharp\");\n\n    // Tell Jupyter to associate %%qsharp magic cells with the qsharp mode\n    window.Jupyter.CodeCell.options_default.highlight_modes[\"qsharp\"] = {\n      reg: [/^%%qsharp/],\n    };\n\n    // Force re-highlighting of all cells the first time this code runs\n    for (const cell of window.Jupyter.notebook.get_cells()) {\n      cell.auto_highlight();\n    }\n  });\n}\n",
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "cell_type": "markdown",
+      "id": "a2f48f2b",
+      "metadata": {},
+      "source": [
+        "Import the Q# module.\n",
+        "\n",
+        "This enables the `%%qsharp` magic and initializes a Q# interpreter singleton."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "1e8e4faa",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "application/javascript": "// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT License.\n\n// This file provides CodeMirror syntax highlighting for Q# magic cells\n// in classic Jupyter Notebooks. It does nothing in other (Jupyter Notebook 7,\n// VS Code, Azure Notebooks, etc.) environments.\n\n// Detect the prerequisites and do nothing if they don't exist.\nif (window.require && window.CodeMirror && window.Jupyter) {\n  // The simple mode plugin for CodeMirror is not loaded by default, so require it.\n  window.require([\"codemirror/addon/mode/simple\"], function defineMode() {\n    let rules = [\n      {\n        token: \"comment\",\n        regex: /(\\/\\/).*/,\n        beginWord: false,\n      },\n      {\n        token: \"string\",\n        regex: String.raw`^\\\"(?:[^\\\"\\\\]|\\\\[\\s\\S])*(?:\\\"|$)`,\n        beginWord: false,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(namespace|open|as|operation|function|body|adjoint|newtype|controlled|internal)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(let|set|w\\/|new|not|and|or|use|borrow|using|borrowing|newtype|mutable)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"meta\",\n        regex: String.raw`(Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"atom\",\n        regex: String.raw`(true|false|Pauli(I|X|Y|Z)|One|Zero)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"builtin\",\n        regex: String.raw`(X|Y|Z|H|HY|S|T|SWAP|CNOT|CCNOT|MultiX|R|RFrac|Rx|Ry|Rz|R1|R1Frac|Exp|ExpFrac|Measure|M|MultiM)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"builtin\",\n        regex: String.raw`(Message|Length|Assert|AssertProb|AssertEqual)\\b`,\n        beginWord: true,\n      },\n    ];\n    let simpleRules = [];\n    for (let rule of rules) {\n      simpleRules.push({\n        token: rule.token,\n        regex: new RegExp(rule.regex, \"g\"),\n        sol: rule.beginWord,\n      });\n      if (rule.beginWord) {\n        // Need an additional rule due to the fact that CodeMirror simple mode doesn't work with ^ token\n        simpleRules.push({\n          token: rule.token,\n          regex: new RegExp(String.raw`\\W` + rule.regex, \"g\"),\n          sol: false,\n        });\n      }\n    }\n\n    // Register the mode defined above with CodeMirror\n    window.CodeMirror.defineSimpleMode(\"qsharp\", { start: simpleRules });\n    window.CodeMirror.defineMIME(\"text/x-qsharp\", \"qsharp\");\n\n    // Tell Jupyter to associate %%qsharp magic cells with the qsharp mode\n    window.Jupyter.CodeCell.options_default.highlight_modes[\"qsharp\"] = {\n      reg: [/^%%qsharp/],\n    };\n\n    // Force re-highlighting of all cells the first time this code runs\n    for (const cell of window.Jupyter.notebook.get_cells()) {\n      cell.auto_highlight();\n    }\n  });\n}\n",
+            "text/plain": []
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "import qsharp\n",
+        "qsharp.init()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "3a536d53",
+      "metadata": {},
+      "source": [
+        "Run Q# using the `%%qsharp` magic.\n",
+        "\n",
+        "`DumpMachine()` and `Message()` output get formatted as HTML. Return value is shown as cell output."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "9df62352",
+      "metadata": {
+        "vscode": {
+          "languageId": "qsharp"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "  <thead>\n",
+              "    <tr>\n",
+              "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+              "      <th style=\"text-align: left\">Amplitude</th>\n",
+              "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+              "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">|1⟩</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <progress max=\"100\" value=\"100\"></progress>\n",
+              "    <span style=\"display: inline-block\">100.0000%</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">0.0000</span>\n",
+              "  </td>\n",
+              "</tr>\n",
+              "\n",
+              "  </tbody>\n",
+              "</table>\n"
+            ],
+            "text/plain": [
+              "STATE:\n",
+              "|1⟩: 1.0000+0.0000𝑖"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<p>The result of the measurement is One</p>"
+            ],
+            "text/plain": [
+              "The result of the measurement is One"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/plain": [
+              "Result.One"
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "%%qsharp\n",
+        "\n",
+        "operation Main() : Result {\n",
+        "    use q = Qubit();\n",
+        "    X(q);\n",
+        "    Microsoft.Quantum.Diagnostics.DumpMachine();\n",
+        "    let r = M(q);\n",
+        "    Message($\"The result of the measurement is {r}\");\n",
+        "    Reset(q);\n",
+        "    r\n",
+        "}\n",
+        "\n",
+        "Main()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4584c494",
+      "metadata": {},
+      "source": [
+        "`qsharp.eval()` does the same thing as the `%%qsharp` magic.\n",
+        "\n",
+        "`DumpMachine()` and `Message()` print to stdout and get displayed in the notebook as plain text"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "7d0995bf",
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "STATE:\n",
+            "|1⟩: 1.0000+0.0000𝑖\n",
+            "The result of the measurement is One\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "Result.One"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "qsharp.eval(\"Main()\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a3bde193",
+      "metadata": {},
+      "source": [
+        "Assign a result to a Python variable."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "50383f8a",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Result: 3 (type: int)\n"
+          ]
+        }
+      ],
+      "source": [
+        "result = qsharp.eval(\"1 + 2\")\n",
+        "\n",
+        "print(f\"Result: {result} (type: {type(result).__name__})\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b06b7857",
+      "metadata": {},
+      "source": [
+        "Errors are exceptions. \n",
+        "\n",
+        "Catch and handle compilation errors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "33fd3c4d",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\u001b[31mQsc.Resolve.NotFound\u001b[0m\n",
+            "\n",
+            "  \u001b[31m×\u001b[0m name error\n",
+            "\u001b[31m  ╰─▶ \u001b[0m`Bar` not found\n",
+            "   ╭─[2:1]\n",
+            " \u001b[2m2\u001b[0m │ operation Foo() : Unit {\n",
+            " \u001b[2m3\u001b[0m │     Bar();\n",
+            "   · \u001b[35;1m    ───\u001b[0m\n",
+            " \u001b[2m4\u001b[0m │     Baz();\n",
+            "   ╰────\n",
+            "\u001b[31mQsc.Resolve.NotFound\u001b[0m\n",
+            "\n",
+            "  \u001b[31m×\u001b[0m name error\n",
+            "\u001b[31m  ╰─▶ \u001b[0m`Baz` not found\n",
+            "   ╭─[3:1]\n",
+            " \u001b[2m3\u001b[0m │     Bar();\n",
+            " \u001b[2m4\u001b[0m │     Baz();\n",
+            "   · \u001b[35;1m    ───\u001b[0m\n",
+            " \u001b[2m5\u001b[0m │ }\n",
+            "   ╰────\n",
+            "\u001b[31mQsc.TypeCk.AmbiguousTy\u001b[0m\n",
+            "\n",
+            "  \u001b[31m×\u001b[0m type error\n",
+            "\u001b[31m  ╰─▶ \u001b[0minsufficient type information to infer type\n",
+            "   ╭─[2:1]\n",
+            " \u001b[2m2\u001b[0m │ operation Foo() : Unit {\n",
+            " \u001b[2m3\u001b[0m │     Bar();\n",
+            "   · \u001b[35;1m    ─────\u001b[0m\n",
+            " \u001b[2m4\u001b[0m │     Baz();\n",
+            "   ╰────\n",
+            "\u001b[36m  help: \u001b[0mprovide a type annotation\n",
+            "\u001b[31mQsc.TypeCk.AmbiguousTy\u001b[0m\n",
+            "\n",
+            "  \u001b[31m×\u001b[0m type error\n",
+            "\u001b[31m  ╰─▶ \u001b[0minsufficient type information to infer type\n",
+            "   ╭─[3:1]\n",
+            " \u001b[2m3\u001b[0m │     Bar();\n",
+            " \u001b[2m4\u001b[0m │     Baz();\n",
+            "   · \u001b[35;1m    ─────\u001b[0m\n",
+            " \u001b[2m5\u001b[0m │ }\n",
+            "   ╰────\n",
+            "\u001b[36m  help: \u001b[0mprovide a type annotation\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "from qsharp import QSharpError\n",
+        "\n",
+        "try:\n",
+        "    qsharp.eval(\n",
+        "        \"\"\"\n",
+        "operation Foo() : Unit {\n",
+        "    Bar();\n",
+        "    Baz();\n",
+        "}\n",
+        "\"\"\"\n",
+        "    )\n",
+        "except QSharpError as ex:\n",
+        "    print(ex)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "00f82a16",
+      "metadata": {},
+      "source": [
+        "Catch and handle runtime errors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "e70a95d9",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Error: Qubit2 released while not in |0⟩ state\n",
+            "Call stack:\n",
+            "    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n",
+            "    at Foo in <expression>\n",
+            "\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n",
+            "\n",
+            "  \u001b[31m×\u001b[0m runtime error\n",
+            "\u001b[31m  ╰─▶ \u001b[0mQubit2 released while not in |0⟩ state\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "try:\n",
+        "    qsharp.eval(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")\n",
+        "except QSharpError as ex:\n",
+        "    print(ex)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "3e294471",
+      "metadata": {},
+      "source": [
+        "A runtime error that's not caught gets reported as a Python exception."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "id": "d40d86cb",
+      "metadata": {},
+      "outputs": [
+        {
+          "ename": "QSharpError",
+          "evalue": "Error: Qubit3 released while not in |0⟩ state\nCall stack:\n    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n    at Foo in <expression>\n\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n\n  \u001b[31m×\u001b[0m runtime error\n\u001b[31m  ╰─▶ \u001b[0mQubit3 released while not in |0⟩ state\n",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[1;31mQSharpError\u001b[0m                               Traceback (most recent call last)",
+            "Cell \u001b[1;32mIn[9], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m qsharp\u001b[39m.\u001b[39;49meval(\u001b[39m\"\u001b[39;49m\u001b[39moperation Foo() : Unit \u001b[39;49m\u001b[39m{\u001b[39;49m\u001b[39m use q = Qubit(); X(q) } Foo()\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n",
+            "File \u001b[1;32mc:\\src\\qsharp\\.venv\\Lib\\site-packages\\qsharp\\_qsharp.py:24\u001b[0m, in \u001b[0;36meval\u001b[1;34m(source)\u001b[0m\n\u001b[0;32m     21\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcallback\u001b[39m(output):\n\u001b[0;32m     22\u001b[0m     \u001b[39mprint\u001b[39m(output)\n\u001b[1;32m---> 24\u001b[0m \u001b[39mreturn\u001b[39;00m _interpreter\u001b[39m.\u001b[39;49minterpret(source, callback)\n",
+            "\u001b[1;31mQSharpError\u001b[0m: Error: Qubit3 released while not in |0⟩ state\nCall stack:\n    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n    at Foo in <expression>\n\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n\n  \u001b[31m×\u001b[0m runtime error\n\u001b[31m  ╰─▶ \u001b[0mQubit3 released while not in |0⟩ state\n"
+          ]
+        }
+      ],
+      "source": [
+        "qsharp.eval(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ba2f98ad",
+      "metadata": {},
+      "source": [
+        "In `%%qsharp` cells, exceptions are handled and displayed as error text."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "id": "1b55e53c",
+      "metadata": {
+        "scrolled": false,
+        "vscode": {
+          "languageId": "qsharp"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "  <thead>\n",
+              "    <tr>\n",
+              "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+              "      <th style=\"text-align: left\">Amplitude</th>\n",
+              "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+              "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">|01111⟩</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <progress max=\"100\" value=\"100\"></progress>\n",
+              "    <span style=\"display: inline-block\">100.0000%</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">0.0000</span>\n",
+              "  </td>\n",
+              "</tr>\n",
+              "\n",
+              "  </tbody>\n",
+              "</table>\n"
+            ],
+            "text/plain": [
+              "STATE:\n",
+              "|01111⟩: 1.0000+0.0000𝑖"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/plain": [
+              "Error: Qubit4 released while not in |0⟩ state\n",
+              "Call stack:\n",
+              "    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n",
+              "    at Bar in <expression>\n",
+              "\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n",
+              "\n",
+              "  \u001b[31m×\u001b[0m runtime error\n",
+              "\u001b[31m  ╰─▶ \u001b[0mQubit4 released while not in |0⟩ state\n"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "%%qsharp\n",
+        "\n",
+        "operation Bar() : Unit {\n",
+        "    use q = Qubit(); \n",
+        "    Microsoft.Quantum.Diagnostics.DumpMachine(); \n",
+        "    X(q);\n",
+        "} \n",
+        "    \n",
+        "Bar()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "98247ac2",
+      "metadata": {},
+      "source": [
+        "Streaming output for long running operations."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "id": "bd25ae87",
+      "metadata": {
+        "vscode": {
+          "languageId": "qsharp"
+        }
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<p>Generating random bit... </p>"
+            ],
+            "text/plain": [
+              "Generating random bit... "
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "  <thead>\n",
+              "    <tr>\n",
+              "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+              "      <th style=\"text-align: left\">Amplitude</th>\n",
+              "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+              "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">|011111⟩</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <progress max=\"100\" value=\"100\"></progress>\n",
+              "    <span style=\"display: inline-block\">100.0000%</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">0.0000</span>\n",
+              "  </td>\n",
+              "</tr>\n",
+              "\n",
+              "  </tbody>\n",
+              "</table>\n"
+            ],
+            "text/plain": [
+              "STATE:\n",
+              "|011111⟩: 1.0000+0.0000𝑖"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<p>Result: Zero</p>"
+            ],
+            "text/plain": [
+              "Result: Zero"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "  <thead>\n",
+              "    <tr>\n",
+              "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+              "      <th style=\"text-align: left\">Amplitude</th>\n",
+              "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+              "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">|111111⟩</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <progress max=\"100\" value=\"100\"></progress>\n",
+              "    <span style=\"display: inline-block\">100.0000%</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">0.0000</span>\n",
+              "  </td>\n",
+              "</tr>\n",
+              "\n",
+              "  </tbody>\n",
+              "</table>\n"
+            ],
+            "text/plain": [
+              "STATE:\n",
+              "|111111⟩: 1.0000+0.0000𝑖"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<p>Result: One</p>"
+            ],
+            "text/plain": [
+              "Result: One"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "  <thead>\n",
+              "    <tr>\n",
+              "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+              "      <th style=\"text-align: left\">Amplitude</th>\n",
+              "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+              "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">|111111⟩</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <progress max=\"100\" value=\"100\"></progress>\n",
+              "    <span style=\"display: inline-block\">100.0000%</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">0.0000</span>\n",
+              "  </td>\n",
+              "</tr>\n",
+              "\n",
+              "  </tbody>\n",
+              "</table>\n"
+            ],
+            "text/plain": [
+              "STATE:\n",
+              "|111111⟩: 1.0000+0.0000𝑖"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<p>Result: One</p>"
+            ],
+            "text/plain": [
+              "Result: One"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "  <thead>\n",
+              "    <tr>\n",
+              "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+              "      <th style=\"text-align: left\">Amplitude</th>\n",
+              "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+              "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">|011111⟩</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <progress max=\"100\" value=\"100\"></progress>\n",
+              "    <span style=\"display: inline-block\">100.0000%</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">0.0000</span>\n",
+              "  </td>\n",
+              "</tr>\n",
+              "\n",
+              "  </tbody>\n",
+              "</table>\n"
+            ],
+            "text/plain": [
+              "STATE:\n",
+              "|011111⟩: 1.0000+0.0000𝑖"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<p>Result: Zero</p>"
+            ],
+            "text/plain": [
+              "Result: Zero"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "  <thead>\n",
+              "    <tr>\n",
+              "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
+              "      <th style=\"text-align: left\">Amplitude</th>\n",
+              "      <th style=\"text-align: left\">Measurement Probability</th>\n",
+              "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">|111111⟩</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <progress max=\"100\" value=\"100\"></progress>\n",
+              "    <span style=\"display: inline-block\">100.0000%</span>\n",
+              "  </td>\n",
+              "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
+              "  <td style=\"text-align: left\">\n",
+              "    <span style=\"display: inline-block\">0.0000</span>\n",
+              "  </td>\n",
+              "</tr>\n",
+              "\n",
+              "  </tbody>\n",
+              "</table>\n"
+            ],
+            "text/plain": [
+              "STATE:\n",
+              "|111111⟩: 1.0000+0.0000𝑖"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "text/html": [
+              "<p>Result: One</p>"
+            ],
+            "text/plain": [
+              "Result: One"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "%%qsharp\n",
+        "\n",
+        "open Microsoft.Quantum.Diagnostics;\n",
+        "\n",
+        "operation Main() : Unit {\n",
+        "    Message(\"Generating random bit... \");\n",
+        "    for i in 0..400000 {\n",
+        "        use q = Qubit();\n",
+        "        H(q);\n",
+        "        let r = M(q);\n",
+        "        if (i % 100000) == 0 {\n",
+        "            DumpMachine();\n",
+        "            Message($\"Result: {r}\");\n",
+        "        }\n",
+        "        Reset(q);\n",
+        "    }\n",
+        "}\n",
+        "\n",
+        "Main()"
+      ]
     }
-   ],
-   "source": [
-    "import qsharp"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3a536d53",
-   "metadata": {},
-   "source": [
-    "Run Q# using the `%%qsharp` magic.\n",
-    "\n",
-    "`DumpMachine()` and `Message()` output get formatted as HTML. Return value is shown as cell output."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "9df62352",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left\">Amplitude</th>\n",
-       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">|1⟩</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <progress max=\"100\" value=\"100\"></progress>\n",
-       "    <span style=\"display: inline-block\">100.0000%</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">0.0000</span>\n",
-       "  </td>\n",
-       "</tr>\n",
-       "\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|1⟩: 1.0000+0.0000𝑖"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
     },
-    {
-     "data": {
-      "text/html": [
-       "<p>The result of the measurement is One</p>"
-      ],
-      "text/plain": [
-       "The result of the measurement is One"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Result.One"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.4"
     }
-   ],
-   "source": [
-    "%%qsharp\n",
-    "\n",
-    "operation Main() : Result {\n",
-    "    use q = Qubit();\n",
-    "    X(q);\n",
-    "    Microsoft.Quantum.Diagnostics.DumpMachine();\n",
-    "    let r = M(q);\n",
-    "    Message($\"The result of the measurement is {r}\");\n",
-    "    Reset(q);\n",
-    "    r\n",
-    "}\n",
-    "\n",
-    "Main()"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "id": "4584c494",
-   "metadata": {},
-   "source": [
-    "`qsharp.eval()` does the same thing as the `%%qsharp` magic.\n",
-    "\n",
-    "`DumpMachine()` and `Message()` print to stdout and get displayed in the notebook as plain text"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "7d0995bf",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "STATE:\n",
-      "|1⟩: 1.0000+0.0000𝑖\n",
-      "The result of the measurement is One\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Result.One"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "qsharp.eval(\"Main()\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a3bde193",
-   "metadata": {},
-   "source": [
-    "Assign a result to a Python variable."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "50383f8a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result: 3 (type: int)\n"
-     ]
-    }
-   ],
-   "source": [
-    "result = qsharp.eval(\"1 + 2\")\n",
-    "\n",
-    "print(f\"Result: {result} (type: {type(result).__name__})\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b06b7857",
-   "metadata": {},
-   "source": [
-    "Errors are exceptions. \n",
-    "\n",
-    "Catch and handle compilation errors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "33fd3c4d",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[31mQsc.Resolve.NotFound\u001b[0m\n",
-      "\n",
-      "  \u001b[31m×\u001b[0m name error\n",
-      "\u001b[31m  ╰─▶ \u001b[0m`Bar` not found\n",
-      "   ╭─[2:1]\n",
-      " \u001b[2m2\u001b[0m │ operation Foo() : Unit {\n",
-      " \u001b[2m3\u001b[0m │     Bar();\n",
-      "   · \u001b[35;1m    ───\u001b[0m\n",
-      " \u001b[2m4\u001b[0m │     Baz();\n",
-      "   ╰────\n",
-      "\u001b[31mQsc.Resolve.NotFound\u001b[0m\n",
-      "\n",
-      "  \u001b[31m×\u001b[0m name error\n",
-      "\u001b[31m  ╰─▶ \u001b[0m`Baz` not found\n",
-      "   ╭─[3:1]\n",
-      " \u001b[2m3\u001b[0m │     Bar();\n",
-      " \u001b[2m4\u001b[0m │     Baz();\n",
-      "   · \u001b[35;1m    ───\u001b[0m\n",
-      " \u001b[2m5\u001b[0m │ }\n",
-      "   ╰────\n",
-      "\u001b[31mQsc.TypeCk.AmbiguousTy\u001b[0m\n",
-      "\n",
-      "  \u001b[31m×\u001b[0m type error\n",
-      "\u001b[31m  ╰─▶ \u001b[0minsufficient type information to infer type\n",
-      "   ╭─[2:1]\n",
-      " \u001b[2m2\u001b[0m │ operation Foo() : Unit {\n",
-      " \u001b[2m3\u001b[0m │     Bar();\n",
-      "   · \u001b[35;1m    ─────\u001b[0m\n",
-      " \u001b[2m4\u001b[0m │     Baz();\n",
-      "   ╰────\n",
-      "\u001b[36m  help: \u001b[0mprovide a type annotation\n",
-      "\u001b[31mQsc.TypeCk.AmbiguousTy\u001b[0m\n",
-      "\n",
-      "  \u001b[31m×\u001b[0m type error\n",
-      "\u001b[31m  ╰─▶ \u001b[0minsufficient type information to infer type\n",
-      "   ╭─[3:1]\n",
-      " \u001b[2m3\u001b[0m │     Bar();\n",
-      " \u001b[2m4\u001b[0m │     Baz();\n",
-      "   · \u001b[35;1m    ─────\u001b[0m\n",
-      " \u001b[2m5\u001b[0m │ }\n",
-      "   ╰────\n",
-      "\u001b[36m  help: \u001b[0mprovide a type annotation\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "from qsharp import QSharpError\n",
-    "\n",
-    "try:\n",
-    "    qsharp.eval(\n",
-    "        \"\"\"\n",
-    "operation Foo() : Unit {\n",
-    "    Bar();\n",
-    "    Baz();\n",
-    "}\n",
-    "\"\"\"\n",
-    "    )\n",
-    "except QSharpError as ex:\n",
-    "    print(ex)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "00f82a16",
-   "metadata": {},
-   "source": [
-    "Catch and handle runtime errors."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "e70a95d9",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Error: Qubit2 released while not in |0⟩ state\n",
-      "Call stack:\n",
-      "    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n",
-      "    at Foo in <expression>\n",
-      "\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n",
-      "\n",
-      "  \u001b[31m×\u001b[0m runtime error\n",
-      "\u001b[31m  ╰─▶ \u001b[0mQubit2 released while not in |0⟩ state\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "try:\n",
-    "    qsharp.eval(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")\n",
-    "except QSharpError as ex:\n",
-    "    print(ex)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3e294471",
-   "metadata": {},
-   "source": [
-    "A runtime error that's not caught gets reported as a Python exception."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "d40d86cb",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "QSharpError",
-     "evalue": "Error: Qubit3 released while not in |0⟩ state\nCall stack:\n    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n    at Foo in <expression>\n\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n\n  \u001b[31m×\u001b[0m runtime error\n\u001b[31m  ╰─▶ \u001b[0mQubit3 released while not in |0⟩ state\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mQSharpError\u001b[0m                               Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[9], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m qsharp\u001b[39m.\u001b[39;49meval(\u001b[39m\"\u001b[39;49m\u001b[39moperation Foo() : Unit \u001b[39;49m\u001b[39m{\u001b[39;49m\u001b[39m use q = Qubit(); X(q) } Foo()\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n",
-      "File \u001b[1;32mc:\\src\\qsharp\\.venv\\Lib\\site-packages\\qsharp\\_qsharp.py:24\u001b[0m, in \u001b[0;36meval\u001b[1;34m(source)\u001b[0m\n\u001b[0;32m     21\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcallback\u001b[39m(output):\n\u001b[0;32m     22\u001b[0m     \u001b[39mprint\u001b[39m(output)\n\u001b[1;32m---> 24\u001b[0m \u001b[39mreturn\u001b[39;00m _interpreter\u001b[39m.\u001b[39;49minterpret(source, callback)\n",
-      "\u001b[1;31mQSharpError\u001b[0m: Error: Qubit3 released while not in |0⟩ state\nCall stack:\n    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n    at Foo in <expression>\n\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n\n  \u001b[31m×\u001b[0m runtime error\n\u001b[31m  ╰─▶ \u001b[0mQubit3 released while not in |0⟩ state\n"
-     ]
-    }
-   ],
-   "source": [
-    "qsharp.eval(\"operation Foo() : Unit { use q = Qubit(); X(q) } Foo()\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ba2f98ad",
-   "metadata": {},
-   "source": [
-    "In `%%qsharp` cells, exceptions are handled and displayed as error text."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "1b55e53c",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left\">Amplitude</th>\n",
-       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">|01111⟩</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <progress max=\"100\" value=\"100\"></progress>\n",
-       "    <span style=\"display: inline-block\">100.0000%</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">0.0000</span>\n",
-       "  </td>\n",
-       "</tr>\n",
-       "\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|01111⟩: 1.0000+0.0000𝑖"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Error: Qubit4 released while not in |0⟩ state\n",
-       "Call stack:\n",
-       "    at QIR.Runtime.__quantum__rt__qubit_release in qir.qs\n",
-       "    at Bar in <expression>\n",
-       "\u001b[31mQsc.Eval.ReleasedQubitNotZero\u001b[0m\n",
-       "\n",
-       "  \u001b[31m×\u001b[0m runtime error\n",
-       "\u001b[31m  ╰─▶ \u001b[0mQubit4 released while not in |0⟩ state\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%%qsharp\n",
-    "\n",
-    "operation Bar() : Unit {\n",
-    "    use q = Qubit(); \n",
-    "    Microsoft.Quantum.Diagnostics.DumpMachine(); \n",
-    "    X(q);\n",
-    "} \n",
-    "    \n",
-    "Bar()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "98247ac2",
-   "metadata": {},
-   "source": [
-    "Streaming output for long running operations."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "bd25ae87",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<p>Generating random bit... </p>"
-      ],
-      "text/plain": [
-       "Generating random bit... "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left\">Amplitude</th>\n",
-       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">|011111⟩</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <progress max=\"100\" value=\"100\"></progress>\n",
-       "    <span style=\"display: inline-block\">100.0000%</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">0.0000</span>\n",
-       "  </td>\n",
-       "</tr>\n",
-       "\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|011111⟩: 1.0000+0.0000𝑖"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: Zero</p>"
-      ],
-      "text/plain": [
-       "Result: Zero"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left\">Amplitude</th>\n",
-       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">|111111⟩</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <progress max=\"100\" value=\"100\"></progress>\n",
-       "    <span style=\"display: inline-block\">100.0000%</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">0.0000</span>\n",
-       "  </td>\n",
-       "</tr>\n",
-       "\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|111111⟩: 1.0000+0.0000𝑖"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: One</p>"
-      ],
-      "text/plain": [
-       "Result: One"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left\">Amplitude</th>\n",
-       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">|111111⟩</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <progress max=\"100\" value=\"100\"></progress>\n",
-       "    <span style=\"display: inline-block\">100.0000%</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">0.0000</span>\n",
-       "  </td>\n",
-       "</tr>\n",
-       "\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|111111⟩: 1.0000+0.0000𝑖"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: One</p>"
-      ],
-      "text/plain": [
-       "Result: One"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left\">Amplitude</th>\n",
-       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">|011111⟩</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <progress max=\"100\" value=\"100\"></progress>\n",
-       "    <span style=\"display: inline-block\">100.0000%</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">0.0000</span>\n",
-       "  </td>\n",
-       "</tr>\n",
-       "\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|011111⟩: 1.0000+0.0000𝑖"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: Zero</p>"
-      ],
-      "text/plain": [
-       "Result: Zero"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "  <thead>\n",
-       "    <tr>\n",
-       "      <th style=\"text-align: left\">Basis State<br />(|𝜓ₙ…𝜓₁⟩)</th>\n",
-       "      <th style=\"text-align: left\">Amplitude</th>\n",
-       "      <th style=\"text-align: left\">Measurement Probability</th>\n",
-       "      <th style=\"text-align: left\" colspan=\"2\">Phase</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">|111111⟩</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">1.0000+0.0000𝑖</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <progress max=\"100\" value=\"100\"></progress>\n",
-       "    <span style=\"display: inline-block\">100.0000%</span>\n",
-       "  </td>\n",
-       "  <td style=\"text-align: left; transform: rotate(0.0000rad)\">↑</td>\n",
-       "  <td style=\"text-align: left\">\n",
-       "    <span style=\"display: inline-block\">0.0000</span>\n",
-       "  </td>\n",
-       "</tr>\n",
-       "\n",
-       "  </tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "STATE:\n",
-       "|111111⟩: 1.0000+0.0000𝑖"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<p>Result: One</p>"
-      ],
-      "text/plain": [
-       "Result: One"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%%qsharp\n",
-    "\n",
-    "open Microsoft.Quantum.Diagnostics;\n",
-    "\n",
-    "operation Main() : Unit {\n",
-    "    Message(\"Generating random bit... \");\n",
-    "    for i in 0..400000 {\n",
-    "        use q = Qubit();\n",
-    "        H(q);\n",
-    "        let r = M(q);\n",
-    "        if (i % 100000) == 0 {\n",
-    "            DumpMachine();\n",
-    "            Message($\"Result: {r}\");\n",
-    "        }\n",
-    "        Reset(q);\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "Main()"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.4"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -13,13 +13,13 @@ use qsc::{
         stateful::{self, LineError},
         Value,
     },
-    PackageType, SourceMap, TargetProfile,
+    PackageType, SourceMap,
 };
 use std::{fmt::Write, sync::Arc};
 
 #[pymodule]
 fn _native(py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<Target>()?;
+    m.add_class::<TargetProfile>()?;
     m.add_class::<Interpreter>()?;
     m.add_class::<Result>()?;
     m.add_class::<Pauli>()?;
@@ -31,9 +31,18 @@ fn _native(py: Python, m: &PyModule) -> PyResult<()> {
 
 #[derive(Clone, Copy)]
 #[pyclass(unsendable)]
-/// A Q# measurement result.
-pub(crate) enum Target {
+/// A Q# target profile.
+///
+/// A target profile describes the capabilities of the hardware or simulator
+/// which will be used to run the Q# program.
+pub(crate) enum TargetProfile {
+    /// Target supports the full set of capabilities required to run any Q# program.
+    ///
+    /// This option maps to the Full Profile as defined by the QIR specification.
     Full,
+    /// Target supports the minimal set of capabilities required to run a quantum program.
+    ///
+    /// This option maps to the Base Profile as defined by the QIR specification.
     Base,
 }
 
@@ -47,10 +56,10 @@ pub(crate) struct Interpreter {
 impl Interpreter {
     #[new]
     /// Initializes a new Q# interpreter.
-    pub(crate) fn new(_py: Python, target: Target) -> PyResult<Self> {
+    pub(crate) fn new(_py: Python, target: TargetProfile) -> PyResult<Self> {
         let target = match target {
-            Target::Full => TargetProfile::Full,
-            Target::Base => TargetProfile::Base,
+            TargetProfile::Full => qsc::TargetProfile::Full,
+            TargetProfile::Base => qsc::TargetProfile::Base,
         };
         match stateful::Interpreter::new(true, SourceMap::default(), PackageType::Lib, target) {
             Ok(interpreter) => Ok(Self { interpreter }),

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -99,7 +99,7 @@ impl Interpreter {
 
     #[allow(clippy::unused_self)]
     fn qir(&mut self, _py: Python, entry_expr: &str) -> PyResult<String> {
-        match self.interpreter.qirgen_line(entry_expr) {
+        match self.interpreter.qirgen(entry_expr) {
             Ok(qir) => Ok(qir),
             Err(err) => Err(QSharpError::new_err(format!("{err:?}"))),
         }

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -89,7 +89,7 @@ impl Interpreter {
     fn qir(&mut self, _py: Python, entry_expr: &str) -> PyResult<String> {
         match self.interpreter.qirgen(entry_expr) {
             Ok(qir) => Ok(qir),
-            Err(err) => Err(QSharpError::new_err(format!("{err:?}"))),
+            Err(errors) => Err(QSharpError::new_err(format_errors(entry_expr, errors))),
         }
     }
 }

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -19,6 +19,7 @@ use std::{fmt::Write, sync::Arc};
 
 #[pymodule]
 fn _native(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<Target>()?;
     m.add_class::<Interpreter>()?;
     m.add_class::<Result>()?;
     m.add_class::<Pauli>()?;
@@ -28,9 +29,21 @@ fn _native(py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+#[pyclass(unsendable)]
+/// A Q# measurement result.
+pub(crate) enum Target {
+    Full,
+    Base,
+}
+
 #[pyclass(unsendable)]
 pub(crate) struct Interpreter {
     pub(crate) interpreter: stateful::Interpreter,
+    // TODO: Smoke and mirrors.
+    // Accumulate Q# source code so we can pass it to compile_to_qir later.
+    code: String,
+    // target: TargetProfile,
 }
 
 #[pymethods]
@@ -38,14 +51,17 @@ pub(crate) struct Interpreter {
 impl Interpreter {
     #[new]
     /// Initializes a new Q# interpreter.
-    pub(crate) fn new(_py: Python) -> PyResult<Self> {
-        match stateful::Interpreter::new(
-            true,
-            SourceMap::default(),
-            PackageType::Lib,
-            TargetProfile::Full,
-        ) {
-            Ok(interpreter) => Ok(Self { interpreter }),
+    pub(crate) fn new(_py: Python, target: Target) -> PyResult<Self> {
+        let target = match target {
+            Target::Full => TargetProfile::Full,
+            Target::Base => TargetProfile::Base,
+        };
+        match stateful::Interpreter::new(true, SourceMap::default(), PackageType::Lib, target) {
+            Ok(interpreter) => Ok(Self {
+                interpreter,
+                code: String::new(),
+                // target,
+            }),
             Err(errors) => {
                 let mut message = String::new();
                 for error in errors {
@@ -70,10 +86,22 @@ impl Interpreter {
         input: &str,
         callback: Option<PyObject>,
     ) -> PyResult<PyObject> {
+        match writeln!(self.code, "{input}") {
+            Ok(_) => (),
+            Err(_) => return Err(QSharpError::new_err("Failed to write to code buffer")),
+        }
         let mut receiver = OptionalCallbackReceiver { callback, py };
         match self.interpreter.interpret_line(&mut receiver, input) {
             Ok(value) => Ok(ValueWrapper(value).into_py(py)),
             Err(errors) => Err(QSharpError::new_err(format_errors(input, errors))),
+        }
+    }
+
+    #[allow(clippy::unused_self)]
+    fn qir(&mut self, _py: Python, entry_expr: &str) -> PyResult<String> {
+        match self.interpreter.qirgen_line(entry_expr) {
+            Ok(qir) => Ok(qir),
+            Err(err) => Err(QSharpError::new_err(format!("{err:?}"))),
         }
     }
 }

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from qsharp._native import Interpreter, Result, Pauli, QSharpError
+from qsharp._native import Interpreter, Result, Pauli, QSharpError, Target
 import pytest
 
 
@@ -9,7 +9,7 @@ import pytest
 
 
 def test_output() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
 
     def callback(output):
         nonlocal called
@@ -22,7 +22,7 @@ def test_output() -> None:
 
 
 def test_dump_output() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
 
     def callback(output):
         nonlocal called
@@ -44,7 +44,7 @@ def test_dump_output() -> None:
 
 
 def test_error() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
 
     with pytest.raises(QSharpError) as excinfo:
         e.interpret("a864")
@@ -52,7 +52,7 @@ def test_error() -> None:
 
 
 def test_multiple_errors() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
 
     with pytest.raises(QSharpError) as excinfo:
         e.interpret("operation Foo() : Unit { Bar(); Baz(); }")
@@ -61,60 +61,60 @@ def test_multiple_errors() -> None:
 
 
 def test_multiple_statements() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret("1; Zero")
     assert value == Result.Zero
 
 
 def test_value_int() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret("5")
     assert value == 5
 
 
 def test_value_double() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret("3.1")
     assert value == 3.1
 
 
 def test_value_bool() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret("true")
     assert value == True
 
 
 def test_value_string() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret('"hello"')
     assert value == "hello"
 
 
 def test_value_result() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret("One")
     assert value == Result.One
 
 
 def test_value_pauli() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret("PauliX")
     assert value == Pauli.X
 
 
 def test_value_tuple() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret('(1, "hello", One)')
     assert value == (1, "hello", Result.One)
 
 
 def test_value_unit() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret("()")
     assert value is None
 
 
 def test_value_array() -> None:
-    e = Interpreter()
+    e = Interpreter(Target.Full)
     value = e.interpret("[1, 2, 3]")
     assert value == [1, 2, 3]

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from qsharp._native import Interpreter, Result, Pauli, QSharpError, Target
+from qsharp._native import Interpreter, Result, Pauli, QSharpError, TargetProfile
 import pytest
 
 
@@ -9,7 +9,7 @@ import pytest
 
 
 def test_output() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
 
     def callback(output):
         nonlocal called
@@ -22,7 +22,7 @@ def test_output() -> None:
 
 
 def test_dump_output() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
 
     def callback(output):
         nonlocal called
@@ -44,7 +44,7 @@ def test_dump_output() -> None:
 
 
 def test_error() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
 
     with pytest.raises(QSharpError) as excinfo:
         e.interpret("a864")
@@ -52,7 +52,7 @@ def test_error() -> None:
 
 
 def test_multiple_errors() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
 
     with pytest.raises(QSharpError) as excinfo:
         e.interpret("operation Foo() : Unit { Bar(); Baz(); }")
@@ -61,60 +61,82 @@ def test_multiple_errors() -> None:
 
 
 def test_multiple_statements() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret("1; Zero")
     assert value == Result.Zero
 
 
 def test_value_int() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret("5")
     assert value == 5
 
 
 def test_value_double() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret("3.1")
     assert value == 3.1
 
 
 def test_value_bool() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret("true")
     assert value == True
 
 
 def test_value_string() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret('"hello"')
     assert value == "hello"
 
 
 def test_value_result() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret("One")
     assert value == Result.One
 
 
 def test_value_pauli() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret("PauliX")
     assert value == Pauli.X
 
 
 def test_value_tuple() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret('(1, "hello", One)')
     assert value == (1, "hello", Result.One)
 
 
 def test_value_unit() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret("()")
     assert value is None
 
 
 def test_value_array() -> None:
-    e = Interpreter(Target.Full)
+    e = Interpreter(TargetProfile.Full)
     value = e.interpret("[1, 2, 3]")
     assert value == [1, 2, 3]
+
+
+def test_target_error() -> None:
+    e = Interpreter(TargetProfile.Base)
+    with pytest.raises(QSharpError) as excinfo:
+        e.interpret("operation Program() : Result { return Zero }")
+    assert str(excinfo.value).startswith("Qsc.BaseProfCk.ResultLiteral") != -1
+
+
+def test_qirgen_compile_error() -> None:
+    e = Interpreter(TargetProfile.Base)
+    e.interpret("operation Program() : Int { return 0 }")
+    with pytest.raises(QSharpError) as excinfo:
+        e.qir("Foo()")
+    assert str(excinfo.value).startswith("Qsc.Resolve.NotFound") != -1
+
+
+def test_qirgen() -> None:
+    e = Interpreter(TargetProfile.Base)
+    e.interpret("operation Program() : Result { use q = Qubit(); return M(q) }")
+    qir = e.qir("Program()")
+    assert isinstance(qir, str)

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -8,10 +8,9 @@ import io
 
 # Tests for the Python library for Q#
 
-qsharp.init(qsharp.Target.Full)
-
 
 def test_stdout() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Full)
     f = io.StringIO()
     with redirect_stdout(f):
         result = qsharp.eval('Message("Hello, world!")')
@@ -21,6 +20,7 @@ def test_stdout() -> None:
 
 
 def test_stdout_multiple_lines() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Full)
     f = io.StringIO()
     with redirect_stdout(f):
         qsharp.eval(
@@ -32,3 +32,10 @@ def test_stdout_multiple_lines() -> None:
         )
 
     assert f.getvalue() == "STATE:\n|0⟩: 1.0000+0.0000𝑖\nHello!\n"
+
+
+def test_compile_qir_input_data() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Base)
+    qsharp.eval("operation Program() : Result { use q = Qubit(); return M(q) }")
+    operation = qsharp.compile("Program()")
+    assert isinstance(operation._repr_qir_(), bytes)

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -8,6 +8,8 @@ import io
 
 # Tests for the Python library for Q#
 
+qsharp.init(qsharp.Target.Full)
+
 
 def test_stdout() -> None:
     f = io.StringIO()


### PR DESCRIPTION
This adds a `compile` method to the Python `qsharp` module and introduces an `init` pattern to be used when starting up a session. The expected usage is that for full compilation and simulation, `qsharp.init()` or `qsharp.init(target=qsharp.Target.Full)` are called at the outset to configure compilation (NOTE: latest allows the user to skip this and just takes the default on first use). If `qsharp.init(target=qsharp.Target.Base)` is used instead then local simulation will follow the same restrictions as base profile code generation. When in this mode, `qsharp.compile(<expr>)` will produce output that can be used as part of submitting to QIR capable targets.