### PR TITLE
Update @vscode/test-web for integration test stability fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@vscode/debugadapter": "^1.63.0",
         "@vscode/debugprotocol": "^1.63.0",
         "@vscode/extension-telemetry": "^0.8.5",
-        "@vscode/test-web": "^0.0.47",
+        "@vscode/test-web": "^0.0.48",
         "chai": "^4.3.10",
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
@@ -1282,14 +1282,14 @@
       }
     },
     "node_modules/@vscode/test-web": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.47.tgz",
-      "integrity": "sha512-p1ym6+h30ecTLCrOcAlD7k3tq/AMVWzZjolbU3jcP0QJV0JSj9hp/Pnmfkrw8s2Xo5ywdbABSFSlNPUpZoicOA==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.48.tgz",
+      "integrity": "sha512-AyNBvhEnhPhrcgPadEJysAPkHsQdTA4vomhKx54CCvEde/VPnuzj86a32gjvHuwJ9zF3QIb4+F5R/AiweaX0Fg==",
       "dev": true,
       "dependencies": {
         "@koa/cors": "^4.0.0",
-        "@koa/router": "^12.0.0",
-        "@playwright/browser-chromium": "^1.38.1",
+        "@koa/router": "^12.0.1",
+        "@playwright/browser-chromium": "^1.39.0",
         "gunzip-maybe": "^1.4.2",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
@@ -1298,9 +1298,9 @@
         "koa-mount": "^4.0.0",
         "koa-static": "^5.0.0",
         "minimist": "^1.2.8",
-        "playwright": "^1.38.1",
+        "playwright": "^1.39.0",
         "tar-fs": "^3.0.4",
-        "vscode-uri": "^3.0.7"
+        "vscode-uri": "^3.0.8"
       },
       "bin": {
         "vscode-test-web": "out/index.js"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@vscode/debugadapter": "^1.63.0",
     "@vscode/debugprotocol": "^1.63.0",
     "@vscode/extension-telemetry": "^0.8.5",
-    "@vscode/test-web": "^0.0.47",
+    "@vscode/test-web": "^0.0.48",
     "chai": "^4.3.10",
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",


### PR DESCRIPTION
Contains a fix for https://github.com/microsoft/vscode-test-web/issues/106 . I see at least one 504 error in main in the last couple of weeks, so this should improve stability.

I'll continue to monitor the integration tests after this and reenable them on PRs if they're stable.