### PR TITLE
Error squiggle span fixes

### DIFF
--- a/compiler/qsc/src/bin/qsc.rs
+++ b/compiler/qsc/src/bin/qsc.rs
@@ -102,10 +102,7 @@ fn main() -> miette::Result<ExitCode> {
         Ok(ExitCode::SUCCESS)
     } else {
         for error in errors {
-            eprintln!(
-                "{:?}",
-                Report::new(WithSource::from_map(&unit.sources, error))
-            );
+            eprintln!("{:?}", Report::new(error));
         }
 
         Ok(ExitCode::FAILURE)

--- a/compiler/qsc/src/error.rs
+++ b/compiler/qsc/src/error.rs
@@ -2,23 +2,19 @@
 // Licensed under the MIT License.
 
 use miette::Diagnostic;
-use qsc_frontend::{compile::PackageStore, error::WithSource};
-use std::{
-    error::Error,
-    fmt::{self, Debug, Display, Formatter},
-};
+use qsc_frontend::compile::PackageStore;
+use std::fmt::{self, Debug, Display, Formatter};
 use thiserror::Error;
 
+pub use qsc_frontend::error::WithSource;
+
 #[derive(Clone, Debug, Error)]
-pub struct WithStack<E>
-where
-    E: Diagnostic + Error,
-{
+pub struct WithStack<E> {
     error: E,
     stack_trace: Option<String>,
 }
 
-impl<E: Diagnostic> WithStack<E> {
+impl<E> WithStack<E> {
     pub(super) fn new(error: E, stack_trace: Option<String>) -> Self {
         WithStack { error, stack_trace }
     }
@@ -26,9 +22,13 @@ impl<E: Diagnostic> WithStack<E> {
     pub(super) fn stack_trace(&self) -> &Option<String> {
         &self.stack_trace
     }
+
+    pub fn error(&self) -> &E {
+        &self.error
+    }
 }
 
-impl<E: Display + Diagnostic> Display for WithStack<E> {
+impl<E: Display> Display for WithStack<E> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         std::fmt::Display::fmt(&self.error, f)
     }
@@ -69,7 +69,7 @@ impl<E: Diagnostic> Diagnostic for WithStack<E> {
     }
 }
 
-pub fn from_eval(
+pub(super) fn from_eval(
     error: qsc_eval::Error,
     store: &PackageStore,
     stack_trace: Option<String>,

--- a/compiler/qsc/src/incremental.rs
+++ b/compiler/qsc/src/incremental.rs
@@ -26,7 +26,7 @@ pub struct Compiler {
 }
 
 /// An incremental compiler error.
-pub type Errors = Vec<WithSource<compile::Error>>;
+pub type Errors = Vec<compile::Error>;
 
 impl Compiler {
     /// Creates a new incremental compiler, compiling the passed in sources.
@@ -49,7 +49,7 @@ impl Compiler {
 
         let (unit, errors) = compile(&store, &dependencies, sources, package_type, target);
         if !errors.is_empty() {
-            return Err(into_errors_with_source(errors, &unit.sources));
+            return Err(errors);
         }
 
         let source_package_id = store.insert(unit);
@@ -171,7 +171,7 @@ impl Compiler {
 
 fn into_errors_with_source<T>(errors: Vec<T>, sources: &SourceMap) -> Errors
 where
-    compile::Error: From<T>,
+    compile::ErrorKind: From<T>,
 {
     errors
         .into_iter()
@@ -181,8 +181,8 @@ where
 
 fn into_errors<T>(errors: Vec<WithSource<T>>) -> Errors
 where
-    compile::Error: From<T>,
-    T: Diagnostic,
+    compile::ErrorKind: From<T>,
+    T: Diagnostic + Send + Sync,
 {
     errors
         .into_iter()

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -51,7 +51,7 @@ impl Error {
 pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Compile(#[from] WithSource<crate::compile::Error>),
+    Compile(#[from] crate::compile::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Pass(#[from] WithSource<qsc_passes::Error>),
@@ -663,7 +663,7 @@ fn eval_error(
     vec![error::from_eval(error, package_store, stack_trace).into()]
 }
 
-fn into_errors(errors: Vec<WithSource<crate::compile::Error>>) -> Vec<Error> {
+fn into_errors(errors: Vec<crate::compile::Error>) -> Vec<Error> {
     errors
         .into_iter()
         .map(|error| Error::Compile(error.into_with_source()))

--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 pub mod compile;
-mod error;
+pub mod error;
 pub mod incremental;
 pub mod interpret;
 

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -271,15 +271,19 @@ fn target_profile_update_causes_error_in_stdlib() {
 }
 
 fn new_language_service(
-    received: &RefCell<Vec<(String, u32, Vec<compile::Error>)>>,
+    received: &RefCell<Vec<(String, u32, Vec<compile::ErrorKind>)>>,
 ) -> LanguageService<'_> {
     LanguageService::new(|uri: &str, version: u32, errors: &[compile::Error]| {
         let mut v = received.borrow_mut();
-        v.push((uri.to_string(), version, errors.to_vec()));
+        v.push((
+            uri.to_string(),
+            version,
+            errors.iter().map(|e| e.error().clone()).collect(),
+        ));
     })
 }
 
-fn expect_errors(errors: &RefCell<Vec<(String, u32, Vec<compile::Error>)>>, expected: &Expect) {
+fn expect_errors(errors: &RefCell<Vec<(String, u32, Vec<compile::ErrorKind>)>>, expected: &Expect) {
     expected.assert_debug_eq(&errors.borrow());
     errors.borrow_mut().clear();
 }

--- a/npm/src/compiler/compiler.ts
+++ b/npm/src/compiler/compiler.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { IDiagnostic } from "../../lib/node/qsc_wasm.cjs";
 import { log } from "../log.js";
 import { VSDiagnostic, mapDiagnostics } from "../vsdiagnostic.js";
 import { IServiceProxy, ServiceState } from "../worker-proxy.js";
@@ -51,9 +50,9 @@ export class Compiler implements ICompiler {
    * @deprecated use the language service for errors and other editor features.
    */
   async checkCode(code: string): Promise<VSDiagnostic[]> {
-    let diags: IDiagnostic[] = [];
+    let diags: VSDiagnostic[] = [];
     const languageService = new this.wasm.LanguageService(
-      (uri: string, version: number, errors: IDiagnostic[]) => {
+      (uri: string, version: number, errors: VSDiagnostic[]) => {
         diags = errors;
       }
     );

--- a/npm/src/language-service/language-service.ts
+++ b/npm/src/language-service/language-service.ts
@@ -3,7 +3,6 @@
 
 import * as wasm from "../../lib/web/qsc_wasm.js";
 import type {
-  IDiagnostic,
   ICompletionList,
   IHover,
   IDefinition,
@@ -307,7 +306,7 @@ export class QSharpLanguageService implements ILanguageService {
     this.eventHandler.removeEventListener(type, listener);
   }
 
-  onDiagnostics(uri: string, version: number, diagnostics: IDiagnostic[]) {
+  onDiagnostics(uri: string, version: number, diagnostics: VSDiagnostic[]) {
     try {
       const code = this.code[uri];
       const empty = diagnostics.length === 0;

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -3,7 +3,7 @@
 
 //@ts-check
 
-import assert from "node:assert";
+import assert from "node:assert/strict";
 import { test } from "node:test";
 import { log } from "../dist/log.js";
 import {
@@ -432,7 +432,7 @@ test("cancel worker", () => {
       assert(cancelledArray.length === 2);
       assert(cancelledArray[0] === "terminated");
       assert(cancelledArray[1] === "terminated");
-      resolve(null);
+      resolve();
     }, 4);
   });
 });
@@ -469,6 +469,63 @@ test("language service diagnostics", async () => {
         return [m1];
     }
 }`
+  );
+  assert(gotDiagnostics);
+});
+
+test("diagnostics with related spans", async () => {
+  const languageService = getLanguageService();
+  let gotDiagnostics = false;
+  languageService.addEventListener("diagnostics", (event) => {
+    gotDiagnostics = true;
+    assert.equal(event.type, "diagnostics");
+    assert.deepEqual(
+      {
+        code: "Qsc.Resolve.Ambiguous",
+        message:
+          "name error: `DumpMachine` could refer to the item in `Microsoft.Quantum.Diagnostics` or `Other`",
+        related: [
+          {
+            start_pos: 196,
+            end_pos: 207,
+            message: "ambiguous name",
+          },
+          {
+            start_pos: 87,
+            end_pos: 116,
+            message: "found in this namespace",
+          },
+          {
+            start_pos: 129,
+            end_pos: 134,
+            message: "and also in this namespace",
+          },
+        ],
+      },
+      {
+        code: event.detail.diagnostics[0].code,
+        message: event.detail.diagnostics[0].message,
+        related: event.detail.diagnostics[0].related?.map((r) => ({
+          start_pos: r.start_pos,
+          message: r.message,
+          end_pos: r.end_pos
+        })),
+      }
+    );
+  });
+
+  await languageService.updateDocument(
+    "test.qs",
+    1,
+    `namespace Other { operation DumpMachine() : Unit { } }
+    namespace Test {
+      open Microsoft.Quantum.Diagnostics;
+      open Other;
+      @EntryPoint()
+      operation Main() : Unit {
+        DumpMachine();
+      }
+    }`
   );
   assert(gotDiagnostics);
 });

--- a/npm/test/basics.js
+++ b/npm/test/basics.js
@@ -508,7 +508,7 @@ test("diagnostics with related spans", async () => {
         related: event.detail.diagnostics[0].related?.map((r) => ({
           start_pos: r.start_pos,
           message: r.message,
-          end_pos: r.end_pos
+          end_pos: r.end_pos,
         })),
       }
     );

--- a/vscode/src/diagnostics.ts
+++ b/vscode/src/diagnostics.ts
@@ -56,11 +56,29 @@ export function startCheckingQSharp(
             severity = vscode.DiagnosticSeverity.Information;
             break;
         }
-        return new vscode.Diagnostic(
+        const vscodeDiagnostic = new vscode.Diagnostic(
           new vscode.Range(getPosition(d.start_pos), getPosition(d.end_pos)),
           d.message,
           severity
         );
+        if (d.code) {
+          vscodeDiagnostic.code = d.code;
+        }
+        if (d.related) {
+          vscodeDiagnostic.relatedInformation = d.related.map((r) => {
+            return new vscode.DiagnosticRelatedInformation(
+              new vscode.Location(
+                vscode.Uri.parse(r.source),
+                new vscode.Range(
+                  getPosition(r.start_pos),
+                  getPosition(r.end_pos)
+                )
+              ),
+              r.message
+            );
+          });
+        }
+        return vscodeDiagnostic;
       })
     );
   }

--- a/wasm/src/debug_service.rs
+++ b/wasm/src/debug_service.rs
@@ -6,7 +6,7 @@ use qsc::interpret::stateful::Interpreter;
 use qsc::interpret::{stateful, StepAction, StepResult};
 use qsc::{fmt_complex, PackageType, SourceMap, TargetProfile};
 
-use crate::{language_service::VSDiagnostic, serializable_type, CallbackReceiver};
+use crate::{serializable_type, CallbackReceiver};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use wasm_bindgen::prelude::*;
@@ -159,7 +159,10 @@ impl DebugService {
                 // TODO: handle multiple errors
                 // https://github.com/microsoft/qsharp/issues/149
                 success = false;
-                Some(VSDiagnostic::from(&errors[0]).json())
+                errors[0]
+                    .stack_trace()
+                    .clone()
+                    .map(serde_json::Value::String)
             }
         };
         if let Some(value) = msg {

--- a/wasm/src/diagnostic.rs
+++ b/wasm/src/diagnostic.rs
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::serializable_type;
+use miette::{Diagnostic, LabeledSpan, Severity};
+use qsc::{self, error::WithSource, interpret::stateful, SourceName};
+use serde::{Deserialize, Serialize};
+use std::{fmt::Write, iter};
+use wasm_bindgen::prelude::*;
+
+serializable_type! {
+    VSDiagnostic,
+    {
+        pub start_pos: u32,
+        pub end_pos: u32,
+        pub message: String,
+        pub severity: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub code: Option<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub related: Vec<Related>
+    },
+    r#"export interface VSDiagnostic {
+        start_pos: number;
+        end_pos: number;
+        message: string;
+        severity: "error" | "warning" | "info"
+        code?: string;
+        related?: IRelatedInformation[];
+    }"#
+}
+
+serializable_type! {
+    Related,
+    {
+        pub source: String,
+        pub start_pos: u32,
+        pub end_pos: u32,
+        pub message: String,
+    },
+    r#"export interface IRelatedInformation {
+        source: string;
+        start_pos: number;
+        end_pos: number;
+        message: string;
+    }"#
+}
+
+impl VSDiagnostic {
+    pub fn json(&self) -> serde_json::Value {
+        serde_json::to_value(self).expect("serializing VSDiagnostic should succeed")
+    }
+
+    /// Creates a [VSDiagnostic] from an interpreter error. See `VSDiagnostic::new()` for details.
+    pub(crate) fn from_interpret_error(
+        source_name: &str,
+        err: &qsc::interpret::stateful::Error,
+    ) -> Self {
+        let labels = match err {
+            stateful::Error::Compile(e) => error_labels(e),
+            stateful::Error::Pass(e) => error_labels(e),
+            stateful::Error::Eval(e) => error_labels(e.error()),
+            stateful::Error::NoEntryPoint => Vec::new(),
+            stateful::Error::TargetMismatch => Vec::new(),
+        };
+
+        Self::new(labels, source_name, err)
+    }
+
+    /// Creates a [VSDiagnostic] from a compiler error. See `VSDiagnostic::new()` for details.
+    pub(crate) fn from_compile_error(source_name: &str, err: &qsc::compile::Error) -> Self {
+        let labels = error_labels(err);
+
+        Self::new(labels, source_name, err)
+    }
+
+    /// Creates a [VSDiagnostic] using the information from a [miette::Diagnostic].
+    /// The error message, code and severity are straightforwardly generated,
+    /// while mapping label spans is a little trickier.
+    ///
+    /// While a [miette::Diagnostic] can be associated with zero or more spans,
+    /// a [VSDiagnostic] is intended to be shown as a squiggle in a specific document,
+    /// and therefore needs to have at least one span that falls in the current document.
+    ///
+    /// If the first label's span falls in the current document, that span will be
+    /// used for the squiggle. Some errors are not associated with a span
+    /// at all, e.g. "entry point not found". Some other errors, e.g. some runtime errors,
+    /// originate outside the current file. In those cases, a default span is
+    /// used just to make the squiggle visible in the current document.
+    ///
+    /// Any labels with associated messages are included as "related information"
+    /// objects in the [VSDiagnostic], whether they fall in the current document or not.
+    /// Editors can display these as links to other source locations.
+    fn new<T>(labels: Vec<Label>, source_name: &str, err: &T) -> VSDiagnostic
+    where
+        T: Diagnostic,
+    {
+        let mut labels = labels.into_iter().peekable();
+
+        let default = (0, 1);
+        let (start_pos, end_pos) = labels
+            .peek()
+            .filter(|l| l.source_name.as_ref() == source_name)
+            .map_or(default, |l| (l.start, l.end));
+
+        let related: Vec<Related> = labels
+            .filter_map(|label| match label.message {
+                Some(message) => Some(Related {
+                    // Here, the stdlib/core files could be mapped to
+                    // "qsharp-library-source" uris to allow for navigation
+                    // in VS Code, but currently only the file path is returned.
+                    source: label.source_name.to_string(),
+                    start_pos: label.start,
+                    end_pos: label.end,
+                    message,
+                }),
+                None => None,
+            })
+            .collect();
+
+        // e.g. "runtime error"
+        let mut message = err.to_string();
+        for source in iter::successors(std::error::Error::source(&err), |e| e.source()) {
+            // e.g. " Qubit0 released while not in |0⟩ state"
+            write!(message, ": {source}").expect("message should be writable");
+        }
+        if let Some(help) = err.help() {
+            // e.g. "qubits should be returned to the |0⟩ state before being released to satisfy the assumption that allocated qubits start in the |0⟩ state"
+            write!(message, "\n\nhelp: {help}").expect("message should be writable");
+        }
+
+        // e.g. Qsc.Eval.ReleasedQubitNotZero
+        let code = err.code().map(|c| c.to_string());
+
+        Self {
+            start_pos,
+            end_pos,
+            severity: (match err.severity().unwrap_or(Severity::Error) {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+                Severity::Advice => "info",
+            })
+            .to_string(),
+            message,
+            code,
+            related,
+        }
+    }
+}
+
+struct Label {
+    pub source_name: SourceName,
+    pub start: u32,
+    pub end: u32,
+    pub message: Option<String>,
+}
+
+fn error_labels<T>(e: &WithSource<T>) -> Vec<Label>
+where
+    T: Diagnostic + Send + Sync,
+{
+    e.labels()
+        .into_iter()
+        .flatten()
+        .map(|l| resolve_label(e, &l))
+        .collect()
+}
+
+fn resolve_label<T>(e: &WithSource<T>, labeled_span: &LabeledSpan) -> Label
+where
+    T: Diagnostic + Send + Sync,
+{
+    let (source, span) = e.resolve_span(labeled_span.inner());
+    let start = u32::try_from(span.offset()).expect("offset should fit in u32");
+    let len = u32::try_from(span.len()).expect("length should fit in u32");
+
+    Label {
+        source_name: source.name.clone(),
+        start,
+        end: start + len,
+        message: labeled_span.label().map(ToString::to_string),
+    }
+}

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::serializable_type;
-use miette::{Diagnostic, Severity};
+use crate::{diagnostic::VSDiagnostic, serializable_type};
 use qsc::{self, compile};
 use serde::{Deserialize, Serialize};
-use std::{fmt::Write, iter};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -18,7 +16,10 @@ impl LanguageService {
         let diagnostics_callback = diagnostics_callback.clone();
         let inner = qsls::LanguageService::new(
             move |uri: &str, version: u32, errors: &[compile::Error]| {
-                let diags = errors.iter().map(VSDiagnostic::from).collect::<Vec<_>>();
+                let diags = errors
+                    .iter()
+                    .map(|err| VSDiagnostic::from_compile_error(uri, err))
+                    .collect::<Vec<_>>();
                 let _ = diagnostics_callback
                     .call3(
                         &JsValue::NULL,
@@ -326,77 +327,4 @@ serializable_type! {
         start: number;
         end: number;
     }"#
-}
-
-serializable_type! {
-    VSDiagnostic,
-    {
-        pub start_pos: usize,
-        pub end_pos: usize,
-        pub message: String,
-        pub severity: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub code: Option<VSDiagnosticCode>,
-    },
-    r#"export interface IDiagnostic {
-        start_pos: number;
-        end_pos: number;
-        message: string;
-        severity: "error" | "warning" | "info"
-        code?: {
-            value: string;
-            target: string;
-        }
-    }"#
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct VSDiagnosticCode {
-    value: String,
-    target: String,
-}
-
-impl VSDiagnostic {
-    pub fn json(&self) -> serde_json::Value {
-        serde_json::to_value(self).expect("serializing VSDiagnostic should succeed")
-    }
-}
-
-impl<T> From<&T> for VSDiagnostic
-where
-    T: Diagnostic,
-{
-    fn from(err: &T) -> Self {
-        let label = err.labels().and_then(|mut ls| ls.next());
-        let offset = label.as_ref().map_or(0, |lbl| lbl.offset());
-        // Monaco handles 0-length diagnostics just fine...?
-        let len = label.as_ref().map_or(1, |lbl| lbl.len());
-        let severity = (match err.severity().unwrap_or(Severity::Error) {
-            Severity::Error => "error",
-            Severity::Warning => "warning",
-            Severity::Advice => "info",
-        })
-        .to_string();
-
-        let mut message = err.to_string();
-        for source in iter::successors(err.source(), |e| e.source()) {
-            write!(message, ": {source}").expect("message should be writable");
-        }
-        if let Some(help) = err.help() {
-            write!(message, "\n\nhelp: {help}").expect("message should be writable");
-        }
-
-        let code = err.code().map(|code| VSDiagnosticCode {
-            value: code.to_string(),
-            target: "".to_string(),
-        });
-
-        VSDiagnostic {
-            start_pos: offset,
-            end_pos: offset + len,
-            severity,
-            message,
-            code,
-        }
-    }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -90,13 +90,8 @@ pub fn get_library_source_content(name: &str) -> Option<String> {
 
 #[wasm_bindgen]
 pub fn get_hir(code: &str) -> String {
-    let package = compile(code);
-    package.to_string()
-}
-
-fn compile(code: &str) -> qsc::hir::Package {
-    STORE_CORE_STD.with(|(store, std)| {
-        let sources = SourceMap::new([("code".into(), code.into())], None);
+    let sources = SourceMap::new([("code".into(), code.into())], None);
+    let package = STORE_CORE_STD.with(|(store, std)| {
         let (unit, _) = compile::compile(
             store,
             &[*std],
@@ -105,7 +100,8 @@ fn compile(code: &str) -> qsc::hir::Package {
             TargetProfile::Full,
         );
         unit.package
-    })
+    });
+    package.to_string()
 }
 
 struct CallbackReceiver<F>

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::language_service::VSDiagnostic;
+use diagnostic::VSDiagnostic;
 use katas::check_solution;
 use num_bigint::BigUint;
 use num_complex::Complex64;
@@ -20,6 +20,7 @@ use std::fmt::Write;
 use wasm_bindgen::prelude::*;
 
 mod debug_service;
+mod diagnostic;
 mod language_service;
 mod logging;
 mod serializable_type;
@@ -89,24 +90,21 @@ pub fn get_library_source_content(name: &str) -> Option<String> {
 
 #[wasm_bindgen]
 pub fn get_hir(code: &str) -> String {
-    let (package, _) = compile(code);
+    let package = compile(code);
     package.to_string()
 }
 
-fn compile(code: &str) -> (qsc::hir::Package, Vec<VSDiagnostic>) {
+fn compile(code: &str) -> qsc::hir::Package {
     STORE_CORE_STD.with(|(store, std)| {
         let sources = SourceMap::new([("code".into(), code.into())], None);
-        let (unit, errors) = compile::compile(
+        let (unit, _) = compile::compile(
             store,
             &[*std],
             sources,
             PackageType::Exe,
             TargetProfile::Full,
         );
-        (
-            unit.package,
-            errors.into_iter().map(|error| (&error).into()).collect(),
-        )
+        unit.package
     })
 }
 
@@ -165,15 +163,16 @@ fn run_internal<F>(code: &str, expr: &str, event_cb: F, shots: u32) -> Result<()
 where
     F: FnMut(&str),
 {
+    let source_name = "code";
     let mut out = CallbackReceiver { event_cb };
-    let sources = SourceMap::new([("code".into(), code.into())], Some(expr.into()));
+    let sources = SourceMap::new([(source_name.into(), code.into())], Some(expr.into()));
     let interpreter =
         stateful::Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full);
     if let Err(err) = interpreter {
         // TODO: handle multiple errors
         // https://github.com/microsoft/qsharp/issues/149
         let e = err[0].clone();
-        let diag: VSDiagnostic = (&e).into();
+        let diag = VSDiagnostic::from_interpret_error(source_name, &e);
         let msg = json!(
             {"type": "Result", "success": false, "result": diag});
         (out.event_cb)(&msg.to_string());
@@ -189,7 +188,7 @@ where
                 // TODO: handle multiple errors
                 // https://github.com/microsoft/qsharp/issues/149
                 success = false;
-                VSDiagnostic::from(&errors[0]).json()
+                VSDiagnostic::from_interpret_error(source_name, &errors[0]).json()
             }
         };
 
@@ -229,7 +228,8 @@ fn check_exercise_solution_internal(
     exercise_sources: Vec<(SourceName, SourceContents)>,
     event_cb: impl Fn(&str),
 ) -> bool {
-    let mut sources = vec![("solution".into(), solution_code.into())];
+    let source_name = "solution";
+    let mut sources = vec![(source_name.into(), solution_code.into())];
     for exercise_source in exercise_sources {
         sources.push(exercise_source);
     }
@@ -242,7 +242,10 @@ fn check_exercise_solution_internal(
             // TODO: handle multiple errors
             // https://github.com/microsoft/qsharp/issues/149
             runtime_success = false;
-            (false, VSDiagnostic::from(&errors[0]).json())
+            (
+                false,
+                VSDiagnostic::from_interpret_error(source_name, &errors[0]).json(),
+            )
         }
     };
     let msg_string =


### PR DESCRIPTION
Fixes #750 . Addresses some of #149 .

Runtime error squiggles in the playground were off by one. The root cause was that we actually use `SourceMap` offsets, not `Source` offsets, to report the error. This sometimes used to "just work" since we always have a single file in the compilation. However, this really broke down when #614 inserted an additional EOF character between sources... and then when #622 moved the entry expression (`""` in this case) to the _beginning_ of the source map. 

Moreover, when runtime error spans came from stdlib, the offsets were just wildly off (since the spans were actually coming from stdlib). This probably wasn't noticeable since the UI "covered up" the problem by mapping the squiggles to the very end of the document.

So, the bulk of this PR is properly resolving `SourceMap` offsets to `Source` offsets in the wasm layer. When the span doesn't belong in the current document, we just show a squiggle at the beginning of the document. But we also take advantage of the "related information" feature of Monaco to still include the relevant stdlib labels in the hover text (see screenshots below).

This brings spans to the realm of "technically correct", but I'm still not happy with the experience in the playground UI for runtime errors. For a better experienece, we should consider:

- Either, grabbing spans from the call stack and squiggle the statements in the stack.
- Or, not bothering with runtime error squiggles at all....

However, this change was already getting too big, and the callstack changes would have been pretty complicated. I decided to just go with this as an incremental improvement, and debate the rest later.

### Playground runtime error changes

**Case 1: The runtime error has a label that belongs in the current file**

This had the off-by-one error, now fixed.

**Before**

![image](https://github.com/microsoft/qsharp/assets/16928427/a94c83db-15e4-424c-82ea-75fd99240866)

**After**

![image](https://github.com/microsoft/qsharp/assets/16928427/1665c0e1-e2db-4ffb-8832-2bb2f459a01e)

**Case 2: The runtime error has a label that belongs in stdlib**

This used to map to the end of the file (just by luck), now it maps to the beginning of the file and shows the label from the original location in the hover text.

**Before**

![image](https://github.com/microsoft/qsharp/assets/16928427/2a45a1a7-d195-4a1d-8972-208d99f92e49)

**After**

![image](https://github.com/microsoft/qsharp/assets/16928427/99c997bf-371c-4f94-962f-ebb35152b6e3)

**Case 3: The runtime error has a label that belongs in stdlib, _and_ the label doesn't contain a message**

This is the worst experience - we could show the stdlib location in the hover, but there's no message in the label so it would be entirely pointless to display. So we omit it. The location of the squiggle is now technically correct but just as unhelpful.

**Before**
![image](https://github.com/microsoft/qsharp/assets/16928427/7d4a0878-3cd4-4f56-b9be-921b70bac9f1)

**After**
![image](https://github.com/microsoft/qsharp/assets/16928427/624aa247-f62c-4a4e-91e8-2c92a0547a6a)

### Other goodness:

- In the playground, we clear the last runtime squiggle when the user starts typing (or click on a different sample).

- Properly reporting compiler errors with multiple spans (e.g. [`Ambiguous`](https://github.com/microsoft/qsharp/blob/c75940913518763000a3b18b053ef683cc0e3ad7/compiler/qsc_frontend/src/resolve.rs#L57)) using VSCode/Monaco's "related information" feature. These related spans show up in the error hover.

![image](https://github.com/microsoft/qsharp/assets/16928427/62ab9118-0603-4d26-9cac-6c1bf2f17f9c)

- `qsc::compile::compile()` now just returns a `WithSource<Error>` instead of relying on the caller to use the `SourceMap` to resolve error spans to source files. Every caller has to do this mapping at _some_ point to report errors, so it makes sense for the errors to just contain that information from the start. Using `WithSource` as the error type also mirrors the error types that `Interpreter` and `Incremental` already return.

- Somehow `VSDiagnostic` was defined in two places. One with the name `IDiagnostic` and the other `VSDiagnostic`. They describe the same thing. Deleted one of the definitions.
