### PR TITLE
Added some unimplemented functions and operations

### DIFF
--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -461,6 +461,10 @@ pub fn std(store: &PackageStore, capabilities: RuntimeCapabilityFlags) -> Compil
                 include_str!("../../../library/std/random.qs").into(),
             ),
             (
+                "unimplemented.qs".into(),
+                include_str!("../../../library/std/unimplemented.qs").into(),
+            ),
+            (
                 "unstable_arithmetic.qs".into(),
                 include_str!("../../../library/std/unstable_arithmetic.qs").into(),
             ),

--- a/library/std/unimplemented.qs
+++ b/library/std/unimplemented.qs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Math {
+    /// ModPowL is not supported. Use ExpModL instead.
+    @Unimplemented()
+    function ModPowL (value : BigInt, exponent : BigInt, modulus : BigInt) : BigInt {
+        fail "";
+    }
+
+    /// ExpD is not supported. Use E()^a instead.
+    @Unimplemented()
+    function ExpD (a : Double) : Double {
+        fail "";
+    }
+}
+
+namespace Microsoft.Quantum.Arithmetic {
+
+    /// Microsoft.Quantum.Arithmetic.ApplyXorInPlace has been moved. Use Microsoft.Quantum.Canon.ApplyXorInPlace instead.
+    @Unimplemented()
+    operation ApplyXorInPlace(value : Int, target : Qubit[]) : Unit is Adj + Ctl {
+        fail "";
+    }
+
+    /// Microsoft.Quantum.Arithmetic.MeasureInteger has been moved. Use Microsoft.Quantum.Measurement.MeasureInteger instead.
+    @Unimplemented()
+    operation MeasureInteger(target : Qubit[]) : Int {
+        fail "";
+    }
+
+    /// LittleEndian type is not supported. All standart library functions use little-endian format for qubit registers `Qubit[]`.
+    @Unimplemented()
+    newtype LittleEndian = Qubit[];
+
+}

--- a/library/std/unimplemented.qs
+++ b/library/std/unimplemented.qs
@@ -8,9 +8,33 @@ namespace Microsoft.Quantum.Math {
         fail "";
     }
 
-    /// ExpD is not supported. Use E()^a instead.
+    /// ExpD(a) is not supported. Use E()^a instead.
     @Unimplemented()
     function ExpD (a : Double) : Double {
+        fail "";
+    }
+
+    /// HalfIntegerBinom has been removed. Provide your own implementation if needed.
+    @Unimplemented()
+    function HalfIntegerBinom (k : Int) : Double {
+        fail "";
+    }
+
+    /// IEEERemainder has been removed. Provide your own implementation if needed.
+    @Unimplemented()
+    function IEEERemainder (x : Double, y : Double) : Double {
+        fail "";
+    }
+
+    /// Microsoft.Quantum.Math.ComplexPolarAsComplex has been moved. Use Microsoft.Quantum.Convert.ComplexPolarAsComplex instead.
+    @Unimplemented()
+    function ComplexPolarAsComplex (input : ComplexPolar) : Complex {
+        fail "";
+    }
+
+    /// Microsoft.Quantum.Math.ComplexAsComplexPolar has been moved. Use Microsoft.Quantum.Convert.ComplexAsComplexPolar instead.
+    @Unimplemented()
+    function ComplexAsComplexPolar (input : Complex) : ComplexPolar {
         fail "";
     }
 }
@@ -29,7 +53,7 @@ namespace Microsoft.Quantum.Arithmetic {
         fail "";
     }
 
-    /// LittleEndian type is not supported. All standart library functions use little-endian format for qubit registers `Qubit[]`.
+    /// Explicit LittleEndian type is not supported. Use Qubit[] directly since all library functions use little-endian format for qubit registers.
     @Unimplemented()
     newtype LittleEndian = Qubit[];
 


### PR DESCRIPTION
This adds a few functions we removed with `@Unimplemented` attribute and a doc comment to direct users to the suggested replacement. This will help users to fix their code. The functions do not include implementations.
Known problems:
* We have to re-introduce namespaces we removed
* Unimplemented functions show in completion lists

NOTE: Not for merging. For experiments only.