### PR TITLE
Fix Completion Items Display Panel Style

### DIFF
--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -53,7 +53,7 @@ body {
   font-size: 16px;
 }
 
-.header {
+.page-header {
   grid-area: header;
   background: var(--heading-background);
   color: var(--main-background);

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -110,7 +110,7 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
 
   return (
     <>
-      <header class="header">Q# playground</header>
+      <header class="page-header">Q# playground</header>
       <Nav
         selected={currentNavItem}
         navSelected={onNavItemSelected}


### PR DESCRIPTION
The Monaco editor makes use of a `header` css class internally for rendering completion item detail panel contents. We had also defined a `header` css class for the page title element, and this was effecting how the Monaco editor rendered the details panel. This PR fixes the issue by renaming our `header` css class to `page-header` to avoid the name collision.