### PR TITLE
Mitigate impact of flaky integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
 
   integration-tests:
     name: Integration tests
+    if: ${{ ! github.event.pull_request }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]

--- a/build.py
+++ b/build.py
@@ -117,14 +117,17 @@ jupyterlab_src = os.path.join(root_dir, "jupyterlab")
 
 def step_start(description):
     global start_time
-    print(f"build.py step: {description}")
+    prefix = "::group::" if os.getenv("GITHUB_ACTIONS") == "true" else ""
+    print(f"{prefix}build.py: {description}")
     start_time = time.time()
 
 
 def step_end():
     global start_time
     duration = time.time() - start_time
-    print(f"build.py step: Finished in {duration:.3f}s.")
+    print(f"build.py: Finished in {duration:.3f}s.")
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        print(f"::endgroup::")
 
 
 if npm_install_needed:
@@ -386,6 +389,6 @@ if build_jupyterlab:
 
 if args.integration_tests:
     step_start("Running the VS Code integration tests")
-    vscode_args = [npm_cmd, "test"]
+    vscode_args = [npm_cmd, "test", "--", "--verbose"]
     subprocess.run(vscode_args, check=True, text=True, cwd=vscode_src)
     step_end()

--- a/vscode/test/runTests.mjs
+++ b/vscode/test/runTests.mjs
@@ -21,6 +21,8 @@ const attachArgName = "--waitForDebugger=";
 const waitForDebugger = process.argv.find((arg) =>
   arg.startsWith(attachArgName)
 );
+const verboseArgName = "--verbose";
+const verbose = process.argv.includes(verboseArgName);
 
 try {
   // Language service tests
@@ -51,6 +53,9 @@ async function runSuite(extensionTestsPath, workspacePath) {
     extensionDevelopmentPath,
     extensionTestsPath,
     folderPath: workspacePath,
+    quality: "stable",
+    printServerLog: verbose,
+    verbose,
     waitForDebugger: waitForDebugger
       ? Number(waitForDebugger.slice(attachArgName.length))
       : undefined,


### PR DESCRIPTION
Temporary until I figure out what's going on:
- Don't run integration tests on pull requests (run on main only)
- Enable verbose output.

Permanent:
- Use `stable` vscode channel instead of `insiders`. No need to be on the bleeding edge for CI.
- Set job timeout to 15 minutes (from the default of 6 hours). This is very generous for the current run. We can extend it later if needed.
- Use `::group::` to collapse chatty workflow output https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines