### PR TITLE
Updated table lookup code for cleaner structure

### DIFF
--- a/library/std/unstable_table_lookup.qs
+++ b/library/std/unstable_table_lookup.qs
@@ -11,7 +11,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
     open Microsoft.Quantum.Unstable.Arithmetic;
 
     @Config(Full)
-    operation BasicSelect(
+    internal operation BasicSelect(
         data : Bool[][],
         address : Qubit[],
         target : Qubit[]


### PR DESCRIPTION
This PR updates Microsoft.Quantum.Unstable.TableLookup.Select operation implementation to have cleaner structure. At this time, I'm not fully convinced that this is necessary, so this PR is in draft. I created this PR to capture some ideas.

The code introduces `BasicSelect` operation, which has limited functionality - no optimizations and only allows for a single control qubit. Then, `Select` builds on top of it to support all the necessary functionality.

* Most notably this change removes `AndChain` custom type and all array construction operations to build the chain. `AndChain` was used to implement multi-controlled version and now the code uses existing internal function `ApplyAsSinglyControlled`.
* Previously Select operation included implementation in the body, but controlled version only had the code for consolidation of controls into a single qubit state, the implementation was in a separate function. Now body and controlled implementations are in the same function (BasicSelect) and consolidation of controls is in a separate function.
* This reworked implementation should have no effect on resource estimation.
* New implementation relies on a language feature - controlled specialization declaration rather than having separate `SinglyControlledSelect` function with controlled qubit as a parameter. This approach has a drawback - an array has to be constructed to call this specialization even though it is singly controlled.

Not yet included:
* BasicSelect missing comments
* Specific tests for controlled versions aren't added
* Other possible optimizations