### PR TITLE
Fix bug in qubit reset on measure logic

### DIFF
--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -118,11 +118,14 @@ pub(super) fn get_global(
         })
 }
 
+#[derive(Copy, Clone, Default)]
+struct HardwareId(usize);
+
 pub struct BaseProfSim {
     next_meas_id: usize,
     next_qubit_id: usize,
-    next_qubit_hardware_id: usize,
-    qubit_map: IndexMap<usize, usize>,
+    next_qubit_hardware_id: HardwareId,
+    qubit_map: IndexMap<usize, HardwareId>,
     instrs: String,
     measurements: String,
 }
@@ -139,7 +142,7 @@ impl BaseProfSim {
         let mut sim = BaseProfSim {
             next_meas_id: 0,
             next_qubit_id: 0,
-            next_qubit_hardware_id: 0,
+            next_qubit_hardware_id: HardwareId::default(),
             qubit_map: IndexMap::new(),
             instrs: String::new(),
             measurements: String::new(),
@@ -157,7 +160,7 @@ impl BaseProfSim {
         write!(
             self.instrs,
             include_str!("./qir_base/postfix.ll"),
-            self.next_qubit_hardware_id, self.next_meas_id
+            self.next_qubit_hardware_id.0, self.next_meas_id
         )
         .expect("writing to string should succeed");
 
@@ -171,12 +174,12 @@ impl BaseProfSim {
         id
     }
 
-    fn map(&mut self, qubit: usize) -> usize {
+    fn map(&mut self, qubit: usize) -> HardwareId {
         if let Some(mapped) = self.qubit_map.get(qubit) {
             *mapped
         } else {
             let mapped = self.next_qubit_hardware_id;
-            self.next_qubit_hardware_id += 1;
+            self.next_qubit_hardware_id.0 += 1;
             self.qubit_map.insert(qubit, mapped);
             mapped
         }
@@ -292,14 +295,14 @@ impl Backend for BaseProfSim {
     }
 
     fn m(&mut self, q: usize) -> Self::ResultType {
-        let q = self.map(q);
+        let mapped_q = self.map(q);
         let id = self.get_meas_id();
         // Measurements are tracked separately from instructions, so that they can be
         // deferred until the end of the program.
         writeln!(
             self.measurements,
             "  call void @__quantum__qis__mz__body({}, {}) #1",
-            Qubit(q),
+            Qubit(mapped_q),
             Result(id),
         )
         .expect("writing to string should succeed");
@@ -498,11 +501,11 @@ impl Backend for BaseProfSim {
     }
 }
 
-struct Qubit(usize);
+struct Qubit(HardwareId);
 
 impl Display for Qubit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "%Qubit* inttoptr (i64 {} to %Qubit*)", self.0)
+        write!(f, "%Qubit* inttoptr (i64 {} to %Qubit*)", self.0 .0)
     }
 }
 

--- a/compiler/qsc_codegen/src/qir_base/tests.rs
+++ b/compiler/qsc_codegen/src/qir_base/tests.rs
@@ -896,3 +896,105 @@ fn complex_program_is_valid() {
         "#]],
     );
 }
+
+#[test]
+fn qubit_ids_properly_reused() {
+    check(
+        indoc! {"
+        namespace Test {
+
+            open Microsoft.Quantum.Intrinsic;
+            open Microsoft.Quantum.Measurement;
+
+            // Verifies the use of the CNOT quantum gate from Q#'s Microsoft.Quantum.Intrinsic namespace.
+            // Expected simulation output: ([0, 0], [1, 1]).
+            @EntryPoint()
+            operation IntrinsicCNOT() : (Result[], Result[]) {
+                use registerA = Qubit[2];           // |00⟩
+                CNOT(registerA[0], registerA[1]);   // |00⟩
+                let resultsA = MeasureEachZ(registerA);
+                ResetAll(registerA);
+
+                use registerB = Qubit[2];           // |00⟩
+                X(registerB[0]);                    // |10⟩
+                CNOT(registerB[0], registerB[1]);   // |11⟩
+                let resultsB = MeasureEachZ(registerB);
+                ResetAll(registerB);
+
+                return (resultsA, resultsB);
+            }
+        }
+        "},
+        Some("Test.IntrinsicCNOT()"),
+        &expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 2 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
+              call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 4 to %Qubit*))
+              call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 4 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
+              call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 1 to %Result*)) #1
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Result* inttoptr (i64 2 to %Result*)) #1
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Result* inttoptr (i64 3 to %Result*)) #1
+              call void @__quantum__rt__tuple_record_output(i64 2, i8* null)
+              call void @__quantum__rt__array_record_output(i64 2, i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+              call void @__quantum__rt__array_record_output(i64 2, i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__rx__body(double, %Qubit*)
+            declare void @__quantum__qis__rxx__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+            declare void @__quantum__qis__ryy__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__rz__body(double, %Qubit*)
+            declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__h__body(%Qubit*)
+            declare void @__quantum__qis__s__body(%Qubit*)
+            declare void @__quantum__qis__s__adj(%Qubit*)
+            declare void @__quantum__qis__t__body(%Qubit*)
+            declare void @__quantum__qis__t__adj(%Qubit*)
+            declare void @__quantum__qis__x__body(%Qubit*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+            declare void @__quantum__qis__z__body(%Qubit*)
+            declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__rt__array_record_output(i64, i8*)
+            declare void @__quantum__rt__tuple_record_output(i64, i8*)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="8" "required_num_results"="4" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}


### PR DESCRIPTION
For base profile, we need to "reset" the qubit identifier for qubits that are measured such that later use of the same ID gets a fresh hardware ID. Because the underlying bug was a subtle misuse of the two types (where we have a map from `usize` to `usize`), this change adds a little bit of extra type safety by ensuring that mapped qubits are a new wrapper type `HardwareId`. Added a test case that confirms qubit reuse behaves as expected.

Thanks @cesarzc for figuring this one out!