### PR TITLE
Allow reuse of unmeasured qubits in QIR codegen

### DIFF
--- a/compiler/qsc_codegen/src/qir_base/tests.rs
+++ b/compiler/qsc_codegen/src/qir_base/tests.rs
@@ -306,6 +306,189 @@ fn output_recording_tuple() {
 }
 
 #[test]
+fn reset_allocates_new_qubit_id() {
+    check(
+        "",
+        Some(indoc! {"{use q = Qubit(); H(q); Reset(q); H(q); M(q)}"}),
+        &expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__rx__body(double, %Qubit*)
+            declare void @__quantum__qis__rxx__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+            declare void @__quantum__qis__ryy__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__rz__body(double, %Qubit*)
+            declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__h__body(%Qubit*)
+            declare void @__quantum__qis__s__body(%Qubit*)
+            declare void @__quantum__qis__s__adj(%Qubit*)
+            declare void @__quantum__qis__t__body(%Qubit*)
+            declare void @__quantum__qis__t__adj(%Qubit*)
+            declare void @__quantum__qis__x__body(%Qubit*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+            declare void @__quantum__qis__z__body(%Qubit*)
+            declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__rt__array_record_output(i64, i8*)
+            declare void @__quantum__rt__tuple_record_output(i64, i8*)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="3" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}
+
+#[test]
+fn reuse_after_measurement_uses_fresh_aux_qubit_id() {
+    check(
+        "",
+        Some(indoc! {"{use q = Qubit(); H(q); M(q); H(q); M(q)}"}),
+        &expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 1 to %Result*)) #1
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__rx__body(double, %Qubit*)
+            declare void @__quantum__qis__rxx__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+            declare void @__quantum__qis__ryy__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__rz__body(double, %Qubit*)
+            declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__h__body(%Qubit*)
+            declare void @__quantum__qis__s__body(%Qubit*)
+            declare void @__quantum__qis__s__adj(%Qubit*)
+            declare void @__quantum__qis__t__body(%Qubit*)
+            declare void @__quantum__qis__t__adj(%Qubit*)
+            declare void @__quantum__qis__x__body(%Qubit*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+            declare void @__quantum__qis__z__body(%Qubit*)
+            declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__rt__array_record_output(i64, i8*)
+            declare void @__quantum__rt__tuple_record_output(i64, i8*)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="3" "required_num_results"="2" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}
+
+#[test]
+fn qubit_allocation_allows_reuse_of_unmeasured_qubits() {
+    check(
+        "",
+        Some(indoc! {"{
+            open Microsoft.Quantum.Measurement;
+            { use (c, q) = (Qubit(), Qubit()); CNOT(c, q); MResetZ(q); }
+            { use (c, q) = (Qubit(), Qubit()); CNOT(c, q); MResetZ(q) }
+        }"}),
+        &expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 1 to %Result*)) #1
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__rx__body(double, %Qubit*)
+            declare void @__quantum__qis__rxx__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+            declare void @__quantum__qis__ryy__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__rz__body(double, %Qubit*)
+            declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__h__body(%Qubit*)
+            declare void @__quantum__qis__s__body(%Qubit*)
+            declare void @__quantum__qis__s__adj(%Qubit*)
+            declare void @__quantum__qis__t__body(%Qubit*)
+            declare void @__quantum__qis__t__adj(%Qubit*)
+            declare void @__quantum__qis__x__body(%Qubit*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+            declare void @__quantum__qis__z__body(%Qubit*)
+            declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__rt__array_record_output(i64, i8*)
+            declare void @__quantum__rt__tuple_record_output(i64, i8*)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="3" "required_num_results"="2" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}
+
+#[test]
 fn verify_all_intrinsics() {
     check(
         "",
@@ -499,158 +682,158 @@ fn complex_program_is_valid() {
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 9 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 9 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 9 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 9 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 9 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 9 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 5 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__s__body(%Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__rz__body(double -0.7853981633974483, %Qubit* inttoptr (i64 4 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 9 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__rz__body(double 0.7853981633974483, %Qubit* inttoptr (i64 4 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 9 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__s__adj(%Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 5 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 9 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 9 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 9 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 9 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 7 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 9 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 9 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 8 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 10 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 10 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 10 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 11 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 11 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 10 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 11 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 11 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 11 to %Qubit*), %Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 11 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 5 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__rz__body(double -0.7853981633974483, %Qubit* inttoptr (i64 4 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 11 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__rz__body(double 0.7853981633974483, %Qubit* inttoptr (i64 4 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 11 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 5 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 11 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 11 to %Qubit*), %Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 11 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 11 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 7 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 11 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 11 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 10 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 10 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 10 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 10 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 10 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 10 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 12 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 12 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 12 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 12 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 12 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 12 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 13 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 13 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 5 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 13 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 13 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 5 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 13 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 13 to %Qubit*))
-              call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 13 to %Qubit*), %Qubit* inttoptr (i64 12 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 13 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 13 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 5 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 13 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 13 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 7 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 3 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 5 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 13 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 13 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 12 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 12 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 12 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 12 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
               call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 1 to %Qubit*))
               call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 2 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 12 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 12 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
               call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
@@ -698,7 +881,7 @@ fn complex_program_is_valid() {
             declare void @__quantum__rt__array_record_output(i64, i8*)
             declare void @__quantum__rt__tuple_record_output(i64, i8*)
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="14" "required_num_results"="6" }
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="8" "required_num_results"="6" }
             attributes #1 = { "irreversible" }
 
             ; module flags


### PR DESCRIPTION
The previous change to disallow qubit reuse was too aggresive with how it used fresh qubit ids, causing programs to get too big too fast. The problem was the assumption that a qubit that is released can never be used again. Instead, this updates the logic to ensure that qubits that are released without ever having been measured or reset can be reused in later allocations. As an example, this takes the Grover's Search sample program from using 29 qubits to using 9 by allowing reuse of unmeasing auxiliary qubits used during decomposition of multi-controlled gates.