### PR TITLE
removed unnecessary hashes around raw string literals

### DIFF
--- a/compiler/qsc/src/interpret/debug/tests.rs
+++ b/compiler/qsc/src/interpret/debug/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use indoc::indoc;
 use miette::Result;
 use qsc_eval::{output::CursorReceiver, val::Value};

--- a/compiler/qsc/src/interpret/stateful/stepping_tests.rs
+++ b/compiler/qsc/src/interpret/stateful/stepping_tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::interpret::stateful::Interpreter;
 use qsc_eval::{output::CursorReceiver, StepAction, StepResult};
 use qsc_fir::fir::StmtId;

--- a/compiler/qsc/src/interpret/stateful/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 mod given_interpreter {
     use crate::interpret::stateful::{Error, InterpretResult, Interpreter};
     use expect_test::Expect;

--- a/compiler/qsc_codegen/src/qir_base/tests.rs
+++ b/compiler/qsc_codegen/src/qir_base/tests.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
+#![allow(clippy::needless_raw_string_hashes)]
 
 use std::sync::Arc;
 

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use std::f64::consts;
 
 use crate::backend::{Backend, SparseSim};

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::{
     backend::{Backend, SparseSim},
     debug::{map_hir_package_to_fir, Frame},

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::compile::TargetProfile;
 
 use super::{compile, Error, PackageStore, SourceMap};

--- a/compiler/qsc_frontend/src/error/tests.rs
+++ b/compiler/qsc_frontend/src/error/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::WithSource;
 use crate::compile::SourceMap;
 use expect_test::expect;

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::compile::{self, compile, PackageStore, SourceMap, TargetProfile};
 use expect_test::{expect, Expect};
 use indoc::indoc;

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::{Error, Names, Res};
 use crate::{compile, resolve::Resolver};
 use expect_test::{expect, Expect};

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::{
     compile::{self, Offsetter},
     resolve::{self, Resolver},

--- a/compiler/qsc_passes/src/baseprofck/tests.rs
+++ b/compiler/qsc_passes/src/baseprofck/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetProfile};

--- a/compiler/qsc_passes/src/borrowck/tests.rs
+++ b/compiler/qsc_passes/src/borrowck/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetProfile};

--- a/compiler/qsc_passes/src/callable_limits/tests.rs
+++ b/compiler/qsc_passes/src/callable_limits/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetProfile};

--- a/compiler/qsc_passes/src/conjugate_invert/tests.rs
+++ b/compiler/qsc_passes/src/conjugate_invert/tests.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
+#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::{expect, Expect};
 use indoc::indoc;

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::entry_point::generate_entry_expr;
 use expect_test::{expect, Expect};
 use indoc::indoc;

--- a/compiler/qsc_passes/src/logic_sep/tests.rs
+++ b/compiler/qsc_passes/src/logic_sep/tests.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
+#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::{expect, Expect};
 use qsc_data_structures::span::Span;

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
+#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::{expect, Expect};
 use indoc::indoc;

--- a/language_service/src/completion/tests.rs
+++ b/language_service/src/completion/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use expect_test::{expect, Expect};
 
 use super::{get_completions, CompletionItem};

--- a/language_service/src/definition/tests.rs
+++ b/language_service/src/definition/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use expect_test::{expect, Expect};
 
 use super::get_definition;

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::get_hover;
 use crate::{
     protocol,

--- a/language_service/src/references/tests.rs
+++ b/language_service/src/references/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::get_references;
 use crate::{
     protocol,

--- a/language_service/src/rename/tests.rs
+++ b/language_service/src/rename/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::{get_rename, prepare_rename};
 use crate::test_utils::{
     compile_notebook_with_fake_stdlib_and_markers, compile_with_fake_stdlib,

--- a/language_service/src/signature_help/tests.rs
+++ b/language_service/src/signature_help/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::get_signature_help;
 use crate::test_utils::{compile_with_fake_stdlib, get_source_and_marker_offsets};
 use expect_test::{expect, Expect};

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::{
     protocol::{DiagnosticUpdate, WorkspaceConfigurationUpdate},
     LanguageService,

--- a/library/tests/src/test_canon.rs
+++ b/library/tests/src/test_canon.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::{test_expression, test_expression_with_lib};
 use indoc::indoc;
 use qsc::interpret::Value;

--- a/library/tests/src/test_measurement.rs
+++ b/library/tests/src/test_measurement.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::test_expression;
 use indoc::indoc;
 use qsc::interpret::Value;

--- a/library/tests/src/tests.rs
+++ b/library/tests/src/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use crate::test_expression;
 use indoc::indoc;
 use qsc::interpret::Value;


### PR DESCRIPTION
The solution does not compile with Rust/Cargo 1.74.0 and clippy 0.1.74 due to to a flood of [unnecessary hashes around raw string literal](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_raw_string_hashes) clippy complaints