### PR TITLE
Fuzz: "thread '<unnamed>' panicked at compiler/qsc_frontend/src/typeck/rules.rs:368:57:" (ubuntu-latest)

### DIFF
--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -2193,20 +2193,23 @@ fn duplicate_commas_in_arg_tuple() {
 #[test]
 fn ignore_item_in_attribute() {
     check_hir(
-        "namespace n{@E{function h():B{h }}function h():B{",
+        "namespace Test {
+            @Attr{function Bar() : Unit { Bar }}
+            function Foo() : Unit {}
+        }",
         &expect![[r#"
             Package:
-                Item 0 [0-49] (Public):
-                    Namespace (Ident 5 [10-11] "n"): Item 1
-                Item 1 [12-49] (Public):
+                Item 0 [0-112] (Public):
+                    Namespace (Ident 5 [10-14] "Test"): Item 1
+                Item 1 [29-102] (Public):
                     Parent: 0
-                    Callable 0 [34-49] (function):
-                        name: Ident 1 [43-44] "h"
-                        input: Pat 2 [44-46] [Type Unit]: Unit
-                        output: ?
+                    Callable 0 [78-102] (function):
+                        name: Ident 1 [87-90] "Foo"
+                        input: Pat 2 [90-92] [Type Unit]: Unit
+                        output: Unit
                         functors: empty set
-                        body: SpecDecl 3 [34-49]: Impl:
-                            Block 4 [48-49]: <empty>
+                        body: SpecDecl 3 [78-102]: Impl:
+                            Block 4 [100-102]: <empty>
                         adj: <none>
                         ctl: <none>
                         ctl-adj: <none>"#]],

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -2189,3 +2189,26 @@ fn duplicate_commas_in_arg_tuple() {
                         ctl-adj: <none>"#]],
     );
 }
+
+#[test]
+fn ignore_item_in_attribute() {
+    check_hir(
+        "namespace n{@E{function h():B{h }}function h():B{",
+        &expect![[r#"
+            Package:
+                Item 0 [0-49] (Public):
+                    Namespace (Ident 5 [10-11] "n"): Item 1
+                Item 1 [12-49] (Public):
+                    Parent: 0
+                    Callable 0 [34-49] (function):
+                        name: Ident 1 [43-44] "h"
+                        input: Pat 2 [44-46] [Type Unit]: Unit
+                        output: ?
+                        functors: empty set
+                        body: SpecDecl 3 [34-49]: Impl:
+                            Block 4 [48-49]: <empty>
+                        adj: <none>
+                        ctl: <none>
+                        ctl-adj: <none>"#]],
+    );
+}

--- a/compiler/qsc_frontend/src/typeck/check.rs
+++ b/compiler/qsc_frontend/src/typeck/check.rs
@@ -266,4 +266,7 @@ impl Visitor<'_> for ItemChecker<'_> {
         self.checker.check_callable_decl(self.names, decl);
         visit::walk_callable_decl(self, decl);
     }
+
+    // We do not typecheck attributes, as they are verified during lowering.
+    fn visit_attr(&mut self, _: &ast::Attr) {}
 }

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -1318,6 +1318,7 @@ fn callable_missing_parens() {
             ]"#]],
     )
 }
+
 #[test]
 fn callable_missing_close_parens() {
     check_vec(
@@ -1346,6 +1347,7 @@ fn callable_missing_close_parens() {
             ]"#]],
     )
 }
+
 #[test]
 fn callable_missing_open_parens() {
     check_vec(


### PR DESCRIPTION
When an attriute expression includes the nested definition of an item, we were incorrectly checking the type signatures of that item even though it was not included in early parts of type checking, leading to a panic. This update correctly ignores items in attributes for both phases of type checking instead of just the first one.

Fixes #846