### PR TITLE
Prevent Hover for Incorrect UDT Field

### DIFF
--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -955,3 +955,18 @@ fn callable_param_doc() {
         "#]],
     );
 }
+
+#[test]
+fn udt_field_incorrect() {
+    check_none(
+        indoc! {r#"
+        namespace Test {
+            newtype Foo = (fst : Int, snd : Int);
+            operation Bar() : Unit {
+                let foo = Foo(1, 2);
+                let x : Int = foo::◉n↘one◉;
+            }
+        }
+    "#}
+    );
+}

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -958,8 +958,7 @@ fn callable_param_doc() {
 
 #[test]
 fn udt_field_incorrect() {
-    check_none(
-        indoc! {r#"
+    check_none(indoc! {r#"
         namespace Test {
             newtype Foo = (fst : Int, snd : Int);
             operation Bar() : Unit {
@@ -967,6 +966,5 @@ fn udt_field_incorrect() {
                 let x : Int = foo::◉n↘one◉;
             }
         }
-    "#}
-    );
+    "#});
 }


### PR DESCRIPTION
Prevents generating a hover card for UDT fields expressions referencing erroneous field names.

Fixes #755.