### PR TITLE
Improve diagnostic message when QIR codegen fails due to a runtime error

### DIFF
--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -38,7 +38,7 @@ export async function getQirForActiveWindow(): Promise<string> {
     if (result?.action !== "set") {
       throw new QirGenerationError(
         "Submitting to Azure is only supported when targeting the QIR base profile. " +
-        "Please update the QIR target via the status bar selector or extension settings."
+          "Please update the QIR target via the status bar selector or extension settings."
       );
     } else {
       await configuration.update(
@@ -74,7 +74,7 @@ export async function getQirForActiveWindow(): Promise<string> {
     log.error("Codegen error. ", e.toString());
     throw new QirGenerationError(
       `Code generation failed due to error: "${e.toString()}". Please ensure the code is compatible with the QIR base profile ` +
-      "by setting the target QIR profile to 'base' and fixing any errors."
+        "by setting the target QIR profile to 'base' and fixing any errors."
     );
   } finally {
     worker.terminate();


### PR DESCRIPTION
This change includes the error string from runtime errors in the pop-up error dialog when QIR generation fails.

<img alt="image" src="https://github.com/microsoft/qsharp/assets/12157751/4784f746-01ef-45cb-acdb-19939a0cbc18">


Closes #747