### PR TITLE
Add target profile setting in VS Code

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -59,6 +59,12 @@
         "category": "Debug",
         "enablement": "!inDebugMode",
         "icon": "$(play)"
+      },
+      {
+        "command": "quantum-set-target",
+        "category": "Q#",
+        "title": "Set the Azure Quantum QIR target profile",
+        "enablement": "resourceLangId == qsharp"
       }
     ],
     "breakpoints": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -125,7 +125,25 @@
           }
         }
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Q#",
+      "properties": {
+        "qsharp.targetProfile": {
+          "type": "string",
+          "default": "full",
+          "enum": [
+            "full",
+            "base"
+          ],
+          "enumDescriptions": [
+            "The full set of capabilities required to run any Q# program. This option maps to the Full Profile as defined by the QIR specification.",
+            "The minimal set of capabilities required to run a quantum program. This option maps to the Base Profile as defined by the QIR specification."
+          ],
+          "description": "Setting the target profile allows the Q# extension to generate programs that are compatible with a specific target. The target is the hardware or simulator which will be used to run the Q# program. The target profile is a description of a target's capabilities."
+        }
+      }
+    }
   },
   "scripts": {
     "tsc:check": "node ../node_modules/typescript/bin/tsc -p ./tsconfig.json",

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -1,18 +1,29 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DocumentFilter, TextDocument, Uri } from "vscode";
+import { DocumentFilter, TextDocument, Uri, languages } from "vscode";
 
 export const qsharpLanguageId = "qsharp";
+
 // Matches all Q# documents, including unsaved files, notebook cells, etc.
 export const qsharpDocumentFilter: DocumentFilter = {
   language: qsharpLanguageId,
 };
+
 // Matches only Q# notebook cell documents.
 export const qsharpNotebookCellDocumentFilter: DocumentFilter = {
   language: qsharpLanguageId,
   notebookType: "jupyter-notebook",
 };
+
+export function isQsharpDocument(document: TextDocument): boolean {
+  return languages.match(qsharpDocumentFilter, document) > 0;
+}
+
+export function isQsharpNotebookCell(document: TextDocument) {
+  return languages.match(qsharpNotebookCellDocumentFilter, document);
+}
+
 export const qsharpExtensionId = "qsharp-vscode";
 
 export interface FileAccessor {

--- a/vscode/src/debugger/activate.ts
+++ b/vscode/src/debugger/activate.ts
@@ -5,11 +5,7 @@
 
 import * as vscode from "vscode";
 import { IDebugServiceWorker, getDebugServiceWorker } from "qsharp-lang";
-import {
-  FileAccessor,
-  qsharpExtensionId,
-  qsharpDocumentFilter,
-} from "../common";
+import { FileAccessor, qsharpExtensionId, isQsharpDocument } from "../common";
 import { QscDebugSession } from "./session";
 
 let debugServiceWorkerFactory: () => IDebugServiceWorker;
@@ -98,10 +94,7 @@ class QsDebugConfigProvider implements vscode.DebugConfigurationProvider {
     // if launch.json is missing or empty
     if (!config.type && !config.request && !config.name) {
       const editor = vscode.window.activeTextEditor;
-      if (
-        editor &&
-        vscode.languages.match(qsharpDocumentFilter, editor.document)
-      ) {
+      if (editor && isQsharpDocument(editor.document)) {
         config.type = "qsharp";
         config.name = "Launch";
         config.request = "launch";
@@ -121,10 +114,7 @@ class QsDebugConfigProvider implements vscode.DebugConfigurationProvider {
       } else {
         // Use the active editor if no program or ${file} is specified.
         const editor = vscode.window.activeTextEditor;
-        if (
-          editor &&
-          vscode.languages.match(qsharpDocumentFilter, editor.document)
-        ) {
+        if (editor && isQsharpDocument(editor.document)) {
           config.program = editor.document.uri.toString();
         }
       }

--- a/vscode/src/debugger/session.ts
+++ b/vscode/src/debugger/session.ts
@@ -22,7 +22,7 @@ import {
   Scope,
 } from "@vscode/debugadapter";
 
-import { FileAccessor, basename, qsharpDocumentFilter } from "../common";
+import { FileAccessor, basename, isQsharpDocument } from "../common";
 import { DebugProtocol } from "@vscode/debugprotocol";
 import {
   IBreakpointSpan,
@@ -464,7 +464,7 @@ export class QscDebugSession extends LoggingDebugSession {
     const targetLineNumber = this.convertClientLineToDebugger(args.line);
     if (
       !file ||
-      !vscode.languages.match(qsharpDocumentFilter, file) ||
+      !isQsharpDocument(file) ||
       targetLineNumber >= file.lineCount
     ) {
       log.trace(`setBreakPointsResponse: %O`, response);
@@ -559,7 +559,7 @@ export class QscDebugSession extends LoggingDebugSession {
       });
 
     // If we couldn't find the file, or it wasn't a Q# file, just return
-    if (!file || !vscode.languages.match(qsharpDocumentFilter, file)) {
+    if (!file || !isQsharpDocument(file)) {
       log.trace(`setBreakPointsResponse: %O`, response);
       this.sendResponse(response);
       return;

--- a/vscode/src/diagnostics.ts
+++ b/vscode/src/diagnostics.ts
@@ -9,7 +9,9 @@ import {
 import * as vscode from "vscode";
 import { qsharpLanguageId } from "./common.js";
 
-export function startCheckingQSharp(languageService: ILanguageService) {
+export function startCheckingQSharp(
+  languageService: ILanguageService
+): vscode.Disposable[] {
   const diagCollection =
     vscode.languages.createDiagnosticCollection(qsharpLanguageId);
 
@@ -65,9 +67,12 @@ export function startCheckingQSharp(languageService: ILanguageService) {
 
   languageService.addEventListener("diagnostics", onDiagnostics);
 
-  return {
-    dispose: () => {
-      languageService.removeEventListener("diagnostics", onDiagnostics);
+  return [
+    {
+      dispose: () => {
+        languageService.removeEventListener("diagnostics", onDiagnostics);
+      },
     },
-  };
+    diagCollection,
+  ];
 }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -21,7 +21,7 @@ import { createDefinitionProvider } from "./definition.js";
 import { startCheckingQSharp } from "./diagnostics.js";
 import { createHoverProvider } from "./hover.js";
 import { registerQSharpNotebookHandlers } from "./notebook.js";
-import { createQirStatusBarItem } from "./statusbar.js";
+import { activateTargetProfileStatusBarItem } from "./statusbar.js";
 
 export async function activate(context: vscode.ExtensionContext) {
   initializeLogger();
@@ -34,7 +34,7 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
 
-  context.subscriptions.push(...createQirStatusBarItem());
+  context.subscriptions.push(...activateTargetProfileStatusBarItem());
 
   context.subscriptions.push(
     ...(await activateLanguageService(context.extensionUri))

--- a/vscode/src/statusbar.ts
+++ b/vscode/src/statusbar.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { log } from "qsharp-lang";
+import * as vscode from "vscode";
+import { isQsharpDocument } from "./common";
+
+export function createQirStatusBarItem(): vscode.Disposable[] {
+  const disposables = [];
+  const statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    200
+  );
+  disposables.push(statusBarItem);
+
+  disposables.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor && isQsharpDocument(editor.document)) {
+        refreshStatusBarItemValue();
+      } else {
+        // Could still be showing if the document language was changed away from Q#
+        statusBarItem.hide();
+      }
+    })
+  );
+
+  disposables.push(
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (
+        vscode.window.activeTextEditor &&
+        isQsharpDocument(vscode.window.activeTextEditor.document) &&
+        event.affectsConfiguration("qsharp.targetProfile")
+      ) {
+        refreshStatusBarItemValue();
+      }
+    })
+  );
+
+  if (
+    vscode.window.activeTextEditor &&
+    isQsharpDocument(vscode.window.activeTextEditor.document)
+  ) {
+    refreshStatusBarItemValue();
+  }
+
+  function refreshStatusBarItemValue() {
+    // The target profile setting is a "window" scoped setting,
+    // meaning it can't be set on a per-folder basis. So we don't
+    // need to pass a specific scope here to retrieve the document
+    // value - we just use the workspace setting.
+    const targetProfile = vscode.workspace
+      .getConfiguration("qsharp")
+      .get<string>("targetProfile");
+    switch (targetProfile) {
+      case "base":
+        statusBarItem.text = "QIR:Base";
+        break;
+      case "full":
+        statusBarItem.text = "QIR:Full";
+        break;
+      default:
+        log.error("invalid target profile found in settings");
+        statusBarItem.text = "QIR:Invalid";
+        break;
+    }
+    statusBarItem.show();
+  }
+
+  return disposables;
+}

--- a/vscode/src/statusbar.ts
+++ b/vscode/src/statusbar.ts
@@ -5,13 +5,18 @@ import { log } from "qsharp-lang";
 import * as vscode from "vscode";
 import { isQsharpDocument } from "./common";
 
-export function createQirStatusBarItem(): vscode.Disposable[] {
+export function activateTargetProfileStatusBarItem(): vscode.Disposable[] {
   const disposables = [];
+
+  disposables.push(registerTargetProfileCommand());
+
   const statusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Right,
     200
   );
   disposables.push(statusBarItem);
+
+  statusBarItem.command = "quantum-set-target";
 
   disposables.push(
     vscode.window.onDidChangeActiveTextEditor((editor) => {
@@ -48,23 +53,64 @@ export function createQirStatusBarItem(): vscode.Disposable[] {
     // meaning it can't be set on a per-folder basis. So we don't
     // need to pass a specific scope here to retrieve the document
     // value - we just use the workspace setting.
+    // VS Code will return the default value defined by the extension
+    // if none was set by the user, so targetProfile should always
+    // be a valid string.
     const targetProfile = vscode.workspace
       .getConfiguration("qsharp")
       .get<string>("targetProfile");
-    switch (targetProfile) {
-      case "base":
-        statusBarItem.text = "QIR:Base";
-        break;
-      case "full":
-        statusBarItem.text = "QIR:Full";
-        break;
-      default:
-        log.error("invalid target profile found in settings");
-        statusBarItem.text = "QIR:Invalid";
-        break;
-    }
+
+    statusBarItem.text = getTargetProfileUiText(targetProfile);
     statusBarItem.show();
   }
 
   return disposables;
+}
+
+function registerTargetProfileCommand() {
+  return vscode.commands.registerCommand("quantum-set-target", async () => {
+    const target = await vscode.window.showQuickPick(
+      targetProfiles.map((profile) => profile.uiText),
+      { placeHolder: "Select the QIR target profile" }
+    );
+
+    if (target) {
+      vscode.workspace
+        .getConfiguration("qsharp")
+        .update(
+          "targetProfile",
+          getTargetProfileSetting(target),
+          vscode.ConfigurationTarget.Global
+        );
+    }
+  });
+}
+
+const targetProfiles = [
+  { configName: "base", uiText: "QIR:Base" },
+  { configName: "full", uiText: "QIR:Full" },
+];
+
+function getTargetProfileUiText(targetProfile?: string) {
+  switch (targetProfile) {
+    case "base":
+      return "QIR:Base";
+    case "full":
+      return "QIR:Full";
+    default:
+      log.error("invalid target profile found");
+      return "QIR:Invalid";
+  }
+}
+
+function getTargetProfileSetting(uiText: string) {
+  switch (uiText) {
+    case "QIR:Base":
+      return "base";
+    case "QIR:Full":
+      return "full";
+    default:
+      log.error("invalid target profile found");
+      return "full";
+  }
 }


### PR DESCRIPTION
- A new configuration setting for target profile.
- Status bar item to show this setting.
- Command to set this setting.
- Language service update to consume this setting.