### PR TITLE
Support Copy-and-Update for Array with Range

### DIFF
--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -1436,7 +1436,7 @@ impl State {
                     })?;
                 }
                 Some(_) => {
-                    unreachable!("update of mutable variable should be disallowed by compiler")
+                    unreachable!("update of immutable variable should be disallowed by compiler")
                 }
                 None => return Err(Error::UnboundName(self.to_global_span(lhs.span))),
             },

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -1254,7 +1254,6 @@ impl State {
         Ok(())
     }
 
-    #[allow(clippy::similar_names)] // `env` and `end` are similar but distinct
     fn eval_update_index_in_place(
         &mut self,
         env: &mut Env,

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -2149,6 +2149,121 @@ fn update_range_to_end() {
 }
 
 #[test]
+fn update_array_with_range() {
+    check_expr("", "[0, 1, 2] w/ 1..2 <- [10, 11]", &expect!["[0, 10, 11]"]);
+}
+
+#[test]
+fn update_array_with_range_start() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ 1... <- [10, 11]",
+        &expect!["[0, 10, 11, 3]"],
+    );
+}
+
+#[test]
+fn update_array_with_range_step() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ ...2... <- [10, 11]",
+        &expect!["[10, 1, 11, 3]"],
+    );
+}
+
+#[test]
+fn update_array_with_range_end() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ ...2 <- [10, 11, 12, 13]",
+        &expect!["[10, 11, 12, 3]"],
+    );
+}
+
+#[test]
+fn update_array_with_range_reverse() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ 2..-1..0 <- [10, 11]",
+        &expect!["[0, 11, 10, 3]"],
+    );
+}
+
+#[test]
+fn update_array_with_range_out_of_range_err() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ 1..5 <- [10, 11, 12, 13]",
+        &expect![[r#"
+            (
+                IndexOutOfRange(
+                    4,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 16,
+                            hi: 20,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn update_array_with_range_negative_index_err() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ -1..0 <- [10, 11, 12, 13]",
+        &expect![[r#"
+            (
+                InvalidIndex(
+                    -1,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 16,
+                            hi: 21,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn update_array_with_range_zero_step_err() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ ...0... <- [10, 11, 12, 13]",
+        &expect![[r#"
+            (
+                RangeStepZero(
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 16,
+                            hi: 23,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
+}
+
+#[test]
 fn assignupdate_expr() {
     check_expr(
         "",
@@ -2158,6 +2273,64 @@ fn assignupdate_expr() {
             x
         }"},
         &expect!["[1, 2, 4]"],
+    );
+}
+
+#[test]
+fn assignupdate_out_of_range_err() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3];
+            set x w/= 4 <- 4;
+            x
+        }"},
+        &expect![[r#"
+            (
+                IndexOutOfRange(
+                    4,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 43,
+                            hi: 44,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn assignupdate_expr_negative_index_err() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3];
+            set x w/= -1 <- 4;
+            x
+        }"},
+        &expect![[r#"
+            (
+                InvalidNegativeInt(
+                    -1,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 43,
+                            hi: 45,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
     );
 }
 
@@ -2176,6 +2349,129 @@ fn assignupdate_expr_using_field_name() {
             p
         }"},
         &expect!["(3, 2)"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3];
+            set x w/= 1..2 <- [10, 11];
+            x
+        }"},
+        &expect!["[1, 10, 11]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_start() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= 1... <- [10, 11];
+            x
+        }"},
+        &expect!["[1, 10, 11, 4]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_step() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= ...2... <- [10, 11];
+            x
+        }"},
+        &expect!["[10, 2, 11, 4]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_end() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= ...2 <- [10, 11, 12, 13];
+            x
+        }"},
+        &expect!["[10, 11, 12, 4]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_reverse() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= 2..-1..0 <- [10, 11];
+            x
+        }"},
+        &expect!["[1, 11, 10, 4]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_out_of_range_err() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= 1..5 <- [10, 11, 12, 13];
+            x
+        }"},
+        &expect![[r#"
+            (
+                IndexOutOfRange(
+                    4,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 46,
+                            hi: 50,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_negative_index_err() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= -1..0 <- [10, 11, 12, 13];
+            x
+        }"},
+        &expect![[r#"
+            (
+                InvalidNegativeInt(
+                    -1,
+                    PackageSpan {
+                        package: PackageId(
+                            2,
+                        ),
+                        span: Span {
+                            lo: 46,
+                            hi: 51,
+                        },
+                    },
+                ),
+                [],
+            )
+        "#]],
     );
 }
 

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -2181,6 +2181,15 @@ fn update_array_with_range_end() {
 }
 
 #[test]
+fn update_array_with_range_fully_open() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ ... <- [10, 11, 12, 13]",
+        &expect!["[10, 11, 12, 13]"],
+    );
+}
+
+#[test]
 fn update_array_with_range_reverse() {
     check_expr(
         "",
@@ -2261,6 +2270,47 @@ fn update_array_with_range_zero_step_err() {
             )
         "#]],
     );
+}
+
+#[test]
+fn update_array_with_range_bigger_than_update() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ 1..3 <- [10]",
+        &expect!["[0, 10, 2, 3]"],
+    );
+}
+
+#[test]
+fn update_array_with_range_smaller_than_update() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ 1..3 <- [10, 11, 12, 13]",
+        &expect!["[0, 10, 11, 12]"],
+    );
+}
+
+#[test]
+fn update_array_with_range_open_ended_bigger_than_update() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ 1... <- [10]",
+        &expect!["[0, 10, 2, 3]"],
+    );
+}
+
+#[test]
+fn update_array_with_range_open_ended_smaller_than_update() {
+    check_expr(
+        "",
+        "[0, 1, 2, 3] w/ 1... <- [10, 11, 12, 13]",
+        &expect!["[0, 10, 11, 12]"],
+    );
+}
+
+#[test]
+fn update_array_with_range_empty_update() {
+    check_expr("", "[0, 1, 2, 3] w/ 1..3 <- []", &expect!["[0, 1, 2, 3]"]);
 }
 
 #[test]
@@ -2405,6 +2455,19 @@ fn assignupdate_expr_using_range_end() {
 }
 
 #[test]
+fn assignupdate_expr_using_range_fully_open() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= ... <- [10, 11, 12, 13];
+            x
+        }"},
+        &expect!["[10, 11, 12, 13]"],
+    );
+}
+
+#[test]
 fn assignupdate_expr_using_range_reverse() {
     check_expr(
         "",
@@ -2414,6 +2477,71 @@ fn assignupdate_expr_using_range_reverse() {
             x
         }"},
         &expect!["[1, 11, 10, 4]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_bigger_than_update() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= 1..3 <- [10];
+            x
+        }"},
+        &expect!["[1, 10, 3, 4]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_smaller_than_update() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= 1..3 <- [10, 11, 12, 13];
+            x
+        }"},
+        &expect!["[1, 10, 11, 12]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_open_ended_bigger_than_update() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= 1... <- [10, 11];
+            x
+        }"},
+        &expect!["[1, 10, 11, 4]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_open_ended_smaller_than_update() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= 1... <- [10, 11, 12, 13];
+            x
+        }"},
+        &expect!["[1, 10, 11, 12]"],
+    );
+}
+
+#[test]
+fn assignupdate_expr_using_range_empty_update() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2, 3, 4];
+            set x w/= 1..3 <- [];
+            x
+        }"},
+        &expect!["[1, 2, 3, 4]"],
     );
 }
 

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -191,12 +191,18 @@ impl Value {
     /// Updates a value in an array in-place.
     /// # Panics
     /// This will panic if the [Value] is not a [`Value::Array`].
-    pub fn update_array(&mut self, index: usize, value: Self) {
+    pub fn update_array(&mut self, index: usize, value: Self) -> core::result::Result<(), usize> {
         let Value::Array(arr) = self else {
             panic!("value should be Array, got {}", self.type_name());
         };
         let arr = Rc::get_mut(arr).expect("array should be uniquely referenced");
-        arr[index] = value;
+        match arr.get_mut(index) {
+            Some(v) => {
+                *v = value;
+                Ok(())
+            }
+            None => Err(index),
+        }
     }
 
     /// Appends a value to an array in-place.

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -1170,6 +1170,71 @@ fn ternop_update_udt_unknown_field_name_known_global() {
 }
 
 #[test]
+fn ternop_update_array_range_takes_array() {
+    check(
+        indoc! {"
+            namespace A {
+                function Foo() : () {
+                    let xs = [0, 1, 2];
+                    let ys = xs w/ 0..1 <- [3, 4];
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #6 30-32 "()" : Unit
+            #8 38-112 "{\n        let xs = [0, 1, 2];\n        let ys = xs w/ 0..1 <- [3, 4];\n    }" : Unit
+            #10 52-54 "xs" : Int[]
+            #12 57-66 "[0, 1, 2]" : Int[]
+            #13 58-59 "0" : Int
+            #14 61-62 "1" : Int
+            #15 64-65 "2" : Int
+            #17 80-82 "ys" : Int[]
+            #19 85-105 "xs w/ 0..1 <- [3, 4]" : Int[]
+            #20 85-87 "xs" : Int[]
+            #23 91-95 "0..1" : Range
+            #24 91-92 "0" : Int
+            #25 94-95 "1" : Int
+            #26 99-105 "[3, 4]" : Int[]
+            #27 100-101 "3" : Int
+            #28 103-104 "4" : Int
+        "##]],
+    );
+}
+
+#[test]
+fn ternop_update_array_range_with_non_array_error() {
+    check(
+        indoc! {"
+            namespace A {
+                function Foo() : () {
+                    let xs = [0, 1, 2];
+                    let ys = xs w/ 0..1 <- 3;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #6 30-32 "()" : Unit
+            #8 38-107 "{\n        let xs = [0, 1, 2];\n        let ys = xs w/ 0..1 <- 3;\n    }" : Unit
+            #10 52-54 "xs" : Int[]
+            #12 57-66 "[0, 1, 2]" : Int[]
+            #13 58-59 "0" : Int
+            #14 61-62 "1" : Int
+            #15 64-65 "2" : Int
+            #17 80-82 "ys" : Int[]
+            #19 85-100 "xs w/ 0..1 <- 3" : Int[]
+            #20 85-87 "xs" : Int[]
+            #23 91-95 "0..1" : Range
+            #24 91-92 "0" : Int
+            #25 94-95 "1" : Int
+            #26 99-100 "3" : Int
+            Error(Type(Error(TyMismatch("Int[]", "Int", Span { lo: 85, hi: 100 }))))
+        "##]],
+    );
+}
+
+#[test]
 fn unop_bitwise_not_bool() {
     check(
         "",


### PR DESCRIPTION
This change adds full support for copy-update and assign-update using ranges. With this fix, patterns like the following are now correctly supported:
```qsharp
[0, 1, 2] w/ 1..2 <- [10, 11]
// yields [0, 10, 11]

[0, 1, 2, 3] w/ ...2... <- [10, 11]
// yields [10, 1, 11, 3]

mutable x = [1, 2, 3, 4];
set x w/= 2..-1..0 <- [10, 11];
// x updated in-place to [1, 11, 10, 4]
```

Fixes #933