### PR TITLE
Remove push trigger for main branch in CI and DevSkim workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI Build and Test
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   merge_group:

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -1,8 +1,6 @@
 name: DevSkim
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   merge_group:


### PR DESCRIPTION
Since we now use merge queues to handle ensuring up-to-date code is checked before going into main, there really isn't value in running these two pipelines after each merge to main. This change disables them for those scenarios and leaves them as part of PR and merge queue runs. After merge to main we still run playground publishing and fuzzing (if applicable).