### PR TITLE
fixed the build script crashes for python versions < 3.9

### DIFF
--- a/build.py
+++ b/build.py
@@ -14,6 +14,9 @@ import functools
 
 from prereqs import check_prereqs
 
+if sys.version_info < (3, 9):
+    raise SystemError("You need Python 3.9 or later to use this script.")
+
 # Disable buffered output so that the log statements and subprocess output get interleaved in proper order
 print = functools.partial(print, flush=True)
 


### PR DESCRIPTION
the build.py was crashing with an ambiguous error with python versions < 3.9. I added a check of the python version to display a message that a newer version of python is needed to run the build.py.