### PR TITLE
Report when qsharp.json can't be parsed

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -352,6 +352,12 @@
         "path": "./syntaxes/qsharp.tmLanguage.json"
       }
     ],
+    "jsonValidation": [
+      {
+        "fileMatch": "qsharp.json",
+        "url": "./qsharp.schema.json"
+      }
+    ],
     "debuggers": [
       {
         "type": "qsharp",

--- a/vscode/qsharp.schema.json
+++ b/vscode/qsharp.schema.json
@@ -1,0 +1,14 @@
+{
+  "title": "Q# project manifest",
+  "type": "object",
+  "properties": {
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "license": {
+      "title": "License",
+      "type": "string"
+    }
+  }
+}

--- a/vscode/src/projectSystem.ts
+++ b/vscode/src/projectSystem.ts
@@ -5,6 +5,7 @@ import { Utils, URI } from "vscode-uri";
 import * as vscode from "vscode";
 
 import { getProjectLoader, log } from "qsharp-lang";
+import { updateQSharpJsonDiagnostics } from "./diagnostics";
 
 /**
  * Finds and parses a manifest. Returns `null` if no manifest was found for the given uri, or if the manifest
@@ -25,12 +26,18 @@ export async function getManifest(uri: string): Promise<{
   try {
     parsedManifest = JSON.parse(manifestDocument.content);
   } catch (e) {
-    log.error(
-      "Found manifest document, but the Q# manifest was not valid JSON",
+    log.warn(
+      `failed to parse manifest at ${manifestDocument.uri.toString()}`,
       e,
+    );
+    updateQSharpJsonDiagnostics(
+      manifestDocument.uri,
+      "Failed to parse Q# manifest. For a minimal Q# project manifest, try: {}",
     );
     return null;
   }
+
+  updateQSharpJsonDiagnostics(manifestDocument.uri);
 
   const manifestDirectory = Utils.dirname(manifestDocument.uri);
 


### PR DESCRIPTION
The error is surfaced when we try to parse the Q# manifest for any reason (running the program, typing in Q# files etc).

![image](https://github.com/microsoft/qsharp/assets/16928427/ae68f020-fe56-43c8-8cf6-951662c5a891)
