### PR TITLE
Telemetry: Use associationId instead of correlationId

### DIFF
--- a/vscode/src/azure/networkRequests.ts
+++ b/vscode/src/azure/networkRequests.ts
@@ -12,7 +12,7 @@ export const useProxy = true;
 export async function azureRequest(
   uri: string,
   token: string,
-  correlationId?: string,
+  associationId?: string,
   method = "GET",
   body?: string,
 ) {
@@ -31,12 +31,12 @@ export async function azureRequest(
 
     if (!response.ok) {
       log.error("Azure request failed", response);
-      if (correlationId) {
+      if (associationId) {
         sendTelemetryEvent(
           EventType.AzureRequestFailed,
           {
             reason: `request to azure returned code ${response.status}`,
-            correlationId,
+            associationId,
           },
           {},
         );
@@ -50,10 +50,10 @@ export async function azureRequest(
 
     return result;
   } catch (e) {
-    if (correlationId) {
+    if (associationId) {
       sendTelemetryEvent(
         EventType.AzureRequestFailed,
-        { reason: `request to azure failed to return`, correlationId },
+        { reason: `request to azure failed to return`, associationId },
         {},
       );
     }
@@ -70,7 +70,7 @@ export async function storageRequest(
   proxy?: string,
   extraHeaders?: [string, string][],
   body?: string | Uint8Array,
-  correlationId?: string,
+  associationId?: string,
 ) {
   const headers: [string, string][] = [
     ["x-ms-version", "2023-01-03"],
@@ -89,12 +89,12 @@ export async function storageRequest(
     const response = await fetch(uri, { method, headers, body });
     if (!response.ok) {
       log.error("Storage request failed", response);
-      if (correlationId) {
+      if (associationId) {
         sendTelemetryEvent(
           EventType.StorageRequestFailed,
           {
             reason: `request to storage on azure returned code ${response.status}`,
-            correlationId,
+            associationId,
           },
           {},
         );
@@ -105,12 +105,12 @@ export async function storageRequest(
     return response;
   } catch (e) {
     log.error(`Failed to fetch ${uri}: ${e}`);
-    if (correlationId) {
+    if (associationId) {
       sendTelemetryEvent(
         EventType.StorageRequestFailed,
         {
           reason: `request to storage on azure failed to return`,
-          correlationId,
+          associationId,
         },
         {},
       );
@@ -201,8 +201,8 @@ export class StorageUris {
 }
 
 export async function checkCorsConfig(token: string, quantumUris: QuantumUris) {
-  const correlationId = getRandomGuid();
-  sendTelemetryEvent(EventType.CheckCorsStart, { correlationId }, {});
+  const associationId = getRandomGuid();
+  sendTelemetryEvent(EventType.CheckCorsStart, { associationId }, {});
 
   log.debug("Checking CORS configuration for the workspace");
 
@@ -211,7 +211,7 @@ export async function checkCorsConfig(token: string, quantumUris: QuantumUris) {
   const sasResponse: ResponseTypes.SasUri = await azureRequest(
     quantumUris.sasUri(),
     token,
-    correlationId,
+    associationId,
     "POST",
     body,
   );
@@ -259,7 +259,7 @@ export async function checkCorsConfig(token: string, quantumUris: QuantumUris) {
   log.debug("Pre-flighted GET request didn't throw, so CORS seems good");
   sendTelemetryEvent(
     EventType.CheckCorsEnd,
-    { correlationId, flowStatus: UserFlowStatus.Succeeded },
+    { associationId, flowStatus: UserFlowStatus.Succeeded },
     {},
   );
 }

--- a/vscode/src/azure/workspaceActions.ts
+++ b/vscode/src/azure/workspaceActions.ts
@@ -26,9 +26,9 @@ export const scopes = {
 
 export async function getAuthSession(
   scopes: string[],
-  correlationId: string,
+  associationId: string,
 ): Promise<vscode.AuthenticationSession> {
-  sendTelemetryEvent(EventType.AuthSessionStart, { correlationId }, {});
+  sendTelemetryEvent(EventType.AuthSessionStart, { associationId }, {});
   log.debug("About to getSession for scopes", scopes.join(","));
   try {
     let session = await vscode.authentication.getSession("microsoft", scopes, {
@@ -44,7 +44,7 @@ export async function getAuthSession(
     sendTelemetryEvent(
       EventType.AuthSessionEnd,
       {
-        correlationId,
+        associationId,
         flowStatus: UserFlowStatus.Succeeded,
       },
       {},
@@ -54,7 +54,7 @@ export async function getAuthSession(
     sendTelemetryEvent(
       EventType.AuthSessionEnd,
       {
-        correlationId,
+        associationId,
         reason: "exception in getAuthSession",
         flowStatus: UserFlowStatus.Failed,
       },
@@ -118,20 +118,20 @@ export async function queryWorkspaces(): Promise<
   WorkspaceConnection | undefined
 > {
   log.debug("Querying for account workspaces");
-  const correlationId = getRandomGuid();
-  sendTelemetryEvent(EventType.QueryWorkspacesStart, { correlationId }, {});
+  const associationId = getRandomGuid();
+  sendTelemetryEvent(EventType.QueryWorkspacesStart, { associationId }, {});
   // *** Authenticate and retrieve tenants the user has Azure resources for ***
 
   // For the MSA case, you need to query the tenants first and get the underlying AzureAD
   // tenant for the 'guest' MSA. See https://stackoverflow.microsoft.com/a/76246/108570
-  const firstAuth = await getAuthSession([scopes.armMgmt], correlationId);
+  const firstAuth = await getAuthSession([scopes.armMgmt], associationId);
 
   if (!firstAuth) {
     log.error("No authentication session returned");
     sendTelemetryEvent(
       EventType.QueryWorkspacesEnd,
       {
-        correlationId,
+        associationId,
         reason: "no auth session returned",
         flowStatus: UserFlowStatus.Failed,
       },
@@ -146,7 +146,7 @@ export async function queryWorkspaces(): Promise<
   const tenants: ResponseTypes.TenantList = await azureRequest(
     azureUris.tenants(),
     firstToken,
-    correlationId,
+    associationId,
   );
   log.trace(`Got tenants: ${JSON.stringify(tenants, null, 2)}`);
   if (!tenants?.value?.length) {
@@ -154,7 +154,7 @@ export async function queryWorkspaces(): Promise<
     sendTelemetryEvent(
       EventType.QueryWorkspacesEnd,
       {
-        correlationId,
+        associationId,
         reason: "no tenants exist for account",
         flowStatus: UserFlowStatus.Failed,
       },
@@ -180,7 +180,7 @@ export async function queryWorkspaces(): Promise<
       sendTelemetryEvent(
         EventType.QueryWorkspacesEnd,
         {
-          correlationId,
+          associationId,
           reason: "aborted tenant choice",
           flowStatus: UserFlowStatus.Aborted,
         },
@@ -200,13 +200,13 @@ export async function queryWorkspaces(): Promise<
   if (accountType !== "aad" || !matchesTenant) {
     tenantAuth = await getAuthSession(
       [scopes.armMgmt, `VSCODE_TENANT:${tenantId}`],
-      correlationId,
+      associationId,
     );
     if (!tenantAuth) {
       sendTelemetryEvent(
         EventType.QueryWorkspacesEnd,
         {
-          correlationId,
+          associationId,
           reason: "authentication session did not return",
           flowStatus: UserFlowStatus.Aborted,
         },
@@ -222,7 +222,7 @@ export async function queryWorkspaces(): Promise<
   const subs: ResponseTypes.SubscriptionList = await azureRequest(
     azureUris.subscriptions(),
     tenantToken,
-    correlationId,
+    associationId,
   );
   log.trace(`Got subscriptions: ${JSON.stringify(subs, null, 2)}`);
   if (!subs?.value?.length) {
@@ -248,7 +248,7 @@ export async function queryWorkspaces(): Promise<
       sendTelemetryEvent(
         EventType.QueryWorkspacesEnd,
         {
-          correlationId,
+          associationId,
           reason: "aborted subscription choice",
           flowStatus: UserFlowStatus.Aborted,
         },
@@ -263,7 +263,7 @@ export async function queryWorkspaces(): Promise<
   const workspaces: ResponseTypes.WorkspaceList = await azureRequest(
     azureUris.workspaces(subId),
     tenantToken,
-    correlationId,
+    associationId,
   );
   if (log.getLogLevel() >= 5) {
     log.trace(`Got workspaces: ${JSON.stringify(workspaces, null, 2)}`);
@@ -273,7 +273,7 @@ export async function queryWorkspaces(): Promise<
     sendTelemetryEvent(
       EventType.QueryWorkspacesEnd,
       {
-        correlationId,
+        associationId,
         reason: "no quantum workspaces in azure subscription",
         flowStatus: UserFlowStatus.Aborted,
       },
@@ -303,7 +303,7 @@ export async function queryWorkspaces(): Promise<
       sendTelemetryEvent(
         EventType.QueryWorkspacesEnd,
         {
-          correlationId,
+          associationId,
           reason: "aborted workspace selection",
           flowStatus: UserFlowStatus.Aborted,
         },
@@ -344,11 +344,11 @@ export async function queryWorkspaces(): Promise<
 }
 
 export async function getTokenForWorkspace(workspace: WorkspaceConnection) {
-  const correlationId = getRandomGuid();
+  const associationId = getRandomGuid();
 
   const workspaceAuth = await getAuthSession(
     [scopes.quantum, `VSCODE_TENANT:${workspace.tenantId}`],
-    correlationId,
+    associationId,
   );
   return workspaceAuth.accessToken;
 }
@@ -359,15 +359,15 @@ export async function getTokenForWorkspace(workspace: WorkspaceConnection) {
 export async function queryWorkspace(workspace: WorkspaceConnection) {
   const token = await getTokenForWorkspace(workspace);
 
-  const correlationId = getRandomGuid();
-  sendTelemetryEvent(EventType.QueryWorkspaceStart, { correlationId }, {});
+  const associationId = getRandomGuid();
+  sendTelemetryEvent(EventType.QueryWorkspaceStart, { associationId }, {});
 
   const quantumUris = new QuantumUris(workspace.endpointUri, workspace.id);
 
   const providerStatus: ResponseTypes.ProviderStatusList = await azureRequest(
     quantumUris.providerStatus(),
     token,
-    correlationId,
+    associationId,
   );
   if (log.getLogLevel() >= 5) {
     log.trace(
@@ -394,7 +394,7 @@ export async function queryWorkspace(workspace: WorkspaceConnection) {
   const jobs: ResponseTypes.JobList = await azureRequest(
     quantumUris.jobs(),
     token,
-    correlationId,
+    associationId,
   );
   log.debug(`Query returned ${jobs.value.length} jobs`);
 
@@ -410,7 +410,7 @@ export async function queryWorkspace(workspace: WorkspaceConnection) {
     sendTelemetryEvent(
       EventType.QueryWorkspaceEnd,
       {
-        correlationId,
+        associationId,
         reason: "no jobs returned",
         flowStatus: UserFlowStatus.Aborted,
       },
@@ -426,7 +426,7 @@ export async function queryWorkspace(workspace: WorkspaceConnection) {
 
   sendTelemetryEvent(
     EventType.QueryWorkspaceEnd,
-    { correlationId, flowStatus: UserFlowStatus.Succeeded },
+    { associationId, flowStatus: UserFlowStatus.Succeeded },
     {},
   );
 
@@ -439,15 +439,15 @@ export async function getJobFiles(
   token: string,
   quantumUris: QuantumUris,
 ): Promise<string> {
-  const correlationId = getRandomGuid();
+  const associationId = getRandomGuid();
   log.debug(`Fetching job file from ${containerName}/${blobName}`);
-  sendTelemetryEvent(EventType.GetJobFilesStart, { correlationId }, {});
+  sendTelemetryEvent(EventType.GetJobFilesStart, { associationId }, {});
 
   const body = JSON.stringify({ containerName, blobName });
   const sasResponse: ResponseTypes.SasUri = await azureRequest(
     quantumUris.sasUri(),
     token,
-    correlationId,
+    associationId,
     "POST",
     body,
   );
@@ -465,7 +465,7 @@ export async function getJobFiles(
     sendTelemetryEvent(
       EventType.GetJobFilesEnd,
       {
-        correlationId,
+        associationId,
         reason: "no files returned",
         flowStatus: UserFlowStatus.Aborted,
       },
@@ -477,7 +477,7 @@ export async function getJobFiles(
   const blob = await file.text();
   sendTelemetryEvent(
     EventType.GetJobFilesEnd,
-    { correlationId, flowStatus: UserFlowStatus.Succeeded },
+    { associationId, flowStatus: UserFlowStatus.Succeeded },
     {},
   );
   return blob;
@@ -490,8 +490,8 @@ export async function submitJob(
   providerId: string,
   target: string,
 ) {
-  const correlationId = getRandomGuid();
-  sendTelemetryEvent(EventType.SubmitToAzureStart, { correlationId }, {});
+  const associationId = getRandomGuid();
+  sendTelemetryEvent(EventType.SubmitToAzureStart, { associationId }, {});
 
   const containerName = getRandomGuid();
   const jobName = await vscode.window.showInputBox({ prompt: "Job name" });
@@ -516,7 +516,7 @@ export async function submitJob(
     sendTelemetryEvent(
       EventType.SubmitToAzureEnd,
       {
-        correlationId,
+        associationId,
         reason: "undefined number of shots",
         flowStatus: UserFlowStatus.Aborted,
       },
@@ -530,7 +530,7 @@ export async function submitJob(
   const sasResponse = await azureRequest(
     quantumUris.sasUri(),
     token,
-    correlationId,
+    associationId,
     "POST",
     body,
   );
@@ -555,7 +555,7 @@ export async function submitJob(
     useProxy ? quantumUris.storageProxy() : undefined,
     undefined,
     undefined,
-    correlationId,
+    associationId,
   );
 
   // Write the input data
@@ -570,7 +570,7 @@ export async function submitJob(
       ["Content-Type", "text/plain"],
     ],
     qirFile,
-    correlationId,
+    associationId,
   );
 
   // PUT the job data
@@ -596,7 +596,7 @@ export async function submitJob(
   await azureRequest(
     putJobUri,
     token,
-    correlationId,
+    associationId,
     "PUT",
     JSON.stringify(payload),
   );
@@ -605,7 +605,7 @@ export async function submitJob(
   sendTelemetryEvent(
     EventType.SubmitToAzureEnd,
     {
-      correlationId,
+      associationId,
       reason: "job submitted",
       flowStatus: UserFlowStatus.Succeeded,
     },

--- a/vscode/src/debugger/session.ts
+++ b/vscode/src/debugger/session.ts
@@ -106,8 +106,8 @@ export class QscDebugSession extends LoggingDebugSession {
     this.setDebuggerColumnsStartAt1(false);
   }
 
-  public async init(correlationId: string): Promise<void> {
-    sendTelemetryEvent(EventType.InitializeRuntimeStart, { correlationId }, {});
+  public async init(associationId: string): Promise<void> {
+    sendTelemetryEvent(EventType.InitializeRuntimeStart, { associationId }, {});
     const file = await this.fileAccessor.openUri(this.program);
     const programText = file.getText();
     const targetProfile = getTarget();
@@ -157,7 +157,7 @@ export class QscDebugSession extends LoggingDebugSession {
       sendTelemetryEvent(
         EventType.InitializeRuntimeEnd,
         {
-          correlationId,
+          associationId,
           reason: "compilation failed",
           flowStatus: UserFlowStatus.Aborted,
         },
@@ -167,7 +167,7 @@ export class QscDebugSession extends LoggingDebugSession {
     }
     sendTelemetryEvent(
       EventType.InitializeRuntimeEnd,
-      { correlationId, flowStatus: UserFlowStatus.Succeeded },
+      { associationId, flowStatus: UserFlowStatus.Succeeded },
       {},
     );
   }
@@ -266,8 +266,8 @@ export class QscDebugSession extends LoggingDebugSession {
     response: DebugProtocol.LaunchResponse,
     args: ILaunchRequestArguments,
   ): Promise<void> {
-    const correlationId = getRandomGuid();
-    sendTelemetryEvent(EventType.Launch, { correlationId }, {});
+    const associationId = getRandomGuid();
+    sendTelemetryEvent(EventType.Launch, { associationId }, {});
     if (this.failureMessage != "") {
       log.info(
         "compilation failed. sending error response and stopping execution.",
@@ -302,20 +302,20 @@ export class QscDebugSession extends LoggingDebugSession {
 
     if (args.noDebug) {
       log.trace(`Running without debugging`);
-      await this.runWithoutDebugging(args, correlationId);
+      await this.runWithoutDebugging(args, associationId);
     } else {
       log.trace(`Running with debugging`);
       if (this.config.stopOnEntry) {
         sendTelemetryEvent(
           EventType.DebugSessionEvent,
-          { correlationId, event: DebugEvent.StepIn },
+          { associationId, event: DebugEvent.StepIn },
           {},
         );
         await this.stepIn();
       } else {
         sendTelemetryEvent(
           EventType.DebugSessionEvent,
-          { correlationId, event: DebugEvent.Continue },
+          { associationId, event: DebugEvent.Continue },
           {},
         );
         await this.continue();
@@ -385,7 +385,7 @@ export class QscDebugSession extends LoggingDebugSession {
 
   private async runWithoutDebugging(
     args: ILaunchRequestArguments,
-    correlationId: string,
+    associationId: string,
   ): Promise<void> {
     const bps: number[] = [];
     // This will be replaced when the interpreter
@@ -403,7 +403,7 @@ export class QscDebugSession extends LoggingDebugSession {
       // Reset the interpreter for the next shot.
       // The interactive interpreter doesn't do this automatically,
       // and doesn't know how to deal with shots like the stateless version.
-      await this.init(correlationId);
+      await this.init(associationId);
       if (this.failureMessage != "") {
         log.info(
           "compilation failed. sending error response and stopping execution.",
@@ -877,10 +877,10 @@ export class QscDebugSession extends LoggingDebugSession {
         variables: variables,
       };
     } else if (handle === "quantum") {
-      const correlationId = getRandomGuid();
+      const associationId = getRandomGuid();
       sendTelemetryEvent(
         EventType.RenderQuantumStateStart,
-        { correlationId },
+        { associationId },
         {},
       );
       const state = await this.debugService.captureQuantumState();
@@ -895,7 +895,7 @@ export class QscDebugSession extends LoggingDebugSession {
       });
       sendTelemetryEvent(
         EventType.RenderQuantumStateEnd,
-        { correlationId },
+        { associationId },
         {},
       );
       response.body = {

--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -66,12 +66,12 @@ export async function getQirForActiveWindow(): Promise<string> {
     worker.terminate();
   }, generateQirTimeoutMs);
   try {
-    const correlationId = getRandomGuid();
-    sendTelemetryEvent(EventType.GenerateQirStart, { correlationId }, {});
+    const associationId = getRandomGuid();
+    sendTelemetryEvent(EventType.GenerateQirStart, { associationId }, {});
     result = await worker.getQir(code);
     sendTelemetryEvent(
       EventType.GenerateQirEnd,
-      { correlationId },
+      { associationId },
       { qirLength: result.length },
     );
     clearTimeout(compilerTimeout);

--- a/vscode/src/telemetry.ts
+++ b/vscode/src/telemetry.ts
@@ -49,108 +49,108 @@ type EventTypes = {
     measurements: { timeToCompletionMs: number; completionListLength: number };
   };
   [EventType.GenerateQirStart]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.GenerateQirEnd]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: { qirLength: number };
   };
   [EventType.RenderQuantumStateStart]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.RenderQuantumStateEnd]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.SubmitToAzureStart]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.SubmitToAzureEnd]: {
     properties: {
-      correlationId: string;
+      associationId: string;
       reason?: string;
       flowStatus: UserFlowStatus;
     };
     measurements: Empty;
   };
   [EventType.AuthSessionStart]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.AuthSessionEnd]: {
     properties: {
-      correlationId: string;
+      associationId: string;
       reason?: string;
       flowStatus: UserFlowStatus;
     };
     measurements: Empty;
   };
   [EventType.QueryWorkspacesStart]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.QueryWorkspacesEnd]: {
     properties: {
-      correlationId: string;
+      associationId: string;
       reason?: string;
       flowStatus: UserFlowStatus;
     };
     measurements: Empty;
   };
   [EventType.AzureRequestFailed]: {
-    properties: { correlationId: string; reason?: string };
+    properties: { associationId: string; reason?: string };
     measurements: Empty;
   };
   [EventType.StorageRequestFailed]: {
-    properties: { correlationId: string; reason?: string };
+    properties: { associationId: string; reason?: string };
     measurements: Empty;
   };
   [EventType.GetJobFilesStart]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.GetJobFilesEnd]: {
     properties: {
-      correlationId: string;
+      associationId: string;
       reason?: string;
       flowStatus: UserFlowStatus;
     };
     measurements: Empty;
   };
   [EventType.QueryWorkspaceStart]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.QueryWorkspaceEnd]: {
     properties: {
-      correlationId: string;
+      associationId: string;
       reason?: string;
       flowStatus: UserFlowStatus;
     };
     measurements: Empty;
   };
   [EventType.CheckCorsStart]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.CheckCorsEnd]: {
     properties: {
-      correlationId: string;
+      associationId: string;
       reason?: string;
       flowStatus: UserFlowStatus;
     };
     measurements: Empty;
   };
   [EventType.InitializeRuntimeStart]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.InitializeRuntimeEnd]: {
     properties: {
-      correlationId: string;
+      associationId: string;
       reason?: string;
       flowStatus: UserFlowStatus;
     };
@@ -158,13 +158,13 @@ type EventTypes = {
   };
   [EventType.DebugSessionEvent]: {
     properties: {
-      correlationId: string;
+      associationId: string;
       event: DebugEvent;
     };
     measurements: Empty;
   };
   [EventType.Launch]: {
-    properties: { correlationId: string };
+    properties: { associationId: string };
     measurements: Empty;
   };
   [EventType.OpenedDocument]: {


### PR DESCRIPTION
It turns out `correlationId` gets eaten by the telemetry infra somewhere along the pipeline. This PR changes the name of the property to `associationId`. I've confirmed that this makes it through the pipeline and shows up in our tools.
