### PR TITLE
Run clippy on `qsc/stateful/re`

### DIFF
--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -157,7 +157,7 @@ impl Interpreter {
         let compiler =
             Compiler::new(std, sources, package_type, capabilities).map_err(into_errors)?;
 
-        for (id, unit) in compiler.package_store().iter() {
+        for (id, unit) in compiler.package_store() {
             fir_store.insert(
                 map_hir_package_to_fir(id),
                 lowerer.lower_package(&unit.package),
@@ -454,7 +454,7 @@ impl Interpreter {
         self.compiler.update(increment);
 
         assert!(stmts.len() == 1, "expected exactly one statement");
-        let stmt_id = stmts.get(0).expect("expected exactly one statement");
+        let stmt_id = stmts.first().expect("expected exactly one statement");
 
         Ok(*stmt_id)
     }

--- a/compiler/qsc/src/interpret/stateful/re/estimates/data.rs
+++ b/compiler/qsc/src/interpret/stateful/re/estimates/data.rs
@@ -10,8 +10,11 @@ mod result;
 mod tfactory;
 
 pub use constraints::Constraints;
-pub use job_params::JobParams;
+pub use job_params::{ErrorBudgetSpecification, JobParams, Profiling};
 pub use logical_counts::LogicalResourceCounts;
 pub use physical_counts::{PhysicalResourceCounts, PhysicalResourceCountsBreakdown};
-pub use report::{FormattedPhysicalResourceCounts, Report};
+pub use report::{format_duration, format_metric_prefix, FormattedPhysicalResourceCounts, Report};
 pub use result::{Failure, Success};
+pub use tfactory::{
+    TFactoryDistillationUnitSpecification, TFactoryProtocolSpecificDistillationUnitSpecification,
+};

--- a/compiler/qsc/src/interpret/stateful/re/estimates/data.rs
+++ b/compiler/qsc/src/interpret/stateful/re/estimates/data.rs
@@ -10,11 +10,8 @@ mod result;
 mod tfactory;
 
 pub use constraints::Constraints;
-pub use job_params::{ErrorBudgetSpecification, JobParams, Profiling};
+pub use job_params::JobParams;
 pub use logical_counts::LogicalResourceCounts;
 pub use physical_counts::{PhysicalResourceCounts, PhysicalResourceCountsBreakdown};
-pub use report::{format_duration, format_metric_prefix, FormattedPhysicalResourceCounts, Report};
+pub use report::{FormattedPhysicalResourceCounts, Report};
 pub use result::{Failure, Success};
-pub use tfactory::{
-    TFactoryDistillationUnitSpecification, TFactoryProtocolSpecificDistillationUnitSpecification,
-};

--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -35,7 +35,7 @@ pub fn generate_qir(
     let package = map_hir_package_to_fir(package);
     let mut sim = BaseProfSim::default();
 
-    for (id, unit) in store.iter() {
+    for (id, unit) in store {
         fir_store.insert(
             map_hir_package_to_fir(id),
             fir_lowerer.lower_package(&unit.package),

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -256,6 +256,13 @@ impl PackageStore {
         }
     }
 }
+impl<'a> IntoIterator for &'a PackageStore {
+    type IntoIter = Iter<'a>;
+    type Item = (qsc_hir::hir::PackageId, &'a CompileUnit);
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
 
 /// A package store that contains one mutable `CompileUnit`.
 pub struct OpenPackageStore {

--- a/compiler/qsc_hir/src/ty.rs
+++ b/compiler/qsc_hir/src/ty.rs
@@ -93,7 +93,7 @@ impl Ty {
                 if items.is_empty() {
                     "Unit".to_string()
                 } else if items.len() == 1 {
-                    let item = items.get(0).expect("expected single item");
+                    let item = items.first().expect("expected single item");
                     format!("({},)", item.display())
                 } else {
                     let items = items.iter().map(Ty::display).collect::<Vec<_>>().join(", ");


### PR DESCRIPTION
This PR applies the Rust 1.74 clippy lints. These don't get hit in our pipeline now, but they will when we update.