### PR TITLE
Parsing Error with UDTs based on Arrays

### DIFF
--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -372,11 +372,8 @@ fn lift_newtype_tuple() {
                 Item 1 [18-46] (Public):
                     Parent: 0
                     Type (Ident 0 [26-29] "Foo"): UDT [18-46]:
-                        TyDef [32-45]: Tuple:
-                            TyDef [33-36]: Field:
-                                type: Int
-                            TyDef [38-44]: Field:
-                                type: Double
+                        TyDef [32-45]: Field:
+                            type: (Int, Double)
                 Item 2 [51-110] (Public):
                     Parent: 0
                     Callable 1 [51-110] (operation):
@@ -470,14 +467,8 @@ fn lift_newtype_nested_tuple() {
                 Item 1 [18-54] (Public):
                     Parent: 0
                     Type (Ident 0 [26-29] "Foo"): UDT [18-54]:
-                        TyDef [32-53]: Tuple:
-                            TyDef [33-36]: Field:
-                                type: Int
-                            TyDef [38-52]: Tuple:
-                                TyDef [39-45]: Field:
-                                    type: Double
-                                TyDef [47-51]: Field:
-                                    type: Bool
+                        TyDef [32-53]: Field:
+                            type: (Int, (Double, Bool))
                 Item 2 [59-126] (Public):
                     Parent: 0
                     Callable 1 [59-126] (operation):
@@ -1943,7 +1934,8 @@ fn item_docs() {
                     Doc:
                         This is a newtype.
                     Type (Ident 0 [102-105] "Foo"): UDT [59-111]:
-                        TyDef [108-110]: Unit
+                        TyDef [108-110]: Field:
+                            type: Unit
                 Item 2 [125-183] (Public):
                     Parent: 0
                     Doc:

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2054,14 +2054,14 @@ fn newtype_unwrap() {
             }
         "},
         "",
-        &expect![[r#"
-            #17 61-70 "(x : Foo)" : UDT<Item 1>
-            #18 62-69 "x : Foo" : UDT<Item 1>
-            #24 76-103 "{\n        let y = x!;\n    }" : Unit
-            #26 90-91 "y" : (Int, Bool)
-            #28 94-96 "x!" : (Int, Bool)
-            #29 94-95 "x" : UDT<Item 1>
-        "#]],
+        &expect![[r##"
+            #16 61-70 "(x : Foo)" : UDT<Item 1>
+            #17 62-69 "x : Foo" : UDT<Item 1>
+            #23 76-103 "{\n        let y = x!;\n    }" : Unit
+            #25 90-91 "y" : (Int, Bool)
+            #27 94-96 "x!" : (Int, Bool)
+            #28 94-95 "x" : UDT<Item 1>
+        "##]],
     );
 }
 

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2054,14 +2054,14 @@ fn newtype_unwrap() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #16 61-70 "(x : Foo)" : UDT<Item 1>
             #17 62-69 "x : Foo" : UDT<Item 1>
             #23 76-103 "{\n        let y = x!;\n    }" : Unit
             #25 90-91 "y" : (Int, Bool)
             #27 94-96 "x!" : (Int, Bool)
             #28 94-95 "x" : UDT<Item 1>
-        "##]],
+        "#]],
     );
 }
 

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -194,10 +194,9 @@ fn ty_def_tuple() {
         "newtype Foo = (Int, Int);",
         &expect![[r#"
             Item _id_ [0-25]:
-                New Type (Ident _id_ [8-11] "Foo"): TyDef _id_ [14-24]: Tuple:
-                    TyDef _id_ [15-18]: Field:
+                New Type (Ident _id_ [8-11] "Foo"): TyDef _id_ [14-24]: Field:
+                    Type _id_ [14-24]: Tuple:
                         Type _id_ [15-18]: Path: Path _id_ [15-18] (Ident _id_ [15-18] "Int")
-                    TyDef _id_ [20-23]: Field:
                         Type _id_ [20-23]: Path: Path _id_ [20-23] (Ident _id_ [20-23] "Int")"#]],
     );
 }
@@ -268,6 +267,36 @@ fn ty_def_tuple_with_name() {
                     Type _id_ [21-31]: Tuple:
                         Type _id_ [22-25]: Path: Path _id_ [22-25] (Ident _id_ [22-25] "Int")
                         Type _id_ [27-30]: Path: Path _id_ [27-30] (Ident _id_ [27-30] "Int")"#]],
+    );
+}
+
+#[test]
+fn ty_def_tuple_array() {
+    check(
+        parse,
+        "newtype Foo = (Int, Int)[];",
+        &expect![[r#"
+        Item _id_ [0-27]:
+            New Type (Ident _id_ [8-11] "Foo"): TyDef _id_ [14-26]: Field:
+                Type _id_ [14-26]: Array: Type _id_ [14-24]: Tuple:
+                    Type _id_ [15-18]: Path: Path _id_ [15-18] (Ident _id_ [15-18] "Int")
+                    Type _id_ [20-23]: Path: Path _id_ [20-23] (Ident _id_ [20-23] "Int")"#]],
+    );
+}
+
+#[test]
+fn ty_def_tuple_lambda_args() {
+    check(
+        parse,
+        "newtype Foo = (Int, Int) -> Int;",
+        &expect![[r#"
+            Item _id_ [0-32]:
+                New Type (Ident _id_ [8-11] "Foo"): TyDef _id_ [14-31]: Field:
+                    Type _id_ [14-31]: Arrow (Function):
+                        param: Type _id_ [14-24]: Tuple:
+                            Type _id_ [15-18]: Path: Path _id_ [15-18] (Ident _id_ [15-18] "Int")
+                            Type _id_ [20-23]: Path: Path _id_ [20-23] (Ident _id_ [20-23] "Int")
+                        return: Type _id_ [28-31]: Path: Path _id_ [28-31] (Ident _id_ [28-31] "Int")"#]],
     );
 }
 

--- a/compiler/qsc_parse/src/ty.rs
+++ b/compiler/qsc_parse/src/ty.rs
@@ -20,7 +20,11 @@ use qsc_ast::ast::{
 
 pub(super) fn ty(s: &mut Scanner) -> Result<Ty> {
     let lo = s.peek().span.lo;
-    let mut lhs = base(s)?;
+    let lhs = base(s)?;
+    array_or_arrow(s, lhs, lo)
+}
+
+pub(super) fn array_or_arrow(s: &mut Scanner<'_>, mut lhs: Ty, lo: u32) -> Result<Ty> {
     loop {
         if let Some(()) = opt(s, array)? {
             lhs = Ty {


### PR DESCRIPTION
This updates the logic for parsing UDT field definitions to treat any `TyDef` with no named fields as a single field rather than a tuple of fields, and in that case allow that field's type to be an array or arrow type. This ends up being simpler and more consistent, since individual unnamed field entries are not directly addressable. All user-facing functionality thus remains the same: you access unnamed fields by using the unwrap (`!`) unary operator, while named fields are treated as separate entities tht are individually addressable.
Fixes #437