### PR TITLE
Ask user for number of shots when submitting job to Azure

### DIFF
--- a/vscode/src/azure/workspaceActions.ts
+++ b/vscode/src/azure/workspaceActions.ts
@@ -316,6 +316,11 @@ export async function submitJob(
       validateInput: validateShotsInput,
     })) || "100";
 
+  // abort if the user hits <Esc> during shots entry
+  if (numberOfShots === undefined) {
+    return;
+  }
+
   // Get a sasUri for the container
   const body = JSON.stringify({ containerName });
   const sasResponse: ResponseTypes.SasUri = await azureRequest(


### PR DESCRIPTION
Asks user for number of shots when submitting to azure. Defaults to 100 if nothing is specified or if the dialog is closed.

Closes #682

