### PR TITLE
Compile/Design-Time Checks for Variable Scopes Don't Work Properly with Qubit Allocation Blocks

### DIFF
--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -668,17 +668,8 @@ impl AstVisitor<'_> for With<'_> {
             ast::StmtKind::Qubit(_, pat, init, block) => {
                 ast_visit::walk_qubit_init(self, init);
                 if let Some(block) = block {
-                    self.with_scope(block.span, ScopeKind::Block, |visitor| {
-                        // The binding is valid after end of the statement, but scoped to the current block.
-                        visitor.resolver.bind_pat(pat, stmt.span.hi);
-
-                        for stmt in &*block.stmts {
-                            if let ast::StmtKind::Item(item) = &*stmt.kind {
-                                visitor.resolver.bind_local_item(visitor.assigner, item);
-                            }
-                        }
-
-                        ast_visit::walk_block(visitor, block);
+                    self.with_pat(block.span, ScopeKind::Block, pat, |visitor| {
+                        visitor.visit_block(block);
                     });
                 } else {
                     // The binding is valid after end of the statement.

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -1381,6 +1381,40 @@ fn use_qubit_block() {
 }
 
 #[test]
+fn use_qubit_block_qubit_restricted_to_block_scope() {
+    check(
+        indoc! {"
+            namespace Foo {
+                operation X(q : Qubit) : Unit {
+                    body intrinsic;
+                }
+                operation A() : Unit {
+                    use q = Qubit() {
+                        X(q);
+                    }
+                    X(q);
+                }
+            }
+        "},
+        &expect![[r#"
+            namespace item0 {
+                operation item1(local8 : Qubit) : Unit {
+                    body intrinsic;
+                }
+                operation item2() : Unit {
+                    use local26 = Qubit() {
+                        item1(local26);
+                    }
+                    item1(q);
+                }
+            }
+
+            // NotFound("q", Span { lo: 173, hi: 174 })
+        "#]],
+    );
+}
+
+#[test]
 fn local_function() {
     check(
         indoc! {"


### PR DESCRIPTION
Fixes #932