### PR TITLE
Use `strip = true` to reduce Linux binary sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,4 @@ pyo3 = { version = "0.18", features = ["abi3-py37", "extension-module"] }
 quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", rev = "e96b9a12a43e98f83f2d4d499f46d651d0c6c341", default-features = false }
 
 [profile.release]
-debug = 1
+strip = true


### PR DESCRIPTION
This updates the workspace settings for cargo to remove `debug =1` and instead use `strip = true` to reduce binary sizes. Previously, the Linux .so that was part of the Python wheel was ~31 MB while other platforms were in the single digits. After this change, the same .so is only ~3.2 MB. Perf testing showed no change in behavior, so the only trade-off for the binary size is no longer including debug symbols for the release binaries.