### PR TITLE
Two errors at EOF when parser error recovery occurs

### DIFF
--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -710,7 +710,9 @@ fn two_files_error_eof() {
 
     expect![[r#"
         Package:
-            Item 0 [16-32] (Public):
-                Namespace (Ident 0 [26-29] "Bar"): <empty>"#]]
+            Item 0 [0-15] (Public):
+                Namespace (Ident 0 [10-13] "Foo"): <empty>
+            Item 1 [16-32] (Public):
+                Namespace (Ident 1 [26-29] "Bar"): <empty>"#]]
     .assert_eq(&unit.package.to_string());
 }

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -707,4 +707,10 @@ fn two_files_error_eof() {
         .collect();
 
     assert_eq!(vec![("test1", Span { lo: 15, hi: 15 }),], errors);
+
+    expect![[r#"
+        Package:
+            Item 0 [16-32] (Public):
+                Namespace (Ident 0 [26-29] "Bar"): <empty>"#]]
+    .assert_eq(&unit.package.to_string());
 }

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -931,9 +931,18 @@ fn doc_without_item() {
             /// This is a doc comment.
         }",
         &expect![[r#"
-            Namespace _id_ [0-62] (Ident _id_ [10-11] "A"):
-                Item _id_ [26-62]:
-                    Err
+            Error(
+                Token(
+                    Close(
+                        Brace,
+                    ),
+                    Eof,
+                    Span {
+                        lo: 62,
+                        hi: 62,
+                    },
+                ),
+            )
 
             [
                 Error(
@@ -944,18 +953,6 @@ fn doc_without_item() {
                         ),
                         Span {
                             lo: 61,
-                            hi: 62,
-                        },
-                    ),
-                ),
-                Error(
-                    Token(
-                        Close(
-                            Brace,
-                        ),
-                        Eof,
-                        Span {
-                            lo: 62,
                             hi: 62,
                         },
                     ),
@@ -1010,67 +1007,48 @@ fn recover_callable_item() {
 }
 
 #[test]
-fn recover_unclosed_callable_item() {
+fn no_recover_unclosed_callable_item() {
     check_vec(
         parse_namespaces,
         "namespace A {
             function Foo() : Int {",
         &expect![[r#"
-            Namespace _id_ [0-48] (Ident _id_ [10-11] "A"):
-                Item _id_ [26-48]:
-                    Callable _id_ [26-48] (Function):
-                        name: Ident _id_ [35-38] "Foo"
-                        input: Pat _id_ [38-40]: Unit
-                        output: Type _id_ [43-46]: Path: Path _id_ [43-46] (Ident _id_ [43-46] "Int")
-                        body: Block: Block _id_ [47-48]: <empty>
-
-            [
-                Error(
-                    Token(
-                        Close(
-                            Brace,
-                        ),
-                        Eof,
-                        Span {
-                            lo: 48,
-                            hi: 48,
-                        },
+            Error(
+                Token(
+                    Close(
+                        Brace,
                     ),
+                    Eof,
+                    Span {
+                        lo: 48,
+                        hi: 48,
+                    },
                 ),
-            ]"#]],
+            )
+        "#]],
     );
 }
 
 #[test]
-fn recover_unclosed_namespace() {
+fn no_recover_unclosed_namespace() {
     check_vec(
         parse_namespaces,
         "namespace A {
             function Foo() : Int { 2 }",
         &expect![[r#"
-            Namespace _id_ [0-52] (Ident _id_ [10-11] "A"):
-                Item _id_ [26-52]:
-                    Callable _id_ [26-52] (Function):
-                        name: Ident _id_ [35-38] "Foo"
-                        input: Pat _id_ [38-40]: Unit
-                        output: Type _id_ [43-46]: Path: Path _id_ [43-46] (Ident _id_ [43-46] "Int")
-                        body: Block: Block _id_ [47-52]:
-                            Stmt _id_ [49-50]: Expr: Expr _id_ [49-50]: Lit: Int(2)
-
-            [
-                Error(
-                    Token(
-                        Close(
-                            Brace,
-                        ),
-                        Eof,
-                        Span {
-                            lo: 52,
-                            hi: 52,
-                        },
+            Error(
+                Token(
+                    Close(
+                        Brace,
                     ),
+                    Eof,
+                    Span {
+                        lo: 52,
+                        hi: 52,
+                    },
                 ),
-            ]"#]],
+            )
+        "#]],
     );
 }
 

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -931,18 +931,9 @@ fn doc_without_item() {
             /// This is a doc comment.
         }",
         &expect![[r#"
-            Error(
-                Token(
-                    Close(
-                        Brace,
-                    ),
-                    Eof,
-                    Span {
-                        lo: 62,
-                        hi: 62,
-                    },
-                ),
-            )
+            Namespace _id_ [0-62] (Ident _id_ [10-11] "A"):
+                Item _id_ [26-62]:
+                    Err
 
             [
                 Error(
@@ -953,6 +944,18 @@ fn doc_without_item() {
                         ),
                         Span {
                             lo: 61,
+                            hi: 62,
+                        },
+                    ),
+                ),
+                Error(
+                    Token(
+                        Close(
+                            Brace,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 62,
                             hi: 62,
                         },
                     ),
@@ -1007,48 +1010,67 @@ fn recover_callable_item() {
 }
 
 #[test]
-fn no_recover_unclosed_callable_item() {
+fn recover_unclosed_callable_item() {
     check_vec(
         parse_namespaces,
         "namespace A {
             function Foo() : Int {",
         &expect![[r#"
-            Error(
-                Token(
-                    Close(
-                        Brace,
+            Namespace _id_ [0-48] (Ident _id_ [10-11] "A"):
+                Item _id_ [26-48]:
+                    Callable _id_ [26-48] (Function):
+                        name: Ident _id_ [35-38] "Foo"
+                        input: Pat _id_ [38-40]: Unit
+                        output: Type _id_ [43-46]: Path: Path _id_ [43-46] (Ident _id_ [43-46] "Int")
+                        body: Block: Block _id_ [47-48]: <empty>
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Brace,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 48,
+                            hi: 48,
+                        },
                     ),
-                    Eof,
-                    Span {
-                        lo: 48,
-                        hi: 48,
-                    },
                 ),
-            )
-        "#]],
+            ]"#]],
     );
 }
 
 #[test]
-fn no_recover_unclosed_namespace() {
+fn recover_unclosed_namespace() {
     check_vec(
         parse_namespaces,
         "namespace A {
             function Foo() : Int { 2 }",
         &expect![[r#"
-            Error(
-                Token(
-                    Close(
-                        Brace,
+            Namespace _id_ [0-52] (Ident _id_ [10-11] "A"):
+                Item _id_ [26-52]:
+                    Callable _id_ [26-52] (Function):
+                        name: Ident _id_ [35-38] "Foo"
+                        input: Pat _id_ [38-40]: Unit
+                        output: Type _id_ [43-46]: Path: Path _id_ [43-46] (Ident _id_ [43-46] "Int")
+                        body: Block: Block _id_ [47-52]:
+                            Stmt _id_ [49-50]: Expr: Expr _id_ [49-50]: Lit: Int(2)
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Brace,
+                        ),
+                        Eof,
+                        Span {
+                            lo: 52,
+                            hi: 52,
+                        },
                     ),
-                    Eof,
-                    Span {
-                        lo: 52,
-                        hi: 52,
-                    },
                 ),
-            )
-        "#]],
+            ]"#]],
     );
 }
 

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -1037,18 +1037,6 @@ fn recover_unclosed_callable_item() {
                         },
                     ),
                 ),
-                Error(
-                    Token(
-                        Close(
-                            Brace,
-                        ),
-                        Eof,
-                        Span {
-                            lo: 48,
-                            hi: 48,
-                        },
-                    ),
-                ),
             ]"#]],
     );
 }

--- a/compiler/qsc_parse/src/prim.rs
+++ b/compiler/qsc_parse/src/prim.rs
@@ -195,9 +195,12 @@ pub(super) fn recovering<T>(
     match p(s) {
         Ok(value) => Ok(value),
         Err(error) if advanced(s, offset) => {
-            s.push_error(error);
-            s.recover(tokens);
-            Ok(default(s.span(offset)))
+            if s.recover(tokens) {
+                s.push_error(error);
+                Ok(default(s.span(offset)))
+            } else {
+                Err(error)
+            }
         }
         Err(error) => Err(error),
     }
@@ -207,9 +210,12 @@ pub(super) fn recovering_token(s: &mut Scanner, t: TokenKind) -> Result<()> {
     match token(s, t) {
         Ok(()) => Ok(()),
         Err(error) => {
-            s.push_error(error);
-            s.recover(&[t]);
-            Ok(())
+            if s.recover(&[t]) {
+                s.push_error(error);
+                Ok(())
+            } else {
+                Err(error)
+            }
         }
     }
 }

--- a/compiler/qsc_parse/src/prim.rs
+++ b/compiler/qsc_parse/src/prim.rs
@@ -195,12 +195,9 @@ pub(super) fn recovering<T>(
     match p(s) {
         Ok(value) => Ok(value),
         Err(error) if advanced(s, offset) => {
-            if s.recover(tokens) {
-                s.push_error(error);
-                Ok(default(s.span(offset)))
-            } else {
-                Err(error)
-            }
+            s.push_error(error);
+            s.recover(tokens);
+            Ok(default(s.span(offset)))
         }
         Err(error) => Err(error),
     }
@@ -210,12 +207,9 @@ pub(super) fn recovering_token(s: &mut Scanner, t: TokenKind) -> Result<()> {
     match token(s, t) {
         Ok(()) => Ok(()),
         Err(error) => {
-            if s.recover(&[t]) {
-                s.push_error(error);
-                Ok(())
-            } else {
-                Err(error)
-            }
+            s.push_error(error);
+            s.recover(&[t]);
+            Ok(())
         }
     }
 }

--- a/compiler/qsc_parse/src/scan.rs
+++ b/compiler/qsc_parse/src/scan.rs
@@ -20,6 +20,7 @@ pub(super) struct Scanner<'a> {
     tokens: Lexer<'a>,
     barriers: Vec<&'a [TokenKind]>,
     errors: Vec<Error>,
+    recovered_eof: bool,
     peek: Token,
     offset: u32,
 }
@@ -36,6 +37,7 @@ impl<'a> Scanner<'a> {
                 .into_iter()
                 .map(|e| Error(ErrorKind::Lex(e)))
                 .collect(),
+            recovered_eof: false,
             peek: peek.unwrap_or_else(|| eof(input.len())),
             offset: 0,
         }
@@ -83,17 +85,14 @@ impl<'a> Scanner<'a> {
     /// Tries to recover from a parse error by advancing tokens until any of the given recovery
     /// tokens, or a barrier token, is found. If a recovery token is found, it is consumed. If a
     /// barrier token is found first, it is not consumed.
-    /// Returns a Boolean indicated whether recover occurred before EOF.
-    pub(super) fn recover(&mut self, tokens: &[TokenKind]) -> bool {
+    pub(super) fn recover(&mut self, tokens: &[TokenKind]) {
         loop {
             let peek = self.peek.kind;
             if contains(peek, tokens) {
                 self.advance();
-                break true;
-            } else if self.barriers.iter().any(|&b| contains(peek, b)) {
-                break true;
-            } else if peek == TokenKind::Eof {
-                break false;
+                break;
+            } else if peek == TokenKind::Eof || self.barriers.iter().any(|&b| contains(peek, b)) {
+                break;
             } else {
                 self.advance();
             }
@@ -101,7 +100,11 @@ impl<'a> Scanner<'a> {
     }
 
     pub(super) fn push_error(&mut self, error: Error) {
-        self.errors.push(error);
+        let is_eof_err = matches!(error.0, ErrorKind::Token(_, TokenKind::Eof, _));
+        if !is_eof_err || !self.recovered_eof {
+            self.errors.push(error);
+            self.recovered_eof = self.recovered_eof || is_eof_err;
+        }
     }
 
     pub(super) fn into_errors(self) -> Vec<Error> {

--- a/compiler/qsc_parse/src/scan.rs
+++ b/compiler/qsc_parse/src/scan.rs
@@ -100,7 +100,10 @@ impl<'a> Scanner<'a> {
     }
 
     pub(super) fn push_error(&mut self, error: Error) {
-        let is_eof_err = matches!(error.0, ErrorKind::Token(_, TokenKind::Eof, _));
+        let is_eof_err = matches!(
+            error.0,
+            ErrorKind::Token(_, TokenKind::Eof, _) | ErrorKind::Rule(_, TokenKind::Eof, _)
+        );
         if !is_eof_err || !self.recovered_eof {
             self.errors.push(error);
             self.recovered_eof = self.recovered_eof || is_eof_err;


### PR DESCRIPTION
Avoids duplicate EOF errors by ignoring additonal EOFs when recovery has already happened.
Fixes #431