### PR TITLE
Pin hatchling to 1.18

### DIFF
--- a/jupyterlab/pyproject.toml
+++ b/jupyterlab/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.4.0", "jupyterlab==4.0.0", "hatch-nodejs-version"]
+requires = ["hatchling<=1.18.0", "jupyterlab==4.0.0", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
We eventually need to update build settings to adjust to https://github.com/pypa/hatch/issues/1113.