### PR TITLE
Publish aarch64 wheels for Linux and Windows

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -161,7 +161,7 @@ jobs:
       cratesIoFeedOverride: $(cratesIoFeedOverride)
       toolchainFeed: $(toolchainFeed)
     displayName: Install Rust toolchain
-    condition: ne(additionalRustTargets, '')
+    condition: ne(variables['additionalRustTargets'], '')
 
   # otherwise just install the default toolchain
   - task: RustInstaller@1
@@ -170,7 +170,7 @@ jobs:
       cratesIoFeedOverride: $(cratesIoFeedOverride)
       toolchainFeed: $(toolchainFeed)
     displayName: Install Rust toolchain
-    condition: eq(additionalRustTargets, '')
+    condition: eq(variables['additionalRustTargets'], '')
 
   - task: UsePythonVersion@0
     inputs:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -176,6 +176,11 @@ jobs:
     displayName: Install Rust toolchain
     condition: eq(variables['additionalRustTargets'], '')
 
+  - script: |
+      rustc --version
+      rustc --print target-list
+    displayName: View rust target info
+
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.11'
@@ -186,7 +191,7 @@ jobs:
 
   - script: |
       chmod +x ./docker/linux-aarch64/install_prereqs.sh
-      ./docker/linux-aarch64/install_prereqs.sh
+      sudo ./docker/linux-aarch64/install_prereqs.sh
     displayName: Install Linux aarch64 cross prereqs
     condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -137,7 +137,7 @@ jobs:
       linux_aarch64:
         imageName: 'ubuntu-20.04'
         arch: aarch64
-        target: aarch64-unknown-linux-gnu
+        additionalRustTargets: aarch64-unknown-linux-gnu
       mac:
         imageName: 'macOS-latest'       # MacOS-specific Py (Mac is usually quite limited).
         arch: x86_64

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -148,7 +148,7 @@ jobs:
       windows_aarch64:
         imageName: 'windows-latest'     # Win-specific Py + Platform-independent Py.
         arch: aarch64
-      additionalRustTargets: aarch64-pc-windows-msvc
+        additionalRustTargets: aarch64-pc-windows-msvc
   pool:
     vmImage: $(imageName)
   variables:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -227,12 +227,12 @@ jobs:
     condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
 
   - script: |
-      echo "##vso[task.setvariable variable=CARGO_BUILD_TARGET]aarch64-pc-windows-msvc"
+      echo ##vso[task.setvariable variable=CARGO_BUILD_TARGET]aarch64-pc-windows-msvc
     displayName: Set cargo build target for Windows aarch64
     condition: and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['arch'], 'aarch64'))
 
   - script: |
-      python build.py --pip --no-check-prereqs --no-test --no-samples
+      python build.py --pip --no-check-prereqs --no-check --no-test --no-samples
     displayName: Cross Build Windows aarch64 Py Packages
     condition: and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['arch'], 'aarch64'))
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -8,6 +8,7 @@ variables:
   RUST_TOOLCHAIN_VERSION: "1.72"
 
 # variables set by pipeline
+# - BASE_IMAGE
 # - BUILD_NUMBER
 # - BUILD_TYPE
 # - cratesIoFeedOverride
@@ -133,7 +134,10 @@ jobs:
       linux_x64:
         imageName: 'ubuntu-20.04'
         arch: x86_64
-        additionalRustTargets: aarch64-unknown-linux-gnu
+      linux_aarch64:
+        imageName: 'ubuntu-20.04'
+        arch: aarch64
+        target: aarch64-unknown-linux-gnu
       mac:
         imageName: 'macOS-latest'       # MacOS-specific Py (Mac is usually quite limited).
         arch: x86_64
@@ -141,7 +145,6 @@ jobs:
       windows:
         imageName: 'windows-latest'     # Win-specific Py + Platform-independent Py.
         arch: x86_64
-        additionalRustTargets: aarch64-pc-windows-msvc
   pool:
     vmImage: $(imageName)
   variables:
@@ -150,6 +153,7 @@ jobs:
 
   steps:
   # common init steps
+  # if we have additional rust targets, we need to install them
   - task: RustInstaller@1
     inputs:
       rustVersion: ms-$(RUST_TOOLCHAIN_VERSION)
@@ -157,6 +161,16 @@ jobs:
       cratesIoFeedOverride: $(cratesIoFeedOverride)
       toolchainFeed: $(toolchainFeed)
     displayName: Install Rust toolchain
+    condition: ne(additionalRustTargets, '')
+
+  # otherwise just install the default toolchain
+  - task: RustInstaller@1
+    inputs:
+      rustVersion: ms-$(RUST_TOOLCHAIN_VERSION)
+      cratesIoFeedOverride: $(cratesIoFeedOverride)
+      toolchainFeed: $(toolchainFeed)
+    displayName: Install Rust toolchain
+    condition: eq(additionalRustTargets, '')
 
   - task: UsePythonVersion@0
     inputs:
@@ -167,8 +181,14 @@ jobs:
     displayName: Install Prereqs and set version
 
   - script: |
+      ./docker/linux-aarch64/install_prereqs.sh
+    displayName: Install Linux aarch64 cross prereqs
+    condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
+
+  - script: |
       python build.py --pip --no-check-prereqs
-    displayName: Build Platform-Dependent Py Packages, non-Linux
+    displayName: Build Platform-Dependent Py Packages
+    condition: or(ne(variables['Agent.OS'], 'Linux'), ne(variables['arch'], 'aarch64'))
 
   - script: |
       python -m pip install auditwheel patchelf
@@ -178,7 +198,20 @@ jobs:
       rm target/wheels/*-linux_x86_64.whl
       ls target/wheels
     displayName: Run auditwheel for Linux Wheels
-    condition: eq(variables['Agent.OS'], 'Linux')
+    condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'x86_64'))
+
+  # for linux aarch64 cross build we want to skip tests as we can't run the code.
+  # and we can't run the samples as qsc is currently cross compiled.
+  - script: |
+      env CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu python build.py --pip --no-check-prereqs --no-test --no-samples
+    displayName: Cross Build Linux aarch64 Py Packages
+    condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
+
+  - script: |
+      ./docker/linux-aarch64/build.sh
+      ./docker/linux-aarch64/run.sh
+    displayName: Run auditwheel and python tests for Linux aarch64 Wheels
+    condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
 
   - script: |
       dir target\wheels\*

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -145,6 +145,10 @@ jobs:
       windows:
         imageName: 'windows-latest'     # Win-specific Py + Platform-independent Py.
         arch: x86_64
+      windows_aarch64:
+        imageName: 'windows-latest'     # Win-specific Py + Platform-independent Py.
+        arch: aarch64
+      additionalRustTargets: aarch64-pc-windows-msvc
   pool:
     vmImage: $(imageName)
   variables:
@@ -181,6 +185,7 @@ jobs:
     displayName: Install Prereqs and set version
 
   - script: |
+      chmod +x ./docker/linux-aarch64/install_prereqs.sh
       ./docker/linux-aarch64/install_prereqs.sh
     displayName: Install Linux aarch64 cross prereqs
     condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
@@ -188,7 +193,7 @@ jobs:
   - script: |
       python build.py --pip --no-check-prereqs
     displayName: Build Platform-Dependent Py Packages
-    condition: or(ne(variables['Agent.OS'], 'Linux'), ne(variables['arch'], 'aarch64'))
+    condition: ne(variables['arch'], 'aarch64')
 
   - script: |
       python -m pip install auditwheel patchelf
@@ -208,10 +213,23 @@ jobs:
     condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
 
   - script: |
+      chmod +x ./docker/linux-aarch64/build.sh
+      chmod +x ./docker/linux-aarch64/run.sh
+
       ./docker/linux-aarch64/build.sh
       ./docker/linux-aarch64/run.sh
     displayName: Run auditwheel and python tests for Linux aarch64 Wheels
     condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
+
+  - script: |
+      echo "##vso[task.setvariable variable=CARGO_BUILD_TARGET]aarch64-pc-windows-msvc"
+    displayName: Set cargo build target for Windows aarch64
+    condition: and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['arch'], 'aarch64'))
+
+  - script: |
+      python build.py --pip --no-check-prereqs --no-test --no-samples
+    displayName: Cross Build Windows aarch64 Py Packages
+    condition: and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['arch'], 'aarch64'))
 
   - script: |
       dir target\wheels\*
@@ -229,7 +247,7 @@ jobs:
     condition: eq(variables['Agent.OS'], 'Darwin')
 
   - publish: $(System.DefaultWorkingDirectory)/target/wheels
-    artifact: Wheels.Win
+    artifact: Wheels.Win.${{ variables['arch'] }}
     displayName: Upload Python Artifacts Win
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
@@ -295,8 +313,12 @@ jobs:
 
   steps:
   - download: current
-    artifact: Wheels.Win
-    displayName: Download Python Artifacts Win
+    artifact: Wheels.Win.x86_64
+    displayName: Download x86_64 Python Artifacts Win
+
+  - download: current
+    artifact: Wheels.Win.aarch64
+    displayName: Download aarch64 Python Artifacts Win
 
   - download: current
     artifact: Wheels.Mac
@@ -304,7 +326,11 @@ jobs:
 
   - download: current
     artifact: Wheels.Linux.x86_64
-    displayName: Download Python Artifacts Linux
+    displayName: Download x86_64 Python Artifacts Linux
+
+  - download: current
+    artifact: Wheels.Linux.aarch64
+    displayName: Download aarch64 Python Artifacts Linux
 
   - download: current
     artifact: Wheels.JupyterLab
@@ -314,7 +340,9 @@ jobs:
       mkdir -p                            target/wheels
       mv ../Wheels.JupyterLab/*.whl       target/wheels
       mv ../Wheels.Linux.x86_64/*.whl     target/wheels
-      mv ../Wheels.Win/*.whl              target/wheels
+      mv ../Wheels.Linux.aarch64/*.whl    target/wheels
+      mv ../Wheels.Win.x86_64/*.whl       target/wheels
+      mv ../Wheels.Win.aarch64/*.whl      target/wheels
       mv ../Wheels.Mac/*.whl              target/wheels
       ls                                  target/wheels/*
     displayName: Move Py Artifacts to Publishing Dir

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -213,7 +213,7 @@ jobs:
   # for linux aarch64 cross build we want to skip tests as we can't run the code.
   # and we can't run the samples as qsc is currently cross compiled.
   - script: |
-      env CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu python build.py --pip --no-check-prereqs --no-test --no-samples
+      env CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu python build.py --pip --no-check-prereqs --no-check --no-test --no-samples
     displayName: Cross Build Linux aarch64 Py Packages
     condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,3 +9,6 @@ rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076c73d0bc438f7a4ef6fdd0c3bb4732149136abd952b110ac93e4edb13a6ba5"
 dependencies = [
  "once_cell",
+ "python3-dll-a",
  "target-lexicon",
 ]
 
@@ -730,6 +731,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "python3-dll-a"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f07cd4412be8fa09a721d40007c483981bbe072cd6a21f2e83e04ec8f8343f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/build.py
+++ b/build.py
@@ -33,7 +33,7 @@ parser.add_argument(
     "--samples",
     action=argparse.BooleanOptionalAction,
     default=True,
-    help="Build the samples (default is --samples)",
+    help="Compile the Q# samples (default is --samples)",
 )
 parser.add_argument("--vscode", action="store_true", help="Build the VS Code extension")
 parser.add_argument(

--- a/build.py
+++ b/build.py
@@ -29,7 +29,12 @@ parser.add_argument("--pip", action="store_true", help="Build the pip wheel")
 parser.add_argument("--wasm", action="store_true", help="Build the WebAssembly files")
 parser.add_argument("--npm", action="store_true", help="Build the npm package")
 parser.add_argument("--play", action="store_true", help="Build the web playground")
-parser.add_argument("--samples", action="store_true", help="Compile the Q# samples")
+parser.add_argument(
+    "--samples",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help="Build the samples (default is --samples)",
+)
 parser.add_argument("--vscode", action="store_true", help="Build the VS Code extension")
 parser.add_argument(
     "--jupyterlab", action="store_true", help="Build the JupyterLab extension"
@@ -79,7 +84,6 @@ build_all = (
 build_cli = build_all or args.cli
 build_pip = build_all or args.pip
 build_wasm = build_all or args.wasm
-build_samples = build_all or args.samples
 build_npm = build_all or args.npm
 build_play = build_all or args.play
 build_vscode = build_all or args.vscode
@@ -94,6 +98,7 @@ npm_cmd = "npm.cmd" if platform.system() == "Windows" else "npm"
 
 build_type = "debug" if args.debug else "release"
 run_tests = args.test
+build_samples = args.samples
 
 # TODO: This requires that both targets are installed on macOS to build Python packages. Add to prereqs checks.
 pip_archflags = "-arch x86_64 -arch arm64" if platform.system() == "Darwin" else None

--- a/docker/linux-aarch64/Dockerfile
+++ b/docker/linux-aarch64/Dockerfile
@@ -15,4 +15,6 @@ RUN apt-get update && \
 RUN pip install -U pip && \
     pip install auditwheel patchelf
 
+RUN alias python=python3
+
 ENTRYPOINT ["sh", "-c", "$*", "--"]

--- a/docker/linux-aarch64/Dockerfile
+++ b/docker/linux-aarch64/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && \
     apt-get clean
 
 # Update pip and install required packages
-RUN pip install -U pip && \
-    pip install auditwheel patchelf
+RUN pip install -U pip
 
 ENTRYPOINT ["sh", "-c", "$*", "--"]

--- a/docker/linux-aarch64/Dockerfile
+++ b/docker/linux-aarch64/Dockerfile
@@ -15,6 +15,4 @@ RUN apt-get update && \
 RUN pip install -U pip && \
     pip install auditwheel patchelf
 
-RUN alias python=python3
-
 ENTRYPOINT ["sh", "-c", "$*", "--"]

--- a/docker/linux-aarch64/Dockerfile
+++ b/docker/linux-aarch64/Dockerfile
@@ -11,7 +11,9 @@ RUN apt-get update && \
     --no-install-recommends -y && \
     apt-get clean
 
-# Update pip and install required packages
-RUN pip install -U pip
+# We don't update pip here as we need to update it
+# inside the virtual environment. Otherwise, we get two versions
+# of pip installed, and the one outside the virtual environment
+# causes problems.
 
 ENTRYPOINT ["sh", "-c", "$*", "--"]

--- a/docker/linux-aarch64/Dockerfile
+++ b/docker/linux-aarch64/Dockerfile
@@ -7,7 +7,7 @@ FROM --platform=arm64 ${BASE_IMAGE}
 # install python and pip
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install \
-    python3-minimal python3-pip \
+    python3-minimal python3-pip python3-venv \
     --no-install-recommends -y && \
     apt-get clean
 

--- a/docker/linux-aarch64/Dockerfile
+++ b/docker/linux-aarch64/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ARG BASE_IMAGE
-FROM --platform=arm64 ${BASE_IMAGE}
+FROM --platform=linux/arm64 ${BASE_IMAGE}
 
 # install python and pip
 RUN apt-get update && \

--- a/docker/linux-aarch64/Dockerfile
+++ b/docker/linux-aarch64/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 ARG BASE_IMAGE
-FROM --platform=linux/arm64 ${BASE_IMAGE}
+FROM --platform=linux/arm64/v8 ${BASE_IMAGE}
 
 # install python and pip
 RUN apt-get update && \

--- a/docker/linux-aarch64/Dockerfile
+++ b/docker/linux-aarch64/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+ARG BASE_IMAGE
+FROM --platform=arm64 ${BASE_IMAGE}
+
+# install python and pip
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install \
+    python3-minimal python3-pip \
+    --no-install-recommends -y && \
+    apt-get clean
+
+# Update pip and install required packages
+RUN pip install -U pip && \
+    pip install auditwheel patchelf
+
+ENTRYPOINT ["sh", "-c", "$*", "--"]

--- a/docker/linux-aarch64/build.sh
+++ b/docker/linux-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+echo "SCRIPT_DIR: ${SCRIPT_DIR}"
+
+BASE_IMAGE="${BASE_IMAGE:-ubuntu:20.04}"
+echo "BASE_IMAGE: ${BASE_IMAGE}"
+
+TAG="${TAG:-qsharp-lang-linux-aarch64-runner}"
+echo "TAG: ${TAG}"
+
+docker build -t ${TAG} --build-arg BASE_IMAGE=${BASE_IMAGE} -f ${SCRIPT_DIR}/Dockerfile ${SCRIPT_DIR}

--- a/docker/linux-aarch64/entrypoint.sh
+++ b/docker/linux-aarch64/entrypoint.sh
@@ -24,7 +24,10 @@ echo "Setting up the virtual environment"
 python3 -m venv /tmp/.venv
 . /tmp/.venv/bin/activate
 
+
 echo "Get pip compatible tags"
+pip --version
+pip install -U pip
 pip debug --verbose
 
 echo "Installing auditwheel and patchelf"

--- a/docker/linux-aarch64/entrypoint.sh
+++ b/docker/linux-aarch64/entrypoint.sh
@@ -20,6 +20,13 @@ echo "PIP_DIR: ${PIP_DIR}"
 WHEEL_DIR="${WHEEL_DIR:-${SCRIPT_DIR}/../../target/wheels}"
 echo "WHEEL_DIR: ${WHEEL_DIR}"
 
+echo "Setting up the virtual environment"
+python3 -m venv /tmp/.venv
+. /tmp/.venv/bin/activate
+
+echo "Installing auditwheel and patchelf"
+pip install auditwheel patchelf
+
 echo "Repairing the wheels"
 ls ${WHEEL_DIR}
 ls ${WHEEL_DIR}/*.whl | xargs auditwheel show
@@ -27,16 +34,10 @@ ls ${WHEEL_DIR}/*.whl | xargs auditwheel repair --wheel-dir ${WHEEL_DIR}/ --plat
 rm ${WHEEL_DIR}/*-linux_${WHEEL_ARCH}.whl
 ls ${WHEEL_DIR}
 
-echo "Setting up the virtual environment"
-python3 -m venv /tmp/.venv
-. /tmp/.venv/bin/activate
-
 echo "Installing the wheels"
 ls ${WHEEL_DIR}/*.whl | xargs pip install
 
 pushd ${PIP_DIR}
-
-pip install auditwheel patchelf
 
 pip install -r test_requirements.txt
 

--- a/docker/linux-aarch64/entrypoint.sh
+++ b/docker/linux-aarch64/entrypoint.sh
@@ -24,6 +24,9 @@ echo "Setting up the virtual environment"
 python3 -m venv /tmp/.venv
 . /tmp/.venv/bin/activate
 
+echo "Get pip compatible tags"
+pip debug --verbose
+
 echo "Installing auditwheel and patchelf"
 pip install auditwheel patchelf
 

--- a/docker/linux-aarch64/entrypoint.sh
+++ b/docker/linux-aarch64/entrypoint.sh
@@ -32,6 +32,10 @@ ls ${WHEEL_DIR}/*.whl | xargs pip install
 
 pushd ${PIP_DIR}
 
+python -m venv /tmp/.venv
+
+. /tmp/.venv/bin/activate
+
 pip install -r test_requirements.txt
 
 python -m pytest

--- a/docker/linux-aarch64/entrypoint.sh
+++ b/docker/linux-aarch64/entrypoint.sh
@@ -5,6 +5,8 @@
 
 set -e
 
+alias python=python3
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "SCRIPT_DIR: ${SCRIPT_DIR}"
 

--- a/docker/linux-aarch64/entrypoint.sh
+++ b/docker/linux-aarch64/entrypoint.sh
@@ -25,10 +25,8 @@ python3 -m venv /tmp/.venv
 . /tmp/.venv/bin/activate
 
 
-echo "Get pip compatible tags"
-pip --version
+echo "Update pip"
 pip install -U pip
-pip debug --verbose
 
 echo "Installing auditwheel and patchelf"
 pip install auditwheel patchelf
@@ -47,6 +45,10 @@ pushd ${PIP_DIR}
 
 pip install -r test_requirements.txt
 
+pushd tests
+
 python3 -m pytest
+
+popd
 
 popd

--- a/docker/linux-aarch64/entrypoint.sh
+++ b/docker/linux-aarch64/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+echo "SCRIPT_DIR: ${SCRIPT_DIR}"
+
+WHEEL_ARCH="${WHEEL_ARCH:-aarch64}"
+echo "WHEEL_ARCH: ${WHEEL_ARCH}"
+
+WHEEL_PLATFORM="${WHEEL_PLATFORM:-manylinux_2_31_${WHEEL_ARCH}}"
+echo "WHEEL_PLATFORM: ${WHEEL_PLATFORM}"
+
+PIP_DIR="${PIP_DIR:-${SCRIPT_DIR}/../../pip}"
+echo "PIP_DIR: ${PIP_DIR}"
+
+WHEEL_DIR="${WHEEL_DIR:-${SCRIPT_DIR}/../../target/wheels}"
+echo "WHEEL_DIR: ${WHEEL_DIR}"
+
+echo "Repairing the wheels"
+ls ${WHEEL_DIR}
+ls ${WHEEL_DIR}/*.whl | xargs auditwheel show
+ls ${WHEEL_DIR}/*.whl | xargs auditwheel repair --wheel-dir ${WHEEL_DIR}/ --plat ${WHEEL_PLATFORM}
+rm ${WHEEL_DIR}/*-linux_${WHEEL_ARCH}.whl
+ls ${WHEEL_DIR}
+
+echo "Installing the wheels"
+ls ${WHEEL_DIR}/*.whl | xargs pip install
+
+pushd ${PIP_DIR}
+
+pip install -r test_requirements.txt
+
+python -m pytest
+
+popd
+
+
+
+

--- a/docker/linux-aarch64/entrypoint.sh
+++ b/docker/linux-aarch64/entrypoint.sh
@@ -5,8 +5,6 @@
 
 set -e
 
-alias python=python3
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "SCRIPT_DIR: ${SCRIPT_DIR}"
 
@@ -29,21 +27,19 @@ ls ${WHEEL_DIR}/*.whl | xargs auditwheel repair --wheel-dir ${WHEEL_DIR}/ --plat
 rm ${WHEEL_DIR}/*-linux_${WHEEL_ARCH}.whl
 ls ${WHEEL_DIR}
 
+echo "Setting up the virtual environment"
+python3 -m venv /tmp/.venv
+. /tmp/.venv/bin/activate
+
 echo "Installing the wheels"
 ls ${WHEEL_DIR}/*.whl | xargs pip install
 
 pushd ${PIP_DIR}
 
-python -m venv /tmp/.venv
-
-. /tmp/.venv/bin/activate
+pip install auditwheel patchelf
 
 pip install -r test_requirements.txt
 
-python -m pytest
+python3 -m pytest
 
 popd
-
-
-
-

--- a/docker/linux-aarch64/install_prereqs.sh
+++ b/docker/linux-aarch64/install_prereqs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+apt-get update
+
+# install cross compiler toolchain
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    g++-aarch64-linux-gnu
+
+# install emulation support
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    qemu qemu-system-misc qemu-user-static qemu-user

--- a/docker/linux-aarch64/run.sh
+++ b/docker/linux-aarch64/run.sh
@@ -14,5 +14,5 @@ echo "TAG: ${TAG}"
 VOLUME_ROOT=$(realpath ${SCRIPT_DIR}/../..)
 echo "VOLUME_ROOT: ${VOLUME_ROOT}"
 
-echo "docker run --rm -it -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qhsarp/docker/linux-aarch64/entrypoint.sh"
-docker run --rm -it -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh
+echo "docker run -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qhsarp/docker/linux-aarch64/entrypoint.sh"
+docker run -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh

--- a/docker/linux-aarch64/run.sh
+++ b/docker/linux-aarch64/run.sh
@@ -14,5 +14,5 @@ echo "TAG: ${TAG}"
 VOLUME_ROOT=$(realpath ${SCRIPT_DIR}/../..)
 echo "VOLUME_ROOT: ${VOLUME_ROOT}"
 
-echo "docker run -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qhsarp/docker/linux-aarch64/entrypoint.sh"
-docker run -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh
+echo "docker run --platform linux/arm64/v8 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qhsarp/docker/linux-aarch64/entrypoint.sh"
+docker run --platform linux/arm64/v8 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh

--- a/docker/linux-aarch64/run.sh
+++ b/docker/linux-aarch64/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+echo "SCRIPT_DIR: ${SCRIPT_DIR}"
+
+TAG="${TAG:-qsharp-lang-linux-aarch64-runner}"
+echo "TAG: ${TAG}"
+
+VOLUME_ROOT=$(realpath ${SCRIPT_DIR}/../..)
+echo "VOLUME_ROOT: ${VOLUME_ROOT}"
+
+echo "docker run --rm -it -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qhsarp/docker/linux-aarch64/entrypoint.sh"
+docker run --rm -it -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh

--- a/docker/linux-aarch64/run.sh
+++ b/docker/linux-aarch64/run.sh
@@ -14,5 +14,5 @@ echo "TAG: ${TAG}"
 VOLUME_ROOT=$(realpath ${SCRIPT_DIR}/../..)
 echo "VOLUME_ROOT: ${VOLUME_ROOT}"
 
-echo "docker run --platform linux/arm64 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qhsarp/docker/linux-aarch64/entrypoint.sh"
-docker run --platform linux/arm64 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh
+echo "docker run --platform linux/arm64/v8 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh"
+docker run --platform linux/arm64/v8 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh

--- a/docker/linux-aarch64/run.sh
+++ b/docker/linux-aarch64/run.sh
@@ -14,5 +14,5 @@ echo "TAG: ${TAG}"
 VOLUME_ROOT=$(realpath ${SCRIPT_DIR}/../..)
 echo "VOLUME_ROOT: ${VOLUME_ROOT}"
 
-echo "docker run --platform linux/arm64/v8 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qhsarp/docker/linux-aarch64/entrypoint.sh"
-docker run --platform linux/arm64/v8 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh
+echo "docker run --platform linux/arm64 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qhsarp/docker/linux-aarch64/entrypoint.sh"
+docker run --platform linux/arm64 -v ${VOLUME_ROOT}:/qsharp -e WHEEL_DIR='/qsharp/target/wheels' ${TAG} bash /qsharp/docker/linux-aarch64/entrypoint.sh

--- a/pip/Cargo.toml
+++ b/pip/Cargo.toml
@@ -19,6 +19,8 @@ miette = { workspace = true, features = ["fancy"] }
 pyo3 = { workspace = true, features = ["abi3-py37", "extension-module"] }
 
 [target.'cfg(any(target_os = "windows"))'.dependencies]
+# generate-import-lib: skip requiring Python 3 distribution
+# files to be present on the (cross-)compile host system.
 pyo3 = { workspace = true, features = ["abi3-py37", "extension-module", "generate-import-lib"] }
 
 [lib]

--- a/pip/Cargo.toml
+++ b/pip/Cargo.toml
@@ -12,9 +12,14 @@ license.workspace = true
 [dependencies]
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
-pyo3 = { workspace = true }
 qsc = { path = "../compiler/qsc" }
 miette = { workspace = true, features = ["fancy"] }
+
+[target.'cfg(not(any(target_os = "windows")))'.dependencies]
+pyo3 = { workspace = true, features = ["abi3-py37", "extension-module"] }
+
+[target.'cfg(any(target_os = "windows"))'.dependencies]
+pyo3 = { workspace = true, features = ["abi3-py37", "extension-module", "generate-import-lib"] }
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
- Added `--samples/--no-samples` so that we can disable the compilation of samples during builds. This is needed when cross-compiling as we can't execute the compiler.
- Adding aarch64 linux release target. Cross-compiling on x86_64 and then running tests in an emulated aarch64 container along with auditwheel
- Adding aarch64 windows release target. This is built but not tested.