### PR TITLE
Fix hatchling build by adding required sections

### DIFF
--- a/jupyterlab/pyproject.toml
+++ b/jupyterlab/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.4.0", "jupyterlab==4.0.0", "hatch-nodejs-version"]
+requires = ["hatchling>=1.19.0", "jupyterlab==4.0.0", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]
@@ -59,6 +59,12 @@ build_cmd = "build:dev"
 npm = ["jlpm"]
 source_dir = "src"
 build_dir = "qsharp-jupyterlab/labextension"
+
+[tool.hatch.build.targets.wheel]
+packages = ["qsharp-jupyterlab"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"./setup.py" = "setup.py"
 
 [tool.check-wheel-contents]
 ignore = ["W002"]


### PR DESCRIPTION
This adds the newly required sections to the hatchling build and making sure the right files get included in the wheel.

See https://github.com/pypa/hatch/issues/1113 for context.