### PR TITLE
Async updates for the language service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,17 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e1373abdaa212b704512ec2bd8b26bd0b7d5c3f70117411a5d9a451383c859"
 
 [[package]]
-name = "async-recursion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,7 +1085,6 @@ dependencies = [
 name = "qsls"
 version = "0.0.0"
 dependencies = [
- "async-recursion",
  "async-trait",
  "enum-iterator",
  "expect-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f4cdac9e4065d7c48e30770f8665b8cef9a3a73a63a4056a33a5f395bc7cf75"
 
 [[package]]
+name = "futures"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+
+[[package]]
+name = "futures-task"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+
+[[package]]
+name = "futures-util"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fuzz"
 version = "0.0.0"
 dependencies = [
@@ -697,6 +786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +1059,7 @@ name = "qsc_wasm"
 version = "0.0.0"
 dependencies = [
  "expect-test",
+ "futures-util",
  "getrandom",
  "indoc",
  "js-sys",
@@ -1004,6 +1100,8 @@ dependencies = [
  "async-trait",
  "enum-iterator",
  "expect-test",
+ "futures",
+ "futures-util",
  "indoc",
  "log",
  "miette",
@@ -1208,6 +1306,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ serde_json = { version = "1.0" }
 pyo3 = { version = "0.20" }
 quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", rev = "f000e0066f56338595be37092cd0498f72ab10a2", default-features = false }
 async-trait = "0.1"
-async-recursion = "1.0"
 tokio = { version = "1.34", features = ["macros", "rt"] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ criterion = { version = "0.5", default-features = false }
 enum-iterator = "1.4"
 env_logger = "0.10.0"
 expect-test = "1.4"
+futures = "0.3"
+futures-util = "0.3"
 fasteval = "0.2"
 getrandom = { version = "0.2" }
 indoc = "2.0"

--- a/language_service/Cargo.toml
+++ b/language_service/Cargo.toml
@@ -14,6 +14,8 @@ indoc = { workspace = true }
 tokio = { workspace = true }
 
 [dependencies]
+futures = { workspace = true }
+futures-util = { workspace = true }
 log = { workspace = true }
 miette = { workspace = true }
 qsc = { path = "../compiler/qsc" }

--- a/language_service/Cargo.toml
+++ b/language_service/Cargo.toml
@@ -24,7 +24,6 @@ enum-iterator = { workspace = true }
 regex-lite = { workspace = true }
 qsc_project = { path = "../compiler/qsc_project", features = ["async"] }
 async-trait = { workspace = true }
-async-recursion = { workspace = true }
 
 [lib]
 doctest = false

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -135,7 +135,7 @@ impl LanguageService {
     pub fn update_notebook_document<'b, I>(
         &mut self,
         notebook_uri: &str,
-        notebook_metadata: &NotebookMetadata,
+        notebook_metadata: NotebookMetadata,
         cells: I,
     ) where
         I: Iterator<Item = (&'b str, u32, &'b str)>, // uri, version, text - basically DidChangeTextDocumentParams in LSP
@@ -143,7 +143,7 @@ impl LanguageService {
         trace!("update_notebook_document: {notebook_uri}");
         self.send_update(Update::NotebookDocument {
             notebook_uri: notebook_uri.into(),
-            notebook_metadata: notebook_metadata.clone(),
+            notebook_metadata,
             cells: cells
                 .map(|(uri, version, contents)| (uri.into(), version, contents.into()))
                 .collect(),
@@ -380,7 +380,7 @@ async fn apply_update(updater: &mut CompilationStateUpdater<'_>, update: Update)
             cells,
         } => updater.update_notebook_document(
             &notebook_uri,
-            &notebook_metadata,
+            notebook_metadata,
             cells
                 .iter()
                 .map(|(uri, version, contents)| (uri.as_ref(), *version, contents.as_ref())),
@@ -390,7 +390,7 @@ async fn apply_update(updater: &mut CompilationStateUpdater<'_>, update: Update)
             cell_uris,
         } => updater.close_notebook_document(&notebook_uri, cell_uris.iter().map(AsRef::as_ref)),
         Update::Configuration { changed } => {
-            updater.update_configuration(&changed);
+            updater.update_configuration(changed);
         }
     }
 }

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -89,10 +89,10 @@ impl LanguageService {
     /// being published.
     ///
     /// LSP: workspace/didChangeConfiguration
-    pub fn update_configuration(&mut self, configuration: &WorkspaceConfigurationUpdate) {
+    pub fn update_configuration(&mut self, configuration: WorkspaceConfigurationUpdate) {
         trace!("update_configuration: {configuration:?}");
         self.send_update(Update::Configuration {
-            changed: configuration.clone(),
+            changed: configuration,
         });
     }
 

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -26,11 +26,11 @@ use compilation::Compilation;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures_util::StreamExt;
 use log::{trace, warn};
-pub use project_system::JSFileEntry;
 use protocol::{
     CompletionList, DiagnosticUpdate, Hover, Location, NotebookMetadata, SignatureHelp,
     WorkspaceConfigurationUpdate,
 };
+use qsc_project::JSFileEntry;
 use state::{CompilationState, CompilationStateUpdater};
 use std::{cell::RefCell, fmt::Debug, future::Future, pin::Pin, rc::Rc, sync::Arc};
 

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -16,146 +16,59 @@ mod qsc_utils;
 pub mod references;
 pub mod rename;
 pub mod signature_help;
+mod state;
 #[cfg(test)]
 mod test_utils;
 #[cfg(test)]
 mod tests;
 
-use async_recursion::async_recursion;
 use compilation::Compilation;
-use log::{error, trace, warn};
-use miette::Diagnostic;
+use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+use futures_util::StreamExt;
+use log::{trace, warn};
 pub use project_system::JSFileEntry;
 use protocol::{
     CompletionList, DiagnosticUpdate, Hover, Location, NotebookMetadata, SignatureHelp,
     WorkspaceConfigurationUpdate,
 };
-use qsc::{compile::Error, target::Profile, PackageType};
-use qsc_project::FileSystemAsync;
-use rustc_hash::{FxHashMap, FxHashSet};
-use std::{future::Future, mem::take, pin::Pin, sync::Arc};
-
-type CompilationUri = Arc<str>;
-type DocumentUri = Arc<str>;
-
-/// the desugared return type of an "async fn"
-type PinnedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
-
-/// represents a unary async fn where `Arg` is the input
-/// parameter and `Return` is the return type. The lifetime
-/// `'a` represents the lifetime of the contained `dyn Fn`.
-type AsyncFunction<'a, Arg, Return> = Box<dyn Fn(Arg) -> PinnedFuture<Return> + 'a>;
-
-pub struct LanguageService<'a> {
-    /// Workspace-wide configuration settings. These can include compiler settings that
-    /// affect error checking and other language server behavior.
-    ///
-    /// Some settings can be set both at the compilation scope and at the workspace scope.
-    /// Compilation-scoped settings take precedence over workspace-scoped settings.
-    configuration: Configuration,
-    /// A `CompilationUri` is an identifier for a unique compilation.
-    /// It is NOT required to be a uri that represents an actual document.
-    ///
-    /// For single Q# documents, the `CompilationUri` is the same as the
-    /// document uri.
-    ///
-    /// For notebooks, the `CompilationUri` is the notebook uri.
-    ///
-    /// The `CompilatinUri` is used when compilation-level errors get reported
-    /// to the client. Compilation-level errors are defined as errors without
-    /// an associated source document.
-    ///
-    /// `PartialConfiguration` contains configuration overrides for this
-    /// compilation, explicitly specified through a project manifest (not currently implemented)
-    /// or notebook metadata.
-    compilations: FxHashMap<CompilationUri, (Compilation, PartialConfiguration)>,
-    /// All the documents that we were told about by the client.
-    ///
-    /// This map doesn't necessarily contain ALL the documents that
-    /// make up a compilation - only the ones that are currently open.
-    open_documents: FxHashMap<DocumentUri, OpenDocument>,
-    /// Documents that we have previously published errors about. We need to
-    /// keep track of this so we can clear errors from them when documents are removed
-    /// from a compilation or when a recompilation occurs.
-    documents_with_errors: FxHashSet<DocumentUri>,
-    /// Callback which will receive diagnostics (compilation errors)
-    /// whenever a (re-)compilation occurs.
-    diagnostics_receiver: Box<dyn Fn(DiagnosticUpdate) + 'a>,
-    /// Callback which lets the service read a file from the target filesystem
-    read_file_callback: AsyncFunction<'a, String, (Arc<str>, Arc<str>)>,
-    /// Callback which lets the service list directory contents
-    /// on the target file system
-    list_directory: AsyncFunction<'a, String, Vec<JSFileEntry>>,
-    /// Fetch the manifest file for a specific path
-    get_manifest: AsyncFunction<'a, String, Option<qsc_project::ManifestDescriptor>>,
-    /// Whether or not a compile is currently running.
-    currently_updating: bool,
-    /// The next compile to run, if any
-    pending_update: Option<PendingUpdate>,
-}
-
-#[derive(Clone)]
-pub enum PendingUpdate {
-    Document {
-        uri: String,
-        version: u32,
-        text: String,
-    },
-    RecompileAll,
-}
-
-#[derive(Debug)]
-struct Configuration {
-    pub target_profile: Profile,
-    pub package_type: PackageType,
-}
-
-impl Default for Configuration {
-    fn default() -> Self {
-        Self {
-            target_profile: Profile::Unrestricted,
-            package_type: PackageType::Exe,
-        }
-    }
-}
+use state::{CompilationState, CompilationStateUpdater};
+use std::{cell::RefCell, fmt::Debug, future::Future, pin::Pin, rc::Rc, sync::Arc};
 
 #[derive(Default)]
-struct PartialConfiguration {
-    pub target_profile: Option<Profile>,
-    pub package_type: Option<PackageType>,
+pub struct LanguageService {
+    state: Rc<RefCell<CompilationState>>,
+    state_updater: Option<UnboundedSender<Update>>,
 }
 
-#[derive(Debug)]
-struct OpenDocument {
-    /// This version is the document version provided by the client.
-    /// It increases strictly with each text change, though this knowledge should
-    /// not be important. The version is only ever used when publishing
-    /// diagnostics to help the client associate the list of diagnostics
-    /// with a snapshot of the document.
-    pub version: u32,
-    pub compilation: CompilationUri,
-}
-
-impl<'a> LanguageService<'a> {
-    pub fn new(
+impl LanguageService {
+    pub fn create_update_worker<'a>(
+        &mut self,
         diagnostics_receiver: impl Fn(DiagnosticUpdate) + 'a,
         read_file: impl Fn(String) -> Pin<Box<dyn Future<Output = (Arc<str>, Arc<str>)>>> + 'a,
         list_directory: impl Fn(String) -> Pin<Box<dyn Future<Output = Vec<JSFileEntry>>>> + 'a,
         get_manifest: impl Fn(String) -> Pin<Box<dyn Future<Output = Option<qsc_project::ManifestDescriptor>>>>
             + 'a,
-    ) -> Self {
-        LanguageService {
-            configuration: Configuration::default(),
-            compilations: FxHashMap::default(),
-            open_documents: FxHashMap::default(),
-            documents_with_errors: FxHashSet::default(),
-            diagnostics_receiver: Box::new(diagnostics_receiver),
-            read_file_callback: Box::new(read_file),
-            list_directory: Box::new(list_directory),
-            get_manifest: Box::new(get_manifest),
-            currently_updating: false,
-            pending_update: None,
-        }
+    ) -> UpdateWorker<'a> {
+        assert!(self.state_updater.is_none());
+        let (send, recv) = unbounded();
+        let worker = UpdateWorker {
+            updater: CompilationStateUpdater::new(
+                self.state.clone(),
+                diagnostics_receiver,
+                read_file,
+                list_directory,
+                get_manifest,
+            ),
+            recv,
+        };
+        self.state_updater = Some(send);
+        worker
+    }
+
+    pub fn stop_updates(&mut self) {
+        // Dropping the sender will cause the
+        // worker created in [`create_update_worker()`] to stop.
+        self.state_updater = None;
     }
 
     /// Updates the workspace configuration. If any compiler settings are updated,
@@ -165,18 +78,9 @@ impl<'a> LanguageService<'a> {
     /// LSP: workspace/didChangeConfiguration
     pub fn update_configuration(&mut self, configuration: &WorkspaceConfigurationUpdate) {
         trace!("update_configuration: {configuration:?}");
-
-        let need_recompile = self.apply_configuration(configuration);
-
-        // Some configuration options require a recompilation as they impact error checking
-        if need_recompile {
-            if self.currently_updating {
-                self.pending_update = Some(PendingUpdate::RecompileAll);
-                trace!("Skipping recompile_all since compilation is in progress");
-                return;
-            }
-            self.recompile_all();
-        }
+        self.queue_update(Update::Configuration {
+            changed: configuration.clone(),
+        });
     }
 
     /// Indicates that the document has been opened or the source has been updated.
@@ -187,98 +91,13 @@ impl<'a> LanguageService<'a> {
     /// This is the "entry point" for the language service's logic, after its constructor.
     ///
     /// LSP: textDocument/didOpen, textDocument/didChange
-    #[async_recursion(?Send)]
-    pub async fn update_document(&mut self, uri: &str, version: u32, text: &str) {
-        if self.currently_updating {
-            self.pending_update = Some(PendingUpdate::Document {
-                uri: uri.into(),
-                version,
-                text: text.into(),
-            });
-            return;
-        }
-        self.currently_updating = true;
+    pub fn update_document(&mut self, uri: &str, version: u32, text: &str) {
         trace!("update_document: {uri} {version}");
-        let manifest = (self.get_manifest)(uri.to_string()).await;
-        let in_project_mode = manifest.is_some();
-        let sources = if let Some(ref manifest) = manifest {
-            match self.load_project(manifest).await {
-                Ok(o) => o.sources,
-                Err(e) => {
-                    error!("failed to load manifest: {e:?}, defaulting to single-file mode");
-                    vec![(Arc::from(uri), Arc::from(text))]
-                }
-            }
-        } else {
-            trace!("Running in single file mode");
-            vec![(Arc::from(uri), Arc::from(text))]
-        };
-        let compilation = Compilation::new(
-            &sources,
-            self.configuration.package_type,
-            self.configuration.target_profile,
-        );
-        // If we are in single file mode, use the file's path as the compilation identifier.
-        // If we are compiling a project, use the path to the project manifest
-        let uri: Arc<str> = if let Some(manifest) = manifest {
-            Arc::from(format!(
-                "{}/qsharp.json",
-                manifest.manifest_dir.to_string_lossy()
-            ))
-        } else {
-            uri.into()
-        };
-        trace!("Loaded project uri {uri} with {} sources", sources.len());
-        self.compilations
-            .insert(uri.clone(), (compilation, PartialConfiguration::default()));
-
-        // There may be open buffers with sources in the project.
-        // These buffers need to have their diagnostics reloaded,
-        // to be in the context of the project.
-        // We remove them from the existing compilations and update
-        // their compilation URI
-        if in_project_mode {
-            for (path, _contents) in &sources {
-                log::trace!("Updating compilation of {path} to {uri}");
-                self.open_documents
-                    .entry(path.clone())
-                    .and_modify(|x| {
-                        // remove any old single-file compilations of this document
-                        // if this is a project
-                        if x.compilation != uri {
-                            self.compilations.remove(&x.compilation);
-                        }
-                        x.compilation = uri.clone();
-                    })
-                    .or_insert(OpenDocument {
-                        version,
-                        compilation: uri.clone(),
-                    });
-            }
-        } else {
-            self.open_documents.insert(
-                uri.clone(),
-                OpenDocument {
-                    version,
-                    compilation: uri.clone(),
-                },
-            );
-        }
-
-        self.publish_diagnostics();
-        if let Some(update) = self.pending_update.take() {
-            match update {
-                PendingUpdate::Document { uri, version, text } => {
-                    self.update_document(&uri, version, &text).await;
-                }
-                PendingUpdate::RecompileAll => {
-                    // just recompile the same URI and text if we need to recompile all
-                    // ideally, we reload sources from disk here
-                    self.update_document(&uri, version, text).await;
-                }
-            }
-        }
-        self.currently_updating = false;
+        self.queue_update(Update::Document {
+            uri: uri.into(),
+            version,
+            text: text.into(),
+        });
     }
 
     /// Indicates that the client is no longer interested in the document,
@@ -287,11 +106,7 @@ impl<'a> LanguageService<'a> {
     /// LSP: textDocument/didClose
     pub fn close_document(&mut self, uri: &str) {
         trace!("close_document: {uri}");
-
-        self.compilations.remove(uri);
-        self.open_documents.remove(uri);
-
-        self.publish_diagnostics();
+        self.queue_update(Update::CloseDocument { uri: uri.into() });
     }
 
     /// The uri refers to the notebook itself, not any of the individual cells.
@@ -313,41 +128,13 @@ impl<'a> LanguageService<'a> {
         I: Iterator<Item = (&'b str, u32, &'b str)>, // uri, version, text - basically DidChangeTextDocumentParams in LSP
     {
         trace!("update_notebook_document: {notebook_uri}");
-
-        let compilation_uri: Arc<str> = notebook_uri.into();
-
-        // First remove all previously known cells for this notebook
-        self.open_documents
-            .retain(|_, open_doc| notebook_uri != open_doc.compilation.as_ref());
-
-        let notebook_configuration = PartialConfiguration {
-            target_profile: notebook_metadata.target_profile,
-            package_type: None,
-        };
-        let configuration = merge_configurations(&notebook_configuration, &self.configuration);
-
-        // Compile the notebook and add each cell into the document map
-        let compilation = Compilation::new_notebook(
-            cells.map(|(cell_uri, version, cell_contents)| {
-                trace!("update_notebook_document: cell: {cell_uri} {version}");
-                self.open_documents.insert(
-                    (*cell_uri).into(),
-                    OpenDocument {
-                        version,
-                        compilation: compilation_uri.clone(),
-                    },
-                );
-                (Arc::from(cell_uri), Arc::from(cell_contents))
-            }),
-            configuration.target_profile,
-        );
-
-        self.compilations.insert(
-            compilation_uri.clone(),
-            (compilation, notebook_configuration),
-        );
-
-        self.publish_diagnostics();
+        self.queue_update(Update::NotebookDocument {
+            notebook_uri: notebook_uri.into(),
+            notebook_metadata: notebook_metadata.clone(),
+            cells: cells
+                .map(|(uri, version, contents)| (uri.into(), version, contents.into()))
+                .collect(),
+        });
     }
 
     /// Indicates that the client is no longer interested in the notebook.
@@ -364,26 +151,10 @@ impl<'a> LanguageService<'a> {
         cell_uris: impl Iterator<Item = &'b str>,
     ) {
         trace!("close_notebook_document: {notebook_uri}");
-
-        for cell_uri in cell_uris {
-            trace!("close_notebook_document: cell: {cell_uri}");
-            self.open_documents.remove(cell_uri);
-        }
-
-        // The client should have sent all cell uris along with
-        // the notebook. Validate our assumptions about the client
-        // here, by checking that all the cells for this notebook
-        // have been removed from the open documents map.
-        for open_doc in self.open_documents.values() {
-            assert!(
-                notebook_uri != open_doc.compilation.as_ref(),
-                "all cells should have been closed along with the notebook"
-            );
-        }
-
-        self.compilations.remove(notebook_uri);
-
-        self.publish_diagnostics();
+        self.queue_update(Update::CloseNotebookDocument {
+            notebook_uri: notebook_uri.into(),
+            cell_uris: cell_uris.map(Into::into).collect(),
+        });
     }
 
     /// LSP: textDocument/completion
@@ -398,7 +169,7 @@ impl<'a> LanguageService<'a> {
         self.document_op(definition::get_definition, "get_definition", uri, offset)
     }
 
-    /// LSP: textDocument/hover
+    /// LSP: textDocument/references
     #[must_use]
     pub fn get_references(
         &self,
@@ -416,6 +187,7 @@ impl<'a> LanguageService<'a> {
         )
     }
 
+    /// LSP: textDocument/hover
     #[must_use]
     pub fn get_hover(&self, uri: &str, offset: u32) -> Option<Hover> {
         self.document_op(hover::get_hover, "get_hover", uri, offset)
@@ -445,146 +217,166 @@ impl<'a> LanguageService<'a> {
     }
 
     /// Executes an operation that takes a document uri and offset, using the current compilation for that document
-    fn document_op<F, T: Default>(&self, op: F, op_name: &str, uri: &str, offset: u32) -> T
+    fn document_op<F, T>(&self, op: F, op_name: &str, uri: &str, offset: u32) -> T
     where
         F: Fn(&Compilation, &str, u32) -> T,
-        T: std::fmt::Debug + Default,
+        T: Debug + Default,
     {
         trace!("{op_name}: uri: {uri}, offset: {offset}");
-        if self.currently_updating {
-            trace!("Skipping {op_name} since compilation is in progress");
-            return T::default();
+
+        // Borrow must succeed here. If it doesn't succeed, a writer
+        // (i.e. [`state::CompilationStateUpdater`]) must be holding a mutable reference across
+        // an `await` point. Which it shouldn't be doing.
+        let compilation_state = self.state.borrow();
+        if let Some(compilation) = compilation_state.get_compilation(uri) {
+            let res = op(compilation, uri, offset);
+            trace!("{op_name} result: {res:?}");
+            res
+        } else {
+            // The current state doesn't yet contain the document. Updates must be pending.
+            trace!("Skipping {op_name} for {uri} since compilation is in progress");
+            T::default()
         }
-        let Some(compilation_uri) = &self
-            .open_documents
-            .get(uri)
-            .as_ref()
-            .map(|x| x.compilation.clone())
-        else {
-            warn!("{op_name} (called on {uri}) should not be called for a document that has not been opened",);
-            return T::default();
-        };
-
-        trace!("{op_name}: compilation_uri: {compilation_uri}");
-        let compilation = self.compilations.get(compilation_uri).unwrap_or_else(|| {
-            panic!("{op_name} should not be called before compilation has been initialized",)
-        });
-
-        let res = op(&compilation.0, uri, offset);
-        trace!("{op_name} result: {res:?}");
-        res
     }
 
-    // It gets really messy knowing when to clear diagnostics
-    // when the document changes ownership between compilations, etc.
-    // So let's do it the simplest way possible. Republish all the diagnostics every time.
-    fn publish_diagnostics(&mut self) {
-        let last_docs_with_errors = take(&mut self.documents_with_errors);
+    fn queue_update(&mut self, update: Update) {
+        if let Some(updater) = self.state_updater.as_mut() {
+            updater
+                .unbounded_send(update)
+                .expect("send error in queue_update");
+        } else {
+            warn!("Ignoring update, no worker is listening");
+        }
+    }
+}
 
-        for (compilation_uri, compilation) in &self.compilations {
-            trace!("publishing diagnostics for {compilation_uri}");
-            for (uri, errors) in map_errors_to_docs(compilation_uri, &compilation.0.errors) {
-                if !self.documents_with_errors.insert(uri.clone()) {
-                    // We already published diagnostics for this document for
-                    // a different compilation.
-                    // When the same document is included in multiple compilations,
-                    // only report the errors for one of them, the goal being
-                    // a less confusing user experience.
-                    continue;
-                }
+pub struct UpdateWorker<'a> {
+    updater: CompilationStateUpdater<'a>,
+    recv: UnboundedReceiver<Update>,
+}
 
-                self.publish_diagnostics_for_doc(&uri, errors);
+impl UpdateWorker<'_> {
+    #[allow(clippy::await_holding_refcell_ref)]
+    pub async fn run(&mut self) {
+        while let Some(update) = self.recv.next().await {
+            trace!("start applying updates");
+            self.apply_this_and_pending(vec![update]).await;
+            trace!("end applying updates updates");
+        }
+    }
+
+    #[cfg(test)]
+    async fn apply_pending(&mut self) {
+        self.apply_this_and_pending(vec![]).await;
+    }
+
+    async fn apply_this_and_pending(&mut self, mut updates: Vec<Update>) {
+        // Consume any backed up messages in the channel as well.
+        while let Ok(update) = self.recv.try_next() {
+            match update {
+                Some(update) => push_update(&mut updates, update),
+                None => return, // channel has been closed, don't bother with updates.
             }
         }
 
-        // Clear errors from any documents that previously had errors
-        for uri in last_docs_with_errors.difference(&self.documents_with_errors) {
-            self.publish_diagnostics_for_doc(uri, vec![]);
-        }
-    }
-
-    fn publish_diagnostics_for_doc(&self, uri: &str, errors: Vec<Error>) {
-        let version = self.open_documents.get(uri).map(|d| d.version);
-        trace!("publishing diagnostics for {uri} {version:?}): {errors:?}");
-        (self.diagnostics_receiver)(DiagnosticUpdate {
-            uri: uri.into(),
-            version,
-            errors,
-        });
-    }
-
-    fn apply_configuration(&mut self, configuration: &WorkspaceConfigurationUpdate) -> bool {
-        let mut need_recompile = false;
-
-        if let Some(package_type) = configuration.package_type {
-            need_recompile |= self.configuration.package_type != package_type;
-            self.configuration.package_type = package_type;
+        if updates.len() > 100 {
+            // This indicates that we're not keeping up with incoming updates.
+            // Harmless, but an indicator that we could try intelligently
+            // dropping updates or otherwise optimizing.
+            warn!(
+                "perf: {} pending updates found even after deduping",
+                updates.len()
+            );
         }
 
-        if let Some(target_profile) = configuration.target_profile {
-            need_recompile |= self.configuration.target_profile != target_profile;
-            self.configuration.target_profile = target_profile;
+        for update in updates.drain(..) {
+            apply_update(&mut self.updater, update).await;
         }
-
-        // Possible optimization: some projects will have overrides for these configurations,
-        // so workspace updates won't impact them. We could exclude those projects
-        // from recompilation, but we don't right now.
-        trace!("need_recompile after configuration update: {need_recompile}");
-        need_recompile
-    }
-
-    /// Recompiles the currently known documents with
-    /// the current configuration. Publishes updated
-    /// diagnostics for all documents.
-    fn recompile_all(&mut self) {
-        for compilation in self.compilations.values_mut() {
-            let configuration = merge_configurations(&compilation.1, &self.configuration);
-            compilation
-                .0
-                .recompile(configuration.package_type, configuration.target_profile);
-        }
-
-        self.publish_diagnostics();
     }
 }
 
-/// Merges workspace configuration with any compilation-specific overrides.
-fn merge_configurations(
-    compilation_scope: &PartialConfiguration,
-    workspace_scope: &Configuration,
-) -> Configuration {
+fn push_update(pending_updates: &mut Vec<Update>, update: Update) {
+    // Dedup consecutive updates to the same document.
+    match &update {
+        Update::Document { uri, .. } => {
+            if let Some(last) = pending_updates.last_mut() {
+                if let Update::Document { uri: last_uri, .. } = last {
+                    if last_uri == uri {
+                        // overwrite the last element
+                        *last = update;
+                        return;
+                    }
+                }
+            }
+        }
+        Update::NotebookDocument { notebook_uri, .. } => {
+            if let Some(last) = pending_updates.last_mut() {
+                if let Update::NotebookDocument {
+                    notebook_uri: last_uri,
+                    ..
+                } = last
+                {
+                    if last_uri == notebook_uri {
+                        // overwrite the last element
+                        *last = update;
+                        return;
+                    }
+                }
+            }
+        }
+        _ => (),
+    }
+    pending_updates.push(update);
+}
+
+async fn apply_update(updater: &mut CompilationStateUpdater<'_>, update: Update) {
+    match update {
+        Update::CloseDocument { uri } => {
+            updater.close_document(&uri);
+        }
+        Update::Document { uri, version, text } => {
+            updater.update_document(&uri, version, &text).await;
+        }
+        Update::NotebookDocument {
+            notebook_uri,
+            notebook_metadata,
+            cells,
+        } => updater.update_notebook_document(
+            &notebook_uri,
+            &notebook_metadata,
+            cells
+                .iter()
+                .map(|(uri, version, contents)| (uri.as_ref(), *version, contents.as_ref())),
+        ),
+        Update::CloseNotebookDocument {
+            notebook_uri,
+            cell_uris,
+        } => updater.close_notebook_document(&notebook_uri, cell_uris.iter().map(AsRef::as_ref)),
+        Update::Configuration { changed } => {
+            updater.update_configuration(&changed);
+        }
+    }
+}
+
+enum Update {
     Configuration {
-        target_profile: compilation_scope
-            .target_profile
-            .unwrap_or(workspace_scope.target_profile),
-        package_type: compilation_scope
-            .package_type
-            .unwrap_or(workspace_scope.package_type),
-    }
-}
-
-fn map_errors_to_docs(
-    compilation_uri: &Arc<str>,
-    errors: &Vec<Error>,
-) -> FxHashMap<Arc<str>, Vec<Error>> {
-    let mut map = FxHashMap::default();
-
-    for err in errors {
-        // Use the compilation_uri as a location for span-less errors
-        let doc = err
-            .labels()
-            .into_iter()
-            .flatten()
-            .next()
-            .map_or(compilation_uri, |l| {
-                let (source, _) = err.resolve_span(l.inner());
-                &source.name
-            });
-
-        map.entry(doc.clone())
-            .or_insert_with(Vec::new)
-            .push(err.clone());
-    }
-
-    map
+        changed: WorkspaceConfigurationUpdate,
+    },
+    Document {
+        uri: String,
+        version: u32,
+        text: String,
+    },
+    CloseDocument {
+        uri: String,
+    },
+    NotebookDocument {
+        notebook_uri: String,
+        notebook_metadata: NotebookMetadata,
+        cells: Vec<(String, u32, String)>,
+    },
+    CloseNotebookDocument {
+        notebook_uri: String,
+        cell_uris: Vec<String>,
+    },
 }

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -75,7 +75,9 @@ impl LanguageService {
         worker
     }
 
-    ///
+    /// Stops the language service from processing further updates.
+    /// This will stop the update worker, and any update operations
+    /// that the language service receives after this call will be ignored.
     pub fn stop_updates(&mut self) {
         // Dropping the sender will cause the
         // worker created in [`create_update_worker()`] to stop.

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -324,7 +324,9 @@ fn push_update(pending_updates: &mut Vec<Update>, update: Update) {
                 }
             }
         }
-        _ => (),
+        Update::Configuration { .. }
+        | Update::CloseDocument { .. }
+        | Update::CloseNotebookDocument { .. } => (), // These events aren't noisy enough to bother deduping.
     }
     pending_updates.push(update);
 }

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -259,9 +259,7 @@ impl UpdateWorker<'_> {
     #[allow(clippy::await_holding_refcell_ref)]
     pub async fn run(&mut self) {
         while let Some(update) = self.recv.next().await {
-            trace!("start applying updates");
             self.apply_this_and_pending(vec![update]).await;
-            trace!("end applying updates updates");
         }
     }
 
@@ -279,6 +277,7 @@ impl UpdateWorker<'_> {
             }
         }
 
+        trace!("applying {} updates", updates.len());
         if updates.len() > 100 {
             // This indicates that we're not keeping up with incoming updates.
             // Harmless, but an indicator that we could try intelligently
@@ -292,6 +291,7 @@ impl UpdateWorker<'_> {
         for update in updates.drain(..) {
             apply_update(&mut self.updater, update).await;
         }
+        trace!("end applying updates");
     }
 }
 

--- a/language_service/src/project_system.rs
+++ b/language_service/src/project_system.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::LanguageService;
-use async_trait::async_trait;
 use std::{convert::Infallible, path::PathBuf};
 
 #[derive(Debug)]
@@ -20,20 +18,5 @@ impl qsc_project::DirEntry for JSFileEntry {
 
     fn path(&self) -> PathBuf {
         PathBuf::from(&self.name)
-    }
-}
-
-#[async_trait(?Send)]
-impl qsc_project::FileSystemAsync for LanguageService<'_> {
-    type Entry = JSFileEntry;
-    async fn read_file(
-        &self,
-        path: &std::path::Path,
-    ) -> miette::Result<(std::sync::Arc<str>, std::sync::Arc<str>)> {
-        Ok((self.read_file_callback)(path.to_string_lossy().to_string()).await)
-    }
-
-    async fn list_directory(&self, path: &std::path::Path) -> miette::Result<Vec<Self::Entry>> {
-        Ok((self.list_directory)(path.to_string_lossy().to_string()).await)
     }
 }

--- a/language_service/src/project_system.rs
+++ b/language_service/src/project_system.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::state::CompilationStateUpdater;
+use async_trait::async_trait;
 use std::{convert::Infallible, path::PathBuf};
 
 #[derive(Debug)]
@@ -18,5 +20,20 @@ impl qsc_project::DirEntry for JSFileEntry {
 
     fn path(&self) -> PathBuf {
         PathBuf::from(&self.name)
+    }
+}
+
+#[async_trait(?Send)]
+impl qsc_project::FileSystemAsync for CompilationStateUpdater<'_> {
+    type Entry = JSFileEntry;
+    async fn read_file(
+        &self,
+        path: &std::path::Path,
+    ) -> miette::Result<(std::sync::Arc<str>, std::sync::Arc<str>)> {
+        Ok((self.read_file_callback)(path.to_string_lossy().to_string()).await)
+    }
+
+    async fn list_directory(&self, path: &std::path::Path) -> miette::Result<Vec<Self::Entry>> {
+        Ok((self.list_directory)(path.to_string_lossy().to_string()).await)
     }
 }

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -100,7 +100,7 @@ pub struct ParameterInformation {
     pub documentation: Option<String>,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct NotebookMetadata {
     pub target_profile: Option<Profile>,
 }

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -3,8 +3,8 @@
 
 use qsc::{compile::Error, target::Profile, PackageType};
 
-/// Workspace configuration
-#[derive(Clone, Debug, Default)]
+/// A change to the workspace configuration
+#[derive(Clone, Debug, Default, Copy)]
 pub struct WorkspaceConfigurationUpdate {
     pub target_profile: Option<Profile>,
     pub package_type: Option<PackageType>,
@@ -100,7 +100,7 @@ pub struct ParameterInformation {
     pub documentation: Option<String>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Copy)]
 pub struct NotebookMetadata {
     pub target_profile: Option<Profile>,
 }

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -63,7 +63,7 @@ struct OpenDocument {
     pub compilation: CompilationUri,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 struct Configuration {
     pub target_profile: Profile,
     pub package_type: PackageType,
@@ -78,7 +78,7 @@ impl Default for Configuration {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Copy)]
 struct PartialConfiguration {
     pub target_profile: Option<Profile>,
     pub package_type: Option<PackageType>,

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -1,0 +1,479 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(test)]
+mod tests;
+
+use super::compilation::Compilation;
+pub use super::project_system::JSFileEntry;
+use super::protocol::{DiagnosticUpdate, NotebookMetadata};
+use crate::protocol::WorkspaceConfigurationUpdate;
+use async_trait::async_trait;
+use log::{error, trace};
+use miette::Diagnostic;
+use qsc::compile::Error;
+use qsc::target::Profile;
+use qsc::PackageType;
+use qsc_project::FileSystemAsync;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::{cell::RefCell, fmt::Debug, future::Future, mem::take, pin::Pin, rc::Rc, sync::Arc};
+
+/// the desugared return type of an "async fn"
+type PinnedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
+
+/// represents a unary async fn where `Arg` is the input
+/// parameter and `Return` is the return type. The lifetime
+/// `'a` represents the lifetime of the contained `dyn Fn`.
+type AsyncFunction<'a, Arg, Return> = Box<dyn Fn(Arg) -> PinnedFuture<Return> + 'a>;
+
+#[derive(Default)]
+pub(super) struct CompilationState {
+    /// A `CompilationUri` is an identifier for a unique compilation.
+    /// It is NOT required to be a uri that represents an actual document.
+    ///
+    /// For single Q# documents, the `CompilationUri` is the same as the
+    /// document uri.
+    ///
+    /// For notebooks, the `CompilationUri` is the notebook uri.
+    ///
+    /// The `CompilatinUri` is used when compilation-level errors get reported
+    /// to the client. Compilation-level errors are defined as errors without
+    /// an associated source document.
+    ///
+    /// `PartialConfiguration` contains configuration overrides for this
+    /// compilation, explicitly specified through a project manifest (not currently implemented)
+    /// or notebook metadata.
+    compilations: FxHashMap<CompilationUri, (Compilation, PartialConfiguration)>,
+    /// All the documents that we were told about by the client.
+    ///
+    /// This map doesn't necessarily contain ALL the documents that
+    /// make up a compilation - only the ones that are currently open.
+    open_documents: FxHashMap<DocumentUri, OpenDocument>,
+}
+
+type CompilationUri = Arc<str>;
+type DocumentUri = Arc<str>;
+
+#[derive(Debug)]
+struct OpenDocument {
+    /// This version is the document version provided by the client.
+    /// It increases strictly with each text change, though this knowledge should
+    /// not be important. The version is only ever used when publishing
+    /// diagnostics to help the client associate the list of diagnostics
+    /// with a snapshot of the document.
+    pub version: u32,
+    pub compilation: CompilationUri,
+}
+
+#[derive(Debug, Clone)]
+struct Configuration {
+    pub target_profile: Profile,
+    pub package_type: PackageType,
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Self {
+            target_profile: Profile::Unrestricted,
+            package_type: PackageType::Exe,
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+struct PartialConfiguration {
+    pub target_profile: Option<Profile>,
+    pub package_type: Option<PackageType>,
+}
+
+pub(super) struct CompilationStateUpdater<'a> {
+    /// Compilation state which is shared with readers. It can only be accessed
+    /// by dynamically borrowing. Mutable references to `CompilationState` should not
+    /// be held across `await` points since that can cause readers to be denied access.
+    state: Rc<RefCell<CompilationState>>,
+    /// Workspace-wide configuration settings. These can include compiler settings that
+    /// affect error checking and other language server behavior.
+    ///
+    /// Some settings can be set both at the compilation scope and at the workspace scope.
+    /// Compilation-scoped settings take precedence over workspace-scoped settings.
+    configuration: Configuration,
+    /// Documents that we have previously published errors about. We need to
+    /// keep track of this so we can clear errors from them when documents are removed
+    /// from a compilation or when a recompilation occurs.
+    documents_with_errors: FxHashSet<DocumentUri>,
+    /// Callback which will receive diagnostics (compilation errors)
+    /// whenever a (re-)compilation occurs.
+    diagnostics_receiver: Box<dyn Fn(DiagnosticUpdate) + 'a>,
+    /// Callback which lets the service read a file from the target filesystem
+    read_file_callback: AsyncFunction<'a, String, (Arc<str>, Arc<str>)>,
+    /// Callback which lets the service list directory contents
+    /// on the target file system
+    list_directory: AsyncFunction<'a, String, Vec<JSFileEntry>>,
+    /// Fetch the manifest file for a specific path
+    get_manifest: AsyncFunction<'a, String, Option<qsc_project::ManifestDescriptor>>,
+}
+
+impl<'a> CompilationStateUpdater<'a> {
+    pub fn new(
+        state: Rc<RefCell<CompilationState>>,
+        diagnostics_receiver: impl Fn(DiagnosticUpdate) + 'a,
+        read_file: impl Fn(String) -> Pin<Box<dyn Future<Output = (Arc<str>, Arc<str>)>>> + 'a,
+        list_directory: impl Fn(String) -> Pin<Box<dyn Future<Output = Vec<JSFileEntry>>>> + 'a,
+        get_manifest: impl Fn(String) -> Pin<Box<dyn Future<Output = Option<qsc_project::ManifestDescriptor>>>>
+            + 'a,
+    ) -> Self {
+        Self {
+            state,
+            configuration: Configuration::default(),
+            documents_with_errors: FxHashSet::default(),
+            diagnostics_receiver: Box::new(diagnostics_receiver),
+            read_file_callback: Box::new(read_file),
+            list_directory: Box::new(list_directory),
+            get_manifest: Box::new(get_manifest),
+        }
+    }
+
+    /// Updates the workspace configuration. If any compiler settings are updated,
+    /// a recompilation may be triggered, which will result in a new set of diagnostics
+    /// being published.
+    pub fn update_configuration(&mut self, configuration: &WorkspaceConfigurationUpdate) {
+        trace!("update_configuration: {configuration:?}");
+
+        let need_recompile = self.apply_configuration(configuration);
+
+        // Some configuration options require a recompilation as they impact error checking
+        if need_recompile {
+            self.recompile_all();
+        }
+    }
+
+    pub(super) async fn update_document(&mut self, uri: &str, version: u32, text: &str) {
+        let manifest = (self.get_manifest)(uri.to_string()).await;
+        let in_project_mode = manifest.is_some();
+        let sources = if let Some(ref manifest) = manifest {
+            let res = self.load_project(manifest).await;
+            match res {
+                Ok(o) => o.sources,
+                Err(e) => {
+                    error!("failed to load manifest: {e:?}, defaulting to single-file mode");
+                    vec![(Arc::from(uri), Arc::from(text))]
+                }
+            }
+        } else {
+            trace!("Running in single file mode");
+            vec![(Arc::from(uri), Arc::from(text))]
+        };
+
+        let compilation = Compilation::new(
+            &sources,
+            self.configuration.package_type,
+            self.configuration.target_profile,
+        );
+        // If we are in single file mode, use the file's path as the compilation identifier.
+        // If we are compiling a project, use the path to the project manifest
+        let uri: Arc<str> = if let Some(manifest) = manifest {
+            Arc::from(format!(
+                "{}/qsharp.json",
+                manifest.manifest_dir.to_string_lossy()
+            ))
+        } else {
+            uri.into()
+        };
+        trace!("Loaded project uri {uri} with {} sources", sources.len());
+
+        self.with_state_mut(|state| {
+            state
+                .compilations
+                .insert(uri.clone(), (compilation, PartialConfiguration::default()));
+
+            // There may be open buffers with sources in the project.
+            // These buffers need to have their diagnostics reloaded,
+            // to be in the context of the project.
+            // We remove them from the existing compilations and update
+            // their compilation URI
+            if in_project_mode {
+                for (path, _contents) in &sources {
+                    log::trace!("Updating compilation of {path} to {uri}");
+                    state
+                        .open_documents
+                        .entry(path.clone())
+                        .and_modify(|x| {
+                            // remove any old single-file compilations of this document
+                            // if this is a project
+                            if x.compilation != uri {
+                                state.compilations.remove(&x.compilation);
+                            }
+                            x.compilation = uri.clone();
+                        })
+                        .or_insert(OpenDocument {
+                            version,
+                            compilation: uri.clone(),
+                        });
+                }
+            } else {
+                state.open_documents.insert(
+                    uri.clone(),
+                    OpenDocument {
+                        version,
+                        compilation: uri.clone(),
+                    },
+                );
+            }
+        });
+
+        self.publish_diagnostics();
+    }
+
+    pub(super) fn close_document(&mut self, uri: &str) {
+        self.with_state_mut(|state| {
+            state.compilations.remove(uri);
+            state.open_documents.remove(uri);
+        });
+        self.publish_diagnostics();
+    }
+
+    pub(super) fn update_notebook_document<'b, I>(
+        &mut self,
+        notebook_uri: &str,
+        notebook_metadata: &NotebookMetadata,
+        cells: I,
+    ) where
+        I: Iterator<Item = (&'b str, u32, &'b str)>, // uri, version, text - basically DidChangeTextDocumentParams in LSP
+    {
+        self.with_state_mut(|state| {
+            let compilation_uri: Arc<str> = notebook_uri.into();
+
+            // First remove all previously known cells for this notebook
+            state
+                .open_documents
+                .retain(|_, open_doc| notebook_uri != open_doc.compilation.as_ref());
+
+            let notebook_configuration = PartialConfiguration {
+                target_profile: notebook_metadata.target_profile,
+                package_type: None,
+            };
+            let configuration = merge_configurations(&notebook_configuration, &self.configuration);
+
+            // Compile the notebook and add each cell into the document map
+            let compilation = Compilation::new_notebook(
+                cells.map(|(cell_uri, version, cell_contents)| {
+                    trace!("update_notebook_document: cell: {cell_uri} {version}");
+                    state.open_documents.insert(
+                        (*cell_uri).into(),
+                        OpenDocument {
+                            version,
+                            compilation: compilation_uri.clone(),
+                        },
+                    );
+                    (Arc::from(cell_uri), Arc::from(cell_contents))
+                }),
+                configuration.target_profile,
+            );
+
+            state.compilations.insert(
+                compilation_uri.clone(),
+                (compilation, notebook_configuration),
+            );
+        });
+        self.publish_diagnostics();
+    }
+
+    pub(super) fn close_notebook_document<'b>(
+        &mut self,
+        notebook_uri: &str,
+        cell_uris: impl Iterator<Item = &'b str>,
+    ) {
+        self.with_state_mut(|state| {
+            trace!("close_notebook_document: {notebook_uri}");
+
+            for cell_uri in cell_uris {
+                trace!("close_notebook_document: cell: {cell_uri}");
+                state.open_documents.remove(cell_uri);
+            }
+
+            // The client should have sent all cell uris along with
+            // the notebook. Validate our assumptions about the client
+            // here, by checking that all the cells for this notebook
+            // have been removed from the open documents map.
+            for open_doc in state.open_documents.values() {
+                assert!(
+                    notebook_uri != open_doc.compilation.as_ref(),
+                    "all cells should have been closed along with the notebook"
+                );
+            }
+
+            state.compilations.remove(notebook_uri);
+        });
+        self.publish_diagnostics();
+    }
+
+    // It gets really messy knowing when to clear diagnostics
+    // when the document changes ownership between compilations, etc.
+    // So let's do it the simplest way possible. Republish all the diagnostics every time.
+    fn publish_diagnostics(&mut self) {
+        let last_docs_with_errors = take(&mut self.documents_with_errors);
+        let mut docs_with_errors = FxHashSet::default();
+
+        self.with_state(|state| {
+            for (compilation_uri, compilation) in &state.compilations {
+                trace!("publishing diagnostics for {compilation_uri}");
+                for (uri, errors) in map_errors_to_docs(compilation_uri, &compilation.0.errors) {
+                    if !docs_with_errors.insert(uri.clone()) {
+                        // We already published diagnostics for this document for
+                        // a different compilation.
+                        // When the same document is included in multiple compilations,
+                        // only report the errors for one of them, the goal being
+                        // a less confusing user experience.
+                        continue;
+                    }
+
+                    self.publish_diagnostics_for_doc(state, &uri, errors);
+                }
+            }
+
+            // Clear errors from any documents that previously had errors
+            for uri in last_docs_with_errors.difference(&docs_with_errors) {
+                self.publish_diagnostics_for_doc(state, uri, vec![]);
+            }
+        });
+
+        self.documents_with_errors = docs_with_errors;
+    }
+
+    fn publish_diagnostics_for_doc(&self, state: &CompilationState, uri: &str, errors: Vec<Error>) {
+        let version = state.open_documents.get(uri).map(|d| d.version);
+        trace!("publishing diagnostics for {uri} {version:?}): {errors:?}");
+        (self.diagnostics_receiver)(DiagnosticUpdate {
+            uri: uri.into(),
+            version,
+            errors,
+        });
+    }
+
+    fn apply_configuration(&mut self, configuration: &WorkspaceConfigurationUpdate) -> bool {
+        let mut need_recompile = false;
+
+        if let Some(package_type) = configuration.package_type {
+            need_recompile |= self.configuration.package_type != package_type;
+            self.configuration.package_type = package_type;
+        }
+
+        if let Some(target_profile) = configuration.target_profile {
+            need_recompile |= self.configuration.target_profile != target_profile;
+            self.configuration.target_profile = target_profile;
+        }
+
+        // Possible optimization: some projects will have overrides for these configurations,
+        // so workspace updates won't impact them. We could exclude those projects
+        // from recompilation, but we don't right now.
+        trace!("need_recompile after configuration update: {need_recompile}");
+        need_recompile
+    }
+
+    /// Recompiles the currently known documents with
+    /// the current configuration. Publishes updated
+    /// diagnostics for all documents.
+    fn recompile_all(&mut self) {
+        self.with_state_mut(|state| {
+            for compilation in state.compilations.values_mut() {
+                let configuration = merge_configurations(&compilation.1, &self.configuration);
+                compilation
+                    .0
+                    .recompile(configuration.package_type, configuration.target_profile);
+            }
+        });
+
+        self.publish_diagnostics();
+    }
+
+    fn with_state<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&CompilationState) -> T,
+    {
+        let state = self.state.borrow();
+        f(&state)
+    }
+
+    fn with_state_mut<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&mut CompilationState) -> T,
+    {
+        let mut state = self.state.borrow_mut();
+        f(&mut state)
+    }
+}
+
+impl CompilationState {
+    pub(crate) fn get_compilation(&self, uri: &str) -> Option<&Compilation> {
+        let Some(compilation_uri) = &self
+            .open_documents
+            .get(uri)
+            .as_ref()
+            .map(|x| x.compilation.clone())
+        else {
+            return None;
+        };
+
+        trace!("document: {uri} compilation_uri: {compilation_uri}");
+
+        Some(&self.compilations.get(compilation_uri).unwrap_or_else(|| {
+            panic!("document associated with compilation that hasn't been initialized ({compilation_uri})" ,)
+        }).0)
+    }
+}
+
+#[async_trait(?Send)]
+impl qsc_project::FileSystemAsync for CompilationStateUpdater<'_> {
+    type Entry = JSFileEntry;
+    async fn read_file(
+        &self,
+        path: &std::path::Path,
+    ) -> miette::Result<(std::sync::Arc<str>, std::sync::Arc<str>)> {
+        Ok((self.read_file_callback)(path.to_string_lossy().to_string()).await)
+    }
+
+    async fn list_directory(&self, path: &std::path::Path) -> miette::Result<Vec<Self::Entry>> {
+        Ok((self.list_directory)(path.to_string_lossy().to_string()).await)
+    }
+}
+
+fn map_errors_to_docs(
+    compilation_uri: &Arc<str>,
+    errors: &Vec<Error>,
+) -> FxHashMap<Arc<str>, Vec<Error>> {
+    let mut map = FxHashMap::default();
+
+    for err in errors {
+        // Use the compilation_uri as a location for span-less errors
+        let doc = err
+            .labels()
+            .into_iter()
+            .flatten()
+            .next()
+            .map_or(compilation_uri, |l| {
+                let (source, _) = err.resolve_span(l.inner());
+                &source.name
+            });
+
+        map.entry(doc.clone())
+            .or_insert_with(Vec::new)
+            .push(err.clone());
+    }
+
+    map
+}
+
+/// Merges workspace configuration with any compilation-specific overrides.
+fn merge_configurations(
+    compilation_overrides: &PartialConfiguration,
+    workspace_scope: &Configuration,
+) -> Configuration {
+    Configuration {
+        target_profile: compilation_overrides
+            .target_profile
+            .unwrap_or(workspace_scope.target_profile),
+        package_type: compilation_overrides
+            .package_type
+            .unwrap_or(workspace_scope.package_type),
+    }
+}

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -63,7 +63,7 @@ struct OpenDocument {
     pub compilation: CompilationUri,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct Configuration {
     pub target_profile: Profile,
     pub package_type: PackageType,
@@ -387,6 +387,12 @@ impl<'a> CompilationStateUpdater<'a> {
         self.publish_diagnostics();
     }
 
+    /// Borrows the compilation state immutably and invokes `f`.
+    /// Warning: This function is not reentrant. For dynamic borrow safety,
+    /// don't call `with_state` from within `with_state` or `with_state_mut`.
+    /// Use a direct reference to the state instead.
+    /// This function may also not be async since holding a borrow across
+    /// `await` points will interfere with other borrowers.
     fn with_state<F, T>(&self, f: F) -> T
     where
         F: FnOnce(&CompilationState) -> T,
@@ -395,6 +401,12 @@ impl<'a> CompilationStateUpdater<'a> {
         f(&state)
     }
 
+    /// Borrows the compilation state immutably and invokes `f`.
+    /// Warning: This function is not reentrant.  For dynamic borrow safety,
+    /// don't call `with_state_mut` from within `with_state` or `with_state_mut`.
+    /// Use a direct reference to the state instead.
+    /// This function may also not be async since holding a borrow across
+    /// `await` points will interfere with other borrowers.
     fn with_state_mut<F, T>(&self, f: F) -> T
     where
         F: FnOnce(&mut CompilationState) -> T,

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -5,7 +5,6 @@
 mod tests;
 
 use super::compilation::Compilation;
-pub use super::project_system::JSFileEntry;
 use super::protocol::{DiagnosticUpdate, NotebookMetadata};
 use crate::protocol::WorkspaceConfigurationUpdate;
 use log::{error, trace};
@@ -13,7 +12,7 @@ use miette::Diagnostic;
 use qsc::compile::Error;
 use qsc::target::Profile;
 use qsc::PackageType;
-use qsc_project::FileSystemAsync;
+use qsc_project::{FileSystemAsync, JSFileEntry};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::{cell::RefCell, fmt::Debug, future::Future, mem::take, pin::Pin, rc::Rc, sync::Arc};
 

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -341,7 +341,10 @@ impl<'a> CompilationStateUpdater<'a> {
 
     fn publish_diagnostics_for_doc(&self, state: &CompilationState, uri: &str, errors: Vec<Error>) {
         let version = state.open_documents.get(uri).map(|d| d.version);
-        trace!("publishing diagnostics for {uri} {version:?}): {errors:?}");
+        trace!(
+            "publishing diagnostics for {uri} {version:?}): {} errors",
+            errors.len()
+        );
         (self.diagnostics_receiver)(DiagnosticUpdate {
             uri: uri.into(),
             version,

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -195,7 +195,7 @@ async fn package_type_update_causes_error() {
     let errors = RefCell::new(Vec::new());
     let mut updater = new_updater(&errors);
 
-    updater.update_configuration(&WorkspaceConfigurationUpdate {
+    updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: None,
         package_type: Some(PackageType::Lib),
     });
@@ -211,7 +211,7 @@ async fn package_type_update_causes_error() {
     "#]],
     );
 
-    updater.update_configuration(&WorkspaceConfigurationUpdate {
+    updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: None,
         package_type: Some(PackageType::Exe),
     });
@@ -243,7 +243,7 @@ async fn target_profile_update_fixes_error() {
     let errors = RefCell::new(Vec::new());
     let mut updater = new_updater(&errors);
 
-    updater.update_configuration(&WorkspaceConfigurationUpdate {
+    updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: Some(Profile::Base),
         package_type: Some(PackageType::Lib),
     });
@@ -302,7 +302,7 @@ async fn target_profile_update_fixes_error() {
         "#]],
     );
 
-    updater.update_configuration(&WorkspaceConfigurationUpdate {
+    updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: Some(Profile::Unrestricted),
         package_type: None,
     });
@@ -341,7 +341,7 @@ async fn target_profile_update_causes_error_in_stdlib() {
         "#]],
     );
 
-    updater.update_configuration(&WorkspaceConfigurationUpdate {
+    updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: Some(Profile::Base),
         package_type: None,
     });
@@ -398,7 +398,7 @@ fn notebook_document_no_errors() {
 
     updater.update_notebook_document(
         "notebook.ipynb",
-        &NotebookMetadata::default(),
+        NotebookMetadata::default(),
         [
             ("cell1", 1, "operation Main() : Unit {}"),
             ("cell2", 1, "Main()"),
@@ -421,7 +421,7 @@ fn notebook_document_errors() {
 
     updater.update_notebook_document(
         "notebook.ipynb",
-        &NotebookMetadata::default(),
+        NotebookMetadata::default(),
         [
             ("cell1", 1, "operation Main() : Unit {}"),
             ("cell2", 1, "Foo()"),
@@ -480,7 +480,7 @@ fn notebook_update_remove_cell_clears_errors() {
 
     updater.update_notebook_document(
         "notebook.ipynb",
-        &NotebookMetadata::default(),
+        NotebookMetadata::default(),
         [
             ("cell1", 1, "operation Main() : Unit {}"),
             ("cell2", 1, "Foo()"),
@@ -533,7 +533,7 @@ fn notebook_update_remove_cell_clears_errors() {
 
     updater.update_notebook_document(
         "notebook.ipynb",
-        &NotebookMetadata::default(),
+        NotebookMetadata::default(),
         [("cell1", 1, "operation Main() : Unit {}")].into_iter(),
     );
 
@@ -558,7 +558,7 @@ fn close_notebook_clears_errors() {
 
     updater.update_notebook_document(
         "notebook.ipynb",
-        &NotebookMetadata::default(),
+        NotebookMetadata::default(),
         [
             ("cell1", 1, "operation Main() : Unit {}"),
             ("cell2", 1, "Foo()"),

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -1,0 +1,660 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::{CompilationState, CompilationStateUpdater};
+use crate::protocol::{DiagnosticUpdate, NotebookMetadata, WorkspaceConfigurationUpdate};
+use expect_test::{expect, Expect};
+use qsc::{compile::ErrorKind, target::Profile, PackageType};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+#[tokio::test]
+async fn no_error() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater
+        .update_document(
+            "foo.qs",
+            1,
+            "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
+        )
+        .await;
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+        []
+    "#]],
+    );
+}
+
+#[tokio::test]
+async fn clear_error() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_document("foo.qs", 1, "namespace {").await;
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Frontend(
+                            Error(
+                                Parse(
+                                    Error(
+                                        Rule(
+                                            "identifier",
+                                            Open(
+                                                Brace,
+                                            ),
+                                            Span {
+                                                lo: 10,
+                                                hi: 11,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+
+    updater
+        .update_document(
+            "foo.qs",
+            2,
+            "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
+        )
+        .await;
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    Some(
+                        2,
+                    ),
+                    [],
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[tokio::test]
+async fn clear_on_document_close() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_document("foo.qs", 1, "namespace {").await;
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Frontend(
+                            Error(
+                                Parse(
+                                    Error(
+                                        Rule(
+                                            "identifier",
+                                            Open(
+                                                Brace,
+                                            ),
+                                            Span {
+                                                lo: 10,
+                                                hi: 11,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+
+    updater.close_document("foo.qs");
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    None,
+                    [],
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[tokio::test]
+async fn compile_error() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_document("foo.qs", 1, "badsyntax").await;
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Frontend(
+                            Error(
+                                Parse(
+                                    Error(
+                                        Token(
+                                            Eof,
+                                            Ident,
+                                            Span {
+                                                lo: 0,
+                                                hi: 9,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[tokio::test]
+async fn package_type_update_causes_error() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: None,
+        package_type: Some(PackageType::Lib),
+    });
+
+    updater
+        .update_document("foo.qs", 1, "namespace Foo { operation Main() : Unit {} }")
+        .await;
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            []
+    "#]],
+    );
+
+    updater.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: None,
+        package_type: Some(PackageType::Exe),
+    });
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Pass(
+                            EntryPoint(
+                                NotFound,
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[tokio::test]
+async fn target_profile_update_fixes_error() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: Some(Profile::Base),
+        package_type: Some(PackageType::Lib),
+    });
+
+    updater
+        .update_document(
+            "foo.qs",
+            1,
+            r#"namespace Foo { operation Main() : Unit { if Zero == Zero { Message("hi") } } }"#,
+        )
+        .await;
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Pass(
+                            BaseProfCk(
+                                ResultComparison(
+                                    Span {
+                                        lo: 45,
+                                        hi: 57,
+                                    },
+                                ),
+                            ),
+                        ),
+                        Pass(
+                            BaseProfCk(
+                                ResultLiteral(
+                                    Span {
+                                        lo: 45,
+                                        hi: 49,
+                                    },
+                                ),
+                            ),
+                        ),
+                        Pass(
+                            BaseProfCk(
+                                ResultLiteral(
+                                    Span {
+                                        lo: 53,
+                                        hi: 57,
+                                    },
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+
+    updater.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: Some(Profile::Unrestricted),
+        package_type: None,
+    });
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    Some(
+                        1,
+                    ),
+                    [],
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[tokio::test]
+async fn target_profile_update_causes_error_in_stdlib() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_document(
+        "foo.qs",
+        1,
+        r#"namespace Foo { @EntryPoint() operation Main() : Unit { use q = Qubit(); let r = M(q); let b = Microsoft.Quantum.Convert.ResultAsBool(r); } }"#,
+    ).await;
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            []
+        "#]],
+    );
+
+    updater.update_configuration(&WorkspaceConfigurationUpdate {
+        target_profile: Some(Profile::Base),
+        package_type: None,
+    });
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Frontend(
+                            Error(
+                                Resolve(
+                                    NotAvailable(
+                                        "ResultAsBool",
+                                        "Microsoft.Quantum.Convert.ResultAsBool",
+                                        Span {
+                                            lo: 121,
+                                            hi: 133,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Type(
+                                    Error(
+                                        AmbiguousTy(
+                                            Span {
+                                                lo: 95,
+                                                hi: 136,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn notebook_document_no_errors() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_notebook_document(
+        "notebook.ipynb",
+        &NotebookMetadata::default(),
+        [
+            ("cell1", 1, "operation Main() : Unit {}"),
+            ("cell2", 1, "Main()"),
+        ]
+        .into_iter(),
+    );
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            []
+        "#]],
+    );
+}
+
+#[test]
+fn notebook_document_errors() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_notebook_document(
+        "notebook.ipynb",
+        &NotebookMetadata::default(),
+        [
+            ("cell1", 1, "operation Main() : Unit {}"),
+            ("cell2", 1, "Foo()"),
+        ]
+        .into_iter(),
+    );
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "cell2",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Frontend(
+                            Error(
+                                Resolve(
+                                    NotFound(
+                                        "Foo",
+                                        Span {
+                                            lo: 27,
+                                            hi: 30,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Type(
+                                    Error(
+                                        AmbiguousTy(
+                                            Span {
+                                                lo: 27,
+                                                hi: 32,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn notebook_update_remove_cell_clears_errors() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_notebook_document(
+        "notebook.ipynb",
+        &NotebookMetadata::default(),
+        [
+            ("cell1", 1, "operation Main() : Unit {}"),
+            ("cell2", 1, "Foo()"),
+        ]
+        .into_iter(),
+    );
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "cell2",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Frontend(
+                            Error(
+                                Resolve(
+                                    NotFound(
+                                        "Foo",
+                                        Span {
+                                            lo: 27,
+                                            hi: 30,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Type(
+                                    Error(
+                                        AmbiguousTy(
+                                            Span {
+                                                lo: 27,
+                                                hi: 32,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+
+    updater.update_notebook_document(
+        "notebook.ipynb",
+        &NotebookMetadata::default(),
+        [("cell1", 1, "operation Main() : Unit {}")].into_iter(),
+    );
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "cell2",
+                    None,
+                    [],
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn close_notebook_clears_errors() {
+    let errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&errors);
+
+    updater.update_notebook_document(
+        "notebook.ipynb",
+        &NotebookMetadata::default(),
+        [
+            ("cell1", 1, "operation Main() : Unit {}"),
+            ("cell2", 1, "Foo()"),
+        ]
+        .into_iter(),
+    );
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "cell2",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Frontend(
+                            Error(
+                                Resolve(
+                                    NotFound(
+                                        "Foo",
+                                        Span {
+                                            lo: 27,
+                                            hi: 30,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Type(
+                                    Error(
+                                        AmbiguousTy(
+                                            Span {
+                                                lo: 27,
+                                                hi: 32,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]],
+    );
+
+    updater.close_notebook_document("notebook.ipynb", ["cell1", "cell2"].into_iter());
+
+    expect_errors(
+        &errors,
+        &expect![[r#"
+            [
+                (
+                    "cell2",
+                    None,
+                    [],
+                ),
+            ]
+        "#]],
+    );
+}
+
+type ErrorInfo = (String, Option<u32>, Vec<ErrorKind>);
+
+fn new_updater(received_errors: &RefCell<Vec<ErrorInfo>>) -> CompilationStateUpdater<'_> {
+    let diagnostic_receiver = move |update: DiagnosticUpdate| {
+        let mut v = received_errors.borrow_mut();
+
+        v.push((
+            update.uri.to_string(),
+            update.version,
+            update
+                .errors
+                .iter()
+                .map(|e| e.error().clone())
+                .collect::<Vec<_>>(),
+        ));
+    };
+
+    CompilationStateUpdater::new(
+        Rc::new(RefCell::new(CompilationState::default())),
+        diagnostic_receiver,
+        // these tests do not test project mode
+        // so we provide these stubbed-out functions
+        |_| Box::pin(std::future::ready((Arc::from(""), Arc::from("")))),
+        |_| Box::pin(std::future::ready(vec![])),
+        |_| Box::pin(std::future::ready(None)),
+    )
+}
+
+fn expect_errors(errors: &RefCell<Vec<ErrorInfo>>, expected: &Expect) {
+    expected.assert_debug_eq(&errors.borrow());
+    // reset accumulated errors after each check
+    errors.borrow_mut().clear();
+}

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -3,223 +3,27 @@
 
 #![allow(clippy::needless_raw_string_hashes)]
 
-use crate::{
-    protocol::{DiagnosticUpdate, NotebookMetadata, WorkspaceConfigurationUpdate},
-    LanguageService,
-};
+use crate::{protocol::DiagnosticUpdate, JSFileEntry, LanguageService, UpdateWorker};
 use expect_test::{expect, Expect};
-use qsc::{compile, target::Profile, PackageType};
-use std::{cell::RefCell, sync::Arc};
+use qsc::compile::{self, ErrorKind};
+use qsc_project::{EntryType, Manifest, ManifestDescriptor};
+use std::{cell::RefCell, future::ready, sync::Arc};
 
 #[tokio::test]
-async fn no_error() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
+async fn single_document() {
+    let received_errors = RefCell::new(Vec::new());
+    let mut ls = LanguageService::default();
+    let mut worker = create_update_worker(&mut ls, &received_errors);
 
-    ls.update_document(
+    ls.update_document("foo.qs", 1, "namespace Foo { }");
+
+    worker.apply_pending().await;
+
+    check_errors_and_compilation(
+        &ls,
+        &mut received_errors.borrow_mut(),
         "foo.qs",
-        1,
-        "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
-    )
-    .await;
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            []
-        "#]],
-    );
-}
-
-#[tokio::test]
-async fn clear_error() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
-
-    ls.update_document("foo.qs", 1, "namespace {").await;
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "foo.qs",
-                    Some(
-                        1,
-                    ),
-                    [
-                        Frontend(
-                            Error(
-                                Parse(
-                                    Error(
-                                        Rule(
-                                            "identifier",
-                                            Open(
-                                                Brace,
-                                            ),
-                                            Span {
-                                                lo: 10,
-                                                hi: 11,
-                                            },
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ],
-                ),
-            ]
-        "#]],
-    );
-
-    ls.update_document(
-        "foo.qs",
-        2,
-        "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
-    )
-    .await;
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "foo.qs",
-                    Some(
-                        2,
-                    ),
-                    [],
-                ),
-            ]
-        "#]],
-    );
-}
-
-#[tokio::test]
-async fn clear_on_document_close() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
-
-    ls.update_document("foo.qs", 1, "namespace {").await;
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "foo.qs",
-                    Some(
-                        1,
-                    ),
-                    [
-                        Frontend(
-                            Error(
-                                Parse(
-                                    Error(
-                                        Rule(
-                                            "identifier",
-                                            Open(
-                                                Brace,
-                                            ),
-                                            Span {
-                                                lo: 10,
-                                                hi: 11,
-                                            },
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ],
-                ),
-            ]
-        "#]],
-    );
-
-    ls.close_document("foo.qs");
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "foo.qs",
-                    None,
-                    [],
-                ),
-            ]
-        "#]],
-    );
-}
-
-#[tokio::test]
-async fn compile_error() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
-
-    ls.update_document("foo.qs", 1, "badsyntax").await;
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "foo.qs",
-                    Some(
-                        1,
-                    ),
-                    [
-                        Frontend(
-                            Error(
-                                Parse(
-                                    Error(
-                                        Token(
-                                            Eof,
-                                            Ident,
-                                            Span {
-                                                lo: 0,
-                                                hi: 9,
-                                            },
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ],
-                ),
-            ]
-        "#]],
-    );
-}
-
-#[tokio::test]
-async fn package_type_update_causes_error() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
-
-    ls.update_configuration(&WorkspaceConfigurationUpdate {
-        target_profile: None,
-        package_type: Some(PackageType::Lib),
-    });
-
-    ls.update_document("foo.qs", 1, "namespace Foo { operation Main() : Unit {} }")
-        .await;
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            []
-    "#]],
-    );
-
-    ls.update_configuration(&WorkspaceConfigurationUpdate {
-        target_profile: None,
-        package_type: Some(PackageType::Exe),
-    });
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
+        &(expect![[r#"
             [
                 (
                     "foo.qs",
@@ -235,417 +39,165 @@ async fn package_type_update_causes_error() {
                     ],
                 ),
             ]
-        "#]],
+        "#]]),
+        &(expect![[r#"
+            SourceMap {
+                sources: [
+                    Source {
+                        name: "foo.qs",
+                        contents: "namespace Foo { }",
+                        offset: 0,
+                    },
+                ],
+                entry: None,
+            }
+        "#]]),
     );
 }
 
 #[tokio::test]
-async fn target_profile_update_fixes_error() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
+#[allow(clippy::too_many_lines)]
+async fn single_document_update() {
+    let received_errors = RefCell::new(Vec::new());
+    let mut ls = LanguageService::default();
+    let mut worker = create_update_worker(&mut ls, &received_errors);
 
-    ls.update_configuration(&WorkspaceConfigurationUpdate {
-        target_profile: Some(Profile::Base),
-        package_type: Some(PackageType::Lib),
-    });
+    ls.update_document("foo.qs", 1, "namespace Foo { }");
 
+    worker.apply_pending().await;
+
+    check_errors_and_compilation(
+        &ls,
+        &mut received_errors.borrow_mut(),
+        "foo.qs",
+        &(expect![[r#"
+            [
+                (
+                    "foo.qs",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Pass(
+                            EntryPoint(
+                                NotFound,
+                            ),
+                        ),
+                    ],
+                ),
+            ]
+        "#]]),
+        &(expect![[r#"
+            SourceMap {
+                sources: [
+                    Source {
+                        name: "foo.qs",
+                        contents: "namespace Foo { }",
+                        offset: 0,
+                    },
+                ],
+                entry: None,
+            }
+        "#]]),
+    );
+
+    // UPDATE 2
     ls.update_document(
         "foo.qs",
         1,
-        r#"namespace Foo { operation Main() : Unit { if Zero == Zero { Message("hi") } } }"#,
-    )
-    .await;
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "foo.qs",
-                    Some(
-                        1,
-                    ),
-                    [
-                        Pass(
-                            BaseProfCk(
-                                ResultComparison(
-                                    Span {
-                                        lo: 45,
-                                        hi: 57,
-                                    },
-                                ),
-                            ),
-                        ),
-                        Pass(
-                            BaseProfCk(
-                                ResultLiteral(
-                                    Span {
-                                        lo: 45,
-                                        hi: 49,
-                                    },
-                                ),
-                            ),
-                        ),
-                        Pass(
-                            BaseProfCk(
-                                ResultLiteral(
-                                    Span {
-                                        lo: 53,
-                                        hi: 57,
-                                    },
-                                ),
-                            ),
-                        ),
-                    ],
-                ),
-            ]
-        "#]],
+        "namespace Foo { @EntryPoint() operation Bar() : Unit {} }",
     );
 
-    ls.update_configuration(&WorkspaceConfigurationUpdate {
-        target_profile: Some(Profile::Unrestricted),
-        package_type: None,
-    });
+    worker.apply_pending().await;
 
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "foo.qs",
-                    Some(
-                        1,
-                    ),
-                    [],
-                ),
-            ]
-        "#]],
-    );
-}
-
-#[tokio::test]
-async fn target_profile_update_causes_error_in_stdlib() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
-
-    ls.update_document(
+    check_errors_and_compilation(
+        &ls,
+        &mut received_errors.borrow_mut(),
         "foo.qs",
-        1,
-        r#"namespace Foo { @EntryPoint() operation Main() : Unit { use q = Qubit(); let r = M(q); let b = Microsoft.Quantum.Convert.ResultAsBool(r); } }"#,
-    ).await;
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            []
-        "#]],
-    );
-
-    ls.update_configuration(&WorkspaceConfigurationUpdate {
-        target_profile: Some(Profile::Base),
-        package_type: None,
-    });
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
+        &(expect![[r#"
             [
                 (
                     "foo.qs",
                     Some(
                         1,
                     ),
-                    [
-                        Frontend(
-                            Error(
-                                Resolve(
-                                    NotAvailable(
-                                        "ResultAsBool",
-                                        "Microsoft.Quantum.Convert.ResultAsBool",
-                                        Span {
-                                            lo: 121,
-                                            hi: 133,
-                                        },
-                                    ),
-                                ),
-                            ),
-                        ),
-                        Frontend(
-                            Error(
-                                Type(
-                                    Error(
-                                        AmbiguousTy(
-                                            Span {
-                                                lo: 95,
-                                                hi: 136,
-                                            },
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ],
+                    [],
                 ),
             ]
-        "#]],
+        "#]]),
+        &(expect![[r#"
+            SourceMap {
+                sources: [
+                    Source {
+                        name: "foo.qs",
+                        contents: "namespace Foo { @EntryPoint() operation Bar() : Unit {} }",
+                        offset: 0,
+                    },
+                ],
+                entry: None,
+            }
+        "#]]),
     );
 }
 
 #[tokio::test]
-async fn notebook_document_no_errors() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
+#[allow(clippy::too_many_lines)]
+async fn document_in_project() {
+    let received_errors = RefCell::new(Vec::new());
+    let mut ls = LanguageService::default();
+    let mut worker = create_update_worker(&mut ls, &received_errors);
 
-    ls.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [
-            ("cell1", 1, "operation Main() : Unit {}"),
-            ("cell2", 1, "Main()"),
-        ]
-        .into_iter(),
-    );
+    ls.update_document("this_file.qs", 1, "namespace Foo { }");
 
-    expect_errors(
-        &errors,
-        &expect![[r#"
+    check_errors_and_no_compilation(
+        &ls,
+        &mut received_errors.borrow_mut(),
+        "this_file.qs",
+        &(expect![[r#"
             []
-        "#]],
-    );
-}
-
-#[tokio::test]
-async fn notebook_document_errors() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
-
-    ls.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [
-            ("cell1", 1, "operation Main() : Unit {}"),
-            ("cell2", 1, "Foo()"),
-        ]
-        .into_iter(),
+        "#]]),
     );
 
-    expect_errors(
-        &errors,
+    // now process background work
+    worker.apply_pending().await;
+
+    check_errors_and_compilation(
+        &ls,
+        &mut received_errors.borrow_mut(),
+        "this_file.qs",
         &expect![[r#"
             [
                 (
-                    "cell2",
-                    Some(
-                        1,
-                    ),
-                    [
-                        Frontend(
-                            Error(
-                                Resolve(
-                                    NotFound(
-                                        "Foo",
-                                        Span {
-                                            lo: 27,
-                                            hi: 30,
-                                        },
-                                    ),
-                                ),
-                            ),
-                        ),
-                        Frontend(
-                            Error(
-                                Type(
-                                    Error(
-                                        AmbiguousTy(
-                                            Span {
-                                                lo: 27,
-                                                hi: 32,
-                                            },
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ],
-                ),
-            ]
-        "#]],
-    );
-}
-
-#[tokio::test]
-async fn notebook_update_remove_cell_clears_errors() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
-
-    ls.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [
-            ("cell1", 1, "operation Main() : Unit {}"),
-            ("cell2", 1, "Foo()"),
-        ]
-        .into_iter(),
-    );
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "cell2",
-                    Some(
-                        1,
-                    ),
-                    [
-                        Frontend(
-                            Error(
-                                Resolve(
-                                    NotFound(
-                                        "Foo",
-                                        Span {
-                                            lo: 27,
-                                            hi: 30,
-                                        },
-                                    ),
-                                ),
-                            ),
-                        ),
-                        Frontend(
-                            Error(
-                                Type(
-                                    Error(
-                                        AmbiguousTy(
-                                            Span {
-                                                lo: 27,
-                                                hi: 32,
-                                            },
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ],
-                ),
-            ]
-        "#]],
-    );
-
-    ls.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [("cell1", 1, "operation Main() : Unit {}")].into_iter(),
-    );
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "cell2",
+                    "./qsharp.json",
                     None,
-                    [],
-                ),
-            ]
-        "#]],
-    );
-}
-
-#[tokio::test]
-async fn close_notebook_clears_errors() {
-    let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
-
-    ls.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [
-            ("cell1", 1, "operation Main() : Unit {}"),
-            ("cell2", 1, "Foo()"),
-        ]
-        .into_iter(),
-    );
-
-    expect_errors(
-        &errors,
-        &expect![[r#"
-            [
-                (
-                    "cell2",
-                    Some(
-                        1,
-                    ),
                     [
-                        Frontend(
-                            Error(
-                                Resolve(
-                                    NotFound(
-                                        "Foo",
-                                        Span {
-                                            lo: 27,
-                                            hi: 30,
-                                        },
-                                    ),
-                                ),
-                            ),
-                        ),
-                        Frontend(
-                            Error(
-                                Type(
-                                    Error(
-                                        AmbiguousTy(
-                                            Span {
-                                                lo: 27,
-                                                hi: 32,
-                                            },
-                                        ),
-                                    ),
-                                ),
+                        Pass(
+                            EntryPoint(
+                                NotFound,
                             ),
                         ),
                     ],
                 ),
             ]
         "#]],
-    );
-
-    ls.close_notebook_document("notebook.ipynb", ["cell1", "cell2"].into_iter());
-
-    expect_errors(
-        &errors,
         &expect![[r#"
-            [
-                (
-                    "cell2",
-                    None,
-                    [],
-                ),
-            ]
+            SourceMap {
+                sources: [
+                    Source {
+                        name: "other_file.qs",
+                        contents: "namespace OtherFile { operation Other() : Unit {} }",
+                        offset: 0,
+                    },
+                    Source {
+                        name: "this_file.qs",
+                        contents: "namespace Foo { }",
+                        offset: 52,
+                    },
+                ],
+                entry: None,
+            }
         "#]],
     );
-}
-
-type ErrorInfo = (String, Option<u32>, Vec<compile::ErrorKind>);
-
-fn new_language_service(received: &RefCell<Vec<ErrorInfo>>) -> LanguageService<'_> {
-    let diagnostic_receiver = move |update: DiagnosticUpdate| {
-        let mut v = received.borrow_mut();
-
-        v.push((
-            update.uri.to_string(),
-            update.version,
-            update.errors.iter().map(|e| e.error().clone()).collect(),
-        ));
-    };
-
-    LanguageService::new(
-        diagnostic_receiver,
-        // these tests do not test project mode
-        // so we provide these stubbed-out functions
-        |_| Box::pin(std::future::ready((Arc::from(""), Arc::from("")))),
-        |_| Box::pin(std::future::ready(vec![])),
-        |_| Box::pin(std::future::ready(None)),
-    )
 }
 
 // the below tests test the asynchronous behavior of the language service.
@@ -654,25 +206,29 @@ fn new_language_service(received: &RefCell<Vec<ErrorInfo>>) -> LanguageService<'
 #[tokio::test]
 async fn completions_requested_before_document_load() {
     let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
+    let mut ls = LanguageService::default();
+    let mut worker = create_update_worker(&mut ls, &errors);
 
-    // we intentionally don't await this to test how LSP features function when
-    // a document hasn't fully loaded
-    #[allow(clippy::let_underscore_future)]
-    let _ = ls.update_document(
+    ls.update_document(
         "foo.qs",
         1,
         "namespace Foo { open Microsoft.Quantum.Diagnostics; @EntryPoint() operation Main() : Unit { DumpMachine() } }",
     );
 
+    // we intentionally don't await work to test how LSP features function when
+    // a document hasn't fully loaded
+
     // this should be empty, because the doc hasn't loaded
     assert!(ls.get_completions("foo.qs", 76).items.is_empty());
+
+    worker.apply_pending().await;
 }
 
 #[tokio::test]
 async fn completions_requested_after_document_load() {
     let errors = RefCell::new(Vec::new());
-    let mut ls = new_language_service(&errors);
+    let mut ls = LanguageService::default();
+    let mut worker = create_update_worker(&mut ls, &errors);
 
     // this test is a contrast to `completions_requested_before_document_load`
     // we want to ensure that completions load when the update_document call has been awaited
@@ -680,14 +236,111 @@ async fn completions_requested_after_document_load() {
         "foo.qs",
         1,
         "namespace Foo { open Microsoft.Quantum.Diagnostics; @EntryPoint() operation Main() : Unit { DumpMachine() } }",
-    ).await;
+    );
+
+    worker.apply_pending().await;
 
     // this should be empty, because the doc hasn't loaded
     assert_eq!(ls.get_completions("foo.qs", 76).items.len(), 13);
 }
 
-fn expect_errors(errors: &RefCell<Vec<ErrorInfo>>, expected: &Expect) {
-    expected.assert_debug_eq(&errors.borrow());
-    // reset accumulated errors after each check
-    errors.borrow_mut().clear();
+fn check_errors_and_compilation(
+    ls: &LanguageService,
+    received_errors: &mut Vec<(String, Option<u32>, Vec<ErrorKind>)>,
+    uri: &str,
+    expected_errors: &Expect,
+    expected_compilation: &Expect,
+) {
+    expected_errors.assert_debug_eq(received_errors);
+    assert_compilation(ls, uri, expected_compilation);
+    received_errors.clear();
+}
+
+fn check_errors_and_no_compilation(
+    ls: &LanguageService,
+    received_errors: &mut Vec<(String, Option<u32>, Vec<ErrorKind>)>,
+    uri: &str,
+    expected_errors: &Expect,
+) {
+    expected_errors.assert_debug_eq(received_errors);
+    received_errors.clear();
+
+    let state = ls.state.try_borrow().expect("borrow should succeed");
+    assert!(state.get_compilation(uri).is_none());
+}
+
+fn assert_compilation(ls: &LanguageService, uri: &str, expected: &Expect) {
+    let state = ls.state.try_borrow().expect("borrow should succeed");
+    let compilation = state
+        .get_compilation(uri)
+        .expect("compilation should exist");
+    expected.assert_debug_eq(&compilation.user_unit().sources);
+}
+
+type ErrorInfo = (String, Option<u32>, Vec<compile::ErrorKind>);
+
+fn create_update_worker<'a>(
+    ls: &mut LanguageService,
+    received_errors: &'a RefCell<Vec<ErrorInfo>>,
+) -> UpdateWorker<'a> {
+    let worker = ls.create_update_worker(
+        |update: DiagnosticUpdate| {
+            let mut v = received_errors.borrow_mut();
+
+            v.push((
+                update.uri.to_string(),
+                update.version,
+                update
+                    .errors
+                    .iter()
+                    .map(|e| e.error().clone())
+                    .collect::<Vec<_>>(),
+            ));
+        },
+        |file| {
+            Box::pin(async {
+                tokio::spawn(ready(match file.as_str() {
+                    "other_file.qs" => (
+                        Arc::from(file),
+                        Arc::from("namespace OtherFile { operation Other() : Unit {} }"),
+                    ),
+                    "this_file.qs" => (Arc::from(file), Arc::from("namespace Foo { }")),
+                    _ => panic!("unknown file"),
+                }))
+                .await
+                .expect("spawn should not fail")
+            })
+        },
+        |_dir_name| {
+            Box::pin(async {
+                tokio::spawn(ready(vec![
+                    JSFileEntry {
+                        name: "other_file.qs".into(),
+                        r#type: EntryType::File,
+                    },
+                    JSFileEntry {
+                        name: "this_file.qs".into(),
+                        r#type: EntryType::File,
+                    },
+                ]))
+                .await
+                .expect("spawn should not fail")
+            })
+        },
+        |file| {
+            Box::pin(async move {
+                tokio::spawn(ready(match file.as_str() {
+                    "this_file.qs" => Some(ManifestDescriptor {
+                        manifest: Manifest::default(),
+                        manifest_dir: ".".into(),
+                    }),
+                    "foo.qs" => None,
+                    _ => panic!("unknown file"),
+                }))
+                .await
+                .expect("spawn should not fail")
+            })
+        },
+    );
+    worker
 }

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -207,7 +207,7 @@ async fn document_in_project() {
 async fn completions_requested_before_document_load() {
     let errors = RefCell::new(Vec::new());
     let mut ls = LanguageService::default();
-    let mut worker = create_update_worker(&mut ls, &errors);
+    let _worker = create_update_worker(&mut ls, &errors);
 
     ls.update_document(
         "foo.qs",
@@ -220,8 +220,6 @@ async fn completions_requested_before_document_load() {
 
     // this should be empty, because the doc hasn't loaded
     assert!(ls.get_completions("foo.qs", 76).items.is_empty());
-
-    worker.apply_pending().await;
 }
 
 #[tokio::test]

--- a/npm/src/compiler/compiler.ts
+++ b/npm/src/compiler/compiler.ts
@@ -48,20 +48,20 @@ export class Compiler implements ICompiler {
   // see https://github.com/microsoft/qsharp/pull/849#discussion_r1409821143
   async checkCode(code: string): Promise<VSDiagnostic[]> {
     let diags: VSDiagnostic[] = [];
-    const languageService = new this.wasm.LanguageService(
-      async (
-        uri: string,
-        version: number | undefined,
-        errors: VSDiagnostic[],
-      ) => {
+    const languageService = new this.wasm.LanguageService();
+    const work = languageService.start_background_work(
+      (uri: string, version: number | undefined, errors: VSDiagnostic[]) => {
         diags = errors;
       },
       () => Promise.resolve(null),
       () => Promise.resolve([]),
-
       () => Promise.resolve(null),
     );
-    await languageService.update_document("code", 1, code);
+    languageService.update_document("code", 1, code);
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 0));
+    languageService.stop_background_work();
+    await work;
+    languageService.free();
     return mapDiagnostics(diags, code);
   }
 

--- a/npm/src/compiler/compiler.ts
+++ b/npm/src/compiler/compiler.ts
@@ -58,7 +58,8 @@ export class Compiler implements ICompiler {
       () => Promise.resolve(null),
     );
     languageService.update_document("code", 1, code);
-    await new Promise<void>((resolve) => setTimeout(() => resolve(), 0));
+    // Yield to let the language service background worker handle the update
+    await Promise.resolve();
     languageService.stop_background_work();
     await work;
     languageService.free();

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -146,10 +146,10 @@ function registerDocumentUpdateHandlers(languageService: ILanguageService) {
     }),
   );
 
-  async function updateIfQsharpDocument(document: vscode.TextDocument) {
+  function updateIfQsharpDocument(document: vscode.TextDocument) {
     if (isQsharpDocument(document) && !isQsharpNotebookCell(document)) {
       // Regular (not notebook) Q# document.
-      await languageService.updateDocument(
+      languageService.updateDocument(
         document.uri.toString(),
         document.version,
         document.getText(),
@@ -229,6 +229,9 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
       createRenameProvider(languageService),
     ),
   );
+
+  // add the language service dispose handler as well
+  subscriptions.push(languageService);
 
   return subscriptions;
 }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["rlib", "cdylib"]
 doctest = false
 
 [dependencies]
+futures-util = { workspace = true }
 js-sys = { workspace = true }
 katas = { path = "../katas"}
 log = { workspace = true }

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -90,7 +90,7 @@ impl LanguageService {
     pub fn update_configuration(&mut self, config: IWorkspaceConfiguration) {
         let config: WorkspaceConfiguration = config.into();
         self.0
-            .update_configuration(&qsls::protocol::WorkspaceConfigurationUpdate {
+            .update_configuration(qsls::protocol::WorkspaceConfigurationUpdate {
                 target_profile: config
                     .targetProfile
                     .map(|s| Profile::from_str(&s).expect("invalid target profile")),

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -120,7 +120,7 @@ impl LanguageService {
         let notebook_metadata: NotebookMetadata = notebook_metadata.into();
         self.0.update_notebook_document(
             notebook_uri,
-            &qsls::protocol::NotebookMetadata {
+            qsls::protocol::NotebookMetadata {
                 target_profile: notebook_metadata
                     .targetProfile
                     .map(|s| Profile::from_str(&s).expect("invalid target profile")),

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -17,6 +17,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::future_to_promise;
 
 #[wasm_bindgen]
 pub struct LanguageService(qsls::LanguageService);

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(non_snake_case)]
+
 use diagnostic::VSDiagnostic;
 use katas::check_solution;
 use num_bigint::BigUint;

--- a/wasm/src/serializable_type.rs
+++ b/wasm/src/serializable_type.rs
@@ -106,7 +106,6 @@
 macro_rules! serializable_type {
     ($struct_ident: ident, $struct: tt, $typescript: literal) => {
         #[derive(Debug, Serialize, Deserialize)]
-        #[allow(non_snake_case)] // These types propagate to JS which expects camelCase
         pub(crate) struct $struct_ident $struct
 
         // TypeScript type definition that will be included in the generated .d.ts file.
@@ -118,7 +117,6 @@ macro_rules! serializable_type {
 
     ($struct_ident: ident, $struct: tt, $typescript: literal, $typescript_type_ident:ident) => {
         #[derive(Debug, Serialize, Deserialize)]
-        #[allow(non_snake_case)] // These types propagate to JS which expects camelCase
         pub(crate) struct $struct_ident $struct
 
         // TypeScript type definition that will be included in the generated .d.ts file.


### PR DESCRIPTION
This PR allows us to use async methods (e.g. for loading the project) when updating the compilation state in the language service, without interfering with read operations such as `getCompletions`. 

We can divide language service methods into two kinds of operations: reads and updates. The `CompilationState` is shared.
* Read operations, which are always synchronous, immutably borrow the `CompilationState`.
* Update operations, instead of performing the update directly, post a message to a channel which is then read by an update worker that processes the updates one by one. The update worker can do asynchronous work without interfering with any other language service operations. The update worker only mutably borrows the `CompilationState` briefly to update it.