### PR TITLE
Add custom intrinsic support to `Backend` trait

### DIFF
--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -40,7 +40,7 @@ pub trait Backend {
     fn qubit_is_zero(&mut self, q: usize) -> bool;
     fn reinit(&mut self);
 
-    fn custom_intrinsic(&mut self, _name: &str, _arg: Value) -> Option<Value> {
+    fn custom_intrinsic(&mut self, _name: &str, _arg: Value) -> Option<Result<Value, String>> {
         None
     }
 }

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -5,6 +5,8 @@ use num_bigint::BigUint;
 use num_complex::Complex;
 use quantum_sparse_sim::QuantumSim;
 
+use crate::val::Value;
+
 /// The trait that must be implemented by a quantum backend, whose functions will be invoked when
 /// quantum intrinsics are called.
 pub trait Backend {
@@ -37,6 +39,10 @@ pub trait Backend {
     fn capture_quantum_state(&mut self) -> (Vec<(BigUint, Complex<f64>)>, usize);
     fn qubit_is_zero(&mut self, q: usize) -> bool;
     fn reinit(&mut self);
+
+    fn custom_intrinsic(&mut self, _name: &str, _arg: Value) -> Option<Value> {
+        None
+    }
 }
 
 /// Default backend used when targeting sparse simulation.

--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -125,7 +125,10 @@ pub(crate) fn call(
         }
         _ => {
             if let Some(result) = sim.custom_intrinsic(name, arg) {
-                Ok(result)
+                match result {
+                    Ok(value) => Ok(value),
+                    Err(message) => Err(Error::IntrinsicFail(name.to_string(), message, name_span)),
+                }
             } else {
                 Err(Error::UnknownIntrinsic(name.to_string(), name_span))
             }

--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -123,7 +123,13 @@ pub(crate) fn call(
         "__quantum__qis__mresetz__body" => {
             Ok(Value::Result(sim.mresetz(arg.unwrap_qubit().0).into()))
         }
-        _ => Err(Error::UnknownIntrinsic(name.to_string(), name_span)),
+        _ => {
+            if let Some(result) = sim.custom_intrinsic(name, arg) {
+                Ok(result)
+            } else {
+                Err(Error::UnknownIntrinsic(name.to_string(), name_span))
+            }
+        }
     }
 }
 

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -180,9 +180,10 @@ impl Backend for CustomSim {
         self.sim.reinit();
     }
 
-    fn custom_intrinsic(&mut self, name: &str, arg: Value) -> Option<Value> {
+    fn custom_intrinsic(&mut self, name: &str, arg: Value) -> Option<Result<Value, String>> {
         match name {
-            "Add1" => Some(Value::Int(arg.unwrap_int() + 1)),
+            "Add1" => Some(Ok(Value::Int(arg.unwrap_int() + 1))),
+            "Check" => Some(Err("cannot verify input".to_string())),
             _ => None,
         }
     }
@@ -1048,7 +1049,7 @@ fn unknown_intrinsic() {
 }
 
 #[test]
-fn custom_intrinsic() {
+fn custom_intrinsic_success() {
     check_intrinsic_result(
         indoc! {"
             namespace Test {
@@ -1059,6 +1060,21 @@ fn custom_intrinsic() {
         "},
         "Test.Add1(1)",
         &expect!["2"],
+    );
+}
+
+#[test]
+fn custom_intrinsic_failure() {
+    check_intrinsic_result(
+        indoc! {"
+            namespace Test {
+                function Check(input : Int) : Int {
+                    body intrinsic;
+                }
+            }
+        "},
+        "Test.Check(1)",
+        &expect!["intrinsic callable `Check` failed: cannot verify input"],
     );
 }
 

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -3,6 +3,7 @@
 
 use std::f64::consts;
 
+use crate::backend::{Backend, SparseSim};
 use crate::debug::map_hir_package_to_fir;
 use crate::tests::eval_expr;
 use crate::{
@@ -61,6 +62,132 @@ impl<'a> NodeLookup for Lookup<'a> {
     }
 }
 
+#[derive(Default)]
+struct CustomSim {
+    sim: SparseSim,
+}
+
+impl Backend for CustomSim {
+    type ResultType = bool;
+
+    fn ccx(&mut self, ctl0: usize, ctl1: usize, q: usize) {
+        self.sim.ccx(ctl0, ctl1, q);
+    }
+
+    fn cx(&mut self, ctl: usize, q: usize) {
+        self.sim.cx(ctl, q);
+    }
+
+    fn cy(&mut self, ctl: usize, q: usize) {
+        self.sim.cy(ctl, q);
+    }
+
+    fn cz(&mut self, ctl: usize, q: usize) {
+        self.sim.cz(ctl, q);
+    }
+
+    fn h(&mut self, q: usize) {
+        self.sim.h(q);
+    }
+
+    fn m(&mut self, q: usize) -> Self::ResultType {
+        self.sim.m(q)
+    }
+
+    fn mresetz(&mut self, q: usize) -> Self::ResultType {
+        self.sim.mresetz(q)
+    }
+
+    fn reset(&mut self, q: usize) {
+        self.sim.reset(q);
+    }
+
+    fn rx(&mut self, theta: f64, q: usize) {
+        self.sim.rx(theta, q);
+    }
+
+    fn rxx(&mut self, theta: f64, q0: usize, q1: usize) {
+        self.sim.rxx(theta, q0, q1);
+    }
+
+    fn ry(&mut self, theta: f64, q: usize) {
+        self.sim.ry(theta, q);
+    }
+
+    fn ryy(&mut self, theta: f64, q0: usize, q1: usize) {
+        self.sim.ryy(theta, q0, q1);
+    }
+
+    fn rz(&mut self, theta: f64, q: usize) {
+        self.sim.rz(theta, q);
+    }
+
+    fn rzz(&mut self, theta: f64, q0: usize, q1: usize) {
+        self.sim.rzz(theta, q0, q1);
+    }
+
+    fn sadj(&mut self, q: usize) {
+        self.sim.sadj(q);
+    }
+
+    fn s(&mut self, q: usize) {
+        self.sim.s(q);
+    }
+
+    fn swap(&mut self, q0: usize, q1: usize) {
+        self.sim.swap(q0, q1);
+    }
+
+    fn tadj(&mut self, q: usize) {
+        self.sim.tadj(q);
+    }
+
+    fn t(&mut self, q: usize) {
+        self.sim.t(q);
+    }
+
+    fn x(&mut self, q: usize) {
+        self.sim.x(q);
+    }
+
+    fn y(&mut self, q: usize) {
+        self.sim.y(q);
+    }
+
+    fn z(&mut self, q: usize) {
+        self.sim.z(q);
+    }
+
+    fn qubit_allocate(&mut self) -> usize {
+        self.sim.qubit_allocate()
+    }
+
+    fn qubit_release(&mut self, q: usize) {
+        self.sim.qubit_release(q);
+    }
+
+    fn capture_quantum_state(
+        &mut self,
+    ) -> (Vec<(num_bigint::BigUint, num_complex::Complex<f64>)>, usize) {
+        self.sim.capture_quantum_state()
+    }
+
+    fn qubit_is_zero(&mut self, q: usize) -> bool {
+        self.sim.qubit_is_zero(q)
+    }
+
+    fn reinit(&mut self) {
+        self.sim.reinit();
+    }
+
+    fn custom_intrinsic(&mut self, name: &str, arg: Value) -> Option<Value> {
+        match name {
+            "Add1" => Some(Value::Int(arg.unwrap_int() + 1)),
+            _ => None,
+        }
+    }
+}
+
 fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Value, Error> {
     let mut fir_lowerer = crate::lower::Lowerer::new();
     let mut core = compile::core();
@@ -106,7 +233,14 @@ fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Va
     let lookup = Lookup {
         fir_store: &fir_store,
     };
-    eval_expr(entry, &lookup, map_hir_package_to_fir(id), out).map_err(|e| e.0)
+    eval_expr(
+        entry,
+        &mut CustomSim::default(),
+        &lookup,
+        map_hir_package_to_fir(id),
+        out,
+    )
+    .map_err(|e| e.0)
 }
 
 fn check_intrinsic_result(file: &str, expr: &str, expect: &Expect) {
@@ -910,6 +1044,21 @@ fn unknown_intrinsic() {
         "},
         "Test.Foo()",
         &expect!["unknown intrinsic `Foo`"],
+    );
+}
+
+#[test]
+fn custom_intrinsic() {
+    check_intrinsic_result(
+        indoc! {"
+            namespace Test {
+                function Add1(input : Int) : Int {
+                    body intrinsic;
+                }
+            }
+        "},
+        "Test.Add1(1)",
+        &expect!["2"],
     );
 }
 

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -75,6 +75,10 @@ pub enum Error {
     #[diagnostic(code("Qsc.Eval.IndexOutOfRange"))]
     IndexOutOfRange(i64, #[label("out of range")] PackageSpan),
 
+    #[error("intrinsic callable `{0}` failed: {1}")]
+    #[diagnostic(code("Qsc.Eval.IntrinsicFail"))]
+    IntrinsicFail(String, String, #[label] PackageSpan),
+
     #[error("negative integers cannot be used here: {0}")]
     #[diagnostic(code("Qsc.Eval.InvalidNegativeInt"))]
     InvalidNegativeInt(i64, #[label("invalid negative integer")] PackageSpan),
@@ -121,6 +125,7 @@ impl Error {
             | Error::EmptyRange(span)
             | Error::IndexOutOfRange(_, span)
             | Error::InvalidIndex(_, span)
+            | Error::IntrinsicFail(_, _, span)
             | Error::IntTooLarge(_, span)
             | Error::InvalidNegativeInt(_, span)
             | Error::MissingSpec(_, span)


### PR DESCRIPTION
This change adds an additional, optional to implement function for the `Backend` trait that can handle custom intrinsic callables by name. This will be an important extensibility point for later backends, though for now the only use is in the test that verifies the behavior.