### PR TITLE
Add help comment to qubit release error

### DIFF
--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -91,6 +91,7 @@ pub enum Error {
     RangeStepZero(#[label("invalid range")] PackageSpan),
 
     #[error("Qubit{0} released while not in |0⟩ state")]
+    #[diagnostic(help("qubits should be returned to the |0⟩ state before being released to satisfy the assumption that allocated qubits start in the |0⟩ state"))]
     #[diagnostic(code("Qsc.Eval.ReleasedQubitNotZero"))]
     ReleasedQubitNotZero(usize, #[label("Qubit{0}")] PackageSpan),
 


### PR DESCRIPTION
This adds additional help text to the `ReleasedQubitNotZero` error to help users understand the value of the strictness. Combined with a call-out in https://github.com/microsoft/qsharp/wiki/Differences-from-the-previous-QDK#stricter-checks-on-qubit-release fixes #450.