### PR TITLE
Table lookup with select networks

### DIFF
--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -445,6 +445,10 @@ pub fn std(store: &PackageStore, target: TargetProfile) -> CompileUnit {
                 "random.qs".into(),
                 include_str!("../../../library/std/random.qs").into(),
             ),
+            (
+                "table_lookup.qs".into(),
+                include_str!("../../../library/std/table_lookup.qs").into(),
+            ),
         ],
         None,
     );

--- a/library/std/table_lookup.qs
+++ b/library/std/table_lookup.qs
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.TableLookup {
+    open Microsoft.Quantum.Arithmetic;
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Measurement;
+
+    /// # Summary
+    /// Performs table lookup using a SELECT network
+    ///
+    /// # Description
+    /// Assuming a zero-initialized `target` register, this operation will
+    /// initialize it with the bitstrings in `data` at indices according to the
+    /// computational values of the `address` register.
+    ///
+    /// # Input
+    /// ## data
+    /// The classical table lookup data which is prepared in `target` with
+    /// respect to the state in `address`. The length of data must be less than
+    /// 2ⁿ, where 𝑛 is the length of `address`. Each entry in data must have
+    /// the same length that must be equal to the length of `target`.
+    /// ## address
+    /// Address register
+    /// ## target
+    /// Zero-initialized target register
+    ///
+    /// # Remarks
+    /// The implementation of the SELECT network is based on unary encoding as
+    /// presented in [1].  The recursive implementation of that algorithm is
+    /// presented in [3].  The adjoint variant is optimized using a
+    /// measurement-based unlookup operation [3]. The controlled adjoint variant
+    /// is not optimized using this technique.
+    ///
+    /// # References
+    /// [1] [arXiv:1805.03662](https://arxiv.org/abs/1805.03662)
+    ///     "Encoding Electronic Spectra in Quantum Circuits with Linear T
+    ///      Complexity"
+    /// [2] [arXiv:1905.07682](https://arxiv.org/abs/1905.07682)
+    ///     "Windowed arithmetic"
+    /// [3] [arXiv:2211.01133](https://arxiv.org/abs/2211.01133)
+    ///     "Space-time optimized table lookup"
+    @Config(Full)
+    operation Select(
+        data : Bool[][],
+        address : Qubit[],
+        target : Qubit[]
+    ) : Unit is Adj + Ctl {
+        body (...) {
+            let (N, n) = DimensionsForSelect(data, address);
+
+            if N == 1 { // base case
+                WriteMemoryContents(Head(data), target);
+            } else {
+                let (most, tail) = MostAndTail(address[...n - 1]);
+                let parts = Partitioned([2^(n - 1)], data);
+
+                within {
+                    X(tail);
+                } apply {
+                    SinglyControlledSelect(tail, parts[0], most, target);
+                }
+
+                SinglyControlledSelect(tail, parts[1], most, target);
+            }
+        }
+        adjoint (...) {
+            Unlookup(Select, data, address, target);
+        }
+
+        controlled (ctls, ...) {
+            let numCtls = Length(ctls);
+
+            if numCtls == 0 {
+                Select(data, address, target);
+            } elif numCtls == 1 {
+                SinglyControlledSelect(ctls[0], data, address, target);
+            } else {
+                use andChainTarget = Qubit();
+                let andChain = MakeAndChain(ctls, andChainTarget);
+                use helper = Qubit[andChain::NGarbageQubits];
+
+                within {
+                    andChain::Apply(helper);
+                } apply {
+                    SinglyControlledSelect(andChainTarget, data, address, target);
+                }
+            }
+        }
+
+        controlled adjoint (ctls, ...) {
+            Controlled Select(ctls, (data, address, target));
+        }
+    }
+
+    internal operation SinglyControlledSelect(
+        ctl : Qubit,
+        data : Bool[][],
+        address : Qubit[],
+        target : Qubit[]
+    ) : Unit {
+        let (N, n) = DimensionsForSelect(data, address);
+
+        if N == 1 { // base case
+            Controlled WriteMemoryContents([ctl], (Head(data), target));
+        } else {
+            use helper = Qubit();
+
+            let (most, tail) = MostAndTail(address[...n - 1]);
+            let parts = Partitioned([2^(n - 1)], data);
+
+            within {
+                X(tail);
+            } apply {
+                ApplyAndAssuming0Target(ctl, tail, helper);
+            }
+
+            SinglyControlledSelect(helper, parts[0], most, target);
+
+            CNOT(ctl, helper);
+
+            SinglyControlledSelect(helper, parts[1], most, target);
+
+            Adjoint ApplyAndAssuming0Target(ctl, tail, helper);
+        }
+    }
+
+    internal function DimensionsForSelect(
+        data : Bool[][],
+        address : Qubit[]
+    ) : (Int, Int) {
+        let N = Length(data);
+        Fact(N > 0, "data cannot be empty");
+
+        let n = Ceiling(Lg(IntAsDouble(N)));
+        Fact(
+            Length(address) >= n,
+            $"address register is too small, requires at least {n} qubits");
+
+        return (N, n);
+    }
+
+    internal operation WriteMemoryContents(
+        value : Bool[],
+        target : Qubit[]
+    ) : Unit is Adj + Ctl {
+        Fact(
+            Length(value) == Length(target),
+            "number of data bits must equal number of target qubits");
+
+        ApplyPauliFromBitString(PauliX, true, value, target);
+    }
+
+    /// # References
+    /// - [arXiv:1905.07682](https://arxiv.org/abs/1905.07682)
+    ///   "Windowed arithmetic"
+    internal operation Unlookup(
+        lookup : (Bool[][], Qubit[], Qubit[]) => Unit,
+        data : Bool[][],
+        select : Qubit[],
+        target : Qubit[]
+    ) : Unit {
+        let numBits = Length(target);
+        let numAddressBits = Length(select);
+
+        let l = MinI(Floor(Lg(IntAsDouble(numBits))), numAddressBits - 1);
+        Fact(
+            l < numAddressBits,
+            $"l = {l} must be smaller than {numAddressBits}");
+
+        let res = Mapped(r -> r == One, ForEach(MResetX, target));
+
+        let dataFixup = Chunks(2^l, Padded(-2^numAddressBits, false,
+                               Mapped(MustBeFixed(res, _), data)));
+
+        let numAddressBitsFixup = numAddressBits - l;
+
+        let selectParts = Partitioned([l], select);
+        let targetFixup = target[...2^l - 1];
+
+        within {
+            EncodeUnary(selectParts[0], targetFixup);
+            ApplyToEachA(H, targetFixup);
+        } apply {
+            lookup(dataFixup, selectParts[1], targetFixup);
+        }
+    }
+
+    // Checks whether specific bitstring `data` must be fixed for a given
+    // measurement result `result`.
+    //
+    // Returns true if the number of indices for which both result and data are
+    // `true` is odd.
+    internal function MustBeFixed(result : Bool[], data : Bool[]) : Bool {
+        Fold((state, (r, d)) -> state != (r and d), false, Zipped(result, data))
+    }
+
+    // Computes unary encoding of value in `input` into `target`
+    //
+    // Assumptions:
+    //    - `target` is zero-initialized
+    //    - length of `input` is n
+    //    - length of `target` is 2^n
+    internal operation EncodeUnary(
+        input : Qubit[],
+        target : Qubit[]
+    ) : Unit is Adj {
+        Fact(
+            Length(target) == 2^Length(input),
+            $"target register should be of length {2^Length(input)}, but is {Length(target)}"
+        );
+
+        X(Head(target));
+
+        for (i, c) in Enumerated(input) {
+            if i == 0 {
+                CNOT(c, target[1]);
+                CNOT(target[1], target[0]);
+            } else {
+                // targets are the first and second 2^i qubits of the target
+                // register
+                let split = Partitioned([2^i, 2^i], target);
+                ApplyToEachA(
+                    (t1, t2) => {
+                        ApplyAndAssuming0Target(c, t1, t2);
+                        CNOT(t2, t1)
+                    },
+                    Zipped(split[0], split[1])
+                );
+            }
+        }
+    }
+
+    internal newtype AndChain = (
+        NGarbageQubits: Int,
+        Apply: Qubit[] => Unit is Adj
+    );
+
+    internal function MakeAndChain(ctls : Qubit[], target : Qubit) : AndChain {
+        AndChain(
+            MaxI(Length(ctls) - 2, 0),
+            helper => AndChainOperation(ctls, helper, target)
+        )
+    }
+
+    internal operation AndChainOperation(ctls : Qubit[], helper : Qubit[], target : Qubit) : Unit is Adj {
+        let n = Length(ctls);
+
+        Fact(Length(helper) == MaxI(n - 2, 0), "Invalid number of helper qubits");
+
+        if n == 0 {
+            X(target);
+        } elif n == 1 {
+            CNOT(ctls[0], target);
+        } else {
+            let ctls1 = ctls[0..0] + helper;
+            let ctls2 = ctls[1...];
+            let tgts = helper + [target];
+
+            for (idx, tgt) in Enumerated(tgts) {
+                ApplyAndAssuming0Target(ctls1[idx], ctls2[idx], tgt);
+            }
+        }
+    }
+}

--- a/library/tests/src/lib.rs
+++ b/library/tests/src/lib.rs
@@ -19,6 +19,8 @@ mod test_math;
 #[cfg(test)]
 mod test_measurement;
 #[cfg(test)]
+mod test_table_lookup;
+#[cfg(test)]
 mod tests;
 
 use qsc::{

--- a/library/tests/src/resources/select.qs
+++ b/library/tests/src/resources/select.qs
@@ -1,0 +1,63 @@
+namespace Test {
+    open Microsoft.Quantum.Arithmetic;
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Measurement;
+    open Microsoft.Quantum.Random;
+    open Microsoft.Quantum.TableLookup;
+
+    internal operation TestSelect(addressBits : Int, dataBits : Int) : Unit {
+        use addressRegister = Qubit[addressBits];
+        use temporaryRegister = Qubit[dataBits];
+        use dataRegister = Qubit[dataBits];
+
+        let data = DrawMany(_ => DrawMany(_ => (DrawRandomInt(0, 1) == 1), dataBits, 0), 2^addressBits, 0);
+
+        for (index, expected) in Enumerated(data) {
+            ApplyXorInPlace(index, addressRegister);
+
+            // a temporary register is not necessary normally, but we want to
+            // test the optimized adjoint operation as well.
+            within {
+                Select(data, addressRegister, temporaryRegister);
+            } apply {
+                ApplyToEach(CNOT, Zipped(temporaryRegister, dataRegister));
+            }
+
+            Fact(Mapped(ResultAsBool, MResetEachZ(dataRegister)) == expected, $"Invalid data result for address {index}");
+            Fact(MeasureInteger(addressRegister) == index, $"Invalid address result for address {index}");
+        }
+    }
+
+    internal operation TestSelectFuzz(rounds : Int) : Unit {
+        for _ in 1..rounds {
+            let addressBits = DrawRandomInt(2, 6);
+            let dataBits = 10;
+            let numData = DrawRandomInt(2^(addressBits - 1) + 1, 2^addressBits - 1);
+
+            let data = DrawMany(_ => DrawMany(_ => (DrawRandomInt(0, 1) == 1), dataBits, 0), numData, 0);
+
+            use addressRegister = Qubit[addressBits];
+            use temporaryRegister = Qubit[dataBits];
+            use dataRegister = Qubit[dataBits];
+
+            for _ in 1..5 {
+                let index = DrawRandomInt(0, numData - 1);
+
+                ApplyXorInPlace(index, addressRegister);
+
+                // a temporary register is not necessary normally, but we want to
+                // test the optimized adjoint operation as well.
+                within {
+                    Select(data, addressRegister, temporaryRegister);
+                } apply {
+                    ApplyToEach(CNOT, Zipped(temporaryRegister, dataRegister));
+                }
+
+                Fact(Mapped(ResultAsBool, MResetEachZ(dataRegister)) == data[index], $"Invalid data result for address {index} (addressBits = {addressBits}, dataBits = {dataBits})");
+                Fact(MeasureInteger(addressRegister) == index, $"Invalid address result for address {index} (addressBits = {addressBits}, dataBits = {dataBits})");
+            }
+        }
+    }
+}

--- a/library/tests/src/test_table_lookup.rs
+++ b/library/tests/src/test_table_lookup.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::test_expression_with_lib;
+use qsc::interpret::Value;
+
+// Tests for Microsoft.Quantum.TableLookup namespace
+
+const SELECT_TEST_LIB: &str = include_str!("resources/select.qs");
+
+#[test]
+fn check_select_exhaustive_bitwidth_1() {
+    test_expression_with_lib(
+        "Test.TestSelect(1, 10)",
+        SELECT_TEST_LIB,
+        &Value::Tuple(vec![].into()),
+    );
+}
+
+#[test]
+fn check_select_exhaustive_bitwidth_2() {
+    test_expression_with_lib(
+        "Test.TestSelect(2, 10)",
+        SELECT_TEST_LIB,
+        &Value::Tuple(vec![].into()),
+    );
+}
+
+#[test]
+fn check_select_exhaustive_bitwidth_3() {
+    test_expression_with_lib(
+        "Test.TestSelect(3, 10)",
+        SELECT_TEST_LIB,
+        &Value::Tuple(vec![].into()),
+    );
+}
+
+#[test]
+fn check_select_exhaustive_bitwidth_4() {
+    test_expression_with_lib(
+        "Test.TestSelect(4, 10)",
+        SELECT_TEST_LIB,
+        &Value::Tuple(vec![].into()),
+    );
+}
+
+#[test]
+fn check_select_fuzz() {
+    test_expression_with_lib(
+        "Test.TestSelectFuzz(20)",
+        SELECT_TEST_LIB,
+        &Value::Tuple(vec![].into()),
+    );
+}


### PR DESCRIPTION
This adds an operation `Select` in a new namespace `Microsoft.Quantum.TableLookup`. It implements a table lookup based on a recursive implementation of the select network algorithm (see references inside the doc string for more details).

The behavior of this operation is similar to [MultiplexOperations](https://learn.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.canon.multiplexoperations), with the following differences:

- It uses an optimized implementation
- It has a name more commonly used in the quantum algorithms community
- It is less general as it writes bit strings instead of allowing an arbitrary set of unitary operations

**NOTE:** Some clippy checks are failing in code that is not changed by this PR. I did not fix these, since they are not related to this PR.