### PR TITLE
Fix release of aux qubit in base profile measurement

### DIFF
--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -378,7 +378,7 @@ namespace Microsoft.Quantum.Intrinsic {
                 EntangleForJointMeasure(bases[i], aux, qubits[i]);
             }
         }
-        __quantum__qis__m__body(aux)
+        __quantum__qis__mresetz__body(aux)
     }
 
     /// # Summary

--- a/library/tests/src/lib.rs
+++ b/library/tests/src/lib.rs
@@ -39,18 +39,23 @@ pub fn test_expression(expr: &str, expected: &Value) {
 }
 
 pub fn test_expression_with_lib(expr: &str, lib: &str, expected: &Value) {
+    test_expression_with_lib_and_profile(expr, lib, Profile::Unrestricted, expected);
+}
+
+pub fn test_expression_with_lib_and_profile(
+    expr: &str,
+    lib: &str,
+    profile: Profile,
+    expected: &Value,
+) {
     let mut stdout = vec![];
     let mut out = GenericReceiver::new(&mut stdout);
 
     let sources = SourceMap::new([("test".into(), lib.into())], Some(expr.into()));
 
-    let mut interpreter = stateful::Interpreter::new(
-        true,
-        sources,
-        PackageType::Exe,
-        Profile::Unrestricted.into(),
-    )
-    .expect("test should compile");
+    let mut interpreter =
+        stateful::Interpreter::new(true, sources, PackageType::Exe, profile.into())
+            .expect("test should compile");
     let result = interpreter
         .eval_entry(&mut out)
         .expect("test should run successfully");

--- a/library/tests/src/tests.rs
+++ b/library/tests/src/tests.rs
@@ -3,9 +3,9 @@
 
 #![allow(clippy::needless_raw_string_hashes)]
 
-use crate::test_expression;
+use crate::{test_expression, test_expression_with_lib_and_profile};
 use indoc::indoc;
-use qsc::interpret::Value;
+use qsc::{interpret::Value, target::Profile};
 
 //
 // Core namespace
@@ -83,5 +83,21 @@ fn check_exp_with_swap() {
             CheckAllZero([aux] + qs)
         }"#},
         &Value::Bool(true),
+    );
+}
+
+#[test]
+fn check_base_profile_measure_resets_aux_qubits() {
+    test_expression_with_lib_and_profile(
+        indoc! {"{
+            use q = Qubit();
+            X(q);
+            let result = M(q);
+            Reset(q);
+            result
+        }"},
+        "",
+        Profile::Base,
+        &Value::RESULT_ONE,
     );
 }


### PR DESCRIPTION
When simulating with Base profile, auxiliary qubits used during measurement were not being reset before being released. This fixes that by using the measure and resest intrinsic and adds a test case to verify behavior.