### PR TITLE
Removed or Moved LaTex Syntax from STD Doc Strings

### DIFF
--- a/library/std/arithmetic.qs
+++ b/library/std/arithmetic.qs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Arithmetic {
     ///
     /// Let us denote `value` by a and let y be an unsigned integer encoded in `target`,
     /// then `ApplyXorInPlace` performs an operation given by the following map:
-    /// $\ket{y}\rightarrow \ket{y\oplus a}$ , where $\oplus$ is the bitwise exclusive OR operator.
+    /// |y⟩ -> |y ⊕ a⟩, where ⊕ is the bitwise exclusive OR operator.
     operation ApplyXorInPlace(value : Int, target : Qubit[]) : Unit is Adj+Ctl {
         body(...) {
             Fact(value >= 0, "value must be non-negative");
@@ -84,9 +84,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// Reversible, in-place ripple-carry addition of two integers without carry out.
     ///
     /// # Description
-    /// Given two $n$-bit integers encoded in LittleEndian registers `xs` and `ys`,
-    /// the operation computes the sum of the two integers modulo $2^n$,
-    /// where $n$ is the length of the inputs arrays `xs` and `ys`,
+    /// Given two n-bit integers encoded in LittleEndian registers `xs` and `ys`,
+    /// the operation computes the sum of the two integers modulo 2^n,
+    /// where n is the length of the inputs arrays `xs` and `ys`,
     /// which must be positive. It does not compute the carry out bit.
     ///
     /// # Input
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// LittleEndian qubit register encoding the first integer summand.
     /// ## ys
     /// LittleEndian qubit register encoding the second integer summand, is
-    /// modified to hold the $n$ least significant bits of the sum.
+    /// modified to hold the n least significant bits of the sum.
     ///
     /// # References
     /// - Yasuhiro Takahashi, Seiichiro Tani, Noboru Kunihiro: "Quantum
@@ -125,9 +125,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// Reversible, in-place ripple-carry addition of two integers.
     ///
     /// # Description
-    /// Given two $n$-bit integers encoded in LittleEndian registers `xs` and `ys`,
+    /// Given two n-bit integers encoded in LittleEndian registers `xs` and `ys`,
     /// and a qubit carry, the operation computes the sum of the two integers
-    /// where the $n$ least significant bits of the result are held in `ys` and
+    /// where the n least significant bits of the result are held in `ys` and
     /// the carry out bit is xored to the qubit `carry`.
     ///
     /// # Input
@@ -135,7 +135,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// LittleEndian qubit register encoding the first integer summand.
     /// ## ys
     /// LittleEndian qubit register encoding the second integer summand, is
-    /// modified to hold the $n$ least significant bits of the sum.
+    /// modified to hold the n least significant bits of the sum.
     /// ## carry
     /// Carry qubit, is xored with the carry out bit of the addition.
     ///

--- a/library/std/arrays.qs
+++ b/library/std/arrays.qs
@@ -1192,10 +1192,10 @@ namespace Microsoft.Quantum.Arrays {
     /// of arrays.
     ///
     /// # Description
-    /// Input as an $r \times c$ matrix with $r$ rows and $c$ columns.  The matrix
-    /// is row-based, i.e., `matrix[i][j]` accesses the element at row $i$ and column $j$.
+    /// Input as an r x c matrix with r rows and c columns.  The matrix
+    /// is row-based, i.e., `matrix[i][j]` accesses the element at row `i` and column `j`.
     ///
-    /// This function returns the $c \times r$ matrix that is the transpose of the
+    /// This function returns the c x r matrix that is the transpose of the
     /// input matrix.
     ///
     /// # Type Parameters
@@ -1204,10 +1204,10 @@ namespace Microsoft.Quantum.Arrays {
     ///
     /// # Input
     /// ## matrix
-    /// Row-based $r \times c$ matrix.
+    /// Row-based r x c matrix.
     ///
     /// # Output
-    /// Transposed $c \times r$ matrix.
+    /// Transposed c x r matrix.
     ///
     /// # Example
     /// ```qsharp

--- a/library/std/canon.qs
+++ b/library/std/canon.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Canon {
     /// The target on which the operation acts.
     ///
     /// # Example
-    /// Prepare a three-qubit $\ket{+}$ state:
+    /// Prepare a three-qubit |+⟩ state:
     /// ```qsharp
     /// use register = Qubit[3];
     /// ApplyToEach(H, register);
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.Canon {
     /// The target on which the operation acts.
     ///
     /// # Example
-    /// Prepare a three-qubit $\ket{+}$ state:
+    /// Prepare a three-qubit |+⟩ state:
     /// ```qsharp
     /// use register = Qubit[3];
     /// ApplyToEach(H, register);
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.Canon {
     /// The target on which the operation acts.
     ///
     /// # Example
-    /// Prepare a three-qubit $\ket{+}$ state:
+    /// Prepare a three-qubit |+⟩ state:
     /// ```qsharp
     /// use register = Qubit[3];
     /// ApplyToEach(H, register);
@@ -107,7 +107,7 @@ namespace Microsoft.Quantum.Canon {
     /// The target on which the operation acts.
     ///
     /// # Example
-    /// Prepare a three-qubit $\ket{+}$ state:
+    /// Prepare a three-qubit |+⟩ state:
     /// ```qsharp
     /// use register = Qubit[3];
     /// ApplyToEach(H, register);
@@ -125,9 +125,14 @@ namespace Microsoft.Quantum.Canon {
     /// # Summary
     /// Applies the controlled-X (CX) gate to a pair of qubits.
     ///
-    /// # Description
+    /// # Input
+    /// ## control
+    /// Control qubit for the CX gate.
+    /// ## target
+    /// Target qubit for the CX gate.
+    ///
+    /// # Remarks
     /// This operation can be simulated by the unitary matrix
-    /// $$
     /// \begin{align}
     ///     \left(\begin{matrix}
     ///         1 & 0 & 0 & 0 \\\\
@@ -136,16 +141,8 @@ namespace Microsoft.Quantum.Canon {
     ///         0 & 0 & 1 & 0
     ///      \end{matrix}\right)
     /// \end{align},
-    /// $$
     /// where rows and columns are organized as in the quantum concepts guide.
     ///
-    /// # Input
-    /// ## control
-    /// Control qubit for the CX gate.
-    /// ## target
-    /// Target qubit for the CX gate.
-    ///
-    /// # Remarks
     /// Equivalent to:
     /// ```qsharp
     /// Controlled X([control], target);
@@ -167,18 +164,6 @@ namespace Microsoft.Quantum.Canon {
     /// # Summary
     /// Applies the controlled-Y (CY) gate to a pair of qubits.
     ///
-    /// # Description
-    /// This operation can be simulated by the unitary matrix
-    /// $$
-    /// \begin{align}
-    ///     1 & 0 & 0 & 0 \\\\
-    ///     0 & 1 & 0 & 0 \\\\
-    ///     0 & 0 & 0 & -i \\\\
-    ///     0 & 0 & i & 0
-    /// \end{align},
-    /// $$
-    /// where rows and columns are organized as in the quantum concepts guide.
-    ///
     /// # Input
     /// ## control
     /// Control qubit for the CY gate.
@@ -186,6 +171,15 @@ namespace Microsoft.Quantum.Canon {
     /// Target qubit for the CY gate.
     ///
     /// # Remarks
+    /// This operation can be simulated by the unitary matrix
+    /// \begin{align}
+    ///     1 & 0 & 0 & 0 \\\\
+    ///     0 & 1 & 0 & 0 \\\\
+    ///     0 & 0 & 0 & -i \\\\
+    ///     0 & 0 & i & 0
+    /// \end{align},
+    /// where rows and columns are organized as in the quantum concepts guide.
+    ///
     /// Equivalent to:
     /// ```qsharp
     /// Controlled Y([control], target);
@@ -203,18 +197,6 @@ namespace Microsoft.Quantum.Canon {
     /// # Summary
     /// Applies the controlled-Z (CZ) gate to a pair of qubits.
     ///
-    /// # Description
-    /// This operation can be simulated by the unitary matrix
-    /// $$
-    /// \begin{align}
-    ///     1 & 0 & 0 & 0 \\\\
-    ///     0 & 1 & 0 & 0 \\\\
-    ///     0 & 0 & 1 & 0 \\\\
-    ///     0 & 0 & 0 & -1
-    /// \end{align},
-    /// $$
-    /// where rows and columns are organized as in the quantum concepts guide.
-    ///
     /// # Input
     /// ## control
     /// Control qubit for the CZ gate.
@@ -222,6 +204,15 @@ namespace Microsoft.Quantum.Canon {
     /// Target qubit for the CZ gate.
     ///
     /// # Remarks
+    /// This operation can be simulated by the unitary matrix
+    /// \begin{align}
+    ///     1 & 0 & 0 & 0 \\\\
+    ///     0 & 1 & 0 & 0 \\\\
+    ///     0 & 0 & 1 & 0 \\\\
+    ///     0 & 0 & 0 & -1
+    /// \end{align},
+    /// where rows and columns are organized as in the quantum concepts guide.
+    ///
     /// Equivalent to:
     /// ```qsharp
     /// Controlled Z([control], target);
@@ -251,19 +242,17 @@ namespace Microsoft.Quantum.Canon {
     /// # Summary
     /// Computes the parity of a register of qubits in-place.
     ///
-    /// # Description
+    /// # Input
+    /// ## qubits
+    /// Array of qubits whose parity is to be computed and stored.
+    ///
+    /// # Remarks
     /// This operation transforms the state of its input as
-    /// $$
     /// \begin{align}
     ///     \ket{q_0} \ket{q_1} \cdots \ket{q_{n - 1}} & \mapsto
     ///     \ket{q_0} \ket{q_0 \oplus q_1} \ket{q_0 \oplus q_1 \oplus q_2} \cdots
     ///         \ket{q_0 \oplus \cdots \oplus q_{n - 1}}.
     /// \end{align}
-    /// $$
-    ///
-    /// # Input
-    /// ## qubits
-    /// Array of qubits whose parity is to be computed and stored.
     operation ApplyCNOTChain(qubits : Qubit[]) : Unit is Adj + Ctl {
         for i in 0..Length(qubits)-2 {
             CNOT(qubits[i], qubits[i+1]);

--- a/library/std/canon.qs
+++ b/library/std/canon.qs
@@ -133,6 +133,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Remarks
     /// This operation can be simulated by the unitary matrix
+    /// $$
     /// \begin{align}
     ///     \left(\begin{matrix}
     ///         1 & 0 & 0 & 0 \\\\
@@ -141,6 +142,7 @@ namespace Microsoft.Quantum.Canon {
     ///         0 & 0 & 1 & 0
     ///      \end{matrix}\right)
     /// \end{align},
+    /// $$
     /// where rows and columns are organized as in the quantum concepts guide.
     ///
     /// Equivalent to:
@@ -172,12 +174,14 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Remarks
     /// This operation can be simulated by the unitary matrix
+    /// $$
     /// \begin{align}
     ///     1 & 0 & 0 & 0 \\\\
     ///     0 & 1 & 0 & 0 \\\\
     ///     0 & 0 & 0 & -i \\\\
     ///     0 & 0 & i & 0
     /// \end{align},
+    /// $$
     /// where rows and columns are organized as in the quantum concepts guide.
     ///
     /// Equivalent to:
@@ -205,12 +209,14 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Remarks
     /// This operation can be simulated by the unitary matrix
+    /// $$
     /// \begin{align}
     ///     1 & 0 & 0 & 0 \\\\
     ///     0 & 1 & 0 & 0 \\\\
     ///     0 & 0 & 1 & 0 \\\\
     ///     0 & 0 & 0 & -1
     /// \end{align},
+    /// $$
     /// where rows and columns are organized as in the quantum concepts guide.
     ///
     /// Equivalent to:
@@ -247,12 +253,14 @@ namespace Microsoft.Quantum.Canon {
     /// Array of qubits whose parity is to be computed and stored.
     ///
     /// # Remarks
-    /// This operation transforms the state of its input as
+    /// This operation transforms the state of its input asd
+    /// $$
     /// \begin{align}
     ///     \ket{q_0} \ket{q_1} \cdots \ket{q_{n - 1}} & \mapsto
     ///     \ket{q_0} \ket{q_0 \oplus q_1} \ket{q_0 \oplus q_1 \oplus q_2} \cdots
     ///         \ket{q_0 \oplus \cdots \oplus q_{n - 1}}.
     /// \end{align}
+    /// $$
     operation ApplyCNOTChain(qubits : Qubit[]) : Unit is Adj + Ctl {
         for i in 0..Length(qubits)-2 {
             CNOT(qubits[i], qubits[i+1]);

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -37,7 +37,13 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the controlled-NOT (CNOT) gate to a pair of qubits.
     ///
-    /// # Description
+    /// # Input
+    /// ## control
+    /// Control qubit for the CNOT gate.
+    /// ## target
+    /// Target qubit for the CNOT gate.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     \operatorname{CNOT} \mathrel{:=}
     ///     \begin{bmatrix}
@@ -50,13 +56,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// where rows and columns are ordered as in the quantum concepts guide.
     ///
-    /// # Input
-    /// ## control
-    /// Control qubit for the CNOT gate.
-    /// ## target
-    /// Target qubit for the CNOT gate.
-    ///
-    /// # Remarks
     /// Equivalent to:
     /// ```qsharp
     /// Controlled X([control], target);
@@ -74,13 +73,6 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the exponential of a multi-qubit Pauli operator.
     ///
-    /// # Description
-    /// \begin{align}
-    ///     e^{i \theta [P_0 \otimes P_1 \cdots P_{N-1}]},
-    /// \end{align}
-    /// where $P_i$ is the $i$th element of `paulis`, and where
-    /// $N = $`Length(paulis)`.
-    ///
     /// # Input
     /// ## paulis
     /// Array of single-qubit Pauli values indicating the tensor product
@@ -90,6 +82,13 @@ namespace Microsoft.Quantum.Intrinsic {
     /// target register is to be rotated.
     /// ## qubits
     /// Register to apply the given rotation to.
+    ///
+    /// # Remarks
+    /// \begin{align}
+    ///     e^{i \theta [P_0 \otimes P_1 \cdots P_{N-1}]},
+    /// \end{align}
+    /// where $P_i$ is the $i$th element of `paulis`, and where
+    /// $N = $`Length(paulis)`.
     operation Exp (paulis : Pauli[], theta : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
         body ... {
             Fact(Length(paulis) == Length(qubits),
@@ -140,21 +139,18 @@ namespace Microsoft.Quantum.Intrinsic {
     }
 
     /// # Summary
-    /// Applies the Hadamard transformation to a single qubit.
-    ///
-    /// # Description
-    /// \begin{align}
-    ///     H \mathrel{:=}
-    ///     \frac{1}{\sqrt{2}}
-    ///     \begin{bmatrix}
-    ///         1 & 1 \\\\
-    ///         1 & -1
-    ///     \end{bmatrix}.
-    /// \end{align}
+    /// Applies the Hadamard transformation to a single qubit.x
     ///
     /// # Input
     /// ## qubit
     /// Qubit to which the gate should be applied.
+    ///
+    /// # Remarks
+    /// \begin{align}
+    ///     e^{i \theta [P_0 \otimes P_1 \cdots P_{N-1}]},
+    /// \end{align}
+    /// where $P_i$ is the $i$th element of `paulis`, and where
+    /// $N = $`Length(paulis)`.
     operation H(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__h__body(qubit);
@@ -202,7 +198,15 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Performs a measurement of a single qubit in the
     /// Pauli _Z_ basis.
     ///
-    /// # Description
+    /// # Input
+    /// ## qubit
+    /// Qubit to be measured.
+    ///
+    /// # Output
+    /// `Zero` if the +1 eigenvalue is observed, and `One` if
+    /// the -1 eigenvalue is observed.
+    ///
+    /// # Remarks
     /// The output result is given by
     /// the distribution
     /// \begin{align}
@@ -210,15 +214,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         \braket{\psi | 0} \braket{0 | \psi}.
     /// \end{align}
     ///
-    /// # Input
-    /// ## qubit
-    /// Qubit to be measured.
-    ///
-    /// # Output
-    /// `Zero` if the $+1$ eigenvalue is observed, and `One` if
-    /// the $-1$ eigenvalue is observed.
-    ///
-    /// # Remarks
     /// Equivalent to:
     /// ```qsharp
     /// Measure([PauliZ], [qubit]);
@@ -231,7 +226,18 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Performs a joint measurement of one or more qubits in the
     /// specified Pauli bases.
     ///
-    /// # Description
+    /// # Input
+    /// ## bases
+    /// Array of single-qubit Pauli values indicating the tensor product
+    /// factors on each qubit.
+    /// ## qubits
+    /// Register of qubits to be measured.
+    ///
+    /// # Output
+    /// `Zero` if the +1 eigenvalue is observed, and `One` if
+    /// the -1 eigenvalue is observed.
+    ///
+    /// # Remarks
     /// The output result is given by the distribution:
     /// \begin{align}
     ///     \Pr(\texttt{Zero} | \ket{\psi}) =
@@ -248,18 +254,6 @@ namespace Microsoft.Quantum.Intrinsic {
     /// That is, measurement returns a `Result` $d$ such that the eigenvalue of the
     /// observed measurement effect is $(-1)^d$.
     ///
-    /// # Input
-    /// ## bases
-    /// Array of single-qubit Pauli values indicating the tensor product
-    /// factors on each qubit.
-    /// ## qubits
-    /// Register of qubits to be measured.
-    ///
-    /// # Output
-    /// `Zero` if the $+1$ eigenvalue is observed, and `One` if
-    /// the $-1$ eigenvalue is observed.
-    ///
-    /// # Remarks
     /// If the basis array and qubit array are different lengths, then the
     /// operation will fail.
     operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
@@ -291,22 +285,21 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies a rotation about the given Pauli axis.
     ///
-    /// # Description
-    /// \begin{align}
-    ///     R_{\mu}(\theta) \mathrel{:=}
-    ///     e^{-i \theta \sigma_{\mu} / 2},
-    /// \end{align}
-    /// where $\mu \in \{I, X, Y, Z\}$.
-    ///
     /// # Input
     /// ## pauli
-    /// Pauli operator ($\mu$) to be exponentiated to form the rotation.
+    /// Pauli operator (μ) to be exponentiated to form the rotation.
     /// ## theta
     /// Angle in radians about which the qubit is to be rotated.
     /// ## qubit
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// \begin{align}
+    ///     R_{\mu}(\theta) \mathrel{:=}
+    ///     e^{-i \theta \sigma_{\mu} / 2},
+    /// \end{align}
+    /// where $\mu \in \{I, X, Y, Z\}$.
+    ///
     /// When called with `pauli = PauliI`, this operation applies
     /// a *global phase*. This phase can be significant
     /// when used with the `Controlled` functor.
@@ -328,12 +321,6 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies a rotation about the |1⟩ state by a given angle.
     ///
-    /// # Description
-    /// \begin{align}
-    ///     R_1(\theta) \mathrel{:=}
-    ///     \operatorname{diag}(1, e^{i\theta}).
-    /// \end{align}
-    ///
     /// # Input
     /// ## theta
     /// Angle about which the qubit is to be rotated.
@@ -341,6 +328,11 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// \begin{align}
+    ///     R_1(\theta) \mathrel{:=}
+    ///     \operatorname{diag}(1, e^{i\theta}).
+    /// \end{align}
+    ///
     /// Equivalent to:
     /// ```qsharp
     /// R(PauliZ, theta, qubit);
@@ -374,17 +366,6 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Applies a rotation about the |1⟩ state by an angle specified
     /// as a dyadic fraction.
     ///
-    /// # Description
-    /// \begin{align}
-    ///     R_1(n, k) \mathrel{:=}
-    ///     \operatorname{diag}(1, e^{i \pi k / 2^n}).
-    /// \end{align}
-    ///
-    /// > [!WARNING]
-    /// > This operation uses the **opposite** sign convention from
-    /// > @"microsoft.quantum.intrinsic.r", and does not include the
-    /// > factor of $1/ 2$ included by @"microsoft.quantum.intrinsic.r1".
-    ///
     /// # Input
     /// ## numerator
     /// Numerator in the dyadic fraction representation of the angle
@@ -396,6 +377,16 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// \begin{align}
+    ///     R_1(n, k) \mathrel{:=}
+    ///     \operatorname{diag}(1, e^{i \pi k / 2^n}).
+    /// \end{align}
+    ///
+    /// > [!WARNING]
+    /// > This operation uses the **opposite** sign convention from
+    /// > @"microsoft.quantum.intrinsic.r", and does not include the
+    /// > factor of $1/ 2$ included by @"microsoft.quantum.intrinsic.r1".
+    ///
     /// Equivalent to:
     /// ```qsharp
     /// RFrac(PauliZ, -numerator, denominator + 1, qubit);
@@ -412,7 +403,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// # Input
     /// ## qubit
-    /// The qubit whose state is to be reset to $\ket{0}$.
+    /// The qubit whose state is to be reset to |0⟩.
     operation Reset(qubit : Qubit) : Unit {
         __quantum__qis__reset__body(qubit);
     }
@@ -423,7 +414,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// # Input
     /// ## qubits
-    /// An array of qubits whose states are to be reset to $\ket{0}$.
+    /// An array of qubits whose states are to be reset to |0⟩.
     operation ResetAll(qubits : Qubit[]) : Unit {
         for q in qubits {
             Reset(q);
@@ -433,17 +424,6 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies a rotation about the given Pauli axis by an angle specified
     /// as a dyadic fraction.
-    ///
-    /// # Description
-    /// \begin{align}
-    ///     R_{\mu}(n, k) \mathrel{:=}
-    ///     e^{i \pi n \sigma_{\mu} / 2^k},
-    /// \end{align}
-    /// where $\mu \in \{I, X, Y, Z\}$.
-    ///
-    /// > [!WARNING]
-    /// > This operation uses the **opposite** sign convention from
-    /// > @"microsoft.quantum.intrinsic.r".
     ///
     /// # Input
     /// ## pauli
@@ -458,6 +438,16 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// \begin{align}
+    ///     R_{\mu}(n, k) \mathrel{:=}
+    ///     e^{i \pi n \sigma_{\mu} / 2^k},
+    /// \end{align}
+    /// where $\mu \in \{I, X, Y, Z\}$.
+    ///
+    /// > [!WARNING]
+    /// > This operation uses the **opposite** sign convention from
+    /// > @"microsoft.quantum.intrinsic.r".
+    ///
     /// Equivalent to:
     /// ```qsharp
     /// // PI() is a Q# function that returns an approximation of π.
@@ -473,7 +463,13 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies a rotation about the _x_-axis by a given angle.
     ///
-    /// # Description
+    /// # Input
+    /// ## theta
+    /// Angle about which the qubit is to be rotated.
+    /// ## qubit
+    /// Qubit to which the gate should be applied.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     R_x(\theta) \mathrel{:=}
     ///     e^{-i \theta \sigma_x / 2} =
@@ -483,13 +479,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///     \end{bmatrix}.
     /// \end{align}
     ///
-    /// # Input
-    /// ## theta
-    /// Angle about which the qubit is to be rotated.
-    /// ## qubit
-    /// Qubit to which the gate should be applied.
-    ///
-    /// # Remarks
     /// Equivalent to:
     /// ```qsharp
     /// R(PauliX, theta, qubit);
@@ -519,7 +508,15 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the two qubit Ising _XX_ rotation gate.
     ///
-    /// # Description
+    /// # Input
+    /// ## theta
+    /// The angle about which the qubits are rotated.
+    /// ## qubit0
+    /// The first qubit input to the gate.
+    /// ## qubit1
+    /// The second qubit input to the gate.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     R_{xx}(\theta) \mathrel{:=}
     ///     \begin{bmatrix}
@@ -529,14 +526,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         -i\sin \theta & 0 & 0 & \cos \theta
     ///     \end{bmatrix}.
     /// \end{align}
-    ///
-    /// # Input
-    /// ## theta
-    /// The angle about which the qubits are rotated.
-    /// ## qubit0
-    /// The first qubit input to the gate.
-    /// ## qubit1
-    /// The second qubit input to the gate.
     operation Rxx(theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__rxx__body(theta, qubit0, qubit1);
@@ -567,7 +556,13 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies a rotation about the _y_-axis by a given angle.
     ///
-    /// # Description
+    /// # Input
+    /// ## theta
+    /// Angle about which the qubit is to be rotated.
+    /// ## qubit
+    /// Qubit to which the gate should be applied.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     R_y(\theta) \mathrel{:=}
     ///     e^{-i \theta \sigma_y / 2} =
@@ -577,13 +572,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///     \end{bmatrix}.
     /// \end{align}
     ///
-    /// # Input
-    /// ## theta
-    /// Angle about which the qubit is to be rotated.
-    /// ## qubit
-    /// Qubit to which the gate should be applied.
-    ///
-    /// # Remarks
     /// Equivalent to:
     /// ```qsharp
     /// R(PauliY, theta, qubit);
@@ -613,7 +601,15 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the two qubit Ising _YY_ rotation gate.
     ///
-    /// # Description
+    /// # Input
+    /// ## theta
+    /// The angle about which the qubits are rotated.
+    /// ## qubit0
+    /// The first qubit input to the gate.
+    /// ## qubit1
+    /// The second qubit input to the gate.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     R_{yy}(\theta) \mathrel{:=}
     ///     \begin{bmatrix}
@@ -623,14 +619,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         i\sin \theta & 0 & 0 & \cos \theta
     ///     \end{bmatrix}.
     /// \end{align}
-    ///
-    /// # Input
-    /// ## theta
-    /// The angle about which the qubits are rotated.
-    /// ## qubit0
-    /// The first qubit input to the gate.
-    /// ## qubit1
-    /// The second qubit input to the gate.
     operation Ryy(theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__ryy__body(theta, qubit0, qubit1);
@@ -661,7 +649,13 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies a rotation about the _z_-axis by a given angle.
     ///
-    /// # Description
+    /// # Input
+    /// ## theta
+    /// Angle about which the qubit is to be rotated.
+    /// ## qubit
+    /// Qubit to which the gate should be applied.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     R_z(\theta) \mathrel{:=}
     ///     e^{-i \theta \sigma_z / 2} =
@@ -671,13 +665,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///     \end{bmatrix}.
     /// \end{align}
     ///
-    /// # Input
-    /// ## theta
-    /// Angle about which the qubit is to be rotated.
-    /// ## qubit
-    /// Qubit to which the gate should be applied.
-    ///
-    /// # Remarks
     /// Equivalent to:
     /// ```qsharp
     /// R(PauliZ, theta, qubit);
@@ -712,7 +699,15 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the two qubit Ising _ZZ_ rotation gate.
     ///
-    /// # Description
+    /// # Input
+    /// ## theta
+    /// The angle about which the qubits are rotated.
+    /// ## qubit0
+    /// The first qubit input to the gate.
+    /// ## qubit1
+    /// The second qubit input to the gate.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     R_{zz}(\theta) \mathrel{:=}
     ///     \begin{bmatrix}
@@ -722,14 +717,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & 0 & 0 & e^{-i \theta / 2}
     ///     \end{bmatrix}.
     /// \end{align}
-    ///
-    /// # Input
-    /// ## theta
-    /// The angle about which the qubits are rotated.
-    /// ## qubit0
-    /// The first qubit input to the gate.
-    /// ## qubit1
-    /// The second qubit input to the gate.
     operation Rzz(theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__rzz__body(theta, qubit0, qubit1);
@@ -760,7 +747,11 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the π/4 phase gate to a single qubit.
     ///
-    /// # Description
+    /// # Input
+    /// ## qubit
+    /// Qubit to which the gate should be applied.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     S \mathrel{:=}
     ///     \begin{bmatrix}
@@ -768,10 +759,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & i
     ///     \end{bmatrix}.
     /// \end{align}
-    ///
-    /// # Input
-    /// ## qubit
-    /// Qubit to which the gate should be applied.
     operation S(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__s__body(qubit);
@@ -834,7 +821,13 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the SWAP gate to a pair of qubits.
     ///
-    /// # Description
+    /// # Input
+    /// ## qubit1
+    /// First qubit to be swapped.
+    /// ## qubit2
+    /// Second qubit to be swapped.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     \operatorname{SWAP} \mathrel{:=}
     ///     \begin{bmatrix}
@@ -847,13 +840,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// where rows and columns are ordered as in the quantum concepts guide.
     ///
-    /// # Input
-    /// ## qubit1
-    /// First qubit to be swapped.
-    /// ## qubit2
-    /// Second qubit to be swapped.
-    ///
-    /// # Remarks
     /// Equivalent to:
     /// ```qsharp
     /// CNOT(qubit1, qubit2);
@@ -883,7 +869,11 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the π/8 gate to a single qubit.
     ///
-    /// # Description
+    /// # Input
+    /// ## qubit
+    /// Qubit to which the gate should be applied.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     T \mathrel{:=}
     ///     \begin{bmatrix}
@@ -891,10 +881,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & e^{i \pi / 4}
     ///     \end{bmatrix}.
     /// \end{align}
-    ///
-    /// # Input
-    /// ## qubit
-    /// Qubit to which the gate should be applied.
     operation T(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__t__body(qubit);
@@ -943,7 +929,11 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the Pauli _X_ gate.
     ///
-    /// # Description
+    /// # Input
+    /// ## qubit
+    /// Qubit to which the gate should be applied.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     \sigma_x \mathrel{:=}
     ///     \begin{bmatrix}
@@ -951,10 +941,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         1 & 0
     ///     \end{bmatrix}.
     /// \end{align}
-    ///
-    /// # Input
-    /// ## qubit
-    /// Qubit to which the gate should be applied.
     operation X(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__x__body(qubit);
@@ -990,7 +976,11 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the Pauli _Y_ gate.
     ///
-    /// # Description
+    /// # Input
+    /// ## qubit
+    /// Qubit to which the gate should be applied.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     \sigma_y \mathrel{:=}
     ///     \begin{bmatrix}
@@ -998,10 +988,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         i & 0
     ///     \end{bmatrix}.
     /// \end{align}
-    ///
-    /// # Input
-    /// ## qubit
-    /// Qubit to which the gate should be applied.
     operation Y(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__y__body(qubit);
@@ -1037,7 +1023,11 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Summary
     /// Applies the Pauli _Z_ gate.
     ///
-    /// # Description
+    /// # Input
+    /// ## qubit
+    /// Qubit to which the gate should be applied.
+    ///
+    /// # Remarks
     /// \begin{align}
     ///     \sigma_z \mathrel{:=}
     ///     \begin{bmatrix}
@@ -1045,10 +1035,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & -1
     ///     \end{bmatrix}.
     /// \end{align}
-    ///
-    /// # Input
-    /// ## qubit
-    /// Qubit to which the gate should be applied.
     operation Z(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__z__body(qubit);

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -366,6 +366,11 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Applies a rotation about the |1⟩ state by an angle specified
     /// as a dyadic fraction.
     ///
+    /// > [!WARNING]
+    /// > This operation uses the **opposite** sign convention from
+    /// > @"microsoft.quantum.intrinsic.r", and does not include the
+    /// > factor of 1/2 included by @"microsoft.quantum.intrinsic.r1".
+    ///
     /// # Input
     /// ## numerator
     /// Numerator in the dyadic fraction representation of the angle
@@ -381,11 +386,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///     R_1(n, k) \mathrel{:=}
     ///     \operatorname{diag}(1, e^{i \pi k / 2^n}).
     /// \end{align}
-    ///
-    /// > [!WARNING]
-    /// > This operation uses the **opposite** sign convention from
-    /// > @"microsoft.quantum.intrinsic.r", and does not include the
-    /// > factor of $1/ 2$ included by @"microsoft.quantum.intrinsic.r1".
     ///
     /// Equivalent to:
     /// ```qsharp
@@ -425,6 +425,10 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Applies a rotation about the given Pauli axis by an angle specified
     /// as a dyadic fraction.
     ///
+    /// > [!WARNING]
+    /// > This operation uses the **opposite** sign convention from
+    /// > @"microsoft.quantum.intrinsic.r".
+    ///
     /// # Input
     /// ## pauli
     /// Pauli operator to be exponentiated to form the rotation.
@@ -443,10 +447,6 @@ namespace Microsoft.Quantum.Intrinsic {
     ///     e^{i \pi n \sigma_{\mu} / 2^k},
     /// \end{align}
     /// where $\mu \in \{I, X, Y, Z\}$.
-    ///
-    /// > [!WARNING]
-    /// > This operation uses the **opposite** sign convention from
-    /// > @"microsoft.quantum.intrinsic.r".
     ///
     /// Equivalent to:
     /// ```qsharp

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -366,10 +366,10 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Applies a rotation about the |1⟩ state by an angle specified
     /// as a dyadic fraction.
     ///
-    /// > [!WARNING]
-    /// > This operation uses the **opposite** sign convention from
-    /// > @"microsoft.quantum.intrinsic.r", and does not include the
-    /// > factor of 1/2 included by @"microsoft.quantum.intrinsic.r1".
+    /// WARNING:
+    /// This operation uses the **opposite** sign convention from
+    /// Microsoft.Quantum.Intrinsic.R, and does not include the
+    /// factor of 1/2 included by Microsoft.Quantum.Intrinsic.R1.
     ///
     /// # Input
     /// ## numerator
@@ -425,9 +425,9 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Applies a rotation about the given Pauli axis by an angle specified
     /// as a dyadic fraction.
     ///
-    /// > [!WARNING]
-    /// > This operation uses the **opposite** sign convention from
-    /// > @"microsoft.quantum.intrinsic.r".
+    /// WARNING:
+    /// This operation uses the **opposite** sign convention from
+    /// Microsoft.Quantum.Intrinsic.R.
     ///
     /// # Input
     /// ## pauli

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -44,6 +44,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Target qubit for the CNOT gate.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     \operatorname{CNOT} \mathrel{:=}
     ///     \begin{bmatrix}
@@ -53,6 +54,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & 0 & 1 & 0
     ///     \end{bmatrix},
     /// \end{align}
+    /// $$
     ///
     /// where rows and columns are ordered as in the quantum concepts guide.
     ///
@@ -84,9 +86,11 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Register to apply the given rotation to.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     e^{i \theta [P_0 \otimes P_1 \cdots P_{N-1}]},
     /// \end{align}
+    /// $$
     /// where $P_i$ is the $i$th element of `paulis`, and where
     /// $N = $`Length(paulis)`.
     operation Exp (paulis : Pauli[], theta : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
@@ -146,9 +150,11 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     e^{i \theta [P_0 \otimes P_1 \cdots P_{N-1}]},
     /// \end{align}
+    /// $$
     /// where $P_i$ is the $i$th element of `paulis`, and where
     /// $N = $`Length(paulis)`.
     operation H(qubit : Qubit) : Unit is Adj + Ctl {
@@ -209,10 +215,12 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Remarks
     /// The output result is given by
     /// the distribution
+    /// $$
     /// \begin{align}
     ///     \Pr(\texttt{Zero} | \ket{\psi}) =
     ///         \braket{\psi | 0} \braket{0 | \psi}.
     /// \end{align}
+    /// $$
     ///
     /// Equivalent to:
     /// ```qsharp
@@ -239,6 +247,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// # Remarks
     /// The output result is given by the distribution:
+    /// $$
     /// \begin{align}
     ///     \Pr(\texttt{Zero} | \ket{\psi}) =
     ///         \frac12 \braket{
@@ -249,6 +258,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///             \psi
     ///         },
     /// \end{align}
+    /// $$
     /// where $P_i$ is the $i$th element of `bases`, and where
     /// $N = \texttt{Length}(\texttt{bases})$.
     /// That is, measurement returns a `Result` $d$ such that the eigenvalue of the
@@ -294,10 +304,12 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_{\mu}(\theta) \mathrel{:=}
     ///     e^{-i \theta \sigma_{\mu} / 2},
     /// \end{align}
+    /// $$
     /// where $\mu \in \{I, X, Y, Z\}$.
     ///
     /// When called with `pauli = PauliI`, this operation applies
@@ -328,10 +340,12 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_1(\theta) \mathrel{:=}
     ///     \operatorname{diag}(1, e^{i\theta}).
     /// \end{align}
+    /// $$
     ///
     /// Equivalent to:
     /// ```qsharp
@@ -382,10 +396,12 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_1(n, k) \mathrel{:=}
     ///     \operatorname{diag}(1, e^{i \pi k / 2^n}).
     /// \end{align}
+    /// $$
     ///
     /// Equivalent to:
     /// ```qsharp
@@ -442,10 +458,12 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_{\mu}(n, k) \mathrel{:=}
     ///     e^{i \pi n \sigma_{\mu} / 2^k},
     /// \end{align}
+    /// $$
     /// where $\mu \in \{I, X, Y, Z\}$.
     ///
     /// Equivalent to:
@@ -470,6 +488,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_x(\theta) \mathrel{:=}
     ///     e^{-i \theta \sigma_x / 2} =
@@ -478,6 +497,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         -i\sin \frac{\theta}{2} & \cos \frac{\theta}{2}
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     ///
     /// Equivalent to:
     /// ```qsharp
@@ -517,6 +537,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// The second qubit input to the gate.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_{xx}(\theta) \mathrel{:=}
     ///     \begin{bmatrix}
@@ -526,6 +547,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         -i\sin \theta & 0 & 0 & \cos \theta
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     operation Rxx(theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__rxx__body(theta, qubit0, qubit1);
@@ -563,6 +585,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_y(\theta) \mathrel{:=}
     ///     e^{-i \theta \sigma_y / 2} =
@@ -571,6 +594,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         \sin \frac{\theta}{2} & \cos \frac{\theta}{2}
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     ///
     /// Equivalent to:
     /// ```qsharp
@@ -610,6 +634,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// The second qubit input to the gate.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_{yy}(\theta) \mathrel{:=}
     ///     \begin{bmatrix}
@@ -619,6 +644,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         i\sin \theta & 0 & 0 & \cos \theta
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     operation Ryy(theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__ryy__body(theta, qubit0, qubit1);
@@ -656,6 +682,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_z(\theta) \mathrel{:=}
     ///     e^{-i \theta \sigma_z / 2} =
@@ -664,6 +691,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & e^{i \theta / 2}
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     ///
     /// Equivalent to:
     /// ```qsharp
@@ -708,6 +736,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// The second qubit input to the gate.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     R_{zz}(\theta) \mathrel{:=}
     ///     \begin{bmatrix}
@@ -717,6 +746,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & 0 & 0 & e^{-i \theta / 2}
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     operation Rzz(theta : Double, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__rzz__body(theta, qubit0, qubit1);
@@ -752,6 +782,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     S \mathrel{:=}
     ///     \begin{bmatrix}
@@ -759,6 +790,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & i
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     operation S(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__s__body(qubit);
@@ -828,6 +860,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Second qubit to be swapped.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     \operatorname{SWAP} \mathrel{:=}
     ///     \begin{bmatrix}
@@ -837,6 +870,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & 0 & 0 & 1
     ///     \end{bmatrix},
     /// \end{align}
+    /// $$
     ///
     /// where rows and columns are ordered as in the quantum concepts guide.
     ///
@@ -874,6 +908,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     T \mathrel{:=}
     ///     \begin{bmatrix}
@@ -881,6 +916,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & e^{i \pi / 4}
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     operation T(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__t__body(qubit);
@@ -934,6 +970,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     \sigma_x \mathrel{:=}
     ///     \begin{bmatrix}
@@ -941,6 +978,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         1 & 0
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     operation X(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__x__body(qubit);
@@ -981,6 +1019,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     \sigma_y \mathrel{:=}
     ///     \begin{bmatrix}
@@ -988,6 +1027,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         i & 0
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     operation Y(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__y__body(qubit);
@@ -1028,6 +1068,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Qubit to which the gate should be applied.
     ///
     /// # Remarks
+    /// $$
     /// \begin{align}
     ///     \sigma_z \mathrel{:=}
     ///     \begin{bmatrix}
@@ -1035,6 +1076,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///         0 & -1
     ///     \end{bmatrix}.
     /// \end{align}
+    /// $$
     operation Z(qubit : Qubit) : Unit is Adj + Ctl {
         body ... {
             __quantum__qis__z__body(qubit);

--- a/library/std/math.qs
+++ b/library/std/math.qs
@@ -95,7 +95,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Ouptut
     /// A double-precision approximation of the the circumference of a circle
-    /// to its diameter, $\pi \approx 3.14159265358979323846$.
+    /// to its diameter, π ≈ 3.14159265358979323846.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Math.E
@@ -108,7 +108,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// A double-precision approximation of the natural logarithic base,
-    /// $e \approx 2.7182818284590452354$.
+    /// e ≈ 2.7182818284590452354.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Math.PI
@@ -365,7 +365,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Description
     /// This will calculate the multiplicative inverse of a
-    /// modular integer $b$ such that $a \cdot b = 1 (\operatorname{mod} \texttt{modulus})$.
+    /// modular integer `b` such that `a • b = 1 (mod modulus)`.
     function InverseModI(a : Int, modulus : Int) : Int {
         let (u, v) = ExtendedGreatestCommonDivisorI(a, modulus);
         let gcd = u * a + v * modulus;
@@ -378,7 +378,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Description
     /// This will calculate the multiplicative inverse of a
-    /// modular integer $b$ such that $a \cdot b = 1 (\operatorname{mod} \texttt{modulus})$.
+    /// modular integer `b` such that `a • b = 1 (mod modulus)`.
     function InverseModL(a : BigInt, modulus : BigInt) : BigInt {
         let (u, v) = ExtendedGreatestCommonDivisorL(a, modulus);
         let gcd = u * a + v * modulus;

--- a/library/std/measurement.qs
+++ b/library/std/measurement.qs
@@ -10,7 +10,7 @@ namespace Microsoft.Quantum.Measurement {
     /// Jointly measures a register of qubits in the Pauli Z basis.
     ///
     /// # Description
-    /// Measures a register of qubits in the $Z \otimes Z \otimes \cdots \otimes Z$
+    /// Measures a register of qubits in the `Z ⊗ Z ⊗ ••• ⊗ Z`
     /// basis, representing the parity of the entire register.
     ///
     /// # Input
@@ -18,10 +18,10 @@ namespace Microsoft.Quantum.Measurement {
     /// The register to be measured.
     ///
     /// # Output
-    /// The result of measuring $Z \otimes Z \otimes \cdots \otimes Z$.
+    /// The result of measuring `Z ⊗ Z ⊗ ••• ⊗ Z`.
     ///
     /// # Remarks
-    /// This operation does not reset the measured qubits to the |0⟩ state, 
+    /// This operation does not reset the measured qubits to the |0⟩ state,
     /// leaving them in the state that corresponds to the measurement result.
     operation MeasureAllZ (register : Qubit[]) : Result {
         Measure(Repeated(PauliZ, Length(register)), register)
@@ -36,7 +36,7 @@ namespace Microsoft.Quantum.Measurement {
     /// An array of measurement results.
     ///
     /// # Remarks
-    /// This operation does not reset the measured qubits to the |0⟩ state, 
+    /// This operation does not reset the measured qubits to the |0⟩ state,
     /// leaving them in the state that corresponds to the measurement results.
     operation MeasureEachZ (register : Qubit[]) : Result[] {
         mutable results = [];
@@ -68,8 +68,8 @@ namespace Microsoft.Quantum.Measurement {
     /// following the measurement.
     ///
     /// # Description
-    /// Performs a single-qubit measurement in the $X$-basis,
-    /// and ensures that the qubit is returned to $\ket{0}$
+    /// Performs a single-qubit measurement in the X-basis,
+    /// and ensures that the qubit is returned to |0⟩
     /// following the measurement.
     ///
     /// # Input
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.Measurement {
     /// A single qubit to be measured.
     ///
     /// # Output
-    /// The result of measuring `target` in the Pauli $X$ basis.
+    /// The result of measuring `target` in the Pauli X basis.
     operation MResetX (target : Qubit) : Result {
         // Map the qubit's state from the Z-basis to the X-basis.
         // Then measure and reset the qubit.
@@ -91,8 +91,8 @@ namespace Microsoft.Quantum.Measurement {
     /// following the measurement.
     ///
     /// # Description
-    /// Performs a single-qubit measurement in the $Y$-basis,
-    /// and ensures that the qubit is returned to $\ket{0}$
+    /// Performs a single-qubit measurement in the Y-basis,
+    /// and ensures that the qubit is returned to |0⟩
     /// following the measurement.
     ///
     /// # Input
@@ -100,7 +100,7 @@ namespace Microsoft.Quantum.Measurement {
     /// A single qubit to be measured.
     ///
     /// # Output
-    /// The result of measuring `target` in the Pauli $Y$ basis.
+    /// The result of measuring `target` in the Pauli Y basis.
     operation MResetY (target : Qubit) : Result {
         // Map the qubit's state from the Z-basis to the Y-basis.
         // Then measure and reset the qubit.
@@ -116,8 +116,8 @@ namespace Microsoft.Quantum.Measurement {
     /// following the measurement.
     ///
     /// # Description
-    /// Performs a single-qubit measurement in the $Z$-basis,
-    /// and ensures that the qubit is returned to $\ket{0}$
+    /// Performs a single-qubit measurement in the Z-basis,
+    /// and ensures that the qubit is returned to |0⟩
     /// following the measurement.
     ///
     /// # Input
@@ -125,7 +125,7 @@ namespace Microsoft.Quantum.Measurement {
     /// A single qubit to be measured.
     ///
     /// # Output
-    /// The result of measuring `target` in the Pauli $Z$ basis.
+    /// The result of measuring `target` in the Pauli Z basis.
     operation MResetZ (target : Qubit) : Result {
         __quantum__qis__mresetz__body(target)
     }

--- a/library/std/random.qs
+++ b/library/std/random.qs
@@ -46,7 +46,7 @@ namespace Microsoft.Quantum.Random {
     /// Fails if `max < min`.
     ///
     /// # Example
-    /// The following Q# snippet randomly draws an angle between $0$ and $2 \pi$:
+    /// The following Q# snippet randomly draws an angle between 0 and 2π:
     /// ```qsharp
     /// let angle = DrawRandomDouble(0.0, 2.0 * PI());
     /// ```

--- a/pip/pyproject.toml
+++ b/pip/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest ~= 7.2.0"]
+jupyterlab = ["qsharp_jupyterlab"]
 
 [build-system]
 requires = ["maturin ~= 0.14.16"]


### PR DESCRIPTION
Limits the use of LaTex syntax to the Remarks second of doc strings in the SDT library files.