### PR TITLE
Cleaning up samples execution in build script

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -213,7 +213,7 @@ jobs:
   # for linux aarch64 cross build we want to skip tests as we can't run the code.
   # and we can't run the samples as qsc is currently cross compiled.
   - script: |
-      env CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu python build.py --pip --no-check-prereqs --no-check --no-test --no-samples
+      env CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu python build.py --pip --no-check-prereqs --no-check --no-test
     displayName: Cross Build Linux aarch64 Py Packages
     condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
 
@@ -232,7 +232,7 @@ jobs:
     condition: and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['arch'], 'aarch64'))
 
   - script: |
-      python build.py --pip --no-check-prereqs --no-check --no-test --no-samples
+      python build.py --pip --no-check-prereqs --no-check --no-test
     displayName: Cross Build Windows aarch64 Py Packages
     condition: and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['arch'], 'aarch64'))
 

--- a/build.py
+++ b/build.py
@@ -29,12 +29,7 @@ parser.add_argument("--pip", action="store_true", help="Build the pip wheel")
 parser.add_argument("--wasm", action="store_true", help="Build the WebAssembly files")
 parser.add_argument("--npm", action="store_true", help="Build the npm package")
 parser.add_argument("--play", action="store_true", help="Build the web playground")
-parser.add_argument(
-    "--samples",
-    action=argparse.BooleanOptionalAction,
-    default=None,
-    help="Compile the Q# samples (default is --no-samples)",
-)
+parser.add_argument("--samples", action="store_true", help="Compile the Q# samples")
 parser.add_argument("--vscode", action="store_true", help="Build the VS Code extension")
 parser.add_argument(
     "--jupyterlab", action="store_true", help="Build the JupyterLab extension"
@@ -75,16 +70,16 @@ build_all = (
     not args.cli
     and not args.pip
     and not args.wasm
+    and not args.samples
     and not args.npm
     and not args.play
     and not args.vscode
     and not args.jupyterlab
-    # allow --no-samples to be passed and still build all
-    and not args.samples is True
 )
 build_cli = build_all or args.cli
 build_pip = build_all or args.pip
 build_wasm = build_all or args.wasm
+build_samples = build_all or args.samples
 build_npm = build_all or args.npm
 build_play = build_all or args.play
 build_vscode = build_all or args.vscode
@@ -99,9 +94,6 @@ npm_cmd = "npm.cmd" if platform.system() == "Windows" else "npm"
 
 build_type = "debug" if args.debug else "release"
 run_tests = args.test
-
-# build samples by default, unless --no-samples is passed
-build_samples = args.samples is not False
 
 # TODO: This requires that both targets are installed on macOS to build Python packages. Add to prereqs checks.
 pip_archflags = "-arch x86_64 -arch arm64" if platform.system() == "Darwin" else None


### PR DESCRIPTION
Reverting workaround for avoiding samples as they now run when they're supposed to.