### PR TITLE
Enable CI checks for merge group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch:
 
 # Cancel in-progress run when a pull request is updated

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
   workflow_dispatch:
   schedule:
     # set schedule to run at 2AM PT on Saturdays
@@ -27,7 +28,7 @@ jobs:
 
       - name: Run DevSkim scanner
         uses: microsoft/DevSkim-Action@v1
-        
+
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
This ensures the same checks are used for pull_requests and merge_groups. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions.