### PR TITLE
Fix cross-unit UDT dependency

### DIFF
--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -484,34 +484,26 @@ fn package_dependency() {
     let unit2 = compile(&store, &[package1], sources2, TargetProfile::Full);
     assert!(unit2.errors.is_empty(), "{:#?}", unit2.errors);
 
-    let ItemKind::Callable(callable) = &unit2
-        .package
-        .items
-        .get(LocalItemId::from(1))
-        .expect("package should have item")
-        .kind
-    else {
-        panic!("item should be a callable");
-    };
-    let SpecBody::Impl(_, block) = &callable.body.body else {
-        panic!("callable body have a block")
-    };
-    let StmtKind::Expr(expr) = &block.stmts[0].kind else {
-        panic!("statement should be an expression")
-    };
-    let ExprKind::Call(callee, _) = &expr.kind else {
-        panic!("expression should be a call")
-    };
-    let ExprKind::Var(res, _) = &callee.kind else {
-        panic!("callee should be a variable")
-    };
-    assert_eq!(
-        &Res::Item(ItemId {
-            package: Some(package1),
-            item: LocalItemId::from(1),
-        }),
-        res
-    );
+    expect![[r#"
+        Package:
+            Item 0 [0-78] (Public):
+                Namespace (Ident 9 [10-18] "Package2"): Item 1
+            Item 1 [25-76] (Public):
+                Parent: 0
+                Callable 0 [25-76] (function):
+                    name: Ident 1 [34-37] "Bar"
+                    input: Pat 2 [37-39] [Type Unit]: Unit
+                    output: Int
+                    functors: empty set
+                    body: SpecDecl 3 [25-76]: Impl:
+                        Block 4 [46-76] [Type Int]:
+                            Stmt 5 [56-70]: Expr: Expr 6 [56-70] [Type Int]: Call:
+                                Expr 7 [56-68] [Type (Unit -> Int)]: Var: Item 1 (Package 1)
+                                Expr 8 [68-70] [Type Unit]: Unit
+                    adj: <none>
+                    ctl: <none>
+                    ctl-adj: <none>"#]]
+    .assert_eq(&unit2.package.to_string());
 }
 
 #[test]
@@ -559,28 +551,26 @@ fn package_dependency_internal_error() {
         .collect();
     assert_eq!(vec![("test", Span { lo: 65, hi: 68 }),], errors);
 
-    let ItemKind::Callable(callable) = &unit2
-        .package
-        .items
-        .get(LocalItemId::from(1))
-        .expect("package should have item")
-        .kind
-    else {
-        panic!("item should be a callable");
-    };
-    let SpecBody::Impl(_, block) = &callable.body.body else {
-        panic!("callable body have a block")
-    };
-    let StmtKind::Expr(expr) = &block.stmts[0].kind else {
-        panic!("statement should be an expression")
-    };
-    let ExprKind::Call(callee, _) = &expr.kind else {
-        panic!("expression should be a call")
-    };
-    let ExprKind::Var(res, _) = &callee.kind else {
-        panic!("callee should be a variable")
-    };
-    assert_eq!(&Res::Err, res);
+    expect![[r#"
+        Package:
+            Item 0 [0-78] (Public):
+                Namespace (Ident 9 [10-18] "Package2"): Item 1
+            Item 1 [25-76] (Public):
+                Parent: 0
+                Callable 0 [25-76] (function):
+                    name: Ident 1 [34-37] "Bar"
+                    input: Pat 2 [37-39] [Type Unit]: Unit
+                    output: Int
+                    functors: empty set
+                    body: SpecDecl 3 [25-76]: Impl:
+                        Block 4 [46-76] [Type Int]:
+                            Stmt 5 [56-70]: Expr: Expr 6 [56-70] [Type Int]: Call:
+                                Expr 7 [56-68] [Type ?]: Var: Err
+                                Expr 8 [68-70] [Type Unit]: Unit
+                    adj: <none>
+                    ctl: <none>
+                    ctl-adj: <none>"#]]
+    .assert_eq(&unit2.package.to_string());
 }
 
 #[test]
@@ -623,34 +613,28 @@ fn package_dependency_udt() {
     let unit2 = compile(&store, &[package1], sources2, TargetProfile::Full);
     assert!(unit2.errors.is_empty(), "{:#?}", unit2.errors);
 
-    let ItemKind::Callable(callable) = &unit2
-        .package
-        .items
-        .get(LocalItemId::from(1))
-        .expect("package should have item")
-        .kind
-    else {
-        panic!("item should be a callable");
-    };
-    let SpecBody::Impl(_, block) = &callable.body.body else {
-        panic!("callable body have a block")
-    };
-    let StmtKind::Expr(expr) = &block.stmts[0].kind else {
-        panic!("statement should be an expression")
-    };
-    let ExprKind::Call(callee, _) = &expr.kind else {
-        panic!("expression should be a call")
-    };
-    let ExprKind::Var(res, _) = &callee.kind else {
-        panic!("callee should be a variable")
-    };
-    assert_eq!(
-        &Res::Item(ItemId {
-            package: Some(package1),
-            item: LocalItemId::from(2),
-        }),
-        res
-    );
+    expect![[r#"
+        Package:
+            Item 0 [0-93] (Public):
+                Namespace (Ident 11 [10-18] "Package2"): Item 1
+            Item 1 [25-91] (Public):
+                Parent: 0
+                Callable 0 [25-91] (function):
+                    name: Ident 1 [34-37] "Baz"
+                    input: Pat 2 [37-39] [Type Unit]: Unit
+                    output: Int
+                    functors: empty set
+                    body: SpecDecl 3 [25-91]: Impl:
+                        Block 4 [46-91] [Type Int]:
+                            Stmt 5 [56-85]: Expr: Expr 6 [56-85] [Type Int]: Call:
+                                Expr 7 [56-68] [Type (UDT<Item 1 (Package 1)> -> Int)]: Var: Item 2 (Package 1)
+                                Expr 8 [69-84] [Type UDT<Item 1 (Package 1)>]: Call:
+                                    Expr 9 [69-81] [Type (Int -> UDT<Item 1 (Package 1)>)]: Var: Item 1 (Package 1)
+                                    Expr 10 [82-83] [Type Int]: Lit: Int(1)
+                    adj: <none>
+                    ctl: <none>
+                    ctl-adj: <none>"#]]
+    .assert_eq(&unit2.package.to_string());
 }
 
 #[test]

--- a/compiler/qsc_frontend/src/typeck/check.rs
+++ b/compiler/qsc_frontend/src/typeck/check.rs
@@ -44,11 +44,14 @@ impl GlobalTable {
             };
 
             match &item.kind {
-                hir::ItemKind::Callable(decl) => self.terms.insert(item_id, decl.scheme()),
+                hir::ItemKind::Callable(decl) => {
+                    self.terms.insert(item_id, decl.scheme().with_package(id))
+                }
                 hir::ItemKind::Namespace(..) => None,
                 hir::ItemKind::Ty(_, udt) => {
                     self.udts.insert(item_id, udt.clone());
-                    self.terms.insert(item_id, udt.cons_scheme(item_id))
+                    self.terms
+                        .insert(item_id, udt.cons_scheme(item_id).with_package(id))
                 }
             };
         }

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -363,9 +363,7 @@ impl<'a> Context<'a> {
                 None => converge(Ty::Err),
                 Some(Res::Item(item)) => {
                     let scheme = self.globals.get(item).expect("item should have scheme");
-                    let (ty, args) = self
-                        .inferrer
-                        .instantiate(&scheme.with_package(item.package), expr.span);
+                    let (ty, args) = self.inferrer.instantiate(scheme, expr.span);
                     self.table.generics.insert(expr.id, args);
                     converge(Ty::Arrow(Box::new(ty)))
                 }

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -363,7 +363,9 @@ impl<'a> Context<'a> {
                 None => converge(Ty::Err),
                 Some(Res::Item(item)) => {
                     let scheme = self.globals.get(item).expect("item should have scheme");
-                    let (ty, args) = self.inferrer.instantiate(scheme, expr.span);
+                    let (ty, args) = self
+                        .inferrer
+                        .instantiate(&scheme.with_package(item.package), expr.span);
                     self.table.generics.insert(expr.id, args);
                     converge(Ty::Arrow(Box::new(ty)))
                 }

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -200,6 +200,20 @@ pub enum Res {
     Local(NodeId),
 }
 
+impl Res {
+    /// Returns an updated resolution with the given package ID.
+    #[must_use]
+    pub fn with_package(&self, package: Option<PackageId>) -> Self {
+        match self {
+            Res::Item(id) if id.package.is_none() => Res::Item(ItemId {
+                package,
+                item: id.item,
+            }),
+            _ => *self,
+        }
+    }
+}
+
 impl Display for Res {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -203,12 +203,15 @@ pub enum Res {
 impl Res {
     /// Returns an updated resolution with the given package ID.
     #[must_use]
-    pub fn with_package(&self, package: Option<PackageId>) -> Self {
+    pub fn with_package(&self, package: PackageId) -> Self {
         match self {
             Res::Item(id) if id.package.is_none() => Res::Item(ItemId {
-                package,
+                package: Some(package),
                 item: id.item,
             }),
+            Res::Item(id) if id.package.expect("none case should be handled above") != package => {
+                panic!("should not try to update Res with existing package id")
+            }
             _ => *self,
         }
     }

--- a/compiler/qsc_hir/src/ty.rs
+++ b/compiler/qsc_hir/src/ty.rs
@@ -52,7 +52,7 @@ impl Ty {
     pub const UNIT: Self = Self::Tuple(Vec::new());
 
     #[must_use]
-    pub fn with_package(&self, package: Option<PackageId>) -> Self {
+    pub fn with_package(&self, package: PackageId) -> Self {
         match self {
             Ty::Array(item) => Ty::Array(Box::new(item.with_package(package))),
             Ty::Arrow(arrow) => Ty::Arrow(Box::new(arrow.with_package(package))),
@@ -118,7 +118,7 @@ impl Scheme {
     }
 
     #[must_use]
-    pub fn with_package(&self, package: Option<PackageId>) -> Self {
+    pub fn with_package(&self, package: PackageId) -> Self {
         Self {
             params: self.params.clone(),
             ty: Box::new(Arrow {
@@ -297,7 +297,7 @@ pub struct Arrow {
 
 impl Arrow {
     #[must_use]
-    pub fn with_package(&self, package: Option<PackageId>) -> Self {
+    pub fn with_package(&self, package: PackageId) -> Self {
         Self {
             kind: self.kind,
             input: Box::new(self.input.with_package(package)),

--- a/compiler/qsc_hir/src/ty.rs
+++ b/compiler/qsc_hir/src/ty.rs
@@ -54,11 +54,9 @@ impl Ty {
     #[must_use]
     pub fn with_package(&self, package: PackageId) -> Self {
         match self {
+            Ty::Infer(_) | Ty::Param(_) | Ty::Prim(_) | Ty::Err => self.clone(),
             Ty::Array(item) => Ty::Array(Box::new(item.with_package(package))),
             Ty::Arrow(arrow) => Ty::Arrow(Box::new(arrow.with_package(package))),
-            Ty::Infer(infer) => Ty::Infer(*infer),
-            Ty::Param(param) => Ty::Param(*param),
-            Ty::Prim(prim) => Ty::Prim(*prim),
             Ty::Tuple(items) => Ty::Tuple(
                 items
                     .iter()
@@ -66,7 +64,6 @@ impl Ty {
                     .collect(),
             ),
             Ty::Udt(res) => Ty::Udt(res.with_package(package)),
-            Ty::Err => Ty::Err,
         }
     }
 }


### PR DESCRIPTION
This fixes a subtle bug in usage of UDTs across compilation units. Because a UDT is captured as a type that includes a `Res` in it, it wil have the placeholder `None` for it's package id when initially compiled (package ids are only known after insertion into the store). Later, a type mismatch could occur because the caller has the package id in the UDT type but the signature stored in the scheme uses UDT types with `None`. This fix adds a notion of updating a scheme to include the package id at type checking time by using `with_package` such that type checking for both internal/`None` resolutions and dependencies from other compilation units with known package ids can all be properly used.