### PR TITLE
Base profile validation should fail for entry point that returns `Unit`

### DIFF
--- a/compiler/qsc_passes/src/baseprofck.rs
+++ b/compiler/qsc_passes/src/baseprofck.rs
@@ -131,6 +131,7 @@ fn any_non_result_ty(ty: &Ty) -> bool {
     match ty {
         Ty::Array(ty) => any_non_result_ty(ty),
         Ty::Prim(Prim::Result) => false,
+        Ty::Tuple(tys) if tys.is_empty() => true,
         Ty::Tuple(tys) => tys.iter().any(any_non_result_ty),
         _ => true,
     }

--- a/compiler/qsc_passes/src/baseprofck/tests.rs
+++ b/compiler/qsc_passes/src/baseprofck/tests.rs
@@ -120,6 +120,26 @@ fn non_result_return_error() {
 }
 
 #[test]
+fn unit_return_error() {
+    check(
+        indoc! {"{
+            operation Foo() : Unit {}
+            Foo()
+        }"},
+        &expect![[r#"
+            [
+                ReturnNonResult(
+                    Span {
+                        lo: 0,
+                        hi: 43,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
 fn unsupported_intrsinsic_error() {
     check(
         indoc! {"{

--- a/compiler/qsc_passes/src/baseprofck/tests.rs
+++ b/compiler/qsc_passes/src/baseprofck/tests.rs
@@ -63,6 +63,12 @@ fn result_comparison_error() {
         }"},
         &expect![[r#"
             [
+                ReturnNonResult(
+                    Span {
+                        lo: 0,
+                        hi: 78,
+                    },
+                ),
                 ResultComparison(
                     Span {
                         lo: 41,
@@ -149,6 +155,12 @@ fn unsupported_intrsinsic_error() {
         }"},
         &expect![[r#"
             [
+                ReturnNonResult(
+                    Span {
+                        lo: 0,
+                        hi: 62,
+                    },
+                ),
                 UnsupportedIntrinsic(
                     Span {
                         lo: 16,


### PR DESCRIPTION
Fixes #722