### PR TITLE
Use PyQIR to validate base profile output

### DIFF
--- a/build.py
+++ b/build.py
@@ -216,7 +216,7 @@ if build_pip:
             "test_requirements.txt",
         ]
         subprocess.run(qir_install_args, check=True, text=True, cwd=qir_test_dir)
-        pyqir_check_args = [python_bin, "-c", '"import pyqir"']
+        pyqir_check_args = [python_bin, "-c", "import pyqir"]
         if (
             subprocess.run(
                 pyqir_check_args, check=False, text=True, cwd=qir_test_dir

--- a/build.py
+++ b/build.py
@@ -215,15 +215,19 @@ if build_pip:
             "-r",
             "test_requirements.txt",
         ]
-        pyqir_install = subprocess.run(
-            qir_install_args, check=False, text=True, cwd=qir_test_dir
-        )
-        if pyqir_install.returncode == 0:
+        subprocess.run(qir_install_args, check=True, text=True, cwd=qir_test_dir)
+        pyqir_check_args = [python_bin, "-c", '"import pyqir"']
+        if (
+            subprocess.run(
+                pyqir_check_args, check=False, text=True, cwd=qir_test_dir
+            ).returncode
+            == 0
+        ):
             print("Running tests for the pip package with PyQIR")
             pytest_args = [python_bin, "-m", "pytest"]
             subprocess.run(pytest_args, check=True, text=True, cwd=qir_test_dir)
         else:
-            print("Skipping PyQIR tests")
+            print("Could not import PyQIR, skipping tests")
 
 if build_wasm:
     print("Building the wasm crate")

--- a/build.py
+++ b/build.py
@@ -205,6 +205,26 @@ if build_pip:
             pytest_args, check=True, text=True, cwd=os.path.join(pip_src, "tests")
         )
 
+        qir_test_dir = os.path.join(pip_src, "tests-qir")
+        # Try to install PyQIR and if successful, run additional tests.
+        qir_install_args = [
+            python_bin,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            "test_requirements.txt",
+        ]
+        pyqir_install = subprocess.run(
+            qir_install_args, check=False, text=True, cwd=qir_test_dir
+        )
+        if pyqir_install.returncode == 0:
+            print("Running tests for the pip package with PyQIR")
+            pytest_args = [python_bin, "-m", "pytest"]
+            subprocess.run(pytest_args, check=True, text=True, cwd=qir_test_dir)
+        else:
+            print("Skipping PyQIR tests")
+
 if build_wasm:
     print("Building the wasm crate")
     # wasm-pack can't build for web and node in the same build, so need to run twice.
@@ -226,7 +246,12 @@ if build_wasm:
 
 if build_samples:
     print("Building qsharp samples")
-    files = [os.path.join(dp, f) for dp, _, filenames in os.walk(samples_src) for f in filenames if os.path.splitext(f)[1] == '.qs']
+    files = [
+        os.path.join(dp, f)
+        for dp, _, filenames in os.walk(samples_src)
+        for f in filenames
+        if os.path.splitext(f)[1] == ".qs"
+    ]
     args = ["cargo", "run", "--bin", "qsc"]
     if build_type == "release":
         args.append("--release")

--- a/pip/test_requirements.txt
+++ b/pip/test_requirements.txt
@@ -1,1 +1,2 @@
 pytest
+pyqir

--- a/pip/tests-qir/test_qir.py
+++ b/pip/tests-qir/test_qir.py
@@ -1,0 +1,102 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import qsharp
+from pyqir import Call, Context, Module, Opcode, qubit_id, result_id
+
+
+def test_compile_qir_input_data() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Base)
+    qsharp.eval("operation Program() : Result { use q = Qubit(); return M(q) }")
+    operation = qsharp.compile("Program()")
+    qir = operation._repr_qir_()
+    assert isinstance(qir, bytes)
+    module = Module.from_ir(Context(), qir.decode(), "module")
+    assert len(module.functions) == 26
+    assert module.functions[0].name == "ENTRYPOINT__main"
+    func = module.functions[0]
+    assert len(func.basic_blocks) == 1
+    assert len(func.basic_blocks[0].instructions) == 3
+    call_m = func.basic_blocks[0].instructions[0]
+    assert isinstance(call_m, Call)
+    assert call_m.callee.name == "__quantum__qis__m__body"
+    assert len(call_m.args) == 2
+    assert qubit_id(call_m.args[0]) == 0
+    assert result_id(call_m.args[1]) == 0
+    record_res = func.basic_blocks[0].instructions[1]
+    assert isinstance(record_res, Call)
+    assert len(record_res.args) == 2
+    assert record_res.callee.name == "__quantum__rt__result_record_output"
+    assert result_id(record_res.args[0]) == 0
+    assert func.basic_blocks[0].instructions[2].opcode == Opcode.RET
+
+
+def test_compile_qir_all_gates() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Base)
+    operation = qsharp.compile(
+        "{\
+        use (q1, q2, q3) = (Qubit(), Qubit(), Qubit());\
+        CCNOT(q1, q2, q3);\
+        CX(q1, q2);\
+        CY(q1, q2);\
+        CZ(q1, q2);\
+        Rx(0.0, q1);\
+        Rxx(0.0, q1, q2);\
+        Ry(0.0, q1);\
+        Ryy(0.0, q1, q2);\
+        Rz(0.0, q1);\
+        Rzz(0.0, q1, q2);\
+        H(q1);\
+        S(q1);\
+        Adjoint S(q1);\
+        T(q1);\
+        Adjoint T(q1);\
+        X(q1);\
+        Y(q1);\
+        Z(q1);\
+        SWAP(q1, q2);\
+        Reset(q1);\
+        (M(q1),\
+        Microsoft.Quantum.Measurement.MResetZ(q1))\
+        }"
+    )
+    qir = operation._repr_qir_()
+    assert isinstance(qir, bytes)
+    module = Module.from_ir(Context(), qir.decode(), "module")
+    assert len(module.functions) == 26
+    assert module.functions[0].name == "ENTRYPOINT__main"
+    func = module.functions[0]
+    assert len(func.basic_blocks) == 1
+    assert len(func.basic_blocks[0].instructions) == 26
+
+    def check_call(i: int, name: str, num_args: int) -> None:
+        call = func.basic_blocks[0].instructions[i]
+        assert isinstance(call, Call)
+        assert call.callee.name == name
+        assert len(call.args) == num_args
+
+    check_call(0, "__quantum__qis__ccx__body", 3)
+    check_call(1, "__quantum__qis__cx__body", 2)
+    check_call(2, "__quantum__qis__cy__body", 2)
+    check_call(3, "__quantum__qis__cz__body", 2)
+    check_call(4, "__quantum__qis__rx__body", 2)
+    check_call(5, "__quantum__qis__rxx__body", 3)
+    check_call(6, "__quantum__qis__ry__body", 2)
+    check_call(7, "__quantum__qis__ryy__body", 3)
+    check_call(8, "__quantum__qis__rz__body", 2)
+    check_call(9, "__quantum__qis__rzz__body", 3)
+    check_call(10, "__quantum__qis__h__body", 1)
+    check_call(11, "__quantum__qis__s__body", 1)
+    check_call(12, "__quantum__qis__s__adj", 1)
+    check_call(13, "__quantum__qis__t__body", 1)
+    check_call(14, "__quantum__qis__t__adj", 1)
+    check_call(15, "__quantum__qis__x__body", 1)
+    check_call(16, "__quantum__qis__y__body", 1)
+    check_call(17, "__quantum__qis__z__body", 1)
+    check_call(18, "__quantum__qis__swap__body", 2)
+    check_call(19, "__quantum__qis__reset__body", 1)
+    check_call(20, "__quantum__qis__m__body", 2)
+    check_call(21, "__quantum__qis__mresetz__body", 2)
+    check_call(22, "__quantum__rt__tuple_record_output", 2)
+    check_call(23, "__quantum__rt__result_record_output", 2)
+    check_call(24, "__quantum__rt__result_record_output", 2)

--- a/pip/tests-qir/test_requirements.txt
+++ b/pip/tests-qir/test_requirements.txt
@@ -1,1 +1,2 @@
 pytest
+pyqir

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -4,7 +4,7 @@
 import qsharp
 from contextlib import redirect_stdout
 import io
-
+from pyqir import Call, Context, Module, Opcode, qubit_id, result_id
 
 # Tests for the Python library for Q#
 
@@ -38,4 +38,94 @@ def test_compile_qir_input_data() -> None:
     qsharp.init(target_profile=qsharp.TargetProfile.Base)
     qsharp.eval("operation Program() : Result { use q = Qubit(); return M(q) }")
     operation = qsharp.compile("Program()")
-    assert isinstance(operation._repr_qir_(), bytes)
+    qir = operation._repr_qir_()
+    assert isinstance(qir, bytes)
+    module = Module.from_ir(Context(), qir.decode(), "module")
+    assert len(module.functions) == 26
+    assert module.functions[0].name == "ENTRYPOINT__main"
+    func = module.functions[0]
+    assert len(func.basic_blocks) == 1
+    assert len(func.basic_blocks[0].instructions) == 3
+    call_m = func.basic_blocks[0].instructions[0]
+    assert isinstance(call_m, Call)
+    assert call_m.callee.name == "__quantum__qis__m__body"
+    assert len(call_m.args) == 2
+    assert qubit_id(call_m.args[0]) == 0
+    assert result_id(call_m.args[1]) == 0
+    record_res = func.basic_blocks[0].instructions[1]
+    assert isinstance(record_res, Call)
+    assert len(record_res.args) == 2
+    assert record_res.callee.name == "__quantum__rt__result_record_output"
+    assert result_id(record_res.args[0]) == 0
+    assert func.basic_blocks[0].instructions[2].opcode == Opcode.RET
+
+
+def test_compile_qir_all_gates() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Base)
+    operation = qsharp.compile(
+        "{\
+        use (q1, q2, q3) = (Qubit(), Qubit(), Qubit());\
+        CCNOT(q1, q2, q3);\
+        CX(q1, q2);\
+        CY(q1, q2);\
+        CZ(q1, q2);\
+        Rx(0.0, q1);\
+        Rxx(0.0, q1, q2);\
+        Ry(0.0, q1);\
+        Ryy(0.0, q1, q2);\
+        Rz(0.0, q1);\
+        Rzz(0.0, q1, q2);\
+        H(q1);\
+        S(q1);\
+        Adjoint S(q1);\
+        T(q1);\
+        Adjoint T(q1);\
+        X(q1);\
+        Y(q1);\
+        Z(q1);\
+        SWAP(q1, q2);\
+        Reset(q1);\
+        (M(q1),\
+        Microsoft.Quantum.Measurement.MResetZ(q1))\
+        }"
+    )
+    qir = operation._repr_qir_()
+    assert isinstance(qir, bytes)
+    module = Module.from_ir(Context(), qir.decode(), "module")
+    assert len(module.functions) == 26
+    assert module.functions[0].name == "ENTRYPOINT__main"
+    func = module.functions[0]
+    assert len(func.basic_blocks) == 1
+    assert len(func.basic_blocks[0].instructions) == 26
+
+    def check_call(i: int, name: str, num_args: int) -> None:
+        call = func.basic_blocks[0].instructions[i]
+        assert isinstance(call, Call)
+        assert call.callee.name == name
+        assert len(call.args) == num_args
+
+    check_call(0, "__quantum__qis__ccx__body", 3)
+    check_call(1, "__quantum__qis__cx__body", 2)
+    check_call(2, "__quantum__qis__cy__body", 2)
+    check_call(3, "__quantum__qis__cz__body", 2)
+    check_call(4, "__quantum__qis__rx__body", 2)
+    check_call(5, "__quantum__qis__rxx__body", 3)
+    check_call(6, "__quantum__qis__ry__body", 2)
+    check_call(7, "__quantum__qis__ryy__body", 3)
+    check_call(8, "__quantum__qis__rz__body", 2)
+    check_call(9, "__quantum__qis__rzz__body", 3)
+    check_call(10, "__quantum__qis__h__body", 1)
+    check_call(11, "__quantum__qis__s__body", 1)
+    check_call(12, "__quantum__qis__s__adj", 1)
+    check_call(13, "__quantum__qis__t__body", 1)
+    check_call(14, "__quantum__qis__t__adj", 1)
+    check_call(15, "__quantum__qis__x__body", 1)
+    check_call(16, "__quantum__qis__y__body", 1)
+    check_call(17, "__quantum__qis__z__body", 1)
+    check_call(18, "__quantum__qis__swap__body", 2)
+    check_call(19, "__quantum__qis__reset__body", 1)
+    check_call(20, "__quantum__qis__m__body", 2)
+    check_call(21, "__quantum__qis__mresetz__body", 2)
+    check_call(22, "__quantum__rt__tuple_record_output", 2)
+    check_call(23, "__quantum__rt__result_record_output", 2)
+    check_call(24, "__quantum__rt__result_record_output", 2)

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -4,7 +4,6 @@
 import qsharp
 from contextlib import redirect_stdout
 import io
-from pyqir import Call, Context, Module, Opcode, qubit_id, result_id
 
 # Tests for the Python library for Q#
 
@@ -40,92 +39,3 @@ def test_compile_qir_input_data() -> None:
     operation = qsharp.compile("Program()")
     qir = operation._repr_qir_()
     assert isinstance(qir, bytes)
-    module = Module.from_ir(Context(), qir.decode(), "module")
-    assert len(module.functions) == 26
-    assert module.functions[0].name == "ENTRYPOINT__main"
-    func = module.functions[0]
-    assert len(func.basic_blocks) == 1
-    assert len(func.basic_blocks[0].instructions) == 3
-    call_m = func.basic_blocks[0].instructions[0]
-    assert isinstance(call_m, Call)
-    assert call_m.callee.name == "__quantum__qis__m__body"
-    assert len(call_m.args) == 2
-    assert qubit_id(call_m.args[0]) == 0
-    assert result_id(call_m.args[1]) == 0
-    record_res = func.basic_blocks[0].instructions[1]
-    assert isinstance(record_res, Call)
-    assert len(record_res.args) == 2
-    assert record_res.callee.name == "__quantum__rt__result_record_output"
-    assert result_id(record_res.args[0]) == 0
-    assert func.basic_blocks[0].instructions[2].opcode == Opcode.RET
-
-
-def test_compile_qir_all_gates() -> None:
-    qsharp.init(target_profile=qsharp.TargetProfile.Base)
-    operation = qsharp.compile(
-        "{\
-        use (q1, q2, q3) = (Qubit(), Qubit(), Qubit());\
-        CCNOT(q1, q2, q3);\
-        CX(q1, q2);\
-        CY(q1, q2);\
-        CZ(q1, q2);\
-        Rx(0.0, q1);\
-        Rxx(0.0, q1, q2);\
-        Ry(0.0, q1);\
-        Ryy(0.0, q1, q2);\
-        Rz(0.0, q1);\
-        Rzz(0.0, q1, q2);\
-        H(q1);\
-        S(q1);\
-        Adjoint S(q1);\
-        T(q1);\
-        Adjoint T(q1);\
-        X(q1);\
-        Y(q1);\
-        Z(q1);\
-        SWAP(q1, q2);\
-        Reset(q1);\
-        (M(q1),\
-        Microsoft.Quantum.Measurement.MResetZ(q1))\
-        }"
-    )
-    qir = operation._repr_qir_()
-    assert isinstance(qir, bytes)
-    module = Module.from_ir(Context(), qir.decode(), "module")
-    assert len(module.functions) == 26
-    assert module.functions[0].name == "ENTRYPOINT__main"
-    func = module.functions[0]
-    assert len(func.basic_blocks) == 1
-    assert len(func.basic_blocks[0].instructions) == 26
-
-    def check_call(i: int, name: str, num_args: int) -> None:
-        call = func.basic_blocks[0].instructions[i]
-        assert isinstance(call, Call)
-        assert call.callee.name == name
-        assert len(call.args) == num_args
-
-    check_call(0, "__quantum__qis__ccx__body", 3)
-    check_call(1, "__quantum__qis__cx__body", 2)
-    check_call(2, "__quantum__qis__cy__body", 2)
-    check_call(3, "__quantum__qis__cz__body", 2)
-    check_call(4, "__quantum__qis__rx__body", 2)
-    check_call(5, "__quantum__qis__rxx__body", 3)
-    check_call(6, "__quantum__qis__ry__body", 2)
-    check_call(7, "__quantum__qis__ryy__body", 3)
-    check_call(8, "__quantum__qis__rz__body", 2)
-    check_call(9, "__quantum__qis__rzz__body", 3)
-    check_call(10, "__quantum__qis__h__body", 1)
-    check_call(11, "__quantum__qis__s__body", 1)
-    check_call(12, "__quantum__qis__s__adj", 1)
-    check_call(13, "__quantum__qis__t__body", 1)
-    check_call(14, "__quantum__qis__t__adj", 1)
-    check_call(15, "__quantum__qis__x__body", 1)
-    check_call(16, "__quantum__qis__y__body", 1)
-    check_call(17, "__quantum__qis__z__body", 1)
-    check_call(18, "__quantum__qis__swap__body", 2)
-    check_call(19, "__quantum__qis__reset__body", 1)
-    check_call(20, "__quantum__qis__m__body", 2)
-    check_call(21, "__quantum__qis__mresetz__body", 2)
-    check_call(22, "__quantum__rt__tuple_record_output", 2)
-    check_call(23, "__quantum__rt__result_record_output", 2)
-    check_call(24, "__quantum__rt__result_record_output", 2)


### PR DESCRIPTION
This change adds new test logic to the Python tests to verify output QIR is valid and contains the expected gate sequence.
Fixes #572