### PR TITLE
Signature Help for Indirect Calls Based on Type

### DIFF
--- a/language_service/src/display.rs
+++ b/language_service/src/display.rs
@@ -71,6 +71,13 @@ impl<'a> CodeDisplay<'a> {
         }
     }
 
+    pub(crate) fn hir_ty(&self, ty: &'a hir::ty::Ty) -> impl Display + 'a {
+        HirTy {
+            compilation: self.compilation,
+            ty,
+        }
+    }
+
     pub(crate) fn hir_pat(&self, pat: &'a hir::Pat) -> impl Display + 'a {
         HirPat {
             compilation: self.compilation,

--- a/language_service/src/signature_help.rs
+++ b/language_service/src/signature_help.rs
@@ -63,7 +63,15 @@ impl<'a> Visitor<'a> for SignatureHelpFinder<'a> {
                     if self.signature_help.is_none() {
                         let callee = unwrap_parens(callee);
                         if let ast::ExprKind::Path(path) = &*callee.kind {
-                            self.process_direct_callee(path, args);
+                            if let Some(resolve::Res::Item(item_id)) =
+                                self.compilation.unit.ast.names.get(path.id)
+                            {
+                                self.process_direct_callee(item_id, args);
+                            } else {
+                                self.process_indirect_callee(callee, args);
+                            }
+                        } else {
+                            self.process_indirect_callee(callee, args);
                         }
                     }
                 }
@@ -74,29 +82,44 @@ impl<'a> Visitor<'a> for SignatureHelpFinder<'a> {
 }
 
 impl SignatureHelpFinder<'_> {
-    fn process_direct_callee(&mut self, callee: &ast::Path, args: &ast::Expr) {
-        if let Some(resolve::Res::Item(item_id)) = self.compilation.unit.ast.names.get(callee.id) {
-            if let (Some(item), _) = find_item(self.compilation, item_id) {
-                if let hir::ItemKind::Callable(callee) = &item.kind {
-                    // Check that the callee has parameters to give help for
-                    if !matches!(&callee.input.kind, hir::PatKind::Tuple(items) if items.is_empty())
-                    {
-                        let documentation = parse_doc_for_summary(&item.doc);
-                        let documentation = (!documentation.is_empty()).then_some(documentation);
+    fn process_indirect_callee(&mut self, callee: &ast::Expr, args: &ast::Expr) {
+        if let Some(ty) = self.compilation.unit.ast.tys.terms.get(callee.id) {
+            if let hir::ty::Ty::Arrow(arrow) = &ty {
+                let sig_info = SignatureInformation {
+                    label: self.display.hir_ty(ty).to_string(),
+                    documentation: None,
+                    parameters: self.get_type_params(&arrow.input),
+                };
 
-                        let sig_info = SignatureInformation {
-                            label: self.display.hir_callable_decl(callee).to_string(),
-                            documentation,
-                            parameters: self.get_params(callee, &item.doc),
-                        };
+                // Capture arrow.input structure in a fake HIR Pat.
+                let params = make_fake_pat(&arrow.input);
 
-                        self.signature_help = Some(SignatureHelp {
-                            signatures: vec![sig_info],
-                            active_signature: 0,
-                            active_parameter: process_args(args, self.offset, &callee.input),
-                        });
-                    }
-                }
+                self.signature_help = Some(SignatureHelp {
+                    signatures: vec![sig_info],
+                    active_signature: 0,
+                    active_parameter: process_args(args, self.offset, &params),
+                });
+            }
+        }
+    }
+
+    fn process_direct_callee(&mut self, item_id: &hir::ItemId, args: &ast::Expr) {
+        if let (Some(item), _) = find_item(self.compilation, item_id) {
+            if let hir::ItemKind::Callable(callee) = &item.kind {
+                let documentation = parse_doc_for_summary(&item.doc);
+                let documentation = (!documentation.is_empty()).then_some(documentation);
+
+                let sig_info = SignatureInformation {
+                    label: self.display.hir_callable_decl(callee).to_string(),
+                    documentation,
+                    parameters: self.get_params(callee, &item.doc),
+                };
+
+                self.signature_help = Some(SignatureHelp {
+                    signatures: vec![sig_info],
+                    active_signature: 0,
+                    active_parameter: process_args(args, self.offset, &callee.input),
+                });
             }
         }
     }
@@ -108,6 +131,8 @@ impl SignatureHelpFinder<'_> {
     /// operation Foo(bar: Int, baz: Double) : Unit {}
     ///               └──┬───┘  └──┬──────┘
     ///               param 1    param 2
+    ///              └─────────┬───────────┘
+    ///                      param 0
     /// ```
     fn get_params(&self, decl: &hir::CallableDecl, doc: &str) -> Vec<ParameterInformation> {
         let mut offset = self.display.get_param_offset(decl);
@@ -205,6 +230,51 @@ impl SignatureHelpFinder<'_> {
             }
         }
     }
+
+    fn get_type_params(&self, ty: &hir::ty::Ty) -> Vec<ParameterInformation> {
+        let mut offset = 1; // 1 for the open parenthesis character
+        self.make_type_param_with_offset(&mut offset, ty)
+    }
+
+    fn make_type_param_with_offset(
+        &self,
+        offset: &mut u32,
+        ty: &hir::ty::Ty,
+    ) -> Vec<ParameterInformation> {
+        if let hir::ty::Ty::Tuple(items) = &ty {
+            let len = usize_to_u32(self.display.hir_ty(ty).to_string().len());
+            let mut rtrn = vec![ParameterInformation {
+                label: Span {
+                    start: *offset,
+                    end: *offset + len,
+                },
+                documentation: None,
+            }];
+            *offset += 1; // for the open parenthesis
+            let mut is_first = true;
+            for item in items {
+                if is_first {
+                    is_first = false;
+                } else {
+                    *offset += 2; // 2 for the comma and space
+                }
+                rtrn.extend(self.make_type_param_with_offset(offset, item));
+            }
+            *offset += 1; // for the close parenthesis
+            rtrn
+        } else {
+            let len = usize_to_u32(self.display.hir_ty(ty).to_string().len());
+            let start = *offset;
+            *offset += len;
+            vec![ParameterInformation {
+                label: Span {
+                    start,
+                    end: *offset,
+                },
+                documentation: None,
+            }]
+        }
+    }
 }
 
 fn unwrap_parens(expr: &ast::Expr) -> &ast::Expr {
@@ -216,6 +286,23 @@ fn unwrap_parens(expr: &ast::Expr) -> &ast::Expr {
 
 fn usize_to_u32(x: usize) -> u32 {
     u32::try_from(x).expect("failed to cast usize to u32 while generating signature help")
+}
+
+/// Captures the hierarchical structure of a type based on Tuples by
+/// creating an HIR Pat with the same hierarchical structure. Other than
+/// the structure, the Pat and sub-Pats have default field values.
+fn make_fake_pat(ty: &hir::ty::Ty) -> hir::Pat {
+    hir::Pat {
+        id: hir::NodeId::default(),
+        span: qsc::Span::default(),
+        ty: hir::ty::Ty::Err,
+        kind: match ty {
+            hir::ty::Ty::Tuple(items) => {
+                hir::PatKind::Tuple(items.iter().map(make_fake_pat).collect())
+            }
+            _ => hir::PatKind::Discard,
+        },
+    }
 }
 
 fn process_args(args: &ast::Expr, location: u32, params: &hir::Pat) -> u32 {

--- a/language_service/src/signature_help/tests.rs
+++ b/language_service/src/signature_help/tests.rs
@@ -2928,3 +2928,53 @@ fn indirect_single_param_call() {
         "#]],
     );
 }
+
+#[test]
+fn udt_constructor_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            newtype Foo = (fst : Int, snd : Double);
+            operation Bar(x : Int) : Unit {
+                let foo = Foo(↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((Int, Double) -> Foo)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 14,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 5,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 7,
+                                    end: 13,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}

--- a/language_service/src/signature_help/tests.rs
+++ b/language_service/src/signature_help/tests.rs
@@ -2297,3 +2297,591 @@ fn single_parameter_before() {
         "#]],
     );
 }
+
+#[test]
+fn indirect_local_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int, y : Int, z : Int) : Unit {}
+            operation Bar() : Unit {
+                let foo = Foo;
+                foo(↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((Int, Int, Int) => Unit)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 16,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 5,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 7,
+                                    end: 10,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 12,
+                                    end: 15,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn indirect_array_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int, y : Int, z : Int) : Unit {}
+            operation Bar() : Unit {
+                let foo = [Foo];
+                foo[0](↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((Int, Int, Int) => Unit)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 16,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 5,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 7,
+                                    end: 10,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 12,
+                                    end: 15,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn indirect_block_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int, y : Int, z : Int) : Unit {}
+            operation Bar() : Unit {
+                ({ Foo }(↘))
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((Int, Int, Int) => Unit)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 16,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 5,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 7,
+                                    end: 10,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 12,
+                                    end: 15,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn indirect_unresolved_lambda_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Bar() : Unit {
+                let foo = (x, y, z) => {};
+                foo(↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((?1, ?2, ?3) => ?5)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 13,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 4,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 6,
+                                    end: 8,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 10,
+                                    end: 12,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn indirect_partially_resolved_lambda_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Bar() : Unit {
+                let foo = (x, y, z) => {};
+                foo(1, ↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((Int, ?2, ?3) => ?5)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 14,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 5,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 7,
+                                    end: 9,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 11,
+                                    end: 13,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 2,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn indirect_resolved_lambda_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Bar() : Unit {
+                let foo = (x, y, z) => {};
+                foo(1, 2, 3);
+                foo(↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((Int, Int, Int) => ?6)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 16,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 5,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 7,
+                                    end: 10,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 12,
+                                    end: 15,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn controlled_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int, y : Int, z : Int) : Unit is Ctl {}
+            operation Bar() : Unit {
+                Controlled Foo(↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((Qubit[], (Int, Int, Int)) => Unit is Ctl)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 27,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 9,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 11,
+                                    end: 26,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 12,
+                                    end: 15,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 17,
+                                    end: 20,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 22,
+                                    end: 25,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn double_controlled_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int, y : Int, z : Int) : Unit is Ctl {}
+            operation Bar() : Unit {
+                Controlled Controlled Foo(↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((Qubit[], (Qubit[], (Int, Int, Int))) => Unit is Ctl)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 38,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 9,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 11,
+                                    end: 37,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 12,
+                                    end: 19,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 21,
+                                    end: 36,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 22,
+                                    end: 25,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 27,
+                                    end: 30,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 32,
+                                    end: 35,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn partial_application_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int, y : Int, z : Int) : Unit {}
+            operation Bar() : Unit {
+                let foo = Foo(1, _, _);
+                foo(↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "((Int, Int) => Unit)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 11,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 2,
+                                    end: 5,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 7,
+                                    end: 10,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn indirect_no_params_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo() : Unit {
+                let foo = Foo;
+                foo(↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "(Unit => Unit)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 5,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 0,
+            }
+        "#]],
+    );
+}

--- a/language_service/src/signature_help/tests.rs
+++ b/language_service/src/signature_help/tests.rs
@@ -2885,3 +2885,46 @@ fn indirect_no_params_call() {
         "#]],
     );
 }
+
+#[test]
+fn indirect_single_param_call() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            operation Foo(x : Int) : Unit {
+                let foo = Foo;
+                foo(↘)
+                let x = 3;
+            }
+        }
+    "#},
+        &expect![[r#"
+            SignatureHelp {
+                signatures: [
+                    SignatureInformation {
+                        label: "(Int => Unit)",
+                        documentation: None,
+                        parameters: [
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 4,
+                                },
+                                documentation: None,
+                            },
+                            ParameterInformation {
+                                label: Span {
+                                    start: 1,
+                                    end: 4,
+                                },
+                                documentation: None,
+                            },
+                        ],
+                    },
+                ],
+                active_signature: 0,
+                active_parameter: 1,
+            }
+        "#]],
+    );
+}

--- a/language_service/src/signature_help/tests.rs
+++ b/language_service/src/signature_help/tests.rs
@@ -2487,7 +2487,7 @@ fn indirect_unresolved_lambda_call() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "((?1, ?2, ?3) => ?5)",
+                        label: "((?1, ?2, ?3) => Unit)",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
@@ -2544,7 +2544,7 @@ fn indirect_partially_resolved_lambda_call() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "((Int, ?2, ?3) => ?5)",
+                        label: "((Int, ?2, ?3) => Unit)",
                         documentation: None,
                         parameters: [
                             ParameterInformation {
@@ -2602,7 +2602,7 @@ fn indirect_resolved_lambda_call() {
             SignatureHelp {
                 signatures: [
                     SignatureInformation {
-                        label: "((Int, Int, Int) => ?6)",
+                        label: "((Int, Int, Int) => Unit)",
                         documentation: None,
                         parameters: [
                             ParameterInformation {


### PR DESCRIPTION
Adds signature help to the language server for indirect call expressions based on the type of the callee expression. This allows signature help to be given for all call expressions, including lambdas, local captures of callables and partial applications, functor applications, arrays of callables, and callables returned from a block, and UDT constructors.