### PR TITLE
Add samples as snippets to completions

### DIFF
--- a/vscode/src/completion.ts
+++ b/vscode/src/completion.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ILanguageService } from "qsharp-lang";
+import { ILanguageService, samples } from "qsharp-lang";
 import * as vscode from "vscode";
 import { CompletionItem } from "vscode";
 
@@ -12,7 +12,18 @@ export function createCompletionItemProvider(
 }
 
 class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
-  constructor(public languageService: ILanguageService) {}
+  private samples: vscode.CompletionItem[] = [];
+
+  constructor(public languageService: ILanguageService) {
+    this.samples = samples.map((s) => {
+      const item = new CompletionItem(
+        s.title + " sample",
+        vscode.CompletionItemKind.Snippet
+      );
+      item.insertText = s.code;
+      return item;
+    });
+  }
 
   async provideCompletionItems(
     document: vscode.TextDocument,
@@ -26,7 +37,7 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
       document.uri.toString(),
       document.offsetAt(position)
     );
-    return completions.items.map((c) => {
+    const results = completions.items.map((c) => {
       let kind;
       switch (c.kind) {
         case "function":
@@ -56,5 +67,6 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
       });
       return item;
     });
+    return results.concat(this.samples);
   }
 }


### PR DESCRIPTION
Add the samples as snippets to the completion list. Now in a file if you start typing 'sample' it will filter to the completions as shown below.

Adding a new menu command to "Open sample" seemed like overkill, and creating/opening a new doc comes with it's own issues. This is a super simple way just to create a new .qs file, type 'sample', and then hit tab to insert the sample.

<img width="389" alt="image" src="https://github.com/microsoft/qsharp/assets/993909/0fa143f2-1092-4790-a1a4-70f9dd964f6f">
