### PR TITLE
Add ability to continue on error for incremental compiler

### DIFF
--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -272,7 +272,7 @@ impl Interpreter {
 
         let increment = self
             .compiler
-            .compile_fragments(&label, fragments)
+            .compile_fragments_fail_fast(&label, fragments)
             .map_err(into_errors)?;
 
         let stmts = self.lower(&increment);

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -750,11 +750,11 @@ mod given_interpreter {
                 &result,
                 &output,
                 &expect![[r#"
-                name error: `Bar` not found
-                   [line_1] [Bar]
-                type error: insufficient type information to infer type
-                   [line_1] [Bar()]
-            "#]],
+                    name error: `Bar` not found
+                       [line_1] [Bar]
+                    type error: insufficient type information to infer type
+                       [line_1] [Bar()]
+                "#]],
             );
         }
 
@@ -862,11 +862,11 @@ mod given_interpreter {
                 &result,
                 &output,
                 &expect![[r#"
-                name error: `Bar` not found
-                   [line_2] [Bar]
-                type error: insufficient type information to infer type
-                   [line_2] [Bar()]
-            "#]],
+                    name error: `Bar` not found
+                       [line_2] [Bar]
+                    type error: insufficient type information to infer type
+                       [line_2] [Bar()]
+                "#]],
             );
         }
 

--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -10,7 +10,7 @@ pub mod incremental;
 pub mod interpret;
 
 pub use qsc_frontend::compile::{
-    AstPackage, CompileUnit, PackageStore, SourceContents, SourceMap, SourceName, TargetProfile,
+    CompileUnit, PackageStore, SourceContents, SourceMap, SourceName, TargetProfile,
 };
 
 pub mod resolve {

--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -10,7 +10,7 @@ pub mod incremental;
 pub mod interpret;
 
 pub use qsc_frontend::compile::{
-    CompileUnit, PackageStore, SourceContents, SourceMap, SourceName, TargetProfile,
+    AstPackage, CompileUnit, PackageStore, SourceContents, SourceMap, SourceName, TargetProfile,
 };
 
 pub mod resolve {


### PR DESCRIPTION
This change is required for the notebook language service (#759). The new public method is not used in this PR yet. It will be used in #759.

This change adds two flavors of `compile_fragments` to the incremental compiler: one that fails fast and one that accumulates errors but continues compilation.

When calling from the interpreter, we want to fail fast when parsing fails, so that we don't pollute the resolver/checker/lowerer state with flawed data when we already _know_ that cell execution will fail.

On the other hand, when calling from the language service, we want to continue compilation even in the case of errors, so we can finish building our AST & HIR we will use for editor features. Also, this way we can report resolve/check errors even if there are syntax error elsewhere in the program (e.g. in another cell).