### PR TITLE
Empty `Result[]` array should be rejected by QIR codegen

### DIFF
--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -60,7 +60,8 @@ pub fn generate_qir(
             .expect("entry expr should be present in map")
             .span,
     };
-    let result = eval_expr(
+
+    let val = eval_expr(
         &mut State::new(package),
         entry_expr,
         &Lookup {
@@ -69,15 +70,12 @@ pub fn generate_qir(
         &mut Env::with_empty_scope(),
         &mut sim,
         &mut out,
-    );
-    match result {
-        Ok(val) => {
-            sim.write_output_recording(&val, entry_span)?;
-            sim.instrs.push_str(POSTFIX);
-            Ok(sim.instrs)
-        }
-        Err((err, stack)) => Err((err, stack)),
-    }
+    )?;
+
+    sim.write_output_recording(&val, entry_span)?;
+    sim.instrs.push_str(POSTFIX);
+
+    Ok(sim.instrs)
 }
 
 /// # Errors
@@ -99,14 +97,10 @@ pub fn generate_qir_for_stmt(
         package: map_fir_package_to_hir(package),
         span: globals.get_stmt(package, stmt).span,
     };
-    match eval_stmt(stmt, globals, env, &mut sim, package, &mut out) {
-        Ok(val) => {
-            sim.write_output_recording(&val, stmt_span)?;
-            sim.instrs.push_str(POSTFIX);
-            Ok(sim.instrs)
-        }
-        Err((err, stack)) => Err((err, stack)),
-    }
+    let val = eval_stmt(stmt, globals, env, &mut sim, package, &mut out)?;
+    sim.write_output_recording(&val, stmt_span)?;
+    sim.instrs.push_str(POSTFIX);
+    Ok(sim.instrs)
 }
 
 struct Lookup<'a> {

--- a/compiler/qsc_codegen/src/qir_base/tests.rs
+++ b/compiler/qsc_codegen/src/qir_base/tests.rs
@@ -237,6 +237,64 @@ fn output_recording_array() {
 }
 
 #[test]
+fn output_recording_empty_array_fails() {
+    check(
+        indoc! {"
+            namespace Test {
+                operation ResultArray(n : Int) : Result[] {
+                    use qs = Qubit[n];
+                    Microsoft.Quantum.Measurement.MResetEachZ(qs)
+                }
+            }
+        "},
+        Some(indoc! {"Test.ResultArray(0)"}),
+        &expect![[r#"
+        EmptyArrayOutput(
+            PackageSpan {
+                package: PackageId(
+                    2,
+                ),
+                span: Span {
+                    lo: 0,
+                    hi: 19,
+                },
+            },
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn output_recording_nested_empty_array_fails() {
+    check(
+        indoc! {"
+            namespace Test {
+                operation ResultArrayTuple(n : Int) : (Result, Result[]) {
+                    open Microsoft.Quantum.Measurement;
+                    open Microsoft.Quantum.Arrays;
+                    use qs = Qubit[1];
+                    (MResetZ(Head(qs)), MResetEachZ(Rest(qs)))
+                }
+            }
+        "},
+        Some(indoc! {"Test.ResultArrayTuple(1)"}),
+        &expect![[r#"
+        EmptyArrayOutput(
+            PackageSpan {
+                package: PackageId(
+                    2,
+                ),
+                span: Span {
+                    lo: 0,
+                    hi: 24,
+                },
+            },
+        )
+    "#]],
+    );
+}
+
+#[test]
 fn output_recording_tuple() {
     check(
         "",

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -17,7 +17,7 @@ pub mod val;
 use crate::val::{FunctorApp, Value};
 use backend::Backend;
 use debug::{map_fir_package_to_hir, CallStack, Frame};
-use error::PackageSpan;
+pub use error::PackageSpan;
 use miette::Diagnostic;
 use num_bigint::BigInt;
 use output::Receiver;
@@ -50,6 +50,13 @@ pub enum Error {
     #[error("division by zero")]
     #[diagnostic(code("Qsc.Eval.DivZero"))]
     DivZero(#[label("cannot divide by zero")] PackageSpan),
+
+    #[error("cannot record output for empty array")]
+    #[diagnostic(help(
+        "returning an empty array in the final result of a program is not supported"
+    ))]
+    #[diagnostic(code("Qsc.Eval.EmptyArrayOutput"))]
+    EmptyArrayOutput(PackageSpan),
 
     #[error("empty range")]
     #[diagnostic(code("Qsc.Eval.EmptyRange"))]
@@ -117,6 +124,7 @@ impl Error {
         match self {
             Error::ArrayTooLarge(span)
             | Error::DivZero(span)
+            | Error::EmptyArrayOutput(span)
             | Error::EmptyRange(span)
             | Error::IndexOutOfRange(_, span)
             | Error::InvalidIndex(_, span)


### PR DESCRIPTION
This adds a new error case for evaluation that is only used by codegen to identify times where an empty array is returned as part the final result of execution. This must be a "runtime" error because the size of the array is not known at compile time but can be known once the program has been evaluated as part of codegen.
Fixes #725