### PR TITLE
Type Annotation Style Consistency

### DIFF
--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -398,16 +398,16 @@ fn block_qubit_use_array_invalid_count_expr() {
                             0,
                         ),
                         span: Span {
-                            lo: 1567,
-                            hi: 1624,
+                            lo: 1568,
+                            hi: 1625,
                         },
                     },
                 ),
                 [
                     Frame {
                         span: Span {
-                            lo: 1572,
-                            hi: 1624,
+                            lo: 1573,
+                            hi: 1625,
                         },
                         id: GlobalId {
                             package: PackageId(

--- a/katas/content/KatasLibrary.qs
+++ b/katas/content/KatasLibrary.qs
@@ -14,7 +14,7 @@ namespace Microsoft.Quantum.Katas {
     operation CheckOperationsEquivalence(
         op : (Qubit[] => Unit is Adj + Ctl),
         reference : (Qubit[] => Unit is Adj + Ctl),
-        inputSize: Int)
+        inputSize : Int)
     : Bool {
         Fact(inputSize > 0, "`inputSize` must be positive");
         use (control, target) = (Qubit[inputSize], Qubit[inputSize]);
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.Katas {
     operation CheckOperationsEquivalenceStrict(
         op : (Qubit[] => Unit is Adj + Ctl),
         reference : (Qubit[] => Unit is Adj + Ctl),
-        inputSize: Int)
+        inputSize : Int)
     : Bool {
         Fact(inputSize > 0, "`inputSize` must be positive");
         let controlledOp = register => Controlled op(register[...0], register[1...]);
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Katas {
     operation CheckOperationsEquivalenceOnZeroState(
         op : (Qubit[] => Unit is Adj + Ctl),
         reference : (Qubit[] => Unit is Adj + Ctl),
-        inputSize: Int)
+        inputSize : Int)
     : Bool {
         Fact(inputSize > 0, "`inputSize` must be positive");
         use target = Qubit[inputSize];
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.Katas {
     operation CheckOperationsEquivalenceOnZeroStateStrict(
         op : (Qubit[] => Unit is Adj + Ctl),
         reference : (Qubit[] => Unit is Adj + Ctl),
-        inputSize: Int)
+        inputSize : Int)
     : Bool {
         Fact(inputSize > 0, "`inputSize` must be positive");
         use control = Qubit();

--- a/katas/content/getting_started/flip_qubit/Placeholder.qs
+++ b/katas/content/getting_started/flip_qubit/Placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation FlipQubit(q : Qubit): Unit is Adj + Ctl {
+    operation FlipQubit(q : Qubit) : Unit is Adj + Ctl {
         // Uncomment the following line to solve this exercise.
         //X(q);
     }

--- a/katas/content/getting_started/flip_qubit/Solution.qs
+++ b/katas/content/getting_started/flip_qubit/Solution.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation FlipQubit(q : Qubit): Unit is Adj + Ctl {
+    operation FlipQubit(q : Qubit) : Unit is Adj + Ctl {
         // Perform a "bit flip" on the qubit by applying the X gate.
         X(q);
     }

--- a/katas/content/getting_started/flip_qubit/Verification.qs
+++ b/katas/content/getting_started/flip_qubit/Verification.qs
@@ -2,7 +2,7 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Katas;
 
-    operation FlipQubit(q : Qubit): Unit is Adj + Ctl {
+    operation FlipQubit(q : Qubit) : Unit is Adj + Ctl {
         X(q);
     }
 

--- a/katas/content/multi_qubit_measurements/common.qs
+++ b/katas/content/multi_qubit_measurements/common.qs
@@ -11,19 +11,19 @@ namespace Kata.Verification {
     // "Framework" operation for testing multi-qubit tasks for distinguishing states of an array of qubits
     // with Int return
     operation DistinguishStates_MultiQubit(
-        nQubits: Int,
-        nStates: Int,
-        statePrep: ((Qubit[], Int, Double) => Unit is Adj),
-        testImpl: (Qubit[] => Int),
-        preserveState: Bool,
-        stateNames: String[]): Bool {
+        nQubits : Int,
+        nStates : Int,
+        statePrep : ((Qubit[], Int, Double) => Unit is Adj),
+        testImpl : (Qubit[] => Int),
+        preserveState : Bool,
+        stateNames : String[]) : Bool {
 
         let nTotal = 100;
         // misclassifications will store the number of times state i has been classified as state j (dimension nStates^2)
         mutable misclassifications = [0, size = nStates * nStates];
         // unknownClassifications will store the number of times state i has been classified as some invalid state (index < 0 or >= nStates)
         mutable unknownClassifications = [0, size = nStates];
-                
+
         use qs = Qubit[nQubits];
         for i in 1 .. nTotal {
             // get a random integer to define the state of the qubits
@@ -31,7 +31,7 @@ namespace Kata.Verification {
             // get a random rotation angle to define the exact state of the qubits
             // for some exercises, this value might be a dummy variable which does not matter
             let alpha = DrawRandomDouble(0.0, 1.0) * PI();
-                
+
             // do state prep: convert |0...0⟩ to outcome with return equal to state
             statePrep(qs, state, alpha);
 
@@ -45,7 +45,7 @@ namespace Kata.Verification {
             }
             else {
                 // classification result is an invalid state index - file it separately
-                set unknownClassifications w/= state <- (unknownClassifications[state] + 1);  
+                set unknownClassifications w/= state <- (unknownClassifications[state] + 1);
             }
 
             if preserveState {

--- a/katas/content/multi_qubit_measurements/full_measurements/solution.qs
+++ b/katas/content/multi_qubit_measurements/full_measurements/solution.qs
@@ -1,10 +1,10 @@
 namespace Kata {
-    
-    operation BasisStateMeasurement(qs: Qubit[]): Int {
+
+    operation BasisStateMeasurement(qs : Qubit[]) : Int {
         // Measurement on the first qubit gives the higher bit of the answer, on the second - the lower
         let m1 = M(qs[0]) == Zero ? 0 | 1;
         let m2 = M(qs[1]) == Zero ? 0 | 1;
         return m1 * 2 + m2;
     }
-    
+
 }

--- a/katas/content/multi_qubit_measurements/joint_measurements/solution.qs
+++ b/katas/content/multi_qubit_measurements/joint_measurements/solution.qs
@@ -1,7 +1,7 @@
 namespace Kata {
 
-    operation ParityMeasurement(qs: Qubit[]): Int {
+    operation ParityMeasurement(qs : Qubit[]) : Int {
         return Measure([PauliZ, PauliZ], qs) == Zero ? 0 | 1;
     }
-    
+
 }

--- a/katas/content/multi_qubit_measurements/joint_measurements/verify.qs
+++ b/katas/content/multi_qubit_measurements/joint_measurements/verify.qs
@@ -1,13 +1,13 @@
 namespace Kata.Verification {
 
     // Two qubit parity Measurement
-    operation StatePrep_ParityMeasurement(qs: Qubit[], state: Int, alpha: Double): Unit is Adj {
+    operation StatePrep_ParityMeasurement(qs : Qubit[], state : Int, alpha : Double) : Unit is Adj {
         // prep cos(alpha) * |0..0⟩ + sin(alpha) * |1..1⟩
         Ry(2.0 * alpha, qs[0]);
         for i in 1 .. Length(qs) - 1 {
             CNOT(qs[0], qs[i]);
         }
-            
+
         if state == 1 {
             // flip the state of the first half of the qubits
             for i in 0 .. Length(qs) / 2 - 1 {

--- a/katas/content/multi_qubit_measurements/measuring_one.qs
+++ b/katas/content/multi_qubit_measurements/measuring_one.qs
@@ -45,7 +45,7 @@ namespace Kata {
         Message($"Simulated measurement probabilities are {simulated_probabilities}");
     }
 
-    operation PrepareEx1State(q: Qubit[]): Unit {
+    operation PrepareEx1State(q : Qubit[]) : Unit {
         Ry(-ArcCos(1.0/9.0), q[0]);
         within {
             S(q[1]);

--- a/katas/content/multi_qubit_measurements/multi_qubit_probabilities.qs
+++ b/katas/content/multi_qubit_measurements/multi_qubit_probabilities.qs
@@ -2,7 +2,7 @@ namespace Kata {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Math;
 
-    operation SetInitialState(qs: Qubit[]): Unit is Adj + Ctl {
+    operation SetInitialState(qs : Qubit[]) : Unit is Adj + Ctl {
         // Next two lines set the second qubit into the desired state
         let second_bit_angle = 2.0 * ArcCos(2.0 / 3.0);
         Ry(second_bit_angle, qs[1]);
@@ -12,13 +12,13 @@ namespace Kata {
         Controlled Ry([qs[1]], (first_bit_angle, qs[0]));
     }
 
-    operation ChangeBasis(qs: Qubit[]): Unit is Adj + Ctl {
+    operation ChangeBasis(qs : Qubit[]) : Unit is Adj + Ctl {
         H(qs[0]);
         H(qs[1]);
     }
 
     @EntryPoint()
-    operation CalculateProbabilities(): Unit {
+    operation CalculateProbabilities() : Unit {
         // This allocates qubits for us to work with
         use qs = Qubit[2];
 

--- a/katas/content/multi_qubit_measurements/partial_measurements_demo.qs
+++ b/katas/content/multi_qubit_measurements/partial_measurements_demo.qs
@@ -8,21 +8,21 @@ namespace Kata {
     operation DemoPartialMeasurement() : Unit {
         let numRuns = 1000;
         let divider = "--------------------------------------------------------------------------------------------------";
-        // 
-        // We can use coefficients without normalization in PrepareArbitraryStateD, 
+        //
+        // We can use coefficients without normalization in PrepareArbitraryStateD,
         // the operation will normalize them automatically.
-        let coefficients = [3., 1., 1., 1.]; 
+        let coefficients = [3., 1., 1., 1.];
         let expected_probabilities = [0.833, 0.167];
-        
+
         // Set up the counter array for measurements.
         mutable countArray = [0, 0];
-        
+
         use qs = Qubit[2];
         for i in 1 .. numRuns {
             // Prepare the state from Exercise 4:
-            // |𝜓❭ = (1/√12)(3|00⟩+|01⟩+|10⟩+|11⟩) 
+            // |𝜓❭ = (1/√12)(3|00⟩+|01⟩+|10⟩+|11⟩)
             PrepareHardyState(qs);
-                
+
             // Display the state of the qubits.
             if i == 1 {
                 Message("The state |𝜓❭ of the system before measurement is:");
@@ -33,26 +33,26 @@ namespace Kata {
             // Measure the first qubit.
             let outcome = M(qs[0]) == Zero ? 0 | 1;
             set countArray w/= outcome <- countArray[outcome] + 1;
-            
-            if countArray[outcome] == 1 { 
+
+            if countArray[outcome] == 1 {
                 // The first time the outcome is 0/1, print the system state afterwards.
                 Message("For outcome {outcome}, the post-measurement state of the system is:");
                 DumpMachine();
             }
             ResetAll(qs);
         }
-        
+
         // Obtain simulated probability of measurement for each outcome
         mutable simulated_probabilities = [];
         for i in 0 .. 1 {
             set simulated_probabilities += [IntAsDouble(countArray[i]) / IntAsDouble(numRuns)];
         }
-        
+
         Message($"Theoretical measurement probabilities are {expected_probabilities}");
         Message($"Simulated measurement probabilities are {simulated_probabilities}");
     }
-    
-    operation PrepareHardyState(q: Qubit[]): Unit {
+
+    operation PrepareHardyState(q : Qubit[]) : Unit {
         Ry(ArcCos(2.0/3.0), q[1]);
         within {
             S(q[0]);
@@ -62,7 +62,7 @@ namespace Kata {
             Rz(ArcTan(1.0/2.0), q[0]);
             CNOT(q[1], q[0]);
             Rz(-ArcTan(2.0), q[0]);
-        }        
+        }
     }
 
 }

--- a/katas/content/multi_qubit_measurements/partial_measurements_for_system/solution.qs
+++ b/katas/content/multi_qubit_measurements/partial_measurements_for_system/solution.qs
@@ -1,6 +1,6 @@
 namespace Kata {
 
-    operation IsPlusPlusMinus(qs: Qubit[]): Int {
+    operation IsPlusPlusMinus(qs : Qubit[]) : Int {
         return Measure([PauliX], [qs[0]]) == Zero ? 0 | 1;
     }
 

--- a/katas/content/multi_qubit_measurements/partial_measurements_for_system/verify.qs
+++ b/katas/content/multi_qubit_measurements/partial_measurements_for_system/verify.qs
@@ -1,7 +1,7 @@
 namespace Kata.Verification {
 
     // Distinguish orthogonal states using partial measurements
-    operation StatePrep_IsPlusPlusMinus(qs: Qubit[], state: Int, dummyVar: Double): Unit is Adj {
+    operation StatePrep_IsPlusPlusMinus(qs : Qubit[], state : Int, dummyVar : Double) : Unit is Adj {
         if state == 0 {
             // prepare the state |++-⟩
             H(qs[0]);
@@ -20,7 +20,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         return DistinguishStates_MultiQubit(
             3,
             2,

--- a/katas/content/multi_qubit_measurements/state_modification/verify.qs
+++ b/katas/content/multi_qubit_measurements/state_modification/verify.qs
@@ -4,31 +4,31 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Math;
 
     // State selection using partial measurements
-    operation stateInitialize_StateSelction(alpha: Double, qs: Qubit[]): Unit {
+    operation stateInitialize_StateSelction(alpha : Double, qs : Qubit[]) : Unit {
         // Prepare the state to be input to the testImplementation
         // set the second qubit in a superposition a |0⟩ + b|1⟩
         // with a = cos alpha, b = sin alpha
-        Ry(2.0 * alpha, qs[1]); 
+        Ry(2.0 * alpha, qs[1]);
 
         H(qs[0]);
         // Apply CX gate
         CX(qs[0], qs[1]);
     }
 
-    operation statePrepare_StateSelction(alpha: Double, Choice: Int, qs: Qubit[]): Unit is Adj {
+    operation statePrepare_StateSelction(alpha : Double, Choice : Int, qs : Qubit[]) : Unit is Adj {
         // The expected state of the second qubit for the exercise.
 
         // set the second qubit in a superposition a |0⟩ + b|1⟩
         // with a = cos alpha, b = sin alpha
-        Ry(2.0 * alpha, qs[1]); 
-        if Choice == 1 { 
+        Ry(2.0 * alpha, qs[1]);
+        if Choice == 1 {
             // if the Choice is 1, change the state to b|0⟩ + a|1⟩
             X(qs[1]);
         }
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         use qs = Qubit[2];
         for i in 0 .. 5 {
             let alpha = (PI() * IntAsDouble(i)) / 5.0;
@@ -45,7 +45,7 @@ namespace Kata.Verification {
 
                 // apply adjoint reference operation and check that the result is correct
                 Adjoint statePrepare_StateSelction(alpha, Choice, qs);
-                
+
                 if not CheckAllZero(qs) {
                     ResetAll(qs);
                     return false;

--- a/katas/content/multi_qubit_measurements/state_preparation/solution.qs
+++ b/katas/content/multi_qubit_measurements/state_preparation/solution.qs
@@ -1,7 +1,7 @@
 namespace Kata {
     open Microsoft.Quantum.Measurement;
 
-    operation PostSelection(qs: Qubit[]): Unit {
+    operation PostSelection(qs : Qubit[]) : Unit {
         // Initialize the extra qubit
         use anc = Qubit();
         // Using the repeat-until-success pattern to prepare the right state
@@ -10,7 +10,7 @@ namespace Kata {
             ApplyToEach(H, qs);
             Controlled X(qs, anc);
             set res = MResetZ(anc);
-        } 
+        }
         until (res == Zero)
         fixup {
             ResetAll(qs);

--- a/katas/content/multi_qubit_measurements/state_preparation/verify.qs
+++ b/katas/content/multi_qubit_measurements/state_preparation/verify.qs
@@ -3,7 +3,7 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Math;
 
     // State preparation using partial measurements
-    operation RefImpl_T4(qs: Qubit[]): Unit is Adj {
+    operation RefImpl_T4(qs : Qubit[]) : Unit is Adj {
         // Rotate first qubit to (sqrt(2) |0⟩ + |1⟩) / sqrt(3)
         let theta = ArcSin(1.0 / Sqrt(3.0));
         Ry(2.0 * theta, qs[0]);
@@ -14,7 +14,7 @@ namespace Kata.Verification {
 
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         use qs = Qubit[2];
 
         // operate the test implementation

--- a/katas/content/multi_qubit_systems/common.qs
+++ b/katas/content/multi_qubit_systems/common.qs
@@ -2,7 +2,7 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Diagnostics;
 
     operation AssertEqualOnZeroState(
-        testImpl: (Qubit[] => Unit is Ctl),
+        testImpl : (Qubit[] => Unit is Ctl),
         refImpl : (Qubit[] => Unit is Adj+Ctl)) : Bool {
 
         use qs = Qubit[3];

--- a/katas/content/multi_qubit_systems/prepare_superposition/verification.qs
+++ b/katas/content/multi_qubit_systems/prepare_superposition/verification.qs
@@ -5,7 +5,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         let isCorrect = AssertEqualOnZeroState(Kata.PrepareSuperposition, PrepareSuperposition_Reference);
         if isCorrect {
             Message("Correct!");

--- a/katas/content/multi_qubit_systems/prepare_with_complex/verification.qs
+++ b/katas/content/multi_qubit_systems/prepare_with_complex/verification.qs
@@ -7,7 +7,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         let isCorrect = AssertEqualOnZeroState(Kata.PrepareWithComplex, PrepareWithComplex_Reference);
         if isCorrect {
             Message("Correct!");

--- a/katas/content/multi_qubit_systems/prepare_with_real/verification.qs
+++ b/katas/content/multi_qubit_systems/prepare_with_real/verification.qs
@@ -6,7 +6,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         let isCorrect = AssertEqualOnZeroState(Kata.PrepareWithReal, PrepareWithReal_Reference);
         if isCorrect {
             Message("Correct!");

--- a/katas/content/oracles/bit_pattern_challenge/solution.qs
+++ b/katas/content/oracles/bit_pattern_challenge/solution.qs
@@ -2,8 +2,8 @@ namespace Kata {
     open Microsoft.Quantum.Arrays;
 
     operation ArbitraryBitPattern_Oracle_Challenge(
-        x: Qubit[],
-        pattern: Bool[])
+        x : Qubit[],
+        pattern : Bool[])
     : Unit is Adj + Ctl {
         within {
             for i in IndexRange(x) {

--- a/katas/content/oracles/bit_pattern_challenge/verification.qs
+++ b/katas/content/oracles/bit_pattern_challenge/verification.qs
@@ -2,7 +2,7 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Arrays;
 
-    operation ArbitraryBitPattern_Oracle_Challenge_Reference(x: Qubit[], pattern: Bool[]): Unit is Adj + Ctl {
+    operation ArbitraryBitPattern_Oracle_Challenge_Reference(x : Qubit[], pattern : Bool[]) : Unit is Adj + Ctl {
         within {
             for i in IndexRange(x) {
                 if not pattern[i] {
@@ -15,7 +15,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         for N in 1..4 {
             for k in 0..((2^N)-1) {
                 let pattern = IntAsBoolArray(k, N);

--- a/katas/content/oracles/bit_pattern_oracle/solution.qs
+++ b/katas/content/oracles/bit_pattern_oracle/solution.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation ArbitraryBitPattern_Oracle(x: Qubit[], y: Qubit, pattern: Bool[])
+    operation ArbitraryBitPattern_Oracle(x : Qubit[], y : Qubit, pattern : Bool[])
     : Unit  is Adj + Ctl {
         ApplyControlledOnBitString(pattern, X, x, y);
     }

--- a/katas/content/oracles/bit_pattern_oracle/verification.qs
+++ b/katas/content/oracles/bit_pattern_oracle/verification.qs
@@ -1,13 +1,13 @@
 namespace Kata.Verification {
     open Microsoft.Quantum.Convert;
 
-    operation ArbitraryBitPattern_Oracle_Reference(x: Qubit[], y: Qubit, pattern: Bool[]): Unit  is Adj + Ctl {
+    operation ArbitraryBitPattern_Oracle_Reference(x : Qubit[], y : Qubit, pattern : Bool[]) : Unit  is Adj + Ctl {
         ApplyControlledOnBitString(pattern, X, x, y);
     }
 
     // ------------------------------------------------------
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         for N in 1..4 {
             for k in 0..((2^N)-1) {
                 let pattern = IntAsBoolArray(k, N);

--- a/katas/content/oracles/classical_oracles/solution.qs
+++ b/katas/content/oracles/classical_oracles/solution.qs
@@ -1,7 +1,7 @@
 namespace Kata {
     open Microsoft.Quantum.Convert;
 
-    function IsSeven(x: Bool[]): Bool {
+    function IsSeven(x : Bool[]) : Bool {
         return BoolArrayAsInt(x) == 7;
     }
 }

--- a/katas/content/oracles/classical_oracles/verification.qs
+++ b/katas/content/oracles/classical_oracles/verification.qs
@@ -1,12 +1,12 @@
 namespace Kata.Verification {
     open Microsoft.Quantum.Convert;
 
-    function IsSeven_Reference(x: Bool[]): Bool {
+    function IsSeven_Reference(x : Bool[]) : Bool {
         return BoolArrayAsInt(x) == 7;
     }
 
     @EntryPoint()
-    function CheckSolution(): Bool {
+    function CheckSolution() : Bool {
         let N = 3;
         for k in 0..((2^N)-1) {
             let x = IntAsBoolArray(k, N);

--- a/katas/content/oracles/kth_bit_oracle/verification.qs
+++ b/katas/content/oracles/kth_bit_oracle/verification.qs
@@ -1,10 +1,10 @@
 namespace Kata.Verification {
-    operation KthBit_Oracle_Reference(x: Qubit[], k: Int): Unit is Adj + Ctl {
+    operation KthBit_Oracle_Reference(x : Qubit[], k : Int) : Unit is Adj + Ctl {
         Z(x[k]);
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         for N in 1..5 {
             for k in 0..(N-1) {
                 let isCorrect = CheckOperationsEqualReferenced(

--- a/katas/content/oracles/marking_oracle_alt_bit.qs
+++ b/katas/content/oracles/marking_oracle_alt_bit.qs
@@ -3,7 +3,7 @@ namespace Kata {
     open Microsoft.Quantum.Diagnostics;
 
     // This operation implements the oracle; we will learn how to implement oracles later in the kata
-    operation AlternatingBitPattern_MarkingOracle(x: Qubit[], y: Qubit) : Unit is Adj + Ctl {
+    operation AlternatingBitPattern_MarkingOracle(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         ApplyControlledOnBitString([false, true, false], X, x, y);
         ApplyControlledOnBitString([true, false, true], X, x, y);
     }

--- a/katas/content/oracles/marking_oracle_as_phase/solution.qs
+++ b/katas/content/oracles/marking_oracle_as_phase/solution.qs
@@ -1,7 +1,7 @@
 namespace Kata {
     operation ApplyMarkingOracleAsPhaseOracle(
-        markingOracle: ((Qubit[], Qubit) => Unit is Adj + Ctl),
-        qubits: Qubit[])
+        markingOracle : ((Qubit[], Qubit) => Unit is Adj + Ctl),
+        qubits : Qubit[])
     : Unit is Adj + Ctl {
         use minus = Qubit();
         within {

--- a/katas/content/oracles/marking_oracle_as_phase/verification.qs
+++ b/katas/content/oracles/marking_oracle_as_phase/verification.qs
@@ -2,9 +2,9 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Convert;
 
     operation ApplyMarkingOracleAsPhaseOracle_Reference(
-        markingOracle: ((Qubit[], Qubit) => Unit is Adj + Ctl),
-        qubits: Qubit[]) : Unit is Adj + Ctl {
-            
+        markingOracle : ((Qubit[], Qubit) => Unit is Adj + Ctl),
+        qubits : Qubit[]) : Unit is Adj + Ctl {
+
         use minus = Qubit();
         within {
             X(minus);
@@ -15,7 +15,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         for N in 1..5 {
             for k in 0..(2^N-1) {
                 let pattern = IntAsBoolArray(k, N);

--- a/katas/content/oracles/marking_oracle_seven/placeholder.qs
+++ b/katas/content/oracles/marking_oracle_seven/placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation IsSeven_MarkingOracle(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation IsSeven_MarkingOracle(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         // Implement your solution here...
 
     }

--- a/katas/content/oracles/marking_oracle_seven/solution.qs
+++ b/katas/content/oracles/marking_oracle_seven/solution.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation IsSeven_MarkingOracle(x: Qubit[], y: Qubit) : Unit is Adj + Ctl {
+    operation IsSeven_MarkingOracle(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         Controlled X(x, y);
     }
 }

--- a/katas/content/oracles/marking_oracle_seven/verification.qs
+++ b/katas/content/oracles/marking_oracle_seven/verification.qs
@@ -1,6 +1,6 @@
 namespace Kata.Verification {
 
-    operation IsSeven_MarkingOracle_Reference(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation IsSeven_MarkingOracle_Reference(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         Controlled X(x, y);
     }
 

--- a/katas/content/oracles/meeting_oracle/placeholder.qs
+++ b/katas/content/oracles/meeting_oracle/placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation Meeting_Oracle(x: Qubit[], jasmine: Qubit[], y: Qubit)
+    operation Meeting_Oracle(x : Qubit[], jasmine : Qubit[], y : Qubit)
     : Unit is Adj + Ctl {
         // Implement your solution here...
 

--- a/katas/content/oracles/meeting_oracle/solution.qs
+++ b/katas/content/oracles/meeting_oracle/solution.qs
@@ -1,12 +1,12 @@
 namespace Kata {
     open Microsoft.Quantum.Arrays;
 
-    operation Or_Oracle(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation Or_Oracle(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         X(y);
         ApplyControlledOnInt(0, X, x, y);
     }
 
-    operation Meeting_Oracle(x: Qubit[], jasmine: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation Meeting_Oracle(x : Qubit[], jasmine : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         use q = Qubit[Length(x)];
         within {
             for i in IndexRange(q) {

--- a/katas/content/oracles/meeting_oracle/verification.qs
+++ b/katas/content/oracles/meeting_oracle/verification.qs
@@ -2,12 +2,12 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Convert;
 
-    operation Or_Oracle_Reference(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation Or_Oracle_Reference(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         X(y);
         ApplyControlledOnInt(0, X, x, y);
     }
 
-    operation Meeting_Oracle_Reference(x: Qubit[], jasmine: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation Meeting_Oracle_Reference(x : Qubit[], jasmine : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         use q = Qubit[Length(x)];
         within {
             for i in IndexRange(q) {
@@ -22,7 +22,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         for N in 1..4 {
             use jasmine = Qubit[N];
             for k in 0..(2^N-1) {

--- a/katas/content/oracles/or_but_kth_oracle/solution.qs
+++ b/katas/content/oracles/or_but_kth_oracle/solution.qs
@@ -1,10 +1,10 @@
 namespace Kata {
-    operation Or_Oracle(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation Or_Oracle(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         X(y);
         ApplyControlledOnInt(0, X, x, y);
     }
 
-    operation OrOfBitsExceptKth_Oracle(x: Qubit[], k: Int): Unit is Adj + Ctl {
+    operation OrOfBitsExceptKth_Oracle(x : Qubit[], k : Int) : Unit is Adj + Ctl {
         use minus = Qubit();
         within {
             X(minus);

--- a/katas/content/oracles/or_but_kth_oracle/verification.qs
+++ b/katas/content/oracles/or_but_kth_oracle/verification.qs
@@ -1,11 +1,11 @@
 namespace Kata.Verification {
 
-    operation Or_Oracle_Reference(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation Or_Oracle_Reference(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         X(y);
         ApplyControlledOnInt(0, X, x, y);
     }
 
-    operation OrOfBitsExceptKth_Oracle_Reference(x: Qubit[], k: Int): Unit is Adj + Ctl {
+    operation OrOfBitsExceptKth_Oracle_Reference(x : Qubit[], k : Int) : Unit is Adj + Ctl {
         use minus = Qubit();
         within {
             X(minus);
@@ -16,7 +16,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         for N in 1..5 {
             for k in 0..(N-1) {
                 let isCorrect = CheckOperationsEqualReferenced(

--- a/katas/content/oracles/or_oracle/solution.qs
+++ b/katas/content/oracles/or_oracle/solution.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation Or_Oracle(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation Or_Oracle(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         X(y);
         ApplyControlledOnInt(0, X, x, y);
     }

--- a/katas/content/oracles/or_oracle/verification.qs
+++ b/katas/content/oracles/or_oracle/verification.qs
@@ -1,5 +1,5 @@
 namespace Kata.Verification {
-    operation Or_Oracle_Reference(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation Or_Oracle_Reference(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         X(y);
         ApplyControlledOnInt(0, X, x, y);
     }

--- a/katas/content/oracles/oracle_converter_demo.qs
+++ b/katas/content/oracles/oracle_converter_demo.qs
@@ -41,14 +41,14 @@ namespace Kata {
         Controlled Z(Most(x), Tail(x));
     }
 
-    operation IsSeven_MarkingOracle(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation IsSeven_MarkingOracle(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         Controlled X(x, y);
     }
 
     operation ApplyMarkingOracleAsPhaseOracle(
-        markingOracle: ((Qubit[], Qubit) => Unit is Adj + Ctl),
-        qubits: Qubit[]) : Unit is Adj + Ctl {
-            
+        markingOracle : ((Qubit[], Qubit) => Unit is Adj + Ctl),
+        qubits : Qubit[]) : Unit is Adj + Ctl {
+
         use minus = Qubit();
         within {
             X(minus);
@@ -56,5 +56,5 @@ namespace Kata {
         } apply {
             markingOracle(qubits, minus);
         }
-    }    
+    }
 }

--- a/katas/content/oracles/phase_oracle_alt_bit.qs
+++ b/katas/content/oracles/phase_oracle_alt_bit.qs
@@ -2,7 +2,7 @@ namespace Kata {
     open Microsoft.Quantum.Diagnostics;
 
     // This operation implements the oracle; we will learn how to implement oracles later in the kata
-    operation AlternatingBitPattern_PhaseOracle(x: Qubit[]): Unit is Adj + Ctl {
+    operation AlternatingBitPattern_PhaseOracle(x : Qubit[]) : Unit is Adj + Ctl {
         use q = Qubit();
         X(q);
         ApplyControlledOnBitString([false, true, false], Z, x, q);
@@ -11,7 +11,7 @@ namespace Kata {
     }
 
     @EntryPoint()
-    operation PhaseOracle_Demo(): Unit {
+    operation PhaseOracle_Demo() : Unit {
         // Allocate 3 qubits in the |000⟩ state
         use q = Qubit[3];
         // Prepare an equal superposition of all basis states
@@ -31,5 +31,5 @@ namespace Kata {
         // Reset our state back to all zeros for deallocation
         ResetAll(q);
     }
-    
+
 }

--- a/katas/content/oracles/phase_oracle_seven/solution.qs
+++ b/katas/content/oracles/phase_oracle_seven/solution.qs
@@ -1,7 +1,7 @@
 namespace Kata {
     open Microsoft.Quantum.Arrays;
 
-    operation IsSeven_PhaseOracle(x: Qubit[]): Unit is Adj + Ctl {
+    operation IsSeven_PhaseOracle(x : Qubit[]) : Unit is Adj + Ctl {
         Controlled Z(Most(x), Tail(x));
     }
 }

--- a/katas/content/oracles/phase_oracle_seven/verification.qs
+++ b/katas/content/oracles/phase_oracle_seven/verification.qs
@@ -6,7 +6,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         let N = 3;
         let isCorrect = CheckOperationsEqualReferenced(
             N,

--- a/katas/content/oracles/test_meeting_oracle.qs
+++ b/katas/content/oracles/test_meeting_oracle.qs
@@ -4,24 +4,24 @@ namespace Kata {
     open Microsoft.Quantum.Convert;
 
     // The classical function to perform the same computation
-    function Meeting_Classical(x: Bool[], jasmine: Bool[]): Bool {
+    function Meeting_Classical(x : Bool[], jasmine : Bool[]) : Bool {
         for i in IndexRange(x) {
             if ((not x[i]) and (not jasmine[i])) {
                 // They have a day that they can both meet
                 return true;
             }
         }
-        
+
         // At least one of them is busy every day of the week
         return false;
     }
 
-    operation Or_Oracle(x: Qubit[], y: Qubit): Unit is Adj + Ctl {
+    operation Or_Oracle(x : Qubit[], y : Qubit) : Unit is Adj + Ctl {
         X(y);
         ApplyControlledOnInt(0, X, x, y);
     }
 
-    operation Meeting_Oracle(x: Qubit[], jasmine: Qubit[], z: Qubit): Unit is Adj + Ctl {
+    operation Meeting_Oracle(x : Qubit[], jasmine : Qubit[], z : Qubit) : Unit is Adj + Ctl {
         use q = Qubit[Length(x)];
         within {
             for i in IndexRange(q) {
@@ -36,17 +36,17 @@ namespace Kata {
     }
 
     @EntryPoint()
-    operation Test_Meeting_Oracle(): Unit {
+    operation Test_Meeting_Oracle() : Unit {
         // There are 2^5 ways to arrange each of the schedules - let's try all of them
-        for k in 0..((2^5)-1) { 
+        for k in 0..((2^5)-1) {
             for j in 0..((2^5)-1) {
                 // Convert your and Jasmine's schedules to bit arrays
                 let binaryX = IntAsBoolArray(k, 5);
                 let binaryJasmine = IntAsBoolArray(j, 5);
-                
+
                 // Calculate the function classically
                 let classicalResult = Meeting_Classical(binaryX, binaryJasmine);
-                    
+
                 // create a register of qubits so we can represent
                 // your schedule, jasmine's schedule, and the output
                 use (x, jasmine, target) = (Qubit[5], Qubit[5], Qubit());
@@ -69,16 +69,16 @@ namespace Kata {
 
                 // Check that the oracle did not change its input states
                 if not CheckAllZero(x) {
-                    Message($"Failed on test case k = {k}, j = {j}. Input state of x changed.");                    
+                    Message($"Failed on test case k = {k}, j = {j}. Input state of x changed.");
                 }
                 if not CheckAllZero(jasmine) {
-                    Message($"Failed on test case k = {k}, j = {j}. Input state of jasmine changed.");                    
+                    Message($"Failed on test case k = {k}, j = {j}. Input state of jasmine changed.");
                 }
 
                 Reset(target);
             }
         }
-        
+
         Message("Success!");
     }
 

--- a/katas/content/qubit/examples/MultiQubitDumpMachineDemo.qs
+++ b/katas/content/qubit/examples/MultiQubitDumpMachineDemo.qs
@@ -2,7 +2,7 @@ namespace Kata {
     open Microsoft.Quantum.Diagnostics;
 
     @EntryPoint()
-    operation MultiQubitDumpMachineDemo(): Unit {
+    operation MultiQubitDumpMachineDemo() : Unit {
         // This line allocates two qubits in state |00⟩.
         use qs = Qubit[2];
         Message("State |00⟩:");

--- a/katas/content/qubit/examples/SingleQubitDumpMachineDemo.qs
+++ b/katas/content/qubit/examples/SingleQubitDumpMachineDemo.qs
@@ -2,7 +2,7 @@ namespace Kata {
     open Microsoft.Quantum.Diagnostics;
 
     @EntryPoint()
-    operation RunExample(): Unit {
+    operation RunExample() : Unit {
         // This line allocates a qubit in state |0⟩.
         use q = Qubit();
         Message("State |0⟩:");
@@ -19,7 +19,7 @@ namespace Kata {
 
         // This line changes the qubit to state |-⟩ = (1/sqrt(2))(|0⟩ - |1⟩).
         // That is, this puts the qubit into a superposition where the absolute
-        // value of the probability amplitudes is 1/sqrt(2), which is 
+        // value of the probability amplitudes is 1/sqrt(2), which is
         // approximately 0.707107.
         H(q);
 

--- a/katas/content/qubit/learn_basis_state_amplitudes/Placeholder.qs
+++ b/katas/content/qubit/learn_basis_state_amplitudes/Placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation LearnBasisStateAmplitudes(qs: Qubit[]): (Double, Double) {
+    operation LearnBasisStateAmplitudes(qs : Qubit[]) : (Double, Double) {
         // Implement your solution here...
 
         return (0.0, 0.0);

--- a/katas/content/qubit/learn_basis_state_amplitudes/Solution.qs
+++ b/katas/content/qubit/learn_basis_state_amplitudes/Solution.qs
@@ -1,7 +1,7 @@
 namespace Kata {
     open Microsoft.Quantum.Diagnostics;
 
-    operation LearnBasisStateAmplitudes(qs: Qubit[]): (Double, Double) {
+    operation LearnBasisStateAmplitudes(qs : Qubit[]) : (Double, Double) {
         DumpMachine(); // Only used to learn the amplitudes.
         return (0.3821, 0.339);
     }

--- a/katas/content/qubit/learn_basis_state_amplitudes/Verification.qs
+++ b/katas/content/qubit/learn_basis_state_amplitudes/Verification.qs
@@ -3,7 +3,7 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Math;
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         use qs = Qubit[2];
 
         // Prepare the state that will be passed to the solution.
@@ -15,7 +15,7 @@ namespace Kata.Verification {
         let (x1, x2) = Kata.LearnBasisStateAmplitudes(qs);
 
         // Calculate the expected values based on the rotation angle.
-        // We convert |00⟩ + |10⟩ to |0⟩ Ry(1.0)|0⟩ + |1⟩ Ry(2.0)|0⟩, so 
+        // We convert |00⟩ + |10⟩ to |0⟩ Ry(1.0)|0⟩ + |1⟩ Ry(2.0)|0⟩, so
         // * the amplitude of |1⟩ = |10⟩ is 1st amp of Ry(2.0)|0⟩
         // * the amplitude of |2⟩ = |01⟩ is 2nd amp of Ry(1.0)|0⟩
         let (x1_exp, x2_exp) = (

--- a/katas/content/qubit/learn_single_qubit_state/Placeholder.qs
+++ b/katas/content/qubit/learn_single_qubit_state/Placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation LearnSingleQubitState(q: Qubit): (Double, Double) {
+    operation LearnSingleQubitState(q : Qubit) : (Double, Double) {
         // Implement your solution here...
 
         return (0.0, 0.0);

--- a/katas/content/qubit/learn_single_qubit_state/Verification.qs
+++ b/katas/content/qubit/learn_single_qubit_state/Verification.qs
@@ -3,7 +3,7 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Math;
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         use q = Qubit();
 
         // Prepare the state that will be passed to the solution.

--- a/katas/content/random_numbers/random_n_bits/solution.qs
+++ b/katas/content/random_numbers/random_n_bits/solution.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation RandomNBits(N: Int): Int {
+    operation RandomNBits(N : Int) : Int {
         mutable result = 0;
         for i in 0..(N - 1) {
             set result = result * 2 + RandomBit();

--- a/katas/content/random_numbers/random_n_bits/verification.qs
+++ b/katas/content/random_numbers/random_n_bits/verification.qs
@@ -1,6 +1,6 @@
 namespace Kata.Verification {
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         // Test random number generation for 1, 2, 3, 10 bits
         let testCases = [(1, 1000), (2, 1000), (3, 1000), (10, 10000)];
         for (N, runs) in testCases {

--- a/katas/content/random_numbers/random_number/solution.qs
+++ b/katas/content/random_numbers/random_number/solution.qs
@@ -1,16 +1,16 @@
 namespace Kata {
     open Microsoft.Quantum.Math;
 
-    operation RandomNumberInRange(min: Int, max: Int): Int {
+    operation RandomNumberInRange(min : Int, max : Int) : Int {
         let nBits = BitSizeI(max - min);
-        mutable output = 0; 
+        mutable output = 0;
         repeat {
-            set output = RandomNBits(nBits); 
+            set output = RandomNBits(nBits);
         } until output <= max - min;
         return output + min;
     }
 
-    operation RandomNBits(N: Int): Int {
+    operation RandomNBits(N : Int) : Int {
         mutable result = 0;
         for i in 0..(N - 1) {
             set result = result * 2 + RandomBit();
@@ -28,7 +28,7 @@ namespace Kata {
         // Measuring the qubit and reset.
         let result = M(q);
         Reset(q);
-        
+
         // Return integer value of result.
         if result == One {
             return 1;

--- a/katas/content/random_numbers/random_number/verification.qs
+++ b/katas/content/random_numbers/random_number/verification.qs
@@ -1,6 +1,6 @@
 namespace Kata.Verification {
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         let testCases = [(1, 3, 1000), (27, 312, 5000), (0, 3, 1000), (0, 1023, 10000)];
         for (min, max, runs) in testCases {
             Message($"Testing for min = {min} and max = {max}...");

--- a/katas/content/random_numbers/random_two_bits/solution.qs
+++ b/katas/content/random_numbers/random_two_bits/solution.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation RandomTwoBits(): Int {
+    operation RandomTwoBits() : Int {
         return 2 * RandomBit() + RandomBit();
     }
 

--- a/katas/content/random_numbers/random_two_bits/verification.qs
+++ b/katas/content/random_numbers/random_two_bits/verification.qs
@@ -1,6 +1,6 @@
 namespace Kata.Verification {
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         Message("Testing two random bits generation...");
         let randomnessVerifier = () => CheckUniformDistribution(Kata.RandomTwoBits, 0, 3, 1000);
         let isCorrect = IsSufficientlyRandom(randomnessVerifier);

--- a/katas/content/random_numbers/weighted_random_bit/solution.qs
+++ b/katas/content/random_numbers/weighted_random_bit/solution.qs
@@ -1,7 +1,7 @@
 namespace Kata {
     open Microsoft.Quantum.Math;
 
-    operation WeightedRandomBit(x : Double): Int {
+    operation WeightedRandomBit(x : Double) : Int {
         // Calculate theta value.
         let theta = 2.0 *  ArcCos(Sqrt(x));  // (or) 2.0 * ArcSin(Sqrt(1.0 - x));
 

--- a/katas/content/random_numbers/weighted_random_bit/verification.qs
+++ b/katas/content/random_numbers/weighted_random_bit/verification.qs
@@ -3,7 +3,7 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Convert;
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         for x in [0.0, 0.25, 0.5, 0.75, 1.0] {
             Message($"Testing generating zero with {x*100.0}% probability...");
             let randomnessVerifier = () => CheckXPercentZero(() => Kata.WeightedRandomBit(x), x);
@@ -46,10 +46,10 @@ namespace Kata.Verification {
             }
         } else {
             if zeroCount < goalZeroCount - 4 * nRuns / 100 {
-                Message($"Unexpectedly low number of 0's generated: expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
+                Message($"Unexpectedly low number of 0's generated : expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
                 return 0x3;
             } elif zeroCount > goalZeroCount + 4 * nRuns / 100 {
-                Message($"Unexpectedly high number of 0's generated: expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
+                Message($"Unexpectedly high number of 0's generated : expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
                 return 0x4;
             }
         }

--- a/katas/content/random_numbers/weighted_random_bit/verification.qs
+++ b/katas/content/random_numbers/weighted_random_bit/verification.qs
@@ -46,10 +46,10 @@ namespace Kata.Verification {
             }
         } else {
             if zeroCount < goalZeroCount - 4 * nRuns / 100 {
-                Message($"Unexpectedly low number of 0's generated : expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
+                Message($"Unexpectedly low number of 0's generated: expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
                 return 0x3;
             } elif zeroCount > goalZeroCount + 4 * nRuns / 100 {
-                Message($"Unexpectedly high number of 0's generated : expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
+                Message($"Unexpectedly high number of 0's generated: expected around {x * IntAsDouble(nRuns)} 0's, got {zeroCount} out of {nRuns}");
                 return 0x4;
             }
         }

--- a/katas/content/single_qubit_measurements/a_b_basis_measurements/solution.qs
+++ b/katas/content/single_qubit_measurements/a_b_basis_measurements/solution.qs
@@ -1,6 +1,6 @@
 namespace Kata {
 
-    operation MeasureInABBasis(alpha: Double, q: Qubit): Result {
+    operation MeasureInABBasis(alpha : Double, q : Qubit) : Result {
         Rx(-2.0 * alpha, q);
         let measurementResult = M(q);
         Rx(2.0 * alpha, q);

--- a/katas/content/single_qubit_measurements/a_b_basis_measurements/verification.qs
+++ b/katas/content/single_qubit_measurements/a_b_basis_measurements/verification.qs
@@ -18,12 +18,12 @@ namespace Kata.Verification {
     }
 
     // We can use the StatePrep_IsQubitA operation for the testing
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         for i in 0 .. 10 {
             let alpha = (PI() * IntAsDouble(i)) / 10.0;
             let isCorrect = DistinguishTwoStates(
-                StatePrep_IsQubitA(alpha, _, _), 
-                q => Kata.MeasureInABBasis(alpha, q) == Zero, 
+                StatePrep_IsQubitA(alpha, _, _),
+                q => Kata.MeasureInABBasis(alpha, q) == Zero,
                 [$"|B⟩=(-i sin({i}π/10)|0⟩ + cos({i}π/10)|1⟩)", $"|A⟩=(cos({i}π/10)|0⟩ + i sin({i}π/10)|1⟩)"],
                 true);
             if not isCorrect {

--- a/katas/content/single_qubit_measurements/common.qs
+++ b/katas/content/single_qubit_measurements/common.qs
@@ -6,7 +6,7 @@ namespace Kata.Verification {
     // "Framework" operation for testing single-qubit tasks for distinguishing states of one qubit
     // with Bool return
     operation DistinguishTwoStates(
-        statePrep: ((Qubit, Int) => Unit is Adj),
+        statePrep : ((Qubit, Int) => Unit is Adj),
         testImpl : (Qubit => Bool),
         stateName : String[],
         checkFinalState : Bool) : Bool {
@@ -14,7 +14,7 @@ namespace Kata.Verification {
         let nTotal = 100;
         let nStates = 2;
         mutable misclassifications = Repeated(0, nStates);
-        
+
         use q = Qubit();
         for i in 1 .. nTotal {
             // get a random bit to define whether qubit will be in a state corresponding to true return (1) or to false one (0)
@@ -30,7 +30,7 @@ namespace Kata.Verification {
             if ans != (state == 1) {
                 set misclassifications w/= state <- misclassifications[state] + 1;
             }
-                
+
             // If the final state is to be verified, check if it matches the measurement outcome
             if checkFinalState {
                 Adjoint statePrep(q, state);
@@ -39,15 +39,15 @@ namespace Kata.Verification {
                 Reset(q);
             }
         }
-        
+
         mutable totalMisclassifications = 0;
         for i in 0 .. nStates - 1 {
             if misclassifications[i] != 0 {
                 set totalMisclassifications += misclassifications[i];
-                Message($"Misclassified {stateName[i]} as {stateName[1 - i]} in {misclassifications[i]} test runs.");   
+                Message($"Misclassified {stateName[i]} as {stateName[1 - i]} in {misclassifications[i]} test runs.");
             }
         }
-        
+
         return totalMisclassifications == 0;
     }
 

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/solution.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/solution.qs
@@ -1,7 +1,7 @@
 namespace Kata {
     open Microsoft.Quantum.Math;
 
-    operation IsQubitPsiPlus(q: Qubit): Bool { 
+    operation IsQubitPsiPlus(q : Qubit) : Bool {
         Ry(-2.0 * ArcTan2(0.8, 0.6), q);
         return M(q) == Zero;
     }

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/verification.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/verification.qs
@@ -4,7 +4,7 @@ namespace Kata.Verification {
     // Distinguish specific orthogonal states
     // |ψ₊⟩ =   0.6 * |0⟩ + 0.8 * |1⟩,
     // |ψ₋⟩ =  -0.8 * |0⟩ + 0.6 * |1⟩.
-    operation StatePrep_IsQubitPsiPlus(q: Qubit, state: Int): Unit is Adj {
+    operation StatePrep_IsQubitPsiPlus(q : Qubit, state : Int) : Unit is Adj {
         if state == 0 {
             // convert |0⟩ to |ψ₋⟩
             X(q);
@@ -15,10 +15,10 @@ namespace Kata.Verification {
         }
     }
 
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         let isCorrect = DistinguishTwoStates(
             StatePrep_IsQubitPsiPlus,
-            Kata.IsQubitPsiPlus, 
+            Kata.IsQubitPsiPlus,
             ["|ψ₋⟩", "|ψ₊⟩"],
             false);
         if isCorrect {

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/solution.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/solution.qs
@@ -1,6 +1,6 @@
 namespace Kata {
 
-    operation IsQubitA(alpha: Double, q: Qubit): Bool { 
+    operation IsQubitA(alpha : Double, q : Qubit) : Bool {
         Rx(-2.0 * alpha, q);
         return M(q) == Zero;
     }

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/verification.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/verification.qs
@@ -5,7 +5,7 @@ namespace Kata.Verification {
     // Distinguish states |A❭ and |B❭
     // |A⟩ =   cos(alpha) * |0⟩ - i sin(alpha) * |1⟩,
     // |B⟩ = - i sin(alpha) * |0⟩ + cos(alpha) * |1⟩.
-    operation StatePrep_IsQubitA(alpha: Double, q: Qubit, state: Int): Unit is Adj {
+    operation StatePrep_IsQubitA(alpha : Double, q : Qubit, state : Int) : Unit is Adj {
         if state == 0 {
             // convert |0⟩ to |B⟩
             X(q);
@@ -17,12 +17,12 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         for i in 0 .. 10 {
             let alpha = (PI() * IntAsDouble(i)) / 10.0;
             let isCorrect = DistinguishTwoStates(
                 StatePrep_IsQubitA(alpha, _, _),
-                Kata.IsQubitA(alpha, _), 
+                Kata.IsQubitA(alpha, _),
                 [$"|B⟩ = -i sin({i}π/10)|0⟩ + cos({i}π/10)|1⟩", $"|A⟩ = cos({i}π/10)|0⟩ + i sin({i}π/10)|1⟩"],
                 false);
             if not isCorrect {

--- a/katas/content/single_qubit_measurements/distinguish_plus_and_minus/solution.qs
+++ b/katas/content/single_qubit_measurements/distinguish_plus_and_minus/solution.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation IsQubitMinus(q : Qubit): Bool {
+    operation IsQubitMinus(q : Qubit) : Bool {
         return Measure([PauliX], [q]) == One;
     }
 

--- a/katas/content/single_qubit_measurements/distinguish_plus_and_minus/verification.qs
+++ b/katas/content/single_qubit_measurements/distinguish_plus_and_minus/verification.qs
@@ -13,7 +13,7 @@ namespace Kata.Verification {
     }
 
     @EntryPoint()
-    operation CheckSolution(): Bool {
+    operation CheckSolution() : Bool {
         let isCorrect = DistinguishTwoStates(
             StatePrep_IsQubitMinus,
             Kata.IsQubitMinus,

--- a/language_service/src/completion/tests.rs
+++ b/language_service/src/completion/tests.rs
@@ -66,7 +66,7 @@ fn in_block_contains_std_functions() {
                             "0600FakeWithParam",
                         ),
                         detail: Some(
-                            "operation FakeWithParam(x: Int) : Unit",
+                            "operation FakeWithParam(x : Int) : Unit",
                         ),
                         additional_text_edits: Some(
                             [

--- a/language_service/src/display.rs
+++ b/language_service/src/display.rs
@@ -98,7 +98,7 @@ struct IdentTy<'a> {
 
 impl<'a> Display for IdentTy<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}: {}", self.ident.name, AstTy { ty: self.ty },)
+        write!(f, "{} : {}", self.ident.name, AstTy { ty: self.ty },)
     }
 }
 
@@ -112,7 +112,7 @@ impl<'a> Display for IdentTyId<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
-            "{}: {}",
+            "{} : {}",
             self.ident.name,
             TyId {
                 ty_id: self.ty_id,
@@ -132,7 +132,7 @@ impl<'a> Display for PathTyId<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
-            "{}: {}",
+            "{} : {}",
             &Path { path: self.path },
             TyId {
                 ty_id: self.ty_id,
@@ -237,8 +237,8 @@ impl<'a> Display for HirPat<'a> {
             compilation: self.compilation,
         };
         match &self.pat.kind {
-            hir::PatKind::Bind(name) => write!(f, "{}: {ty}", name.name),
-            hir::PatKind::Discard => write!(f, "_: {ty}"),
+            hir::PatKind::Bind(name) => write!(f, "{} : {ty}", name.name),
+            hir::PatKind::Discard => write!(f, "_ : {ty}"),
             hir::PatKind::Tuple(items) => {
                 let mut elements = items.iter();
                 if let Some(elem) = elements.next() {
@@ -293,7 +293,7 @@ impl<'a> Display for AstPat<'a> {
                 Some(ty) => write!(f, "{}", AstTy { ty }),
                 None => write!(
                     f,
-                    "_: {}",
+                    "_ : {}",
                     TyId {
                         ty_id: self.pat.id,
                         compilation: self.compilation
@@ -638,7 +638,7 @@ impl<'a> Display for TyDef<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self.def.kind.as_ref() {
             ast::TyDefKind::Field(name, ty) => match name {
-                Some(name) => write!(f, "{}: {}", name.name, AstTy { ty }),
+                Some(name) => write!(f, "{} : {}", name.name, AstTy { ty }),
                 None => write!(f, "{}", AstTy { ty }),
             },
             ast::TyDefKind::Paren(def) => write!(f, "{}", TyDef { def }),

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -69,7 +69,7 @@ fn callable_with_callable_types() {
         &expect![[r#"
             ```qsharp
             Test
-            operation Foo(x: (Int => Int)) : (Int => Int)
+            operation Foo(x : (Int => Int)) : (Int => Int)
             ```
             ---
             Doc comment!
@@ -128,7 +128,7 @@ fn callable_with_callable_types_functors() {
         &expect![[r#"
             ```qsharp
             Test
-            operation Foo(x: (Int => Int is Adj + Ctl)) : (Int => Int is Adj) is Adj
+            operation Foo(x : (Int => Int is Adj + Ctl)) : (Int => Int is Adj) is Adj
             ```
             ---
             Doc comment!
@@ -166,7 +166,7 @@ fn callable_param() {
         &expect![[r#"
             parameter of `Foo`
             ```qsharp
-            x: Int
+            x : Int
             ```
         "#]],
     );
@@ -183,7 +183,7 @@ fn callable_param_ref() {
         &expect![[r#"
             parameter of `Foo`
             ```qsharp
-            x: Int
+            x : Int
             ```
         "#]],
     );
@@ -203,7 +203,7 @@ fn callable_spec_param() {
         &expect![[r#"
             parameter of `Foo`
             ```qsharp
-            ctrl: Qubit[]
+            ctrl : Qubit[]
             ```
         "#]],
     );
@@ -223,7 +223,7 @@ fn callable_spec_param_ref() {
         &expect![[r#"
             parameter of `Foo`
             ```qsharp
-            ctrl: Qubit[]
+            ctrl : Qubit[]
             ```
         "#]],
     );
@@ -242,7 +242,7 @@ fn identifier() {
         &expect![[r#"
             local
             ```qsharp
-            x: Int
+            x : Int
             ```
         "#]],
     );
@@ -262,7 +262,7 @@ fn identifier_ref() {
         &expect![[r#"
             local
             ```qsharp
-            x: Int
+            x : Int
             ```
         "#]],
     );
@@ -281,7 +281,7 @@ fn identifier_tuple() {
         &expect![[r#"
             local
             ```qsharp
-            y: Double
+            y : Double
             ```
         "#]],
     );
@@ -301,7 +301,7 @@ fn identifier_tuple_ref() {
         &expect![[r#"
             local
             ```qsharp
-            y: Double
+            y : Double
             ```
         "#]],
     );
@@ -322,7 +322,7 @@ fn identifier_for_loop() {
         &expect![[r#"
             local
             ```qsharp
-            i: Int
+            i : Int
             ```
         "#]],
     );
@@ -343,7 +343,7 @@ fn identifier_for_loop_ref() {
         &expect![[r#"
             local
             ```qsharp
-            i: Int
+            i : Int
             ```
         "#]],
     );
@@ -365,7 +365,7 @@ fn identifier_nested_ref() {
         &expect![[r#"
             local
             ```qsharp
-            x: Int
+            x : Int
             ```
         "#]],
     );
@@ -386,7 +386,7 @@ fn lambda() {
         &expect![[r#"
             local
             ```qsharp
-            lambda: ((Double, String) => Int)
+            lambda : ((Double, String) => Int)
             ```
         "#]],
     );
@@ -407,7 +407,7 @@ fn lambda_ref() {
         &expect![[r#"
             local
             ```qsharp
-            lambda: ((Double, String) => Int)
+            lambda : ((Double, String) => Int)
             ```
         "#]],
     );
@@ -428,7 +428,7 @@ fn lambda_param() {
         &expect![[r#"
             lambda parameter
             ```qsharp
-            y: String
+            y : String
             ```
         "#]],
     );
@@ -448,7 +448,7 @@ fn lambda_param_ref() {
         &expect![[r#"
             lambda parameter
             ```qsharp
-            y: String
+            y : String
             ```
         "#]],
     );
@@ -469,7 +469,7 @@ fn lambda_closure_ref() {
         &expect![[r#"
             local
             ```qsharp
-            a: Int
+            a : Int
             ```
         "#]],
     );
@@ -490,7 +490,7 @@ fn identifier_udt() {
         &expect![[r#"
             local
             ```qsharp
-            a: Pair
+            a : Pair
             ```
         "#]],
     );
@@ -506,7 +506,7 @@ fn udt() {
     "#},
         &expect![[r#"
             ```qsharp
-            newtype Pair = (Int, snd: Int)
+            newtype Pair = (Int, snd : Int)
             ```
         "#]],
     );
@@ -599,7 +599,7 @@ fn udt_field() {
     "#},
         &expect![[r#"
             ```qsharp
-            snd: Int
+            snd : Int
             ```
         "#]],
     );
@@ -619,7 +619,7 @@ fn udt_field_ref() {
     "#},
         &expect![[r#"
             ```qsharp
-            snd: Int
+            snd : Int
             ```
         "#]],
     );
@@ -692,7 +692,7 @@ fn foreign_call_with_param() {
         &expect![[r#"
             ```qsharp
             FakeStdLib
-            operation FakeWithParam(x: Int) : Unit
+            operation FakeWithParam(x : Int) : Unit
             ```
         "#]],
     );
@@ -946,7 +946,7 @@ fn callable_param_doc() {
         &expect![[r#"
             parameter of `Foo`
             ```qsharp
-            x: Int
+            x : Int
             ```
             ---
             Doc string for `x`

--- a/language_service/src/signature_help/tests.rs
+++ b/language_service/src/signature_help/tests.rs
@@ -32,27 +32,27 @@ fn first_argument() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(x: Int, y: Double, z: String) : Unit",
+                        label: "operation Foo(x : Int, y : Double, z : String) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 31,
+                                    start: 23,
+                                    end: 33,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 33,
-                                    end: 42,
+                                    start: 35,
+                                    end: 45,
                                 },
                                 documentation: None,
                             },
@@ -82,27 +82,27 @@ fn mid_argument() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(x: Int, y: Double, z: String) : Unit",
+                        label: "operation Foo(x : Int, y : Double, z : String) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 31,
+                                    start: 23,
+                                    end: 33,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 33,
-                                    end: 42,
+                                    start: 35,
+                                    end: 45,
                                 },
                                 documentation: None,
                             },
@@ -132,27 +132,27 @@ fn second_argument() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(x: Int, y: Double, z: String) : Unit",
+                        label: "operation Foo(x : Int, y : Double, z : String) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 31,
+                                    start: 23,
+                                    end: 33,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 33,
-                                    end: 42,
+                                    start: 35,
+                                    end: 45,
                                 },
                                 documentation: None,
                             },
@@ -182,27 +182,27 @@ fn last_argument() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(x: Int, y: Double, z: String) : Unit",
+                        label: "operation Foo(x : Int, y : Double, z : String) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 31,
+                                    start: 23,
+                                    end: 33,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 33,
-                                    end: 42,
+                                    start: 35,
+                                    end: 45,
                                 },
                                 documentation: None,
                             },
@@ -249,27 +249,27 @@ fn revisit_second_argument() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(x: Int, y: Double, z: String) : Unit",
+                        label: "operation Foo(x : Int, y : Double, z : String) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 31,
+                                    start: 23,
+                                    end: 33,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 33,
-                                    end: 42,
+                                    start: 35,
+                                    end: 45,
                                 },
                                 documentation: None,
                             },
@@ -300,20 +300,20 @@ fn nested_call_argument() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Bar(a: Int, b: Double) : Double",
+                        label: "operation Bar(a : Int, b : Double) : Double",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 31,
+                                    start: 23,
+                                    end: 33,
                                 },
                                 documentation: None,
                             },
@@ -344,20 +344,20 @@ fn nested_call_second_argument() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Bar(a: Int, b: Double) : Double",
+                        label: "operation Bar(a : Int, b : Double) : Double",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 31,
+                                    start: 23,
+                                    end: 33,
                                 },
                                 documentation: None,
                             },
@@ -387,27 +387,27 @@ fn tuple_argument() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(x: Int, y: (Int, Double), z: String) : Unit",
+                        label: "operation Foo(x : Int, y : (Int, Double), z : String) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 38,
+                                    start: 23,
+                                    end: 40,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 40,
-                                    end: 49,
+                                    start: 42,
+                                    end: 52,
                                 },
                                 documentation: None,
                             },
@@ -437,27 +437,27 @@ fn arguments_in_nested_tuple() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(w: Int, (x: Double, y: String), z: Bool) : Unit",
+                        label: "operation Foo(w : Int, (x : Double, y : String), z : Bool) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 44,
+                                    start: 23,
+                                    end: 47,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 46,
-                                    end: 53,
+                                    start: 49,
+                                    end: 57,
                                 },
                                 documentation: None,
                             },
@@ -487,27 +487,27 @@ fn first_inner_argument_in_nested_tuple() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(w: Int, (x: Double, y: String), z: Bool) : Unit",
+                        label: "operation Foo(w : Int, (x : Double, y : String), z : Bool) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 44,
+                                    start: 23,
+                                    end: 47,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 46,
-                                    end: 53,
+                                    start: 49,
+                                    end: 57,
                                 },
                                 documentation: None,
                             },
@@ -537,27 +537,27 @@ fn second_inner_argument_in_nested_tuple() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(w: Int, (x: Double, y: String), z: Bool) : Unit",
+                        label: "operation Foo(w : Int, (x : Double, y : String), z : Bool) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 44,
+                                    start: 23,
+                                    end: 47,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 46,
-                                    end: 53,
+                                    start: 49,
+                                    end: 57,
                                 },
                                 documentation: None,
                             },
@@ -587,27 +587,27 @@ fn argument_after_nested_tuple() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "operation Foo(w: Int, (x: Double, y: String), z: Bool) : Unit",
+                        label: "operation Foo(w : Int, (x : Double, y : String), z : Bool) : Unit",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
                                 label: Span {
                                     start: 14,
-                                    end: 20,
+                                    end: 21,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 22,
-                                    end: 44,
+                                    start: 23,
+                                    end: 47,
                                 },
                                 documentation: None,
                             },
                             ParameterInformation {
                                 label: Span {
-                                    start: 46,
-                                    end: 53,
+                                    start: 49,
+                                    end: 57,
                                 },
                                 documentation: None,
                             },

--- a/library/core/qir.qs
+++ b/library/core/qir.qs
@@ -10,7 +10,7 @@ namespace QIR.Runtime {
         body intrinsic;
     }
 
-    operation AllocateQubitArray(size: Int) : Qubit[] {
+    operation AllocateQubitArray(size : Int) : Qubit[] {
         if size < 0 {
             fail "Cannot allocate qubit array with a negative length";
         }

--- a/library/std/arithmetic.qs
+++ b/library/std/arithmetic.qs
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// This operation resets its input register to the |00...0> state,
     /// suitable for releasing back to a target machine.
     @Config(Full)
-    operation MeasureInteger(target: Qubit[]): Int {
+    operation MeasureInteger(target : Qubit[]) : Int {
         let nBits = Length(target);
         Fact(nBits < 64, $"`Length(target)` must be less than 64, but was {nBits}.");
 
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// Automatically chooses between addition with
     /// carry and without, depending on the register size of `ys`,
     /// which holds the result after operation is complete.
-    operation AddI (xs: Qubit[], ys: Qubit[]) : Unit is Adj + Ctl {
+    operation AddI (xs : Qubit[], ys : Qubit[]) : Unit is Adj + Ctl {
         if Length(xs) == Length(ys) {
             RippleCarryAdderNoCarryTTK(xs, ys);
         }

--- a/library/std/arrays.qs
+++ b/library/std/arrays.qs
@@ -395,7 +395,7 @@ namespace Microsoft.Quantum.Arrays {
     /// let flattened = Flattened([[1, 2], [3], [4, 5, 6]]);
     /// // flattened = [1, 2, 3, 4, 5, 6]
     /// ```
-    function Flattened<'T>(arrays : 'T[][]): 'T[] {
+    function Flattened<'T>(arrays : 'T[][]) : 'T[] {
         mutable output = [];
         for array in arrays {
             set output += array;
@@ -934,7 +934,7 @@ namespace Microsoft.Quantum.Arrays {
     /// // The following returns [[2, 3], [5, 7], []];
     /// let split = Partitioned([2, 2], [2, 3, 5, 7]);
     /// ```
-    function Partitioned<'T>(partitionSizes: Int[], array: 'T[]) : 'T[][] {
+    function Partitioned<'T>(partitionSizes : Int[], array : 'T[]) : 'T[][] {
         mutable output = Repeated([], Length(partitionSizes) + 1);
         mutable partitionStartIndex = 0;
         for index in IndexRange(partitionSizes) {

--- a/library/std/canon.qs
+++ b/library/std/canon.qs
@@ -286,7 +286,7 @@ namespace Microsoft.Quantum.Canon {
     /// ```qsharp
     /// X(q);
     /// ```
-    operation ApplyP(pauli: Pauli, target : Qubit): Unit is Adj + Ctl {
+    operation ApplyP(pauli : Pauli, target : Qubit) : Unit is Adj + Ctl {
         if   pauli == PauliX { X(target); }
         elif pauli == PauliY { Y(target); }
         elif pauli == PauliZ { Z(target); }
@@ -313,7 +313,7 @@ namespace Microsoft.Quantum.Canon {
     /// Z(target[1]);
     /// X(target[2]);
     /// ```
-    operation ApplyPauli(pauli: Pauli[], target: Qubit[]) : Unit is Adj + Ctl {
+    operation ApplyPauli(pauli : Pauli[], target : Qubit[]) : Unit is Adj + Ctl {
         Fact(Length(pauli) == Length(target), "`pauli` and `target` must be of the same length.");
         for i in 0..Length(pauli)-1 {
             ApplyP(pauli[i], target[i]);
@@ -384,10 +384,10 @@ namespace Microsoft.Quantum.Canon {
     /// ApplyPauliFromBitString(PauliZ, false, n, qubits);
     /// ```
     operation ApplyPauliFromInt(
-        pauli: Pauli,
-        bitApply: Bool,
-        numberState: Int,
-        qubits: Qubit[]): Unit is Adj + Ctl {
+        pauli : Pauli,
+        bitApply : Bool,
+        numberState : Int,
+        qubits : Qubit[]) : Unit is Adj + Ctl {
 
         let length = Length(qubits);
         Fact(numberState >= 0, "number must be non-negative");
@@ -423,10 +423,10 @@ namespace Microsoft.Quantum.Canon {
     /// For example, `numberState = 537` means that `oracle`
     /// is applied if and only if `controlRegister` is in the state $\ket{537}$.
     operation ApplyControlledOnInt<'T>(
-        numberState: Int,
-        oracle: ('T => Unit is Adj + Ctl),
-        controlRegister: Qubit[],
-        target: 'T): Unit is Adj + Ctl {
+        numberState : Int,
+        oracle : ('T => Unit is Adj + Ctl),
+        controlRegister : Qubit[],
+        target : 'T) : Unit is Adj + Ctl {
 
         within {
             ApplyPauliFromInt(PauliX, false, numberState, controlRegister);
@@ -458,10 +458,10 @@ namespace Microsoft.Quantum.Canon {
     /// For example, `bits = [0,1,0,0,1]` means that `oracle` is applied if and only if `controlRegister`
     /// is in the state $\ket{0}\ket{1}\ket{0}\ket{0}\ket{1}$.
     operation ApplyControlledOnBitString<'T>(
-        bits: Bool[],
-        oracle: ('T => Unit is Adj + Ctl),
-        controlRegister: Qubit[],
-        target: 'T): Unit is Adj + Ctl {
+        bits : Bool[],
+        oracle : ('T => Unit is Adj + Ctl),
+        controlRegister : Qubit[],
+        target : 'T) : Unit is Adj + Ctl {
 
         // The control register must have enough bits to implement the requested control.
         Fact(Length(bits) <= Length(controlRegister), "Control register shorter than control pattern.");

--- a/library/std/math.qs
+++ b/library/std/math.qs
@@ -462,7 +462,7 @@ namespace Microsoft.Quantum.Math {
     /// Finds the continued fraction convergent closest to `fraction`
     /// with the denominator less or equal to `denominatorBound`
     /// Using process similar to this: https://nrich.maths.org/1397
-    function ContinuedFractionConvergentI(fraction : (Int, Int), denominatorBound : Int): (Int, Int) {
+    function ContinuedFractionConvergentI(fraction : (Int, Int), denominatorBound : Int) : (Int, Int) {
         Fact(denominatorBound > 0, "Denominator bound must be positive");
 
         let (a, b) = fraction;

--- a/samples/algorithms/Grover.qs
+++ b/samples/algorithms/Grover.qs
@@ -35,9 +35,9 @@ namespace Sample {
     /// Implements Grover's algorithm, which searches all possible inputs to an
     /// operation to find a particular marked state.
     operation GroverSearch(
-        nQubits: Int,
-        iterations: Int,
-        phaseOracle: Qubit[] => Unit): Result[] {
+        nQubits : Int,
+        iterations : Int,
+        phaseOracle : Qubit[] => Unit) : Result[] {
 
         use qubits = Qubit[nQubits];
 
@@ -90,7 +90,7 @@ namespace Sample {
     /// # Summary
     /// Given a register in the all-zeros state, prepares a uniform
     /// superposition over all basis states.
-    operation PrepareUniform(inputQubits : Qubit[]): Unit is Adj + Ctl {
+    operation PrepareUniform(inputQubits : Qubit[]) : Unit is Adj + Ctl {
         for q in inputQubits {
             H(q);
         }
@@ -98,13 +98,13 @@ namespace Sample {
 
     /// # Summary
     /// Reflects about the all-ones state.
-    operation ReflectAboutAllOnes(inputQubits : Qubit[]): Unit {
+    operation ReflectAboutAllOnes(inputQubits : Qubit[]) : Unit {
         Controlled Z(Most(inputQubits), Tail(inputQubits));
     }
 
     /// # Summary
     /// Reflects about the uniform superposition state.
-    operation ReflectAboutUniform(inputQubits : Qubit[]): Unit {
+    operation ReflectAboutUniform(inputQubits : Qubit[]) : Unit {
         within {
             // Transform the uniform superposition to all-zero.
             Adjoint PrepareUniform(inputQubits);

--- a/samples/algorithms/HiddenShift.qs
+++ b/samples/algorithms/HiddenShift.qs
@@ -16,7 +16,7 @@ namespace Sample {
     open Microsoft.Quantum.Measurement;
 
     @EntryPoint()
-    operation Main(): Int[] {
+    operation Main() : Int[] {
         let nQubits = 10;
 
         // Consider the case of finding a hidden shift 𝑠 between two Boolean
@@ -85,7 +85,7 @@ namespace Sample {
     operation FindHiddenShift (
         Ufstar : (Qubit[] => Unit),
         Ug : (Qubit[] => Unit),
-        n: Int)
+        n : Int)
     : Result[] {
         // We allocate n clean qubits. Note that the function Ufstar and Ug are
         // unitary operations on n qubits defined via phase encoding.
@@ -163,7 +163,7 @@ namespace Sample {
     /// applying the diagonal operation, and then undoing the bit flips to the
     /// |x〉 register. We use this principle to define shifted versions of the IP
     /// operation.
-    operation ShiftedBentFunction(shift: Int, register: Qubit[]) : Unit {
+    operation ShiftedBentFunction(shift : Int, register : Qubit[]) : Unit {
         Fact(Length(register) % 2 == 0, "Length of register must be even.");
         let u = Length(register) / 2;
         within {

--- a/samples/algorithms/Shor.qs
+++ b/samples/algorithms/Shor.qs
@@ -70,7 +70,7 @@ namespace Sample {
             else {
                 // Find divisor.
                 let gcd = GreatestCommonDivisorI(number, generator);
-                Message($"We have guessed a divisor {gcd} by accident. " + 
+                Message($"We have guessed a divisor {gcd} by accident. " +
                     "No quantum computation was done.");
 
                 // Set the flag `foundFactors` to true, indicating that we
@@ -85,7 +85,7 @@ namespace Sample {
         }
         until foundFactors
         fixup {
-            Message("The estimated period did not yield a valid factor. " + 
+            Message("The estimated period did not yield a valid factor. " +
                 "Trying again.");
         }
 
@@ -297,7 +297,7 @@ namespace Sample {
 
     /// # Summary
     /// Interprets `target` as encoding unsigned little-endian integer k and
-    /// performs transformation |k⟩ ↦ |gᵖ⋅k mod N ⟩ where p is `power`, g is 
+    /// performs transformation |k⟩ ↦ |gᵖ⋅k mod N ⟩ where p is `power`, g is
     /// `generator` and N is `modulus`.
     ///
     /// # Input
@@ -359,7 +359,7 @@ namespace Sample {
     ///
     /// # Description
     /// Given the classical constants `c` and `modulus`, and an input quantum
-    /// register |𝑦⟩ in little-endian format, this operation computes 
+    /// register |𝑦⟩ in little-endian format, this operation computes
     /// `(c*x) % modulus` into |𝑦⟩.
     ///
     /// # Input
@@ -455,7 +455,7 @@ namespace Sample {
     /// Constant number to add to |𝑦⟩.
     /// ## y
     /// Quantum register of second summand and target; must not be empty.
-    operation AddConstant(c : Int, y : Qubit[]): Unit is Adj + Ctl {
+    operation AddConstant(c : Int, y : Qubit[]) : Unit is Adj + Ctl {
         // We are using this version instead of the library version that is
         // based on Fourier angles to show an advantage of sparse simulation
         // in this sample.

--- a/samples/algorithms/SuperdenseCoding.qs
+++ b/samples/algorithms/SuperdenseCoding.qs
@@ -13,7 +13,7 @@ namespace Sample {
     open Microsoft.Quantum.Random;
 
     @EntryPoint()
-    operation Main(): (Bool, Bool) {
+    operation Main() : (Bool, Bool) {
         use (aliceQubit, bobQubit) = (Qubit(), Qubit());
 
         // The protocol starts with the preparation of an entangled state, which

--- a/samples/algorithms/Teleportation.qs
+++ b/samples/algorithms/Teleportation.qs
@@ -90,13 +90,13 @@ namespace Sample {
 
     /// # Summary
     /// Sets a qubit in state |0⟩ to |+⟩.
-    operation SetToPlus(q: Qubit) : Unit is Adj + Ctl {
+    operation SetToPlus(q : Qubit) : Unit is Adj + Ctl {
         H(q);
     }
 
     /// # Summary
     /// Sets a qubit in state |0⟩ to |−⟩.
-    operation SetToMinus(q: Qubit) : Unit is Adj + Ctl {
+    operation SetToMinus(q : Qubit) : Unit is Adj + Ctl {
         X(q);
         H(q);
     }

--- a/samples/language/Array.qs
+++ b/samples/language/Array.qs
@@ -22,7 +22,7 @@ namespace MyQuantumApp {
     operation Main() : Int[] {
 
         // A basic Int Array literal
-        let intArray: Int[] = [1, 2, 3, 4];
+        let intArray : Int[] = [1, 2, 3, 4];
         // A basic String Array literal
         let stringArray = ["a", "string", "array"];
 
@@ -30,7 +30,7 @@ namespace MyQuantumApp {
         let intArray = Repeated(0, 10);
 
         // Arrays can be sliced with ranges.
-        let slice = intArray[1..2..4];  // contains [2,4] 
+        let slice = intArray[1..2..4];  // contains [2,4]
         let slice = intArray[2..-1..0]; // contains [3,2,1]
         let slice = intArray[...]; // contains [1, 2, 3, 4];
 

--- a/samples/language/CopyAndUpdateOperator.qs
+++ b/samples/language/CopyAndUpdateOperator.qs
@@ -7,7 +7,7 @@
 /// copied version of the structure.
 namespace MyQuantumApp {
 
-    newtype Pair = (first: Int, second: Int);
+    newtype Pair = (first : Int, second : Int);
 
     @EntryPoint()
     operation Main() : Unit {

--- a/samples/language/DataTypes.qs
+++ b/samples/language/DataTypes.qs
@@ -3,12 +3,12 @@
 ///
 /// # Description
 /// Q# has a pragmatic and intuitive type system. All data types in Q# are immutable. The available
-/// primitive data types are: `Unit`, `Int`, `BigInt`, `Double`, `Bool`, `String`, `Qubit`, `Result`, 
+/// primitive data types are: `Unit`, `Int`, `BigInt`, `Double`, `Bool`, `String`, `Qubit`, `Result`,
 /// `Pauli`, and `Range`. In addition to these primitive types, Q# offers primitive aggregate types
 /// as well, `Array` and `Tuple`; composite types (a.k.a. user-defined types or UDTs); and function
 /// and operation types.
 namespace MyQuantumApp {
-    
+
     /// In the below code, all varibles have type annotations to showcase their type.
     @EntryPoint()
     operation MeasureOneQubit() : Unit {
@@ -16,17 +16,17 @@ namespace MyQuantumApp {
         // keyword.
         // The resulting value represents an opaque identifier by which virtual quantum memory
         // can be addressed. Values of type Qubit are instantiated via allocation.
-        use q: Qubit = Qubit();  
+        use q : Qubit = Qubit();
 
         // A 64-bit signed integer.
-        let integer: Int = 42;
+        let integer : Int = 42;
 
         // The singleton type whose only value is ().
-        let unit: Unit = ();
+        let unit : Unit = ();
 
         // BigInt literals are always suffixed with an L, and can be declared in
         // binary, octal, decimal, or hexadecimal.
-        let binaryBigInt: BigInt = 0b101010L;
+        let binaryBigInt : BigInt = 0b101010L;
         let octalBigInt = 0o52L;
         let decimalBigInt = 42L;
         let hexadecimalBigInt = 0x2aL;
@@ -54,20 +54,20 @@ namespace MyQuantumApp {
         // A collection that contains a sequence of values of the same type.
         let array_of_ints = [1, 2, 3];
 
-        // A tuple contains a fixed number of items of potentially different types. 
+        // A tuple contains a fixed number of items of potentially different types.
         // Tuples containing a single element are equivalent to the element they contain.
         let tuple = (1, "one", One);
 
         // A user-defined-type (UDT) consisting of two named parameters, `Real` and `Imaginary`,
         // and one anonymous parameter of Boolean type.
-        newtype ComplexBool = (Real: Double, Imaginary : Double, Bool);
+        newtype ComplexBool = (Real : Double, Imaginary : Double, Bool);
         // Instantiation of the above UDT.
         let complex = ComplexBool(42.0, 0.0, false);
 
         // A function that takes an integer and returns a boolean. This variable declaration
         // uses a Lambda function as its right hand side.
         // The function signature is provided as an annotation here, for clarity.
-        let functionType: Int => Bool = (int) => int == 0;
+        let functionType : Int => Bool = (int) => int == 0;
     }
 
 }

--- a/samples/language/Diagnostics.qs
+++ b/samples/language/Diagnostics.qs
@@ -9,7 +9,7 @@
 namespace MyQuantumApp {
     open Microsoft.Quantum.Diagnostics;
     @EntryPoint()
-    operation Main(): Unit {
+    operation Main() : Unit {
         // `Message` emits a debug log.
         Message("Program is starting.");
 

--- a/samples/language/Functions.qs
+++ b/samples/language/Functions.qs
@@ -1,9 +1,9 @@
 /// # Sample
-/// Functions  
+/// Functions
 ///
 /// # Description
 /// A function's execution always produces the same output, given the same input.
-/// Q# allows you to explicitly split out such purely deterministic computations into functions. 
+/// Q# allows you to explicitly split out such purely deterministic computations into functions.
 /// Functions in Q#, contrasted with _operations_, are pure, i.e. lacking side-effects.
 /// Thus, functions can only call other functions, while operations can call both functions and operations.
 namespace MyQuantumApp {
@@ -13,7 +13,7 @@ namespace MyQuantumApp {
         return ();
     }
 
-    function MyFunction(qubits: Qubit[]) : Int {
+    function MyFunction(qubits : Qubit[]) : Int {
         // Functions can call other functions.
         let length = Length(qubits);
 

--- a/samples/language/PartialApplication.qs
+++ b/samples/language/PartialApplication.qs
@@ -8,7 +8,7 @@
 namespace MyQuantumApp {
     open Microsoft.Quantum.Arrays;
     @EntryPoint()
-    operation Main(): Unit {
+    operation Main() : Unit {
         // This takes our adding function and partially applies it,
         // filling the second argument with `1` and returning another
         // function that takes one argument and passes it in to `Add`.
@@ -32,11 +32,11 @@ namespace MyQuantumApp {
         let incremented = Mapped(Add(_, 1), intArray);
     }
 
-    function Add(x: Int, y: Int): Int {
+    function Add(x : Int, y : Int) : Int {
         return x + y;
     }
 
-    function AddMany(a: Int, b: Int, c: Int, d: Int): Int {
+    function AddMany(a : Int, b : Int, c : Int, d : Int) : Int {
         return a + b + c + d;
     }
 }

--- a/samples/language/Tuple.qs
+++ b/samples/language/Tuple.qs
@@ -5,7 +5,7 @@
 /// A tuple literal is a sequence of one or more expressions of any type,
 /// separated by commas and enclosed in parentheses `(` and `)`. The type of
 /// the tuple includes the information about each item type.
-/// 
+///
 /// Tuples containing a single item are treated as identical to the item
 /// itself, both in type and value, which is called singleton tuple equivalence.
 namespace MyQuantumApp {
@@ -17,7 +17,7 @@ namespace MyQuantumApp {
 
         // A tuple of type `Pauli`, and a nested tuple of type `(Int, Int)`.
         // The type annotation is provided for clarity, but not necessary.
-        let myTuple: (Pauli, (Int, Int)) = (PauliX, (3, 1));
+        let myTuple : (Pauli, (Int, Int)) = (PauliX, (3, 1));
 
         return (0, "Foo");
     }

--- a/samples/language/TypeDeclarations.qs
+++ b/samples/language/TypeDeclarations.qs
@@ -8,13 +8,13 @@ namespace MyQuantumApp {
     @EntryPoint()
     operation Main() : Unit {
         // UDTs are defined with the `newtype` keyword.
-        newtype Point3d = (X: Double, Y: Double, Z: Double);
+        newtype Point3d = (X : Double, Y : Double, Z : Double);
 
         // The items within a UDT can be either named or unnamed.
-        newtype DoubleInt = (Double, ItemName: Int);
+        newtype DoubleInt = (Double, ItemName : Int);
 
         // UDTs can also be nested.
-        newtype Nested = (Double, (ItemName: Int, String));
+        newtype Nested = (Double, (ItemName : Int, String));
 
         let point = Point3d(1.0, 2.0, 3.0);
 
@@ -22,7 +22,7 @@ namespace MyQuantumApp {
         // or by deconstruction.
         // The below line accesses the field `x` on `point` by
         // name, using the item access operator `::`:
-        let x: Double = point::X;
+        let x : Double = point::X;
 
         // The below line accesses the field `x` via deconstruction:
         let (x, _, _) = point!;

--- a/samples/language/Variables.qs
+++ b/samples/language/Variables.qs
@@ -23,7 +23,7 @@ namespace MyQuantumApp {
 
         // UDTs can also be updated with copy-and-update expressions (`w/`)
         // or evaluate-and-reassign expressions (`w/=`).
-        newtype Point3d = (X: Double, Y: Double, Z: Double);
+        newtype Point3d = (X : Double, Y : Double, Z : Double);
 
         mutable point = Point3d(0.0, 0.0, 0.0);
 
@@ -34,7 +34,7 @@ namespace MyQuantumApp {
         // The below line also mutates `point`, moving the X coordinate by -1.0,
         // using copy-and-update.
         set point = point w/ X <- point::X + 1.0;
-         
+
     }
 
 }


### PR DESCRIPTION
Updates LS displays, Katas, Libraries, and Samples to consistently use `<name> : <type>` type annotation style, over `<name>: <type>` style, as per our style guidelines.