### PR TITLE
Better breakpoint granularity and diagnostic information in debug adapter

### DIFF
--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -15,7 +15,7 @@ use miette::Diagnostic;
 use num_bigint::BigUint;
 use num_complex::Complex;
 use qsc_codegen::qir_base::generate_qir_for_stmt;
-use qsc_data_structures::index_map::IndexMap;
+use qsc_data_structures::{index_map::IndexMap, span::Span};
 use qsc_eval::backend::Backend;
 use qsc_eval::{
     backend::SparseSim,
@@ -691,11 +691,15 @@ impl<'a> BreakpointCollector<'a> {
     fn add_stmt(&mut self, stmt: &qsc_fir::fir::Stmt) {
         let source: &Source = self.get_source(self.offset);
         if source.offset == self.offset {
-            self.statements.insert(BreakpointSpan {
+            let span = stmt.span.subtract(source.offset);
+            let bps = BreakpointSpan {
                 id: stmt.id.into(),
-                lo: stmt.span.lo - source.offset,
-                hi: stmt.span.hi - source.offset,
-            });
+                lo: span.lo,
+                hi: span.hi,
+            };
+            if span != Span::default() {
+                self.statements.insert(bps);
+            }
         }
     }
 }

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -691,7 +691,7 @@ impl<'a> BreakpointCollector<'a> {
     fn add_stmt(&mut self, stmt: &qsc_fir::fir::Stmt) {
         let source: &Source = self.get_source(self.offset);
         if source.offset == self.offset {
-            let span = stmt.span.subtract(source.offset);
+            let span = stmt.span - source.offset;
             let bps = BreakpointSpan {
                 id: stmt.id.into(),
                 lo: span.lo,

--- a/compiler/qsc_data_structures/src/span.rs
+++ b/compiler/qsc_data_structures/src/span.rs
@@ -16,6 +16,16 @@ pub struct Span {
     pub hi: u32,
 }
 
+impl Span {
+    #[must_use]
+    pub fn subtract(&self, offset: u32) -> Span {
+        Span {
+            lo: self.lo - offset,
+            hi: self.hi - offset,
+        }
+    }
+}
+
 impl Add<u32> for Span {
     type Output = Self;
 

--- a/compiler/qsc_data_structures/src/span.rs
+++ b/compiler/qsc_data_structures/src/span.rs
@@ -4,7 +4,7 @@
 use miette::SourceSpan;
 use std::{
     fmt::{self, Display, Formatter},
-    ops::{Add, Index},
+    ops::{Add, Index, Sub},
 };
 
 /// A region between two offsets in an array. Spans are the half-open interval `[lo, hi)`.
@@ -16,16 +16,6 @@ pub struct Span {
     pub hi: u32,
 }
 
-impl Span {
-    #[must_use]
-    pub fn subtract(&self, offset: u32) -> Span {
-        Span {
-            lo: self.lo - offset,
-            hi: self.hi - offset,
-        }
-    }
-}
-
 impl Add<u32> for Span {
     type Output = Self;
 
@@ -33,6 +23,17 @@ impl Add<u32> for Span {
         Self {
             lo: self.lo + rhs,
             hi: self.hi + rhs,
+        }
+    }
+}
+
+impl Sub<u32> for Span {
+    type Output = Self;
+
+    fn sub(self, rhs: u32) -> Self::Output {
+        Self {
+            lo: self.lo - rhs,
+            hi: self.hi - rhs,
         }
     }
 }

--- a/compiler/qsc_passes/src/replace_qubit_allocation.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation.rs
@@ -64,7 +64,7 @@ impl<'a> ReplaceQubitAllocation<'a> {
             if let PatKind::Bind(id) = pat.kind {
                 let id = IdentTemplate {
                     id: id.id,
-                    span: id.span,
+                    span: stmt_span,
                     name: id.name,
                     ty: pat.ty,
                 };

--- a/compiler/qsc_passes/src/replace_qubit_allocation.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation.rs
@@ -308,14 +308,14 @@ impl MutVisitor for ReplaceQubitAllocation<'_> {
                 Some(s) => {
                     if let StmtKind::Expr(end) = &mut s.kind {
                         let end_capture = self.gen_ident(end.ty.clone(), end.span);
-                        *s = end_capture.gen_id_init(
+                        *s = end_capture.gen_steppable_id_init(
                             Mutability::Immutable,
                             take(end),
                             self.assigner,
                         );
                         Some(Stmt {
                             id: self.assigner.next_node(),
-                            span: s.span,
+                            span: Span::default(),
                             kind: StmtKind::Expr(end_capture.gen_local_ref(self.assigner)),
                         })
                     } else {
@@ -500,10 +500,10 @@ fn create_general_dealloc_stmt(
 ) -> Stmt {
     Stmt {
         id: assigner.next_node(),
-        span: ident.span,
+        span: Span::default(),
         kind: StmtKind::Semi(Expr {
             id: assigner.next_node(),
-            span: ident.span,
+            span: Span::default(),
             ty: Ty::UNIT,
             kind: ExprKind::Call(Box::new(call_expr), Box::new(ident.gen_local_ref(assigner))),
         }),

--- a/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
@@ -47,7 +47,7 @@ fn test_single_qubit() {
                                 Stmt 9 [80-90]: Local (Immutable):
                                     Pat 10 [84-85] [Type Int]: Bind: Ident 11 [84-85] "x"
                                     Expr 12 [88-89] [Type Int]: Lit: Int(3)
-                                Stmt 20 [59-60]: Semi: Expr 21 [59-60] [Type Unit]: Call:
+                                Stmt 20 [0-0]: Semi: Expr 21 [0-0] [Type Unit]: Call:
                                     Expr 19 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 22 [59-60] [Type Qubit]: Var: Local 7
                         adj: <none>
@@ -86,7 +86,7 @@ fn test_qubit_array() {
                                 Stmt 10 [81-91]: Local (Immutable):
                                     Pat 11 [85-86] [Type Int]: Bind: Ident 12 [85-86] "x"
                                     Expr 13 [89-90] [Type Int]: Lit: Int(3)
-                                Stmt 21 [59-60]: Semi: Expr 22 [59-60] [Type Unit]: Call:
+                                Stmt 21 [0-0]: Semi: Expr 22 [0-0] [Type Unit]: Call:
                                     Expr 20 [59-60] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
                                     Expr 23 [59-60] [Type (Qubit)[]]: Var: Local 7
                         adj: <none>
@@ -135,10 +135,10 @@ fn test_qubit_tuple() {
                                 Stmt 11 [91-101]: Local (Immutable):
                                     Pat 12 [95-96] [Type Int]: Bind: Ident 13 [95-96] "x"
                                     Expr 14 [99-100] [Type Int]: Lit: Int(3)
-                                Stmt 33 [73-80]: Semi: Expr 34 [73-80] [Type Unit]: Call:
+                                Stmt 33 [0-0]: Semi: Expr 34 [0-0] [Type Unit]: Call:
                                     Expr 32 [73-80] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 35 [73-80] [Type Qubit]: Var: Local 18
-                                Stmt 37 [64-71]: Semi: Expr 38 [64-71] [Type Unit]: Call:
+                                Stmt 37 [0-0]: Semi: Expr 38 [0-0] [Type Unit]: Call:
                                     Expr 36 [64-71] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 39 [64-71] [Type Qubit]: Var: Local 16
                         adj: <none>
@@ -189,10 +189,10 @@ fn test_multiple_qubits_tuple() {
                                 Stmt 15 [97-107]: Local (Immutable):
                                     Pat 16 [101-102] [Type Int]: Bind: Ident 17 [101-102] "x"
                                     Expr 18 [105-106] [Type Int]: Lit: Int(3)
-                                Stmt 37 [78-86]: Semi: Expr 38 [78-86] [Type Unit]: Call:
+                                Stmt 37 [0-0]: Semi: Expr 38 [0-0] [Type Unit]: Call:
                                     Expr 36 [78-86] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
                                     Expr 39 [78-86] [Type (Qubit)[]]: Var: Local 22
-                                Stmt 41 [69-76]: Semi: Expr 42 [69-76] [Type Unit]: Call:
+                                Stmt 41 [0-0]: Semi: Expr 42 [0-0] [Type Unit]: Call:
                                     Expr 40 [69-76] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 43 [69-76] [Type Qubit]: Var: Local 20
                         adj: <none>
@@ -248,10 +248,10 @@ fn test_multiple_callables() {
                                 Stmt 14 [96-106]: Local (Immutable):
                                     Pat 15 [100-101] [Type Int]: Bind: Ident 16 [100-101] "x"
                                     Expr 17 [104-105] [Type Int]: Lit: Int(3)
-                                Stmt 54 [78-85]: Semi: Expr 55 [78-85] [Type Unit]: Call:
+                                Stmt 54 [0-0]: Semi: Expr 55 [0-0] [Type Unit]: Call:
                                     Expr 53 [78-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 56 [78-85] [Type Qubit]: Var: Local 39
-                                Stmt 58 [69-76]: Semi: Expr 59 [69-76] [Type Unit]: Call:
+                                Stmt 58 [0-0]: Semi: Expr 59 [0-0] [Type Unit]: Call:
                                     Expr 57 [69-76] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 60 [69-76] [Type Qubit]: Var: Local 37
                         adj: <none>
@@ -286,10 +286,10 @@ fn test_multiple_callables() {
                                 Stmt 32 [192-202]: Local (Immutable):
                                     Pat 33 [196-197] [Type Int]: Bind: Ident 34 [196-197] "x"
                                     Expr 35 [200-201] [Type Int]: Lit: Int(3)
-                                Stmt 78 [174-181]: Semi: Expr 79 [174-181] [Type Unit]: Call:
+                                Stmt 78 [0-0]: Semi: Expr 79 [0-0] [Type Unit]: Call:
                                     Expr 77 [174-181] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 80 [174-181] [Type Qubit]: Var: Local 63
-                                Stmt 82 [165-172]: Semi: Expr 83 [165-172] [Type Unit]: Call:
+                                Stmt 82 [0-0]: Semi: Expr 83 [0-0] [Type Unit]: Call:
                                     Expr 81 [165-172] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 84 [165-172] [Type Qubit]: Var: Local 61
                         adj: <none>
@@ -353,13 +353,13 @@ fn test_qubit_block() {
                                     Stmt 23 [153-163]: Local (Immutable):
                                         Pat 24 [157-158] [Type Int]: Bind: Ident 25 [157-158] "y"
                                         Expr 26 [161-162] [Type Int]: Lit: Int(3)
-                                    Stmt 54 [128-129]: Semi: Expr 55 [128-129] [Type Unit]: Call:
+                                    Stmt 54 [0-0]: Semi: Expr 55 [0-0] [Type Unit]: Call:
                                         Expr 53 [128-129] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                         Expr 56 [128-129] [Type Qubit]: Var: Local 21
-                                    Stmt 58 [78-85]: Semi: Expr 59 [78-85] [Type Unit]: Call:
+                                    Stmt 58 [0-0]: Semi: Expr 59 [0-0] [Type Unit]: Call:
                                         Expr 57 [78-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                         Expr 60 [78-85] [Type Qubit]: Var: Local 34
-                                    Stmt 62 [69-76]: Semi: Expr 63 [69-76] [Type Unit]: Call:
+                                    Stmt 62 [0-0]: Semi: Expr 63 [0-0] [Type Unit]: Call:
                                         Expr 61 [69-76] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                         Expr 64 [69-76] [Type Qubit]: Var: Local 32
                                 Stmt 27 [182-192]: Local (Immutable):
@@ -410,13 +410,13 @@ fn test_qubit_nested_block() {
                                     Stmt 14 [110-120]: Local (Immutable):
                                         Pat 15 [114-115] [Type Int]: Bind: Ident 16 [114-115] "x"
                                         Expr 17 [118-119] [Type Int]: Lit: Int(3)
-                                    Stmt 34 [84-85]: Semi: Expr 35 [84-85] [Type Unit]: Call:
+                                    Stmt 34 [0-0]: Semi: Expr 35 [0-0] [Type Unit]: Call:
                                         Expr 33 [84-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                         Expr 36 [84-85] [Type Qubit]: Var: Local 11
                                 Stmt 18 [139-149]: Local (Immutable):
                                     Pat 19 [143-144] [Type Int]: Bind: Ident 20 [143-144] "y"
                                     Expr 21 [147-148] [Type Int]: Lit: Int(3)
-                                Stmt 40 [59-60]: Semi: Expr 41 [59-60] [Type Unit]: Call:
+                                Stmt 40 [0-0]: Semi: Expr 41 [0-0] [Type Unit]: Call:
                                     Expr 39 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 42 [59-60] [Type Qubit]: Var: Local 7
                         adj: <none>
@@ -483,7 +483,7 @@ fn test_qubit_multiple_nested_blocks() {
                                     Stmt 28 [187-198]: Local (Immutable):
                                         Pat 29 [191-193] [Type Int]: Bind: Ident 30 [191-193] "y2"
                                         Expr 31 [196-197] [Type Int]: Lit: Int(3)
-                                    Stmt 67 [162-163]: Semi: Expr 68 [162-163] [Type Unit]: Call:
+                                    Stmt 67 [0-0]: Semi: Expr 68 [0-0] [Type Unit]: Call:
                                         Expr 66 [162-163] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                         Expr 69 [162-163] [Type Qubit]: Var: Local 26
                                 Stmt 32 [217-228]: Local (Immutable):
@@ -501,13 +501,13 @@ fn test_qubit_multiple_nested_blocks() {
                                     Stmt 47 [304-315]: Local (Immutable):
                                         Pat 48 [308-310] [Type Int]: Bind: Ident 49 [308-310] "z2"
                                         Expr 50 [313-314] [Type Int]: Lit: Int(3)
-                                    Stmt 76 [279-280]: Semi: Expr 77 [279-280] [Type Unit]: Call:
+                                    Stmt 76 [0-0]: Semi: Expr 77 [0-0] [Type Unit]: Call:
                                         Expr 75 [279-280] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                         Expr 78 [279-280] [Type Qubit]: Var: Local 45
                                 Stmt 51 [334-345]: Local (Immutable):
                                     Pat 52 [338-340] [Type Int]: Bind: Ident 53 [338-340] "x4"
                                     Expr 54 [343-344] [Type Int]: Lit: Int(3)
-                                Stmt 80 [79-80]: Semi: Expr 81 [79-80] [Type Unit]: Call:
+                                Stmt 80 [0-0]: Semi: Expr 81 [0-0] [Type Unit]: Call:
                                     Expr 79 [79-80] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 82 [79-80] [Type Qubit]: Var: Local 11
                         adj: <none>
@@ -563,17 +563,17 @@ fn test_early_returns() {
                                             Stmt 45 [0-0]: Local (Immutable):
                                                 Pat 46 [138-140] [Type Unit]: Bind: Ident 44 [138-140] "@generated_ident_44"
                                                 Expr 20 [138-140] [Type Unit]: Unit
-                                            Stmt 48 [106-107]: Semi: Expr 49 [106-107] [Type Unit]: Call:
+                                            Stmt 48 [0-0]: Semi: Expr 49 [0-0] [Type Unit]: Call:
                                                 Expr 47 [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                                 Expr 50 [106-107] [Type Qubit]: Var: Local 16
-                                            Stmt 52 [59-60]: Semi: Expr 53 [59-60] [Type Unit]: Call:
+                                            Stmt 52 [0-0]: Semi: Expr 53 [0-0] [Type Unit]: Call:
                                                 Expr 51 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                                 Expr 54 [59-60] [Type Qubit]: Var: Local 7
                                             Stmt 55 [131-140]: Semi: Expr 56 [131-140] [Type Unit]: Return: Expr 57 [138-140] [Type Unit]: Var: Local 44
-                                        Stmt 61 [106-107]: Semi: Expr 62 [106-107] [Type Unit]: Call:
+                                        Stmt 61 [0-0]: Semi: Expr 62 [0-0] [Type Unit]: Call:
                                             Expr 60 [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                             Expr 63 [106-107] [Type Qubit]: Var: Local 16
-                                Stmt 90 [0-0]: Local (Immutable):
+                                Stmt 90 [161-233]: Local (Immutable):
                                     Pat 91 [161-233] [Type Unit]: Bind: Ident 89 [161-233] "@generated_ident_89"
                                     Expr 22 [161-233] [Type Unit]: If:
                                         Expr 23 [164-169] [Type Bool]: Lit: Bool(false)
@@ -587,17 +587,17 @@ fn test_early_returns() {
                                                 Stmt 70 [0-0]: Local (Immutable):
                                                     Pat 71 [220-222] [Type Unit]: Bind: Ident 69 [220-222] "@generated_ident_69"
                                                     Expr 32 [220-222] [Type Unit]: Unit
-                                                Stmt 73 [188-189]: Semi: Expr 74 [188-189] [Type Unit]: Call:
+                                                Stmt 73 [0-0]: Semi: Expr 74 [0-0] [Type Unit]: Call:
                                                     Expr 72 [188-189] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                                     Expr 75 [188-189] [Type Qubit]: Var: Local 28
-                                                Stmt 77 [59-60]: Semi: Expr 78 [59-60] [Type Unit]: Call:
+                                                Stmt 77 [0-0]: Semi: Expr 78 [0-0] [Type Unit]: Call:
                                                     Expr 76 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                                     Expr 79 [59-60] [Type Qubit]: Var: Local 7
                                                 Stmt 80 [213-222]: Semi: Expr 81 [213-222] [Type Unit]: Return: Expr 82 [220-222] [Type Unit]: Var: Local 69
-                                            Stmt 86 [188-189]: Semi: Expr 87 [188-189] [Type Unit]: Call:
+                                            Stmt 86 [0-0]: Semi: Expr 87 [0-0] [Type Unit]: Call:
                                                 Expr 85 [188-189] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                                 Expr 88 [188-189] [Type Qubit]: Var: Local 28
-                                Stmt 95 [59-60]: Semi: Expr 96 [59-60] [Type Unit]: Call:
+                                Stmt 95 [0-0]: Semi: Expr 96 [0-0] [Type Unit]: Call:
                                     Expr 94 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 97 [59-60] [Type Qubit]: Var: Local 7
                                 Stmt 92 [0-0]: Expr: Expr 93 [161-233] [Type Unit]: Var: Local 89
@@ -650,14 +650,14 @@ fn test_end_exprs() {
                                             Expr 34 [127-128] [Type Qubit]: Call:
                                                 Expr 33 [127-128] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                                 Expr 35 [127-128] [Type Unit]: Unit
-                                        Stmt 39 [0-0]: Local (Immutable):
+                                        Stmt 39 [152-153]: Local (Immutable):
                                             Pat 40 [152-153] [Type Int]: Bind: Ident 38 [152-153] "@generated_ident_38"
                                             Expr 26 [152-153] [Type Int]: Lit: Int(3)
-                                        Stmt 44 [127-128]: Semi: Expr 45 [127-128] [Type Unit]: Call:
+                                        Stmt 44 [0-0]: Semi: Expr 45 [0-0] [Type Unit]: Call:
                                             Expr 43 [127-128] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                             Expr 46 [127-128] [Type Qubit]: Var: Local 23
                                         Stmt 41 [0-0]: Expr: Expr 42 [152-153] [Type Int]: Var: Local 38
-                                Stmt 48 [59-60]: Semi: Expr 49 [59-60] [Type Unit]: Call:
+                                Stmt 48 [0-0]: Semi: Expr 49 [0-0] [Type Unit]: Call:
                                     Expr 47 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 50 [59-60] [Type Qubit]: Var: Local 7
                         adj: <none>
@@ -701,17 +701,17 @@ fn test_array_expr() {
                                                 Expr 23 [87-88] [Type Qubit]: Call:
                                                     Expr 22 [87-88] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                                     Expr 24 [87-88] [Type Unit]: Unit
-                                            Stmt 28 [0-0]: Local (Immutable):
+                                            Stmt 28 [112-113]: Local (Immutable):
                                                 Pat 29 [112-113] [Type Int]: Bind: Ident 27 [112-113] "@generated_ident_27"
                                                 Expr 16 [112-113] [Type Int]: Lit: Int(3)
-                                            Stmt 33 [87-88]: Semi: Expr 34 [87-88] [Type Unit]: Call:
+                                            Stmt 33 [0-0]: Semi: Expr 34 [0-0] [Type Unit]: Call:
                                                 Expr 32 [87-88] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                                 Expr 35 [87-88] [Type Qubit]: Var: Local 13
                                             Stmt 30 [0-0]: Expr: Expr 31 [112-113] [Type Int]: Var: Local 27
                                 Stmt 17 [134-144]: Local (Immutable):
                                     Pat 18 [138-139] [Type Int]: Bind: Ident 19 [138-139] "x"
                                     Expr 20 [142-143] [Type Int]: Lit: Int(3)
-                                Stmt 42 [59-60]: Semi: Expr 43 [59-60] [Type Unit]: Call:
+                                Stmt 42 [0-0]: Semi: Expr 43 [0-0] [Type Unit]: Call:
                                     Expr 41 [59-60] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
                                     Expr 44 [59-60] [Type (Qubit)[]]: Var: Local 7
                         adj: <none>
@@ -759,18 +759,18 @@ fn test_rtrn_expr() {
                                                 Expr 27 [104-105] [Type Qubit]: Call:
                                                     Expr 26 [104-105] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
                                                     Expr 28 [104-105] [Type Unit]: Unit
-                                            Stmt 32 [0-0]: Local (Immutable):
+                                            Stmt 32 [129-130]: Local (Immutable):
                                                 Pat 33 [129-130] [Type Int]: Bind: Ident 31 [129-130] "@generated_ident_31"
                                                 Expr 18 [129-130] [Type Int]: Lit: Int(3)
-                                            Stmt 37 [104-105]: Semi: Expr 38 [104-105] [Type Unit]: Call:
+                                            Stmt 37 [0-0]: Semi: Expr 38 [0-0] [Type Unit]: Call:
                                                 Expr 36 [104-105] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                                 Expr 39 [104-105] [Type Qubit]: Var: Local 15
                                             Stmt 34 [0-0]: Expr: Expr 35 [129-130] [Type Int]: Var: Local 31
-                                    Stmt 43 [58-59]: Semi: Expr 44 [58-59] [Type Unit]: Call:
+                                    Stmt 43 [0-0]: Semi: Expr 44 [0-0] [Type Unit]: Call:
                                         Expr 42 [58-59] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                         Expr 45 [58-59] [Type Qubit]: Var: Local 7
                                     Stmt 46 [79-140]: Semi: Expr 47 [79-140] [Type Unit]: Return: Expr 48 [86-140] [Type Int]: Var: Local 25
-                                Stmt 52 [58-59]: Semi: Expr 53 [58-59] [Type Unit]: Call:
+                                Stmt 52 [0-0]: Semi: Expr 53 [0-0] [Type Unit]: Call:
                                     Expr 51 [58-59] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                     Expr 54 [58-59] [Type Qubit]: Var: Local 7
                         adj: <none>

--- a/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
@@ -39,17 +39,17 @@ fn test_single_qubit() {
                         functors: empty set
                         body: SpecDecl 3 [22-96]: Impl:
                             Block 4 [45-96] [Type Unit]:
-                                Stmt 17 [59-60]: Local (Immutable):
-                                    Pat 18 [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "q"
-                                    Expr 15 [59-60] [Type Qubit]: Call:
-                                        Expr 14 [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr 16 [59-60] [Type Unit]: Unit
+                                Stmt 17 [55-71]: Local (Immutable):
+                                    Pat 18 [55-71] [Type Qubit]: Bind: Ident 7 [55-71] "q"
+                                    Expr 15 [55-71] [Type Qubit]: Call:
+                                        Expr 14 [55-71] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 16 [55-71] [Type Unit]: Unit
                                 Stmt 9 [80-90]: Local (Immutable):
                                     Pat 10 [84-85] [Type Int]: Bind: Ident 11 [84-85] "x"
                                     Expr 12 [88-89] [Type Int]: Lit: Int(3)
                                 Stmt 20 [0-0]: Semi: Expr 21 [0-0] [Type Unit]: Call:
-                                    Expr 19 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr 22 [59-60] [Type Qubit]: Var: Local 7
+                                    Expr 19 [55-71] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 22 [55-71] [Type Qubit]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -78,17 +78,17 @@ fn test_qubit_array() {
                         functors: empty set
                         body: SpecDecl 3 [22-97]: Impl:
                             Block 4 [45-97] [Type Unit]:
-                                Stmt 18 [59-60]: Local (Immutable):
-                                    Pat 19 [59-60] [Type (Qubit)[]]: Bind: Ident 7 [59-60] "q"
-                                    Expr 16 [59-60] [Type Qubit]: Call:
-                                        Expr 15 [59-60] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
+                                Stmt 18 [55-72]: Local (Immutable):
+                                    Pat 19 [55-72] [Type (Qubit)[]]: Bind: Ident 7 [55-72] "q"
+                                    Expr 16 [55-72] [Type Qubit]: Call:
+                                        Expr 15 [55-72] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
                                         Expr 9 [69-70] [Type Int]: Lit: Int(3)
                                 Stmt 10 [81-91]: Local (Immutable):
                                     Pat 11 [85-86] [Type Int]: Bind: Ident 12 [85-86] "x"
                                     Expr 13 [89-90] [Type Int]: Lit: Int(3)
                                 Stmt 21 [0-0]: Semi: Expr 22 [0-0] [Type Unit]: Call:
-                                    Expr 20 [59-60] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
-                                    Expr 23 [59-60] [Type (Qubit)[]]: Var: Local 7
+                                    Expr 20 [55-72] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
+                                    Expr 23 [55-72] [Type (Qubit)[]]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -345,17 +345,17 @@ fn test_qubit_block() {
                                     Stmt 15 [101-111]: Local (Immutable):
                                         Pat 16 [105-106] [Type Int]: Bind: Ident 17 [105-106] "x"
                                         Expr 18 [109-110] [Type Int]: Lit: Int(3)
-                                    Stmt 51 [128-129]: Local (Immutable):
-                                        Pat 52 [128-129] [Type Qubit]: Bind: Ident 21 [128-129] "c"
-                                        Expr 49 [128-129] [Type Qubit]: Call:
-                                            Expr 48 [128-129] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr 50 [128-129] [Type Unit]: Unit
+                                    Stmt 51 [124-140]: Local (Immutable):
+                                        Pat 52 [124-140] [Type Qubit]: Bind: Ident 21 [124-140] "c"
+                                        Expr 49 [124-140] [Type Qubit]: Call:
+                                            Expr 48 [124-140] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 50 [124-140] [Type Unit]: Unit
                                     Stmt 23 [153-163]: Local (Immutable):
                                         Pat 24 [157-158] [Type Int]: Bind: Ident 25 [157-158] "y"
                                         Expr 26 [161-162] [Type Int]: Lit: Int(3)
                                     Stmt 54 [0-0]: Semi: Expr 55 [0-0] [Type Unit]: Call:
-                                        Expr 53 [128-129] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr 56 [128-129] [Type Qubit]: Var: Local 21
+                                        Expr 53 [124-140] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 56 [124-140] [Type Qubit]: Var: Local 21
                                     Stmt 58 [0-0]: Semi: Expr 59 [0-0] [Type Unit]: Call:
                                         Expr 57 [78-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
                                         Expr 60 [78-85] [Type Qubit]: Var: Local 34
@@ -396,29 +396,29 @@ fn test_qubit_nested_block() {
                         functors: empty set
                         body: SpecDecl 3 [22-155]: Impl:
                             Block 4 [45-155] [Type Unit]:
-                                Stmt 26 [59-60]: Local (Immutable):
-                                    Pat 27 [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "a"
-                                    Expr 24 [59-60] [Type Qubit]: Call:
-                                        Expr 23 [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr 25 [59-60] [Type Unit]: Unit
+                                Stmt 26 [55-71]: Local (Immutable):
+                                    Pat 27 [55-71] [Type Qubit]: Bind: Ident 7 [55-71] "a"
+                                    Expr 24 [55-71] [Type Qubit]: Call:
+                                        Expr 23 [55-71] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 25 [55-71] [Type Unit]: Unit
                                 Stmt 37 [80-130]: Expr: Expr 38 [80-130] [Type Unit]: Expr Block: Block 13 [96-130] [Type Unit]:
-                                    Stmt 31 [84-85]: Local (Immutable):
-                                        Pat 32 [84-85] [Type Qubit]: Bind: Ident 11 [84-85] "b"
-                                        Expr 29 [84-85] [Type Qubit]: Call:
-                                            Expr 28 [84-85] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr 30 [84-85] [Type Unit]: Unit
+                                    Stmt 31 [80-130]: Local (Immutable):
+                                        Pat 32 [80-130] [Type Qubit]: Bind: Ident 11 [80-130] "b"
+                                        Expr 29 [80-130] [Type Qubit]: Call:
+                                            Expr 28 [80-130] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 30 [80-130] [Type Unit]: Unit
                                     Stmt 14 [110-120]: Local (Immutable):
                                         Pat 15 [114-115] [Type Int]: Bind: Ident 16 [114-115] "x"
                                         Expr 17 [118-119] [Type Int]: Lit: Int(3)
                                     Stmt 34 [0-0]: Semi: Expr 35 [0-0] [Type Unit]: Call:
-                                        Expr 33 [84-85] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr 36 [84-85] [Type Qubit]: Var: Local 11
+                                        Expr 33 [80-130] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 36 [80-130] [Type Qubit]: Var: Local 11
                                 Stmt 18 [139-149]: Local (Immutable):
                                     Pat 19 [143-144] [Type Int]: Bind: Ident 20 [143-144] "y"
                                     Expr 21 [147-148] [Type Int]: Lit: Int(3)
                                 Stmt 40 [0-0]: Semi: Expr 41 [0-0] [Type Unit]: Call:
-                                    Expr 39 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr 42 [59-60] [Type Qubit]: Var: Local 7
+                                    Expr 39 [55-71] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 42 [55-71] [Type Qubit]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -463,11 +463,11 @@ fn test_qubit_multiple_nested_blocks() {
                                 Stmt 5 [55-66]: Local (Immutable):
                                     Pat 6 [59-61] [Type Int]: Bind: Ident 7 [59-61] "x1"
                                     Expr 8 [64-65] [Type Int]: Lit: Int(3)
-                                Stmt 59 [79-80]: Local (Immutable):
-                                    Pat 60 [79-80] [Type Qubit]: Bind: Ident 11 [79-80] "a"
-                                    Expr 57 [79-80] [Type Qubit]: Call:
-                                        Expr 56 [79-80] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr 58 [79-80] [Type Unit]: Unit
+                                Stmt 59 [75-91]: Local (Immutable):
+                                    Pat 60 [75-91] [Type Qubit]: Bind: Ident 11 [75-91] "a"
+                                    Expr 57 [75-91] [Type Qubit]: Call:
+                                        Expr 56 [75-91] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 58 [75-91] [Type Unit]: Unit
                                 Stmt 13 [100-111]: Local (Immutable):
                                     Pat 14 [104-106] [Type Int]: Bind: Ident 15 [104-106] "x2"
                                     Expr 16 [109-110] [Type Int]: Lit: Int(3)
@@ -475,17 +475,17 @@ fn test_qubit_multiple_nested_blocks() {
                                     Stmt 20 [134-145]: Local (Immutable):
                                         Pat 21 [138-140] [Type Int]: Bind: Ident 22 [138-140] "y1"
                                         Expr 23 [143-144] [Type Int]: Lit: Int(3)
-                                    Stmt 64 [162-163]: Local (Immutable):
-                                        Pat 65 [162-163] [Type Qubit]: Bind: Ident 26 [162-163] "b"
-                                        Expr 62 [162-163] [Type Qubit]: Call:
-                                            Expr 61 [162-163] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr 63 [162-163] [Type Unit]: Unit
+                                    Stmt 64 [158-174]: Local (Immutable):
+                                        Pat 65 [158-174] [Type Qubit]: Bind: Ident 26 [158-174] "b"
+                                        Expr 62 [158-174] [Type Qubit]: Call:
+                                            Expr 61 [158-174] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 63 [158-174] [Type Unit]: Unit
                                     Stmt 28 [187-198]: Local (Immutable):
                                         Pat 29 [191-193] [Type Int]: Bind: Ident 30 [191-193] "y2"
                                         Expr 31 [196-197] [Type Int]: Lit: Int(3)
                                     Stmt 67 [0-0]: Semi: Expr 68 [0-0] [Type Unit]: Call:
-                                        Expr 66 [162-163] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr 69 [162-163] [Type Qubit]: Var: Local 26
+                                        Expr 66 [158-174] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 69 [158-174] [Type Qubit]: Var: Local 26
                                 Stmt 32 [217-228]: Local (Immutable):
                                     Pat 33 [221-223] [Type Int]: Bind: Ident 34 [221-223] "x3"
                                     Expr 35 [226-227] [Type Int]: Lit: Int(3)
@@ -493,23 +493,23 @@ fn test_qubit_multiple_nested_blocks() {
                                     Stmt 39 [251-262]: Local (Immutable):
                                         Pat 40 [255-257] [Type Int]: Bind: Ident 41 [255-257] "z1"
                                         Expr 42 [260-261] [Type Int]: Lit: Int(3)
-                                    Stmt 73 [279-280]: Local (Immutable):
-                                        Pat 74 [279-280] [Type Qubit]: Bind: Ident 45 [279-280] "c"
-                                        Expr 71 [279-280] [Type Qubit]: Call:
-                                            Expr 70 [279-280] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                            Expr 72 [279-280] [Type Unit]: Unit
+                                    Stmt 73 [275-291]: Local (Immutable):
+                                        Pat 74 [275-291] [Type Qubit]: Bind: Ident 45 [275-291] "c"
+                                        Expr 71 [275-291] [Type Qubit]: Call:
+                                            Expr 70 [275-291] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                            Expr 72 [275-291] [Type Unit]: Unit
                                     Stmt 47 [304-315]: Local (Immutable):
                                         Pat 48 [308-310] [Type Int]: Bind: Ident 49 [308-310] "z2"
                                         Expr 50 [313-314] [Type Int]: Lit: Int(3)
                                     Stmt 76 [0-0]: Semi: Expr 77 [0-0] [Type Unit]: Call:
-                                        Expr 75 [279-280] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr 78 [279-280] [Type Qubit]: Var: Local 45
+                                        Expr 75 [275-291] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 78 [275-291] [Type Qubit]: Var: Local 45
                                 Stmt 51 [334-345]: Local (Immutable):
                                     Pat 52 [338-340] [Type Int]: Bind: Ident 53 [338-340] "x4"
                                     Expr 54 [343-344] [Type Int]: Lit: Int(3)
                                 Stmt 80 [0-0]: Semi: Expr 81 [0-0] [Type Unit]: Call:
-                                    Expr 79 [79-80] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr 82 [79-80] [Type Qubit]: Var: Local 11
+                                    Expr 79 [75-91] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 82 [75-91] [Type Qubit]: Var: Local 11
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -546,60 +546,60 @@ fn test_early_returns() {
                         functors: empty set
                         body: SpecDecl 3 [22-239]: Impl:
                             Block 4 [45-239] [Type Unit]:
-                                Stmt 37 [59-60]: Local (Immutable):
-                                    Pat 38 [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "a"
-                                    Expr 35 [59-60] [Type Qubit]: Call:
-                                        Expr 34 [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr 36 [59-60] [Type Unit]: Unit
+                                Stmt 37 [55-71]: Local (Immutable):
+                                    Pat 38 [55-71] [Type Qubit]: Bind: Ident 7 [55-71] "a"
+                                    Expr 35 [55-71] [Type Qubit]: Call:
+                                        Expr 34 [55-71] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 36 [55-71] [Type Unit]: Unit
                                 Stmt 9 [80-151]: Expr: Expr 10 [80-151] [Type Unit]: If:
                                     Expr 11 [83-87] [Type Bool]: Lit: Bool(true)
                                     Expr 12 [88-151] [Type Unit]: Expr Block: Block 13 [88-151] [Type Unit]:
-                                        Stmt 42 [106-107]: Local (Immutable):
-                                            Pat 43 [106-107] [Type Qubit]: Bind: Ident 16 [106-107] "b"
-                                            Expr 40 [106-107] [Type Qubit]: Call:
-                                                Expr 39 [106-107] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                Expr 41 [106-107] [Type Unit]: Unit
+                                        Stmt 42 [102-118]: Local (Immutable):
+                                            Pat 43 [102-118] [Type Qubit]: Bind: Ident 16 [102-118] "b"
+                                            Expr 40 [102-118] [Type Qubit]: Call:
+                                                Expr 39 [102-118] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                Expr 41 [102-118] [Type Unit]: Unit
                                         Stmt 18 [131-141]: Semi: Expr 58 [131-140] [Type Unit]: Expr Block: Block 59 [131-140] [Type Unit]:
                                             Stmt 45 [0-0]: Local (Immutable):
                                                 Pat 46 [138-140] [Type Unit]: Bind: Ident 44 [138-140] "@generated_ident_44"
                                                 Expr 20 [138-140] [Type Unit]: Unit
                                             Stmt 48 [0-0]: Semi: Expr 49 [0-0] [Type Unit]: Call:
-                                                Expr 47 [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr 50 [106-107] [Type Qubit]: Var: Local 16
+                                                Expr 47 [102-118] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 50 [102-118] [Type Qubit]: Var: Local 16
                                             Stmt 52 [0-0]: Semi: Expr 53 [0-0] [Type Unit]: Call:
-                                                Expr 51 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr 54 [59-60] [Type Qubit]: Var: Local 7
+                                                Expr 51 [55-71] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 54 [55-71] [Type Qubit]: Var: Local 7
                                             Stmt 55 [131-140]: Semi: Expr 56 [131-140] [Type Unit]: Return: Expr 57 [138-140] [Type Unit]: Var: Local 44
                                         Stmt 61 [0-0]: Semi: Expr 62 [0-0] [Type Unit]: Call:
-                                            Expr 60 [106-107] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                            Expr 63 [106-107] [Type Qubit]: Var: Local 16
+                                            Expr 60 [102-118] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                            Expr 63 [102-118] [Type Qubit]: Var: Local 16
                                 Stmt 90 [161-233]: Local (Immutable):
                                     Pat 91 [161-233] [Type Unit]: Bind: Ident 89 [161-233] "@generated_ident_89"
                                     Expr 22 [161-233] [Type Unit]: If:
                                         Expr 23 [164-169] [Type Bool]: Lit: Bool(false)
                                         Expr 24 [170-233] [Type Unit]: Expr Block: Block 25 [170-233] [Type Unit]:
-                                            Stmt 67 [188-189]: Local (Immutable):
-                                                Pat 68 [188-189] [Type Qubit]: Bind: Ident 28 [188-189] "c"
-                                                Expr 65 [188-189] [Type Qubit]: Call:
-                                                    Expr 64 [188-189] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                    Expr 66 [188-189] [Type Unit]: Unit
+                                            Stmt 67 [184-200]: Local (Immutable):
+                                                Pat 68 [184-200] [Type Qubit]: Bind: Ident 28 [184-200] "c"
+                                                Expr 65 [184-200] [Type Qubit]: Call:
+                                                    Expr 64 [184-200] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                    Expr 66 [184-200] [Type Unit]: Unit
                                             Stmt 30 [213-223]: Semi: Expr 83 [213-222] [Type Unit]: Expr Block: Block 84 [213-222] [Type Unit]:
                                                 Stmt 70 [0-0]: Local (Immutable):
                                                     Pat 71 [220-222] [Type Unit]: Bind: Ident 69 [220-222] "@generated_ident_69"
                                                     Expr 32 [220-222] [Type Unit]: Unit
                                                 Stmt 73 [0-0]: Semi: Expr 74 [0-0] [Type Unit]: Call:
-                                                    Expr 72 [188-189] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                    Expr 75 [188-189] [Type Qubit]: Var: Local 28
+                                                    Expr 72 [184-200] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                    Expr 75 [184-200] [Type Qubit]: Var: Local 28
                                                 Stmt 77 [0-0]: Semi: Expr 78 [0-0] [Type Unit]: Call:
-                                                    Expr 76 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                    Expr 79 [59-60] [Type Qubit]: Var: Local 7
+                                                    Expr 76 [55-71] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                    Expr 79 [55-71] [Type Qubit]: Var: Local 7
                                                 Stmt 80 [213-222]: Semi: Expr 81 [213-222] [Type Unit]: Return: Expr 82 [220-222] [Type Unit]: Var: Local 69
                                             Stmt 86 [0-0]: Semi: Expr 87 [0-0] [Type Unit]: Call:
-                                                Expr 85 [188-189] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr 88 [188-189] [Type Qubit]: Var: Local 28
+                                                Expr 85 [184-200] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 88 [184-200] [Type Qubit]: Var: Local 28
                                 Stmt 95 [0-0]: Semi: Expr 96 [0-0] [Type Unit]: Call:
-                                    Expr 94 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr 97 [59-60] [Type Qubit]: Var: Local 7
+                                    Expr 94 [55-71] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 97 [55-71] [Type Qubit]: Var: Local 7
                                 Stmt 92 [0-0]: Expr: Expr 93 [161-233] [Type Unit]: Var: Local 89
                         adj: <none>
                         ctl: <none>
@@ -633,11 +633,11 @@ fn test_end_exprs() {
                         functors: empty set
                         body: SpecDecl 3 [22-170]: Impl:
                             Block 4 [45-170] [Type Unit]:
-                                Stmt 31 [59-60]: Local (Immutable):
-                                    Pat 32 [59-60] [Type Qubit]: Bind: Ident 7 [59-60] "a"
-                                    Expr 29 [59-60] [Type Qubit]: Call:
-                                        Expr 28 [59-60] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr 30 [59-60] [Type Unit]: Unit
+                                Stmt 31 [55-71]: Local (Immutable):
+                                    Pat 32 [55-71] [Type Qubit]: Bind: Ident 7 [55-71] "a"
+                                    Expr 29 [55-71] [Type Qubit]: Call:
+                                        Expr 28 [55-71] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 30 [55-71] [Type Unit]: Unit
                                 Stmt 9 [80-92]: Local (Immutable):
                                     Pat 10 [84-85] [Type Int]: Bind: Ident 11 [84-85] "x"
                                     Expr 12 [88-91] [Type Int]: Expr Block: Block 13 [88-91] [Type Int]:
@@ -645,21 +645,21 @@ fn test_end_exprs() {
                                 Stmt 16 [101-164]: Local (Immutable):
                                     Pat 17 [105-106] [Type Int]: Bind: Ident 18 [105-106] "y"
                                     Expr 19 [109-163] [Type Int]: Expr Block: Block 20 [109-163] [Type Int]:
-                                        Stmt 36 [127-128]: Local (Immutable):
-                                            Pat 37 [127-128] [Type Qubit]: Bind: Ident 23 [127-128] "b"
-                                            Expr 34 [127-128] [Type Qubit]: Call:
-                                                Expr 33 [127-128] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                Expr 35 [127-128] [Type Unit]: Unit
+                                        Stmt 36 [123-139]: Local (Immutable):
+                                            Pat 37 [123-139] [Type Qubit]: Bind: Ident 23 [123-139] "b"
+                                            Expr 34 [123-139] [Type Qubit]: Call:
+                                                Expr 33 [123-139] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                Expr 35 [123-139] [Type Unit]: Unit
                                         Stmt 39 [152-153]: Local (Immutable):
                                             Pat 40 [152-153] [Type Int]: Bind: Ident 38 [152-153] "@generated_ident_38"
                                             Expr 26 [152-153] [Type Int]: Lit: Int(3)
                                         Stmt 44 [0-0]: Semi: Expr 45 [0-0] [Type Unit]: Call:
-                                            Expr 43 [127-128] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                            Expr 46 [127-128] [Type Qubit]: Var: Local 23
+                                            Expr 43 [123-139] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                            Expr 46 [123-139] [Type Qubit]: Var: Local 23
                                         Stmt 41 [0-0]: Expr: Expr 42 [152-153] [Type Int]: Var: Local 38
                                 Stmt 48 [0-0]: Semi: Expr 49 [0-0] [Type Unit]: Call:
-                                    Expr 47 [59-60] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr 50 [59-60] [Type Qubit]: Var: Local 7
+                                    Expr 47 [55-71] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 50 [55-71] [Type Qubit]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -691,29 +691,29 @@ fn test_array_expr() {
                         functors: empty set
                         body: SpecDecl 3 [22-150]: Impl:
                             Block 4 [45-150] [Type Unit]:
-                                Stmt 39 [59-60]: Local (Immutable):
-                                    Pat 40 [59-60] [Type (Qubit)[]]: Bind: Ident 7 [59-60] "a"
-                                    Expr 37 [59-60] [Type Qubit]: Call:
-                                        Expr 36 [59-60] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
+                                Stmt 39 [55-125]: Local (Immutable):
+                                    Pat 40 [55-125] [Type (Qubit)[]]: Bind: Ident 7 [55-125] "a"
+                                    Expr 37 [55-125] [Type Qubit]: Call:
+                                        Expr 36 [55-125] [Type (Int => (Qubit)[])]: Var: Item 6 (Package 0)
                                         Expr 9 [69-123] [Type Int]: Expr Block: Block 10 [69-123] [Type Int]:
-                                            Stmt 25 [87-88]: Local (Immutable):
-                                                Pat 26 [87-88] [Type Qubit]: Bind: Ident 13 [87-88] "b"
-                                                Expr 23 [87-88] [Type Qubit]: Call:
-                                                    Expr 22 [87-88] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                    Expr 24 [87-88] [Type Unit]: Unit
+                                            Stmt 25 [83-99]: Local (Immutable):
+                                                Pat 26 [83-99] [Type Qubit]: Bind: Ident 13 [83-99] "b"
+                                                Expr 23 [83-99] [Type Qubit]: Call:
+                                                    Expr 22 [83-99] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                    Expr 24 [83-99] [Type Unit]: Unit
                                             Stmt 28 [112-113]: Local (Immutable):
                                                 Pat 29 [112-113] [Type Int]: Bind: Ident 27 [112-113] "@generated_ident_27"
                                                 Expr 16 [112-113] [Type Int]: Lit: Int(3)
                                             Stmt 33 [0-0]: Semi: Expr 34 [0-0] [Type Unit]: Call:
-                                                Expr 32 [87-88] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr 35 [87-88] [Type Qubit]: Var: Local 13
+                                                Expr 32 [83-99] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 35 [83-99] [Type Qubit]: Var: Local 13
                                             Stmt 30 [0-0]: Expr: Expr 31 [112-113] [Type Int]: Var: Local 27
                                 Stmt 17 [134-144]: Local (Immutable):
                                     Pat 18 [138-139] [Type Int]: Bind: Ident 19 [138-139] "x"
                                     Expr 20 [142-143] [Type Int]: Lit: Int(3)
                                 Stmt 42 [0-0]: Semi: Expr 43 [0-0] [Type Unit]: Call:
-                                    Expr 41 [59-60] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
-                                    Expr 44 [59-60] [Type (Qubit)[]]: Var: Local 7
+                                    Expr 41 [55-125] [Type ((Qubit)[] => Unit)]: Var: Item 7 (Package 0)
+                                    Expr 44 [55-125] [Type (Qubit)[]]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],
@@ -745,34 +745,34 @@ fn test_rtrn_expr() {
                         functors: empty set
                         body: SpecDecl 3 [22-147]: Impl:
                             Block 4 [44-147] [Type Int]:
-                                Stmt 23 [58-59]: Local (Immutable):
-                                    Pat 24 [58-59] [Type Qubit]: Bind: Ident 7 [58-59] "a"
-                                    Expr 21 [58-59] [Type Qubit]: Call:
-                                        Expr 20 [58-59] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                        Expr 22 [58-59] [Type Unit]: Unit
+                                Stmt 23 [54-70]: Local (Immutable):
+                                    Pat 24 [54-70] [Type Qubit]: Bind: Ident 7 [54-70] "a"
+                                    Expr 21 [54-70] [Type Qubit]: Call:
+                                        Expr 20 [54-70] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                        Expr 22 [54-70] [Type Unit]: Unit
                                 Stmt 9 [79-141]: Semi: Expr 49 [79-140] [Type Unit]: Expr Block: Block 50 [79-140] [Type Unit]:
                                     Stmt 40 [0-0]: Local (Immutable):
                                         Pat 41 [86-140] [Type Int]: Bind: Ident 25 [86-140] "@generated_ident_25"
                                         Expr 11 [86-140] [Type Int]: Expr Block: Block 12 [86-140] [Type Int]:
-                                            Stmt 29 [104-105]: Local (Immutable):
-                                                Pat 30 [104-105] [Type Qubit]: Bind: Ident 15 [104-105] "b"
-                                                Expr 27 [104-105] [Type Qubit]: Call:
-                                                    Expr 26 [104-105] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
-                                                    Expr 28 [104-105] [Type Unit]: Unit
+                                            Stmt 29 [100-116]: Local (Immutable):
+                                                Pat 30 [100-116] [Type Qubit]: Bind: Ident 15 [100-116] "b"
+                                                Expr 27 [100-116] [Type Qubit]: Call:
+                                                    Expr 26 [100-116] [Type (Unit => Qubit)]: Var: Item 4 (Package 0)
+                                                    Expr 28 [100-116] [Type Unit]: Unit
                                             Stmt 32 [129-130]: Local (Immutable):
                                                 Pat 33 [129-130] [Type Int]: Bind: Ident 31 [129-130] "@generated_ident_31"
                                                 Expr 18 [129-130] [Type Int]: Lit: Int(3)
                                             Stmt 37 [0-0]: Semi: Expr 38 [0-0] [Type Unit]: Call:
-                                                Expr 36 [104-105] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                                Expr 39 [104-105] [Type Qubit]: Var: Local 15
+                                                Expr 36 [100-116] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                                Expr 39 [100-116] [Type Qubit]: Var: Local 15
                                             Stmt 34 [0-0]: Expr: Expr 35 [129-130] [Type Int]: Var: Local 31
                                     Stmt 43 [0-0]: Semi: Expr 44 [0-0] [Type Unit]: Call:
-                                        Expr 42 [58-59] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                        Expr 45 [58-59] [Type Qubit]: Var: Local 7
+                                        Expr 42 [54-70] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                        Expr 45 [54-70] [Type Qubit]: Var: Local 7
                                     Stmt 46 [79-140]: Semi: Expr 47 [79-140] [Type Unit]: Return: Expr 48 [86-140] [Type Int]: Var: Local 25
                                 Stmt 52 [0-0]: Semi: Expr 53 [0-0] [Type Unit]: Call:
-                                    Expr 51 [58-59] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
-                                    Expr 54 [58-59] [Type Qubit]: Var: Local 7
+                                    Expr 51 [54-70] [Type (Qubit => Unit)]: Var: Item 5 (Package 0)
+                                    Expr 54 [54-70] [Type Qubit]: Var: Local 7
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -622,7 +622,7 @@ test("debug service getting breakpoints after loaded source succeeds when file n
     );
     assert.equal(true, result);
     const bps = await debugService.getBreakpoints("test.qs");
-    assert.equal(bps.length, 5);
+    assert.equal(bps.length, 4);
   } finally {
     debugService.terminate();
   }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "eslint:check": "eslint -c ./.eslintrc.cjs --max-warnings 0 ./",
     "prettier:check": "prettier -c --no-config ./",
     "check": "npm run eslint:check && npm run prettier:check",
-    "prettier:fix": "prettier -w --no-config ./",
-    "vscode:dev": "cd vscode && npx serve --cors -l 5000 --ssl-cert $HOME/certs/localhost.pem --ssl-key $HOME/certs/localhost-key.pem"
+    "prettier:fix": "prettier -w --no-config ./"
   },
   "private": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "eslint:check": "eslint -c ./.eslintrc.cjs --max-warnings 0 ./",
     "prettier:check": "prettier -c --no-config ./",
     "check": "npm run eslint:check && npm run prettier:check",
-    "prettier:fix": "prettier -w --no-config ./"
+    "prettier:fix": "prettier -w --no-config ./",
+    "vscode:dev": "cd vscode && npx serve --cors -l 5000 --ssl-cert $HOME/certs/localhost.pem --ssl-key $HOME/certs/localhost-key.pem"
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
This PR adds

- metadata to the debug breakpoint information stored in the debugger extension.
- enables inline breakpoints and fixes issues with multi-line statements where breakpoints weren't being set correctly.
- breakpoints for if/while loops
  - more work needs to be done to support stepping for the conditional checks (while, elif) 
- filters bp requests to ensure we are processing Q# files
- trace instead of error logging when failing to load files. Almost all failures are false positives for cached BPs from previous sessions.