### PR TITLE
Add performance benchmarks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,4 +162,4 @@ jobs:
       - uses: boa-dev/criterion-compare-action@v3
         with:
           branchName: ${{ github.base_ref }}
-          cwd: "qsc"
+          cwd: "compiler/qsc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,4 @@ jobs:
       - uses: boa-dev/criterion-compare-action@v3
         with:
           branchName: ${{ github.base_ref }}
+          cwd: "qsc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,22 +55,6 @@ jobs:
       - name: Clippy Lints
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-  benches:
-    name: Benches
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: "true"
-      - name: Setup rust toolchain
-        uses: ./.github/actions/toolchains/rust
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
-          components: ${{ env.RUST_TOOLCHAIN_COMPONENTS }}
-      - uses: Swatinem/rust-cache@v2
-      - name: cargo bench
-        run: cargo bench --workspace
-
   web-check:
     name: Check web files
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,12 @@ jobs:
         run: python ./prereqs.py --install
       - name: Run integration tests
         run: python ./build.py --no-check --no-test --wasm --npm --vscode --integration-tests
+
+  runBenchmark:
+    name: run benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: boa-dev/criterion-compare-action@v3
+        with:
+          branchName: ${{ github.base_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,4 @@ jobs:
         with:
           branchName: ${{ github.base_ref }}
           cwd: "compiler/qsc"
+        if: ${{ github.base_ref != null }}


### PR DESCRIPTION
goals:
- [x] as non-flakey as possible
    -  Accomplished by not failing the stage based on any threshold
- [x] provide high-level insights to flag potential degradation, but don't block PRs


This PR adds a CI stage to benchmark a feature branch against main. It only works on criterion benches, so we are using it in `compiler/qsc`. I believe this is a good starting point, as that encapsulates all compiler logic.