### PR TITLE
Remove prerelease on rc builds for ext and jupyter

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -314,7 +314,7 @@ jobs:
       VSIX_FNAME=`ls $VSIX_RPATH`
       vsce publish --packagePath $VSIX_RPATH/$VSIX_FNAME 2>&1 > pub.log
     condition: and(succeeded(), neq(variables['BUILD_TYPE'], 'dev'))
-    displayName: Publish pre-release VSCode Extension
+    displayName: Publish VSCode Extension
     env:
       VSCE_PAT: $(PAT)
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -91,9 +91,15 @@ jobs:
       python build.py --wasm --npm --vscode
     displayName: Build VSCode Extension
 
-  # TODO: When the VSCode Extension is ready for publishing, remove the `--pre-release` flag for 'stable' BUILD_TYPE
   - script: |
       vsce package --pre-release
+    condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'dev'))
+    displayName: Pack pre-release VSCode Extension
+    workingDirectory: '$(System.DefaultWorkingDirectory)/vscode'
+
+  - script: |
+      vsce package
+    condition: and(succeeded(), neq(variables['BUILD_TYPE'], 'dev'))
     displayName: Pack VSCode Extension
     workingDirectory: '$(System.DefaultWorkingDirectory)/vscode'
 
@@ -294,12 +300,21 @@ jobs:
       npm install -g @vscode/vsce
     displayName: Install Prereqs for VSCode Ext Publishing
 
-  # TODO: When the VSCode Extension is ready for publishing, remove the `--pre-release` flag for 'stable' BUILD_TYPE
   - script: |
       VSIX_RPATH=../VSIX
       VSIX_FNAME=`ls $VSIX_RPATH`
       vsce publish --pre-release --packagePath $VSIX_RPATH/$VSIX_FNAME 2>&1 > pub.log
-    displayName: Publish VSCode Extension
+    condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'dev'))
+    displayName: Publish pre-release VSCode Extension
+    env:
+      VSCE_PAT: $(PAT)
+
+  - script: |
+      VSIX_RPATH=../VSIX
+      VSIX_FNAME=`ls $VSIX_RPATH`
+      vsce publish --packagePath $VSIX_RPATH/$VSIX_FNAME 2>&1 > pub.log
+    condition: and(succeeded(), neq(variables['BUILD_TYPE'], 'dev'))
+    displayName: Publish pre-release VSCode Extension
     env:
       VSCE_PAT: $(PAT)
 

--- a/version.py
+++ b/version.py
@@ -55,10 +55,12 @@ update_file(
     r'version = "{}"'.format(pip_version),
 )
 
+# Publish the jupyterlab extension without the 'pre-release' tagging for rc builds.
+# It is already stable and the prior publishing (and yanking) of release versions causes issues.
 update_file(
     os.path.join(root_dir, "jupyterlab/pyproject.toml"),
     r'version = "0.0.0"',
-    r'version = "{}"'.format(pip_version),
+    r'version = "{}"'.format(pip_version if BUILD_TYPE == "dev" else version_triple),
 )
 
 update_file(


### PR DESCRIPTION
Publish the RC builds of VS Code and qsharp-jupyterlab without the pre-release specifiers (until we get to the final 1.0 build)