### PR TITLE
Shared settings should include tests for clippy scans

### DIFF
--- a/.vscode/settings.shared.json
+++ b/.vscode/settings.shared.json
@@ -3,6 +3,9 @@
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.check.extraArgs": [
+      "--all-targets"
+    ],
     "[css]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode",
       "editor.formatOnSave": true


### PR DESCRIPTION
The shared settings file correctly configures rust-analyzer to use clippy as the default check command, but should also include the setting that passes `--all-targets` as an additional command. This ensures that test code also gets clippy lints in the editor.