### PR TITLE
Remove Unnecessary open of `Microsoft.Quantum.Intrinsic`

### DIFF
--- a/samples/language/GettingStarted.qs
+++ b/samples/language/GettingStarted.qs
@@ -4,7 +4,6 @@
 /// # Description
 /// This is a minimal Q# program that can be used to start writing Q# code.
 namespace MyQuantumProgram {
-    open Microsoft.Quantum.Intrinsic;
 
     @EntryPoint()
     operation Main() : Result[] {


### PR DESCRIPTION
Updates the Minimal Sample to not explicitly open `Microsoft.Quantum.Intrinsic` since it is implicitly opened.