### PR TITLE
Throw vscode dialog if qsharp.json isn't valid

### DIFF
--- a/vscode/src/projectSystem.ts
+++ b/vscode/src/projectSystem.ts
@@ -33,10 +33,10 @@ export async function getManifest(uri: string): Promise<{
   try {
     parsedManifest = JSON.parse(manifestDocument.content);
   } catch (e) {
-    log.error(
-      "Found manifest document, but the Q# manifest was not valid JSON",
-      e,
-    );
+    const message =
+      "Found manifest document, but the Q# manifest was not valid JSON";
+    vscode.window.showErrorMessage(message);
+    log.error(message, e);
     PROJECT_MODE = false;
     return null;
   }


### PR DESCRIPTION
@idavis pointed out that if a `qsharp.json` file is invalid (empty, or invalid JSON), we log to the
extension logs and fail. This is not a great user experience, as the error is almost completely
undiscoverable. 
