### PR TITLE
Optimize `Value::unit()` to avoid additional allocations

### DIFF
--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -164,13 +164,17 @@ impl Display for Value {
     }
 }
 
+thread_local! {
+    static UNIT: Rc<[Value; 0]> = Rc::new([]);
+}
+
 impl Value {
     pub const RESULT_ZERO: Self = Self::Result(Result::Val(false));
     pub const RESULT_ONE: Self = Self::Result(Result::Val(true));
 
     #[must_use]
     pub fn unit() -> Self {
-        Self::Tuple([].as_slice().into())
+        UNIT.with(|unit| Self::Tuple(unit.clone()))
     }
 
     /// Convert the [Value] into an array of [Value]


### PR DESCRIPTION
This changes the implementation of `Value::unit()` to use a thread local `Rc` for the empty tuple, allowing unit to be created once and then reused instead of allocating a fresh instance each time. Because many Q# expressions return unit that then just gets consumed by the semicolon terminated statement they are part of, this saves both an allocation on the creation and a deallocation as the `Rc` count gets decremented but does not go to zero, keeping the underlying empty array from needing to be dropped. This results in some nice performance gains during execution:

```
Teleport evaluation     time:   [79.585 µs 79.755 µs 79.976 µs]
                        change: [-9.9140% -9.2630% -8.6576%] (p = 0.00 < 0.05)
                        Performance has improved.

Deutsch-Jozsa evaluation
                        time:   [19.515 ms 19.539 ms 19.563 ms]
                        change: [-4.1731% -4.0486% -3.9176%] (p = 0.00 < 0.05)
                        Performance has improved.

Large file parity evaluation
                        time:   [27.749 ms 27.863 ms 27.997 ms]
                        change: [-5.8747% -5.4819% -5.0196%] (p = 0.00 < 0.05)
                        Performance has improved.
```