### PR TITLE
Return statements in lambdas are checked against the surrounding scope's expected return type

### DIFF
--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -329,11 +329,13 @@ impl<'a> Context<'a> {
             ExprKind::Lambda(kind, input, body) => {
                 let input = self.infer_pat(input);
                 let prev_ret_ty = self.return_ty.take();
-                let output_ty =
-                    self.inferrer.fresh_ty(TySource::not_divergent(body.span));
+                let output_ty = self.inferrer.fresh_ty(TySource::not_divergent(body.span));
                 self.return_ty = Some(output_ty);
                 let body_ty = self.infer_expr(body).ty;
-                let output_ty = self.return_ty.take().expect("return type should be present");
+                let output_ty = self
+                    .return_ty
+                    .take()
+                    .expect("return type should be present");
                 self.return_ty = prev_ret_ty;
                 if body_ty != Ty::UNIT {
                     self.inferrer.eq(body.span, output_ty.clone(), body_ty);

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -38,7 +38,7 @@ struct Context<'a> {
     names: &'a Names,
     globals: &'a HashMap<ItemId, Scheme>,
     table: &'a mut Table,
-    return_ty: Option<&'a Ty>,
+    return_ty: Option<Ty>,
     typed_holes: Vec<(NodeId, Span)>,
     new: Vec<NodeId>,
     inferrer: &'a mut Inferrer,
@@ -77,11 +77,11 @@ impl<'a> Context<'a> {
             self.inferrer.eq(input.span, expected, actual);
         }
 
-        self.return_ty = Some(spec.output);
+        self.return_ty = Some(spec.output.clone());
         let block = self.infer_block(spec.block);
         if let Some(return_ty) = self.return_ty.take() {
             let span = spec.block.stmts.last().map_or(spec.block.span, |s| s.span);
-            self.inferrer.eq(span, return_ty.clone(), block.ty);
+            self.inferrer.eq(span, return_ty, block.ty);
         }
     }
 
@@ -328,11 +328,20 @@ impl<'a> Context<'a> {
             }
             ExprKind::Lambda(kind, input, body) => {
                 let input = self.infer_pat(input);
-                let body = self.infer_expr(body).ty;
+                let prev_ret_ty = self.return_ty.take();
+                let output_ty =
+                    self.inferrer.fresh_ty(TySource::not_divergent(body.span));
+                self.return_ty = Some(output_ty);
+                let body_ty = self.infer_expr(body).ty;
+                let output_ty = self.return_ty.take().expect("return type should be present");
+                self.return_ty = prev_ret_ty;
+                if body_ty != Ty::UNIT {
+                    self.inferrer.eq(body.span, output_ty.clone(), body_ty);
+                }
                 converge(Ty::Arrow(Box::new(Arrow {
                     kind: convert::callable_kind_from_ast(*kind),
                     input: Box::new(input),
-                    output: Box::new(body),
+                    output: Box::new(output_ty),
                     functors: self.inferrer.fresh_functor(),
                 })))
             }

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -338,6 +338,8 @@ impl<'a> Context<'a> {
                     .expect("return type should be present");
                 self.return_ty = prev_ret_ty;
                 if body_ty != Ty::UNIT {
+                    // Only when the type of the body is not `UNIT` do we need to unify with the inferred output type.
+                    // Otherwise we'd get spurious errors from lambdas that use explicit return-expr rather than implicit.
                     self.inferrer.eq(body.span, output_ty.clone(), body_ty);
                 }
                 converge(Ty::Arrow(Box::new(Arrow {

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2329,6 +2329,38 @@ fn infinite() {
 }
 
 #[test]
+fn lambda_inner_return() {
+    check(
+        indoc! {"
+            namespace A {
+                function Foo() : Unit {
+                    let f = () -> {
+                        return 42;
+                    };
+                    let r = f();
+                }
+            }
+        "},
+        "",
+        &expect![[r#"
+            #6 30-32 "()" : Unit
+            #10 40-126 "{\n        let f = () -> {\n            return 42;\n        };\n        let r = f();\n    }" : Unit
+            #12 54-55 "f" : (Unit -> Int)
+            #14 58-98 "() -> {\n            return 42;\n        }" : (Unit -> Int)
+            #15 58-60 "()" : Unit
+            #16 64-98 "{\n            return 42;\n        }" : Int
+            #17 64-98 "{\n            return 42;\n        }" : Int
+            #19 78-87 "return 42" : Unit
+            #20 85-87 "42" : Int
+            #22 112-113 "r" : Int
+            #24 116-119 "f()" : Int
+            #25 116-117 "f" : (Unit -> Int)
+            #28 117-119 "()" : Unit
+        "#]],
+    );
+}
+
+#[test]
 fn lambda_adj() {
     check(
         indoc! {"


### PR DESCRIPTION
Fixes #510