### PR TITLE
Use empty string for signature help when no documentation present

### DIFF
--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -190,7 +190,7 @@ impl LanguageService {
                     .into_iter()
                     .map(|sig| SignatureInformation {
                         label: sig.label,
-                        documentation: sig.documentation,
+                        documentation: sig.documentation.unwrap_or_default(),
                         parameters: sig
                             .parameters
                             .into_iter()
@@ -199,7 +199,7 @@ impl LanguageService {
                                     start: param.label.start,
                                     end: param.label.end,
                                 },
-                                documentation: param.documentation,
+                                documentation: param.documentation.unwrap_or_default(),
                             })
                             .collect(),
                     })
@@ -347,12 +347,12 @@ serializable_type! {
     SignatureInformation,
     {
         label: String,
-        documentation: Option<String>,
+        documentation: String,
         parameters: Vec<ParameterInformation>,
     },
     r#"export interface ISignatureInformation {
         label: string;
-        documentation?: string;
+        documentation: string;
         parameters: IParameterInformation[];
     }"#
 }
@@ -361,11 +361,11 @@ serializable_type! {
     ParameterInformation,
     {
         label: Span,
-        documentation: Option<String>,
+        documentation: String,
     },
     r#"export interface IParameterInformation {
         label: ISpan;
-        documentation?: string;
+        documentation: string;
     }"#
 }
 


### PR DESCRIPTION
VSCode/Monaco expect the documentation member of `SignatureInformation` and `ParamterInformation` to always be defined in order to check the length (see https://github.com/microsoft/vscode/blob/eb55c74a90679ba9471ea942b7cb8e6df2b24fad/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts#L285-L296). As a result, we should not be serializing `None` values as undefined, but rather convert those to the empty string before sending them as part of the serialized `ISignatureHelp` type.

Fixes #913