### PR TITLE
Update devcontainer for Python 3.12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,19 +2,15 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
 	"name": "qsharp",
-	"image": "mcr.microsoft.com/devcontainers/rust:dev-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:3",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			"nodeGypDependencies": true,
 			"version": "lts"
 		},
-		"ghcr.io/devcontainers/features/python:1": {
-			"installTools": true,
-			"installJupyterlab": true,
-			"version": "3.11"
-		}
+		"ghcr.io/devcontainers/features/rust:1": {}
 	},
-	"postCreateCommand": "npm install -g wasm-pack",
+	"postCreateCommand": "npm install -g wasm-pack && cargo update --dry-run",
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
This change updates the devcontainer definition to use a Python base image and install Rust as a feature rather than the other way around. This avoids an issue where the Python feature fails building 3.12 from source, and generally makes perf better for fresh containers since Rust and npm features install quickly. Of note, this also adds `cargo update --dry-run` as a post-build command to ensure the crates.io index is updated on new container creation, preventing an issue where crates would get downgraded on first build due to old index cache.