### PR TITLE
Items in a cell should be usable before definition

### DIFF
--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -392,6 +392,13 @@ impl Interpreter {
                 .collect());
         }
 
+        // Items must be processed before top-level statements, so sort the fragments.
+        // Note that stable sorting is used here to preserve the order of top-level statements.
+        fragments.sort_by_key(|f| match f {
+            Fragment::Item(_) => 0,
+            Fragment::Stmt(_) => 1,
+        });
+
         for fragment in fragments {
             match fragment {
                 Fragment::Item(item) => match item.kind {

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -469,6 +469,19 @@ mod given_interpreter {
         }
 
         #[test]
+        fn items_usable_before_definition_top_level() {
+            let mut interpreter = get_interpreter();
+            let (result, output) = line(
+                &mut interpreter,
+                indoc! {r#"
+                    B();
+                    function B() : Unit {}
+                "#},
+            );
+            is_only_value(&result, &output, &Value::unit());
+        }
+
+        #[test]
         fn namespace_usable_before_definition() {
             let mut interpreter = get_interpreter();
             let (result, output) = line(


### PR DESCRIPTION
Missed case in the interpreter. I believe #628 originally intended to address this.