### PR TITLE
Provide more specific error messages for missing `Item`s

### DIFF
--- a/compiler/qsc_parse/src/item.rs
+++ b/compiler/qsc_parse/src/item.rs
@@ -38,6 +38,14 @@ pub(super) fn parse(s: &mut Scanner) -> Result<Box<Item>> {
         ty
     } else if let Some(callable) = opt(s, parse_callable_decl)? {
         Box::new(ItemKind::Callable(callable))
+    } else if visibility.is_some() {
+        let err_item = default(s.span(lo));
+        s.push_error(Error(ErrorKind::FloatingVisibility(err_item.span)));
+        return Ok(err_item);
+    } else if !attrs.is_empty() {
+        let err_item = default(s.span(lo));
+        s.push_error(Error(ErrorKind::FloatingAttr(err_item.span)));
+        return Ok(err_item);
     } else if doc.is_some() {
         let err_item = default(s.span(lo));
         s.push_error(Error(ErrorKind::FloatingDocComment(err_item.span)));

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -892,6 +892,52 @@ fn floating_doc_comments_in_namespace() {
 }
 
 #[test]
+fn floating_attr_in_namespace() {
+    check_vec(
+        parse_namespaces,
+        "namespace MyQuantumProgram { @EntryPoint() }",
+        &expect![[r#"
+        Namespace _id_ [0-44] (Ident _id_ [10-26] "MyQuantumProgram"):
+            Item _id_ [29-42]:
+                Err
+
+        [
+            Error(
+                FloatingAttr(
+                    Span {
+                        lo: 29,
+                        hi: 42,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+}
+
+#[test]
+fn floating_visibility_in_namespace() {
+    check_vec(
+        parse_namespaces,
+        "namespace MyQuantumProgram { internal }",
+        &expect![[r#"
+            Namespace _id_ [0-39] (Ident _id_ [10-26] "MyQuantumProgram"):
+                Item _id_ [29-37]:
+                    Err
+
+            [
+                Error(
+                    FloatingVisibility(
+                        Span {
+                            lo: 29,
+                            hi: 37,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
 fn two_namespaces() {
     check_vec(
         parse_namespaces,

--- a/compiler/qsc_parse/src/lib.rs
+++ b/compiler/qsc_parse/src/lib.rs
@@ -49,9 +49,15 @@ enum ErrorKind {
     #[error("expected {0}, found {1}")]
     #[diagnostic(code("Qsc.Parse.Token"))]
     Token(TokenKind, TokenKind, #[label] Span),
+    #[error("expected item after attribute")]
+    #[diagnostic(code("Qsc.Parse.FloatingAttr"))]
+    FloatingAttr(#[label] Span),
     #[error("expected item after doc comment")]
     #[diagnostic(code("Qsc.Parse.FloatingDocComment"))]
     FloatingDocComment(#[label] Span),
+    #[error("expected item after visibility modifier")]
+    #[diagnostic(code("Qsc.Parse.FloatingVisibility"))]
+    FloatingVisibility(#[label] Span),
     #[error("expected {0}, found {1}")]
     #[diagnostic(code("Qsc.Parse.Rule"))]
     Rule(&'static str, TokenKind, #[label] Span),
@@ -78,6 +84,8 @@ impl ErrorKind {
             Self::MissingSemi(span) => Self::MissingSemi(span + offset),
             Self::MissingParens(span) => Self::MissingParens(span + offset),
             Self::FloatingDocComment(span) => Self::FloatingDocComment(span + offset),
+            Self::FloatingAttr(span) => Self::FloatingAttr(span + offset),
+            Self::FloatingVisibility(span) => Self::FloatingVisibility(span + offset),
         }
     }
 }


### PR DESCRIPTION
This adds more granular error messages when attributes or visibility modifiers are present without an attribute, following the pattern introducing for the "floating" doc comment errors.

![image](https://github.com/microsoft/qsharp/assets/10567287/f6ffbebe-1ea0-43a0-a45f-a41524f5aee0)

Fixes #757