### PR TITLE
Fix panic when QIR entry expr defines items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,7 @@ dependencies = [
  "clap 4.1.8",
  "criterion",
  "env_logger",
+ "expect-test",
  "indoc 2.0.0",
  "log",
  "miette",

--- a/compiler/qsc/Cargo.toml
+++ b/compiler/qsc/Cargo.toml
@@ -27,6 +27,7 @@ qsc_passes = { path = "../qsc_passes" }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+expect-test = { workspace = true }
 criterion = { workspace = true, features = ["cargo_bench_support"] }
 indoc = { workspace = true }
 

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -696,11 +696,6 @@ mod given_interpreter {
                 !3 = !{i32 1, !"dynamic_result_management", i1 false}
             "#]].assert_eq(&res);
 
-            // Can't validate here in this test, but note that the following call will cause
-            // `lower_fragments` (https://github.com/microsoft/qsharp/blob/e0c4dd334a81a0b0be82f4fbff0d850acc0a5fc8/compiler/qsc_frontend/src/incremental.rs#L235)
-            // to yield items that were previously declared in the qirgen call.
-            // this is because `lowerer.drain_items` is being called (it wasn't called
-            // previously as part of `qirgen()`).
             let (result, output) = line(
                 &mut interpreter,
                 indoc! {"operation Baz() : Result { use q = Qubit(); let r = M(q); Reset(q); return r; } "},

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -720,7 +720,6 @@ mod given_interpreter {
                 TargetProfile::Base,
             )
             .expect("interpreter should be created");
-            // this panics today. It shouldn't
             let res = interpreter
                 .qirgen("{ operation Foo() : Result { use q = Qubit(); let r = M(q); Reset(q); return r; }; Foo() }")
                 .expect("expected success");

--- a/compiler/qsc_frontend/src/incremental.rs
+++ b/compiler/qsc_frontend/src/incremental.rs
@@ -99,6 +99,8 @@ impl Compiler {
         self.ast_assigner.visit_stmt(&mut stmt);
         self.resolver.with(&mut self.hir_assigner).visit_stmt(&stmt);
         self.checker
+            .collect_stmt_items(self.resolver.names(), &stmt);
+        self.checker
             .check_stmt_fragment(self.resolver.names(), &stmt);
         self.checker.solve(self.resolver.names());
 

--- a/compiler/qsc_frontend/src/incremental.rs
+++ b/compiler/qsc_frontend/src/incremental.rs
@@ -82,7 +82,7 @@ impl Compiler {
     /// Compile a string with a single fragment of Q# code that is an expression.
     /// # Errors
     /// Returns a vector of errors if the input fails compilation.
-    pub fn compile_expr(&mut self, input: &str) -> Result<Fragment, Vec<Error>> {
+    pub fn compile_expr(&mut self, input: &str) -> Result<Vec<Fragment>, Vec<Error>> {
         let (expr, errors) = qsc_parse::expr(input);
         if !errors.is_empty() {
             return Err(errors
@@ -104,11 +104,12 @@ impl Compiler {
             .check_stmt_fragment(self.resolver.names(), &stmt);
         self.checker.solve(self.resolver.names());
 
-        let fragment = self.lower_stmt(&stmt);
+        let fragments = self.lower_fragment(qsc_parse::Fragment::Stmt(Box::new(stmt)));
         let errors = self.drain_errors();
         if errors.is_empty() {
-            Ok(fragment.expect("lowering an expression should not produce None"))
+            Ok(fragments)
         } else {
+            self.lowerer.clear_items();
             Err(errors)
         }
     }


### PR DESCRIPTION
This fixes a missed case after the changes in #628 that meant `compile_expr` could panic if the given expression was a block that included defining new items.