### PR TITLE
Suppress more raw string hash warnings

### DIFF
--- a/compiler/qsc/src/interpret/stateful/re/counts/tests.rs
+++ b/compiler/qsc/src/interpret/stateful/re/counts/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use std::convert::Into;
 
 use crate::{

--- a/compiler/qsc/src/interpret/stateful/re/estimates/data/report.rs
+++ b/compiler/qsc/src/interpret/stateful/re/estimates/data/report.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
This fixes builds with Rust 1.74