### PR TITLE
Fix activation event for notebooks

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -15,7 +15,7 @@
   "browser": "./out/extension.js",
   "virtualWorkspaces": true,
   "activationEvents": [
-    "onNotebook:jupyter",
+    "onNotebook:jupyter-notebook",
     "onDebug",
     "onDebugResolve:qsharp",
     "onDebugDynamicConfigurations:qsharp"
@@ -278,7 +278,7 @@
   "scripts": {
     "build": "npm run tsc:check && node build.mjs",
     "build:watch": "node build.mjs --watch",
-    "start": "npm exec --no @vscode/test-web --extensionDevelopmentPath . ../samples",
+    "start": "npm exec --no -- @vscode/test-web --extensionDevelopmentPath . ../samples",
     "test": "node ./test/runTests.mjs",
     "pretest": "npm exec --no playwright install && node ./test/buildTests.mjs",
     "tsc:check": "node ../node_modules/typescript/bin/tsc -p ./tsconfig.json"


### PR DESCRIPTION
The correct notebook type to use for activation is `jupyter-notebook`, as seen [here](https://github.com/microsoft/qsharp/blob/569711f6df6a4790eed57f54015b2a2c1887c2be/vscode/src/notebook.ts#L13C30-L13C30) and [here](https://github.com/microsoft/vscode-jupyter/blob/450e4d0b8aa08e5471f108ee7100e7439aa34e49/package.json#L56). I'm not sure of the original reason that I had it wrong, but I'm guessing I copied [this incorrect sample](https://github.com/microsoft/notebook-extension-samples/blob/eb8c02dc206ee74f6550359af20881c8f3a98209/notebook-provider/package.json#L22).

Also fixed an issue where `npm start` was opening VS Code on the wrong workspace directory because the arguments were being parsed incorrectly.