### PR TITLE
Remove test profile from qsc_project Cargo.toml

### DIFF
--- a/compiler/qsc_project/Cargo.toml
+++ b/compiler/qsc_project/Cargo.toml
@@ -25,8 +25,5 @@ qsc_project = { path = ".", features = ["fs"] }
 fs = []
 async = ["async-trait"]
 
-[profile.test]
-default = ["fs"]
-
 [lib]
 doctest = false


### PR DESCRIPTION
Profile settings are not respected in a child Cargo.toml of a workspace, so these should just be removed.