### PR TITLE
Add artifact validation for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,52 @@ jobs:
         run: python ./prereqs.py --install
       - name: Build and Test
         run: python ./build.py --no-check
-
+      # Now we need to prepare the artifacts for upload.
+      # Run auditwheel on Linux
+      - name: Run auditwheel for Linux Wheels
+        uses: |
+          python -m pip install auditwheel patchelf
+          ls target/wheels
+          ls target/wheels/*.whl | xargs auditwheel show
+          ls target/wheels/*.whl | xargs auditwheel repair --wheel-dir ./target/wheels/ --plat manylinux_2_31_x86_64
+          rm target/wheels/*-linux_x86_64.whl
+          ls target/wheels
+        if: matrix.os == 'ubuntu-latest'
+      # publish wheels for active target
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-wheels
+          if-no-files-found: error
+          path: |
+            ./target/wheels/*.whl
+      # Publish vsix for VSCode if on linux
+      - name: Create VSCode Ext Package
+        working-directory: ./vscode
+        run: |
+          npm install -g @vscode/vsce
+          vsce package
+        if: matrix.os == 'ubuntu-latest'
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-vsix
+          if-no-files-found: error
+          path: |
+            ./vscode/*.vsix
+        if: matrix.os == 'ubuntu-latest'
+      # Create npm package
+      - name: Create npm package
+        working-directory: ./npm
+        run: |
+          mkdir -p ../target/npm
+          npm pack --pack-destination ../target/npm
+        if: matrix.os == 'ubuntu-latest'
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-npm
+          if-no-files-found: error
+          path: |
+            ../target/npm
+        if: matrix.os == 'ubuntu-latest'
   integration-tests:
     name: Integration tests
     if: ${{ ! github.event.pull_request }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,4 +228,4 @@ jobs:
       - name: Run python compatibility checks
         run: |
           ls -la ./target/wheels
-          python ./build.py --no-check --artifact-tests
+          python ./build.py --no-check --no-check-prereqs --artifact-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,8 @@ jobs:
         run: |
           python -m pip install auditwheel patchelf
           ls target/wheels
-          ls target/wheels/*.whl | xargs auditwheel show
-          ls target/wheels/*.whl | xargs auditwheel repair --wheel-dir ./target/wheels/ --plat manylinux_2_31_x86_64
+          ls target/wheels/*x86_64*.whl | xargs auditwheel show
+          ls target/wheels/*x86_64*.whl | xargs auditwheel repair --wheel-dir ./target/wheels/ --plat manylinux_2_31_x86_64
           rm target/wheels/*-linux_x86_64.whl
           ls target/wheels
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      #- uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
       - name: Prereqs
         run: python ./prereqs.py --install
       - name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,9 +220,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: Swatinem/rust-cache@v2
-      - name: Prereqs
-        run: python ./prereqs.py --install
       - uses: actions/download-artifact@v4
         with:
           pattern: build-artifact-wheels-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: Swatinem/rust-cache@v2
+      #- uses: Swatinem/rust-cache@v2
       - name: Prereqs
         run: python ./prereqs.py --install
       - name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        pyver: ['3.8', '3.9', '3.10', '3.11']
+        pyver: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       # publish wheels for active target
       - uses: actions/upload-artifact@v4
         with:
-          name: build-artifact-wheels
+          name: build-artifact-wheels-${{ matrix.os }}
           if-no-files-found: error
           path: |
             ./target/wheels/*.whl
@@ -202,8 +202,9 @@ jobs:
     needs: [build]
     strategy:
       matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
         pyver: ['3.8', '3.9', '3.10', '3.11']
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -224,7 +225,7 @@ jobs:
         run: python ./prereqs.py --install
       - uses: actions/download-artifact@v4
         with:
-          name: build-artifact-wheels
+          pattern: build-artifact-wheels-*
           path: ./target/wheels
           merge-multiple: true
       - name: Run python compatibility checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       # Now we need to prepare the artifacts for upload.
       # Run auditwheel on Linux
       - name: Run auditwheel for Linux Wheels
-        uses: |
+        run: |
           python -m pip install auditwheel patchelf
           ls target/wheels
           ls target/wheels/*.whl | xargs auditwheel show

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
           name: build-artifact-npm
           if-no-files-found: error
           path: |
-            ../target/npm
+            ./target/npm
         if: matrix.os == 'ubuntu-20.04'
   integration-tests:
     name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,3 +198,36 @@ jobs:
         run: python ./prereqs.py --install
       - name: Run integration tests
         run: python ./build.py --no-check --no-test --wasm --npm --vscode --integration-tests
+  python-compat-checks:
+    needs: [build]
+    strategy:
+      matrix:
+        pyver: ['3.8', '3.9', '3.10', '3.11']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "true"
+      - name: Setup rust toolchain
+        uses: ./.github/actions/toolchains/rust
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          components: ${{ env.RUST_TOOLCHAIN_COMPONENTS }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.pyver }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Prereqs
+        run: python ./prereqs.py --install
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-artifact-wheels
+          path: ./target/wheels
+          merge-multiple: true
+      - name: Run python compatibility checks
+        run: |
+          ls -la ./target/wheels
+          python ./build.py --no-check --artifact-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -41,7 +41,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -57,7 +57,7 @@ jobs:
 
   benches:
     name: Benches
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -73,7 +73,7 @@ jobs:
 
   web-check:
     name: Check web files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -90,7 +90,7 @@ jobs:
     name: Build and test
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-20.04, macos-latest]
 
     runs-on: ${{matrix.os}}
 
@@ -128,7 +128,7 @@ jobs:
           ls target/wheels/*x86_64*.whl | xargs auditwheel repair --wheel-dir ./target/wheels/ --plat manylinux_2_31_x86_64
           rm target/wheels/*-linux_x86_64.whl
           ls target/wheels
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
       # publish wheels for active target
       - uses: actions/upload-artifact@v4
         with:
@@ -142,35 +142,35 @@ jobs:
         run: |
           npm install -g @vscode/vsce
           vsce package
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
       - uses: actions/upload-artifact@v4
         with:
           name: build-artifact-vsix
           if-no-files-found: error
           path: |
             ./vscode/*.vsix
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
       # Create npm package
       - name: Create npm package
         working-directory: ./npm
         run: |
           mkdir -p ../target/npm
           npm pack --pack-destination ../target/npm
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
       - uses: actions/upload-artifact@v4
         with:
           name: build-artifact-npm
           if-no-files-found: error
           path: |
             ../target/npm
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
   integration-tests:
     name: Integration tests
     if: ${{ ! github.event.pull_request }}
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-20.04, macos-latest]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,5 +227,4 @@ jobs:
           merge-multiple: true
       - name: Run python compatibility checks
         run: |
-          ls -la ./target/wheels
           python ./build.py --no-check --no-check-prereqs --artifact-tests

--- a/build.py
+++ b/build.py
@@ -76,6 +76,8 @@ args = parser.parse_args()
 
 if args.check_prereqs:
     check_prereqs()
+else:
+    print("Skipping prerequisites check")
 
 # If no specific project given then build all
 build_all = (


### PR DESCRIPTION
Python 3.8 is excluded as the build can't be run from 3.8 but we allow 3.8 as a target Python version.

Build is moved to ubuntu-20.04 for binary compat generation. This caused issues with the rust caching action as it wasn't separating by target os, so we were getting symbos issues with glibc versions.

This adds ~10s to the main build for packaging and uploading artifacts. The secondary (non-required) build for checks is ~20s-120s.

Fixes #950