### PR TITLE
Add qubit number pre-check to Grover

### DIFF
--- a/samples/algorithms/Grover.qs
+++ b/samples/algorithms/Grover.qs
@@ -59,6 +59,9 @@ namespace Sample {
     /// Returns the optimal number of Grover iterations needed to find a marked
     /// item, given the number of qubits in a register.
     function CalculateOptimalIterations(nQubits : Int) : Int {
+        if nQubits > 63 {
+            fail "This sample supports at most 63 qubits.";
+        }
         let nItems = 1 <<< nQubits; // 2^nQubits
         let angle = ArcSin(1. / Sqrt(IntAsDouble(nItems)));
         let iterations = Round(0.25 * PI() / angle - 0.5);


### PR DESCRIPTION
Because the Grover's algorithm sample does a bit shift by the number of qubits, we should verify that the sample does not use more than 63 qubits since that would cause a somewhat arcane error in the bitwise operation.