### PR TITLE
Add `dump_machine` to Python API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
+ "num-bigint",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -695,7 +696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
 dependencies = [
  "once_cell",
- "python3-dll-a",
  "target-lexicon",
 ]
 
@@ -731,15 +731,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "python3-dll-a"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f07cd4412be8fa09a721d40007c483981bbe072cd6a21f2e83e04ec8f8343f"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "num-complex",
  "pyo3",
  "qsc",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
 dependencies = [
  "once_cell",
+ "python3-dll-a",
  "target-lexicon",
 ]
 
@@ -731,6 +732,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "python3-dll-a"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f07cd4412be8fa09a721d40007c483981bbe072cd6a21f2e83e04ec8f8343f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"
 rand = "0.8"
 serde_json = { version = "1.0" }
-pyo3 = { version = "0.20", features = ["abi3-py37", "extension-module", "generate-import-lib", "num-bigint"] }
+pyo3 = { version = "0.20" }
 quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", rev = "f000e0066f56338595be37092cd0498f72ab10a2", default-features = false }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"
 rand = "0.8"
 serde_json = { version = "1.0" }
-pyo3 = { version = "0.20", features = ["abi3-py37", "extension-module", "num-bigint"] }
+pyo3 = { version = "0.20", features = ["abi3-py37", "extension-module", "generate-import-lib", "num-bigint"] }
 quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", rev = "f000e0066f56338595be37092cd0498f72ab10a2", default-features = false }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"
 rand = "0.8"
 serde_json = { version = "1.0" }
-pyo3 = { version = "0.20", features = ["abi3-py37", "extension-module"] }
+pyo3 = { version = "0.20", features = ["abi3-py37", "extension-module", "num-bigint"] }
 quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", rev = "f000e0066f56338595be37092cd0498f72ab10a2", default-features = false }
 
 [profile.release]

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -326,6 +326,11 @@ impl Interpreter {
         self.run_with_sim(&mut SparseSim::new(), receiver, expr, shots)
     }
 
+    /// Gets the current quantum state of the simulator.
+    pub fn get_quantum_state(&mut self) -> (Vec<(BigUint, Complex<f64>)>, usize) {
+        self.sim.capture_quantum_state()
+    }
+
     /// Performs QIR codegen using the given entry expression on a new instance of the environment
     /// and simulator but using the current compilation.
     pub fn qirgen(&mut self, expr: &str) -> Result<String, Vec<Error>> {

--- a/pip/Cargo.toml
+++ b/pip/Cargo.toml
@@ -14,14 +14,15 @@ num-bigint = { workspace = true }
 num-complex = { workspace = true }
 qsc = { path = "../compiler/qsc" }
 miette = { workspace = true, features = ["fancy"] }
+rustc-hash = { workspace = true }
 
 [target.'cfg(not(any(target_os = "windows")))'.dependencies]
-pyo3 = { workspace = true, features = ["abi3-py37", "extension-module"] }
+pyo3 = { workspace = true, features = ["abi3-py37", "extension-module", "num-bigint"] }
 
 [target.'cfg(any(target_os = "windows"))'.dependencies]
 # generate-import-lib: skip requiring Python 3 distribution
 # files to be present on the (cross-)compile host system.
-pyo3 = { workspace = true }
+pyo3 = { workspace = true, features = ["abi3-py37", "extension-module", "generate-import-lib", "num-bigint"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/pip/Cargo.toml
+++ b/pip/Cargo.toml
@@ -21,7 +21,7 @@ pyo3 = { workspace = true, features = ["abi3-py37", "extension-module"] }
 [target.'cfg(any(target_os = "windows"))'.dependencies]
 # generate-import-lib: skip requiring Python 3 distribution
 # files to be present on the (cross-)compile host system.
-pyo3 = { workspace = true, features = ["abi3-py37", "extension-module", "generate-import-lib"] }
+pyo3 = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from ._qsharp import init, eval, eval_file, run, compile
+from ._qsharp import init, eval, eval_file, run, compile, dump_machine
 
 from ._native import Result, Pauli, QSharpError, TargetProfile
 
@@ -21,6 +21,7 @@ __all__ = [
     "eval",
     "eval_file",
     "run",
+    "dump_machine",
     "compile",
     "Result",
     "Pauli",

--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -3,7 +3,7 @@
 
 from ._qsharp import init, eval, eval_file, run, compile, dump_machine
 
-from ._native import Result, Pauli, QSharpError, TargetProfile
+from ._native import Result, Pauli, QSharpError, TargetProfile, StateDump
 
 # IPython notebook specific features
 try:
@@ -27,4 +27,5 @@ __all__ = [
     "Pauli",
     "QSharpError",
     "TargetProfile",
+    "StateDump"
 ]

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from enum import Enum
-from typing import Any, Callable, ClassVar
+from typing import Any, Callable, ClassVar, Tuple
 
 class TargetProfile:
     """
@@ -75,7 +75,7 @@ class Interpreter:
         """
         ...
 
-    def dump_machine(self) -> (dict, int):
+    def dump_machine(self) -> Tuple[dict, int]:
         """
         Returns the state of the simulator.
 

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -75,7 +75,7 @@ class Interpreter:
         """
         ...
 
-    def dump_machine(self):
+    def dump_machine(self) -> (dict, int):
         """
         Returns the state of the simulator.
 

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from enum import Enum
-from typing import Any, Callable, ClassVar, Tuple
+from typing import Any, Callable, ClassVar, Tuple, Optional
 
 class TargetProfile:
     """
@@ -75,11 +75,11 @@ class Interpreter:
         """
         ...
 
-    def dump_machine(self) -> Tuple[dict, int]:
+    def dump_machine(self) -> StateDump:
         """
-        Returns the state of the simulator.
+        Returns the sparse state vector of the simulator as a StateDump object.
 
-        :returns state: The state of the simulator.
+        :returns: The state of the simulator.
         """
         ...
 
@@ -107,6 +107,27 @@ class Output:
     Outputs can be a state dumps or messages. These are normally printed to the console.
     """
 
+    def __repr__(self) -> str: ...
+    def __str__(self) -> str: ...
+    def _repr_html_(self) -> str: ...
+
+class StateDump:
+    """
+    A state dump returned from the Q# interpreter.
+    """
+
+    """
+    The number of allocated qubits at the time of the dump.
+    """
+    qubit_count: int
+
+    """
+    Get the amplitudes of the state vector as a dictionary from state integer to
+    pair of real and imaginary amplitudes.
+    """
+    def get_dict(self) -> dict: ...
+    def __getitem__(self, index: int) -> Optional[Tuple[float, float]]: ...
+    def __len__(self) -> int: ...
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
     def _repr_html_(self) -> str: ...

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -75,6 +75,14 @@ class Interpreter:
         """
         ...
 
+    def dump_machine(self):
+        """
+        Returns the state of the simulator.
+
+        :returns state: The state of the simulator.
+        """
+        ...
+
 class Result(Enum):
     """
     A Q# measurement result.

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -88,6 +88,16 @@ def compile(entry_expr):
     ll_str = get_interpreter().qir(entry_expr)
     return QirInputData("main", ll_str)
 
+def dump_machine():
+    """
+    Returns the sparse state vector of the simulator as a
+    (amplitudes, qubit_count) tuple, where amplitudes is a dictionary from state integer to
+    pair of real and imaginary amplitudes.
+
+    :returns: The state of the simulator as a tuple.
+    """
+    return get_interpreter().dump_machine()
+
 
 # Class that wraps generated QIR, which can be used by
 # azure-quantum as input data.

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from ._native import Interpreter, TargetProfile
-from typing import Tuple
+from ._native import Interpreter, TargetProfile, StateDump
 
 _interpreter = None
 
@@ -89,13 +88,11 @@ def compile(entry_expr):
     ll_str = get_interpreter().qir(entry_expr)
     return QirInputData("main", ll_str)
 
-def dump_machine() -> Tuple[dict, int]:
+def dump_machine() -> StateDump:
     """
-    Returns the sparse state vector of the simulator as a
-    (amplitudes, qubit_count) tuple, where amplitudes is a dictionary from state integer to
-    pair of real and imaginary amplitudes.
+    Returns the sparse state vector of the simulator as a StateDump object.
 
-    :returns: The state of the simulator as a tuple.
+    :returns: The state of the simulator.
     """
     return get_interpreter().dump_machine()
 

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 from ._native import Interpreter, TargetProfile
+from typing import Tuple
 
 _interpreter = None
 
@@ -88,7 +89,7 @@ def compile(entry_expr):
     ll_str = get_interpreter().qir(entry_expr)
     return QirInputData("main", ll_str)
 
-def dump_machine() -> (dict, int):
+def dump_machine() -> Tuple[dict, int]:
     """
     Returns the sparse state vector of the simulator as a
     (amplitudes, qubit_count) tuple, where amplitudes is a dictionary from state integer to

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -88,7 +88,7 @@ def compile(entry_expr):
     ll_str = get_interpreter().qir(entry_expr)
     return QirInputData("main", ll_str)
 
-def dump_machine():
+def dump_machine() -> (dict, int):
     """
     Returns the sparse state vector of the simulator as a
     (amplitudes, qubit_count) tuple, where amplitudes is a dictionary from state integer to

--- a/pip/src/displayable_output.rs
+++ b/pip/src/displayable_output.rs
@@ -7,9 +7,10 @@ mod tests;
 use num_bigint::BigUint;
 use num_complex::{Complex64, ComplexFloat};
 use qsc::{fmt_basis_state_label, fmt_complex, format_state_id, get_phase};
+use rustc_hash::FxHashMap;
 use std::fmt::Write;
 
-pub struct DisplayableState(pub Vec<(BigUint, Complex64)>, pub usize);
+pub struct DisplayableState(pub FxHashMap<BigUint, Complex64>, pub usize);
 
 impl DisplayableState {
     pub fn to_plain(&self) -> String {

--- a/pip/src/displayable_output/tests.rs
+++ b/pip/src/displayable_output/tests.rs
@@ -3,12 +3,18 @@
 
 use num_bigint::BigUint;
 use num_complex::Complex;
+use rustc_hash::FxHashMap;
 
 use crate::displayable_output::DisplayableState;
 
 #[test]
 fn display_neg_zero() {
-    let s = DisplayableState(vec![(BigUint::default(), Complex::new(-0.0, -0.0))], 1);
+    let s = DisplayableState(
+        vec![(BigUint::default(), Complex::new(-0.0, -0.0))]
+            .into_iter()
+            .collect::<FxHashMap<_, _>>(),
+        1,
+    );
     // -0 should be displayed as 0.0000 without a minus sign
     assert_eq!("STATE:\n|0⟩: 0.0000+0.0000𝑖", s.to_plain());
 }
@@ -16,7 +22,9 @@ fn display_neg_zero() {
 #[test]
 fn display_rounds_to_neg_zero() {
     let s = DisplayableState(
-        vec![(BigUint::default(), Complex::new(-0.00001, -0.00001))],
+        vec![(BigUint::default(), Complex::new(-0.00001, -0.00001))]
+            .into_iter()
+            .collect::<FxHashMap<_, _>>(),
         1,
     );
     // -0.00001 should be displayed as 0.0000 without a minus sign

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -101,6 +101,9 @@ impl Interpreter {
         }
     }
 
+    /// Dumps the quantum state of the interpreter.
+    /// Returns a tuple of a dictionary mapping bitstrings to complex amplitudes and the
+    /// total number of allocated qubits.
     fn dump_machine(&mut self, py: Python) -> (Py<PyDict>, usize) {
         let (state, num_qubits) = self.interpreter.get_quantum_state();
         (

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -102,8 +102,8 @@ impl Interpreter {
     }
 
     /// Dumps the quantum state of the interpreter.
-    /// Returns a tuple of a dictionary mapping bitstrings to complex amplitudes and the
-    /// total number of allocated qubits.
+    /// Returns a tuple of (amplitudes, num_qubits), where amplitudes is a dictionary from integer indices to
+    /// pairs of real and imaginary amplitudes.
     fn dump_machine(&mut self, py: Python) -> (Py<PyDict>, usize) {
         let (state, num_qubits) = self.interpreter.get_quantum_state();
         (

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -57,11 +57,14 @@ def test_dump_machine() -> None:
     """,
         callback,
     )
-    (state, qubit_count) = e.dump_machine()
-    assert qubit_count == 2
-    assert len(state) == 1
-    assert state[1][0] == 1.0
-    assert state[1][1] == 0.0
+    state_dump = e.dump_machine()
+    assert state_dump.qubit_count == 2
+    assert len(state_dump) == 1
+    assert state_dump[1][0] == 1.0
+    assert state_dump[1][1] == 0.0
+    state_dict = state_dump.get_dict()
+    assert state_dict[1][0] == 1.0
+    assert state_dict[1][1] == 0.0
 
 def test_error() -> None:
     e = Interpreter(TargetProfile.Full)

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -42,6 +42,26 @@ def test_dump_output() -> None:
     )
     assert called
 
+def test_dump_machine() -> None:
+    e = Interpreter(TargetProfile.Full)
+
+    def callback(output):
+        assert output.__repr__() == "STATE:\n|01⟩: 1.0000+0.0000𝑖"
+
+    value = e.interpret(
+        """
+    use q1 = Qubit();
+    use q2 = Qubit();
+    X(q1);
+    Microsoft.Quantum.Diagnostics.DumpMachine();
+    """,
+        callback,
+    )
+    (state, qubit_count) = e.dump_machine()
+    assert qubit_count == 2
+    assert len(state) == 1
+    assert state[1][0] == 1.0
+    assert state[1][1] == 0.0
 
 def test_error() -> None:
     e = Interpreter(TargetProfile.Full)

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -32,6 +32,25 @@ def test_stdout_multiple_lines() -> None:
 
     assert f.getvalue() == "STATE:\n|0⟩: 1.0000+0.0000𝑖\nHello!\n"
 
+def test_dump_machine() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Full)
+    qsharp.eval(
+        """
+    use q1 = Qubit();
+    use q2 = Qubit();
+    X(q1);
+    """
+    )
+    (state, qubit_count) = qsharp.dump_machine()
+    assert qubit_count == 2
+    assert len(state) == 1
+    assert state[1] == (1.0, 0.0)
+    qsharp.eval("X(q2);")
+    (state, qubit_count) = qsharp.dump_machine()
+    assert qubit_count == 2
+    assert len(state) == 1
+    assert state[3] == (1.0, 0.0)
+
 
 def test_compile_qir_input_data() -> None:
     qsharp.init(target_profile=qsharp.TargetProfile.Base)

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -41,15 +41,15 @@ def test_dump_machine() -> None:
     X(q1);
     """
     )
-    (state, qubit_count) = qsharp.dump_machine()
-    assert qubit_count == 2
-    assert len(state) == 1
-    assert state[1] == (1.0, 0.0)
+    state_dump = qsharp.dump_machine()
+    assert state_dump.qubit_count == 2
+    assert len(state_dump) == 1
+    assert state_dump[1] == (1.0, 0.0)
     qsharp.eval("X(q2);")
-    (state, qubit_count) = qsharp.dump_machine()
-    assert qubit_count == 2
-    assert len(state) == 1
-    assert state[3] == (1.0, 0.0)
+    state_dump = qsharp.dump_machine()
+    assert state_dump.qubit_count == 2
+    assert len(state_dump) == 1
+    assert state_dump[3] == (1.0, 0.0)
 
 
 def test_compile_qir_input_data() -> None:


### PR DESCRIPTION
This adds a `dump_machine` API that allows Python code to get the allocated qubit count and dictionary of sparse state amplitudes in Python. This will enable more test scenarios in Python for Q# code.

This also includes an update to how `BigInt` values are returned in Python by using the arbitrary bitwidth Python integer type instead of formatting them as a string.

![image](https://github.com/microsoft/qsharp/assets/10567287/44a4c014-dfaa-41c6-b0ee-b18de8a5d39c)
