### PR TITLE
Use Node 18 for GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           submodules: "true"
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.17.1'
+          node-version: '18.17.1'
       - name: npm install
         run: npm install
       - name: npm check
@@ -108,7 +108,7 @@ jobs:
           python-version: '3.11'
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.17.1'
+          node-version: '18.17.1'
       - uses: Swatinem/rust-cache@v2
       - name: Prereqs
         run: python ./prereqs.py --install

--- a/.github/workflows/publish-playground.yml
+++ b/.github/workflows/publish-playground.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: '3.11'
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.17.1'
+          node-version: '18.17.1'
       - uses: Swatinem/rust-cache@v2
       - name: Prereqs
         run: python ./prereqs.py --install

--- a/npm/README.md
+++ b/npm/README.md
@@ -68,7 +68,3 @@ at <src/vs/base/common/cancellation.ts>. This code uses a simplified version of 
 
 Node.js tests can be run via `node --test` (see
 <https://nodejs.org/dist/latest-v18.x/docs/api/test.html#test-runner-execution-model>).
-
-The test module was also added to Node.js v16.17.0, and Electron 22 (which VS Code plans to move to
-in first half of 2023) includes v16.17.1, so v16.17 should be our minimum Node.js
-version supported (it shipped in Aug 2022).

--- a/npm/package.json
+++ b/npm/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "engines": {
-    "node": ">=16.17.0"
+    "node": ">=18.17.1"
   },
   "repository": {
     "type": "git",

--- a/npm/package.json
+++ b/npm/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "engines": {
-    "node": ">=18.17.1"
+    "node": ">=16.17.0"
   },
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "url": "^0.11.1"
       },
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=18.17.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2236,7 +2236,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=18.17.1"
       }
     },
     "playground": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2236,7 +2236,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "engines": {
-        "node": ">=18.17.1"
+        "node": ">=16.17.0"
       }
     },
     "playground": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=16.17.0"
+    "node": ">=18.17.1"
   },
   "scripts": {
     "eslint:check": "eslint -c ./.eslintrc.cjs --max-warnings 0 ./",

--- a/prereqs.py
+++ b/prereqs.py
@@ -15,9 +15,9 @@ import functools
 python_ver = (3, 11)  # Python support for Windows on ARM64 requires v3.11 or later
 rust_ver = (1, 72)  # Ensure Rust version 1.69 or later is installed
 node_ver = (
-    16,
+    18,
     17,
-)  # Node.js version 16.17 or later is required to support the Node.js 'test' module
+)
 wasmpack_ver = (0, 12, 1)  # Latest tested wasm-pack version
 rust_fmt_ver = (1, 6, 0)  # Current version when Rust 1.72 shipped
 clippy_ver = (0, 1, 69)


### PR DESCRIPTION
Node.js seems to have fixed a bunch of test runner issues v18.

Bumping the prerequisite to v18.