### PR TITLE
Make TargetMismatch error more user-friendly

### DIFF
--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -63,9 +63,9 @@ pub enum Error {
     #[error("entry point not found")]
     #[diagnostic(code("Qsc.Interpret.NoEntryPoint"))]
     NoEntryPoint,
-    #[error("code generation target mismatch")]
-    #[diagnostic(code("Qsc.Interpret.TargetMismatch"))]
-    TargetMismatch,
+    #[error("unsupported runtime capabilities for code generation")]
+    #[diagnostic(code("Qsc.Interpret.UnsupportedRuntimeCapabilities"))]
+    UnsupportedRuntimeCapabilities,
 }
 
 struct Lookup<'a> {
@@ -368,7 +368,7 @@ impl Interpreter {
     /// and simulator but using the current compilation.
     pub fn qirgen(&mut self, expr: &str) -> Result<String, Vec<Error>> {
         if self.capabilities != RuntimeCapabilityFlags::empty() {
-            return Err(vec![Error::TargetMismatch]);
+            return Err(vec![Error::UnsupportedRuntimeCapabilities]);
         }
 
         let mut sim = BaseProfSim::new();

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -203,11 +203,24 @@ fn format_errors(errors: Vec<stateful::Error>) -> String {
             if let Some(stack_trace) = e.stack_trace() {
                 write!(message, "{stack_trace}").unwrap();
             }
+            let additional_help = python_help(&e);
             let report = Report::new(e);
             write!(message, "{report:?}").unwrap();
+            if let Some(additional_help) = additional_help {
+                writeln!(message, "{additional_help}").unwrap();
+            }
             message
         })
         .collect::<String>()
+}
+
+/// Additional help text for an error specific to the Python module
+fn python_help(error: &stateful::Error) -> Option<String> {
+    if matches!(error, stateful::Error::UnsupportedRuntimeCapabilities) {
+        Some("Unsupported target profile. Initialize Q# by running `qsharp.init(target_profile=qsharp.TargetProfile.Base)` before performing code generation.".into())
+    } else {
+        None
+    }
 }
 
 #[pyclass(unsendable)]

--- a/wasm/src/diagnostic.rs
+++ b/wasm/src/diagnostic.rs
@@ -61,7 +61,7 @@ impl VSDiagnostic {
             stateful::Error::Pass(e) => error_labels(e),
             stateful::Error::Eval(e) => error_labels(e.error()),
             stateful::Error::NoEntryPoint => Vec::new(),
-            stateful::Error::TargetMismatch => Vec::new(),
+            stateful::Error::UnsupportedRuntimeCapabilities => Vec::new(),
         };
 
         Self::new(labels, source_name, err)


### PR DESCRIPTION
The name of this error didn't make any sense anymore :) . It's also not clear to the user what they should do to fix it when we run into this error in Python.

Before:

![Screenshot 2023-12-13 111658](https://github.com/microsoft/qsharp/assets/16928427/acc7db8b-2add-4089-b16e-26e825993b0b)


After:

![Screenshot 2023-12-13 111536](https://github.com/microsoft/qsharp/assets/16928427/a207d5ce-98be-4082-b277-30776066b6a5)
