### PR TITLE
Relax clippy docs requirements

### DIFF
--- a/compiler/qsc/build.rs
+++ b/compiler/qsc/build.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 use std::process::Command;
 

--- a/compiler/qsc/src/bin/qsc.rs
+++ b/compiler/qsc/src/bin/qsc.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 use clap::{crate_version, ArgGroup, Parser, ValueEnum};
 use log::info;

--- a/compiler/qsc/src/bin/qsi.rs
+++ b/compiler/qsc/src/bin/qsi.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 use clap::{crate_version, Parser};
 use miette::{Context, IntoDiagnostic, Report, Result};

--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 pub mod compile;
 mod error;

--- a/compiler/qsc_ast/src/lib.rs
+++ b/compiler/qsc_ast/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 pub mod assigner;
 pub mod ast;

--- a/compiler/qsc_codegen/src/lib.rs
+++ b/compiler/qsc_codegen/src/lib.rs
@@ -2,5 +2,6 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 pub mod qir_base;

--- a/compiler/qsc_data_structures/src/lib.rs
+++ b/compiler/qsc_data_structures/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 pub mod index_map;
 pub mod span;

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 #[cfg(test)]
 mod tests;

--- a/compiler/qsc_fir/src/lib.rs
+++ b/compiler/qsc_fir/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 pub mod assigner;
 pub mod fir;

--- a/compiler/qsc_frontend/src/lib.rs
+++ b/compiler/qsc_frontend/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 mod closure;
 pub mod compile;

--- a/compiler/qsc_hir/src/lib.rs
+++ b/compiler/qsc_hir/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 pub mod assigner;
 pub mod global;

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 mod baseprofck;
 mod borrowck;

--- a/katas/src/lib.rs
+++ b/katas/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 #[cfg(test)]
 mod tests;

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 use crate::qsc_utils::compile_document;
 use log::trace;

--- a/library/tests/src/lib.rs
+++ b/library/tests/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 #[cfg(test)]
 mod test_arrays;

--- a/pip/src/lib.rs
+++ b/pip/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 mod displayable_output;
 mod interpreter;

--- a/wasm/build.rs
+++ b/wasm/build.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 use std::process::Command;
 


### PR DESCRIPTION
We've discussed relaxing the clippy requirements for doc comments on public functions given that our crates are not published for use outside of the codebase. If we ever decide to publish we can turn these back on and follow more formal commenting requirements.