### PR TITLE
Fix lambda return type inference

### DIFF
--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -331,16 +331,16 @@ impl<'a> Context<'a> {
                 let prev_ret_ty = self.return_ty.take();
                 let output_ty = self.inferrer.fresh_ty(TySource::not_divergent(body.span));
                 self.return_ty = Some(output_ty);
-                let body_ty = self.infer_expr(body).ty;
+                let body_partial = self.infer_expr(body);
                 let output_ty = self
                     .return_ty
                     .take()
                     .expect("return type should be present");
                 self.return_ty = prev_ret_ty;
-                if body_ty != Ty::UNIT {
-                    // Only when the type of the body is not `UNIT` do we need to unify with the inferred output type.
+                if !body_partial.diverges {
+                    // Only when the type of the body converges do we need to unify with the inferred output type.
                     // Otherwise we'd get spurious errors from lambdas that use explicit return-expr rather than implicit.
-                    self.inferrer.eq(body.span, output_ty.clone(), body_ty);
+                    self.inferrer.eq(body.span, output_ty.clone(), body_partial.ty);
                 }
                 converge(Ty::Arrow(Box::new(Arrow {
                     kind: convert::callable_kind_from_ast(*kind),

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -340,7 +340,8 @@ impl<'a> Context<'a> {
                 if !body_partial.diverges {
                     // Only when the type of the body converges do we need to unify with the inferred output type.
                     // Otherwise we'd get spurious errors from lambdas that use explicit return-expr rather than implicit.
-                    self.inferrer.eq(body.span, output_ty.clone(), body_partial.ty);
+                    self.inferrer
+                        .eq(body.span, output_ty.clone(), body_partial.ty);
                 }
                 converge(Ty::Arrow(Box::new(Arrow {
                     kind: convert::callable_kind_from_ast(*kind),

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2365,6 +2365,100 @@ fn lambda_inner_return() {
 }
 
 #[test]
+fn lambda_inner_return_without_call_ambiguous() {
+    check(
+        indoc! {"
+            namespace A {
+                function Foo() : Unit {
+                    let f = (a, b) -> {
+                        return a + b;
+                    };
+                }
+            }
+        "},
+        "",
+        &expect![[r#"
+            #6 30-32 "()" : Unit
+            #10 40-112 "{\n        let f = (a, b) -> {\n            return a + b;\n        };\n    }" : Unit
+            #12 54-55 "f" : ((?2, ?2) -> ?2)
+            #14 58-105 "(a, b) -> {\n            return a + b;\n        }" : ((?2, ?2) -> ?2)
+            #15 58-64 "(a, b)" : (?2, ?2)
+            #16 59-60 "a" : ?2
+            #18 62-63 "b" : ?2
+            #20 68-105 "{\n            return a + b;\n        }" : Unit
+            #21 68-105 "{\n            return a + b;\n        }" : Unit
+            #23 82-94 "return a + b" : Unit
+            #24 89-94 "a + b" : ?2
+            #25 89-90 "a" : ?2
+            #28 93-94 "b" : ?2
+            Error(Type(Error(AmbiguousTy(Span { lo: 62, hi: 63 }))))
+        "#]],
+    );
+}
+
+#[test]
+fn lambda_implicit_return_without_call_ambiguous() {
+    check(
+        indoc! {"
+            namespace A {
+                function Foo() : Unit {
+                    let f = (a, b) -> {
+                        a + b
+                    };
+                }
+            }
+        "},
+        "",
+        &expect![[r#"
+            #6 30-32 "()" : Unit
+            #10 40-104 "{\n        let f = (a, b) -> {\n            a + b\n        };\n    }" : Unit
+            #12 54-55 "f" : ((?2, ?2) -> ?2)
+            #14 58-97 "(a, b) -> {\n            a + b\n        }" : ((?2, ?2) -> ?2)
+            #15 58-64 "(a, b)" : (?2, ?2)
+            #16 59-60 "a" : ?2
+            #18 62-63 "b" : ?2
+            #20 68-97 "{\n            a + b\n        }" : ?2
+            #21 68-97 "{\n            a + b\n        }" : ?2
+            #23 82-87 "a + b" : ?2
+            #24 82-83 "a" : ?2
+            #27 86-87 "b" : ?2
+            Error(Type(Error(AmbiguousTy(Span { lo: 62, hi: 63 }))))
+        "#]],
+    );
+}
+
+#[test]
+fn lambda_implicit_unit_return() {
+    check(
+        indoc! {"
+            namespace A {
+                function Foo() : Unit {
+                    let f = (a, b) -> {};
+                    f(1, 2);
+                }
+            }
+        "},
+        "",
+        &expect![[r#"
+            #6 30-32 "()" : Unit
+            #10 40-94 "{\n        let f = (a, b) -> {};\n        f(1, 2);\n    }" : Unit
+            #12 54-55 "f" : ((Int, Int) -> Unit)
+            #14 58-70 "(a, b) -> {}" : ((Int, Int) -> Unit)
+            #15 58-64 "(a, b)" : (Int, Int)
+            #16 59-60 "a" : Int
+            #18 62-63 "b" : Int
+            #20 68-70 "{}" : Unit
+            #21 68-70 "{}" : Unit
+            #23 80-87 "f(1, 2)" : Unit
+            #24 80-81 "f" : ((Int, Int) -> Unit)
+            #27 81-87 "(1, 2)" : (Int, Int)
+            #28 82-83 "1" : Int
+            #29 85-86 "2" : Int
+        "#]],
+    );
+}
+
+#[test]
 fn lambda_adj() {
     check(
         indoc! {"

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2352,8 +2352,8 @@ fn lambda_inner_return() {
             #12 54-55 "f" : (Unit -> Int)
             #14 58-98 "() -> {\n            return 42;\n        }" : (Unit -> Int)
             #15 58-60 "()" : Unit
-            #16 64-98 "{\n            return 42;\n        }" : Int
-            #17 64-98 "{\n            return 42;\n        }" : Int
+            #16 64-98 "{\n            return 42;\n        }" : Unit
+            #17 64-98 "{\n            return 42;\n        }" : Unit
             #19 78-87 "return 42" : Unit
             #20 85-87 "42" : Int
             #22 112-113 "r" : Int


### PR DESCRIPTION
Previous fix for #510 incorrectly checked inferred lambda body type for unit instead of checking for convergence. This created two bugs: ambiguous types would be treated as unit improperly and implicit unit return would be treated as ambiguous.
Fixes #700
Fixes #790