### PR TITLE
Remove `DefaultWithSpan` trait

### DIFF
--- a/compiler/qsc_ast/src/ast.rs
+++ b/compiler/qsc_ast/src/ast.rs
@@ -107,22 +107,6 @@ impl Hash for NodeId {
     }
 }
 
-/// Trait that allows creation of a default value with a span.
-pub trait DefaultWithSpan {
-    /// Creates a default value with the given span by using the `Default` and `WithSpan` traits.
-    #[must_use]
-    fn default_with_span(span: Span) -> Self;
-}
-
-impl<T> DefaultWithSpan for Box<T>
-where
-    T: Default + WithSpan,
-{
-    fn default_with_span(span: Span) -> Self {
-        Box::new(T::default().with_span(span))
-    }
-}
-
 /// The root node of an AST.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Package {
@@ -586,14 +570,6 @@ impl Display for Ty {
 impl WithSpan for Ty {
     fn with_span(self, span: Span) -> Self {
         Self { span, ..self }
-    }
-}
-
-impl DefaultWithSpan for Ty {
-    /// Creates a default value with the given span by using the `Default` and `WithSpan` traits.
-    #[must_use]
-    fn default_with_span(span: Span) -> Self {
-        Self::default().with_span(span)
     }
 }
 

--- a/compiler/qsc_data_structures/src/span.rs
+++ b/compiler/qsc_data_structures/src/span.rs
@@ -80,3 +80,13 @@ pub trait WithSpan {
     #[must_use]
     fn with_span(self, span: Span) -> Self;
 }
+
+impl<T> WithSpan for Box<T>
+where
+    T: WithSpan,
+{
+    fn with_span(mut self, span: Span) -> Self {
+        *self = (*self).with_span(span);
+        self
+    }
+}

--- a/compiler/qsc_parse/src/prim.rs
+++ b/compiler/qsc_parse/src/prim.rs
@@ -9,8 +9,8 @@ use crate::{
     lex::{Delim, TokenKind},
     ErrorKind,
 };
-use qsc_ast::ast::{DefaultWithSpan, Ident, NodeId, Pat, PatKind, Path};
-use qsc_data_structures::span::Span;
+use qsc_ast::ast::{Ident, NodeId, Pat, PatKind, Path};
+use qsc_data_structures::span::{Span, WithSpan};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum FinalSep {
@@ -172,7 +172,7 @@ pub(super) fn many<T>(s: &mut Scanner, mut p: impl Parser<T>) -> Result<Vec<T>> 
 
 pub(super) fn seq<T>(s: &mut Scanner, mut p: impl Parser<T>) -> Result<(Vec<T>, FinalSep)>
 where
-    T: DefaultWithSpan,
+    T: Default + WithSpan,
 {
     let mut xs = Vec::new();
     let mut final_sep = FinalSep::Missing;
@@ -180,7 +180,7 @@ where
         let mut span = s.peek().span;
         span.hi = span.lo;
         s.push_error(Error(ErrorKind::MissingSeqEntry(span)));
-        xs.push(T::default_with_span(span));
+        xs.push(T::default().with_span(span));
         s.advance();
     }
     while let Some(x) = opt(s, &mut p)? {
@@ -190,7 +190,7 @@ where
                 let mut span = s.peek().span;
                 span.hi = span.lo;
                 s.push_error(Error(ErrorKind::MissingSeqEntry(span)));
-                xs.push(T::default_with_span(span));
+                xs.push(T::default().with_span(span));
                 s.advance();
             }
             final_sep = FinalSep::Present;


### PR DESCRIPTION
This follows up on feedback from #836 and removes the `DefaultWithSpan` trait in favor of a cleaner implementation of the `WithSpan` trait for boxed types. The impl for `Box<T>` now correctly avoids the extra allocation by editing the item in place and then returning it.