### PR TITLE
Renaming QIR profile targets

### DIFF
--- a/compiler/qsc/benches/eval.rs
+++ b/compiler/qsc/benches/eval.rs
@@ -13,9 +13,13 @@ const LARGE: &str = include_str!("./large.qs");
 pub fn teleport(c: &mut Criterion) {
     c.bench_function("Teleport evaluation", |b| {
         let sources = SourceMap::new([("Teleportation.qs".into(), TELEPORT.into())], None);
-        let mut evaluator =
-            stateful::Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full)
-                .expect("code should compile");
+        let mut evaluator = stateful::Interpreter::new(
+            true,
+            sources,
+            PackageType::Exe,
+            TargetProfile::Unrestricted,
+        )
+        .expect("code should compile");
         b.iter(move || {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);
@@ -27,9 +31,13 @@ pub fn teleport(c: &mut Criterion) {
 pub fn deutsch_jozsa(c: &mut Criterion) {
     c.bench_function("Deutsch-Jozsa evaluation", |b| {
         let sources = SourceMap::new([("DeutschJozsa.qs".into(), DEUTSCHJOZSA.into())], None);
-        let mut evaluator =
-            stateful::Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full)
-                .expect("code should compile");
+        let mut evaluator = stateful::Interpreter::new(
+            true,
+            sources,
+            PackageType::Exe,
+            TargetProfile::Unrestricted,
+        )
+        .expect("code should compile");
         b.iter(move || {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);
@@ -41,9 +49,13 @@ pub fn deutsch_jozsa(c: &mut Criterion) {
 pub fn large_file(c: &mut Criterion) {
     c.bench_function("Large file parity evaluation", |b| {
         let sources = SourceMap::new([("large.qs".into(), LARGE.into())], None);
-        let mut evaluator =
-            stateful::Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full)
-                .expect("code should compile");
+        let mut evaluator = stateful::Interpreter::new(
+            true,
+            sources,
+            PackageType::Exe,
+            TargetProfile::Unrestricted,
+        )
+        .expect("code should compile");
         b.iter(move || {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);

--- a/compiler/qsc/benches/large.rs
+++ b/compiler/qsc/benches/large.rs
@@ -12,14 +12,14 @@ pub fn large_file(c: &mut Criterion) {
     c.bench_function("Large input file", |b| {
         b.iter(|| {
             let mut store = PackageStore::new(compile::core());
-            let std = store.insert(compile::std(&store, TargetProfile::Full));
+            let std = store.insert(compile::std(&store, TargetProfile::Unrestricted));
             let sources = SourceMap::new([("large.qs".into(), INPUT.into())], None);
             let (_, reports) = compile(
                 &store,
                 &[std],
                 sources,
                 PackageType::Exe,
-                TargetProfile::Full,
+                TargetProfile::Unrestricted,
             );
             assert!(reports.is_empty());
         })

--- a/compiler/qsc/benches/library.rs
+++ b/compiler/qsc/benches/library.rs
@@ -8,7 +8,7 @@ use qsc_frontend::compile::{PackageStore, TargetProfile};
 pub fn library(c: &mut Criterion) {
     let store = PackageStore::new(compile::core());
     c.bench_function("Standard library", |b| {
-        b.iter(|| compile::std(&store, TargetProfile::Full))
+        b.iter(|| compile::std(&store, TargetProfile::Unrestricted))
     });
 }
 

--- a/compiler/qsc/src/bin/qsc.rs
+++ b/compiler/qsc/src/bin/qsc.rs
@@ -68,7 +68,7 @@ fn main() -> miette::Result<ExitCode> {
     let (package_type, target) = if cli.emit.contains(&Emit::Qir) {
         (PackageType::Exe, TargetProfile::Base)
     } else {
-        (PackageType::Lib, TargetProfile::Full)
+        (PackageType::Lib, TargetProfile::Unrestricted)
     };
 
     if !cli.nostdlib {

--- a/compiler/qsc/src/bin/qsi.rs
+++ b/compiler/qsc/src/bin/qsi.rs
@@ -94,7 +94,7 @@ fn main() -> miette::Result<ExitCode> {
             !cli.nostdlib,
             SourceMap::new(sources, cli.entry.map(std::convert::Into::into)),
             PackageType::Exe,
-            TargetProfile::Full,
+            TargetProfile::Unrestricted,
         ) {
             Ok(interpreter) => interpreter,
             Err(errors) => {
@@ -113,7 +113,7 @@ fn main() -> miette::Result<ExitCode> {
         !cli.nostdlib,
         SourceMap::new(sources, None),
         PackageType::Lib,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     ) {
         Ok(interpreter) => interpreter,
         Err(errors) => {

--- a/compiler/qsc/src/interpret/debug/tests.rs
+++ b/compiler/qsc/src/interpret/debug/tests.rs
@@ -63,8 +63,13 @@ fn stack_traces_can_cross_eval_session_and_file_boundaries() {
         ],
         None,
     );
-    let mut interpreter = Interpreter::new(true, source_map, PackageType::Lib, TargetProfile::Full)
-        .expect("Failed to compile base environment.");
+    let mut interpreter = Interpreter::new(
+        true,
+        source_map,
+        PackageType::Lib,
+        TargetProfile::Unrestricted,
+    )
+    .expect("Failed to compile base environment.");
 
     let (result, _) = line(
         &mut interpreter,
@@ -132,8 +137,13 @@ fn stack_traces_can_cross_file_and_entry_boundaries() {
         ],
         Some("Adjoint Test2.A(0)".into()),
     );
-    let mut interpreter = Interpreter::new(true, source_map, PackageType::Exe, TargetProfile::Full)
-        .expect("Failed to compile base environment.");
+    let mut interpreter = Interpreter::new(
+        true,
+        source_map,
+        PackageType::Exe,
+        TargetProfile::Unrestricted,
+    )
+    .expect("Failed to compile base environment.");
 
     let (result, _) = eval(&mut interpreter);
 

--- a/compiler/qsc/src/interpret/stateful/stepping_tests.rs
+++ b/compiler/qsc/src/interpret/stateful/stepping_tests.rs
@@ -40,7 +40,7 @@ mod given_interpreter_with_sources {
         fn in_one_level_operation_works() -> Result<(), Vec<crate::interpret::stateful::Error>> {
             let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
             let mut interpreter =
-                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full)?;
+                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Unrestricted)?;
             interpreter.set_entry()?;
             let ids = get_breakpoint_ids(&interpreter, "test");
             let expected_id = ids[0];
@@ -60,7 +60,7 @@ mod given_interpreter_with_sources {
         fn next_crosses_operation_works() -> Result<(), Vec<crate::interpret::stateful::Error>> {
             let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
             let mut interpreter =
-                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full)?;
+                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Unrestricted)?;
             interpreter.set_entry()?;
             let ids = get_breakpoint_ids(&interpreter, "test");
             let expected_id = ids[0];
@@ -76,7 +76,7 @@ mod given_interpreter_with_sources {
         fn in_multiple_operations_works() -> Result<(), Vec<crate::interpret::stateful::Error>> {
             let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
             let mut interpreter =
-                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full)?;
+                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Unrestricted)?;
             interpreter.set_entry()?;
             let ids = get_breakpoint_ids(&interpreter, "test");
             let expected_id = ids[0];
@@ -99,7 +99,7 @@ mod given_interpreter_with_sources {
         fn out_multiple_operations_works() -> Result<(), Vec<crate::interpret::stateful::Error>> {
             let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
             let mut interpreter =
-                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full)?;
+                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Unrestricted)?;
             interpreter.set_entry()?;
             let ids = get_breakpoint_ids(&interpreter, "test");
             let expected_id = ids[0];

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -58,7 +58,7 @@ mod given_interpreter {
                     false,
                     SourceMap::default(),
                     PackageType::Lib,
-                    TargetProfile::Full,
+                    TargetProfile::Unrestricted,
                 )
                 .expect("interpreter should be created");
 
@@ -1062,7 +1062,7 @@ mod given_interpreter {
 
             let sources = SourceMap::new([("test".into(), source.into())], None);
             let mut interpreter =
-                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full)
+                Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Unrestricted)
                     .expect("interpreter should be created");
 
             let (result, output) = entry(&mut interpreter);
@@ -1080,7 +1080,7 @@ mod given_interpreter {
 
             let sources = SourceMap::new([("test".into(), source.into())], None);
             let mut interpreter =
-                Interpreter::new(true, sources, PackageType::Lib, TargetProfile::Full)
+                Interpreter::new(true, sources, PackageType::Lib, TargetProfile::Unrestricted)
                     .expect("interpreter should be created");
 
             let (result, output) = line(&mut interpreter, "Test.Main()");
@@ -1102,7 +1102,7 @@ mod given_interpreter {
 
             let sources = SourceMap::new([("test".into(), source.into())], None);
             let mut interpreter =
-                Interpreter::new(true, sources, PackageType::Lib, TargetProfile::Full)
+                Interpreter::new(true, sources, PackageType::Lib, TargetProfile::Unrestricted)
                     .expect("interpreter should be created");
 
             let (result, output) = line(&mut interpreter, "Test.Hello()");
@@ -1128,7 +1128,7 @@ mod given_interpreter {
 
             let sources = SourceMap::new([("test".into(), source.into())], None);
             let mut interpreter =
-                Interpreter::new(true, sources, PackageType::Lib, TargetProfile::Full)
+                Interpreter::new(true, sources, PackageType::Lib, TargetProfile::Unrestricted)
                     .expect("interpreter should be created");
             let (result, output) = line(&mut interpreter, "Test.Hello()");
             is_only_value(&result, &output, &Value::String("hello there...".into()));
@@ -1154,7 +1154,7 @@ mod given_interpreter {
             );
 
             let mut interpreter =
-                Interpreter::new(true, sources, PackageType::Lib, TargetProfile::Full)
+                Interpreter::new(true, sources, PackageType::Lib, TargetProfile::Unrestricted)
                     .expect("interpreter should be created");
             let (result, output) = entry(&mut interpreter);
             is_only_error(
@@ -1173,7 +1173,7 @@ mod given_interpreter {
             true,
             SourceMap::default(),
             PackageType::Lib,
-            TargetProfile::Full,
+            TargetProfile::Unrestricted,
         )
         .expect("interpreter should be created")
     }

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -196,26 +196,26 @@ fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Va
     let core_fir = fir_lowerer.lower_package(&core.package);
     let mut store = PackageStore::new(core);
 
-    let mut std = compile::std(&store, TargetProfile::Full);
+    let mut std = compile::std(&store, TargetProfile::Unrestricted);
     assert!(std.errors.is_empty());
     assert!(run_default_passes(
         store.core(),
         &mut std,
         PackageType::Lib,
-        TargetProfile::Full
+        TargetProfile::Unrestricted
     )
     .is_empty());
     let std_fir = fir_lowerer.lower_package(&std.package);
     let std_id = store.insert(std);
 
     let sources = SourceMap::new([("test".into(), file.into())], Some(expr.into()));
-    let mut unit = compile(&store, &[std_id], sources, TargetProfile::Full);
+    let mut unit = compile(&store, &[std_id], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty());
     assert!(run_default_passes(
         store.core(),
         &mut unit,
         PackageType::Lib,
-        TargetProfile::Full
+        TargetProfile::Unrestricted
     )
     .is_empty());
     let unit_fir = fir_lowerer.lower_package(&unit.package);

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -100,26 +100,26 @@ fn check_expr(file: &str, expr: &str, expect: &Expect) {
     let core_fir = fir_lowerer.lower_package(&core.package);
     let mut store = PackageStore::new(core);
 
-    let mut std = compile::std(&store, TargetProfile::Full);
+    let mut std = compile::std(&store, TargetProfile::Unrestricted);
     assert!(std.errors.is_empty());
     assert!(run_default_passes(
         store.core(),
         &mut std,
         PackageType::Lib,
-        TargetProfile::Full
+        TargetProfile::Unrestricted
     )
     .is_empty());
     let std_fir = fir_lowerer.lower_package(&std.package);
     let std_id = store.insert(std);
 
     let sources = SourceMap::new([("test".into(), file.into())], Some(expr.into()));
-    let mut unit = compile(&store, &[std_id], sources, TargetProfile::Full);
+    let mut unit = compile(&store, &[std_id], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
     let pass_errors = run_default_passes(
         store.core(),
         &mut unit,
         PackageType::Lib,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert!(pass_errors.is_empty(), "{pass_errors:?}");
     let unit_fir = fir_lowerer.lower_package(&unit.package);

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -37,7 +37,7 @@ use thiserror::Error;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TargetProfile {
-    Full,
+    Unrestricted,
     Base,
 }
 
@@ -45,7 +45,7 @@ impl TargetProfile {
     #[must_use]
     pub fn to_str(&self) -> &'static str {
         match self {
-            Self::Full => "Full",
+            Self::Unrestricted => "Unrestricted",
             Self::Base => "Base",
         }
     }
@@ -61,7 +61,7 @@ impl FromStr for TargetProfile {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "Full" => Ok(TargetProfile::Full),
+            "Unrestricted" => Ok(TargetProfile::Unrestricted),
             "Base" => Ok(Self::Base),
             _ => Err(()),
         }

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -69,7 +69,7 @@ fn one_file_no_entry() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
 
@@ -98,7 +98,7 @@ fn one_file_error() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     let errors: Vec<_> = unit
         .errors
@@ -141,7 +141,7 @@ fn two_files_dependency() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
 }
@@ -180,7 +180,7 @@ fn two_files_mutual_dependency() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
 }
@@ -217,7 +217,7 @@ fn two_files_error() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     let errors: Vec<_> = unit
         .errors
@@ -253,7 +253,7 @@ fn entry_call_operation() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
 
@@ -292,7 +292,7 @@ fn entry_error() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert_eq!(
         ("<entry>", Span { lo: 4, hi: 5 }),
@@ -334,7 +334,7 @@ fn replace_node() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
     Replacer.visit_package(&mut unit.package);
@@ -417,7 +417,7 @@ fn insert_core_call() {
     );
 
     let store = PackageStore::new(super::core());
-    let mut unit = compile(&store, &[], sources, TargetProfile::Full);
+    let mut unit = compile(&store, &[], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
     let mut inserter = Inserter { core: store.core() };
     inserter.visit_package(&mut unit.package);
@@ -463,7 +463,7 @@ fn package_dependency() {
         )],
         None,
     );
-    let unit1 = compile(&store, &[], sources1, TargetProfile::Full);
+    let unit1 = compile(&store, &[], sources1, TargetProfile::Unrestricted);
     assert!(unit1.errors.is_empty(), "{:#?}", unit1.errors);
     let package1 = store.insert(unit1);
 
@@ -481,7 +481,7 @@ fn package_dependency() {
         )],
         None,
     );
-    let unit2 = compile(&store, &[package1], sources2, TargetProfile::Full);
+    let unit2 = compile(&store, &[package1], sources2, TargetProfile::Unrestricted);
     assert!(unit2.errors.is_empty(), "{:#?}", unit2.errors);
 
     expect![[r#"
@@ -524,7 +524,7 @@ fn package_dependency_internal_error() {
         )],
         None,
     );
-    let unit1 = compile(&store, &[], sources1, TargetProfile::Full);
+    let unit1 = compile(&store, &[], sources1, TargetProfile::Unrestricted);
     assert!(unit1.errors.is_empty(), "{:#?}", unit1.errors);
     let package1 = store.insert(unit1);
 
@@ -542,7 +542,7 @@ fn package_dependency_internal_error() {
         )],
         None,
     );
-    let unit2 = compile(&store, &[package1], sources2, TargetProfile::Full);
+    let unit2 = compile(&store, &[package1], sources2, TargetProfile::Unrestricted);
 
     let errors: Vec<_> = unit2
         .errors
@@ -592,7 +592,7 @@ fn package_dependency_udt() {
         )],
         None,
     );
-    let unit1 = compile(&store, &[], sources1, TargetProfile::Full);
+    let unit1 = compile(&store, &[], sources1, TargetProfile::Unrestricted);
     assert!(unit1.errors.is_empty(), "{:#?}", unit1.errors);
     let package1 = store.insert(unit1);
 
@@ -610,7 +610,7 @@ fn package_dependency_udt() {
         )],
         None,
     );
-    let unit2 = compile(&store, &[package1], sources2, TargetProfile::Full);
+    let unit2 = compile(&store, &[package1], sources2, TargetProfile::Unrestricted);
     assert!(unit2.errors.is_empty(), "{:#?}", unit2.errors);
 
     expect![[r#"
@@ -655,7 +655,7 @@ fn package_dependency_nested_udt() {
         )],
         None,
     );
-    let unit1 = compile(&store, &[], sources1, TargetProfile::Full);
+    let unit1 = compile(&store, &[], sources1, TargetProfile::Unrestricted);
     assert!(unit1.errors.is_empty(), "{:#?}", unit1.errors);
     let package1 = store.insert(unit1);
 
@@ -678,7 +678,7 @@ fn package_dependency_nested_udt() {
         )],
         None,
     );
-    let unit2 = compile(&store, &[package1], sources2, TargetProfile::Full);
+    let unit2 = compile(&store, &[package1], sources2, TargetProfile::Unrestricted);
     assert!(unit2.errors.is_empty(), "{:#?}", unit2.errors);
 
     expect![[r#"
@@ -733,7 +733,7 @@ fn package_dependency_nested_udt() {
 #[test]
 fn std_dependency() {
     let mut store = PackageStore::new(super::core());
-    let std = store.insert(super::std(&store, TargetProfile::Full));
+    let std = store.insert(super::std(&store, TargetProfile::Unrestricted));
     let sources = SourceMap::new(
         [(
             "test".into(),
@@ -752,7 +752,7 @@ fn std_dependency() {
         Some("Foo.Main()".into()),
     );
 
-    let unit = compile(&store, &[std], sources, TargetProfile::Full);
+    let unit = compile(&store, &[std], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
 }
 
@@ -785,7 +785,7 @@ fn std_dependency_base_profile() {
 #[test]
 fn introduce_prelude_ambiguity() {
     let mut store = PackageStore::new(super::core());
-    let std = store.insert(super::std(&store, TargetProfile::Full));
+    let std = store.insert(super::std(&store, TargetProfile::Unrestricted));
     let sources = SourceMap::new(
         [(
             "test".into(),
@@ -800,7 +800,7 @@ fn introduce_prelude_ambiguity() {
         Some("Foo.Main()".into()),
     );
 
-    let unit = compile(&store, &[std], sources, TargetProfile::Full);
+    let unit = compile(&store, &[std], sources, TargetProfile::Unrestricted);
     let errors: Vec<Error> = unit.errors;
     assert!(
         errors.len() == 1
@@ -827,7 +827,7 @@ fn entry_parse_error() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
 
     assert_eq!(
@@ -858,7 +858,7 @@ fn two_files_error_eof() {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     let errors: Vec<_> = unit
         .errors

--- a/compiler/qsc_frontend/src/incremental/tests.rs
+++ b/compiler/qsc_frontend/src/incremental/tests.rs
@@ -14,7 +14,7 @@ use std::fmt::Write;
 #[test]
 fn one_callable() {
     let store = PackageStore::new(compile::core());
-    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Full);
+    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Unrestricted);
     let unit = compiler
         .compile_fragments(
             &mut CompileUnit::default(),
@@ -62,7 +62,7 @@ fn one_callable() {
 #[test]
 fn one_statement() {
     let store = PackageStore::new(compile::core());
-    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Full);
+    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Unrestricted);
     let unit = compiler
         .compile_fragments(
             &mut CompileUnit::default(),
@@ -96,7 +96,7 @@ fn one_statement() {
 #[test]
 fn parse_error() {
     let store = PackageStore::new(compile::core());
-    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Full);
+    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Unrestricted);
     let errors = compiler
         .compile_fragments(&mut CompileUnit::default(), "test_1", "}}", fail_on_error)
         .expect_err("should fail");
@@ -136,7 +136,7 @@ fn parse_error() {
 #[test]
 fn conditional_compilation_not_available() {
     let store = PackageStore::new(compile::core());
-    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Full);
+    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Unrestricted);
     let errors = compiler
         .compile_fragments(
             &mut CompileUnit::default(),
@@ -159,9 +159,9 @@ fn conditional_compilation_not_available() {
 #[test]
 fn errors_across_multiple_lines() {
     let mut store = PackageStore::new(compile::core());
-    let std = compile::std(&store, TargetProfile::Full);
+    let std = compile::std(&store, TargetProfile::Unrestricted);
     let std_id = store.insert(std);
-    let mut compiler = Compiler::new(&store, [std_id], TargetProfile::Full);
+    let mut compiler = Compiler::new(&store, [std_id], TargetProfile::Unrestricted);
     let mut unit = CompileUnit::default();
     compiler
         .compile_fragments(
@@ -225,7 +225,7 @@ fn errors_across_multiple_lines() {
 #[test]
 fn continue_after_parse_error() {
     let store = PackageStore::new(compile::core());
-    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Full);
+    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Unrestricted);
     let mut errors = Vec::new();
 
     compiler
@@ -296,7 +296,7 @@ fn continue_after_parse_error() {
 #[test]
 fn continue_after_lower_error() {
     let store = PackageStore::new(compile::core());
-    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Full);
+    let mut compiler = Compiler::new(&store, vec![], TargetProfile::Unrestricted);
     let mut unit = CompileUnit::default();
 
     let mut errors = Vec::new();

--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -225,9 +225,10 @@ impl With<'_> {
                 if matches!(inner.kind.as_ref(), ast::ExprKind::Path(path)
                     if TargetProfile::is_target_str(path.name.name.as_ref())))
             {
-                self.lowerer
-                    .errors
-                    .push(Error::InvalidAttrArgs("Full or Base", attr.arg.span));
+                self.lowerer.errors.push(Error::InvalidAttrArgs(
+                    "Unrestricted or Base",
+                    attr.arg.span,
+                ));
             }
             None
         } else {

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -11,7 +11,7 @@ fn check_hir(input: &str, expect: &Expect) {
         &PackageStore::new(compile::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     expect.assert_eq(&unit.package.to_string());
 }
@@ -22,7 +22,7 @@ fn check_errors(input: &str, expect: &Expect) {
         &PackageStore::new(compile::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
 
     let lower_errors: Vec<_> = unit
@@ -106,7 +106,7 @@ fn test_target_profile_full_attr_allowed() {
     check_errors(
         indoc! {"
             namespace input {
-                @Config(Full)
+                @Config(Unrestricted)
                 operation Foo() : Unit {
                     body ... {}
                 }
@@ -132,7 +132,7 @@ fn test_target_profile_attr_wrong_args() {
         &expect![[r#"
             [
                 InvalidAttrArgs(
-                    "Full or Base",
+                    "Unrestricted or Base",
                     Span {
                         lo: 29,
                         hi: 34,

--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -217,7 +217,7 @@ impl Resolver {
         self.dropped_names.extend(dropped_names);
     }
 
-    pub(super) fn bind_fragments(&mut self, ast: &mut ast::Package, assigner: &mut Assigner) {
+    pub(super) fn bind_fragments(&mut self, ast: &ast::Package, assigner: &mut Assigner) {
         for node in &mut ast.nodes.iter() {
             match node {
                 ast::TopLevelNode::Namespace(namespace) => {

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -95,7 +95,8 @@ fn compile(input: &str) -> (Package, Names, Vec<Error>) {
 
     AstAssigner::new().visit_package(&mut package);
 
-    let mut cond_compile = compile::preprocess::Conditional::new(compile::TargetProfile::Full);
+    let mut cond_compile =
+        compile::preprocess::Conditional::new(compile::TargetProfile::Unrestricted);
     cond_compile.visit_package(&mut package);
     let dropped_names = cond_compile.into_names();
 
@@ -1937,13 +1938,13 @@ fn multiple_definition_dropped_is_not_found() {
     check(
         indoc! {"
             namespace A {
-                @Config(Full)
+                @Config(Unrestricted)
                 operation B() : Unit {}
                 @Config(Base)
                 operation B() : Unit {}
                 @Config(Base)
                 operation C() : Unit {}
-                @Config(Full)
+                @Config(Unrestricted)
                 operation C() : Unit {}
             }
             namespace D {
@@ -1960,13 +1961,13 @@ fn multiple_definition_dropped_is_not_found() {
         "},
         &expect![[r#"
             namespace item0 {
-                @Config(Full)
+                @Config(Unrestricted)
                 operation item1() : Unit {}
                 @Config(Base)
                 operation B() : Unit {}
                 @Config(Base)
                 operation C() : Unit {}
-                @Config(Full)
+                @Config(Unrestricted)
                 operation item2() : Unit {}
             }
             namespace item3 {
@@ -1981,8 +1982,8 @@ fn multiple_definition_dropped_is_not_found() {
                 }
             }
 
-            // NotFound("B", Span { lo: 249, hi: 250 })
-            // NotFound("C", Span { lo: 262, hi: 263 })
+            // NotFound("B", Span { lo: 265, hi: 266 })
+            // NotFound("C", Span { lo: 278, hi: 279 })
         "#]],
     );
 }

--- a/compiler/qsc_passes/src/baseprofck/tests.rs
+++ b/compiler/qsc_passes/src/baseprofck/tests.rs
@@ -9,9 +9,9 @@ use crate::baseprofck::check_base_profile_compliance;
 
 fn check(expr: &str, expect: &Expect) {
     let mut store = PackageStore::new(compile::core());
-    let std = store.insert(compile::std(&store, TargetProfile::Full));
+    let std = store.insert(compile::std(&store, TargetProfile::Unrestricted));
     let sources = SourceMap::new([("test".into(), "".into())], Some(expr.into()));
-    let unit = compile(&store, &[std], sources, TargetProfile::Full);
+    let unit = compile(&store, &[std], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 
     let errors = check_base_profile_compliance(&unit.package);

--- a/compiler/qsc_passes/src/borrowck/tests.rs
+++ b/compiler/qsc_passes/src/borrowck/tests.rs
@@ -11,7 +11,7 @@ use crate::borrowck::Checker;
 fn check(expr: &str, expect: &Expect) {
     let store = PackageStore::new(compile::core());
     let sources = SourceMap::new([("test".into(), "".into())], Some(expr.into()));
-    let unit = compile(&store, &[], sources, TargetProfile::Full);
+    let unit = compile(&store, &[], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 
     let mut borrow_check = Checker::default();

--- a/compiler/qsc_passes/src/callable_limits/tests.rs
+++ b/compiler/qsc_passes/src/callable_limits/tests.rs
@@ -11,7 +11,7 @@ use crate::callable_limits::CallableLimits;
 fn check(file: &str, expect: &Expect) {
     let store = PackageStore::new(compile::core());
     let sources = SourceMap::new([("test".into(), file.into())], None);
-    let unit = compile(&store, &[], sources, TargetProfile::Full);
+    let unit = compile(&store, &[], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 
     let mut call_limits = CallableLimits::default();

--- a/compiler/qsc_passes/src/conjugate_invert/tests.rs
+++ b/compiler/qsc_passes/src/conjugate_invert/tests.rs
@@ -13,7 +13,7 @@ use crate::conjugate_invert::invert_conjugate_exprs;
 fn check(file: &str, expect: &Expect) {
     let store = PackageStore::new(compile::core());
     let sources = SourceMap::new([("test".into(), file.into())], None);
-    let mut unit = compile(&store, &[], sources, TargetProfile::Full);
+    let mut unit = compile(&store, &[], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 
     let errors = invert_conjugate_exprs(store.core(), &mut unit.package, &mut unit.assigner);

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -12,7 +12,7 @@ fn check(file: &str, expr: &str, expect: &Expect) {
         &PackageStore::new(compile::core()),
         &[],
         sources,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 

--- a/compiler/qsc_passes/src/invert_block.rs
+++ b/compiler/qsc_passes/src/invert_block.rs
@@ -80,7 +80,7 @@ impl<'a> MutVisitor for BlockInverter<'a> {
 }
 
 impl<'a> BlockInverter<'a> {
-    fn reverse_loop(&mut self, pat: &mut Pat, iterable: &mut Expr, block: &mut Block) -> Expr {
+    fn reverse_loop(&mut self, pat: &Pat, iterable: &Expr, block: &Block) -> Expr {
         let mut wrapper = Block {
             id: NodeId::default(),
             span: Span::default(),
@@ -209,9 +209,9 @@ impl<'a> BlockInverter<'a> {
     fn reverse_range_loop(
         &mut self,
         wrapper: &mut Block,
-        iterable: &mut Expr,
-        pat: &mut Pat,
-        block: &mut Block,
+        iterable: &Expr,
+        pat: &Pat,
+        block: &Block,
     ) {
         // Create a new binding for the range expr.
         let new_range_id = self.assigner.next_node();

--- a/compiler/qsc_passes/src/logic_sep/tests.rs
+++ b/compiler/qsc_passes/src/logic_sep/tests.rs
@@ -27,12 +27,12 @@ impl<'a> Visitor<'a> for StmtSpans {
 
 fn check(block_str: &str, expect: &Expect) {
     let mut store = PackageStore::new(compile::core());
-    let std = store.insert(compile::std(&store, TargetProfile::Full));
+    let std = store.insert(compile::std(&store, TargetProfile::Unrestricted));
     let unit = compile(
         &store,
         &[std],
         SourceMap::new([], Some(block_str.into())),
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 

--- a/compiler/qsc_passes/src/loop_unification/tests.rs
+++ b/compiler/qsc_passes/src/loop_unification/tests.rs
@@ -13,7 +13,7 @@ use crate::loop_unification::LoopUni;
 fn check(file: &str, expect: &Expect) {
     let store = PackageStore::new(compile::core());
     let sources = SourceMap::new([("test".into(), file.into())], None);
-    let mut unit = compile(&store, &[], sources, TargetProfile::Full);
+    let mut unit = compile(&store, &[], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
     LoopUni {
         core: store.core(),

--- a/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
@@ -10,7 +10,7 @@ use qsc_hir::{mut_visit::MutVisitor, validate::Validator, visit::Visitor};
 fn check(file: &str, expect: &Expect) {
     let store = PackageStore::new(compile::core());
     let sources = SourceMap::new([("test".into(), file.into())], None);
-    let mut unit = compile(&store, &[], sources, TargetProfile::Full);
+    let mut unit = compile(&store, &[], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
     ReplaceQubitAllocation::new(store.core(), &mut unit.assigner).visit_package(&mut unit.package);
     Validator::default().visit_package(&unit.package);

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -13,7 +13,7 @@ use crate::spec_gen::generate_specs;
 fn check(file: &str, expect: &Expect) {
     let store = PackageStore::new(compile::core());
     let sources = SourceMap::new([("test".into(), file.into())], None);
-    let mut unit = compile(&store, &[], sources, TargetProfile::Full);
+    let mut unit = compile(&store, &[], sources, TargetProfile::Unrestricted);
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
 
     let errors = generate_specs(store.core(), &mut unit.package, &mut unit.assigner);

--- a/fuzz/fuzz_targets/compile.rs
+++ b/fuzz/fuzz_targets/compile.rs
@@ -12,7 +12,7 @@ fn compile(data: &[u8]) {
         thread_local! {
             static STORE_STD: (PackageStore, PackageId) = {
                 let mut store = PackageStore::new(qsc::compile::core());
-                let std = store.insert(qsc::compile::std(&store, TargetProfile::Full));
+                let std = store.insert(qsc::compile::std(&store, TargetProfile::Unrestricted));
                 (store, std)
             };
         }
@@ -23,7 +23,7 @@ fn compile(data: &[u8]) {
                 &[*std],
                 sources,
                 qsc::PackageType::Lib,
-                TargetProfile::Full,
+                TargetProfile::Unrestricted,
             );
         });
     }

--- a/katas/src/lib.rs
+++ b/katas/src/lib.rs
@@ -32,8 +32,12 @@ pub fn check_solution(
     receiver: &mut impl Receiver,
 ) -> Result<bool, Vec<stateful::Error>> {
     let source_map = SourceMap::new(exercise_sources, Some(EXERCISE_ENTRY.into()));
-    let mut interpreter: Interpreter =
-        Interpreter::new(true, source_map, PackageType::Exe, TargetProfile::Full)?;
+    let mut interpreter: Interpreter = Interpreter::new(
+        true,
+        source_map,
+        PackageType::Exe,
+        TargetProfile::Unrestricted,
+    )?;
     interpreter.eval_entry(receiver).map(|value| {
         if let Value::Bool(success) = value {
             success

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -48,7 +48,7 @@ struct WorkspaceConfiguration {
 impl Default for WorkspaceConfiguration {
     fn default() -> Self {
         Self {
-            target_profile: TargetProfile::Full,
+            target_profile: TargetProfile::Unrestricted,
             package_type: PackageType::Exe,
         }
     }

--- a/language_service/src/test_utils.rs
+++ b/language_service/src/test_utils.rs
@@ -70,7 +70,7 @@ pub(crate) fn compile_with_fake_stdlib(source_name: &str, source_contents: &str)
         &[PackageId::CORE],
         std_source_map,
         PackageType::Lib,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     assert!(std_errors.is_empty());
     let std_package_id = package_store.insert(std_compile_unit);
@@ -80,7 +80,7 @@ pub(crate) fn compile_with_fake_stdlib(source_name: &str, source_contents: &str)
         &[std_package_id],
         source_map,
         PackageType::Exe,
-        TargetProfile::Full,
+        TargetProfile::Unrestricted,
     );
     Compilation {
         package_store,

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -180,7 +180,7 @@ fn target_profile_update_fixes_error() {
     );
 
     ls.update_configuration(&WorkspaceConfigurationUpdate {
-        target_profile: Some(TargetProfile::Full),
+        target_profile: Some(TargetProfile::Unrestricted),
         package_type: None,
     });
 

--- a/library/std/arithmetic.qs
+++ b/library/std/arithmetic.qs
@@ -75,7 +75,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// # Remarks
     /// This operation resets its input register to the |00...0> state,
     /// suitable for releasing back to a target machine.
-    @Config(Full)
+    @Config(Unrestricted)
     operation MeasureInteger(target : Qubit[]) : Int {
         let nBits = Length(target);
         Fact(nBits < 64, $"`Length(target)` must be less than 64, but was {nBits}.");
@@ -342,7 +342,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// Length(ys) = n > 0, c is a BigInt number, 0 ≤ c < 2ⁿ.
     /// NOTE: Use RippleCarryIncByL directly if the choice of implementation
     /// is important.
-    @Config(Full)
+    @Config(Unrestricted)
     operation IncByL (c : BigInt, ys : Qubit[]) : Unit is Adj + Ctl {
         RippleCarryIncByL(c, ys);
     }
@@ -355,7 +355,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// and Length(xs) ≤ Length(ys) = n.
     /// NOTE: Use RippleCarryIncByLE or LookAheadIncByLE directly if
     /// the choice of implementation is important.
-    @Config(Full)
+    @Config(Unrestricted)
     operation IncByLE (xs : Qubit[], ys : Qubit[]) : Unit is Adj + Ctl {
         RippleCarryIncByLE(xs, ys);
     }
@@ -369,7 +369,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// Length(xs) = Length(ys) ≤ Length(zs) = n, assuming zs is 0-initialized.
     /// NOTE: Use RippleCarryAddLE or LookAheadAddLE directly if
     /// the choice of implementation is important.
-    @Config(Full)
+    @Config(Unrestricted)
     operation AddLE (xs : Qubit[], ys : Qubit[], zs : Qubit[]) : Unit is Adj {
         RippleCarryAddLE(xs, ys, zs);
     }
@@ -386,7 +386,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// # Reference
     ///     - [arXiv:1709.06648](https://arxiv.org/pdf/1709.06648.pdf)
     ///       "Halving the cost of quantum addition" by Craig Gidney.
-    @Config(Full)
+    @Config(Unrestricted)
     operation RippleCarryIncByL (c : BigInt, ys : Qubit[]) : Unit is Adj + Ctl {
         let ysLen = Length(ys);
         Fact(ysLen > 0, "Length of `ys` must be at least 1.");
@@ -422,7 +422,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// # Reference
     ///     - [arXiv:1709.06648](https://arxiv.org/pdf/1709.06648.pdf)
     ///       "Halving the cost of quantum addition" by Craig Gidney.
-    @Config(Full)
+    @Config(Unrestricted)
     operation RippleCarryIncByLE (xs : Qubit[], ys : Qubit[]) : Unit is Adj + Ctl {
         let xsLen = Length(xs);
         let ysLen = Length(ys);
@@ -457,7 +457,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// Sets a zero-initialized little-endian register zs to the sum of
     /// little-endian registers xs and ys using the ripple-carry algorithm.
     ///
-    /// # Description 
+    /// # Description
     /// Computes zs := xs + ys + zs[0] modulo 2ⁿ, where xs, ys, and zs are
     /// little-endian registers, Length(xs) = Length(ys) ≤ Length(zs) = n,
     /// assuming zs is 0-initialized, except for maybe zs[0], which can be
@@ -468,7 +468,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// # Reference
     ///     - [arXiv:1709.06648](https://arxiv.org/pdf/1709.06648.pdf)
     ///       "Halving the cost of quantum addition" by Craig Gidney.
-    @Config(Full)
+    @Config(Unrestricted)
     operation RippleCarryAddLE (xs : Qubit[], ys : Qubit[], zs : Qubit[]) : Unit is Adj {
         let xsLen = Length(xs);
         let zsLen = Length(zs);

--- a/library/std/arithmetic_internal.qs
+++ b/library/std/arithmetic_internal.qs
@@ -7,7 +7,7 @@ namespace Microsoft.Quantum.Arithmetic {
     open Microsoft.Quantum.Math;
 
     // Computes ys += xs + carryIn using a ripple carry architecture
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation IncWithCarryIn(carryIn : Qubit, xs : Qubit[], ys : Qubit[])
     : Unit is Adj + Ctl {
         // We assume that it has already been checked that xs and ys are of
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
     /// # Summary
     /// Implements Half-adder. Adds qubit x to qubit y and sets carryOut appropriately
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation HalfAdderForInc(x : Qubit, y : Qubit, carryOut : Qubit)
     : Unit is Adj + Ctl {
         body (...) {
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
     /// # Summary
     /// Implements Full-adder. Adds qubit carryIn and x to qubit y and sets carryOut appropriately.
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation FullAdderForInc(carryIn : Qubit, x : Qubit, y : Qubit, carryOut : Qubit)
     : Unit is Adj + Ctl {
         body (...) {
@@ -90,7 +90,7 @@ namespace Microsoft.Quantum.Arithmetic {
     }
 
     // Computes carryOut := carryIn + x + y
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation FullAdder(carryIn : Qubit, x : Qubit, y : Qubit, carryOut : Qubit)
     : Unit is Adj {
         CNOT(x, y);
@@ -103,7 +103,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
     /// # Summary
     /// Computes carry bit for a full adder.
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation CarryForInc(carryIn : Qubit, x : Qubit, y : Qubit, carryOut : Qubit)
     : Unit is Adj + Ctl {
         body (...) {
@@ -125,7 +125,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
     /// # Summary
     /// Uncomputes carry bit for a full adder.
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation UncarryForInc(carryIn : Qubit, x : Qubit, y : Qubit, carryOut : Qubit)
     : Unit is Adj + Ctl {
         body (...) {
@@ -153,7 +153,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// Applies AND gate between `control1` and `control2` and stores the result
     /// in `target` assuming `target` is in |0> state. This allows for an
     /// otimized adjoint implementation.
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation ApplyAndAssuming0Target(control1 : Qubit, control2 : Qubit, target: Qubit)
     : Unit is Adj {
         body (...) {

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool` representing the `input`.
-    @Config(Full)
+    @Config(Unrestricted)
     function ResultAsBool(input : Result) : Bool {
         input == One
     }
@@ -42,7 +42,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result` representing the `input`.
-    @Config(Full)
+    @Config(Unrestricted)
     function BoolAsResult(input : Bool) : Result {
         if input {One} else {Zero}
     }
@@ -112,7 +112,7 @@ namespace Microsoft.Quantum.Convert {
     /// // The following returns 1
     /// let int1 = ResultArrayAsInt([One,Zero])
     /// ```
-    @Config(Full)
+    @Config(Unrestricted)
     function ResultArrayAsInt(results : Result[]) : Int {
         let nBits = Length(results);
         Fact(nBits < 64, $"`Length(bits)` must be less than 64, but was {nBits}.");
@@ -137,7 +137,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool[]` representing the `input`.
-    @Config(Full)
+    @Config(Unrestricted)
     function ResultArrayAsBoolArray(input : Result[]) : Bool[] {
         mutable output = [];
         for r in input {
@@ -157,7 +157,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result[]` representing the `input`.
-    @Config(Full)
+    @Config(Unrestricted)
     function BoolArrayAsResultArray(input : Bool[]) : Result[] {
         mutable output = [];
         for b in input {

--- a/library/std/diagnostics.qs
+++ b/library/std/diagnostics.qs
@@ -8,12 +8,12 @@ namespace Microsoft.Quantum.Diagnostics {
         body intrinsic;
     }
 
-    @Config(Full)
+    @Config(Unrestricted)
     operation CheckZero(qubit : Qubit) : Bool {
         body intrinsic;
     }
 
-    @Config(Full)
+    @Config(Unrestricted)
     operation CheckAllZero(qubits : Qubit[]) : Bool {
         for q in qubits {
             if not CheckZero(q) {

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -226,7 +226,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// Measure([PauliZ], [qubit]);
     /// ```
-    @Config(Full)
+    @Config(Unrestricted)
     operation M(qubit : Qubit) : Result {
         __quantum__qis__m__body(qubit)
     }
@@ -298,7 +298,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// If the basis array and qubit array are different lengths, then the
     /// operation will fail.
-    @Config(Full)
+    @Config(Unrestricted)
     operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
         if Length(bases) != Length(qubits) {
             fail "Arrays 'bases' and 'qubits' must be of the same length.";

--- a/library/std/random.qs
+++ b/library/std/random.qs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let roll = DrawRandomInt(1, 6);
     /// ```
-    @Config(Full)
+    @Config(Unrestricted)
     operation DrawRandomInt(min : Int, max : Int) : Int {
         body intrinsic;
     }
@@ -50,7 +50,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let angle = DrawRandomDouble(0.0, 2.0 * PI());
     /// ```
-    @Config(Full)
+    @Config(Unrestricted)
     operation DrawRandomDouble(min : Double, max : Double) : Double {
         body intrinsic;
     }

--- a/library/tests/src/lib.rs
+++ b/library/tests/src/lib.rs
@@ -38,7 +38,7 @@ pub fn test_expression_with_lib(expr: &str, lib: &str, expected: &Value) {
     let sources = SourceMap::new([("test".into(), lib.into())], Some(expr.into()));
 
     let mut interpreter =
-        stateful::Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full)
+        stateful::Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Unrestricted)
             .expect("test should compile");
     let result = interpreter
         .eval_entry(&mut out)

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -12,11 +12,9 @@ class TargetProfile:
     The target profile is a description of a target's capabilities.
     """
 
-    Full: ClassVar[Any]
+    Unrestricted: ClassVar[Any]
     """
     Describes the full set of capabilities required to run any Q# program.
-
-    This option maps to the Full Profile as defined by the QIR specification.
     """
 
     Base: ClassVar[Any]

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -6,7 +6,7 @@ from ._native import Interpreter, TargetProfile
 _interpreter = None
 
 
-def init(target_profile: TargetProfile = TargetProfile.Full) -> None:
+def init(target_profile: TargetProfile = TargetProfile.Unrestricted) -> None:
     """
     Initializes the Q# interpreter.
 

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -39,10 +39,8 @@ fn _native(py: Python, m: &PyModule) -> PyResult<()> {
 /// A target profile describes the capabilities of the hardware or simulator
 /// which will be used to run the Q# program.
 pub(crate) enum TargetProfile {
-    /// Target supports the full set of capabilities required to run any Q# program.
-    ///
-    /// This option maps to the Full Profile as defined by the QIR specification.
-    Full,
+    /// Target supports the unrestricted set of capabilities required to run any Q# program.
+    Unrestricted,
     /// Target supports the minimal set of capabilities required to run a quantum program.
     ///
     /// This option maps to the Base Profile as defined by the QIR specification.
@@ -61,7 +59,7 @@ impl Interpreter {
     /// Initializes a new Q# interpreter.
     pub(crate) fn new(_py: Python, target: TargetProfile) -> PyResult<Self> {
         let target = match target {
-            TargetProfile::Full => qsc::TargetProfile::Full,
+            TargetProfile::Unrestricted => qsc::TargetProfile::Unrestricted,
             TargetProfile::Base => qsc::TargetProfile::Base,
         };
         match stateful::Interpreter::new(true, SourceMap::default(), PackageType::Lib, target) {

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -9,7 +9,7 @@ import pytest
 
 
 def test_output() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
 
     def callback(output):
         nonlocal called
@@ -22,7 +22,7 @@ def test_output() -> None:
 
 
 def test_dump_output() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
 
     def callback(output):
         nonlocal called
@@ -44,7 +44,7 @@ def test_dump_output() -> None:
 
 
 def test_error() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
 
     with pytest.raises(QSharpError) as excinfo:
         e.interpret("a864")
@@ -52,7 +52,7 @@ def test_error() -> None:
 
 
 def test_multiple_errors() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
 
     with pytest.raises(QSharpError) as excinfo:
         e.interpret("operation Foo() : Unit { Bar(); Baz(); }")
@@ -61,61 +61,61 @@ def test_multiple_errors() -> None:
 
 
 def test_multiple_statements() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret("1; Zero")
     assert value == Result.Zero
 
 
 def test_value_int() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret("5")
     assert value == 5
 
 
 def test_value_double() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret("3.1")
     assert value == 3.1
 
 
 def test_value_bool() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret("true")
     assert value == True
 
 
 def test_value_string() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret('"hello"')
     assert value == "hello"
 
 
 def test_value_result() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret("One")
     assert value == Result.One
 
 
 def test_value_pauli() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret("PauliX")
     assert value == Pauli.X
 
 
 def test_value_tuple() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret('(1, "hello", One)')
     assert value == (1, "hello", Result.One)
 
 
 def test_value_unit() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret("()")
     assert value is None
 
 
 def test_value_array() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
     value = e.interpret("[1, 2, 3]")
     assert value == [1, 2, 3]
 
@@ -136,7 +136,7 @@ def test_qirgen_compile_error() -> None:
 
 
 def test_error_spans_from_multiple_lines() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
 
     # Qsc.Resolve.Ambiguous is chosen as a test case
     # because it contains multiple spans which can be from different lines
@@ -156,7 +156,7 @@ def test_qirgen() -> None:
 
 
 def test_run_with_shots() -> None:
-    e = Interpreter(TargetProfile.Full)
+    e = Interpreter(TargetProfile.Unrestricted)
 
     def callback(output):
         nonlocal called

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -9,7 +9,7 @@ import io
 
 
 def test_stdout() -> None:
-    qsharp.init(target_profile=qsharp.TargetProfile.Full)
+    qsharp.init(target_profile=qsharp.TargetProfile.Unrestricted)
     f = io.StringIO()
     with redirect_stdout(f):
         result = qsharp.eval('Message("Hello, world!")')
@@ -19,7 +19,7 @@ def test_stdout() -> None:
 
 
 def test_stdout_multiple_lines() -> None:
-    qsharp.init(target_profile=qsharp.TargetProfile.Full)
+    qsharp.init(target_profile=qsharp.TargetProfile.Unrestricted)
     f = io.StringIO()
     with redirect_stdout(f):
         qsharp.eval(

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -97,13 +97,13 @@
       "properties": {
         "Q#.targetProfile": {
           "type": "string",
-          "default": "full",
+          "default": "unrestricted",
           "enum": [
-            "full",
+            "unrestricted",
             "base"
           ],
           "enumDescriptions": [
-            "The full set of capabilities required to run any Q# program. This option maps to the Full Profile as defined by the QIR specification.",
+            "The unrestricted set of capabilities required to run any Q# program.",
             "The minimal set of capabilities required to run a quantum program. This option maps to the Base Profile as defined by the QIR specification."
           ],
           "description": "Setting the target profile allows the Q# extension to generate programs that are compatible with a specific target. The target is the hardware or simulator which will be used to run the Q# program. The target profile is a description of a target's capabilities."

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -227,11 +227,11 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
 async function updateLanguageServiceProfile(languageService: ILanguageService) {
   const targetProfile = vscode.workspace
     .getConfiguration("Q#")
-    .get<string>("targetProfile", "full");
+    .get<string>("targetProfile", "unrestricted");
 
   switch (targetProfile) {
     case "base":
-    case "full":
+    case "unrestricted":
       break;
     default:
       log.warn(`Invalid value for target profile: ${targetProfile}`);
@@ -239,7 +239,7 @@ async function updateLanguageServiceProfile(languageService: ILanguageService) {
   log.debug("Target profile set to: " + targetProfile);
 
   languageService.updateConfiguration({
-    targetProfile: targetProfile as "base" | "full",
+    targetProfile: targetProfile as "base" | "unrestricted",
   });
 }
 

--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -29,7 +29,10 @@ export async function getQirForActiveWindow(): Promise<string> {
 
   const configuration = vscode.workspace.getConfiguration("Q#");
   // Check that the current target is base profile, and current doc has no errors.
-  const targetProfile = configuration.get<string>("targetProfile", "full");
+  const targetProfile = configuration.get<string>(
+    "targetProfile",
+    "unrestricted",
+  );
   if (targetProfile !== "base") {
     const result = await vscode.window.showWarningMessage(
       "Submitting to Azure is only supported when targeting the QIR base profile.",

--- a/vscode/src/statusbar.ts
+++ b/vscode/src/statusbar.ts
@@ -64,7 +64,7 @@ export function activateTargetProfileStatusBarItem(): vscode.Disposable[] {
     // be a valid string.
     const targetProfile = vscode.workspace
       .getConfiguration("Q#")
-      .get<string>("targetProfile", "full");
+      .get<string>("targetProfile", "unrestricted");
 
     statusBarItem.text = getTargetProfileUiText(targetProfile);
     statusBarItem.show();
@@ -73,7 +73,22 @@ export function activateTargetProfileStatusBarItem(): vscode.Disposable[] {
   return disposables;
 }
 
+function initializeTargetProfile() {
+  const configuration = vscode.workspace.getConfiguration("Q#");
+  const current = configuration.get<string>("targetProfile", "unset");
+  // If the target profile is unset or full, set it to unrestricted.
+  if (current == "unset" || current == "full") {
+    configuration.update(
+      "targetProfile",
+      "unrestricted",
+      vscode.ConfigurationTarget.Global,
+    );
+  }
+}
+
 function registerTargetProfileCommand() {
+  initializeTargetProfile();
+
   return vscode.commands.registerCommand(
     "qsharp-vscode.setTargetProfile",
     async () => {
@@ -97,15 +112,15 @@ function registerTargetProfileCommand() {
 
 const targetProfiles = [
   { configName: "base", uiText: "QIR:Base" },
-  { configName: "full", uiText: "QIR:Full" },
+  { configName: "unrestricted", uiText: "QIR:Unrestricted" },
 ];
 
 function getTargetProfileUiText(targetProfile?: string) {
   switch (targetProfile) {
     case "base":
       return "QIR:Base";
-    case "full":
-      return "QIR:Full";
+    case "unrestricted":
+      return "QIR:Unrestricted";
     default:
       log.error("invalid target profile found");
       return "QIR:Invalid";
@@ -116,10 +131,10 @@ function getTargetProfileSetting(uiText: string) {
   switch (uiText) {
     case "QIR:Base":
       return "base";
-    case "QIR:Full":
-      return "full";
+    case "QIR:Unrestricted":
+      return "unrestricted";
     default:
       log.error("invalid target profile found");
-      return "full";
+      return "unrestricted";
   }
 }

--- a/wasm/src/debug_service.rs
+++ b/wasm/src/debug_service.rs
@@ -25,7 +25,7 @@ impl DebugService {
                 false,
                 SourceMap::default(),
                 PackageType::Lib,
-                TargetProfile::Full,
+                TargetProfile::Unrestricted,
             )
             .expect("Couldn't create interpreter"),
         }
@@ -36,7 +36,12 @@ impl DebugService {
             [(path.into(), source.into())],
             entry.as_deref().map(|value| value.into()),
         );
-        match Interpreter::new(true, source_map, qsc::PackageType::Exe, TargetProfile::Full) {
+        match Interpreter::new(
+            true,
+            source_map,
+            qsc::PackageType::Exe,
+            TargetProfile::Unrestricted,
+        ) {
             Ok(interpreter) => {
                 self.interpreter = interpreter;
                 match self.interpreter.set_entry() {

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -41,7 +41,7 @@ impl LanguageService {
             .update_configuration(&qsls::protocol::WorkspaceConfigurationUpdate {
                 target_profile: config.targetProfile.map(|s| match s.as_str() {
                     "base" => qsc::TargetProfile::Base,
-                    "full" => qsc::TargetProfile::Full,
+                    "unrestricted" => qsc::TargetProfile::Unrestricted,
                     _ => panic!("invalid target profile"),
                 }),
                 package_type: config.packageType.map(|s| match s.as_str() {
@@ -219,7 +219,7 @@ serializable_type! {
         pub packageType: Option<String>,
     },
     r#"export interface IWorkspaceConfiguration {
-        targetProfile?: "full" | "base";
+        targetProfile?: "unrestricted" | "base";
         packageType?: "exe" | "lib";
     }"#,
     IWorkspaceConfiguration

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -31,7 +31,7 @@ mod tests;
 thread_local! {
     static STORE_CORE_STD: (PackageStore, PackageId) = {
         let mut store = PackageStore::new(compile::core());
-        let std = store.insert(compile::std(&store, TargetProfile::Full));
+        let std = store.insert(compile::std(&store, TargetProfile::Unrestricted));
         (store, std)
     };
 }
@@ -97,7 +97,7 @@ pub fn get_hir(code: &str) -> String {
             &[*std],
             sources,
             PackageType::Exe,
-            TargetProfile::Full,
+            TargetProfile::Unrestricted,
         );
         unit.package
     });
@@ -163,7 +163,7 @@ where
     let mut out = CallbackReceiver { event_cb };
     let sources = SourceMap::new([(source_name.into(), code.into())], Some(expr.into()));
     let interpreter =
-        stateful::Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Full);
+        stateful::Interpreter::new(true, sources, PackageType::Exe, TargetProfile::Unrestricted);
     if let Err(err) = interpreter {
         // TODO: handle multiple errors
         // https://github.com/microsoft/qsharp/issues/149


### PR DESCRIPTION
There is no such thing as the Full QIR Profile. It is a colloquialism used when talking about classic QIR generation with no restrictions. This PR renames the setting to `Unrestricted` and removes descriptions referring to it as a profile.

When the command is loaded it overrides the `targetProfile` setting for `Q#` if it is unset or set to `full`.