### PR TITLE
Bring back red squigglies in playground (update file version when in SFM)

### DIFF
--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -200,6 +200,7 @@ impl<'a> LanguageService<'a> {
         self.currently_updating = true;
         trace!("update_document: {uri} {version}");
         let manifest = (self.get_manifest)(uri.to_string()).await;
+        let in_project_mode = manifest.is_some();
         let sources = if let Some(ref manifest) = manifest {
             match self.load_project(manifest).await {
                 Ok(o) => o.sources,
@@ -236,22 +237,32 @@ impl<'a> LanguageService<'a> {
         // to be in the context of the project.
         // We remove them from the existing compilations and update
         // their compilation URI
-        for (path, _contents) in &sources {
-            log::trace!("Updating compilation of {path} to {uri}");
-            self.open_documents
-                .entry(path.clone())
-                .and_modify(|x| {
-                    // remove any old single-file compilations of this document
-                    // if this is a project
-                    if x.compilation != uri {
-                        self.compilations.remove(&x.compilation);
-                    }
-                    x.compilation = uri.clone();
-                })
-                .or_insert(OpenDocument {
+        if in_project_mode {
+            for (path, _contents) in &sources {
+                log::trace!("Updating compilation of {path} to {uri}");
+                self.open_documents
+                    .entry(path.clone())
+                    .and_modify(|x| {
+                        // remove any old single-file compilations of this document
+                        // if this is a project
+                        if x.compilation != uri {
+                            self.compilations.remove(&x.compilation);
+                        }
+                        x.compilation = uri.clone();
+                    })
+                    .or_insert(OpenDocument {
+                        version,
+                        compilation: uri.clone(),
+                    });
+            }
+        } else {
+            self.open_documents.insert(
+                uri.clone(),
+                OpenDocument {
                     version,
                     compilation: uri.clone(),
-                });
+                },
+            );
         }
 
         self.publish_diagnostics();

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -86,7 +86,7 @@ async fn clear_error() {
                 (
                     "foo.qs",
                     Some(
-                        1,
+                        2,
                     ),
                     [],
                 ),


### PR DESCRIPTION
This error was caused by a document version mismatch when reporting diagnostics back to the
playground. 

We perform a manual version check [here](https://github.com/microsoft/qsharp/blob/main/playground/src/editor.tsx#L106), which was failing. While
removing that version check would have restored diagnostic reporting, it would have
masked the underlying bug. Even though we don't use versions for anything, this version
mismatch would have gone undetected for a while and perhaps caused other issues. For that reason,
I am happy we have the above linked forward-thinking version check! 

Ultimately, the source of the version mismatch was failing to update `open_documents` in the language
service when running in single file mode.
