### PR TITLE
Fix dev build name

### DIFF
--- a/version.py
+++ b/version.py
@@ -80,6 +80,12 @@ if BUILD_TYPE != "dev":
         r'"name": "qsharp-lang-vscode-dev",',
         r'"name": "qsharp-lang-vscode",',
     )
+    update_file(
+        os.path.join(root_dir, "vscode/package.json"),
+        r"[DEV BUILD] Azure Quantum Development Kit",
+        r"Azure Quantum Development Kit",
+    )
+
 else:
     # Update the README to contain the dev version contents
     with open(

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qsharp-lang-vscode-dev",
-  "displayName": "Azure Quantum Development Kit (QDK) Preview",
+  "displayName": "[DEV BUILD] Azure Quantum Development Kit (QDK) Preview",
   "description": "Q# Language Support",
   "version": "0.0.0",
   "publisher": "quantum",


### PR DESCRIPTION
The two different marketplace extensions can't have the same name. Prefix the dev build with '[DEV BUILD]'