### PR TITLE
Recover from missing semicolons

### DIFF
--- a/compiler/qsc_parse/src/item.rs
+++ b/compiler/qsc_parse/src/item.rs
@@ -320,7 +320,7 @@ fn parse_callable_body(s: &mut Scanner) -> Result<CallableBody> {
         let specs = many(s, parse_spec_decl)?;
         if specs.is_empty() {
             let stmts = stmt::parse_many(s)?;
-            check_semis(&stmts)?;
+            check_semis(s, &stmts);
             recovering_token(s, TokenKind::Close(Delim::Brace))?;
             Ok(CallableBody::Block(Box::new(Block {
                 id: NodeId::default(),

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -479,15 +479,29 @@ fn function_body_missing_semi_between_stmts() {
         parse,
         "function Foo() : () { f(x) g(y) }",
         &expect![[r#"
-            Error(
-                MissingSemi(
-                    Span {
-                        lo: 26,
-                        hi: 26,
-                    },
+            Item _id_ [0-33]:
+                Callable _id_ [0-33] (Function):
+                    name: Ident _id_ [9-12] "Foo"
+                    input: Pat _id_ [12-14]: Unit
+                    output: Type _id_ [17-19]: Unit
+                    body: Block: Block _id_ [20-33]:
+                        Stmt _id_ [22-26]: Expr: Expr _id_ [22-26]: Call:
+                            Expr _id_ [22-23]: Path: Path _id_ [22-23] (Ident _id_ [22-23] "f")
+                            Expr _id_ [23-26]: Paren: Expr _id_ [24-25]: Path: Path _id_ [24-25] (Ident _id_ [24-25] "x")
+                        Stmt _id_ [27-31]: Expr: Expr _id_ [27-31]: Call:
+                            Expr _id_ [27-28]: Path: Path _id_ [27-28] (Ident _id_ [27-28] "g")
+                            Expr _id_ [28-31]: Paren: Expr _id_ [29-30]: Path: Path _id_ [29-30] (Ident _id_ [29-30] "y")
+
+            [
+                Error(
+                    MissingSemi(
+                        Span {
+                            lo: 26,
+                            hi: 26,
+                        },
+                    ),
                 ),
-            )
-        "#]],
+            ]"#]],
     );
 }
 

--- a/compiler/qsc_parse/src/prim.rs
+++ b/compiler/qsc_parse/src/prim.rs
@@ -203,6 +203,17 @@ pub(super) fn recovering<T>(
     }
 }
 
+pub(super) fn recovering_semi(s: &mut Scanner) -> Result<()> {
+    match token(s, TokenKind::Semi) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            s.push_error(error);
+            // no recovery, just move on to the next token
+            Ok(())
+        }
+    }
+}
+
 pub(super) fn recovering_token(s: &mut Scanner, t: TokenKind) -> Result<()> {
     match token(s, t) {
         Ok(()) => Ok(()),

--- a/compiler/qsc_parse/src/stmt.rs
+++ b/compiler/qsc_parse/src/stmt.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::{
     lex::{Delim, TokenKind},
-    prim::{barrier, recovering, recovering_token},
+    prim::{barrier, recovering, recovering_semi, recovering_token},
     ErrorKind,
 };
 use qsc_ast::ast::{
@@ -91,7 +91,7 @@ fn parse_local(s: &mut Scanner) -> Result<Box<StmtKind>> {
     let lhs = pat(s)?;
     token(s, TokenKind::Eq)?;
     let rhs = expr(s)?;
-    token(s, TokenKind::Semi)?;
+    recovering_semi(s)?;
     Ok(Box::new(StmtKind::Local(mutability, lhs, rhs)))
 }
 
@@ -113,7 +113,7 @@ fn parse_qubit(s: &mut Scanner) -> Result<Box<StmtKind>> {
     let rhs = parse_qubit_init(s)?;
     let block = opt(s, parse_block)?;
     if block.is_none() {
-        token(s, TokenKind::Semi)?;
+        recovering_semi(s)?;
     }
 
     Ok(Box::new(StmtKind::Qubit(source, lhs, rhs, block)))

--- a/compiler/qsc_parse/src/stmt/tests.rs
+++ b/compiler/qsc_parse/src/stmt/tests.rs
@@ -452,15 +452,24 @@ fn call_no_semi_call() {
         parse_block,
         "{ f(x) g(y) }",
         &expect![[r#"
-            Error(
-                MissingSemi(
-                    Span {
-                        lo: 6,
-                        hi: 6,
-                    },
+            Block _id_ [0-13]:
+                Stmt _id_ [2-6]: Expr: Expr _id_ [2-6]: Call:
+                    Expr _id_ [2-3]: Path: Path _id_ [2-3] (Ident _id_ [2-3] "f")
+                    Expr _id_ [3-6]: Paren: Expr _id_ [4-5]: Path: Path _id_ [4-5] (Ident _id_ [4-5] "x")
+                Stmt _id_ [7-11]: Expr: Expr _id_ [7-11]: Call:
+                    Expr _id_ [7-8]: Path: Path _id_ [7-8] (Ident _id_ [7-8] "g")
+                    Expr _id_ [8-11]: Paren: Expr _id_ [9-10]: Path: Path _id_ [9-10] (Ident _id_ [9-10] "y")
+
+            [
+                Error(
+                    MissingSemi(
+                        Span {
+                            lo: 6,
+                            hi: 6,
+                        },
+                    ),
                 ),
-            )
-        "#]],
+            ]"#]],
     );
 }
 
@@ -491,15 +500,29 @@ fn expr_plus_if_no_semi() {
         parse_block,
         "{ 1 + if true { 2 } else { 3 } f(x) }",
         &expect![[r#"
-            Error(
-                MissingSemi(
-                    Span {
-                        lo: 30,
-                        hi: 30,
-                    },
+            Block _id_ [0-37]:
+                Stmt _id_ [2-30]: Expr: Expr _id_ [2-30]: BinOp (Add):
+                    Expr _id_ [2-3]: Lit: Int(1)
+                    Expr _id_ [6-30]: If:
+                        Expr _id_ [9-13]: Lit: Bool(true)
+                        Block _id_ [14-19]:
+                            Stmt _id_ [16-17]: Expr: Expr _id_ [16-17]: Lit: Int(2)
+                        Expr _id_ [20-30]: Expr Block: Block _id_ [25-30]:
+                            Stmt _id_ [27-28]: Expr: Expr _id_ [27-28]: Lit: Int(3)
+                Stmt _id_ [31-35]: Expr: Expr _id_ [31-35]: Call:
+                    Expr _id_ [31-32]: Path: Path _id_ [31-32] (Ident _id_ [31-32] "f")
+                    Expr _id_ [32-35]: Paren: Expr _id_ [33-34]: Path: Path _id_ [33-34] (Ident _id_ [33-34] "x")
+
+            [
+                Error(
+                    MissingSemi(
+                        Span {
+                            lo: 30,
+                            hi: 30,
+                        },
+                    ),
                 ),
-            )
-        "#]],
+            ]"#]],
     );
 }
 

--- a/compiler/qsc_parse/src/stmt/tests.rs
+++ b/compiler/qsc_parse/src/stmt/tests.rs
@@ -209,17 +209,23 @@ fn stmt_missing_semi() {
         parse,
         "let x = 2",
         &expect![[r#"
-            Error(
-                Token(
-                    Semi,
-                    Eof,
-                    Span {
-                        lo: 9,
-                        hi: 9,
-                    },
+            Stmt _id_ [0-9]: Local (Immutable):
+                Pat _id_ [4-5]: Bind:
+                    Ident _id_ [4-5] "x"
+                Expr _id_ [8-9]: Lit: Int(2)
+
+            [
+                Error(
+                    Token(
+                        Semi,
+                        Eof,
+                        Span {
+                            lo: 9,
+                            hi: 9,
+                        },
+                    ),
                 ),
-            )
-        "#]],
+            ]"#]],
     );
 }
 
@@ -682,6 +688,55 @@ fn recover_statements_before_and_after() {
                         Span {
                             lo: 67,
                             hi: 70,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn recover_missing_semicolon() {
+    check(
+        parse_block,
+        "{
+            let x = 2 + 2;
+            let y = Foo(x)
+            let z = x * 3;
+            z
+        }",
+        &expect![[r#"
+            Block _id_ [0-106]:
+                Stmt _id_ [14-28]: Local (Immutable):
+                    Pat _id_ [18-19]: Bind:
+                        Ident _id_ [18-19] "x"
+                    Expr _id_ [22-27]: BinOp (Add):
+                        Expr _id_ [22-23]: Lit: Int(2)
+                        Expr _id_ [26-27]: Lit: Int(2)
+                Stmt _id_ [41-55]: Local (Immutable):
+                    Pat _id_ [45-46]: Bind:
+                        Ident _id_ [45-46] "y"
+                    Expr _id_ [49-55]: Call:
+                        Expr _id_ [49-52]: Path: Path _id_ [49-52] (Ident _id_ [49-52] "Foo")
+                        Expr _id_ [52-55]: Paren: Expr _id_ [53-54]: Path: Path _id_ [53-54] (Ident _id_ [53-54] "x")
+                Stmt _id_ [68-82]: Local (Immutable):
+                    Pat _id_ [72-73]: Bind:
+                        Ident _id_ [72-73] "z"
+                    Expr _id_ [76-81]: BinOp (Mul):
+                        Expr _id_ [76-77]: Path: Path _id_ [76-77] (Ident _id_ [76-77] "x")
+                        Expr _id_ [80-81]: Lit: Int(3)
+                Stmt _id_ [95-96]: Expr: Expr _id_ [95-96]: Path: Path _id_ [95-96] (Ident _id_ [95-96] "z")
+
+            [
+                Error(
+                    Token(
+                        Semi,
+                        Keyword(
+                            Let,
+                        ),
+                        Span {
+                            lo: 68,
+                            hi: 71,
                         },
                     ),
                 ),


### PR DESCRIPTION
This is to lay the groundwork for signature help.

We should be able to parse just enough to know that the below is a function call, even before the user has typed the trailing semicolon. This way signature help can provide accurate parameter info when invoked at the cursor shown below.

```qsharp
namespace MyQuantumProgram {
    open Microsoft.Quantum.Intrinsic;

    operation Foo(x: Int, y: Double, z: String) : Unit {}

    @EntryPoint()
    operation Main() : Unit {
        Foo(↘️)
        let x = 3;
    }
}

```

cc @ScottCarda-MS 