### PR TITLE
Update to Rust 1.72.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
 	"name": "qsharp",
-	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/rust:dev-bullseye",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			"nodeGypDependencies": true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN_VERSION: "1.70"
+  RUST_TOOLCHAIN_VERSION: "1.72"
   RUST_TOOLCHAIN_COMPONENTS: rustfmt clippy
 
 jobs:

--- a/.github/workflows/publish-playground.yml
+++ b/.github/workflows/publish-playground.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN_VERSION: "1.70"
+  RUST_TOOLCHAIN_VERSION: "1.72"
   RUST_TOOLCHAIN_COMPONENTS: rustfmt clippy
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "pip",
     "wasm",
 ]
+resolver = "2"
 
 [workspace.package]
 authors = ["Microsoft"]

--- a/compiler/qsc/src/interpret/debug.rs
+++ b/compiler/qsc/src/interpret/debug.rs
@@ -26,7 +26,9 @@ pub(crate) fn format_call_stack(
     frames.reverse();
 
     for frame in frames {
-        let Some(Global::Callable(call)) = globals.get(frame.id) else { panic!("missing global"); };
+        let Some(Global::Callable(call)) = globals.get(frame.id) else {
+            panic!("missing global");
+        };
 
         trace.push_str("    at ");
         if frame.functor.adjoint {

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -248,6 +248,9 @@ impl Interpreter {
     /// Resumes execution with specified `StepAction`.
     /// # Errors
     /// Returns a vector of errors if evaluating the entry point fails.
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     pub fn eval_step(
         &mut self,
         receiver: &mut impl Receiver,
@@ -292,6 +295,9 @@ impl Interpreter {
     /// Executes the entry expression until the end of execution.
     /// # Errors
     /// Returns a vector of errors if evaluating the entry point fails.
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     pub fn eval_entry(&mut self, receiver: &mut impl Receiver) -> Result<Value, Vec<Error>> {
         let expr = self.get_entry_expr()?;
         let globals = Lookup {
@@ -591,6 +597,9 @@ impl Interpreter {
         format_call_stack(&self.store, &globals, call_stack, error)
     }
 
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     #[must_use]
     pub fn get_stack_frames(&self) -> Vec<StackFrame> {
         let globals = Lookup {
@@ -635,6 +644,9 @@ impl Interpreter {
         self.sim.capture_quantum_state()
     }
 
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     #[must_use]
     pub fn get_breakpoints(&self, path: &str) -> Vec<BreakpointSpan> {
         let unit = self

--- a/compiler/qsc/src/interpret/stateless.rs
+++ b/compiler/qsc/src/interpret/stateless.rs
@@ -185,6 +185,9 @@ where
     /// # Errors
     ///
     /// Returns a vector of errors if evaluating the entry point fails.
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     pub fn eval_entry(&mut self, receiver: &mut impl Receiver) -> Result<Value, Vec<Error>> {
         let expr = self.get_entry_expr()?;
         eval_expr(

--- a/compiler/qsc_ast/src/ast.rs
+++ b/compiler/qsc_ast/src/ast.rs
@@ -123,7 +123,7 @@ impl Display for Package {
         if let Some(e) = &self.entry {
             write!(indent, "\nentry expression: {e}")?;
         }
-        for ns in self.namespaces.iter() {
+        for ns in &*self.namespaces {
             write!(indent, "\n{ns}")?;
         }
         Ok(())
@@ -162,7 +162,7 @@ impl Display for Namespace {
             indent = set_indentation(indent, 1);
         }
 
-        for i in self.items.iter() {
+        for i in &*self.items {
             write!(indent, "\n{i}")?;
         }
 
@@ -213,7 +213,7 @@ impl Display for Item {
             indent = set_indentation(indent, 1);
         }
 
-        for attr in self.attrs.iter() {
+        for attr in &*self.attrs {
             write!(indent, "\n{attr}")?;
         }
 
@@ -392,7 +392,7 @@ impl Display for CallableDecl {
         if !self.generics.is_empty() {
             write!(indent, "\ngenerics:")?;
             indent = set_indentation(indent, 2);
-            for param in self.generics.iter() {
+            for param in &*self.generics {
                 write!(indent, "\n{param}")?;
             }
             indent = set_indentation(indent, 1);
@@ -610,7 +610,7 @@ impl Display for Block {
             let mut indent = set_indentation(indented(f), 0);
             write!(indent, "Block {} {}:", self.id, self.span)?;
             indent = set_indentation(indent, 1);
-            for s in self.stmts.iter() {
+            for s in &*self.stmts {
                 write!(indent, "\n{s}")?;
             }
         }

--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -27,6 +27,9 @@ const POSTFIX: &str = include_str!("./qir_base/postfix.ll");
 /// # Errors
 ///
 /// This function will return an error if execution was unable to complete.
+/// # Panics
+///
+/// This function will panic if compiler state is invalid or in out-of-memory conditions.
 pub fn generate_qir(
     store: &PackageStore,
     package: hir::PackageId,
@@ -72,6 +75,9 @@ pub fn generate_qir(
 
 /// # Errors
 /// This function will return an error if execution was unable to complete.
+/// # Panics
+///
+/// This function will panic if compiler state is invalid or in out-of-memory conditions.
 pub fn generate_qir_for_stmt(
     stmt: StmtId,
     globals: &impl NodeLookup,

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -1718,7 +1718,9 @@ fn update_functor_app(functor: Functor, app: FunctorApp) -> FunctorApp {
 
 fn follow_field_path(mut value: Value, path: &[usize]) -> Option<Value> {
     for &index in path {
-        let Value::Tuple(items) = value else { return None; };
+        let Value::Tuple(items) = value else {
+            return None;
+        };
         value = items[index].clone();
     }
     Some(value)

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -30,7 +30,9 @@ pub(super) fn eval_expr(
     let mut env = Env::with_empty_scope();
     let mut sim = SparseSim::new();
     state.push_expr(expr);
-    let StepResult::Return(value) = state.eval(globals, &mut env, &mut sim, out, &[], StepAction::Continue)? else{
+    let StepResult::Return(value) =
+        state.eval(globals, &mut env, &mut sim, out, &[], StepAction::Continue)?
+    else {
         unreachable!("eval_expr should always return a value");
     };
     Ok(value)

--- a/compiler/qsc_fir/src/ty.rs
+++ b/compiler/qsc_fir/src/ty.rs
@@ -472,10 +472,14 @@ impl Udt {
     fn find_field(&self, path: &FieldPath) -> Option<&UdtField> {
         let mut udt_def = &self.definition;
         for &index in &path.indices {
-            let UdtDefKind::Tuple(items) = &udt_def.kind else { return None };
+            let UdtDefKind::Tuple(items) = &udt_def.kind else {
+                return None;
+            };
             udt_def = &items[index];
         }
-        let UdtDefKind::Field(field) = &udt_def.kind else { return None };
+        let UdtDefKind::Field(field) = &udt_def.kind else {
+            return None;
+        };
         Some(field)
     }
 
@@ -544,7 +548,7 @@ impl Display for UdtDefKind {
                 } else {
                     write!(indent, "Tuple:")?;
                     indent = set_indentation(indent, 1);
-                    for t in ts.iter() {
+                    for t in ts {
                         write!(indent, "\n{t}")?;
                     }
                 }

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -258,8 +258,12 @@ fn entry_call_operation() {
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
 
     let entry = &unit.package.entry.expect("package should have entry");
-    let ExprKind::Call(callee, _) = &entry.kind else { panic!("entry should be a call") };
-    let ExprKind::Var(res, _) = &callee.kind else { panic!("callee should be a variable") };
+    let ExprKind::Call(callee, _) = &entry.kind else {
+        panic!("entry should be a call")
+    };
+    let ExprKind::Var(res, _) = &callee.kind else {
+        panic!("callee should be a variable")
+    };
     assert_eq!(
         &Res::Item(ItemId {
             package: None,
@@ -340,8 +344,13 @@ fn replace_node() {
         .items
         .get(LocalItemId::from(1))
         .expect("package should have item")
-        .kind else { panic!("item should be a callable"); };
-    let SpecBody::Impl(_, block) = &callable.body.body else { panic!("callable body have a block") };
+        .kind
+    else {
+        panic!("item should be a callable");
+    };
+    let SpecBody::Impl(_, block) = &callable.body.body else {
+        panic!("callable body have a block")
+    };
     expect![[r#"
         Block 4 [39-56] [Type Int]:
             Stmt 5 [49-50]: Expr: Expr 8 [49-50] [Type Int]: Lit: Int(2)"#]]
@@ -476,11 +485,22 @@ fn package_dependency() {
         .items
         .get(foo_id)
         .expect("package should have item")
-        .kind else { panic!("item should be a callable"); };
-    let SpecBody::Impl(_, block) = &callable.body.body else { panic!("callable body have a block") };
-    let StmtKind::Expr(expr) = &block.stmts[0].kind else { panic!("statement should be an expression") };
-    let ExprKind::Call(callee, _) = &expr.kind else { panic!("expression should be a call") };
-    let ExprKind::Var(res, _) = &callee.kind else { panic!("callee should be a variable") };
+        .kind
+    else {
+        panic!("item should be a callable");
+    };
+    let SpecBody::Impl(_, block) = &callable.body.body else {
+        panic!("callable body have a block")
+    };
+    let StmtKind::Expr(expr) = &block.stmts[0].kind else {
+        panic!("statement should be an expression")
+    };
+    let ExprKind::Call(callee, _) = &expr.kind else {
+        panic!("expression should be a call")
+    };
+    let ExprKind::Var(res, _) = &callee.kind else {
+        panic!("callee should be a variable")
+    };
     assert_eq!(
         &Res::Item(ItemId {
             package: Some(package1),
@@ -531,11 +551,22 @@ fn package_dependency_internal() {
         .items
         .get(LocalItemId::from(1))
         .expect("package should have item")
-        .kind else { panic!("item should be a callable"); };
-    let SpecBody::Impl(_, block) = &callable.body.body else { panic!("callable body have a block") };
-    let StmtKind::Expr(expr) = &block.stmts[0].kind else { panic!("statement should be an expression") };
-    let ExprKind::Call(callee, _) = &expr.kind else { panic!("expression should be a call") };
-    let ExprKind::Var(res, _) = &callee.kind else { panic!("callee should be a variable") };
+        .kind
+    else {
+        panic!("item should be a callable");
+    };
+    let SpecBody::Impl(_, block) = &callable.body.body else {
+        panic!("callable body have a block")
+    };
+    let StmtKind::Expr(expr) = &block.stmts[0].kind else {
+        panic!("statement should be an expression")
+    };
+    let ExprKind::Call(callee, _) = &expr.kind else {
+        panic!("expression should be a call")
+    };
+    let ExprKind::Var(res, _) = &callee.kind else {
+        panic!("callee should be a variable")
+    };
     assert_eq!(&Res::Err, res);
 }
 

--- a/compiler/qsc_frontend/src/error.rs
+++ b/compiler/qsc_frontend/src/error.rs
@@ -30,6 +30,9 @@ impl<E: Diagnostic> WithSource<E> {
     /// Construct a diagnostic with source information from a source map.
     /// Since errors may contain labeled spans from any source file in the
     /// compilation, the entire source map is needed to resolve offsets.
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     pub fn from_map(sources: &SourceMap, error: E) -> Self {
         // Filter the source map to the relevant sources
         // to avoid cloning all of them.

--- a/compiler/qsc_frontend/src/incremental.rs
+++ b/compiler/qsc_frontend/src/incremental.rs
@@ -52,6 +52,9 @@ pub struct Compiler {
 }
 
 impl Compiler {
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     pub fn new(store: &PackageStore, dependencies: impl IntoIterator<Item = PackageId>) -> Self {
         let mut resolve_globals = resolve::GlobalTable::new();
         let mut typeck_globals = typeck::GlobalTable::new();

--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -106,7 +106,7 @@ pub(super) struct With<'a> {
 
 impl With<'_> {
     pub(super) fn lower_package(&mut self, package: &ast::Package) -> hir::Package {
-        for namespace in package.namespaces.iter() {
+        for namespace in &*package.namespaces {
             self.lower_namespace(namespace);
         }
 
@@ -116,9 +116,9 @@ impl With<'_> {
     }
 
     pub(super) fn lower_namespace(&mut self, namespace: &ast::Namespace) {
-        let Some(&resolve::Res::Item(hir::ItemId {
-            item: id, ..
-        })) = self.names.get(namespace.name.id) else {
+        let Some(&resolve::Res::Item(hir::ItemId { item: id, .. })) =
+            self.names.get(namespace.name.id)
+        else {
             panic!("namespace should have item ID");
         };
 

--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -301,7 +301,7 @@ impl Resolver {
                 .namespaces
                 .insert(Rc::clone(&namespace.name.name));
 
-            for item in namespace.items.iter() {
+            for item in &*namespace.items {
                 match bind_global_item(
                     &mut self.names,
                     &mut self.globals,
@@ -357,7 +357,7 @@ impl AstVisitor<'_> for With<'_> {
 
         let kind = ScopeKind::Namespace(Rc::clone(&namespace.name.name));
         self.with_scope(kind, |visitor| {
-            for item in namespace.items.iter() {
+            for item in &*namespace.items {
                 if let ast::ItemKind::Open(name, alias) = &*item.kind {
                     visitor.resolver.bind_open(name, alias);
                 }
@@ -402,7 +402,7 @@ impl AstVisitor<'_> for With<'_> {
 
     fn visit_block(&mut self, block: &ast::Block) {
         self.with_scope(ScopeKind::Block, |visitor| {
-            for stmt in block.stmts.iter() {
+            for stmt in &*block.stmts {
                 if let ast::StmtKind::Item(item) = &*stmt.kind {
                     visitor.resolver.bind_local_item(visitor.assigner, item);
                 }
@@ -499,7 +499,7 @@ impl GlobalTable {
         package: &ast::Package,
     ) -> Vec<Error> {
         let mut errors = Vec::new();
-        for namespace in package.namespaces.iter() {
+        for namespace in &*package.namespaces {
             self.names.insert(
                 namespace.name.id,
                 Res::Item(intrapackage(assigner.next_item())),
@@ -508,7 +508,7 @@ impl GlobalTable {
                 .namespaces
                 .insert(Rc::clone(&namespace.name.name));
 
-            for item in namespace.items.iter() {
+            for item in &*namespace.items {
                 match bind_global_item(
                     &mut self.names,
                     &mut self.scope,

--- a/compiler/qsc_frontend/src/typeck/convert.rs
+++ b/compiler/qsc_frontend/src/typeck/convert.rs
@@ -215,7 +215,7 @@ fn synthesize_functor_params_in_pat(
         }
         hir::PatKind::Tuple(items) => {
             let mut params = Vec::new();
-            for item in items.iter_mut() {
+            for item in &mut *items {
                 params.append(&mut synthesize_functor_params_in_pat(next_param, item));
             }
             if !params.is_empty() {

--- a/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/compiler/qsc_frontend/src/typeck/infer.rs
@@ -410,7 +410,7 @@ impl Inferrer {
         self.solver
             .errors
             .drain(..)
-            .chain(unresolved_ty_errs.into_iter())
+            .chain(unresolved_ty_errs)
             .collect()
     }
 
@@ -735,10 +735,10 @@ fn check_adj(ty: Ty, span: Span) -> (Vec<Constraint>, Vec<Error>) {
 
 fn check_call(callee: Ty, input: &ArgTy, output: Ty, span: Span) -> (Vec<Constraint>, Vec<Error>) {
     let Ty::Arrow(arrow) = callee else {
-        return (Vec::new(), vec![Error(ErrorKind::MissingClassCall(
-            callee,
-            span,
-        ))]);
+        return (
+            Vec::new(),
+            vec![Error(ErrorKind::MissingClassCall(callee, span))],
+        );
     };
 
     let mut app = input.apply(&arrow.input, span);
@@ -772,10 +772,7 @@ fn check_ctl(op: Ty, with_ctls: Ty, span: Span) -> (Vec<Constraint>, Vec<Error>)
     let Ty::Arrow(arrow) = op else {
         return (
             Vec::new(),
-            vec![Error(ErrorKind::MissingClassCtl(
-                op,
-                span,
-            ))],
+            vec![Error(ErrorKind::MissingClassCtl(op, span))],
         );
     };
 

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -131,7 +131,7 @@ impl<'a> Context<'a> {
     fn infer_block(&mut self, block: &Block) -> Partial<Ty> {
         let mut diverges = false;
         let mut last = None;
-        for stmt in block.stmts.iter() {
+        for stmt in &*block.stmts {
             let stmt = self.infer_stmt(stmt);
             diverges = diverges || stmt.diverges;
             last = Some(stmt);

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -136,10 +136,10 @@ fn empty_callable() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 40-42 "{}" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -152,11 +152,11 @@ fn return_constant() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 39-44 "{ 4 }" : Int
             #12 41-42 "4" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -169,12 +169,12 @@ fn return_wrong_type() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 39-47 "{ true }" : Bool
             #12 41-45 "true" : Bool
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Bool), Span { lo: 41, hi: 45 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -187,12 +187,12 @@ fn return_semi() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 39-45 "{ 4; }" : Unit
             #12 41-42 "4" : Int
             Error(Type(Error(TyMismatch(Prim(Int), Tuple([]), Span { lo: 41, hi: 43 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -208,13 +208,13 @@ fn return_var() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 39-75 "{\n        let x = 4;\n        x\n    }" : Int
             #12 53-54 "x" : Int
             #14 57-58 "4" : Int
             #16 68-69 "x" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -228,7 +228,7 @@ fn call_function() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-39 "(x : Int)" : Int
             #7 31-38 "x : Int" : Int
             #15 46-51 "{ x }" : Int
@@ -239,7 +239,7 @@ fn call_function() {
             #30 79-82 "Foo" : (Int -> Int)
             #33 82-85 "(4)" : Int
             #34 83-84 "4" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -253,7 +253,7 @@ fn call_generic_identity() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #7 39-47 "(x : 'T)" : 0
             #8 40-46 "x : 'T" : 0
             #14 53-58 "{ x }" : 0
@@ -264,7 +264,7 @@ fn call_generic_identity() {
             #29 86-94 "Identity" : (Int -> Int)
             #32 94-97 "(4)" : Int
             #33 95-96 "4" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -277,7 +277,7 @@ fn call_generic_length() {
             }
         "},
         "Length([true, false, true])",
-        &expect![[r##"
+        &expect![[r#"
             #7 58-69 "(xs : 'T[])" : ?
             #8 59-68 "xs : 'T[]" : ?
             #17 98-125 "Length([true, false, true])" : Int
@@ -287,7 +287,7 @@ fn call_generic_length() {
             #23 106-110 "true" : Bool
             #24 112-117 "false" : Bool
             #25 119-123 "true" : Bool
-        "##]],
+        "#]],
     );
 }
 
@@ -300,7 +300,7 @@ fn add_wrong_types() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 40-52 "{ 1 + [2]; }" : Unit
             #12 42-49 "1 + [2]" : Int
@@ -308,7 +308,7 @@ fn add_wrong_types() {
             #14 46-49 "[2]" : (Int)[]
             #15 47-48 "2" : Int
             Error(Type(Error(TyMismatch(Prim(Int), Array(Prim(Int)), Span { lo: 42, hi: 49 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -321,7 +321,7 @@ fn int_as_double_error() {
             }
         "},
         "Microsoft.Quantum.Convert.IntAsDouble(false)",
-        &expect![[r##"
+        &expect![[r#"
             #6 62-71 "(a : Int)" : ?
             #7 63-70 "a : Int" : ?
             #16 103-147 "Microsoft.Quantum.Convert.IntAsDouble(false)" : Double
@@ -329,7 +329,7 @@ fn int_as_double_error() {
             #21 140-147 "(false)" : Bool
             #22 141-146 "false" : Bool
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Bool), Span { lo: 103, hi: 147 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -342,7 +342,7 @@ fn length_type_error() {
             }
         "},
         "Length((1, 2, 3))",
-        &expect![[r##"
+        &expect![[r#"
             #7 58-69 "(xs : 'T[])" : ?
             #8 59-68 "xs : 'T[]" : ?
             #17 98-115 "Length((1, 2, 3))" : Int
@@ -354,7 +354,7 @@ fn length_type_error() {
             #25 112-113 "3" : Int
             Error(Type(Error(TyMismatch(Array(Infer(InferTyId(0))), Tuple([Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 98, hi: 115 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 98, hi: 104 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -370,7 +370,7 @@ fn single_arg_for_tuple() {
             use q = Qubit();
             Ry(q);
         }"},
-        &expect![[r##"
+        &expect![[r#"
             #6 56-87 "(theta : Double, qubit : Qubit)" : (Double, Qubit)
             #7 57-71 "theta : Double" : Double
             #12 73-86 "qubit : Qubit" : Qubit
@@ -384,7 +384,7 @@ fn single_arg_for_tuple() {
             #33 140-143 "(q)" : Qubit
             #34 141-142 "q" : Qubit
             Error(Type(Error(TyMismatch(Tuple([Prim(Double), Prim(Qubit)]), Prim(Qubit), Span { lo: 138, hi: 143 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -393,7 +393,7 @@ fn array_index_error() {
     check(
         "",
         "[1, 2, 3][false]",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-16 "[1, 2, 3][false]" : ?0
             #2 0-9 "[1, 2, 3]" : (Int)[]
             #3 1-2 "1" : Int
@@ -402,7 +402,7 @@ fn array_index_error() {
             #6 10-15 "false" : Bool
             Error(Type(Error(MissingClassHasIndex(Array(Prim(Int)), Prim(Bool), Span { lo: 0, hi: 16 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 16 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -411,12 +411,12 @@ fn array_repeat_error() {
     check(
         "",
         "[4, size = true]",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-16 "[4, size = true]" : (Int)[]
             #2 1-2 "4" : Int
             #3 11-15 "true" : Bool
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Bool), Span { lo: 11, hi: 15 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -431,7 +431,7 @@ fn assignop_error() {
                 x
             }
         "},
-        &expect![[r##"
+        &expect![[r#"
             #1 0-48 "{\n    mutable x = false;\n    set x += 1;\n    x\n}" : Bool
             #2 0-48 "{\n    mutable x = false;\n    set x += 1;\n    x\n}" : Bool
             #4 14-15 "x" : Bool
@@ -442,7 +442,7 @@ fn assignop_error() {
             #14 45-46 "x" : Bool
             Error(Type(Error(TyMismatch(Prim(Bool), Prim(Int), Span { lo: 29, hi: 39 }))))
             Error(Type(Error(MissingClassAdd(Prim(Bool), Span { lo: 33, hi: 34 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -451,7 +451,7 @@ fn binop_add_invalid() {
     check(
         "",
         "(1, 3) + 5.4",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-12 "(1, 3) + 5.4" : (Int, Int)
             #2 0-6 "(1, 3)" : (Int, Int)
             #3 1-2 "1" : Int
@@ -459,7 +459,7 @@ fn binop_add_invalid() {
             #5 9-12 "5.4" : Double
             Error(Type(Error(TyMismatch(Tuple([Prim(Int), Prim(Int)]), Prim(Double), Span { lo: 0, hi: 12 }))))
             Error(Type(Error(MissingClassAdd(Tuple([Prim(Int), Prim(Int)]), Span { lo: 0, hi: 6 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -468,12 +468,12 @@ fn binop_add_mismatch() {
     check(
         "",
         "1 + 5.4",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-7 "1 + 5.4" : Int
             #2 0-1 "1" : Int
             #3 4-7 "5.4" : Double
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Double), Span { lo: 0, hi: 7 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -482,12 +482,12 @@ fn binop_andb_invalid() {
     check(
         "",
         "2.8 &&& 5.4",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-11 "2.8 &&& 5.4" : Double
             #2 0-3 "2.8" : Double
             #3 8-11 "5.4" : Double
             Error(Type(Error(MissingClassInteger(Prim(Double), Span { lo: 0, hi: 3 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -496,12 +496,12 @@ fn binop_andb_mismatch() {
     check(
         "",
         "28 &&& 54L",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-10 "28 &&& 54L" : Int
             #2 0-2 "28" : Int
             #3 7-10 "54L" : BigInt
             Error(Type(Error(TyMismatch(Prim(Int), Prim(BigInt), Span { lo: 0, hi: 10 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -515,7 +515,7 @@ fn binop_equal_callable() {
             }
         "},
         "Test.A == Test.B",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-33 "()" : Unit
             #10 41-43 "{}" : Unit
             #14 58-60 "()" : Unit
@@ -524,7 +524,7 @@ fn binop_equal_callable() {
             #20 73-79 "Test.A" : (Unit -> Unit)
             #24 83-89 "Test.B" : (Unit -> Unit)
             Error(Type(Error(MissingClassEq(Arrow(Arrow { kind: Function, input: Tuple([]), output: Tuple([]), functors: Value(Empty) }), Span { lo: 73, hi: 79 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -533,7 +533,7 @@ fn binop_equal_tuple_arity_mismatch() {
     check(
         "",
         "(1, 2, 3) == (1, 2, 3, 4)",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-25 "(1, 2, 3) == (1, 2, 3, 4)" : Bool
             #2 0-9 "(1, 2, 3)" : (Int, Int, Int)
             #3 1-2 "1" : Int
@@ -545,7 +545,7 @@ fn binop_equal_tuple_arity_mismatch() {
             #9 20-21 "3" : Int
             #10 23-24 "4" : Int
             Error(Type(Error(TyMismatch(Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 0, hi: 25 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -554,7 +554,7 @@ fn binop_equal_tuple_type_mismatch() {
     check(
         "",
         "(1, 2, 3) == (1, Zero, 3)",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-25 "(1, 2, 3) == (1, Zero, 3)" : Bool
             #2 0-9 "(1, 2, 3)" : (Int, Int, Int)
             #3 1-2 "1" : Int
@@ -565,7 +565,7 @@ fn binop_equal_tuple_type_mismatch() {
             #8 17-21 "Zero" : Result
             #9 23-24 "3" : Int
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Result), Span { lo: 0, hi: 25 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -574,12 +574,12 @@ fn binop_eq_mismatch() {
     check(
         "",
         "18L == 18",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-9 "18L == 18" : Bool
             #2 0-3 "18L" : BigInt
             #3 7-9 "18" : Int
             Error(Type(Error(TyMismatch(Prim(BigInt), Prim(Int), Span { lo: 0, hi: 9 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -588,12 +588,12 @@ fn binop_neq_mismatch() {
     check(
         "",
         "18L != 18",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-9 "18L != 18" : Bool
             #2 0-3 "18L" : BigInt
             #3 7-9 "18" : Int
             Error(Type(Error(TyMismatch(Prim(BigInt), Prim(Int), Span { lo: 0, hi: 9 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -602,7 +602,7 @@ fn binop_neq_tuple_type_mismatch() {
     check(
         "",
         "(1, 2, 3) != (1, Zero, 3)",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-25 "(1, 2, 3) != (1, Zero, 3)" : Bool
             #2 0-9 "(1, 2, 3)" : (Int, Int, Int)
             #3 1-2 "1" : Int
@@ -613,7 +613,7 @@ fn binop_neq_tuple_type_mismatch() {
             #8 17-21 "Zero" : Result
             #9 23-24 "3" : Int
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Result), Span { lo: 0, hi: 25 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -622,7 +622,7 @@ fn binop_neq_tuple_arity_mismatch() {
     check(
         "",
         "(1, 2, 3) != (1, 2, 3, 4)",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-25 "(1, 2, 3) != (1, 2, 3, 4)" : Bool
             #2 0-9 "(1, 2, 3)" : (Int, Int, Int)
             #3 1-2 "1" : Int
@@ -634,7 +634,7 @@ fn binop_neq_tuple_arity_mismatch() {
             #9 20-21 "3" : Int
             #10 23-24 "4" : Int
             Error(Type(Error(TyMismatch(Tuple([Prim(Int), Prim(Int), Prim(Int)]), Tuple([Prim(Int), Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 0, hi: 25 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -643,12 +643,12 @@ fn binop_orb_invalid() {
     check(
         "",
         "2.8 ||| 5.4",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-11 "2.8 ||| 5.4" : Double
             #2 0-3 "2.8" : Double
             #3 8-11 "5.4" : Double
             Error(Type(Error(MissingClassInteger(Prim(Double), Span { lo: 0, hi: 3 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -657,12 +657,12 @@ fn binop_orb_mismatch() {
     check(
         "",
         "28 ||| 54L",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-10 "28 ||| 54L" : Int
             #2 0-2 "28" : Int
             #3 7-10 "54L" : BigInt
             Error(Type(Error(TyMismatch(Prim(Int), Prim(BigInt), Span { lo: 0, hi: 10 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -671,12 +671,12 @@ fn binop_xorb_invalid() {
     check(
         "",
         "2.8 ^^^ 5.4",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-11 "2.8 ^^^ 5.4" : Double
             #2 0-3 "2.8" : Double
             #3 8-11 "5.4" : Double
             Error(Type(Error(MissingClassInteger(Prim(Double), Span { lo: 0, hi: 3 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -685,12 +685,12 @@ fn binop_xorb_mismatch() {
     check(
         "",
         "28 ^^^ 54L",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-10 "28 ^^^ 54L" : Int
             #2 0-2 "28" : Int
             #3 7-10 "54L" : BigInt
             Error(Type(Error(TyMismatch(Prim(Int), Prim(BigInt), Span { lo: 0, hi: 10 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -699,7 +699,7 @@ fn let_tuple_arity_error() {
     check(
         "",
         "{ let (x, y, z) = (0, 1); }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-27 "{ let (x, y, z) = (0, 1); }" : Unit
             #2 0-27 "{ let (x, y, z) = (0, 1); }" : Unit
             #4 6-15 "(x, y, z)" : (Int, Int, ?2)
@@ -711,7 +711,7 @@ fn let_tuple_arity_error() {
             #13 22-23 "1" : Int
             Error(Type(Error(TyMismatch(Tuple([Infer(InferTyId(0)), Infer(InferTyId(1)), Infer(InferTyId(2))]), Tuple([Prim(Int), Prim(Int)]), Span { lo: 18, hi: 24 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 13, hi: 14 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -726,7 +726,7 @@ fn set_tuple_arity_error() {
                 x
             }
         "},
-        &expect![[r##"
+        &expect![[r#"
             #1 0-66 "{\n    mutable (x, y) = (0, 1);\n    set (x, y) = (1, 2, 3);\n    x\n}" : Int
             #2 0-66 "{\n    mutable (x, y) = (0, 1);\n    set (x, y) = (1, 2, 3);\n    x\n}" : Int
             #4 14-20 "(x, y)" : (Int, Int)
@@ -745,7 +745,7 @@ fn set_tuple_arity_error() {
             #24 55-56 "3" : Int
             #26 63-64 "x" : Int
             Error(Type(Error(TyMismatch(Tuple([Prim(Int), Prim(Int)]), Tuple([Prim(Int), Prim(Int), Prim(Int)]), Span { lo: 39, hi: 45 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -754,14 +754,14 @@ fn qubit_array_length_error() {
     check(
         "",
         "{ use q = Qubit[false]; }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-25 "{ use q = Qubit[false]; }" : Unit
             #2 0-25 "{ use q = Qubit[false]; }" : Unit
             #4 6-7 "q" : (Qubit)[]
             #6 10-22 "Qubit[false]" : (Qubit)[]
             #7 16-21 "false" : Bool
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Bool), Span { lo: 16, hi: 21 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -770,7 +770,7 @@ fn qubit_tuple_arity_error() {
     check(
         "",
         "{ use (q, q1) = (Qubit[3], Qubit(), Qubit()); }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-47 "{ use (q, q1) = (Qubit[3], Qubit(), Qubit()); }" : Unit
             #2 0-47 "{ use (q, q1) = (Qubit[3], Qubit(), Qubit()); }" : Unit
             #4 6-13 "(q, q1)" : ((Qubit)[], Qubit)
@@ -782,7 +782,7 @@ fn qubit_tuple_arity_error() {
             #12 27-34 "Qubit()" : Qubit
             #13 36-43 "Qubit()" : Qubit
             Error(Type(Error(TyMismatch(Tuple([Array(Prim(Qubit)), Prim(Qubit), Prim(Qubit)]), Tuple([Infer(InferTyId(0)), Infer(InferTyId(1))]), Span { lo: 6, hi: 13 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -791,7 +791,7 @@ fn for_loop_not_iterable() {
     check(
         "",
         "for i in (1, true, One) {}",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-26 "for i in (1, true, One) {}" : Unit
             #2 4-5 "i" : ?0
             #4 9-23 "(1, true, One)" : (Int, Bool, Result)
@@ -801,7 +801,7 @@ fn for_loop_not_iterable() {
             #8 24-26 "{}" : Unit
             Error(Type(Error(MissingClassIterable(Tuple([Prim(Int), Prim(Bool), Prim(Result)]), Span { lo: 9, hi: 23 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 4, hi: 5 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -810,12 +810,12 @@ fn if_cond_error() {
     check(
         "",
         "if 4 {}",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-7 "if 4 {}" : Unit
             #2 3-4 "4" : Int
             #3 5-7 "{}" : Unit
             Error(Type(Error(TyMismatch(Prim(Bool), Prim(Int), Span { lo: 3, hi: 4 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -824,13 +824,13 @@ fn if_no_else_must_be_unit() {
     check(
         "",
         "if true { 4 }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-13 "if true { 4 }" : Int
             #2 3-7 "true" : Bool
             #3 8-13 "{ 4 }" : Int
             #5 10-11 "4" : Int
             Error(Type(Error(TyMismatch(Prim(Int), Tuple([]), Span { lo: 0, hi: 13 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -839,7 +839,7 @@ fn if_else_fail() {
     check(
         "",
         r#"if false {} else { fail "error"; }"#,
-        &expect![[r##"
+        &expect![[r#"
             #1 0-34 "if false {} else { fail \"error\"; }" : Unit
             #2 3-8 "false" : Bool
             #3 9-11 "{}" : Unit
@@ -847,7 +847,7 @@ fn if_else_fail() {
             #5 17-34 "{ fail \"error\"; }" : Unit
             #7 19-31 "fail \"error\"" : Unit
             #8 24-31 "\"error\"" : String
-        "##]],
+        "#]],
     );
 }
 
@@ -866,7 +866,7 @@ fn if_cond_fail() {
             }
         "#},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 28-30 "()" : Unit
             #10 37-154 "{\n        if fail \"error\" {\n            \"this type doesn't matter\"\n        } else {\n            \"foo\"\n        }\n    }" : Int
             #12 47-148 "if fail \"error\" {\n            \"this type doesn't matter\"\n        } else {\n            \"foo\"\n        }" : Int
@@ -877,7 +877,7 @@ fn if_cond_fail() {
             #18 114-148 "else {\n            \"foo\"\n        }" : String
             #19 119-148 "{\n            \"foo\"\n        }" : String
             #21 133-138 "\"foo\"" : String
-        "##]],
+        "#]],
     );
 }
 
@@ -896,7 +896,7 @@ fn if_all_diverge() {
             }
         "#},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 28-30 "()" : Unit
             #10 37-145 "{\n        if fail \"cond\" {\n            fail \"true\"\n        } else {\n            fail \"false\"\n        }\n    }" : Int
             #12 47-139 "if fail \"cond\" {\n            fail \"true\"\n        } else {\n            fail \"false\"\n        }" : Int
@@ -909,7 +909,7 @@ fn if_all_diverge() {
             #20 103-139 "{\n            fail \"false\"\n        }" : Int
             #22 117-129 "fail \"false\"" : Int
             #23 122-129 "\"false\"" : String
-        "##]],
+        "#]],
     );
 }
 
@@ -918,13 +918,13 @@ fn ternop_cond_error() {
     check(
         "",
         "7 ? 1 | 0",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-9 "7 ? 1 | 0" : Int
             #2 0-1 "7" : Int
             #3 4-5 "1" : Int
             #4 8-9 "0" : Int
             Error(Type(Error(TyMismatch(Prim(Bool), Prim(Int), Span { lo: 0, hi: 1 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -933,7 +933,7 @@ fn ternop_update_invalid_container() {
     check(
         "",
         "(1, 2, 3) w/ 2 <- 4",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-19 "(1, 2, 3) w/ 2 <- 4" : (Int, Int, Int)
             #2 0-9 "(1, 2, 3)" : (Int, Int, Int)
             #3 1-2 "1" : Int
@@ -942,7 +942,7 @@ fn ternop_update_invalid_container() {
             #6 13-14 "2" : Int
             #7 18-19 "4" : Int
             Error(Type(Error(MissingClassHasIndex(Tuple([Prim(Int), Prim(Int), Prim(Int)]), Prim(Int), Span { lo: 0, hi: 19 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -951,7 +951,7 @@ fn ternop_update_invalid_index() {
     check(
         "",
         "[1, 2, 3] w/ false <- 4",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-23 "[1, 2, 3] w/ false <- 4" : (Int)[]
             #2 0-9 "[1, 2, 3]" : (Int)[]
             #3 1-2 "1" : Int
@@ -960,7 +960,7 @@ fn ternop_update_invalid_index() {
             #6 13-18 "false" : Bool
             #7 22-23 "4" : Int
             Error(Type(Error(MissingClassHasIndex(Array(Prim(Int)), Prim(Bool), Span { lo: 0, hi: 23 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -977,7 +977,7 @@ fn ternop_update_array_index_var() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #8 38-117 "{\n        let xs = [2];\n        let i = 0;\n        let ys = xs w/ i <- 3;\n    }" : Unit
             #10 52-54 "xs" : (Int)[]
@@ -990,7 +990,7 @@ fn ternop_update_array_index_var() {
             #22 98-100 "xs" : (Int)[]
             #25 104-105 "i" : Int
             #28 109-110 "3" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1007,7 +1007,7 @@ fn ternop_update_array_index_expr() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #8 38-121 "{\n        let xs = [2];\n        let i = 0;\n        let ys = xs w/ i + 1 <- 3;\n    }" : Unit
             #10 52-54 "xs" : (Int)[]
@@ -1022,7 +1022,7 @@ fn ternop_update_array_index_expr() {
             #26 104-105 "i" : Int
             #29 108-109 "1" : Int
             #30 113-114 "3" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1040,7 +1040,7 @@ fn ternop_update_udt_known_field_name() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #19 79-81 "()" : Unit
             #21 87-155 "{\n        let p = Pair(1, 2);\n        let q = p w/ First <- 3;\n    }" : Unit
             #23 101-102 "p" : UDT<Item 1>
@@ -1054,7 +1054,7 @@ fn ternop_update_udt_known_field_name() {
             #36 133-134 "p" : UDT<Item 1>
             #39 138-143 "First" : ?
             #42 147-148 "3" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1072,7 +1072,7 @@ fn ternop_update_udt_known_field_name_expr() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #19 79-81 "()" : Unit
             #21 87-159 "{\n        let p = Pair(1, 2);\n        let q = p w/ First + 1 <- 3;\n    }" : Unit
             #23 101-102 "p" : UDT<Item 1>
@@ -1089,7 +1089,7 @@ fn ternop_update_udt_known_field_name_expr() {
             #43 146-147 "1" : Int
             #44 151-152 "3" : Int
             Error(Resolve(NotFound("First", Span { lo: 138, hi: 143 })))
-        "##]],
+        "#]],
     );
 }
 
@@ -1107,7 +1107,7 @@ fn ternop_update_udt_unknown_field_name() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #19 79-81 "()" : Unit
             #21 87-155 "{\n        let p = Pair(1, 2);\n        let q = p w/ Third <- 3;\n    }" : Unit
             #23 101-102 "p" : UDT<Item 1>
@@ -1122,7 +1122,7 @@ fn ternop_update_udt_unknown_field_name() {
             #39 138-143 "Third" : ?
             #42 147-148 "3" : Int
             Error(Type(Error(MissingClassHasField(Udt(Item(ItemId { package: None, item: LocalItemId(1) })), "Third", Span { lo: 133, hi: 148 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1142,7 +1142,7 @@ fn ternop_update_udt_unknown_field_name_known_global() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #19 81-83 "()" : Unit
             #21 89-91 "{}" : Unit
             #25 109-111 "()" : Unit
@@ -1159,7 +1159,7 @@ fn ternop_update_udt_unknown_field_name_known_global() {
             #45 168-173 "Third" : ?
             #48 177-178 "3" : Int
             Error(Type(Error(MissingClassHasField(Udt(Item(ItemId { package: None, item: LocalItemId(1) })), "Third", Span { lo: 163, hi: 178 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1168,11 +1168,11 @@ fn unop_bitwise_not_bool() {
     check(
         "",
         "~~~false",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-8 "~~~false" : Bool
             #2 3-8 "false" : Bool
             Error(Type(Error(MissingClassInteger(Prim(Bool), Span { lo: 3, hi: 8 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1181,11 +1181,11 @@ fn unop_bitwise_not_double() {
     check(
         "",
         "~~~2.0",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-6 "~~~2.0" : Double
             #2 3-6 "2.0" : Double
             Error(Type(Error(MissingClassInteger(Prim(Double), Span { lo: 3, hi: 6 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1194,11 +1194,11 @@ fn unop_not_int() {
     check(
         "",
         "not 0",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-5 "not 0" : Int
             #2 4-5 "0" : Int
             Error(Type(Error(TyMismatch(Prim(Bool), Prim(Int), Span { lo: 4, hi: 5 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1207,11 +1207,11 @@ fn unop_neg_bool() {
     check(
         "",
         "-false",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-6 "-false" : Bool
             #2 1-6 "false" : Bool
             Error(Type(Error(MissingClassNum(Prim(Bool), Span { lo: 1, hi: 6 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1220,11 +1220,11 @@ fn unop_pos_bool() {
     check(
         "",
         "+false",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-6 "+false" : Bool
             #2 1-6 "false" : Bool
             Error(Type(Error(MissingClassNum(Prim(Bool), Span { lo: 1, hi: 6 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1233,12 +1233,12 @@ fn while_cond_error() {
     check(
         "",
         "while Zero {}",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-13 "while Zero {}" : Unit
             #2 6-10 "Zero" : Result
             #3 11-13 "{}" : Unit
             Error(Type(Error(TyMismatch(Prim(Bool), Prim(Result), Span { lo: 6, hi: 10 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1254,7 +1254,7 @@ fn controlled_spec_impl() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-42 "(q : Qubit)" : Qubit
             #7 32-41 "q : Qubit" : Qubit
             #17 72-75 "..." : Qubit
@@ -1263,7 +1263,7 @@ fn controlled_spec_impl() {
             #21 99-101 "cs" : (Qubit)[]
             #23 103-106 "..." : Qubit
             #24 108-110 "{}" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -1285,7 +1285,7 @@ fn call_controlled() {
                 Controlled A.Foo([q1], q2);
             }
         "},
-        &expect![[r##"
+        &expect![[r#"
             #6 31-42 "(q : Qubit)" : Qubit
             #7 32-41 "q : Qubit" : Qubit
             #17 72-75 "..." : Qubit
@@ -1307,7 +1307,7 @@ fn call_controlled() {
             #43 186-190 "[q1]" : (Qubit)[]
             #44 187-189 "q1" : Qubit
             #47 192-194 "q2" : Qubit
-        "##]],
+        "#]],
     );
 }
 
@@ -1330,7 +1330,7 @@ fn call_controlled_nested() {
                 Controlled Controlled A.Foo([q1], ([q2], q3));
             }
         "},
-        &expect![[r##"
+        &expect![[r#"
             #6 31-42 "(q : Qubit)" : Qubit
             #7 32-41 "q : Qubit" : Qubit
             #17 72-75 "..." : Qubit
@@ -1358,7 +1358,7 @@ fn call_controlled_nested() {
             #53 226-230 "[q2]" : (Qubit)[]
             #54 227-229 "q2" : Qubit
             #57 232-234 "q3" : Qubit
-        "##]],
+        "#]],
     );
 }
 
@@ -1379,7 +1379,7 @@ fn call_controlled_error() {
                 Controlled A.Foo([1], q);
             }
         "},
-        &expect![[r##"
+        &expect![[r#"
             #6 31-42 "(q : Qubit)" : Qubit
             #7 32-41 "q : Qubit" : Qubit
             #17 72-75 "..." : Qubit
@@ -1400,7 +1400,7 @@ fn call_controlled_error() {
             #40 164-165 "1" : Int
             #41 168-169 "q" : Qubit
             Error(Type(Error(TyMismatch(Prim(Qubit), Prim(Int), Span { lo: 146, hi: 170 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1413,12 +1413,12 @@ fn adj_requires_unit_return() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-33 "()" : Unit
             #11 47-52 "{ 1 }" : Int
             #13 49-50 "1" : Int
             Error(Type(Error(TyMismatch(Tuple([]), Prim(Int), Span { lo: 36, hi: 39 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1431,12 +1431,12 @@ fn ctl_requires_unit_return() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-33 "()" : Unit
             #11 47-52 "{ 1 }" : Int
             #13 49-50 "1" : Int
             Error(Type(Error(TyMismatch(Tuple([]), Prim(Int), Span { lo: 36, hi: 39 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1449,12 +1449,12 @@ fn adj_ctl_requires_unit_return() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-33 "()" : Unit
             #13 53-58 "{ 1 }" : Int
             #15 55-56 "1" : Int
             Error(Type(Error(TyMismatch(Tuple([]), Prim(Int), Span { lo: 36, hi: 39 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1467,13 +1467,13 @@ fn adj_non_adj() {
             }
         "},
         "Adjoint A.Foo",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-33 "()" : Unit
             #9 46-48 "{}" : Unit
             #10 51-64 "Adjoint A.Foo" : (Unit => Unit is Ctl)
             #11 59-64 "A.Foo" : (Unit => Unit is Ctl)
             Error(Type(Error(MissingFunctor(Value(Adj), Value(Ctl), Span { lo: 59, hi: 64 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1486,13 +1486,13 @@ fn ctl_non_ctl() {
             }
         "},
         "Controlled A.Foo",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-33 "()" : Unit
             #9 46-48 "{}" : Unit
             #10 51-67 "Controlled A.Foo" : (((Qubit)[], Unit) => Unit is Adj)
             #11 62-67 "A.Foo" : (Unit => Unit is Adj)
             Error(Type(Error(MissingFunctor(Value(Ctl), Value(Adj), Span { lo: 62, hi: 67 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1507,7 +1507,7 @@ fn fail_diverges() {
                 4
             }
         "#},
-        &expect![[r##"
+        &expect![[r#"
             #1 0-42 "if true {\n    fail \"true\"\n} else {\n    4\n}" : Int
             #2 3-7 "true" : Bool
             #3 8-27 "{\n    fail \"true\"\n}" : Int
@@ -1516,7 +1516,7 @@ fn fail_diverges() {
             #7 28-42 "else {\n    4\n}" : Int
             #8 33-42 "{\n    4\n}" : Int
             #10 39-40 "4" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1536,7 +1536,7 @@ fn return_diverges() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-40 "(x : Bool)" : Bool
             #7 31-39 "x : Bool" : Bool
             #15 47-153 "{\n        let x = if x {\n            return 1\n        } else {\n            true\n        };\n        2\n    }" : Int
@@ -1550,7 +1550,7 @@ fn return_diverges() {
             #28 108-136 "{\n            true\n        }" : Bool
             #30 122-126 "true" : Bool
             #32 146-147 "2" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1569,7 +1569,7 @@ fn return_diverges_stmt_after() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-40 "(x : Bool)" : Bool
             #7 31-39 "x : Bool" : Bool
             #15 47-132 "{\n        let x = {\n            return 1;\n            true\n        };\n        x\n    }" : Int
@@ -1580,7 +1580,7 @@ fn return_diverges_stmt_after() {
             #23 86-87 "1" : Int
             #25 101-105 "true" : Bool
             #27 125-126 "x" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -1595,14 +1595,14 @@ fn return_mismatch() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-40 "(x : Bool)" : Bool
             #7 31-39 "x : Bool" : Bool
             #15 47-75 "{\n        return true;\n    }" : Int
             #17 57-68 "return true" : Unit
             #18 64-68 "true" : Bool
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Bool), Span { lo: 64, hi: 68 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1617,14 +1617,14 @@ fn array_unknown_field_error() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-43 "(x : Qubit[])" : (Qubit)[]
             #7 31-42 "x : Qubit[]" : (Qubit)[]
             #16 50-73 "{\n        x::Size\n    }" : Int
             #18 60-67 "x::Size" : Int
             #19 60-61 "x" : (Qubit)[]
             Error(Type(Error(MissingClassHasField(Array(Prim(Qubit)), "Size", Span { lo: 60, hi: 67 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1639,7 +1639,7 @@ fn range_fields_are_int() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-41 "(r : Range)" : Range
             #7 31-40 "r : Range" : Range
             #22 60-103 "{\n        (r::Start, r::Step, r::End)\n    }" : (Int, Int, Int)
@@ -1650,7 +1650,7 @@ fn range_fields_are_int() {
             #31 81-82 "r" : Range
             #35 90-96 "r::End" : Int
             #36 90-91 "r" : Range
-        "##]],
+        "#]],
     );
 }
 
@@ -1659,7 +1659,7 @@ fn range_to_field_start() {
     check(
         "",
         "(...2..8)::Start",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-16 "(...2..8)::Start" : ?0
             #2 0-9 "(...2..8)" : RangeTo
             #3 1-8 "...2..8" : RangeTo
@@ -1667,7 +1667,7 @@ fn range_to_field_start() {
             #5 7-8 "8" : Int
             Error(Type(Error(MissingClassHasField(Prim(RangeTo), "Start", Span { lo: 0, hi: 16 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 16 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1676,13 +1676,13 @@ fn range_to_field_step() {
     check(
         "",
         "(...2..8)::Step",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-15 "(...2..8)::Step" : Int
             #2 0-9 "(...2..8)" : RangeTo
             #3 1-8 "...2..8" : RangeTo
             #4 4-5 "2" : Int
             #5 7-8 "8" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1691,13 +1691,13 @@ fn range_to_field_end() {
     check(
         "",
         "(...2..8)::End",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-14 "(...2..8)::End" : Int
             #2 0-9 "(...2..8)" : RangeTo
             #3 1-8 "...2..8" : RangeTo
             #4 4-5 "2" : Int
             #5 7-8 "8" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1706,13 +1706,13 @@ fn range_from_field_start() {
     check(
         "",
         "(0..2...)::Start",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-16 "(0..2...)::Start" : Int
             #2 0-9 "(0..2...)" : RangeFrom
             #3 1-8 "0..2..." : RangeFrom
             #4 1-2 "0" : Int
             #5 4-5 "2" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1721,13 +1721,13 @@ fn range_from_field_step() {
     check(
         "",
         "(0..2...)::Step",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-15 "(0..2...)::Step" : Int
             #2 0-9 "(0..2...)" : RangeFrom
             #3 1-8 "0..2..." : RangeFrom
             #4 1-2 "0" : Int
             #5 4-5 "2" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1736,7 +1736,7 @@ fn range_from_field_end() {
     check(
         "",
         "(0..2...)::End",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-14 "(0..2...)::End" : ?0
             #2 0-9 "(0..2...)" : RangeFrom
             #3 1-8 "0..2..." : RangeFrom
@@ -1744,7 +1744,7 @@ fn range_from_field_end() {
             #5 4-5 "2" : Int
             Error(Type(Error(MissingClassHasField(Prim(RangeFrom), "End", Span { lo: 0, hi: 14 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 14 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1753,12 +1753,12 @@ fn range_full_field_start() {
     check(
         "",
         "...::Start",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-10 "...::Start" : ?0
             #2 0-3 "..." : RangeFull
             Error(Type(Error(MissingClassHasField(Prim(RangeFull), "Start", Span { lo: 0, hi: 10 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 10 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1767,10 +1767,10 @@ fn range_full_implicit_step() {
     check(
         "",
         "...::Step",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-9 "...::Step" : Int
             #2 0-3 "..." : RangeFull
-        "##]],
+        "#]],
     );
 }
 
@@ -1779,12 +1779,12 @@ fn range_full_explicit_step() {
     check(
         "",
         "(...2...)::Step",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-15 "(...2...)::Step" : Int
             #2 0-9 "(...2...)" : RangeFull
             #3 1-8 "...2..." : RangeFull
             #4 4-5 "2" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1793,12 +1793,12 @@ fn range_full_field_end() {
     check(
         "",
         "...::End",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-8 "...::End" : ?0
             #2 0-3 "..." : RangeFull
             Error(Type(Error(MissingClassHasField(Prim(RangeFull), "End", Span { lo: 0, hi: 8 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 8 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1807,10 +1807,10 @@ fn interpolate_int() {
     check(
         "",
         r#"$"{4}""#,
-        &expect![[r##"
+        &expect![[r#"
             #1 0-6 "$\"{4}\"" : String
             #2 3-4 "4" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1819,10 +1819,10 @@ fn interpolate_string() {
     check(
         "",
         r#"$"{"foo"}""#,
-        &expect![[r##"
+        &expect![[r#"
             #1 0-10 "$\"{\"foo\"}\"" : String
             #2 3-8 "\"foo\"" : String
-        "##]],
+        "#]],
     );
 }
 
@@ -1831,14 +1831,14 @@ fn interpolate_qubit() {
     check(
         "",
         r#"{ use q = Qubit(); $"{q}" }"#,
-        &expect![[r##"
+        &expect![[r#"
             #1 0-27 "{ use q = Qubit(); $\"{q}\" }" : String
             #2 0-27 "{ use q = Qubit(); $\"{q}\" }" : String
             #4 6-7 "q" : Qubit
             #6 10-17 "Qubit()" : Qubit
             #8 19-25 "$\"{q}\"" : String
             #9 22-23 "q" : Qubit
-        "##]],
+        "#]],
     );
 }
 
@@ -1851,13 +1851,13 @@ fn interpolate_function() {
             }
         "},
         r#"$"{A.Foo}""#,
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #8 38-40 "{}" : Unit
             #9 43-53 "$\"{A.Foo}\"" : String
             #10 46-51 "A.Foo" : (Unit -> Unit)
             Error(Type(Error(MissingClassShow(Arrow(Arrow { kind: Function, input: Tuple([]), output: Tuple([]), functors: Value(Empty) }), Span { lo: 46, hi: 51 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1870,13 +1870,13 @@ fn interpolate_operation() {
             }
         "},
         r#"$"{A.Foo}""#,
-        &expect![[r##"
+        &expect![[r#"
             #6 31-33 "()" : Unit
             #8 39-41 "{}" : Unit
             #9 44-54 "$\"{A.Foo}\"" : String
             #10 47-52 "A.Foo" : (Unit => Unit)
             Error(Type(Error(MissingClassShow(Arrow(Arrow { kind: Operation, input: Tuple([]), output: Tuple([]), functors: Value(Empty) }), Span { lo: 47, hi: 52 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1885,13 +1885,13 @@ fn interpolate_int_array() {
     check(
         "",
         r#"$"{[1, 2, 3]}""#,
-        &expect![[r##"
+        &expect![[r#"
             #1 0-14 "$\"{[1, 2, 3]}\"" : String
             #2 3-12 "[1, 2, 3]" : (Int)[]
             #3 4-5 "1" : Int
             #4 7-8 "2" : Int
             #5 10-11 "3" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1905,7 +1905,7 @@ fn interpolate_function_array() {
             }
         "},
         r#"$"{[A.Foo, A.Bar]}""#,
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #8 38-40 "{}" : Unit
             #12 57-59 "()" : Unit
@@ -1915,7 +1915,7 @@ fn interpolate_function_array() {
             #17 74-79 "A.Foo" : (Unit -> Unit)
             #21 81-86 "A.Bar" : (Unit -> Unit)
             Error(Type(Error(MissingClassShow(Arrow(Arrow { kind: Function, input: Tuple([]), output: Tuple([]), functors: Value(Empty) }), Span { lo: 73, hi: 87 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1924,12 +1924,12 @@ fn interpolate_int_string_tuple() {
     check(
         "",
         r#"$"{(1, "foo")}""#,
-        &expect![[r##"
+        &expect![[r#"
             #1 0-15 "$\"{(1, \"foo\")}\"" : String
             #2 3-13 "(1, \"foo\")" : (Int, String)
             #3 4-5 "1" : Int
             #4 7-12 "\"foo\"" : String
-        "##]],
+        "#]],
     );
 }
 
@@ -1942,7 +1942,7 @@ fn interpolate_int_function_tuple() {
             }
         "},
         r#"$"{(1, A.Foo)}""#,
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #8 38-40 "{}" : Unit
             #9 43-58 "$\"{(1, A.Foo)}\"" : String
@@ -1950,7 +1950,7 @@ fn interpolate_int_function_tuple() {
             #11 47-48 "1" : Int
             #12 50-55 "A.Foo" : (Unit -> Unit)
             Error(Type(Error(MissingClassShow(Arrow(Arrow { kind: Function, input: Tuple([]), output: Tuple([]), functors: Value(Empty) }), Span { lo: 46, hi: 56 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -1964,14 +1964,14 @@ fn newtype_cons() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #12 56-58 "()" : Unit
             #16 68-81 "{ NewInt(5) }" : UDT<Item 1>
             #18 70-79 "NewInt(5)" : UDT<Item 1>
             #19 70-76 "NewInt" : (Int -> UDT<Item 1>)
             #22 76-79 "(5)" : Int
             #23 77-78 "5" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -1985,7 +1985,7 @@ fn newtype_cons_wrong_input() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #12 56-58 "()" : Unit
             #16 68-83 "{ NewInt(5.0) }" : UDT<Item 1>
             #18 70-81 "NewInt(5.0)" : UDT<Item 1>
@@ -1993,7 +1993,7 @@ fn newtype_cons_wrong_input() {
             #22 76-81 "(5.0)" : Double
             #23 77-80 "5.0" : Double
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Double), Span { lo: 70, hi: 81 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2007,7 +2007,7 @@ fn newtype_does_not_match_base_ty() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #12 56-58 "()" : Unit
             #16 65-78 "{ NewInt(5) }" : UDT<Item 1>
             #18 67-76 "NewInt(5)" : UDT<Item 1>
@@ -2015,7 +2015,7 @@ fn newtype_does_not_match_base_ty() {
             #22 73-76 "(5)" : Int
             #23 74-75 "5" : Int
             Error(Type(Error(TyMismatch(Prim(Int), Udt(Item(ItemId { package: None, item: LocalItemId(1) })), Span { lo: 67, hi: 76 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2030,7 +2030,7 @@ fn newtype_does_not_match_other_newtype() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #18 84-86 "()" : Unit
             #22 97-111 "{ NewInt1(5) }" : UDT<Item 1>
             #24 99-109 "NewInt1(5)" : UDT<Item 1>
@@ -2038,7 +2038,7 @@ fn newtype_does_not_match_other_newtype() {
             #28 106-109 "(5)" : Int
             #29 107-108 "5" : Int
             Error(Type(Error(TyMismatch(Udt(Item(ItemId { package: None, item: LocalItemId(2) })), Udt(Item(ItemId { package: None, item: LocalItemId(1) })), Span { lo: 99, hi: 109 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2054,14 +2054,14 @@ fn newtype_unwrap() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #17 61-70 "(x : Foo)" : UDT<Item 1>
             #18 62-69 "x : Foo" : UDT<Item 1>
             #24 76-103 "{\n        let y = x!;\n    }" : Unit
             #26 90-91 "y" : (Int, Bool)
             #28 94-96 "x!" : (Int, Bool)
             #29 94-95 "x" : UDT<Item 1>
-        "##]],
+        "#]],
     );
 }
 
@@ -2077,14 +2077,14 @@ fn newtype_field() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #13 59-68 "(x : Foo)" : UDT<Item 1>
             #14 60-67 "x : Foo" : UDT<Item 1>
             #20 74-105 "{\n        let y = x::Bar;\n    }" : Unit
             #22 88-89 "y" : Int
             #24 92-98 "x::Bar" : Int
             #25 92-93 "x" : UDT<Item 1>
-        "##]],
+        "#]],
     );
 }
 
@@ -2100,7 +2100,7 @@ fn newtype_field_invalid() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #13 59-68 "(x : Foo)" : UDT<Item 1>
             #14 60-67 "x : Foo" : UDT<Item 1>
             #20 74-106 "{\n        let y = x::Nope;\n    }" : Unit
@@ -2109,7 +2109,7 @@ fn newtype_field_invalid() {
             #25 92-93 "x" : UDT<Item 1>
             Error(Type(Error(MissingClassHasField(Udt(Item(ItemId { package: None, item: LocalItemId(1) })), "Nope", Span { lo: 92, hi: 99 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 92, hi: 99 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2118,7 +2118,7 @@ fn unknown_name_fits_any_ty() {
     check(
         "",
         "{ let x : Int = foo; let y : Qubit = foo; }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-43 "{ let x : Int = foo; let y : Qubit = foo; }" : Unit
             #2 0-43 "{ let x : Int = foo; let y : Qubit = foo; }" : Unit
             #4 6-13 "x : Int" : Int
@@ -2127,7 +2127,7 @@ fn unknown_name_fits_any_ty() {
             #18 37-40 "foo" : ?
             Error(Resolve(NotFound("foo", Span { lo: 16, hi: 19 })))
             Error(Resolve(NotFound("foo", Span { lo: 37, hi: 40 })))
-        "##]],
+        "#]],
     );
 }
 
@@ -2136,7 +2136,7 @@ fn unknown_name_has_any_class() {
     check(
         "",
         "{ foo(); foo + 1 }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-18 "{ foo(); foo + 1 }" : ?
             #2 0-18 "{ foo(); foo + 1 }" : ?
             #4 2-7 "foo()" : ?0
@@ -2148,7 +2148,7 @@ fn unknown_name_has_any_class() {
             Error(Resolve(NotFound("foo", Span { lo: 2, hi: 5 })))
             Error(Resolve(NotFound("foo", Span { lo: 9, hi: 12 })))
             Error(Type(Error(AmbiguousTy(Span { lo: 2, hi: 7 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2164,7 +2164,7 @@ fn local_function() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 39-99 "{\n        function Bar() : Int { 2 }\n        Bar() + 1\n    }" : Int
             #15 61-63 "()" : Unit
@@ -2175,7 +2175,7 @@ fn local_function() {
             #25 84-87 "Bar" : (Unit -> Int)
             #28 87-89 "()" : Unit
             #29 92-93 "1" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -2191,7 +2191,7 @@ fn local_function_error() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 39-97 "{\n        function Bar() : Int { 2.0 }\n        Bar()\n    }" : Int
             #15 61-63 "()" : Unit
@@ -2201,7 +2201,7 @@ fn local_function_error() {
             #24 86-89 "Bar" : (Unit -> Int)
             #27 89-91 "()" : Unit
             Error(Type(Error(TyMismatch(Prim(Int), Prim(Double), Span { lo: 72, hi: 75 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2217,7 +2217,7 @@ fn local_function_use_before_declare() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #8 38-91 "{\n        Bar();\n        function Bar() : () {}\n    }" : Unit
             #10 48-53 "Bar()" : Unit
@@ -2225,7 +2225,7 @@ fn local_function_use_before_declare() {
             #14 51-53 "()" : Unit
             #19 75-77 "()" : Unit
             #21 83-85 "{}" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -2241,7 +2241,7 @@ fn local_function_last_stmt_is_unit_block() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 39-96 "{\n        Bar();\n        function Bar() : Int { 4 }\n    }" : Unit
             #12 49-54 "Bar()" : Int
@@ -2251,7 +2251,7 @@ fn local_function_last_stmt_is_unit_block() {
             #25 85-90 "{ 4 }" : Int
             #27 87-88 "4" : Int
             Error(Type(Error(TyMismatch(Prim(Int), Tuple([]), Span { lo: 64, hi: 90 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2267,7 +2267,7 @@ fn local_type() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #8 38-96 "{\n        newtype Bar = Int;\n        let x = Bar(5);\n    }" : Unit
             #17 79-80 "x" : UDT<Item 2>
@@ -2275,7 +2275,7 @@ fn local_type() {
             #20 83-86 "Bar" : (Int -> UDT<Item 2>)
             #23 86-89 "(5)" : Int
             #24 87-88 "5" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -2287,7 +2287,7 @@ fn local_open() {
             namespace B { function Bar() : () {} }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 26-28 "()" : Unit
             #8 34-52 "{ open B; Bar(); }" : Unit
             #13 44-49 "Bar()" : Unit
@@ -2295,7 +2295,7 @@ fn local_open() {
             #17 47-49 "()" : Unit
             #23 81-83 "()" : Unit
             #25 89-91 "{}" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -2311,7 +2311,7 @@ fn infinite() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #8 38-97 "{\n        let x = invalid;\n        let xs = [x, [x]];\n    }" : Unit
             #10 52-53 "x" : ?0
@@ -2324,7 +2324,7 @@ fn infinite() {
             Error(Resolve(NotFound("invalid", Span { lo: 56, hi: 63 })))
             Error(Type(Error(TyMismatch(Infer(InferTyId(0)), Array(Infer(InferTyId(0))), Span { lo: 86, hi: 89 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 52, hi: 53 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2338,7 +2338,7 @@ fn lambda_adj() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-53 "(op : () => () is Adj)" : (Unit => Unit is Adj)
             #7 32-52 "op : () => () is Adj" : (Unit => Unit is Adj)
             #14 59-61 "{}" : Unit
@@ -2350,7 +2350,7 @@ fn lambda_adj() {
             #27 93-101 "() => ()" : (Unit => Unit is Adj)
             #28 93-95 "()" : Unit
             #29 99-101 "()" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -2364,7 +2364,7 @@ fn lambda_ctl() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-53 "(op : () => () is Ctl)" : (Unit => Unit is Ctl)
             #7 32-52 "op : () => () is Ctl" : (Unit => Unit is Ctl)
             #14 59-61 "{}" : Unit
@@ -2376,7 +2376,7 @@ fn lambda_ctl() {
             #27 93-101 "() => ()" : (Unit => Unit is Ctl)
             #28 93-95 "()" : Unit
             #29 99-101 "()" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -2390,7 +2390,7 @@ fn lambda_adj_ctl() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-59 "(op : () => () is Adj + Ctl)" : (Unit => Unit is Adj + Ctl)
             #7 32-58 "op : () => () is Adj + Ctl" : (Unit => Unit is Adj + Ctl)
             #16 65-67 "{}" : Unit
@@ -2402,7 +2402,7 @@ fn lambda_adj_ctl() {
             #29 99-107 "() => ()" : (Unit => Unit is Adj + Ctl)
             #30 99-101 "()" : Unit
             #31 105-107 "()" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -2417,14 +2417,14 @@ fn lambda_functors_let_binding() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #8 38-94 "{\n        let op : Qubit => Unit is Adj = q => ();\n    }" : Unit
             #10 52-77 "op : Qubit => Unit is Adj" : (Qubit => Unit is Adj)
             #20 80-87 "q => ()" : (Qubit => Unit is Adj)
             #21 80-81 "q" : Qubit
             #23 85-87 "()" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -2440,7 +2440,7 @@ fn lambda_adjoint_before_functors_inferred() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #15 56-108 "{\n        let op = q => ();\n        Adjoint op\n    }" : (Qubit => Unit is Adj)
             #17 70-72 "op" : (Qubit => Unit is Adj)
@@ -2449,7 +2449,7 @@ fn lambda_adjoint_before_functors_inferred() {
             #22 80-82 "()" : Unit
             #24 92-102 "Adjoint op" : (Qubit => Unit is Adj)
             #25 100-102 "op" : (Qubit => Unit is Adj)
-        "##]],
+        "#]],
     );
 }
 
@@ -2465,7 +2465,7 @@ fn lambda_invalid_adjoint_before_functors_inferred() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #15 56-108 "{\n        let op = q => ();\n        Adjoint op\n    }" : (Qubit => Unit is Ctl)
             #17 70-72 "op" : (Qubit => Unit is Ctl)
@@ -2475,7 +2475,7 @@ fn lambda_invalid_adjoint_before_functors_inferred() {
             #24 92-102 "Adjoint op" : (Qubit => Unit is Ctl)
             #25 100-102 "op" : (Qubit => Unit is Ctl)
             Error(Type(Error(MissingFunctor(Value(Adj), Value(Ctl), Span { lo: 92, hi: 102 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2495,7 +2495,7 @@ fn lambda_multiple_uses_functors_inferred() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 35-60 "(op : Qubit => () is Adj)" : (Qubit => Unit is Adj)
             #7 36-59 "op : Qubit => () is Adj" : (Qubit => Unit is Adj)
             #16 66-68 "{}" : Unit
@@ -2519,7 +2519,7 @@ fn lambda_multiple_uses_functors_inferred() {
             #65 243-248 "opCtl" : (((Qubit)[], Qubit) => Unit is Adj + Ctl)
             #67 251-264 "Controlled op" : (((Qubit)[], Qubit) => Unit is Adj + Ctl)
             #68 262-264 "op" : (Qubit => Unit is Adj + Ctl)
-        "##]],
+        "#]],
     );
 }
 
@@ -2531,7 +2531,7 @@ fn partial_app_one_hole() {
             function Foo(x : Int) : Int { x }
             let f = Foo(_);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-85 "{\n            function Foo(x : Int) : Int { x }\n            let f = Foo(_);\n        }" : Unit
             #2 0-85 "{\n            function Foo(x : Int) : Int { x }\n            let f = Foo(_);\n        }" : Unit
             #7 26-35 "(x : Int)" : Int
@@ -2543,7 +2543,7 @@ fn partial_app_one_hole() {
             #25 68-71 "Foo" : (Int -> Int)
             #28 71-74 "(_)" : Int
             #29 72-73 "_" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -2555,7 +2555,7 @@ fn partial_app_one_given_one_hole() {
             function Foo(x : Int, y : Int) : Int { x + y }
             let f = Foo(2, _);
         }"},
-        &expect![[r##"
+        &expect![[r#"
             #1 0-77 "{\n    function Foo(x : Int, y : Int) : Int { x + y }\n    let f = Foo(2, _);\n}" : Unit
             #2 0-77 "{\n    function Foo(x : Int, y : Int) : Int { x + y }\n    let f = Foo(2, _);\n}" : Unit
             #7 18-36 "(x : Int, y : Int)" : (Int, Int)
@@ -2571,7 +2571,7 @@ fn partial_app_one_given_one_hole() {
             #37 68-74 "(2, _)" : (Int, Int)
             #38 69-70 "2" : Int
             #39 72-73 "_" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -2583,7 +2583,7 @@ fn partial_app_two_holes() {
             function Foo(x : Int, y : Int) : Int { x + y }
             let f = Foo(_, _);
         }"},
-        &expect![[r##"
+        &expect![[r#"
             #1 0-77 "{\n    function Foo(x : Int, y : Int) : Int { x + y }\n    let f = Foo(_, _);\n}" : Unit
             #2 0-77 "{\n    function Foo(x : Int, y : Int) : Int { x + y }\n    let f = Foo(_, _);\n}" : Unit
             #7 18-36 "(x : Int, y : Int)" : (Int, Int)
@@ -2599,7 +2599,7 @@ fn partial_app_two_holes() {
             #37 68-74 "(_, _)" : (Int, Int)
             #38 69-70 "_" : Int
             #39 72-73 "_" : Int
-        "##]],
+        "#]],
     );
 }
 
@@ -2611,7 +2611,7 @@ fn partial_app_nested_tuple() {
             function Foo(a : Int, (b : Bool, c : Double, d : String), e : Result) : () {}
             let f = Foo(_, (_, 1.0, _), _);
         }"},
-        &expect![[r##"
+        &expect![[r#"
             #1 0-121 "{\n    function Foo(a : Int, (b : Bool, c : Double, d : String), e : Result) : () {}\n    let f = Foo(_, (_, 1.0, _), _);\n}" : Unit
             #2 0-121 "{\n    function Foo(a : Int, (b : Bool, c : Double, d : String), e : Result) : () {}\n    let f = Foo(_, (_, 1.0, _), _);\n}" : Unit
             #7 18-75 "(a : Int, (b : Bool, c : Double, d : String), e : Result)" : (Int, (Bool, Double, String), Result)
@@ -2632,7 +2632,7 @@ fn partial_app_nested_tuple() {
             #47 107-110 "1.0" : Double
             #48 112-113 "_" : String
             #49 116-117 "_" : Result
-        "##]],
+        "#]],
     );
 }
 
@@ -2644,7 +2644,7 @@ fn partial_app_nested_tuple_singleton_unwrap() {
             function Foo(a : Int, (b : Bool, c : Double, d : String), e : Result) : () {}
             let f = Foo(_, (true, 1.0, _), _);
         }"},
-        &expect![[r##"
+        &expect![[r#"
             #1 0-124 "{\n    function Foo(a : Int, (b : Bool, c : Double, d : String), e : Result) : () {}\n    let f = Foo(_, (true, 1.0, _), _);\n}" : Unit
             #2 0-124 "{\n    function Foo(a : Int, (b : Bool, c : Double, d : String), e : Result) : () {}\n    let f = Foo(_, (true, 1.0, _), _);\n}" : Unit
             #7 18-75 "(a : Int, (b : Bool, c : Double, d : String), e : Result)" : (Int, (Bool, Double, String), Result)
@@ -2665,7 +2665,7 @@ fn partial_app_nested_tuple_singleton_unwrap() {
             #47 110-113 "1.0" : Double
             #48 115-116 "_" : String
             #49 119-120 "_" : Result
-        "##]],
+        "#]],
     );
 }
 
@@ -2677,7 +2677,7 @@ fn partial_app_too_many_args() {
             function Foo(x : Int) : Int { x }
             let f = Foo(1, _, _);
         }"},
-        &expect![[r##"
+        &expect![[r#"
             #1 0-67 "{\n    function Foo(x : Int) : Int { x }\n    let f = Foo(1, _, _);\n}" : Unit
             #2 0-67 "{\n    function Foo(x : Int) : Int { x }\n    let f = Foo(1, _, _);\n}" : Unit
             #7 18-27 "(x : Int)" : Int
@@ -2694,7 +2694,7 @@ fn partial_app_too_many_args() {
             Error(Type(Error(TyMismatch(Prim(Int), Tuple([Prim(Int), Infer(InferTyId(1)), Infer(InferTyId(2))]), Span { lo: 52, hi: 64 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 59, hi: 60 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 62, hi: 63 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2703,12 +2703,12 @@ fn typed_hole_error_concrete_type() {
     check(
         "",
         "_ + 3",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-5 "_ + 3" : Int
             #2 0-1 "_" : Int
             #3 4-5 "3" : Int
             Error(Type(Error(TyHole(Prim(Int), Span { lo: 0, hi: 1 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2717,7 +2717,7 @@ fn typed_hole_error_ambiguous_type() {
     check(
         "",
         "_(3)",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-4 "_(3)" : ?1
             #2 0-1 "_" : ?0
             #3 1-4 "(3)" : Int
@@ -2725,7 +2725,7 @@ fn typed_hole_error_ambiguous_type() {
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 1 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 0, hi: 4 }))))
             Error(Type(Error(TyHole(Infer(InferTyId(0)), Span { lo: 0, hi: 1 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2738,7 +2738,7 @@ fn functors_in_arg_superset_of_empty() {
             operation Bar(q : Qubit) : () is Adj {}
             Foo(Bar);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-137 "{\n            operation Foo(op : Qubit => ()) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            Foo(Bar);\n        }" : Unit
             #2 0-137 "{\n            operation Foo(op : Qubit => ()) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            Foo(Bar);\n        }" : Unit
             #7 27-45 "(op : Qubit => ())" : (Qubit => Unit)
@@ -2751,7 +2751,7 @@ fn functors_in_arg_superset_of_empty() {
             #32 118-121 "Foo" : ((Qubit => Unit is Adj) => Unit)
             #35 121-126 "(Bar)" : (Qubit => Unit is Adj)
             #36 122-125 "Bar" : (Qubit => Unit is Adj)
-        "##]],
+        "#]],
     );
 }
 
@@ -2764,7 +2764,7 @@ fn functors_in_arg_superset_of_adj() {
             operation Bar(q : Qubit) : () is Adj + Ctl {}
             Foo(Bar);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-150 "{\n            operation Foo(op : Qubit => () is Adj) : () {}\n            operation Bar(q : Qubit) : () is Adj + Ctl {}\n            Foo(Bar);\n        }" : Unit
             #2 0-150 "{\n            operation Foo(op : Qubit => () is Adj) : () {}\n            operation Bar(q : Qubit) : () is Adj + Ctl {}\n            Foo(Bar);\n        }" : Unit
             #7 27-52 "(op : Qubit => () is Adj)" : (Qubit => Unit is Adj)
@@ -2777,7 +2777,7 @@ fn functors_in_arg_superset_of_adj() {
             #35 131-134 "Foo" : ((Qubit => Unit is Adj + Ctl) => Unit)
             #38 134-139 "(Bar)" : (Qubit => Unit is Adj + Ctl)
             #39 135-138 "Bar" : (Qubit => Unit is Adj + Ctl)
-        "##]],
+        "#]],
     );
 }
 
@@ -2790,7 +2790,7 @@ fn functors_in_arg_subset_of_ctl_adj() {
             operation Bar(q : Qubit) : () is Adj {}
             Foo(Bar);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-150 "{\n            operation Foo(op : Qubit => () is Adj + Ctl) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            Foo(Bar);\n        }" : Unit
             #2 0-150 "{\n            operation Foo(op : Qubit => () is Adj + Ctl) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            Foo(Bar);\n        }" : Unit
             #7 27-58 "(op : Qubit => () is Adj + Ctl)" : (Qubit => Unit is Adj + Ctl)
@@ -2804,7 +2804,7 @@ fn functors_in_arg_subset_of_ctl_adj() {
             #38 134-139 "(Bar)" : (Qubit => Unit is Adj)
             #39 135-138 "Bar" : (Qubit => Unit is Adj)
             Error(Type(Error(MissingFunctor(Value(CtlAdj), Value(Adj), Span { lo: 131, hi: 139 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2817,7 +2817,7 @@ fn functors_in_arg_eq_to_adj() {
             operation Bar(q : Qubit) : () is Adj {}
             Foo(Bar);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-144 "{\n            operation Foo(op : Qubit => () is Adj) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            Foo(Bar);\n        }" : Unit
             #2 0-144 "{\n            operation Foo(op : Qubit => () is Adj) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            Foo(Bar);\n        }" : Unit
             #7 27-52 "(op : Qubit => () is Adj)" : (Qubit => Unit is Adj)
@@ -2830,7 +2830,7 @@ fn functors_in_arg_eq_to_adj() {
             #33 125-128 "Foo" : ((Qubit => Unit is Adj) => Unit)
             #36 128-133 "(Bar)" : (Qubit => Unit is Adj)
             #37 129-132 "Bar" : (Qubit => Unit is Adj)
-        "##]],
+        "#]],
     );
 }
 
@@ -2843,7 +2843,7 @@ fn functors_in_arg_nested_arrow_superset_of_adj() {
             operation Bar(op : Qubit => () is Adj + Ctl) : () {}
             Foo(Bar);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-165 "{\n            operation Foo(op : (Qubit => () is Adj) => ()) : () {}\n            operation Bar(op : Qubit => () is Adj + Ctl) : () {}\n            Foo(Bar);\n        }" : Unit
             #2 0-165 "{\n            operation Foo(op : (Qubit => () is Adj) => ()) : () {}\n            operation Bar(op : Qubit => () is Adj + Ctl) : () {}\n            Foo(Bar);\n        }" : Unit
             #7 27-60 "(op : (Qubit => () is Adj) => ())" : ((Qubit => Unit is Adj) => Unit)
@@ -2857,7 +2857,7 @@ fn functors_in_arg_nested_arrow_superset_of_adj() {
             #43 149-154 "(Bar)" : ((Qubit => Unit is Adj) => Unit)
             #44 150-153 "Bar" : ((Qubit => Unit is Adj) => Unit)
             Error(Type(Error(MissingFunctor(Value(CtlAdj), Value(Adj), Span { lo: 146, hi: 154 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2870,7 +2870,7 @@ fn functors_in_arg_nested_arrow_subset_of_adj() {
             operation Bar(op : Qubit => ()) : () {}
             Foo(Bar);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-152 "{\n            operation Foo(op : (Qubit => () is Adj) => ()) : () {}\n            operation Bar(op : Qubit => ()) : () {}\n            Foo(Bar);\n        }" : Unit
             #2 0-152 "{\n            operation Foo(op : (Qubit => () is Adj) => ()) : () {}\n            operation Bar(op : Qubit => ()) : () {}\n            Foo(Bar);\n        }" : Unit
             #7 27-60 "(op : (Qubit => () is Adj) => ())" : ((Qubit => Unit is Adj) => Unit)
@@ -2883,7 +2883,7 @@ fn functors_in_arg_nested_arrow_subset_of_adj() {
             #37 133-136 "Foo" : (((Qubit => Unit is Adj) => Unit) => Unit)
             #40 136-141 "(Bar)" : ((Qubit => Unit is Adj) => Unit)
             #41 137-140 "Bar" : ((Qubit => Unit is Adj) => Unit)
-        "##]],
+        "#]],
     );
 }
 
@@ -2896,7 +2896,7 @@ fn functors_in_arg_nested_arrow_eq_to_adj() {
             operation Bar(op : Qubit => () is Adj) : () {}
             Foo(Bar);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-159 "{\n            operation Foo(op : (Qubit => () is Adj) => ()) : () {}\n            operation Bar(op : Qubit => () is Adj) : () {}\n            Foo(Bar);\n        }" : Unit
             #2 0-159 "{\n            operation Foo(op : (Qubit => () is Adj) => ()) : () {}\n            operation Bar(op : Qubit => () is Adj) : () {}\n            Foo(Bar);\n        }" : Unit
             #7 27-60 "(op : (Qubit => () is Adj) => ())" : ((Qubit => Unit is Adj) => Unit)
@@ -2909,7 +2909,7 @@ fn functors_in_arg_nested_arrow_eq_to_adj() {
             #38 140-143 "Foo" : (((Qubit => Unit is Adj) => Unit) => Unit)
             #41 143-148 "(Bar)" : ((Qubit => Unit is Adj) => Unit)
             #42 144-147 "Bar" : ((Qubit => Unit is Adj) => Unit)
-        "##]],
+        "#]],
     );
 }
 
@@ -2922,7 +2922,7 @@ fn functors_in_arg_array_superset_of_adj() {
             operation Bar(q : Qubit) : () is Adj + Ctl {}
             Foo([Bar]);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-157 "{\n            operation Foo(ops : (Qubit => () is Adj)[]) : () {}\n            operation Bar(q : Qubit) : () is Adj + Ctl {}\n            Foo([Bar]);\n        }" : Unit
             #2 0-157 "{\n            operation Foo(ops : (Qubit => () is Adj)[]) : () {}\n            operation Bar(q : Qubit) : () is Adj + Ctl {}\n            Foo([Bar]);\n        }" : Unit
             #7 27-57 "(ops : (Qubit => () is Adj)[])" : ((Qubit => Unit is Adj))[]
@@ -2936,7 +2936,7 @@ fn functors_in_arg_array_superset_of_adj() {
             #40 139-146 "([Bar])" : ((Qubit => Unit is Adj + Ctl))[]
             #41 140-145 "[Bar]" : ((Qubit => Unit is Adj + Ctl))[]
             #42 141-144 "Bar" : (Qubit => Unit is Adj + Ctl)
-        "##]],
+        "#]],
     );
 }
 
@@ -2949,7 +2949,7 @@ fn functors_in_arg_array_subset_of_adj() {
             operation Bar(q : Qubit) : () {}
             Foo([Bar]);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-144 "{\n            operation Foo(ops : (Qubit => () is Adj)[]) : () {}\n            operation Bar(q : Qubit) : () {}\n            Foo([Bar]);\n        }" : Unit
             #2 0-144 "{\n            operation Foo(ops : (Qubit => () is Adj)[]) : () {}\n            operation Bar(q : Qubit) : () {}\n            Foo([Bar]);\n        }" : Unit
             #7 27-57 "(ops : (Qubit => () is Adj)[])" : ((Qubit => Unit is Adj))[]
@@ -2964,7 +2964,7 @@ fn functors_in_arg_array_subset_of_adj() {
             #38 127-132 "[Bar]" : ((Qubit => Unit))[]
             #39 128-131 "Bar" : (Qubit => Unit)
             Error(Type(Error(MissingFunctor(Value(Adj), Value(Empty), Span { lo: 123, hi: 133 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -2976,7 +2976,7 @@ fn functors_in_array_all_same() {
             operation Foo(q : Qubit) : () is Adj {}
             let ops = [Foo, Foo, Foo];
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-102 "{\n            operation Foo(q : Qubit) : () is Adj {}\n            let ops = [Foo, Foo, Foo];\n        }" : Unit
             #2 0-102 "{\n            operation Foo(q : Qubit) : () is Adj {}\n            let ops = [Foo, Foo, Foo];\n        }" : Unit
             #7 27-38 "(q : Qubit)" : Qubit
@@ -2987,7 +2987,7 @@ fn functors_in_array_all_same() {
             #20 77-80 "Foo" : (Qubit => Unit is Adj)
             #23 82-85 "Foo" : (Qubit => Unit is Adj)
             #26 87-90 "Foo" : (Qubit => Unit is Adj)
-        "##]],
+        "#]],
     );
 }
 
@@ -3001,7 +3001,7 @@ fn functors_in_array_mixed() {
             operation Baz(q : Qubit) : () is Adj + Ctl {}
             let ops = [Foo, Bar, Baz];
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-205 "{\n            operation Foo(q : Qubit) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            operation Baz(q : Qubit) : () is Adj + Ctl {}\n            let ops = [Foo, Bar, Baz];\n        }" : Unit
             #2 0-205 "{\n            operation Foo(q : Qubit) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            operation Baz(q : Qubit) : () is Adj + Ctl {}\n            let ops = [Foo, Bar, Baz];\n        }" : Unit
             #7 27-38 "(q : Qubit)" : Qubit
@@ -3020,7 +3020,7 @@ fn functors_in_array_mixed() {
             #53 190-193 "Baz" : (Qubit => Unit is Adj + Ctl)
             Error(Type(Error(FunctorMismatch(Value(Empty), Value(Adj), Span { lo: 185, hi: 188 }))))
             Error(Type(Error(FunctorMismatch(Value(Empty), Value(CtlAdj), Span { lo: 190, hi: 193 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -3034,7 +3034,7 @@ fn functors_in_array_mixed_lambda_all_empty() {
             operation Baz(q : Qubit) : () is Adj + Ctl {}
             let ops = [Foo, q => Bar(q), q => Baz(q)];
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-221 "{\n            operation Foo(q : Qubit) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            operation Baz(q : Qubit) : () is Adj + Ctl {}\n            let ops = [Foo, q => Bar(q), q => Baz(q)];\n        }" : Unit
             #2 0-221 "{\n            operation Foo(q : Qubit) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            operation Baz(q : Qubit) : () is Adj + Ctl {}\n            let ops = [Foo, q => Bar(q), q => Baz(q)];\n        }" : Unit
             #7 27-38 "(q : Qubit)" : Qubit
@@ -3061,7 +3061,7 @@ fn functors_in_array_mixed_lambda_all_empty() {
             #65 203-206 "Baz" : (Qubit => Unit is Adj + Ctl)
             #68 206-209 "(q)" : Qubit
             #69 207-208 "q" : Qubit
-        "##]],
+        "#]],
     );
 }
 
@@ -3075,7 +3075,7 @@ fn functors_in_array_mixed_lambda_all_ctl_adj() {
             operation Baz(q : Qubit) : () is Adj + Ctl {}
             let ops = [q => Foo(q), q => Bar(q), Baz];
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-221 "{\n            operation Foo(q : Qubit) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            operation Baz(q : Qubit) : () is Adj + Ctl {}\n            let ops = [q => Foo(q), q => Bar(q), Baz];\n        }" : Unit
             #2 0-221 "{\n            operation Foo(q : Qubit) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            operation Baz(q : Qubit) : () is Adj + Ctl {}\n            let ops = [q => Foo(q), q => Bar(q), Baz];\n        }" : Unit
             #7 27-38 "(q : Qubit)" : Qubit
@@ -3102,7 +3102,7 @@ fn functors_in_array_mixed_lambda_all_ctl_adj() {
             #65 201-204 "(q)" : Qubit
             #66 202-203 "q" : Qubit
             #69 206-209 "Baz" : (Qubit => Unit is Adj + Ctl)
-        "##]],
+        "#]],
     );
 }
 
@@ -3118,7 +3118,7 @@ fn functors_in_arg_bound_to_let_becomes_monotype() {
             foo(Bar);
             foo(Baz);
         }",
-        &expect![[r##"
+        &expect![[r#"
             #1 0-251 "{\n            operation Foo(op : Qubit => () is Adj) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            operation Baz(q : Qubit) : () is Adj + Ctl {}\n            let foo = Foo;\n            foo(Bar);\n            foo(Baz);\n        }" : Unit
             #2 0-251 "{\n            operation Foo(op : Qubit => () is Adj) : () {}\n            operation Bar(q : Qubit) : () is Adj {}\n            operation Baz(q : Qubit) : () is Adj + Ctl {}\n            let foo = Foo;\n            foo(Bar);\n            foo(Baz);\n        }" : Unit
             #7 27-52 "(op : Qubit => () is Adj)" : (Qubit => Unit is Adj)
@@ -3141,7 +3141,7 @@ fn functors_in_arg_bound_to_let_becomes_monotype() {
             #66 235-240 "(Baz)" : (Qubit => Unit is Adj + Ctl)
             #67 236-239 "Baz" : (Qubit => Unit is Adj + Ctl)
             Error(Type(Error(FunctorMismatch(Value(Adj), Value(CtlAdj), Span { lo: 232, hi: 240 }))))
-        "##]],
+        "#]],
     );
 }
 
@@ -3158,7 +3158,7 @@ fn duplicate_callable_decls_inferred_and_ignored() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 33-35 "()" : Unit
             #10 43-51 "{ true }" : Bool
             #12 45-49 "true" : Bool
@@ -3171,7 +3171,7 @@ fn duplicate_callable_decls_inferred_and_ignored() {
             #33 127-130 "Foo" : (Unit -> Bool)
             #36 130-132 "()" : Unit
             Error(Resolve(Duplicate("Foo", "Test", Span { lo: 65, hi: 68 })))
-        "##]],
+        "#]],
     );
 }
 
@@ -3188,7 +3188,7 @@ fn duplicate_type_decls_inferred_and_ignored() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #18 81-83 "()" : Unit
             #22 91-127 "{\n        let val = Foo(true);\n    }" : Unit
             #24 105-108 "val" : UDT<Item 1>
@@ -3197,7 +3197,7 @@ fn duplicate_type_decls_inferred_and_ignored() {
             #30 114-120 "(true)" : Bool
             #31 115-119 "true" : Bool
             Error(Resolve(Duplicate("Foo", "Test", Span { lo: 53, hi: 56 })))
-        "##]],
+        "#]],
     );
 }
 
@@ -3206,14 +3206,14 @@ fn instantiate_duplicate_ty_param_names() {
     check(
         "namespace Test { function Foo<'T, 'T>() : () { let f = Foo; } }",
         "",
-        &expect![[r##"
+        &expect![[r#"
             #8 37-39 "()" : Unit
             #10 45-61 "{ let f = Foo; }" : Unit
             #12 51-52 "f" : (Unit -> Unit)
             #14 55-58 "Foo" : (Unit -> Unit)
             Error(Type(Error(AmbiguousTy(Span { lo: 55, hi: 58 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 55, hi: 58 }))))
-        "##]],
+        "#]],
     );
 }
 #[test]
@@ -3224,7 +3224,7 @@ fn ambiguous_generic() {
             function Bar() : () { let x = Foo([]); }
         }",
         "",
-        &expect![[r##"
+        &expect![[r#"
             #7 45-52 "(x: 'T)" : 0
             #8 46-51 "x: 'T" : 0
             #14 58-63 "{ x }" : 0
@@ -3237,7 +3237,7 @@ fn ambiguous_generic() {
             #32 109-113 "([])" : (?2)[]
             #33 110-112 "[]" : (?2)[]
             Error(Type(Error(AmbiguousTy(Span { lo: 110, hi: 112 }))))
-        "##]],
+        "#]],
     );
 }
 #[test]
@@ -3250,13 +3250,13 @@ fn invalid_ident() {
 }
         "#,
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 31-33 "()" : Unit
             #8 39-76 "{\n        let x : 'invalid = 0;\n    }" : Unit
             #10 53-65 "x : 'invalid" : ?
             #14 68-69 "0" : Int
             Error(Resolve(NotFound("'invalid", Span { lo: 57, hi: 65 })))
-        "##]],
+        "#]],
     );
 }
 #[test]
@@ -3264,12 +3264,12 @@ fn undeclared_generic_param() {
     check(
         r#"namespace c{operation y(g: 'U): Unit {} }"#,
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 23-30 "(g: 'U)" : ?
             #7 24-29 "g: 'U" : ?
             #14 37-39 "{}" : Unit
             Error(Resolve(NotFound("'U", Span { lo: 27, hi: 29 })))
-        "##]],
+        "#]],
     );
 }
 
@@ -3287,7 +3287,7 @@ fn use_bound_item_in_another_bound_item() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 28-30 "()" : Unit
             #10 38-133 "{\n        function C() : Unit {\n            D();\n        }\n        function D() : Unit {}\n    }" : Unit
             #15 58-60 "()" : Unit
@@ -3297,7 +3297,7 @@ fn use_bound_item_in_another_bound_item() {
             #25 83-85 "()" : Unit
             #30 115-117 "()" : Unit
             #34 125-127 "{}" : Unit
-        "##]],
+        "#]],
     );
 }
 
@@ -3318,7 +3318,7 @@ fn inferred_generic_tuple_arguments_for_passed_callable() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #7 39-65 "(f : 'T -> Unit, arg : 'T)" : ((0 -> Unit), 0)
             #8 40-54 "f : 'T -> Unit" : (0 -> Unit)
             #16 56-64 "arg : 'T" : 0
@@ -3349,6 +3349,6 @@ fn inferred_generic_tuple_arguments_for_passed_callable() {
             #86 243-249 "(1, 2)" : (Int, Int)
             #87 244-245 "1" : Int
             #88 247-248 "2" : Int
-        "##]],
+        "#]],
     );
 }

--- a/compiler/qsc_hir/src/ty.rs
+++ b/compiler/qsc_hir/src/ty.rs
@@ -478,10 +478,14 @@ impl Udt {
     fn find_field(&self, path: &FieldPath) -> Option<&UdtField> {
         let mut udt_def = &self.definition;
         for &index in &path.indices {
-            let UdtDefKind::Tuple(items) = &udt_def.kind else { return None };
+            let UdtDefKind::Tuple(items) = &udt_def.kind else {
+                return None;
+            };
             udt_def = &items[index];
         }
-        let UdtDefKind::Field(field) = &udt_def.kind else { return None };
+        let UdtDefKind::Field(field) = &udt_def.kind else {
+            return None;
+        };
         Some(field)
     }
 
@@ -571,7 +575,7 @@ impl Display for UdtDefKind {
                 } else {
                     write!(indent, "Tuple:")?;
                     indent = set_indentation(indent, 1);
-                    for t in ts.iter() {
+                    for t in ts {
                         write!(indent, "\n{t}")?;
                     }
                 }

--- a/compiler/qsc_parse/src/expr.rs
+++ b/compiler/qsc_parse/src/expr.rs
@@ -320,7 +320,11 @@ fn expr_interpolate(s: &mut Scanner) -> Result<Vec<StringComponent>> {
     let TokenKind::String(StringToken::Interpolated(InterpolatedStart::DollarQuote, mut end)) =
         token.kind
     else {
-        return Err(Error(ErrorKind::Rule("interpolated string", token.kind, token.span)));
+        return Err(Error(ErrorKind::Rule(
+            "interpolated string",
+            token.kind,
+            token.span,
+        )));
     };
 
     let mut components = Vec::new();
@@ -337,7 +341,11 @@ fn expr_interpolate(s: &mut Scanner) -> Result<Vec<StringComponent>> {
         let TokenKind::String(StringToken::Interpolated(InterpolatedStart::RBrace, next_end)) =
             token.kind
         else {
-            return Err(Error(ErrorKind::Rule("interpolated string", token.kind, token.span)));
+            return Err(Error(ErrorKind::Rule(
+                "interpolated string",
+                token.kind,
+                token.span,
+            )));
         };
 
         let lit = shorten(1, 1, s.read());

--- a/compiler/qsc_parse/src/lex/cooked/tests.rs
+++ b/compiler/qsc_parse/src/lex/cooked/tests.rs
@@ -60,7 +60,9 @@ fn op_string(kind: TokenKind) -> Option<String> {
 #[test]
 fn basic_ops() {
     for kind in enum_iterator::all() {
-        let Some(input) = op_string(kind) else { continue };
+        let Some(input) = op_string(kind) else {
+            continue;
+        };
         let actual: Vec<_> = Lexer::new(&input).collect();
         let len = input
             .len()

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -109,7 +109,7 @@ pub fn run_default_passes(
         .chain(borrow_errors.into_iter().map(Error::BorrowCk))
         .chain(spec_errors.into_iter().map(Error::SpecGen))
         .chain(conjugate_errors.into_iter().map(Error::ConjInvert))
-        .chain(entry_point_errors.into_iter())
+        .chain(entry_point_errors)
         .chain(base_prof_errors.into_iter().map(Error::BaseProfCk))
         .collect()
 }

--- a/compiler/qsc_passes/src/loop_unification.rs
+++ b/compiler/qsc_passes/src/loop_unification.rs
@@ -130,7 +130,9 @@ impl LoopUni<'_> {
         let array_id = self.gen_ident("array_id", iterable.ty.clone(), iterable_span);
         let array_capture = array_id.gen_id_init(Mutability::Immutable, *iterable, self.assigner);
 
-        let Ty::Array(item_ty) = &array_id.ty else { panic!("iterator should have array type"); };
+        let Ty::Array(item_ty) = &array_id.ty else {
+            panic!("iterator should have array type");
+        };
         let mut len_callee = create_gen_core_ref(
             self.core,
             "Microsoft.Quantum.Core",

--- a/compiler/qsc_passes/src/spec_gen.rs
+++ b/compiler/qsc_passes/src/spec_gen.rs
@@ -220,11 +220,13 @@ impl<'a> MutVisitor for SpecImplPass<'a> {
         let ctl_adj = &mut decl.ctl_adj;
 
         let SpecBody::Impl(_, body_block) = &body.body else {
-                if body.body == SpecBody::Gen(SpecGen::Intrinsic) && [adj, ctl, ctl_adj].into_iter().any(|x| Option::is_some(x)) {
-                    self.errors.push(Error::MissingBody(body.span));
-                }
-                return;
-            };
+            if body.body == SpecBody::Gen(SpecGen::Intrinsic)
+                && [adj, ctl, ctl_adj].into_iter().any(|x| Option::is_some(x))
+            {
+                self.errors.push(Error::MissingBody(body.span));
+            }
+            return;
+        };
 
         if let Some(ctl) = ctl.as_mut() {
             if ctl.body == SpecBody::Gen(SpecGen::Distribute)

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -81,6 +81,9 @@ impl<'a> LanguageService<'a> {
 
     /// Indicates that the client is no longer interested in the document,
     /// typically occurs when the document is closed in the editor.
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     pub fn close_document(&mut self, uri: &str) {
         trace!("close_document: {uri:?}");
         let document_state = self.document_map.remove(uri);
@@ -96,6 +99,9 @@ impl<'a> LanguageService<'a> {
         );
     }
 
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     #[must_use]
     pub fn get_completions(&self, uri: &str, offset: u32) -> CompletionList {
         trace!("get_completions: uri: {uri:?}, offset: {offset:?}");
@@ -110,6 +116,9 @@ impl<'a> LanguageService<'a> {
         res
     }
 
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     #[must_use]
     pub fn get_definition(&self, uri: &str, offset: u32) -> Option<Definition> {
         trace!("get_definition: uri: {uri:?}, offset: {offset:?}");
@@ -122,6 +131,9 @@ impl<'a> LanguageService<'a> {
         res
     }
 
+    /// # Panics
+    ///
+    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     #[must_use]
     pub fn get_hover(&self, uri: &str, offset: u32) -> Option<Hover> {
         trace!("get_hover: uri: {uri:?}, offset: {offset:?}");

--- a/prereqs.py
+++ b/prereqs.py
@@ -13,13 +13,13 @@ import tempfile
 import functools
 
 python_ver = (3, 11)  # Python support for Windows on ARM64 requires v3.11 or later
-rust_ver = (1, 69)  # Ensure Rust version 1.69 or later is installed
+rust_ver = (1, 72)  # Ensure Rust version 1.69 or later is installed
 node_ver = (
     16,
     17,
 )  # Node.js version 16.17 or later is required to support the Node.js 'test' module
 wasmpack_ver = (0, 12, 1)  # Latest tested wasm-pack version
-rust_fmt_ver = (1, 5, 2)  # Current version when Rust 1.70 shipped
+rust_fmt_ver = (1, 6, 0)  # Current version when Rust 1.72 shipped
 clippy_ver = (0, 1, 69)
 
 # Disable buffered output so that the log statements and subprocess output get interleaved in proper order

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -340,7 +340,7 @@ mod test {
             code,
             expr,
             |_msg_| {
-                assert!(_msg_.contains(r#"\ta\n\t"#) || _msg_.contains("result"));
+                assert!(_msg_.contains(r"\ta\n\t") || _msg_.contains("result"));
             },
             1,
         );


### PR DESCRIPTION
This update comes with changes to clippy and rustfmt that can cause validation failures, so the change includes all the updates to source code and configuration to bring the codebase into alignment with the latest Rust lints. Without this, new users who install the latest stable rust would see these failures locally and be blocked from developing.

The prerequisites check is also updated to force everyone to upgrade.