### PR TITLE
Add ability to set target profile in language service

### DIFF
--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -34,6 +34,7 @@ pub struct LanguageService<'a> {
     diagnostics_receiver: Box<DiagnosticsReceiver<'a>>,
 }
 
+#[derive(Debug)]
 struct WorkspaceConfiguration {
     pub target_profile: TargetProfile,
     pub package_type: PackageType,
@@ -192,6 +193,7 @@ impl<'a> LanguageService<'a> {
             self.configuration.target_profile = target_profile;
         }
 
+        trace!("need_recompile after configuration update: {need_recompile:?}");
         need_recompile
     }
 
@@ -215,6 +217,11 @@ impl<'a> LanguageService<'a> {
 
         // Now recompile everything with current settings
         for source in sources {
+            trace!(
+                "recompiling {:?} with settings {:?}",
+                source.0,
+                self.configuration
+            );
             self.update_document(&source.0, source.1, &source.2);
         }
     }

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use qsc::{PackageType, TargetProfile};
+
+/// Workspace configuration
+#[derive(Clone, Debug, Default)]
+pub struct WorkspaceConfigurationUpdate {
+    pub target_profile: Option<TargetProfile>,
+    pub package_type: Option<PackageType>,
+}
+
 /// Represents a span of text used by the Language Server API
 #[derive(Debug, PartialEq)]
 pub struct Span {

--- a/language_service/src/qsc_utils.rs
+++ b/language_service/src/qsc_utils.rs
@@ -23,6 +23,7 @@ pub(crate) fn compile_document(
     source_name: &str,
     source_contents: &str,
     package_type: PackageType,
+    target_profile: TargetProfile,
 ) -> Compilation {
     let mut package_store = PackageStore::new(compile::core());
     let std_package_id = package_store.insert(compile::std(&package_store, TargetProfile::Full));
@@ -34,7 +35,7 @@ pub(crate) fn compile_document(
         &[std_package_id],
         source_map,
         package_type,
-        TargetProfile::Full,
+        target_profile,
     );
     Compilation {
         package_store,

--- a/language_service/src/qsc_utils.rs
+++ b/language_service/src/qsc_utils.rs
@@ -26,7 +26,7 @@ pub(crate) fn compile_document(
     target_profile: TargetProfile,
 ) -> Compilation {
     let mut package_store = PackageStore::new(compile::core());
-    let std_package_id = package_store.insert(compile::std(&package_store, TargetProfile::Full));
+    let std_package_id = package_store.insert(compile::std(&package_store, target_profile));
 
     // Source map only contains the current document.
     let source_map = SourceMap::new([(source_name.into(), source_contents.into())], None);

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -198,6 +198,78 @@ fn target_profile_update_fixes_error() {
     );
 }
 
+#[test]
+fn target_profile_update_causes_error_in_stdlib() {
+    let errors = RefCell::new(Vec::new());
+    let mut ls = new_language_service(&errors);
+
+    ls.update_document(
+        "foo.qs",
+        1,
+        r#"namespace Foo { @EntryPoint() operation Main() : Unit { use q = Qubit(); let r = M(q); let b = Microsoft.Quantum.Convert.ResultAsBool(r); } }"#,
+    );
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    1,
+                    [],
+                ),
+            ]
+        "#]],
+    );
+
+    ls.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: Some(TargetProfile::Base),
+        package_type: None,
+    });
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    1,
+                    [
+                        Frontend(
+                            Error(
+                                Resolve(
+                                    NotAvailable(
+                                        "ResultAsBool",
+                                        "Microsoft.Quantum.Convert.ResultAsBool",
+                                        Span {
+                                            lo: 121,
+                                            hi: 133,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Type(
+                                    Error(
+                                        AmbiguousTy(
+                                            Span {
+                                                lo: 95,
+                                                hi: 136,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+}
+
 fn new_language_service(
     received: &RefCell<Vec<(String, u32, Vec<compile::Error>)>>,
 ) -> LanguageService<'_> {

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::{protocol::WorkspaceConfigurationUpdate, LanguageService};
+use expect_test::{expect, Expect};
+use qsc::{compile, PackageType, TargetProfile};
+use std::cell::RefCell;
+
+#[test]
+fn no_error() {
+    let errors = RefCell::new(Vec::new());
+    let mut ls = new_language_service(&errors);
+
+    ls.update_document(
+        "foo.qs",
+        1,
+        "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
+    );
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+        [
+            (
+                "foo.qs",
+                1,
+                [],
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn compile_error() {
+    let errors = RefCell::new(Vec::new());
+    let mut ls = new_language_service(&errors);
+
+    ls.update_document("foo.qs", 1, "badsyntax");
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+        [
+            (
+                "foo.qs",
+                1,
+                [
+                    Frontend(
+                        Error(
+                            Parse(
+                                Error(
+                                    Token(
+                                        Eof,
+                                        Ident,
+                                        Span {
+                                            lo: 0,
+                                            hi: 9,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn package_type_update_causes_error() {
+    let errors = RefCell::new(Vec::new());
+    let mut ls = new_language_service(&errors);
+
+    ls.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: None,
+        package_type: Some(PackageType::Lib),
+    });
+
+    ls.update_document("foo.qs", 1, "namespace Foo { operation Main() : Unit {} }");
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+        [
+            (
+                "foo.qs",
+                1,
+                [],
+            ),
+        ]
+    "#]],
+    );
+
+    ls.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: None,
+        package_type: Some(PackageType::Exe),
+    });
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    1,
+                    [
+                        Pass(
+                            EntryPoint(
+                                NotFound,
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn target_profile_update_fixes_error() {
+    let errors = RefCell::new(Vec::new());
+    let mut ls = new_language_service(&errors);
+
+    ls.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: Some(TargetProfile::Base),
+        package_type: Some(PackageType::Lib),
+    });
+
+    ls.update_document(
+        "foo.qs",
+        1,
+        r#"namespace Foo { operation Main() : Unit { if Zero == Zero { Message("hi") } } }"#,
+    );
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+    [
+        (
+            "foo.qs",
+            1,
+            [
+                Pass(
+                    BaseProfCk(
+                        ResultComparison(
+                            Span {
+                                lo: 45,
+                                hi: 57,
+                            },
+                        ),
+                    ),
+                ),
+                Pass(
+                    BaseProfCk(
+                        ResultLiteral(
+                            Span {
+                                lo: 45,
+                                hi: 49,
+                            },
+                        ),
+                    ),
+                ),
+                Pass(
+                    BaseProfCk(
+                        ResultLiteral(
+                            Span {
+                                lo: 53,
+                                hi: 57,
+                            },
+                        ),
+                    ),
+                ),
+            ],
+        ),
+    ]
+"#]],
+    );
+
+    ls.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: Some(TargetProfile::Full),
+        package_type: None,
+    });
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+        [
+            (
+                "foo.qs",
+                1,
+                [],
+            ),
+        ]
+    "#]],
+    );
+}
+
+fn new_language_service(
+    received: &RefCell<Vec<(String, u32, Vec<compile::Error>)>>,
+) -> LanguageService<'_> {
+    LanguageService::new(|uri: &str, version: u32, errors: &[compile::Error]| {
+        let mut v = received.borrow_mut();
+        v.push((uri.to_string(), version, errors.to_vec()));
+    })
+}
+
+fn expect_errors(errors: &RefCell<Vec<(String, u32, Vec<compile::Error>)>>, expected: &Expect) {
+    expected.assert_debug_eq(&errors.borrow());
+    errors.borrow_mut().clear();
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -25,7 +25,8 @@
     "build": "npm run generate && npm run build:tsc",
     "generate": "node generate_katas_content.js && node generate_samples_content.js",
     "build:tsc": "node ../node_modules/typescript/bin/tsc -p ./src/tsconfig.json",
-    "tsc:watch": "node ../node_modules/typescript/bin/tsc -p ./src/tsconfig.json --watch"
+    "tsc:watch": "node ../node_modules/typescript/bin/tsc -p ./src/tsconfig.json --watch",
+    "test": "node --test"
   },
   "type": "module",
   "files": [

--- a/npm/src/compiler/compiler.ts
+++ b/npm/src/compiler/compiler.ts
@@ -56,7 +56,7 @@ export class Compiler implements ICompiler {
         diags = errors;
       }
     );
-    languageService.update_document("code", 1, code, true /* exe */);
+    languageService.update_document("code", 1, code);
     return mapDiagnostics(diags, code);
   }
 

--- a/npm/src/language-service/language-service.ts
+++ b/npm/src/language-service/language-service.ts
@@ -98,7 +98,9 @@ export class QSharpLanguageService implements ILanguageService {
   ): Promise<ICompletionList> {
     const code = this.code[documentUri];
     if (code === undefined) {
-      log.error(`expected ${documentUri} to be in the document map`);
+      log.error(
+        `getCompletions: expected ${documentUri} to be in the document map`
+      );
       return { items: [] };
     }
     const convertedOffset = mapUtf16UnitsToUtf8Units([offset], code)[offset];
@@ -125,7 +127,7 @@ export class QSharpLanguageService implements ILanguageService {
   ): Promise<IHover | undefined> {
     const code = this.code[documentUri];
     if (code === undefined) {
-      log.error(`expected ${documentUri} to be in the document map`);
+      log.error(`getHover: expected ${documentUri} to be in the document map`);
       return undefined;
     }
     const convertedOffset = mapUtf16UnitsToUtf8Units([offset], code)[offset];
@@ -147,7 +149,9 @@ export class QSharpLanguageService implements ILanguageService {
   ): Promise<IDefinition | undefined> {
     let code = this.code[documentUri];
     if (code === undefined) {
-      log.error(`expected ${documentUri} to be in the document map`);
+      log.error(
+        `getDefinition: expected ${documentUri} to be in the document map`
+      );
       return undefined;
     }
     const convertedOffset = mapUtf16UnitsToUtf8Units([offset], code)[offset];
@@ -163,7 +167,7 @@ export class QSharpLanguageService implements ILanguageService {
       if (url.protocol === qsharpLibraryUriScheme + ":") {
         code = wasm.get_library_source_content(url.pathname);
         if (code === undefined) {
-          log.error(`expected ${url} to be in the library`);
+          log.error(`getDefinition: expected ${url} to be in the library`);
           return undefined;
         }
       }
@@ -195,15 +199,16 @@ export class QSharpLanguageService implements ILanguageService {
   onDiagnostics(uri: string, version: number, diagnostics: IDiagnostic[]) {
     try {
       const code = this.code[uri];
-      if (code === undefined) {
-        log.error(`expected ${uri} to be in the document map`);
+      const empty = diagnostics.length === 0;
+      if (code === undefined && !empty) {
+        log.error(`onDiagnostics: expected ${uri} to be in the document map`);
         return;
       }
       const event = new Event("diagnostics") as LanguageServiceEvent & Event;
       event.detail = {
         uri,
         version,
-        diagnostics: mapDiagnostics(diagnostics, code),
+        diagnostics: empty ? [] : mapDiagnostics(diagnostics, code as string),
       };
       this.eventHandler.dispatchEvent(event);
     } catch (e) {

--- a/npm/src/language-service/language-service.ts
+++ b/npm/src/language-service/language-service.ts
@@ -8,6 +8,7 @@ import type {
   IHover,
   IDefinition,
   LanguageService,
+  IWorkspaceConfiguration,
 } from "../../lib/node/qsc_wasm.cjs";
 import { log } from "../log.js";
 import {
@@ -32,12 +33,8 @@ export type LanguageServiceEvent = {
 // These need to be async/promise results for when communicating across a WebWorker, however
 // for running the compiler in the same thread the result will be synchronous (a resolved promise).
 export interface ILanguageService {
-  updateDocument(
-    uri: string,
-    version: number,
-    code: string,
-    isExe: boolean
-  ): Promise<void>;
+  updateConfiguration(config: IWorkspaceConfiguration): Promise<void>;
+  updateDocument(uri: string, version: number, code: string): Promise<void>;
   closeDocument(uri: string): Promise<void>;
   getCompletions(documentUri: string, offset: number): Promise<ICompletionList>;
   getHover(documentUri: string, offset: number): Promise<IHover | undefined>;
@@ -77,14 +74,17 @@ export class QSharpLanguageService implements ILanguageService {
     );
   }
 
+  async updateConfiguration(config: IWorkspaceConfiguration): Promise<void> {
+    this.languageService.update_configuration(config);
+  }
+
   async updateDocument(
     documentUri: string,
     version: number,
-    code: string,
-    isExe: boolean
+    code: string
   ): Promise<void> {
     this.code[documentUri] = code;
-    this.languageService.update_document(documentUri, version, code, isExe);
+    this.languageService.update_document(documentUri, version, code);
   }
 
   async closeDocument(documentUri: string): Promise<void> {

--- a/npm/src/language-service/language-service.ts
+++ b/npm/src/language-service/language-service.ts
@@ -201,6 +201,12 @@ export class QSharpLanguageService implements ILanguageService {
       const code = this.code[uri];
       const empty = diagnostics.length === 0;
       if (code === undefined && !empty) {
+        // We need the contents of the document to convert error offsets to utf16.
+        // But the contents aren't available after a document is closed.
+        // It is possible to get a diagnostics event after a document is closed,
+        // but it will be done with an empty array, to clear the diagnostics.
+        // In that case, it's ok not to have the document contents available,
+        // because there are no offsets to convert.
         log.error(`onDiagnostics: expected ${uri} to be in the document map`);
         return;
       }

--- a/npm/src/language-service/worker-proxy.ts
+++ b/npm/src/language-service/worker-proxy.ts
@@ -12,6 +12,7 @@ import {
 import { ILanguageService, LanguageServiceEvent } from "./language-service.js";
 
 const requests: MethodMap<ILanguageService> = {
+  updateConfiguration: "request",
   updateDocument: "request",
   closeDocument: "request",
   getCompletions: "request",

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -468,8 +468,7 @@ test("language service diagnostics", async () => {
         let m1 = M(q1);
         return [m1];
     }
-}`,
-    true // PackageType "exe"
+}`
   );
   assert(gotDiagnostics);
 });
@@ -496,12 +495,49 @@ test("language service diagnostics - web worker", async () => {
         let m1 = M(q1);
         return [m1];
     }
-}`,
-    true // PackageType "exe"
+}`
   );
   languageService.terminate();
   assert(gotDiagnostics);
 });
+
+test("language service configuration update", async () => {
+  const languageService = getLanguageServiceWorker();
+  let gotDiagnostics = false;
+  let expectedMessages = [
+    "entry point not found\n\nhelp: a single callable with the `@EntryPoint()` attribute must be present if no entry expression is provided",
+  ];
+  languageService.addEventListener("diagnostics", (event) => {
+    gotDiagnostics = true;
+    assert.equal(event.type, "diagnostics");
+    assert.equal(event.detail.diagnostics.length, expectedMessages.length);
+    event.detail.diagnostics.map((d, i) =>
+      assert.equal(d.message, expectedMessages[i])
+    );
+  });
+  await languageService.updateDocument(
+    "test.qs",
+    1,
+    `namespace Sample {
+    operation main() : Unit {
+    }
+}`
+  );
+  // Above document should have generated a missing entrypoint error
+  assert(gotDiagnostics);
+
+  // Reset expectations
+  gotDiagnostics = false;
+  expectedMessages = [];
+
+  await languageService.updateConfiguration({ packageType: "lib" });
+
+  // Updating the config should cause another diagnostics event clearing the errors
+  assert(gotDiagnostics);
+
+  languageService.terminate();
+});
+
 async function testCompilerError(useWorker) {
   const compiler = useWorker ? getCompilerWorker() : getCompiler();
   if (useWorker) {

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -532,10 +532,10 @@ test("language service configuration update", async () => {
 
   await languageService.updateConfiguration({ packageType: "lib" });
 
+  languageService.terminate();
+
   // Updating the config should cause another diagnostics event clearing the errors
   assert(gotDiagnostics);
-
-  languageService.terminate();
 });
 
 async function testCompilerError(useWorker) {

--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -181,8 +181,7 @@ export function Editor(props: {
       await props.languageService.updateDocument(
         srcModel.uri.toString(),
         srcModel.getVersionId(),
-        srcModel.getValue(),
-        !props.kataExercise // Kata exercises are always libraries
+        srcModel.getValue()
       );
       const measure = performance.measure(
         "update-document",
@@ -205,6 +204,10 @@ export function Editor(props: {
   }, []);
 
   useEffect(() => {
+    props.languageService.updateConfiguration({
+      packageType: props.kataExercise ? "lib" : "exe",
+    });
+
     function onDiagnostics(evt: LanguageServiceEvent) {
       const diagnostics = evt.detail.diagnostics;
       errMarks.current.checkDiags = diagnostics;
@@ -218,7 +221,7 @@ export function Editor(props: {
       log.info("Removing diagnostics listener");
       props.languageService.removeEventListener("diagnostics", onDiagnostics);
     };
-  }, [props.languageService]);
+  }, [props.languageService, props.kataExercise]);
 
   useEffect(() => {
     const theEditor = editor.current;

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -143,8 +143,7 @@ function registerDocumentUpdateHandlers(languageService: ILanguageService) {
       languageService.updateDocument(
         document.uri.toString(),
         document.version,
-        document.getText(),
-        true // PackageType "exe"
+        document.getText()
       );
     }
   }

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -33,17 +33,25 @@ impl LanguageService {
         LanguageService(inner)
     }
 
-    pub fn update_document(&mut self, uri: &str, version: u32, text: &str, is_exe: bool) {
-        self.0.update_document(
-            uri,
-            version,
-            text,
-            if is_exe {
-                qsc::PackageType::Exe
-            } else {
-                qsc::PackageType::Lib
-            },
-        );
+    pub fn update_configuration(&mut self, config: IWorkspaceConfiguration) {
+        let config: WorkspaceConfiguration = config.into();
+        self.0
+            .update_configuration(&qsls::protocol::WorkspaceConfigurationUpdate {
+                target_profile: config.targetProfile.map(|s| match s.as_str() {
+                    "base" => qsc::TargetProfile::Base,
+                    "full" => qsc::TargetProfile::Full,
+                    _ => panic!("invalid target profile"),
+                }),
+                package_type: config.packageType.map(|s| match s.as_str() {
+                    "lib" => qsc::PackageType::Lib,
+                    "exe" => qsc::PackageType::Exe,
+                    _ => panic!("invalid package type"),
+                }),
+            })
+    }
+
+    pub fn update_document(&mut self, uri: &str, version: u32, text: &str) {
+        self.0.update_document(uri, version, text);
     }
 
     pub fn close_document(&mut self, uri: &str) {
@@ -109,6 +117,19 @@ impl LanguageService {
             .into()
         })
     }
+}
+
+serializable_type! {
+    WorkspaceConfiguration,
+    {
+        pub targetProfile: Option<String>,
+        pub packageType: Option<String>,
+    },
+    r#"export interface IWorkspaceConfiguration {
+        targetProfile?: "full" | "base";
+        packageType?: "exe" | "lib";
+    }"#,
+    IWorkspaceConfiguration
 }
 
 serializable_type! {


### PR DESCRIPTION
Introducing a `WorkspaceConfiguration` concept to the language service which provides a central means of setting compiler options, including `TargetProfile` as well as `PackageType`, which we were previously passing in `update_document`.

In a future PR, these settings can be wired up to VS Code settings or to a VS Code command. (Draft PR #663)

I'm keeping compatibility with LSP in mind. The new `update_configuration` method carries the semantics of the [`workspace/didChangeConfiguration`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeConfiguration) notification in LSP. 

We don't currently support per-document settings. I'm not sure if we would want to, given our current user scenarios (where would we persist such a setting in VS Code?). As we flesh out Q# "projects" and other ways of passing compiler settings, we can work those into the language service as well.