### PR TITLE
Improved handling of int overflow

### DIFF
--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -1571,7 +1571,8 @@ fn eval_binop_exp(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Resu
                 Err(Error::InvalidNegativeInt(rhs_val, rhs_span))
             } else {
                 let result: i64 = match rhs_val.try_into() {
-                    Ok(v) => val.checked_pow(v)
+                    Ok(v) => val
+                        .checked_pow(v)
                         .ok_or(Error::IntTooLarge(rhs_val, rhs_span)),
                     Err(_) => Err(Error::IntTooLarge(rhs_val, rhs_span)),
                 }?;
@@ -1716,6 +1717,7 @@ fn eval_binop_orb(lhs_val: Value, rhs_val: Value) -> Value {
     }
 }
 
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn eval_binop_shl(lhs_val: Value, rhs_val: Value) -> Value {
     match lhs_val {
         Value::BigInt(val) => {
@@ -1738,6 +1740,7 @@ fn eval_binop_shl(lhs_val: Value, rhs_val: Value) -> Value {
     }
 }
 
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn eval_binop_shr(lhs_val: Value, rhs_val: Value) -> Value {
     match lhs_val {
         Value::BigInt(val) => {

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -964,7 +964,7 @@ impl State {
             BinOp::Gte => self.eval_binop_simple(eval_binop_gte),
             BinOp::Lt => self.eval_binop_simple(eval_binop_lt),
             BinOp::Lte => self.eval_binop_simple(eval_binop_lte),
-            BinOp::Mod => self.eval_binop_simple(eval_binop_mod),
+            BinOp::Mod => self.eval_binop_with_error(span, eval_binop_mod)?,
             BinOp::Mul => self.eval_binop_simple(eval_binop_mul),
             BinOp::Neq => {
                 let rhs_val = self.pop_val();
@@ -1496,7 +1496,7 @@ fn eval_binop_add(lhs_val: Value, rhs_val: Value) -> Value {
         }
         Value::Int(val) => {
             let rhs = rhs_val.unwrap_int();
-            Value::Int(val + rhs)
+            Value::Int(val.wrapping_add(rhs))
         }
         Value::String(val) => {
             let rhs = rhs_val.unwrap_string();
@@ -1535,7 +1535,7 @@ fn eval_binop_div(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Resu
             if rhs == 0 {
                 Err(Error::DivZero(rhs_span))
             } else {
-                Ok(Value::Int(val / rhs))
+                Ok(Value::Int(val.wrapping_div(rhs)))
             }
         }
         Value::Double(val) => {
@@ -1570,11 +1570,12 @@ fn eval_binop_exp(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Resu
             if rhs_val < 0 {
                 Err(Error::InvalidNegativeInt(rhs_val, rhs_span))
             } else {
-                let rhs_val: u32 = match rhs_val.try_into() {
-                    Ok(v) => Ok(v),
+                let result: i64 = match rhs_val.try_into() {
+                    Ok(v) => val.checked_pow(v)
+                        .ok_or(Error::IntTooLarge(rhs_val, rhs_span)),
                     Err(_) => Err(Error::IntTooLarge(rhs_val, rhs_span)),
                 }?;
-                Ok(Value::Int(val.pow(rhs_val)))
+                Ok(Value::Int(result))
             }
         }
         _ => panic!("value should support exp"),
@@ -1653,19 +1654,31 @@ fn eval_binop_lte(lhs_val: Value, rhs_val: Value) -> Value {
     }
 }
 
-fn eval_binop_mod(lhs_val: Value, rhs_val: Value) -> Value {
+fn eval_binop_mod(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Result<Value, Error> {
     match lhs_val {
         Value::BigInt(val) => {
             let rhs = rhs_val.unwrap_big_int();
-            Value::BigInt(val % rhs)
+            if rhs == BigInt::from(0) {
+                Err(Error::DivZero(rhs_span))
+            } else {
+                Ok(Value::BigInt(val % rhs))
+            }
         }
         Value::Int(val) => {
             let rhs = rhs_val.unwrap_int();
-            Value::Int(val % rhs)
+            if rhs == 0 {
+                Err(Error::DivZero(rhs_span))
+            } else {
+                Ok(Value::Int(val.wrapping_rem(rhs)))
+            }
         }
         Value::Double(val) => {
             let rhs = rhs_val.unwrap_double();
-            Value::Double(val % rhs)
+            if rhs == 0.0 {
+                Err(Error::DivZero(rhs_span))
+            } else {
+                Ok(Value::Double(val % rhs))
+            }
         }
         _ => panic!("value should support mod"),
     }
@@ -1679,7 +1692,7 @@ fn eval_binop_mul(lhs_val: Value, rhs_val: Value) -> Value {
         }
         Value::Int(val) => {
             let rhs = rhs_val.unwrap_int();
-            Value::Int(val * rhs)
+            Value::Int(val.wrapping_mul(rhs))
         }
         Value::Double(val) => {
             let rhs = rhs_val.unwrap_double();
@@ -1716,9 +1729,9 @@ fn eval_binop_shl(lhs_val: Value, rhs_val: Value) -> Value {
         Value::Int(val) => {
             let rhs = rhs_val.unwrap_int();
             if rhs > 0 {
-                Value::Int(val << rhs)
+                Value::Int(val.wrapping_shl(rhs as u32))
             } else {
-                Value::Int(val >> rhs.abs())
+                Value::Int(val.wrapping_shr(rhs.wrapping_abs() as u32))
             }
         }
         _ => panic!("value should support shl"),
@@ -1738,9 +1751,9 @@ fn eval_binop_shr(lhs_val: Value, rhs_val: Value) -> Value {
         Value::Int(val) => {
             let rhs = rhs_val.unwrap_int();
             if rhs > 0 {
-                Value::Int(val >> rhs)
+                Value::Int(val.wrapping_shr(rhs as u32))
             } else {
-                Value::Int(val << rhs.abs())
+                Value::Int(val.wrapping_shl(rhs.wrapping_abs() as u32))
             }
         }
         _ => panic!("value should support shr"),
@@ -1759,7 +1772,7 @@ fn eval_binop_sub(lhs_val: Value, rhs_val: Value) -> Value {
         }
         Value::Int(val) => {
             let rhs = rhs_val.unwrap_int();
-            Value::Int(val - rhs)
+            Value::Int(val.wrapping_sub(rhs))
         }
         _ => panic!("value is not subtractable"),
     }

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -483,8 +483,9 @@ fn binop_add_int() {
 #[test]
 fn binop_add_int_wrap() {
     check_expr(
-        "", "0x7FFFFFFFFFFFFFFF + 1",
-        &expect!["-9223372036854775808"]
+        "",
+        "0x7FFFFFFFFFFFFFFF + 1",
+        &expect!["-9223372036854775808"],
     );
 }
 
@@ -575,8 +576,9 @@ fn binop_div_int() {
 #[test]
 fn binop_div_int_wrap() {
     check_expr(
-        "", "(-0x8000000000000000) / (-1)",
-        &expect!["-9223372036854775808"]
+        "",
+        "(-0x8000000000000000) / (-1)",
+        &expect!["-9223372036854775808"],
     );
 }
 
@@ -1069,10 +1071,7 @@ fn binop_mod_int() {
 
 #[test]
 fn binop_mod_int_wrap() {
-    check_expr(
-        "", "(-0x8000000000000000) % (-1)",
-        &expect!["0"]
-    );
+    check_expr("", "(-0x8000000000000000) % (-1)", &expect!["0"]);
 }
 
 #[test]
@@ -1140,9 +1139,10 @@ fn binop_mul_int() {
 #[test]
 fn binop_mul_int_wrap() {
     check_expr(
-        "", "0x7FFFFFFFFFFFFFFF * 0xFF",
-        &expect!["9223372036854775553"]
-    )
+        "",
+        "0x7FFFFFFFFFFFFFFF * 0xFF",
+        &expect!["9223372036854775553"],
+    );
 }
 
 #[test]
@@ -1355,9 +1355,10 @@ fn binop_sub_int() {
 #[test]
 fn binop_sub_int_wrap() {
     check_expr(
-        "", "-0x8000000000000000 - 1",
-        &expect!["9223372036854775807"]
-    )
+        "",
+        "-0x8000000000000000 - 1",
+        &expect!["9223372036854775807"],
+    );
 }
 
 #[test]

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -1311,9 +1311,34 @@ fn binop_shl_int_negative() {
 }
 
 #[test]
-fn binop_shl_int_wrap() {
-    check_expr("", "5<<<65", &expect!["10"]);
-    check_expr("", "5<<<(-0x8000000000000000)", &expect!["5"]);
+fn binop_shl_int_truncate() {
+    check_expr("", "1 <<< 63", &expect!["-9223372036854775808"]);
+    check_expr("", "2 <<< 63", &expect!["0"]);
+}
+
+#[test]
+fn binop_shl_int_overflow() {
+    check_expr(
+        "",
+        "1 <<< 64",
+        &expect![[r#"
+            (
+                IntTooLarge(
+                    64,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 6,
+                            hi: 8,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
 }
 
 #[test]
@@ -1337,9 +1362,34 @@ fn binop_shr_int_negative() {
 }
 
 #[test]
-fn binop_shr_int_wrap() {
-    check_expr("", "5>>>65", &expect!["2"]);
-    check_expr("", "5>>>(-0x8000000000000000)", &expect!["5"]);
+fn binop_shr_int_truncate() {
+    check_expr("", "(-9223372036854775808) >>> 63", &expect!["-1"]);
+    check_expr("", "1 >>> 63", &expect!["0"]);
+}
+
+#[test]
+fn binop_shr_int_overflow() {
+    check_expr(
+        "",
+        "1 >>> 64",
+        &expect![[r#"
+            (
+                IntTooLarge(
+                    64,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 6,
+                            hi: 8,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
 }
 
 #[test]

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -481,6 +481,14 @@ fn binop_add_int() {
 }
 
 #[test]
+fn binop_add_int_wrap() {
+    check_expr(
+        "", "0x7FFFFFFFFFFFFFFF + 1",
+        &expect!["-9223372036854775808"]
+    );
+}
+
+#[test]
 fn binop_add_string() {
     check_expr("", r#""Hello," + " World!""#, &expect!["Hello, World!"]);
 }
@@ -562,6 +570,14 @@ fn binop_div_bigint_zero() {
 #[test]
 fn binop_div_int() {
     check_expr("", "12 / 3", &expect!["4"]);
+}
+
+#[test]
+fn binop_div_int_wrap() {
+    check_expr(
+        "", "(-0x8000000000000000) / (-1)",
+        &expect!["-9223372036854775808"]
+    );
 }
 
 #[test]
@@ -843,6 +859,31 @@ fn binop_exp_int_negative_exp() {
 }
 
 #[test]
+fn binop_exp_int_too_large() {
+    check_expr(
+        "",
+        "100^50",
+        &expect![[r#"
+            (
+                IntTooLarge(
+                    50,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 4,
+                            hi: 6,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
+}
+
+#[test]
 fn binop_gt_bigint() {
     check_expr("", "23L > 3L", &expect!["true"]);
 }
@@ -998,13 +1039,93 @@ fn binop_mod_bigint() {
 }
 
 #[test]
+fn binop_mod_bigint_zero() {
+    check_expr(
+        "",
+        "12L % 0L",
+        &expect![[r#"
+            (
+                DivZero(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 6,
+                            hi: 8,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
+}
+
+#[test]
 fn binop_mod_int() {
     check_expr("", "8 % 6", &expect!["2"]);
 }
 
 #[test]
+fn binop_mod_int_wrap() {
+    check_expr(
+        "", "(-0x8000000000000000) % (-1)",
+        &expect!["0"]
+    );
+}
+
+#[test]
+fn binop_mod_int_zero() {
+    check_expr(
+        "",
+        "12 % 0",
+        &expect![[r#"
+            (
+                DivZero(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 5,
+                            hi: 6,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
+}
+
+#[test]
 fn binop_mod_double() {
     check_expr("", "8.411 % 6.833", &expect!["1.5779999999999994"]);
+}
+
+#[test]
+fn binop_mod_double_zero() {
+    check_expr(
+        "",
+        "1.2 % 0.0",
+        &expect![[r#"
+            (
+                DivZero(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 6,
+                            hi: 9,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
 }
 
 #[test]
@@ -1015,6 +1136,13 @@ fn binop_mul_bigint() {
 #[test]
 fn binop_mul_int() {
     check_expr("", "8 * 6", &expect!["48"]);
+}
+#[test]
+fn binop_mul_int_wrap() {
+    check_expr(
+        "", "0x7FFFFFFFFFFFFFFF * 0xFF",
+        &expect!["9223372036854775553"]
+    )
 }
 
 #[test]
@@ -1183,6 +1311,12 @@ fn binop_shl_int_negative() {
 }
 
 #[test]
+fn binop_shl_int_wrap() {
+    check_expr("", "5<<<65", &expect!["10"]);
+    check_expr("", "5<<<(-0x8000000000000000)", &expect!["5"]);
+}
+
+#[test]
 fn binop_shr_bigint() {
     check_expr("", "4L >>> 2", &expect!["1"]);
 }
@@ -1203,6 +1337,12 @@ fn binop_shr_int_negative() {
 }
 
 #[test]
+fn binop_shr_int_wrap() {
+    check_expr("", "5>>>65", &expect!["2"]);
+    check_expr("", "5>>>(-0x8000000000000000)", &expect!["5"]);
+}
+
+#[test]
 fn binop_sub_bigint() {
     check_expr("", "4L - 2L", &expect!["2"]);
 }
@@ -1210,6 +1350,14 @@ fn binop_sub_bigint() {
 #[test]
 fn binop_sub_int() {
     check_expr("", "4 - 2", &expect!["2"]);
+}
+
+#[test]
+fn binop_sub_int_wrap() {
+    check_expr(
+        "", "-0x8000000000000000 - 1",
+        &expect!["9223372036854775807"]
+    )
 }
 
 #[test]

--- a/compiler/qsc_parse/src/expr/tests.rs
+++ b/compiler/qsc_parse/src/expr/tests.rs
@@ -45,13 +45,19 @@ fn lit_int_overflow_min() {
         "9_223_372_036_854_775_808",
         &expect!["Expr _id_ [0-25]: Lit: Int(-9223372036854775808)"],
     );
+}
 
+#[test]
+fn lit_int_overflow_min_hexadecimal() {
     check(
         expr,
         "0x8000000000000000",
         &expect!["Expr _id_ [0-18]: Lit: Int(-9223372036854775808)"],
     );
+}
 
+#[test]
+fn lit_int_overflow_min_binary() {
     check(
         expr,
         "0b1000000000000000000000000000000000000000000000000000000000000000",
@@ -76,7 +82,10 @@ fn lit_int_too_big() {
             )
         "#]],
     );
+}
 
+#[test]
+fn lit_int_too_big_hexadecimal() {
     check(
         expr,
         "0x8000000000000001",
@@ -92,7 +101,10 @@ fn lit_int_too_big() {
             )
         "#]],
     );
+}
 
+#[test]
+fn lit_int_too_big_binary() {
     check(
         expr,
         "0b1000000000000000000000000000000000000000000000000000000000000001",

--- a/compiler/qsc_parse/src/expr/tests.rs
+++ b/compiler/qsc_parse/src/expr/tests.rs
@@ -36,12 +36,26 @@ fn lit_int_max() {
 // NOTE: Since we need to support literals of value i64::MIN while also parsing the negative sign
 // as a unary operator, we need to allow one special case of overflow that is the absolute value
 // of i64::MIN. This will wrap to a negative value. See the `lit_int_min` test below.
+// To check for other issues with handling i64::MIN, hexadecimal and binary literals
+// of i64::MIN also need to be tested.
 #[test]
 fn lit_int_overflow_min() {
     check(
         expr,
         "9_223_372_036_854_775_808",
         &expect!["Expr _id_ [0-25]: Lit: Int(-9223372036854775808)"],
+    );
+
+    check(
+        expr,
+        "0x8000000000000000",
+        &expect!["Expr _id_ [0-18]: Lit: Int(-9223372036854775808)"],
+    );
+
+    check(
+        expr,
+        "0b1000000000000000000000000000000000000000000000000000000000000000",
+        &expect!["Expr _id_ [0-66]: Lit: Int(-9223372036854775808)"],
     );
 }
 
@@ -57,6 +71,38 @@ fn lit_int_too_big() {
                     Span {
                         lo: 0,
                         hi: 25,
+                    },
+                ),
+            )
+        "#]],
+    );
+
+    check(
+        expr,
+        "0x8000000000000001",
+        &expect![[r#"
+            Error(
+                Lit(
+                    "integer",
+                    Span {
+                        lo: 0,
+                        hi: 18,
+                    },
+                ),
+            )
+        "#]],
+    );
+
+    check(
+        expr,
+        "0b1000000000000000000000000000000000000000000000000000000000000001",
+        &expect![[r#"
+            Error(
+                Lit(
+                    "integer",
+                    Span {
+                        lo: 0,
+                        hi: 66,
                     },
                 ),
             )

--- a/library/tests/src/test_math.rs
+++ b/library/tests/src/test_math.rs
@@ -68,8 +68,8 @@ fn check_abs_i() {
     test_expression("Microsoft.Quantum.Math.AbsI(1000)", &Value::Int(1000));
     test_expression("Microsoft.Quantum.Math.AbsI(-1000)", &Value::Int(1000));
     test_expression(
-        "Microsoft.Quantum.Math.AbsI(-0x8000000000000000)",
-        &Value::Int(-0x8000000000000000)
+        "Microsoft.Quantum.Math.AbsI(-0x8000_0000_0000_0000)",
+        &Value::Int(-0x8000_0000_0000_0000),
     );
 }
 

--- a/library/tests/src/test_math.rs
+++ b/library/tests/src/test_math.rs
@@ -67,6 +67,10 @@ fn check_abs_i() {
     test_expression("Microsoft.Quantum.Math.AbsI(0)", &Value::Int(0));
     test_expression("Microsoft.Quantum.Math.AbsI(1000)", &Value::Int(1000));
     test_expression("Microsoft.Quantum.Math.AbsI(-1000)", &Value::Int(1000));
+    test_expression(
+        "Microsoft.Quantum.Math.AbsI(-0x8000000000000000)",
+        &Value::Int(-0x8000000000000000)
+    );
 }
 
 #[test]


### PR DESCRIPTION
* Fixes #828, using wrapped arithmetic operations for the 64 bit ints, preventing panic in debug mode.
* Modulo by 0 now produces Error::DivZero rather than panicking
* Allow i64::MIN literals of any radix (not just decimal)
* Added relevant tests

Note: For consistency, wrapping_* methods are now  used for almost all arithmetic operations, except for exponentiation and shifting:
* In the case of exponentiation, the previous behavior was to produce Error::IntTooLarge for extremely large exponents (larger than u32::MAX).  I simply extended that behavior to always produce Error::IntTooLarge in case of overflow.  Since this error complains about the exponent, it could be misleading since `10000000^3` will say that 3 is too large, so you may want to consider changing this.  Alternatively, it might make more sense to instead implement 64-bit modular exponentiation, but I'm not sure what the desired behavior is.
* In the case of shifting, Error::IntTooLarge is produced when the shift is more than 63 bits (bits that fall off the end are still truncated).