### PR TITLE
Disable other extensions when testing

### DIFF
--- a/.vscode/launch.shared.json
+++ b/.vscode/launch.shared.json
@@ -11,6 +11,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "--disable-extensions",
                 "--extensionDevelopmentPath=${workspaceFolder}/vscode",
                 "${workspaceFolder}/samples/"
             ]


### PR DESCRIPTION
If you have the QDK installed already, pressing F5 to launch/test the extension while developing causes conflicts. This settings disables other extensions when launch the extension from the repo for testing.