### PR TITLE
Fixes a bug in single output recording

### DIFF
--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -567,6 +567,7 @@ mod given_interpreter {
                 define void @ENTRYPOINT__main() #0 {
                   call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
                   call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+                  call void @__quantum__rt__tuple_record_output(i64 1, i8* null)
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
@@ -633,6 +634,7 @@ mod given_interpreter {
                 define void @ENTRYPOINT__main() #0 {
                   call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
                   call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+                  call void @__quantum__rt__tuple_record_output(i64 1, i8* null)
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
@@ -701,6 +703,7 @@ mod given_interpreter {
                 define void @ENTRYPOINT__main() #0 {
                   call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
                   call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+                  call void @__quantum__rt__tuple_record_output(i64 1, i8* null)
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
@@ -808,6 +811,7 @@ mod given_interpreter {
                 define void @ENTRYPOINT__main() #0 {
                   call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
                   call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+                  call void @__quantum__rt__tuple_record_output(i64 1, i8* null)
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
@@ -889,6 +893,7 @@ mod given_interpreter {
                 define void @ENTRYPOINT__main() #0 {
                   call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
                   call void @__quantum__qis__reset__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+                  call void @__quantum__rt__tuple_record_output(i64 1, i8* null)
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }

--- a/compiler/qsc_codegen/src/qir_base/tests.rs
+++ b/compiler/qsc_codegen/src/qir_base/tests.rs
@@ -69,6 +69,7 @@ fn simple_entry_program_is_valid() {
             define void @ENTRYPOINT__main() #0 {
               call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
               call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__rt__tuple_record_output(i64 1, i8* null)
               call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
               ret void
             }
@@ -132,6 +133,7 @@ fn simple_program_is_valid() {
             define void @ENTRYPOINT__main() #0 {
               call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
               call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__rt__tuple_record_output(i64 1, i8* null)
               call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
               ret void
             }

--- a/pip/tests-qir/test_qir.py
+++ b/pip/tests-qir/test_qir.py
@@ -16,19 +16,19 @@ def test_compile_qir_input_data() -> None:
     assert module.functions[0].name == "ENTRYPOINT__main"
     func = module.functions[0]
     assert len(func.basic_blocks) == 1
-    assert len(func.basic_blocks[0].instructions) == 3
+    assert len(func.basic_blocks[0].instructions) == 4
     call_m = func.basic_blocks[0].instructions[0]
     assert isinstance(call_m, Call)
     assert call_m.callee.name == "__quantum__qis__m__body"
     assert len(call_m.args) == 2
     assert qubit_id(call_m.args[0]) == 0
     assert result_id(call_m.args[1]) == 0
-    record_res = func.basic_blocks[0].instructions[1]
+    record_res = func.basic_blocks[0].instructions[2]
     assert isinstance(record_res, Call)
     assert len(record_res.args) == 2
     assert record_res.callee.name == "__quantum__rt__result_record_output"
     assert result_id(record_res.args[0]) == 0
-    assert func.basic_blocks[0].instructions[2].opcode == Opcode.RET
+    assert func.basic_blocks[0].instructions[3].opcode == Opcode.RET
 
 
 def test_compile_qir_all_gates() -> None:


### PR DESCRIPTION
This change applies a temporary fix to output recording when only a single result is present. By treating it as a tuple with arity one we include at least one aggregate recording function and trigger logic in the service.