### PR TITLE
Generate Python code and open browser for workspace

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -70,6 +70,14 @@
           "when": "qsharp-vscode.treeItemIsWorkspace"
         },
         {
+          "command": "qsharp-vscode.workspacePythonCode",
+          "when": "qsharp-vscode.treeItemIsWorkspace"
+        },
+        {
+          "command": "qsharp-vscode.workspaceOpenPortal",
+          "when": "qsharp-vscode.treeItemIsWorkspace"
+        },
+        {
           "command": "qsharp-vscode.downloadResults",
           "when": "qsharp-vscode.treeItemSupportsDownload"
         },
@@ -96,8 +104,12 @@
       ],
       "view/item/context": [
         {
-          "command": "qsharp-vscode.workspacesRemove",
+          "command": "qsharp-vscode.workspaceOpenPortal",
           "group": "inline",
+          "when": "view == quantum-workspaces && viewItem == workspace"
+        },
+        {
+          "command": "qsharp-vscode.workspacesRemove",
           "when": "view == quantum-workspaces && viewItem == workspace"
         },
         {
@@ -109,6 +121,10 @@
           "command": "qsharp-vscode.downloadResults",
           "group": "inline",
           "when": "view == quantum-workspaces && viewItem == result-download"
+        },
+        {
+          "command": "qsharp-vscode.workspacePythonCode",
+          "when": "view == quantum-workspaces && viewItem == workspace"
         }
       ]
     },
@@ -150,14 +166,25 @@
       {
         "command": "qsharp-vscode.workspacesAdd",
         "category": "Q#",
-        "title": "Add an Azure Quantum workspace",
+        "title": "Connect to an Azure Quantum workspace",
         "icon": "$(add)"
       },
       {
         "command": "qsharp-vscode.workspacesRemove",
         "category": "Q#",
-        "title": "Remove the Azure Quantum workspace",
+        "title": "Remove workspace connection",
         "icon": "$(remove)"
+      },
+      {
+        "command": "qsharp-vscode.workspacePythonCode",
+        "category": "Q#",
+        "title": "Copy Python code to connect to workspace"
+      },
+      {
+        "command": "qsharp-vscode.workspaceOpenPortal",
+        "category": "Q#",
+        "title": "Open the workspace in the Azure portal",
+        "icon": "$(link-external)"
       },
       {
         "command": "qsharp-vscode.targetSubmit",

--- a/vscode/src/azure/commands.ts
+++ b/vscode/src/azure/commands.ts
@@ -12,7 +12,9 @@ import {
   WorkspaceTreeProvider,
 } from "./treeView";
 import {
+  getAzurePortalWorkspaceLink,
   getJobFiles,
+  getPythonCodeForWorkspace,
   getTokenForWorkspace,
   queryWorkspaces,
   submitJob,
@@ -302,6 +304,44 @@ export async function initAzureWorkspaces(context: vscode.ExtensionContext) {
           );
           return;
         }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "qsharp-vscode.workspacePythonCode",
+      async (arg: WorkspaceTreeItem) => {
+        // Could be run via the treeItem icon or the menu command.
+        const treeItem = arg || currentTreeItem;
+        if (treeItem?.type !== "workspace") return;
+        const workspace = treeItem.itemData as WorkspaceConnection;
+        const str = getPythonCodeForWorkspace(workspace);
+        if (str) {
+          vscode.env.clipboard.writeText(str);
+          vscode.window.showInformationMessage(
+            "Python code has been copied to the clipboard"
+          );
+        } else {
+          vscode.window.showErrorMessage(
+            "Failed to generate Python code for workspace"
+          );
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "qsharp-vscode.workspaceOpenPortal",
+      async (arg: WorkspaceTreeItem) => {
+        // Could be run via the treeItem icon or the menu command.
+        const treeItem = arg || currentTreeItem;
+        if (treeItem?.type !== "workspace") return;
+        const workspace = treeItem.itemData as WorkspaceConnection;
+
+        const link = getAzurePortalWorkspaceLink(workspace);
+        vscode.env.openExternal(vscode.Uri.parse(link));
       }
     )
   );

--- a/vscode/src/azure/workspaceActions.ts
+++ b/vscode/src/azure/workspaceActions.ts
@@ -72,6 +72,55 @@ export function getRandomGuid(): string {
   );
 }
 
+export function getAzurePortalWorkspaceLink(workspace: WorkspaceConnection) {
+  // Portal link format:
+  // - https://portal.azure.com/#resource/subscriptions/<sub guid>/resourceGroups/<group>/providers/Microsoft.Quantum/Workspaces/<name>/overview
+
+  return `https://portal.azure.com/#resource${workspace.id}/overview`;
+}
+
+export function getPythonCodeForWorkspace(workspace: WorkspaceConnection) {
+  // id starts with the pattern: "/subscriptions/<sub guid>/resourceGroups/<group>>/providers/Microsoft.Quantum/Workspaces/<name>"
+  // endpointUri format: "https:/westus2.quantum.azure.com"
+
+  // Regular expression to extract subscriptionId and resourceGroup from the id
+  const idRegex =
+    /\/subscriptions\/(?<subscriptionId>[^/]+)\/resourceGroups\/(?<resourceGroup>[^/]+)/;
+
+  // Regular expression to extract the first part of the endpointUri
+  const endpointRegex = /https:\/\/(?<location>[^.]+)\./;
+
+  const idMatch = workspace.id.match(idRegex);
+  const endpointMatch = workspace.endpointUri.match(endpointRegex);
+
+  const subscriptionId = idMatch?.groups?.subscriptionId;
+  const resourceGroup = idMatch?.groups?.resourceGroup;
+  const location = endpointMatch?.groups?.location;
+
+  if (!subscriptionId || !resourceGroup || !location) return "";
+
+  const pythonCode = `
+# If developing locally, on first run this will open a browser to authenticate the
+# connection with Azure. In remote scenarios, such as SSH or Codespaces, it may
+# be necesssary to install the Azure CLI and run 'az login --use-device-code' to
+# authenticate. For unattended scenarios, such as batch jobs, a service principal
+# should be configured and used for authentication. For more information, see
+# https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication-overview
+
+# Make sure to install the necessary package with: pip install azure-quantum
+import azure.quantum
+
+workspace = azure.quantum.Workspace(
+    subscription_id = "${subscriptionId}",
+    resource_group = "${resourceGroup}",
+    name = "${workspace.name}",
+    location = "${location}",
+)
+`;
+
+  return pythonCode;
+}
+
 export async function queryWorkspaces(): Promise<
   WorkspaceConnection | undefined
 > {


### PR DESCRIPTION
Fixes #761 

Also adds the ability to right-click on a workspace in the tree view and generate the Python code to connect to it.