### PR TITLE
Cancel queued CI workflows if PR gets updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Cancel in-progress run when a pull request is updated
+# Code taken from:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN_VERSION: "1.72"


### PR DESCRIPTION
Problem: 

The MacOS agent experiences extreme queue contention today.

- Multiple PRs are in progress, running checks at the same time.
- Person A's PR's checks complete, Person A merges their PR. This causes checks to be queued on `main`.
- Person B's checks are still in progress.
- Person B notices their branch is outdated and will eventually fail to merge. So they hit "Update branch". This queues up yet _another_ set of checks. These new checks are now queued _behind_ their existing checks _and_ behind the `main` checks, delaying Person B even further.

The delays are compounded as we hit "update branch" over and over again hoping to get our PRs in.

Mitigation: cancel any existing workflows for a PR if that PR gets updated.