### PR TITLE
Refactor the incremental compiler

### DIFF
--- a/compiler/qsc/src/incremental.rs
+++ b/compiler/qsc/src/incremental.rs
@@ -139,15 +139,7 @@ impl Compiler {
     pub fn update(&mut self, new: Increment) {
         let (_, unit) = self.store.get_open_mut();
 
-        // Extend the AST and HIR packages
-        unit.ast.package.extend(new.ast.package);
-        unit.package.extend(new.hir);
-
-        // The new `Increment` will contain the names and tys
-        // from the original package as well, so just
-        // replace the current tables instead of extending.
-        unit.ast.names = new.ast.names;
-        unit.ast.tys = new.ast.tys;
+        self.frontend.update(unit, new);
     }
 
     /// Returns a reference to the underlying package store.

--- a/compiler/qsc/src/incremental.rs
+++ b/compiler/qsc/src/incremental.rs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::compile::{self, compile, core, std};
+use miette::Diagnostic;
+use qsc_frontend::{
+    compile::{OpenPackageStore, PackageStore, SourceMap, TargetProfile},
+    error::WithSource,
+    incremental::CompileUnitAddition,
+};
+use qsc_hir::hir::PackageId;
+use qsc_passes::{PackageType, PassContext};
+
+/// An incremental Q# compiler.
+pub struct Compiler {
+    /// A package store that contains the current, mutable, `CompileUnit`
+    /// as well as all its immutable dependencies.
+    store: OpenPackageStore,
+    /// The ID of the source package. The source package
+    /// is made up of the initial sources passed in when creating the compiler.
+    source_package_id: PackageId,
+    /// Context for passes that is reused across incremental compilations.
+    passes: PassContext,
+    /// The frontend incremental compiler.
+    frontend: qsc_frontend::incremental::Compiler,
+}
+
+/// An incremental compiler error.
+pub type Errors = Vec<WithSource<compile::Error>>;
+
+impl Compiler {
+    /// Creates a new incremental compiler, compiling the passed in sources.
+    /// # Errors
+    /// If compiling the sources fails, compiler errors are returned.
+    pub fn new(
+        include_std: bool,
+        sources: SourceMap,
+        package_type: PackageType,
+        target: TargetProfile,
+    ) -> Result<Self, Errors> {
+        let core = core();
+        let mut store = PackageStore::new(core);
+        let mut dependencies = Vec::new();
+        if include_std {
+            let std = std(&store, target);
+            let id = store.insert(std);
+            dependencies.push(id);
+        }
+
+        let (unit, errors) = compile(&store, &dependencies, sources, package_type, target);
+        if !errors.is_empty() {
+            return Err(into_errors_with_source(errors, &unit.sources));
+        }
+
+        let source_package_id = store.insert(unit);
+        dependencies.push(source_package_id);
+
+        let frontend = qsc_frontend::incremental::Compiler::new(&store, dependencies, target);
+        let store = store.open();
+
+        Ok(Self {
+            store,
+            source_package_id,
+            frontend,
+            passes: PassContext::new(target),
+        })
+    }
+
+    /// Compiles Q# fragments. Fragments are Q# code that can contain
+    /// top-level statements as well as namespaces. A notebook cell
+    /// or an interpreter entry is an example of fragments.
+    ///
+    /// This method returns the AST and HIR packages that were created as a result of
+    /// the compilation, however it does *not* update the current compilation.
+    ///
+    /// The caller can use the returned packages to perform passes,
+    /// get information about the newly added items, or do other modifications.
+    /// It is then the caller's responsibility to merge
+    /// these packages into the current `CompileUnit` using the `update()` method.
+    pub fn compile_fragments(
+        &mut self,
+        source_name: &str,
+        source_contents: &str,
+    ) -> Result<CompileUnitAddition, Errors> {
+        let (core, unit) = self.store.get_open_mut();
+
+        let mut unit_addition = self
+            .frontend
+            .compile_fragments(unit, source_name, source_contents)
+            .map_err(into_errors)?;
+
+        let pass_errors = self.passes.run_default_passes(
+            &mut unit_addition.hir,
+            &mut unit.assigner,
+            core,
+            PackageType::Lib,
+        );
+
+        if !pass_errors.is_empty() {
+            return Err(into_errors_with_source(pass_errors, &unit.sources));
+        }
+
+        Ok(unit_addition)
+    }
+
+    /// Compiles an entry expression.
+    ///
+    /// This method returns the AST and HIR packages that were created as a result of
+    /// the compilation, however it does *not* update the current compilation.
+    ///
+    /// The caller can use the returned packages to perform passes,
+    /// get information about the newly added items, or do other modifications.
+    /// It is then the caller's responsibility to merge
+    /// these packages into the current `CompileUnit` using the `update()` method.
+    pub fn compile_expr(&mut self, expr: &str) -> Result<CompileUnitAddition, Errors> {
+        let (core, unit) = self.store.get_open_mut();
+
+        let mut unit_addition = self
+            .frontend
+            .compile_expr(unit, "<entry>", expr)
+            .map_err(into_errors)?;
+
+        let pass_errors = self.passes.run_default_passes(
+            &mut unit_addition.hir,
+            &mut unit.assigner,
+            core,
+            PackageType::Lib,
+        );
+
+        if !pass_errors.is_empty() {
+            return Err(into_errors_with_source(pass_errors, &unit.sources));
+        }
+
+        Ok(unit_addition)
+    }
+
+    /// Updates the current compilation with the AST and HIR packages,
+    /// and any associated context, returned from a previous incremental compilation.
+    pub fn update(&mut self, addition: CompileUnitAddition) {
+        let (_, unit) = self.store.get_open_mut();
+
+        // Extend the AST and HIR packages
+        unit.ast.package.extend(addition.ast.package);
+        unit.package.extend(addition.hir);
+
+        // The other package will contain the names and tys
+        // from the original package as well, so just
+        // replace the current tables instead of extending.
+        unit.ast.names = addition.ast.names;
+        unit.ast.tys = addition.ast.tys;
+    }
+
+    /// Returns a reference to the underlying package store.
+    #[must_use]
+    pub fn package_store(&self) -> &PackageStore {
+        self.store.package_store()
+    }
+
+    /// Returns ID of the current `CompileUnit`.
+    #[must_use]
+    pub fn package_id(&self) -> PackageId {
+        self.store.open_package_id()
+    }
+
+    /// Returns the ID of the source package created from the sources
+    /// passed in during inital creation.
+    #[must_use]
+    pub fn source_package_id(&self) -> PackageId {
+        self.source_package_id
+    }
+
+    /// Consumes the incremental compiler and returns an immutable package store.
+    /// This method can be used to finalize the compilation.
+    #[must_use]
+    pub fn into_package_store(self) -> (PackageStore, PackageId) {
+        self.store.into_package_store()
+    }
+}
+
+fn into_errors_with_source<T>(errors: Vec<T>, sources: &SourceMap) -> Errors
+where
+    compile::Error: From<T>,
+{
+    errors
+        .into_iter()
+        .map(|e| WithSource::from_map(sources, e.into()))
+        .collect()
+}
+
+fn into_errors<T>(errors: Vec<WithSource<T>>) -> Errors
+where
+    compile::Error: From<T>,
+    T: Diagnostic,
+{
+    errors
+        .into_iter()
+        .map(qsc_frontend::error::WithSource::into_with_source)
+        .collect()
+}

--- a/compiler/qsc/src/interpret/debug/tests.rs
+++ b/compiler/qsc/src/interpret/debug/tests.rs
@@ -87,7 +87,7 @@ fn stack_traces_can_cross_eval_session_and_file_boundaries() {
                              at Adjoint Test.C in 1.qs
                              at Adjoint Test.B in 1.qs
                              at Adjoint Test2.A in 2.qs
-                             at Z in <expression>
+                             at Z in line_0
                     "#};
             assert_eq!(expectation, stack_trace);
         }

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -259,7 +259,7 @@ impl Interpreter {
         Err(vec![Error::NoEntryPoint])
     }
 
-    /// # Errors    
+    /// # Errors
     /// If the parsing of the fragments fails, an error is returned.
     /// If the compilation of the fragments fails, an error is returned.
     /// If there is a runtime error when interpreting the fragments, an error is returned.

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -9,9 +9,8 @@ mod stepping_tests;
 
 use super::debug::format_call_stack;
 use crate::{
-    compile::{self, compile},
     error::{self, WithStack},
-    hir,
+    incremental::Compiler,
 };
 use miette::Diagnostic;
 use num_bigint::BigUint;
@@ -27,44 +26,32 @@ use qsc_eval::{
     Env, Global, NodeLookup, State, StepAction, StepResult, VariableInfo,
 };
 use qsc_fir::{
-    fir::{
-        Block, BlockId, CallableDecl, Expr, ExprId, ItemKind, LocalItemId, Package, PackageId, Pat,
-        PatId, Stmt, StmtId,
-    },
+    fir::{Block, BlockId, Expr, ExprId, ItemKind, Package, PackageId, Pat, PatId, Stmt, StmtId},
     visit::{self, Visitor},
 };
 use qsc_frontend::{
     compile::{CompileUnit, PackageStore, Source, SourceMap, TargetProfile},
     error::WithSource,
-    incremental::{self, Compiler, Fragment},
 };
-use qsc_passes::{PackageType, PassContext};
+use qsc_passes::PackageType;
 use std::collections::HashSet;
 use thiserror::Error;
-
-#[derive(Clone, Debug, Diagnostic, Error)]
-#[diagnostic(transparent)]
-#[error(transparent)]
-pub struct Error(#[from] ErrorKind);
 
 impl Error {
     #[must_use]
     pub fn stack_trace(&self) -> &Option<String> {
-        match &self.0 {
-            ErrorKind::Eval(err) => err.stack_trace(),
+        match &self {
+            Error::Eval(err) => err.stack_trace(),
             _ => &None,
         }
     }
 }
 
 #[derive(Clone, Debug, Diagnostic, Error)]
-enum ErrorKind {
+pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Compile(#[from] WithSource<compile::Error>),
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    Incremental(#[from] WithSource<incremental::Error>),
+    Compile(#[from] WithSource<crate::compile::Error>),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Pass(#[from] WithSource<qsc_passes::Error>),
@@ -81,9 +68,6 @@ enum ErrorKind {
 
 struct Lookup<'a> {
     fir_store: &'a IndexMap<PackageId, qsc_fir::fir::Package>,
-    package: PackageId,
-    udts: &'a HashSet<LocalItemId>,
-    callables: &'a IndexMap<LocalItemId, CallableDecl>,
 }
 
 impl<'a> Lookup<'a> {
@@ -96,7 +80,7 @@ impl<'a> Lookup<'a> {
 
 impl<'a> NodeLookup for Lookup<'a> {
     fn get(&self, id: GlobalId) -> Option<Global<'a>> {
-        get_global(self.fir_store, self.udts, self.callables, self.package, id)
+        get_global(self.fir_store, id)
     }
     fn get_block(&self, package: PackageId, id: BlockId) -> &qsc_fir::fir::Block {
         self.get_package(package)
@@ -124,33 +108,41 @@ impl<'a> NodeLookup for Lookup<'a> {
     }
 }
 
+/// A Q# interpreter.
 pub struct Interpreter {
-    // compilation state (ast, hir)
-    store: PackageStore,
+    /// The incremental Q# compiler.
     compiler: Compiler,
-    passes: PassContext,
-    lines: u32,
+    /// The `TargetProfile` used for compilation.
     target: TargetProfile,
-    // fir state
+    /// The number of lines that have so far been compiled.
+    /// This field is used to generate a unique label
+    /// for each line evaluated with `eval_fragments`.
+    lines: u32,
+    // The FIR store
     fir_store: IndexMap<PackageId, qsc_fir::fir::Package>,
-    udts: HashSet<LocalItemId>,
-    callables: IndexMap<LocalItemId, CallableDecl>,
+    /// FIR lowerer
     lowerer: qsc_eval::lower::Lowerer,
-    // package IDs (used to index into both ast/hir and fir package stores)
+    /// The ID of the current package.
+    /// This ID is valid both for the FIR store and the `PackageStore`.
     package: PackageId,
+    /// The ID of the source package. The source package
+    /// is made up of the initial sources passed in when creating the interpreter.
+    /// This ID is valid both for the FIR store and the `PackageStore`.
     source_package: PackageId,
-    // evaluator state
-    env: Env,
+    /// The default simulator backend.
     sim: SparseSim,
+    /// The evaluator environment.
+    env: Env,
+    /// The current state of the evaluator.
     state: State,
 }
 
 pub type InterpretResult = Result<Value, Vec<Error>>;
 
 impl Interpreter {
+    /// Creates a new incremental compiler, compiling the passed in sources.
     /// # Errors
-    /// If the compilation of the standard library fails, an error is returned.
-    /// If the compilation of the sources fails, an error is returned.
+    /// If compiling the sources fails, compiler errors are returned.
     pub fn new(
         std: bool,
         sources: SourceMap,
@@ -158,56 +150,31 @@ impl Interpreter {
         target: TargetProfile,
     ) -> Result<Self, Vec<Error>> {
         let mut lowerer = qsc_eval::lower::Lowerer::new();
-        let core = compile::core();
-        let core_fir = lowerer.lower_package(&core.package);
         let mut fir_store = IndexMap::new();
-        fir_store.insert(
-            map_hir_package_to_fir(qsc_hir::hir::PackageId::CORE),
-            core_fir,
-        );
-        let mut store = PackageStore::new(core);
-        let mut dependencies = Vec::new();
-        if std {
-            let std = compile::std(&store, target);
-            let std_fir = lowerer.lower_package(&std.package);
-            let id = store.insert(std);
-            fir_store.insert(map_hir_package_to_fir(id), std_fir);
-            dependencies.push(id);
+
+        let compiler = Compiler::new(std, sources, package_type, target).map_err(into_errors)?;
+
+        for (id, unit) in compiler.package_store().iter() {
+            fir_store.insert(
+                map_hir_package_to_fir(id),
+                lowerer.lower_package(&unit.package),
+            );
         }
 
-        let (unit, errors) = compile(&store, &dependencies, sources, package_type, target);
-        if !errors.is_empty() {
-            return Err(errors
-                .into_iter()
-                .map(|error| Error(WithSource::from_map(&unit.sources, error).into()))
-                .collect());
-        }
+        let source_package_id = compiler.source_package_id();
+        let package_id = compiler.package_id();
 
-        let user_fir = lowerer.lower_package(&unit.package);
-        let package = store.insert(unit);
-        fir_store.insert(map_hir_package_to_fir(package), user_fir);
-
-        dependencies.push(package);
-        let unit = CompileUnit::default();
-        let user_fir = lowerer.lower_package(&unit.package);
-        let user_package = store.insert(unit);
-        fir_store.insert(map_hir_package_to_fir(user_package), user_fir);
-        let compiler = Compiler::new(&store, dependencies, target);
         Ok(Self {
-            store,
             compiler,
-            passes: PassContext::new(target),
             lines: 0,
             target,
             fir_store,
-            udts: HashSet::new(),
-            callables: IndexMap::new(),
             lowerer,
             env: Env::with_empty_scope(),
             sim: SparseSim::new(),
-            state: State::new(map_hir_package_to_fir(package)),
-            package: map_hir_package_to_fir(user_package),
-            source_package: map_hir_package_to_fir(package),
+            state: State::new(map_hir_package_to_fir(source_package_id)),
+            package: map_hir_package_to_fir(package_id),
+            source_package: map_hir_package_to_fir(source_package_id),
         })
     }
 
@@ -225,9 +192,6 @@ impl Interpreter {
     /// Resumes execution with specified `StepAction`.
     /// # Errors
     /// Returns a vector of errors if evaluating the entry point fails.
-    /// # Panics
-    ///
-    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     pub fn eval_step(
         &mut self,
         receiver: &mut impl Receiver,
@@ -236,9 +200,6 @@ impl Interpreter {
     ) -> Result<StepResult, Vec<Error>> {
         let globals = Lookup {
             fir_store: &self.fir_store,
-            package: self.package,
-            udts: &self.udts,
-            callables: &self.callables,
         };
 
         self.state
@@ -251,31 +212,22 @@ impl Interpreter {
                 step,
             )
             .map_err(|(error, call_stack)| {
-                let stack_trace = if call_stack.is_empty() {
-                    None
-                } else {
-                    Some(self.render_call_stack(call_stack, &error))
-                };
-
-                vec![Error(
-                    error::from_eval(error, &self.store, stack_trace).into(),
-                )]
+                eval_error(
+                    self.compiler.package_store(),
+                    &self.fir_store,
+                    call_stack,
+                    error,
+                )
             })
     }
 
     /// Executes the entry expression until the end of execution.
     /// # Errors
     /// Returns a vector of errors if evaluating the entry point fails.
-    /// # Panics
-    ///
-    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     pub fn eval_entry(&mut self, receiver: &mut impl Receiver) -> Result<Value, Vec<Error>> {
         let expr = self.get_entry_expr()?;
         let globals = Lookup {
             fir_store: &self.fir_store,
-            package: self.package,
-            udts: &self.udts,
-            callables: &self.callables,
         };
 
         eval_expr(
@@ -287,15 +239,12 @@ impl Interpreter {
             receiver,
         )
         .map_err(|(error, call_stack)| {
-            let stack_trace = if call_stack.is_empty() {
-                None
-            } else {
-                Some(self.render_call_stack(call_stack, &error))
-            };
-
-            vec![Error(
-                error::from_eval(error, &self.store, stack_trace).into(),
-            )]
+            eval_error(
+                self.compiler.package_store(),
+                &self.fir_store,
+                call_stack,
+                error,
+            )
         })
     }
 
@@ -307,10 +256,10 @@ impl Interpreter {
         if let Some(entry) = unit.entry {
             return Ok(entry);
         };
-        Err(vec![Error(ErrorKind::NoEntryPoint)])
+        Err(vec![Error::NoEntryPoint])
     }
 
-    /// # Errors
+    /// # Errors    
     /// If the parsing of the fragments fails, an error is returned.
     /// If the compilation of the fragments fails, an error is returned.
     /// If there is a runtime error when interpreting the fragments, an error is returned.
@@ -319,36 +268,22 @@ impl Interpreter {
         receiver: &mut impl Receiver,
         fragments: &str,
     ) -> InterpretResult {
+        let label = self.next_line_label();
+
+        let unit_addition = self
+            .compiler
+            .compile_fragments(&label, fragments)
+            .map_err(into_errors)?;
+
+        let stmts = self.lower(&unit_addition);
+
+        self.compiler.update(unit_addition);
+
         let mut result = Value::unit();
 
-        let label = &self.next_line_label();
-
-        let (items, stmts) =
-            self.compile_incremental(|c, p| c.compile_fragments(p, label, fragments))?;
-
-        for item in items {
-            match item.kind {
-                qsc_hir::hir::ItemKind::Callable(callable) => {
-                    let callable = self.lower_callable_decl(&callable);
-
-                    self.callables
-                        .insert(qsc_eval::lower::lower_local_item_id(item.id), callable);
-                }
-                qsc_hir::hir::ItemKind::Namespace(..) => {}
-                qsc_hir::hir::ItemKind::Ty(..) => {
-                    self.udts
-                        .insert(qsc_eval::lower::lower_local_item_id(item.id));
-                }
-            }
-        }
-
-        for stmt in stmts {
-            let stmt_id = self.lower_stmt(&stmt);
+        for stmt_id in stmts {
             let globals = Lookup {
                 fir_store: &self.fir_store,
-                package: self.package,
-                udts: &self.udts,
-                callables: &self.callables,
             };
 
             match eval_stmt(
@@ -361,64 +296,17 @@ impl Interpreter {
             ) {
                 Ok(value) => result = value,
                 Err((error, call_stack)) => {
-                    let stack_trace = if call_stack.is_empty() {
-                        None
-                    } else {
-                        Some(self.render_call_stack(call_stack, &error))
-                    };
-
-                    return Err(vec![Error(
-                        error::from_eval(error, &self.store, stack_trace).into(),
-                    )]);
+                    return Err(eval_error(
+                        self.compiler.package_store(),
+                        &self.fir_store,
+                        call_stack,
+                        error,
+                    ))
                 }
             }
         }
 
         Ok(result)
-    }
-
-    fn compile_incremental(
-        &mut self,
-        mut compile: impl FnMut(
-            &mut Compiler,
-            &mut CompileUnit,
-        ) -> Result<Vec<Fragment>, Vec<incremental::Error>>,
-    ) -> Result<(Vec<hir::Item>, Vec<hir::Stmt>), Vec<Error>> {
-        let (core, package) = self.store.get_mut(map_fir_package_to_hir(self.package));
-
-        let package = package.expect("expected to find package");
-
-        let mut fragments = compile(&mut self.compiler, package).map_err(|errors| {
-            errors
-                .into_iter()
-                .map(|error| Error(WithSource::from_map(&package.sources, error).into()))
-                .collect::<Vec<_>>()
-        })?;
-
-        let pass_errors = fragments
-            .iter_mut()
-            .flat_map(|fragment| self.passes.run(core, &mut package.assigner, fragment))
-            .collect::<Vec<_>>();
-        if !pass_errors.is_empty() {
-            return Err(pass_errors
-                .into_iter()
-                .map(|error| Error(WithSource::from_map(&package.sources, error).into()))
-                .collect());
-        }
-
-        // Partition list into items and statements since items are always
-        // meant to be processed before statements.
-        let mut items = Vec::new();
-        let mut stmts = Vec::new();
-
-        for f in fragments {
-            match f {
-                Fragment::Item(item) => items.push(item),
-                Fragment::Stmt(stmt) => stmts.push(stmt),
-            }
-        }
-
-        Ok((items, stmts))
     }
 
     /// Runs the given entry expression on a new instance of the environment and simulator,
@@ -436,7 +324,7 @@ impl Interpreter {
     /// and simulator but using the current compilation.
     pub fn qirgen(&mut self, expr: &str) -> Result<String, Vec<Error>> {
         if self.target != TargetProfile::Base {
-            return Err(vec![Error(ErrorKind::TargetMismatch)]);
+            return Err(vec![Error::TargetMismatch]);
         }
 
         let mut sim = BaseProfSim::new();
@@ -461,74 +349,42 @@ impl Interpreter {
         expr: &str,
         shots: u32,
     ) -> Result<Vec<InterpretResult>, Vec<Error>> {
-        let (items, stmts) = self.compile_incremental(|c, p| c.compile_expr(p, "<entry>", expr))?;
+        let stmt_id = self.compile_expr_to_stmt(expr)?;
 
-        Ok(self.run_internal(sim, receiver, items, stmts, shots))
+        Ok(self.run_internal(sim, receiver, stmt_id, shots))
     }
 
     fn run_internal(
         &mut self,
         sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
         receiver: &mut impl Receiver,
-        items: Vec<hir::Item>,
-        stmts: Vec<hir::Stmt>,
+        stmt_id: StmtId,
         shots: u32,
     ) -> Vec<InterpretResult> {
-        for item in items {
-            match item.kind {
-                qsc_hir::hir::ItemKind::Callable(callable) => {
-                    let callable = self.lower_callable_decl(&callable);
-
-                    self.callables
-                        .insert(qsc_eval::lower::lower_local_item_id(item.id), callable);
-                }
-                qsc_hir::hir::ItemKind::Namespace(..) => {}
-                qsc_hir::hir::ItemKind::Ty(..) => {
-                    self.udts
-                        .insert(qsc_eval::lower::lower_local_item_id(item.id));
-                }
-            }
-        }
-
-        let mut stmt_ids = Vec::new();
-        for stmt in stmts {
-            stmt_ids.push(self.lower_stmt(&stmt));
-        }
-
         let globals = Lookup {
             fir_store: &self.fir_store,
-            package: self.package,
-            udts: &self.udts,
-            callables: &self.callables,
         };
 
         let mut results: Vec<InterpretResult> = Vec::new();
         for i in 0..shots {
-            for stmt_id in &stmt_ids {
-                results.push(
-                    match eval_stmt(
-                        *stmt_id,
-                        &globals,
-                        &mut Env::with_empty_scope(),
-                        sim,
-                        self.package,
-                        receiver,
-                    ) {
-                        Ok(value) => Ok(value),
-                        Err((error, call_stack)) => {
-                            let stack_trace = if call_stack.is_empty() {
-                                None
-                            } else {
-                                Some(self.render_call_stack(call_stack, &error))
-                            };
-
-                            Err(vec![Error(
-                                error::from_eval(error, &self.store, stack_trace).into(),
-                            )])
-                        }
-                    },
-                );
-            }
+            results.push(
+                match eval_stmt(
+                    stmt_id,
+                    &globals,
+                    &mut Env::with_empty_scope(),
+                    sim,
+                    self.package,
+                    receiver,
+                ) {
+                    Ok(value) => Ok(value),
+                    Err((error, call_stack)) => Err(eval_error(
+                        self.compiler.package_store(),
+                        &self.fir_store,
+                        call_stack,
+                        error,
+                    )),
+                },
+            );
 
             if i != 0 {
                 // If running more than one shot, re-initialize the simulator to start the next shot
@@ -540,8 +396,35 @@ impl Interpreter {
         results
     }
 
-    fn package(&self) -> &CompileUnit {
-        self.store
+    fn compile_expr_to_stmt(&mut self, expr: &str) -> Result<StmtId, Vec<Error>> {
+        let unit_addition = self.compiler.compile_expr(expr).map_err(into_errors)?;
+
+        let stmts = self.lower(&unit_addition);
+
+        self.compiler.update(unit_addition);
+
+        assert!(stmts.len() == 1, "expected exactly one statement");
+        let stmt_id = stmts.get(0).expect("expected exactly one statement");
+
+        Ok(*stmt_id)
+    }
+
+    fn lower(
+        &mut self,
+        unit_addition: &qsc_frontend::incremental::CompileUnitAddition,
+    ) -> Vec<StmtId> {
+        let fir_package = self
+            .fir_store
+            .get_mut(self.package)
+            .expect("package should be in store");
+
+        self.lowerer
+            .lower_and_update_package(fir_package, &unit_addition.hir)
+    }
+
+    fn source_package(&self) -> &CompileUnit {
+        self.compiler
+            .package_store()
             .get(map_fir_package_to_hir(self.source_package))
             .expect("Could not load package")
     }
@@ -552,47 +435,10 @@ impl Interpreter {
         label
     }
 
-    fn lower_callable_decl(&mut self, callable: &qsc_hir::hir::CallableDecl) -> CallableDecl {
-        let callable = self.lowerer.lower_callable_decl(callable);
-        self.update_fir_package();
-        callable
-    }
-
-    fn lower_stmt(&mut self, stmt: &qsc_hir::hir::Stmt) -> StmtId {
-        let stmt_id = self.lowerer.lower_stmt(stmt);
-        self.update_fir_package();
-        stmt_id
-    }
-
-    fn update_fir_package(&mut self) {
-        let package = self
-            .fir_store
-            .get_mut(self.package)
-            .expect("package should be in store");
-
-        self.lowerer.update_package(package);
-    }
-
-    fn render_call_stack(&self, call_stack: Vec<Frame>, error: &dyn std::error::Error) -> String {
-        let globals = Lookup {
-            fir_store: &self.fir_store,
-            package: self.package,
-            udts: &self.udts,
-            callables: &self.callables,
-        };
-        format_call_stack(&self.store, &globals, call_stack, error)
-    }
-
-    /// # Panics
-    ///
-    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     #[must_use]
     pub fn get_stack_frames(&self) -> Vec<StackFrame> {
         let globals = Lookup {
             fir_store: &self.fir_store,
-            package: self.package,
-            udts: &self.udts,
-            callables: &self.callables,
         };
         let frames = self.state.get_stack_frames();
         let stack_frames = frames
@@ -606,7 +452,8 @@ impl Interpreter {
                 };
 
                 let hir_package = self
-                    .store
+                    .compiler
+                    .package_store()
                     .get(map_fir_package_to_hir(frame.id.package))
                     .expect("package should exist");
                 let source = hir_package
@@ -630,12 +477,9 @@ impl Interpreter {
         self.sim.capture_quantum_state()
     }
 
-    /// # Panics
-    ///
-    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     #[must_use]
     pub fn get_breakpoints(&self, path: &str) -> Vec<BreakpointSpan> {
-        let unit = self.package();
+        let unit = self.source_package();
 
         if let Some(source) = unit.sources.find_by_name(path) {
             let package = self
@@ -684,26 +528,17 @@ pub struct StackFrame {
     pub hi: u32,
 }
 
-fn get_global<'a>(
-    fir_store: &'a IndexMap<PackageId, qsc_fir::fir::Package>,
-    udts: &'a HashSet<LocalItemId>,
-    callables: &'a IndexMap<LocalItemId, CallableDecl>,
-    package: PackageId,
+fn get_global(
+    fir_store: &IndexMap<PackageId, qsc_fir::fir::Package>,
     id: GlobalId,
-) -> Option<Global<'a>> {
-    if id.package == package {
-        udts.contains(&id.item)
-            .then_some(Global::Udt)
-            .or_else(|| callables.get(id.item).map(Global::Callable))
-    } else {
-        fir_store
-            .get(id.package)
-            .and_then(|package| match &package.items.get(id.item)?.kind {
-                ItemKind::Callable(callable) => Some(Global::Callable(callable)),
-                ItemKind::Namespace(..) => None,
-                ItemKind::Ty(..) => Some(Global::Udt),
-            })
-    }
+) -> Option<Global<'_>> {
+    fir_store
+        .get(id.package)
+        .and_then(|package| match &package.items.get(id.item)?.kind {
+            ItemKind::Callable(callable) => Some(Global::Callable(callable)),
+            ItemKind::Namespace(..) => None,
+            ItemKind::Ty(..) => Some(Global::Udt),
+        })
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -797,4 +632,31 @@ impl<'a> Visitor<'a> for BreakpointCollector<'a> {
             .get(id)
             .expect("couldn't find stmt in FIR")
     }
+}
+
+fn eval_error(
+    package_store: &PackageStore,
+    fir_store: &IndexMap<PackageId, qsc_fir::fir::Package>,
+    call_stack: Vec<Frame>,
+    error: qsc_eval::Error,
+) -> Vec<Error> {
+    let stack_trace = if call_stack.is_empty() {
+        None
+    } else {
+        Some(format_call_stack(
+            package_store,
+            &Lookup { fir_store },
+            call_stack,
+            &error,
+        ))
+    };
+
+    vec![error::from_eval(error, package_store, stack_trace).into()]
+}
+
+fn into_errors(errors: Vec<WithSource<crate::compile::Error>>) -> Vec<Error> {
+    errors
+        .into_iter()
+        .map(|error| Error::Compile(error.into_with_source()))
+        .collect::<Vec<_>>()
 }

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -270,14 +270,14 @@ impl Interpreter {
     ) -> InterpretResult {
         let label = self.next_line_label();
 
-        let unit_addition = self
+        let increment = self
             .compiler
             .compile_fragments(&label, fragments)
             .map_err(into_errors)?;
 
-        let stmts = self.lower(&unit_addition);
+        let stmts = self.lower(&increment);
 
-        self.compiler.update(unit_addition);
+        self.compiler.update(increment);
 
         let mut result = Value::unit();
 
@@ -397,11 +397,11 @@ impl Interpreter {
     }
 
     fn compile_expr_to_stmt(&mut self, expr: &str) -> Result<StmtId, Vec<Error>> {
-        let unit_addition = self.compiler.compile_expr(expr).map_err(into_errors)?;
+        let increment = self.compiler.compile_expr(expr).map_err(into_errors)?;
 
-        let stmts = self.lower(&unit_addition);
+        let stmts = self.lower(&increment);
 
-        self.compiler.update(unit_addition);
+        self.compiler.update(increment);
 
         assert!(stmts.len() == 1, "expected exactly one statement");
         let stmt_id = stmts.get(0).expect("expected exactly one statement");
@@ -409,10 +409,7 @@ impl Interpreter {
         Ok(*stmt_id)
     }
 
-    fn lower(
-        &mut self,
-        unit_addition: &qsc_frontend::incremental::CompileUnitAddition,
-    ) -> Vec<StmtId> {
+    fn lower(&mut self, unit_addition: &qsc_frontend::incremental::Increment) -> Vec<StmtId> {
         let fir_package = self
             .fir_store
             .get_mut(self.package)

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -277,6 +277,12 @@ impl Interpreter {
 
         let stmts = self.lower(&increment);
 
+        // Updating the compiler state with the new AST/HIR nodes
+        // is not necessary for the interpreter to function, as all
+        // the state required for evaluation already exists in the
+        // FIR store. It could potentially save some memory
+        // *not* to do hold on to the AST/HIR, but it is done
+        // here to keep the package stores consistent.
         self.compiler.update(increment);
 
         let mut result = Value::unit();
@@ -401,6 +407,12 @@ impl Interpreter {
 
         let stmts = self.lower(&increment);
 
+        // Updating the compiler state with the new AST/HIR nodes
+        // is not necessary for the interpreter to function, as all
+        // the state required for evaluation already exists in the
+        // FIR store. It could potentially save some memory
+        // *not* to do hold on to the AST/HIR, but it is done
+        // here to keep the package stores consistent.
         self.compiler.update(increment);
 
         assert!(stmts.len() == 1, "expected exactly one statement");

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -934,6 +934,27 @@ mod given_interpreter {
         }
 
         #[test]
+        fn qirgen_entry_expr_profile_incompatible() {
+            let mut interpreter = Interpreter::new(
+                true,
+                SourceMap::default(),
+                PackageType::Lib,
+                TargetProfile::Base,
+            )
+            .expect("interpreter should be created");
+            let res = interpreter
+                .qirgen("1")
+                .expect_err("expected qirgen to fail");
+            is_error(
+                &res,
+                &expect![[r#"
+                non-Result return type in entry expression
+                   [<entry>] [1]
+            "#]],
+            );
+        }
+
+        #[test]
         fn run_with_shots() {
             let mut interpreter = get_interpreter();
             let (result, output) = line(&mut interpreter, "operation Foo() : Int { 1 }");

--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -6,9 +6,12 @@
 
 pub mod compile;
 mod error;
+pub mod incremental;
 pub mod interpret;
 
-pub use qsc_frontend::compile::{CompileUnit, PackageStore, SourceContents, SourceMap, SourceName};
+pub use qsc_frontend::compile::{
+    CompileUnit, PackageStore, SourceContents, SourceMap, SourceName, TargetProfile,
+};
 
 pub mod resolve {
     pub use qsc_frontend::resolve::Res;
@@ -28,9 +31,7 @@ pub mod ast {
 
 pub use qsc_data_structures::span::Span;
 
-pub use qsc_frontend::compile::TargetProfile;
-
-pub use qsc_passes::PackageType;
+pub use qsc_passes::{PackageType, PassContext};
 
 pub use qsc_eval::{
     backend::{Backend, SparseSim},

--- a/compiler/qsc_ast/src/ast.rs
+++ b/compiler/qsc_ast/src/ast.rs
@@ -121,22 +121,6 @@ pub struct Package {
     pub entry: Option<Box<Expr>>,
 }
 
-fn take_and_concat<T>(left: &mut Box<[T]>, right: &mut Box<[T]>) -> Box<[T]> {
-    let mut v = std::mem::take(left).into_vec();
-    v.reserve_exact(right.len());
-    v.extend(std::mem::take(right).into_vec());
-    v.into_boxed_slice()
-}
-
-impl Package {
-    /// Extends the `Package` with the contents of another `Package`.
-    /// `other` should not contain any `NodeId`s
-    /// that conflict with the current `Package`.
-    pub fn extend(&mut self, mut other: Package) {
-        self.nodes = take_and_concat(&mut self.nodes, &mut other.nodes);
-    }
-}
-
 impl Display for Package {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut indent = set_indentation(indented(f), 0);

--- a/compiler/qsc_ast/src/mut_visit.rs
+++ b/compiler/qsc_ast/src/mut_visit.rs
@@ -4,7 +4,8 @@
 use crate::ast::{
     Attr, Block, CallableBody, CallableDecl, Expr, ExprKind, FunctorExpr, FunctorExprKind, Ident,
     Item, ItemKind, Namespace, Package, Pat, PatKind, Path, QubitInit, QubitInitKind, SpecBody,
-    SpecDecl, Stmt, StmtKind, StringComponent, Ty, TyDef, TyDefKind, TyKind, Visibility,
+    SpecDecl, Stmt, StmtKind, StringComponent, TopLevelNode, Ty, TyDef, TyDefKind, TyKind,
+    Visibility,
 };
 use qsc_data_structures::span::Span;
 
@@ -79,10 +80,10 @@ pub trait MutVisitor: Sized {
 }
 
 pub fn walk_package(vis: &mut impl MutVisitor, package: &mut Package) {
-    package
-        .namespaces
-        .iter_mut()
-        .for_each(|n| vis.visit_namespace(n));
+    package.nodes.iter_mut().for_each(|n| match n {
+        TopLevelNode::Namespace(ns) => vis.visit_namespace(ns),
+        TopLevelNode::Stmt(stmt) => vis.visit_stmt(stmt),
+    });
     package.entry.iter_mut().for_each(|e| vis.visit_expr(e));
 }
 

--- a/compiler/qsc_ast/src/visit.rs
+++ b/compiler/qsc_ast/src/visit.rs
@@ -4,7 +4,8 @@
 use crate::ast::{
     Attr, Block, CallableBody, CallableDecl, Expr, ExprKind, FunctorExpr, FunctorExprKind, Ident,
     Item, ItemKind, Namespace, Package, Pat, PatKind, Path, QubitInit, QubitInitKind, SpecBody,
-    SpecDecl, Stmt, StmtKind, StringComponent, Ty, TyDef, TyDefKind, TyKind, Visibility,
+    SpecDecl, Stmt, StmtKind, StringComponent, TopLevelNode, Ty, TyDef, TyDefKind, TyKind,
+    Visibility,
 };
 
 pub trait Visitor<'a>: Sized {
@@ -74,10 +75,10 @@ pub trait Visitor<'a>: Sized {
 }
 
 pub fn walk_package<'a>(vis: &mut impl Visitor<'a>, package: &'a Package) {
-    package
-        .namespaces
-        .iter()
-        .for_each(|n| vis.visit_namespace(n));
+    package.nodes.iter().for_each(|n| match n {
+        TopLevelNode::Namespace(ns) => vis.visit_namespace(ns),
+        TopLevelNode::Stmt(stmt) => vis.visit_stmt(stmt),
+    });
     package.entry.iter().for_each(|e| vis.visit_expr(e));
 }
 

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -15,8 +15,11 @@ use crate::{
 use miette::{Diagnostic, Report};
 use preprocess::TrackedName;
 use qsc_ast::{
-    assigner::Assigner as AstAssigner, ast, mut_visit::MutVisitor,
-    validate::Validator as AstValidator, visit::Visitor as _,
+    assigner::Assigner as AstAssigner,
+    ast::{self, TopLevelNode},
+    mut_visit::MutVisitor,
+    validate::Validator as AstValidator,
+    visit::Visitor as _,
 };
 use qsc_data_structures::{
     index_map::{self, IndexMap},
@@ -68,10 +71,11 @@ impl FromStr for TargetProfile {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Default)]
 pub struct CompileUnit {
-    pub package: hir::Package,
-    pub ast: AstPackage,
     pub assigner: HirAssigner,
+    pub ast_assigner: AstAssigner,
     pub sources: SourceMap,
+    pub ast: AstPackage,
+    pub package: hir::Package,
     pub errors: Vec<Error>,
     pub dropped_names: Vec<TrackedName>,
 }
@@ -212,13 +216,67 @@ impl PackageStore {
     }
 
     #[must_use]
-    pub fn get_mut(&mut self, id: PackageId) -> (&global::Table, Option<&mut CompileUnit>) {
-        (&self.core, self.units.get_mut(id))
-    }
-
-    #[must_use]
     pub fn iter(&self) -> Iter {
         Iter(self.units.iter())
+    }
+
+    /// "Opens" the package store. This inserts an empty
+    /// package into the store, which will be considered
+    /// the open package and which can be incrementally updated.
+    #[must_use]
+    pub fn open(mut self) -> OpenPackageStore {
+        let id = self.next_id;
+        self.next_id = id.successor();
+        self.units.insert(id, CompileUnit::default());
+
+        OpenPackageStore {
+            store: self,
+            open: id,
+        }
+    }
+}
+
+/// A package store that contains one mutable `CompileUnit`.
+pub struct OpenPackageStore {
+    store: PackageStore,
+    open: PackageId,
+}
+
+impl OpenPackageStore {
+    /// Returns a reference to the underlying, immutable,
+    /// package store.
+    #[must_use]
+    pub fn package_store(&self) -> &PackageStore {
+        &self.store
+    }
+
+    /// Returns the ID of the open package.
+    #[must_use]
+    pub fn open_package_id(&self) -> PackageId {
+        self.open
+    }
+
+    /// Returns a mutable reference to the open package,
+    /// along with a reference to the core library that can be used
+    /// to perform passes.
+    #[must_use]
+    pub fn get_open_mut(&mut self) -> (&global::Table, &mut CompileUnit) {
+        let id = self.open;
+
+        (
+            &self.store.core,
+            self.store
+                .units
+                .get_mut(id)
+                .expect("open package id should exist in store"),
+        )
+    }
+
+    /// Consumes the `OpenPackageStore` and returns a `PackageStore`
+    /// along with the id of the formerly open package.
+    #[must_use]
+    pub fn into_package_store(self) -> (PackageStore, PackageId) {
+        (self.store, self.open)
     }
 }
 
@@ -283,12 +341,13 @@ pub fn compile(
 
     CompileUnit {
         package,
+        assigner: hir_assigner,
         ast: AstPackage {
             package: ast_package,
             tys,
             names,
         },
-        assigner: hir_assigner,
+        ast_assigner,
         sources,
         errors,
         dropped_names,
@@ -400,7 +459,7 @@ fn parse_all(sources: &SourceMap) -> (ast::Package, Vec<qsc_parse::Error>) {
         let (source_namespaces, source_errors) = qsc_parse::namespaces(&source.contents);
         for mut namespace in source_namespaces {
             Offsetter(source.offset).visit_namespace(&mut namespace);
-            namespaces.push(namespace);
+            namespaces.push(TopLevelNode::Namespace(namespace));
         }
 
         append_parse_errors(&mut errors, source.offset, source_errors);
@@ -419,7 +478,7 @@ fn parse_all(sources: &SourceMap) -> (ast::Package, Vec<qsc_parse::Error>) {
 
     let package = ast::Package {
         id: ast::NodeId::default(),
-        namespaces: namespaces.into_boxed_slice(),
+        nodes: namespaces.into_boxed_slice(),
         entry,
     };
 

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -71,11 +71,10 @@ impl FromStr for TargetProfile {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Default)]
 pub struct CompileUnit {
-    pub assigner: HirAssigner,
-    pub ast_assigner: AstAssigner,
-    pub sources: SourceMap,
-    pub ast: AstPackage,
     pub package: hir::Package,
+    pub ast: AstPackage,
+    pub assigner: HirAssigner,
+    pub sources: SourceMap,
     pub errors: Vec<Error>,
     pub dropped_names: Vec<TrackedName>,
 }
@@ -341,13 +340,12 @@ pub fn compile(
 
     CompileUnit {
         package,
-        assigner: hir_assigner,
         ast: AstPackage {
             package: ast_package,
             tys,
             names,
         },
-        ast_assigner,
+        assigner: hir_assigner,
         sources,
         errors,
         dropped_names,

--- a/compiler/qsc_frontend/src/error.rs
+++ b/compiler/qsc_frontend/src/error.rs
@@ -12,10 +12,7 @@ use std::{
 };
 
 #[derive(Clone, Debug)]
-pub struct WithSource<E>
-where
-    E: Diagnostic,
-{
+pub struct WithSource<E> {
     sources: Vec<Source>,
     error: E,
 }
@@ -24,6 +21,10 @@ impl<E: Diagnostic> WithSource<E> {
     pub fn error(&self) -> &E {
         &self.error
     }
+
+    pub fn into_error(self) -> E {
+        self.error
+    }
 }
 
 impl<E: Diagnostic> WithSource<E> {
@@ -31,8 +32,6 @@ impl<E: Diagnostic> WithSource<E> {
     /// Since errors may contain labeled spans from any source file in the
     /// compilation, the entire source map is needed to resolve offsets.
     /// # Panics
-    ///
-    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
     pub fn from_map(sources: &SourceMap, error: E) -> Self {
         // Filter the source map to the relevant sources
         // to avoid cloning all of them.
@@ -58,6 +57,16 @@ impl<E: Diagnostic> WithSource<E> {
         Self {
             sources: filtered,
             error,
+        }
+    }
+
+    pub fn into_with_source<T>(self) -> WithSource<T>
+    where
+        T: From<E>,
+    {
+        WithSource {
+            sources: self.sources,
+            error: self.error.into(),
         }
     }
 }

--- a/compiler/qsc_frontend/src/error.rs
+++ b/compiler/qsc_frontend/src/error.rs
@@ -31,7 +31,6 @@ impl<E: Diagnostic> WithSource<E> {
     /// Construct a diagnostic with source information from a source map.
     /// Since errors may contain labeled spans from any source file in the
     /// compilation, the entire source map is needed to resolve offsets.
-    /// # Panics
     pub fn from_map(sources: &SourceMap, error: E) -> Self {
         // Filter the source map to the relevant sources
         // to avoid cloning all of them.

--- a/compiler/qsc_frontend/src/incremental.rs
+++ b/compiler/qsc_frontend/src/incremental.rs
@@ -41,7 +41,7 @@ pub type Error = WithSource<compile::Error>;
 /// These packages can be merged into the original
 /// `CompileUnit` that was used for the incremental compilation.
 #[derive(Debug)]
-pub struct CompileUnitAddition {
+pub struct Increment {
     pub ast: AstPackage,
     pub hir: hir::Package,
 }
@@ -94,7 +94,7 @@ impl Compiler {
         unit: &mut CompileUnit,
         source_name: &str,
         source_contents: &str,
-    ) -> Result<CompileUnitAddition, Vec<Error>> {
+    ) -> Result<Increment, Vec<Error>> {
         let (mut ast, parse_errors) =
             Self::parse_fragments(&mut unit.sources, source_name, source_contents);
 
@@ -105,7 +105,7 @@ impl Compiler {
         let (hir, lower_errors) = self.resolve_check_lower(unit, &mut ast);
 
         if lower_errors.is_empty() {
-            Ok(CompileUnitAddition {
+            Ok(Increment {
                 ast: AstPackage {
                     package: ast,
                     names: self.resolver.names().clone(),
@@ -134,7 +134,7 @@ impl Compiler {
         unit: &mut CompileUnit,
         source_name: &str,
         source_contents: &str,
-    ) -> Result<CompileUnitAddition, Vec<Error>> {
+    ) -> Result<Increment, Vec<Error>> {
         let (mut ast, parse_errors) =
             Self::parse_expr(&mut unit.sources, source_name, source_contents);
 
@@ -145,7 +145,7 @@ impl Compiler {
         let (package, errors) = self.resolve_check_lower(unit, &mut ast);
 
         if errors.is_empty() {
-            Ok(CompileUnitAddition {
+            Ok(Increment {
                 ast: AstPackage {
                     package: ast,
                     names: self.resolver.names().clone(),

--- a/compiler/qsc_frontend/src/incremental.rs
+++ b/compiler/qsc_frontend/src/incremental.rs
@@ -5,55 +5,49 @@
 mod tests;
 
 use crate::{
-    compile::{preprocess, CompileUnit, Offsetter, PackageStore, TargetProfile},
-    lower::{self, Lowerer},
+    compile::{
+        self, preprocess, AstPackage, CompileUnit, Offsetter, PackageStore, SourceMap,
+        TargetProfile,
+    },
+    error::WithSource,
+    lower::Lowerer,
     resolve::{self, Resolver},
     typeck::{self, Checker},
 };
-use miette::Diagnostic;
-use qsc_ast::{assigner::Assigner as AstAssigner, ast, mut_visit::MutVisitor, visit::Visitor};
+use qsc_ast::{
+    assigner::Assigner as AstAssigner,
+    ast::{self, Stmt, TopLevelNode},
+    mut_visit::MutVisitor,
+    visit::Visitor,
+};
 use qsc_hir::{
     assigner::Assigner as HirAssigner,
     hir::{self, PackageId},
 };
-use thiserror::Error;
 
-#[derive(Clone, Debug, Diagnostic, Error)]
-#[diagnostic(transparent)]
-#[error(transparent)]
-pub struct Error(ErrorKind);
-
-#[derive(Clone, Debug, Diagnostic, Error)]
-#[diagnostic(transparent)]
-enum ErrorKind {
-    #[error("syntax error")]
-    Parse(#[from] qsc_parse::Error),
-    #[error("name error")]
-    Resolve(#[from] resolve::Error),
-    #[error("type error")]
-    Type(#[from] typeck::Error),
-    #[error(transparent)]
-    Lower(#[from] lower::Error),
-}
-
-#[derive(Debug)]
-pub enum Fragment {
-    Stmt(hir::Stmt),
-    Item(hir::Item),
-}
-
+/// The frontend for an incremental compiler.
+/// It is used to update a single `CompileUnit`
+/// with additional sources.
 pub struct Compiler {
-    ast_assigner: AstAssigner,
     resolver: Resolver,
     checker: Checker,
     lowerer: Lowerer,
     target: TargetProfile,
 }
 
+pub type Error = WithSource<compile::Error>;
+
+/// The result of an incremental compilation.
+/// These packages can be merged into the original
+/// `CompileUnit` that was used for the incremental compilation.
+#[derive(Debug)]
+pub struct CompileUnitAddition {
+    pub ast: AstPackage,
+    pub hir: hir::Package,
+}
+
 impl Compiler {
-    /// # Panics
-    ///
-    /// This function will panic if compiler state is invalid or in out-of-memory conditions.
+    /// Creates a new compiler.
     pub fn new(
         store: &PackageStore,
         dependencies: impl IntoIterator<Item = PackageId>,
@@ -78,7 +72,6 @@ impl Compiler {
         }
 
         Self {
-            ast_assigner: AstAssigner::new(),
             resolver: Resolver::with_persistent_local_scope(resolve_globals, dropped_names),
             checker: Checker::new(typeck_globals),
             lowerer: Lowerer::new(),
@@ -86,227 +79,227 @@ impl Compiler {
         }
     }
 
-    /// Compile a string with a single fragment of Q# code that is an expression.
-    /// # Errors
-    /// Returns a vector of errors if the input fails compilation.
-    pub fn compile_expr(
-        &mut self,
-        unit: &mut CompileUnit,
-        source_name: &str,
-        source_contents: &str,
-    ) -> Result<Vec<Fragment>, Vec<Error>> {
-        let fragments = self.compile(unit, source_name, source_contents, |s| {
-            let (expr, errors) = qsc_parse::expr(s);
-            if !errors.is_empty() {
-                return (Vec::new(), errors);
-            }
-
-            let fragment = qsc_parse::Fragment::Stmt(Box::new(ast::Stmt {
-                id: ast::NodeId::default(),
-                span: expr.span,
-                kind: Box::new(ast::StmtKind::Expr(expr)),
-            }));
-
-            (vec![fragment], errors)
-        })?;
-
-        Ok(fragments)
-    }
-
-    /// Compile a string with one or more fragments of Q# code.
-    /// # Errors
-    /// Returns a vector of errors if any of the input fails compilation.
+    /// Compiles Q# fragments.
+    ///
+    /// Uses the assigners and other mutable state from the passed in
+    /// `CompileUnit` to guarantee uniqueness, however does not
+    /// update the `CompileUnit` with the resulting AST and HIR packages.
+    ///
+    /// The caller can use the returned packages to perform passes,
+    /// get information about the newly added items, or do other modifications.
+    /// It is then the caller's responsibility to merge
+    /// these packages into the current `CompileUnit`.
     pub fn compile_fragments(
         &mut self,
         unit: &mut CompileUnit,
         source_name: &str,
         source_contents: &str,
-    ) -> Result<Vec<Fragment>, Vec<Error>> {
-        self.compile(unit, source_name, source_contents, qsc_parse::fragments)
+    ) -> Result<CompileUnitAddition, Vec<Error>> {
+        let (mut ast, parse_errors) =
+            Self::parse_fragments(&mut unit.sources, source_name, source_contents);
+
+        if !parse_errors.is_empty() {
+            return Err(parse_errors);
+        }
+
+        let (hir, lower_errors) = self.resolve_check_lower(unit, &mut ast);
+
+        if lower_errors.is_empty() {
+            Ok(CompileUnitAddition {
+                ast: AstPackage {
+                    package: ast,
+                    names: self.resolver.names().clone(),
+                    tys: self.checker.table().clone(),
+                },
+                hir,
+            })
+        } else {
+            self.lowerer.clear_items();
+            Err(lower_errors)
+        }
     }
 
-    fn compile<F>(
+    /// Compiles an entry expression.
+    ///
+    /// Uses the assigners and other mutable state from the passed in
+    /// `CompileUnit` to guarantee uniqueness, however does not
+    /// update the `CompileUnit` with the resulting AST and HIR packages.
+    ///
+    /// The caller can use the returned packages to perform passes,
+    /// get information about the newly added items, or do other modifications.
+    /// It is then the caller's responsibility to merge
+    /// these packages into the current `CompileUnit`.
+    pub fn compile_expr(
         &mut self,
         unit: &mut CompileUnit,
         source_name: &str,
         source_contents: &str,
-        parse: F,
-    ) -> Result<Vec<Fragment>, Vec<Error>>
-    where
-        F: Fn(&str) -> (Vec<qsc_parse::Fragment>, Vec<qsc_parse::Error>),
-    {
-        // Append the line to the source map with the appropriate offset
-        let offset = unit
-            .sources
-            .push(source_name.into(), source_contents.into());
+    ) -> Result<CompileUnitAddition, Vec<Error>> {
+        let (mut ast, parse_errors) =
+            Self::parse_expr(&mut unit.sources, source_name, source_contents);
 
-        let (mut fragments, errors) = parse(source_contents);
-        if !errors.is_empty() {
-            return Err(errors
-                .into_iter()
-                .map(|e| Error(ErrorKind::Parse(e.with_offset(offset))))
-                .collect());
+        if !parse_errors.is_empty() {
+            return Err(parse_errors);
         }
 
-        let mut offsetter = Offsetter(offset);
-        for fragment in &mut fragments {
-            match fragment {
-                qsc_parse::Fragment::Namespace(namespace) => offsetter.visit_namespace(namespace),
-                qsc_parse::Fragment::Stmt(stmt) => offsetter.visit_stmt(stmt),
-            }
-        }
+        let (package, errors) = self.resolve_check_lower(unit, &mut ast);
 
-        let mut cond_compile = preprocess::Conditional::new(self.target);
-        for fragment in &mut fragments {
-            match fragment {
-                qsc_parse::Fragment::Namespace(namespace) => {
-                    cond_compile.visit_namespace(namespace);
-                }
-                qsc_parse::Fragment::Stmt(stmt) => {
-                    cond_compile.visit_stmt(stmt);
-                }
-            }
-        }
-        self.resolver
-            .extend_dropped_names(cond_compile.into_names());
-
-        // Namespaces must be processed before top-level statements, so sort the fragments.
-        // Note that stable sorting is used here to preserve the order of top-level statements.
-        fragments.sort_by_key(|f| match f {
-            qsc_parse::Fragment::Namespace(_) => 0,
-            qsc_parse::Fragment::Stmt(_) => 1,
-        });
-
-        self.assign_ast_ids(&mut fragments);
-
-        self.bind_items(&mut unit.assigner, &fragments);
-
-        self.resolve(&mut unit.assigner, &fragments);
-
-        self.collect_items(&fragments);
-
-        self.type_check(&fragments);
-
-        let fragments = fragments
-            .into_iter()
-            .flat_map(|f| self.lower_fragment(&mut unit.assigner, f))
-            .collect();
-
-        let errors = self.drain_errors();
         if errors.is_empty() {
-            Ok(fragments)
+            Ok(CompileUnitAddition {
+                ast: AstPackage {
+                    package: ast,
+                    names: self.resolver.names().clone(),
+                    tys: self.checker.table().clone(),
+                },
+                hir: package,
+            })
         } else {
             self.lowerer.clear_items();
             Err(errors)
         }
     }
 
-    fn type_check(&mut self, fragments: &Vec<qsc_parse::Fragment>) {
-        for fragment in fragments {
-            match fragment {
-                qsc_parse::Fragment::Namespace(namespace) => self
-                    .checker
-                    .check_namespace_fragment(self.resolver.names(), namespace),
-                qsc_parse::Fragment::Stmt(stmt) => self
-                    .checker
-                    .check_stmt_fragment(self.resolver.names(), stmt),
-            }
-        }
+    fn resolve_check_lower(
+        &mut self,
+        unit: &mut CompileUnit,
+        ast: &mut ast::Package,
+    ) -> (hir::Package, Vec<Error>) {
+        let mut cond_compile = preprocess::Conditional::new(self.target);
+        cond_compile.visit_package(ast);
+        self.resolver
+            .extend_dropped_names(cond_compile.into_names());
 
+        self.check(&mut unit.ast_assigner, &mut unit.assigner, ast);
         self.checker.solve(self.resolver.names());
+
+        let package = self.lower(&mut unit.assigner, &*ast);
+
+        let errors: Vec<Error> = self
+            .drain_errors()
+            .into_iter()
+            .map(|e| WithSource::from_map(&unit.sources, e))
+            .collect();
+
+        (package, errors)
     }
 
-    fn collect_items(&mut self, fragments: &Vec<qsc_parse::Fragment>) {
-        for fragment in fragments {
-            match fragment {
-                qsc_parse::Fragment::Namespace(namespace) => self
-                    .checker
-                    .collect_namespace_items(self.resolver.names(), namespace),
-                qsc_parse::Fragment::Stmt(stmt) => {
-                    self.checker.collect_stmt_items(self.resolver.names(), stmt);
-                }
+    fn parse_expr(
+        sources: &mut SourceMap,
+        source_name: &str,
+        source_contents: &str,
+    ) -> (ast::Package, Vec<Error>) {
+        let offset = sources.push(source_name.into(), source_contents.into());
+
+        let (expr, errors) = qsc_parse::expr(source_contents);
+        let mut stmt = Box::new(Stmt {
+            id: ast::NodeId::default(),
+            span: expr.span,
+            kind: Box::new(ast::StmtKind::Expr(expr)),
+        });
+
+        let mut offsetter = Offsetter(offset);
+        offsetter.visit_stmt(&mut stmt);
+
+        let top_level_nodes = Box::new([TopLevelNode::Stmt(stmt)]);
+
+        let package = ast::Package {
+            id: ast::NodeId::default(),
+            nodes: top_level_nodes,
+            entry: None,
+        };
+
+        (package, with_source(errors, sources, offset))
+    }
+
+    fn parse_fragments(
+        sources: &mut SourceMap,
+        source_name: &str,
+        source_contents: &str,
+    ) -> (ast::Package, Vec<Error>) {
+        let offset = sources.push(source_name.into(), source_contents.into());
+
+        let (mut top_level_nodes, errors) = qsc_parse::top_level_nodes(source_contents);
+        let mut offsetter = Offsetter(offset);
+        for node in &mut top_level_nodes {
+            match node {
+                ast::TopLevelNode::Namespace(ns) => offsetter.visit_namespace(ns),
+                ast::TopLevelNode::Stmt(stmt) => offsetter.visit_stmt(stmt),
             }
         }
+
+        let package = ast::Package {
+            id: ast::NodeId::default(),
+            nodes: top_level_nodes.into_boxed_slice(),
+            entry: None,
+        };
+
+        (package, with_source(errors, sources, offset))
     }
 
-    fn resolve(&mut self, hir_assigner: &mut HirAssigner, fragments: &Vec<qsc_parse::Fragment>) {
-        for fragment in fragments {
-            match fragment {
-                qsc_parse::Fragment::Namespace(namespace) => {
-                    self.resolver.with(hir_assigner).visit_namespace(namespace);
-                }
-                qsc_parse::Fragment::Stmt(stmt) => {
-                    self.resolver.with(hir_assigner).visit_stmt(stmt);
-                }
-            }
-        }
+    fn lower(&mut self, hir_assigner: &mut HirAssigner, package: &ast::Package) -> hir::Package {
+        self.lowerer
+            .with(hir_assigner, self.resolver.names(), self.checker.table())
+            .lower_package(package)
     }
 
-    fn bind_items(&mut self, hir_assigner: &mut HirAssigner, fragments: &Vec<qsc_parse::Fragment>) {
-        for fragment in fragments {
-            match fragment {
-                qsc_parse::Fragment::Namespace(namespace) => {
-                    self.resolver.bind_namespace_items(hir_assigner, namespace);
+    fn check(
+        &mut self,
+        ast_assigner: &mut AstAssigner,
+        hir_assigner: &mut HirAssigner,
+        package: &mut ast::Package,
+    ) {
+        ast_assigner.visit_package(package);
+
+        // bind_items
+        for node in &mut package.nodes.iter() {
+            match node {
+                ast::TopLevelNode::Namespace(ns) => {
+                    self.resolver.bind_namespace_items(hir_assigner, ns);
                 }
-                qsc_parse::Fragment::Stmt(stmt) => {
+                ast::TopLevelNode::Stmt(stmt) => {
                     if let ast::StmtKind::Item(item) = stmt.kind.as_ref() {
                         self.resolver.bind_local_item(hir_assigner, item);
                     }
                 }
             }
         }
+
+        // resolve
+        self.resolver.with(hir_assigner).visit_package(package);
+
+        self.checker.check_package(self.resolver.names(), package);
     }
 
-    fn assign_ast_ids(&mut self, fragments: &mut Vec<qsc_parse::Fragment>) {
-        for fragment in fragments {
-            match fragment {
-                qsc_parse::Fragment::Namespace(namespace) => {
-                    self.ast_assigner.visit_namespace(namespace);
-                }
-                qsc_parse::Fragment::Stmt(stmt) => self.ast_assigner.visit_stmt(stmt),
-            }
-        }
-    }
-
-    fn lower_fragment(
-        &mut self,
-        hir_assigner: &mut HirAssigner,
-        fragment: qsc_parse::Fragment,
-    ) -> Vec<Fragment> {
-        let fragment = match fragment {
-            qsc_parse::Fragment::Namespace(namespace) => {
-                self.lower_namespace(hir_assigner, &namespace);
-                None
-            }
-            qsc_parse::Fragment::Stmt(stmt) => self.lower_stmt(hir_assigner, &stmt),
-        };
-
-        self.lowerer
-            .drain_items()
-            .map(Fragment::Item)
-            .chain(fragment)
-            .collect()
-    }
-
-    fn lower_namespace(&mut self, hir_assigner: &mut HirAssigner, namespace: &ast::Namespace) {
-        self.lowerer
-            .with(hir_assigner, self.resolver.names(), self.checker.table())
-            .lower_namespace(namespace);
-    }
-
-    fn lower_stmt(&mut self, hir_assigner: &mut HirAssigner, stmt: &ast::Stmt) -> Option<Fragment> {
-        self.lowerer
-            .with(hir_assigner, self.resolver.names(), self.checker.table())
-            .lower_stmt(stmt)
-            .map(Fragment::Stmt)
-    }
-
-    fn drain_errors(&mut self) -> Vec<Error> {
+    fn drain_errors(&mut self) -> Vec<compile::Error> {
         self.resolver
             .drain_errors()
-            .map(|e| Error(e.into()))
-            .chain(self.checker.drain_errors().map(|e| Error(e.into())))
-            .chain(self.lowerer.drain_errors().map(|e| Error(e.into())))
+            .map(|e| compile::Error(e.into()))
+            .chain(
+                self.checker
+                    .drain_errors()
+                    .map(|e| compile::Error(e.into())),
+            )
+            .chain(
+                self.lowerer
+                    .drain_errors()
+                    .map(|e| compile::Error(e.into())),
+            )
             .collect()
     }
+}
+
+fn with_source(
+    errors: Vec<qsc_parse::Error>,
+    sources: &SourceMap,
+    offset: u32,
+) -> Vec<WithSource<compile::Error>> {
+    errors
+        .into_iter()
+        .map(|e| {
+            WithSource::from_map(
+                sources,
+                compile::Error(compile::ErrorKind::Parse(e.with_offset(offset))),
+            )
+        })
+        .collect()
 }

--- a/compiler/qsc_frontend/src/incremental/tests.rs
+++ b/compiler/qsc_frontend/src/incremental/tests.rs
@@ -75,7 +75,10 @@ fn one_statement() {
             terms:
             node_id:1,node_id:2,node_id:3,node_id:4,
             hir:
-            Package:"#]],
+            Package:
+                Stmt 0 [0-16]: Qubit (Fresh)
+                    Pat 1 [4-5] [Type Qubit]: Bind: Ident 2 [4-5] "q"
+                    QubitInit 3 [8-15] [Type Qubit]: Single"#]],
         &unit,
     );
 }

--- a/compiler/qsc_frontend/src/incremental/tests.rs
+++ b/compiler/qsc_frontend/src/incremental/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::{Compiler, Fragment};
+use super::{CompileUnitAddition, Compiler};
 use crate::compile::{self, CompileUnit, PackageStore, TargetProfile};
 use expect_test::{expect, Expect};
 use indoc::indoc;
@@ -11,7 +11,7 @@ use miette::Diagnostic;
 fn one_callable() {
     let store = PackageStore::new(compile::core());
     let mut compiler = Compiler::new(&store, vec![], TargetProfile::Full);
-    let fragments = compiler
+    let unit = compiler
         .compile_fragments(
             &mut CompileUnit::default(),
             "test_1",
@@ -19,14 +19,38 @@ fn one_callable() {
         )
         .expect("compilation should succeed");
 
-    check_fragment_kinds(
+    check_unit(
         &expect![[r#"
-        [
-            "callable",
-            "namespace",
-        ]
-    "#]],
-        &fragments,
+            ast:
+            Package 0:
+                Namespace 1 [0-44] (Ident 2 [10-13] "Foo"):
+                    Item 3 [16-42]:
+                        Callable 4 [16-42] (Operation):
+                            name: Ident 5 [26-30] "Main"
+                            input: Pat 6 [30-32]: Unit
+                            output: Type 7 [35-39]: Path: Path 8 [35-39] (Ident 9 [35-39] "Unit")
+                            body: Block: Block 10 [40-42]: <empty>
+            names:
+            node_id:2,node_id:5,node_id:8,
+            terms:
+            node_id:6,node_id:10,
+            hir:
+            Package:
+                Item 0 [0-44] (Public):
+                    Namespace (Ident 5 [10-13] "Foo"): Item 1
+                Item 1 [16-42] (Public):
+                    Parent: 0
+                    Callable 0 [16-42] (operation):
+                        name: Ident 1 [26-30] "Main"
+                        input: Pat 2 [30-32] [Type Unit]: Unit
+                        output: Unit
+                        functors: empty set
+                        body: SpecDecl 3 [16-42]: Impl:
+                            Block 4 [40-42]: <empty>
+                        adj: <none>
+                        ctl: <none>
+                        ctl-adj: <none>"#]],
+        &unit,
     );
 }
 
@@ -34,17 +58,25 @@ fn one_callable() {
 fn one_statement() {
     let store = PackageStore::new(compile::core());
     let mut compiler = Compiler::new(&store, vec![], TargetProfile::Full);
-    let fragments = compiler
+    let unit = compiler
         .compile_fragments(&mut CompileUnit::default(), "test_1", "use q = Qubit();")
         .expect("compilation should succeed");
 
-    check_fragment_kinds(
+    check_unit(
         &expect![[r#"
-            [
-                "statement",
-            ]
-        "#]],
-        &fragments,
+            ast:
+            Package 0:
+                Stmt 1 [0-16]: Qubit (Fresh)
+                    Pat 2 [4-5]: Bind:
+                        Ident 3 [4-5] "q"
+                    QubitInit 4 [8-15] Single
+            names:
+            node_id:3,
+            terms:
+            node_id:1,node_id:2,node_id:3,node_id:4,
+            hir:
+            Package:"#]],
+        &unit,
     );
 }
 
@@ -141,18 +173,30 @@ fn errors_across_multiple_lines() {
     .assert_debug_eq(&labels);
 }
 
-fn check_fragment_kinds(expect: &Expect, actual: &[Fragment]) {
-    expect.assert_debug_eq(
-        &actual
+fn check_unit(expect: &Expect, actual: &CompileUnitAddition) {
+    let ast = format!("ast:\n{}", actual.ast.package);
+
+    let names = format!(
+        "\nnames:\n{}",
+        actual
+            .ast
+            .names
             .iter()
-            .map(|f| match f {
-                Fragment::Stmt(_) => "statement",
-                Fragment::Item(item) => match item.kind {
-                    qsc_hir::hir::ItemKind::Callable(_) => "callable",
-                    qsc_hir::hir::ItemKind::Namespace(_, _) => "namespace",
-                    qsc_hir::hir::ItemKind::Ty(_, _) => "ty",
-                },
-            })
-            .collect::<Vec<&str>>(),
+            .map(|n| format!("node_id:{},", n.0))
+            .collect::<String>()
     );
+    let terms = format!(
+        "\nterms:\n{}",
+        actual
+            .ast
+            .tys
+            .terms
+            .iter()
+            .map(|n| format!("node_id:{},", n.0))
+            .collect::<String>()
+    );
+
+    let hir = format!("\nhir:\n{}", actual.hir);
+
+    expect.assert_eq(&[ast, names, terms, hir].into_iter().collect::<String>());
 }

--- a/compiler/qsc_frontend/src/incremental/tests.rs
+++ b/compiler/qsc_frontend/src/incremental/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::{CompileUnitAddition, Compiler};
+use super::{Compiler, Increment};
 use crate::compile::{self, CompileUnit, PackageStore, TargetProfile};
 use expect_test::{expect, Expect};
 use indoc::indoc;
@@ -173,7 +173,7 @@ fn errors_across_multiple_lines() {
     .assert_debug_eq(&labels);
 }
 
-fn check_unit(expect: &Expect, actual: &CompileUnitAddition) {
+fn check_unit(expect: &Expect, actual: &Increment) {
     let ast = format!("ast:\n{}", actual.ast.package);
 
     let names = format!(

--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -220,6 +220,27 @@ impl Resolver {
         self.dropped_names.extend(dropped_names);
     }
 
+    pub(super) fn bind_fragments(&mut self, ast: &mut ast::Package, assigner: &mut Assigner) {
+        for node in &mut ast.nodes.iter() {
+            match node {
+                ast::TopLevelNode::Namespace(namespace) => {
+                    bind_global_items(
+                        &mut self.names,
+                        &mut self.globals,
+                        namespace,
+                        assigner,
+                        &mut self.errors,
+                    );
+                }
+                ast::TopLevelNode::Stmt(stmt) => {
+                    if let ast::StmtKind::Item(item) = stmt.kind.as_ref() {
+                        self.bind_local_item(assigner, item);
+                    }
+                }
+            }
+        }
+    }
+
     fn resolve_ident(&mut self, kind: NameKind, name: &Ident) {
         let namespace = None;
         match resolve(kind, &self.globals, &self.scopes, name, &namespace) {
@@ -311,34 +332,6 @@ impl Resolver {
         }
     }
 
-    pub(super) fn bind_namespace_items(
-        &mut self,
-        assigner: &mut Assigner,
-        namespace: &ast::Namespace,
-    ) {
-        if !self.names.contains_key(namespace.name.id) {
-            let id = assigner.next_item();
-            self.names
-                .insert(namespace.name.id, Res::Item(intrapackage(id)));
-            self.globals
-                .namespaces
-                .insert(Rc::clone(&namespace.name.name));
-
-            for item in &*namespace.items {
-                match bind_global_item(
-                    &mut self.names,
-                    &mut self.globals,
-                    &namespace.name.name,
-                    || intrapackage(assigner.next_item()),
-                    item,
-                ) {
-                    Ok(()) => {}
-                    Err(error) => self.errors.push(error),
-                }
-            }
-        }
-    }
-
     fn bind_type_parameters(&mut self, decl: &CallableDecl) {
         decl.generics.iter().enumerate().for_each(|(ix, ident)| {
             let scope = self
@@ -388,8 +381,6 @@ impl With<'_> {
 
 impl AstVisitor<'_> for With<'_> {
     fn visit_namespace(&mut self, namespace: &ast::Namespace) {
-        self.resolver.bind_namespace_items(self.assigner, namespace);
-
         let kind = ScopeKind::Namespace(Rc::clone(&namespace.name.name));
         self.with_scope(kind, |visitor| {
             for item in &*namespace.items {
@@ -553,28 +544,17 @@ impl GlobalTable {
         for node in &*package.nodes {
             match node {
                 TopLevelNode::Namespace(namespace) => {
-                    self.names.insert(
-                        namespace.name.id,
-                        Res::Item(intrapackage(assigner.next_item())),
+                    bind_global_items(
+                        &mut self.names,
+                        &mut self.scope,
+                        namespace,
+                        assigner,
+                        &mut errors,
                     );
-                    self.scope
-                        .namespaces
-                        .insert(Rc::clone(&namespace.name.name));
-
-                    for item in &*namespace.items {
-                        match bind_global_item(
-                            &mut self.names,
-                            &mut self.scope,
-                            &namespace.name.name,
-                            || intrapackage(assigner.next_item()),
-                            item,
-                        ) {
-                            Ok(()) => {}
-                            Err(error) => errors.push(error),
-                        }
-                    }
                 }
-                TopLevelNode::Stmt(_) => todo!("Not yet supported for top-level statements"),
+                TopLevelNode::Stmt(_) => {
+                    unimplemented!("did not expect top-level statements in the ast")
+                }
             }
         }
         errors
@@ -603,6 +583,33 @@ impl GlobalTable {
                     self.scope.namespaces.insert(global.name);
                 }
             }
+        }
+    }
+}
+
+fn bind_global_items(
+    names: &mut IndexMap<NodeId, Res>,
+    scope: &mut GlobalScope,
+    namespace: &ast::Namespace,
+    assigner: &mut Assigner,
+    errors: &mut Vec<Error>,
+) {
+    names.insert(
+        namespace.name.id,
+        Res::Item(intrapackage(assigner.next_item())),
+    );
+    scope.namespaces.insert(Rc::clone(&namespace.name.name));
+
+    for item in &*namespace.items {
+        match bind_global_item(
+            names,
+            scope,
+            &namespace.name.name,
+            || intrapackage(assigner.next_item()),
+            item,
+        ) {
+            Ok(()) => {}
+            Err(error) => errors.push(error),
         }
     }
 }

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -7,7 +7,7 @@ use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_ast::{
     assigner::Assigner as AstAssigner,
-    ast::{Ident, NodeId, Package, Path},
+    ast::{Ident, NodeId, Package, Path, TopLevelNode},
     mut_visit::MutVisitor,
     visit::{self, Visitor},
 };
@@ -85,7 +85,11 @@ fn compile(input: &str) -> (Package, Names, Vec<Error>) {
     assert!(parse_errors.is_empty(), "parse failed: {parse_errors:#?}");
     let mut package = Package {
         id: NodeId::default(),
-        namespaces: namespaces.into_boxed_slice(),
+        nodes: namespaces
+            .into_iter()
+            .map(TopLevelNode::Namespace)
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
         entry: None,
     };
 

--- a/compiler/qsc_frontend/src/typeck.rs
+++ b/compiler/qsc_frontend/src/typeck.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 
 pub(super) use check::{Checker, GlobalTable};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Table {
     pub udts: HashMap<ItemId, Udt>,
 

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -790,7 +790,7 @@ pub(super) fn expr(
     context.solve()
 }
 
-pub(super) fn stmt_fragment(
+pub(super) fn stmt(
     names: &Names,
     globals: &HashMap<ItemId, Scheme>,
     table: &mut Table,

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -10,7 +10,7 @@ use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_ast::{
     assigner::Assigner as AstAssigner,
-    ast::{Block, Expr, NodeId, Package, Pat, QubitInit},
+    ast::{Block, Expr, NodeId, Package, Pat, QubitInit, TopLevelNode},
     mut_visit::MutVisitor,
     visit::{self, Visitor},
 };
@@ -122,7 +122,11 @@ fn parse(input: &str, entry_expr: &str) -> Package {
 
     Package {
         id: NodeId::default(),
-        namespaces: namespaces.into_boxed_slice(),
+        nodes: namespaces
+            .into_iter()
+            .map(TopLevelNode::Namespace)
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
         entry,
     }
 }

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -215,8 +215,23 @@ impl Display for Res {
 pub struct Package {
     /// The items in the package.
     pub items: IndexMap<LocalItemId, Item>,
+    /// The top-level statements in the package.
+    pub stmts: Vec<Stmt>,
     /// The entry expression for an executable package.
     pub entry: Option<Expr>,
+}
+
+impl Package {
+    /// Extends the `Package` with the contents of another `Package`.
+    /// `other` should not contain any `LocalItemId`s
+    /// that conflict with the current `Package`.
+    pub fn extend(&mut self, mut other: Package) {
+        for (k, v) in other.items.drain() {
+            self.items.insert(k, v);
+        }
+
+        self.stmts.extend(other.stmts);
+    }
 }
 
 impl Display for Package {

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -249,6 +249,9 @@ impl Display for Package {
         for item in self.items.values() {
             write!(indent, "\n{item}")?;
         }
+        for stmt in &self.stmts {
+            write!(indent, "\n{stmt}")?;
+        }
         Ok(())
     }
 }

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -238,19 +238,6 @@ pub struct Package {
     pub entry: Option<Expr>,
 }
 
-impl Package {
-    /// Extends the `Package` with the contents of another `Package`.
-    /// `other` should not contain any `LocalItemId`s
-    /// that conflict with the current `Package`.
-    pub fn extend(&mut self, mut other: Package) {
-        for (k, v) in other.items.drain() {
-            self.items.insert(k, v);
-        }
-
-        self.stmts.extend(other.stmts);
-    }
-}
-
 impl Display for Package {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let mut indent = set_indentation(indented(f), 0);

--- a/compiler/qsc_hir/src/mut_visit.rs
+++ b/compiler/qsc_hir/src/mut_visit.rs
@@ -53,6 +53,7 @@ pub trait MutVisitor: Sized {
 
 pub fn walk_package(vis: &mut impl MutVisitor, package: &mut Package) {
     package.items.values_mut().for_each(|i| vis.visit_item(i));
+    package.stmts.iter_mut().for_each(|s| vis.visit_stmt(s));
     package.entry.iter_mut().for_each(|e| vis.visit_expr(e));
 }
 

--- a/compiler/qsc_hir/src/visit.rs
+++ b/compiler/qsc_hir/src/visit.rs
@@ -48,6 +48,7 @@ pub trait Visitor<'a>: Sized {
 
 pub fn walk_package<'a>(vis: &mut impl Visitor<'a>, package: &'a Package) {
     package.items.values().for_each(|i| vis.visit_item(i));
+    package.stmts.iter().for_each(|s| vis.visit_stmt(s));
     package.entry.iter().for_each(|e| vis.visit_expr(e));
 }
 

--- a/compiler/qsc_parse/src/lib.rs
+++ b/compiler/qsc_parse/src/lib.rs
@@ -18,13 +18,11 @@ mod ty;
 
 use lex::TokenKind;
 use miette::Diagnostic;
-use qsc_ast::ast::{Expr, Namespace};
+use qsc_ast::ast::{Expr, Namespace, TopLevelNode};
 use qsc_data_structures::span::Span;
 use scan::Scanner;
 use std::result;
 use thiserror::Error;
-
-pub use item::Fragment;
 
 #[derive(Clone, Copy, Debug, Diagnostic, Eq, Error, PartialEq)]
 #[error(transparent)]
@@ -102,10 +100,10 @@ pub fn namespaces(input: &str) -> (Vec<Namespace>, Vec<Error>) {
     }
 }
 
-pub fn fragments(input: &str) -> (Vec<Fragment>, Vec<Error>) {
+pub fn top_level_nodes(input: &str) -> (Vec<TopLevelNode>, Vec<Error>) {
     let mut scanner = Scanner::new(input);
-    match item::parse_fragments(&mut scanner) {
-        Ok(fragments) => (fragments, scanner.into_errors()),
+    match item::parse_top_level_nodes(&mut scanner) {
+        Ok(nodes) => (nodes, scanner.into_errors()),
         Err(error) => {
             let mut errors = scanner.into_errors();
             errors.push(error);

--- a/compiler/qsc_passes/src/baseprofck.rs
+++ b/compiler/qsc_passes/src/baseprofck.rs
@@ -7,10 +7,7 @@ mod tests;
 use miette::Diagnostic;
 use qsc_data_structures::span::Span;
 use qsc_hir::{
-    hir::{
-        BinOp, CallableDecl, CallableKind, Expr, ExprKind, Item, ItemKind, Lit, Package, SpecBody,
-        SpecGen, Stmt, StmtKind,
-    },
+    hir::{BinOp, CallableKind, Expr, ExprKind, Item, ItemKind, Lit, Package, SpecBody, SpecGen},
     ty::{Prim, Ty},
     visit::{walk_expr, walk_item, Visitor},
 };
@@ -56,27 +53,6 @@ pub fn check_base_profile_compliance(package: &Package) -> Vec<Error> {
         }
     }
     checker.visit_package(package);
-
-    checker.errors
-}
-
-#[must_use]
-pub fn check_base_profile_compliance_for_stmt(stmt: &Stmt) -> Vec<Error> {
-    let mut checker = Checker { errors: Vec::new() };
-    checker.visit_stmt(stmt);
-    if let StmtKind::Expr(expr) = &stmt.kind {
-        if any_non_result_ty(&expr.ty) {
-            checker.errors.push(Error::ReturnNonResult(stmt.span));
-        }
-    }
-
-    checker.errors
-}
-
-#[must_use]
-pub fn check_base_profile_compliance_for_callable(decl: &CallableDecl) -> Vec<Error> {
-    let mut checker = Checker { errors: Vec::new() };
-    checker.visit_callable_decl(decl);
 
     checker.errors
 }

--- a/compiler/qsc_passes/src/conjugate_invert.rs
+++ b/compiler/qsc_passes/src/conjugate_invert.rs
@@ -8,12 +8,11 @@ use std::{collections::HashSet, mem::take};
 
 use miette::Diagnostic;
 use qsc_data_structures::span::Span;
-use qsc_frontend::compile::CompileUnit;
 use qsc_hir::{
     assigner::Assigner,
     global::Table,
     hir::{
-        Block, CallableDecl, Expr, ExprKind, Ident, Mutability, NodeId, Pat, PatKind, Res, Stmt,
+        Block, Expr, ExprKind, Ident, Mutability, NodeId, Package, Pat, PatKind, Res, Stmt,
         StmtKind,
     },
     mut_visit::{self, MutVisitor},
@@ -47,41 +46,17 @@ pub enum Error {
 
 /// Generates adjoint inverted blocks for within-blocks across all conjugate expressions,
 /// eliminating the conjugate expression from the compilation unit.
-pub(super) fn invert_conjugate_exprs(core: &Table, unit: &mut CompileUnit) -> Vec<Error> {
-    let mut pass = ConjugateElim {
-        core,
-        assigner: &mut unit.assigner,
-        errors: Vec::new(),
-    };
-    pass.visit_package(&mut unit.package);
-    pass.errors
-}
-
-pub(super) fn invert_conjugate_exprs_for_callable(
+pub(super) fn invert_conjugate_exprs(
     core: &Table,
+    package: &mut Package,
     assigner: &mut Assigner,
-    decl: &mut CallableDecl,
 ) -> Vec<Error> {
     let mut pass = ConjugateElim {
         core,
         assigner,
         errors: Vec::new(),
     };
-    pass.visit_callable_decl(decl);
-    pass.errors
-}
-
-pub(super) fn invert_conjugate_exprs_for_stmt(
-    core: &Table,
-    assigner: &mut Assigner,
-    stmt: &mut Stmt,
-) -> Vec<Error> {
-    let mut pass = ConjugateElim {
-        core,
-        assigner,
-        errors: Vec::new(),
-    };
-    pass.visit_stmt(stmt);
+    pass.visit_package(package);
     pass.errors
 }
 

--- a/compiler/qsc_passes/src/conjugate_invert/tests.rs
+++ b/compiler/qsc_passes/src/conjugate_invert/tests.rs
@@ -16,7 +16,7 @@ fn check(file: &str, expect: &Expect) {
     let mut unit = compile(&store, &[], sources, TargetProfile::Full);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 
-    let errors = invert_conjugate_exprs(store.core(), &mut unit);
+    let errors = invert_conjugate_exprs(store.core(), &mut unit.package, &mut unit.assigner);
     Validator::default().visit_package(&unit.package);
     if errors.is_empty() {
         expect.assert_eq(&unit.package.to_string());

--- a/compiler/qsc_passes/src/entry_point.rs
+++ b/compiler/qsc_passes/src/entry_point.rs
@@ -7,7 +7,6 @@ mod tests;
 use super::Error as PassErr;
 use miette::Diagnostic;
 use qsc_data_structures::span::Span;
-use qsc_frontend::compile::CompileUnit;
 use qsc_hir::{
     assigner::Assigner,
     hir::{
@@ -42,15 +41,18 @@ pub enum Error {
 
 // If no entry expression is provided, generate one from the entry point callable.
 // Only one callable should be annotated with the entry point attribute.
-pub(super) fn generate_entry_expr(unit: &mut CompileUnit) -> Vec<super::Error> {
-    if unit.package.entry.is_some() {
+pub(super) fn generate_entry_expr(
+    package: &mut Package,
+    assigner: &mut Assigner,
+) -> Vec<super::Error> {
+    if package.entry.is_some() {
         return vec![];
     }
-    let callables = get_callables(&unit.package);
+    let callables = get_callables(package);
 
-    match create_entry_from_callables(&mut unit.assigner, callables) {
+    match create_entry_from_callables(assigner, callables) {
         Ok(expr) => {
-            unit.package.entry = Some(expr);
+            package.entry = Some(expr);
             vec![]
         }
         Err(errs) => errs,

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -16,7 +16,7 @@ fn check(file: &str, expr: &str, expect: &Expect) {
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 
-    let errors = generate_entry_expr(&mut unit);
+    let errors = generate_entry_expr(&mut unit.package, &mut unit.assigner);
     if errors.is_empty() {
         expect.assert_eq(
             &unit

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -117,6 +117,7 @@ impl PassContext {
             .collect()
     }
 }
+
 /// Run the default set of passes required for evaluation.
 pub fn run_default_passes(
     core: &Table,

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -21,14 +21,11 @@ use callable_limits::CallableLimits;
 use entry_point::generate_entry_expr;
 use loop_unification::LoopUni;
 use miette::Diagnostic;
-use qsc_frontend::{
-    compile::{CompileUnit, TargetProfile},
-    incremental::Fragment,
-};
+use qsc_frontend::compile::{CompileUnit, TargetProfile};
 use qsc_hir::{
     assigner::Assigner,
     global::{self, Table},
-    hir::{Item, ItemKind},
+    hir::Package,
     mut_visit::MutVisitor,
     validate::Validator,
     visit::Visitor,
@@ -59,6 +56,67 @@ pub struct PassContext {
     borrow_check: borrowck::Checker,
 }
 
+impl PassContext {
+    #[must_use]
+    pub fn new(target: TargetProfile) -> Self {
+        Self {
+            target,
+            borrow_check: borrowck::Checker::default(),
+        }
+    }
+
+    /// Run the default set of passes required for evaluation.
+    pub fn run_default_passes(
+        &mut self,
+        package: &mut Package,
+        assigner: &mut Assigner,
+        core: &Table,
+        package_type: PackageType,
+    ) -> Vec<Error> {
+        let mut call_limits = CallableLimits::default();
+        call_limits.visit_package(package);
+        let callable_errors = call_limits.errors;
+
+        self.borrow_check.visit_package(package);
+        let borrow_errors = &mut self.borrow_check.errors;
+
+        let spec_errors = spec_gen::generate_specs(core, package, assigner);
+        Validator::default().visit_package(package);
+
+        let conjugate_errors = conjugate_invert::invert_conjugate_exprs(core, package, assigner);
+        Validator::default().visit_package(package);
+
+        let entry_point_errors = if package_type == PackageType::Exe {
+            let entry_point_errors = generate_entry_expr(package, assigner);
+            Validator::default().visit_package(package);
+            entry_point_errors
+        } else {
+            Vec::new()
+        };
+
+        LoopUni { core, assigner }.visit_package(package);
+        Validator::default().visit_package(package);
+
+        ReplaceQubitAllocation::new(core, assigner).visit_package(package);
+        Validator::default().visit_package(package);
+
+        let base_prof_errors = if self.target == TargetProfile::Base {
+            baseprofck::check_base_profile_compliance(package)
+        } else {
+            Vec::new()
+        };
+
+        callable_errors
+            .into_iter()
+            .map(Error::CallableLimits)
+            .chain(borrow_errors.drain(..).map(Error::BorrowCk))
+            .chain(spec_errors.into_iter().map(Error::SpecGen))
+            .chain(conjugate_errors.into_iter().map(Error::ConjInvert))
+            .chain(entry_point_errors)
+            .chain(base_prof_errors.into_iter().map(Error::BaseProfCk))
+            .collect()
+    }
+}
 /// Run the default set of passes required for evaluation.
 pub fn run_default_passes(
     core: &Table,
@@ -66,53 +124,12 @@ pub fn run_default_passes(
     package_type: PackageType,
     target: TargetProfile,
 ) -> Vec<Error> {
-    let mut call_limits = CallableLimits::default();
-    call_limits.visit_package(&unit.package);
-    let callable_errors = call_limits.errors;
-
-    let mut borrow_check = borrowck::Checker::default();
-    borrow_check.visit_package(&unit.package);
-    let borrow_errors = borrow_check.errors;
-
-    let spec_errors = spec_gen::generate_specs(core, unit);
-    Validator::default().visit_package(&unit.package);
-
-    let conjugate_errors = conjugate_invert::invert_conjugate_exprs(core, unit);
-    Validator::default().visit_package(&unit.package);
-
-    let entry_point_errors = if package_type == PackageType::Exe {
-        let entry_point_errors = generate_entry_expr(unit);
-        Validator::default().visit_package(&unit.package);
-        entry_point_errors
-    } else {
-        Vec::new()
-    };
-
-    LoopUni {
+    PassContext::new(target).run_default_passes(
+        &mut unit.package,
+        &mut unit.assigner,
         core,
-        assigner: &mut unit.assigner,
-    }
-    .visit_package(&mut unit.package);
-    Validator::default().visit_package(&unit.package);
-
-    ReplaceQubitAllocation::new(core, &mut unit.assigner).visit_package(&mut unit.package);
-    Validator::default().visit_package(&unit.package);
-
-    let base_prof_errors = if target == TargetProfile::Base {
-        baseprofck::check_base_profile_compliance(&unit.package)
-    } else {
-        Vec::new()
-    };
-
-    callable_errors
-        .into_iter()
-        .map(Error::CallableLimits)
-        .chain(borrow_errors.into_iter().map(Error::BorrowCk))
-        .chain(spec_errors.into_iter().map(Error::SpecGen))
-        .chain(conjugate_errors.into_iter().map(Error::ConjInvert))
-        .chain(entry_point_errors)
-        .chain(base_prof_errors.into_iter().map(Error::BaseProfCk))
-        .collect()
+        package_type,
+    )
 }
 
 pub fn run_core_passes(core: &mut CompileUnit) -> Vec<Error> {
@@ -138,82 +155,4 @@ pub fn run_core_passes(core: &mut CompileUnit) -> Vec<Error> {
         .map(Error::BorrowCk)
         .chain(base_prof_errors.into_iter().map(Error::BaseProfCk))
         .collect()
-}
-
-impl PassContext {
-    #[must_use]
-    pub fn new(target: TargetProfile) -> Self {
-        Self {
-            target,
-            borrow_check: borrowck::Checker::default(),
-        }
-    }
-
-    pub fn run(
-        &mut self,
-        core: &Table,
-        assigner: &mut Assigner,
-        fragment: &mut Fragment,
-    ) -> Vec<Error> {
-        let mut errors = Vec::new();
-
-        match fragment {
-            Fragment::Stmt(stmt) => {
-                self.borrow_check.visit_stmt(stmt);
-                errors.extend(self.borrow_check.errors.drain(..).map(Error::BorrowCk));
-
-                errors.extend(
-                    conjugate_invert::invert_conjugate_exprs_for_stmt(core, assigner, stmt)
-                        .into_iter()
-                        .map(Error::ConjInvert),
-                );
-                LoopUni { core, assigner }.visit_stmt(stmt);
-                ReplaceQubitAllocation::new(core, assigner).visit_stmt(stmt);
-
-                if self.target == TargetProfile::Base {
-                    errors.extend(
-                        baseprofck::check_base_profile_compliance_for_stmt(stmt)
-                            .into_iter()
-                            .map(Error::BaseProfCk),
-                    );
-                }
-            }
-            Fragment::Item(Item {
-                kind: ItemKind::Callable(decl),
-                ..
-            }) => {
-                let mut call_limits = CallableLimits::default();
-                call_limits.visit_callable_decl(decl);
-                errors.extend(call_limits.errors.into_iter().map(Error::CallableLimits));
-
-                let mut borrow_check = borrowck::Checker::default();
-                borrow_check.visit_callable_decl(decl);
-                errors.extend(borrow_check.errors.into_iter().map(Error::BorrowCk));
-
-                errors.extend(
-                    spec_gen::generate_specs_for_callable(core, assigner, decl)
-                        .into_iter()
-                        .map(Error::SpecGen),
-                );
-                errors.extend(
-                    conjugate_invert::invert_conjugate_exprs_for_callable(core, assigner, decl)
-                        .into_iter()
-                        .map(Error::ConjInvert),
-                );
-                LoopUni { core, assigner }.visit_callable_decl(decl);
-                ReplaceQubitAllocation::new(core, assigner).visit_callable_decl(decl);
-
-                if self.target == TargetProfile::Base {
-                    errors.extend(
-                        baseprofck::check_base_profile_compliance_for_callable(decl)
-                            .into_iter()
-                            .map(Error::BaseProfCk),
-                    );
-                }
-            }
-            Fragment::Item(_) => {}
-        }
-
-        errors
-    }
 }

--- a/compiler/qsc_passes/src/replace_qubit_allocation.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation.rs
@@ -384,7 +384,7 @@ impl MutVisitor for ReplaceQubitAllocation<'_> {
 
     fn visit_stmt(&mut self, stmt: &mut Stmt) {
         // This function is not called by visit_block above, so the only time it will be used is for
-        // top-level statement fragments. Given that, the qubits allocated will always be live for
+        // top-level statements. Given that, the qubits allocated will always be live for
         // the entirety of a global scope, so only qubit allocations need to be generated.
         match stmt.kind.clone() {
             StmtKind::Qubit(_, pat, qubit_init, None) => {

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -16,7 +16,7 @@ fn check(file: &str, expect: &Expect) {
     let mut unit = compile(&store, &[], sources, TargetProfile::Full);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 
-    let errors = generate_specs(store.core(), &mut unit);
+    let errors = generate_specs(store.core(), &mut unit.package, &mut unit.assigner);
     Validator::default().visit_package(&unit.package);
     if errors.is_empty() {
         expect.assert_eq(&unit.package.to_string());

--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -29,7 +29,7 @@ pub(crate) fn get_completions(
     // Determine context for the offset
     let mut context_finder = ContextFinder {
         offset,
-        context: if compilation.unit.ast.package.namespaces.as_ref().is_empty() {
+        context: if compilation.unit.ast.package.nodes.is_empty() {
             // The parser failed entirely, no context to go on
             Context::NoCompilation
         } else {


### PR DESCRIPTION
The motivation for this refactoring is to be able to implement language service support for notebook cells. (You can preview how that's going to fit together at #759.) But it achieves more than that, by eliminating a lot of code duplicated between the batch compilation and incremental compilation paths, devising a coherent model for the incremental compiler, and clearly separating the evaluation parts of the `Interpreter` from the compilation parts.

**1. New top-level nodes in the AST and HIR**

Previously, the incremental compilation was made up of loose AST and HIR nodes stored in `stateful::Interpreter`, and an empty `CompileUnit` in the package store. This packages in this `CompileUnit` were not updated as fragments got compiled in.

Every feature in the language service is implemented using an AST visitor and uses the HIR package for lookups. This imposes the requirement that notebook cells are able to be represented as AST and HIR packages. They should be kept up to date with each cell added to the compilation.

Q# notebook cells were previously thought of as "fragments" (not "real" packages). This PR makes fragments syntax official, so to speak, by adding the ability for `ast::Package` and `hir::Package` to contain top-level statements.

When we are able to represent each incremental unit (notebook cell) as a whole package, we can eliminate a lot of lowering/resolution/checking code that was designed to work with loose statement/item nodes (e.g. `check_stmt_fragment`).. We can now use their package counterparts (e.g. `check_package`), making for more code shared between the batch and incremental compilers.

**2. Layering and `qsc::incremental`**

Previously, the incremental compiler implementation was spread out between `stateful` and `qsc_frontend::incremental`. The `stateful::Interpret` struct contained too much state, making it really hard to write code that mutates logically separate parts of the struct (e.g. compiler state vs. evaluator state) without angering the Rust borrow checker.

The new `qsc::incremental` module is mainly the compiler-y parts of `stateful` pulled out into their own module, bridging the gap between `stateful` and `qsc_frontend::incremental`. The layering is meant to parallel that of batch compilation:

`qsi` -> `qsc::interpret::stateful` -> `qsc::incremental` -> `qsc_frontend::incremental`
`qsc` -> `qsc::compiler` -> `qsc_frontend::compiler`

**3. Mutable `CompileUnit` in the `PackageStore`**

#675 required that the current compilation be available to be looked up in the `PackageStore`, since errors may contain the `PackageId` of the current package. But the current compilation also needs to be updated with incremental changes. Adding a `get_mut` to the `PackageStore` felt wrong since almost all use cases of the `PackageStore` require packages to remain immutable. To address the awkwardness, the concept of an `OpenPackageStore` is introduced. A `PackageStore` can be "opened" for modifications, making it possible to obtain a mutable reference to only the last `CompileUnit` in the store (the open package). The incremental compiler uses the open package store to keep updating the compilation, while the rest of the components (evaluator, error span lookups, etc) have access to the regular, immutable, `PackageStore` for lookups.