### PR TITLE
Format compilation errors from project import in Python

### DIFF
--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -32,12 +32,16 @@ class Interpreter:
         self,
         target_profile: TargetProfile,
         manifest_descriptor: Optional[Dict[str, str]],
+        read_file: Callable[[str], str],
+        list_directory: Callable[[str], str],
     ) -> None:
         """
         Initializes the Q# interpreter.
 
         :param target_profile: The target profile to use for the interpreter.
         :param manifest_descriptor: A dictionary that represents the manifest descriptor
+        :param read_file: A function that reads a file from the file system.
+        :param list_directory: A function that lists the contents of a directory.
         """
         ...
     def interpret(self, input: str, output_fn: Callable[[Output], None]) -> Any:

--- a/pip/src/fs.rs
+++ b/pip/src/fs.rs
@@ -35,20 +35,20 @@ struct FsHooks {
 
 #[derive(Debug)]
 struct Entry {
-    entry_type: EntryType,
+    ty: EntryType,
     path: String,
-    entry_name: String,
+    name: String,
 }
 
 impl DirEntry for Entry {
     type Error = pyo3::PyErr;
 
     fn entry_type(&self) -> Result<EntryType, Self::Error> {
-        Ok(self.entry_type)
+        Ok(self.ty)
     }
 
     fn entry_name(&self) -> String {
-        self.entry_name.clone()
+        self.name.clone()
     }
 
     fn path(&self) -> PathBuf {
@@ -101,9 +101,9 @@ fn list_directory(py: Python, list_directory: &PyObject, path: &Path) -> PyResul
             };
 
             Ok(Entry {
-                entry_type,
+                ty: entry_type,
                 path: get_dict_string(dict, "path")?.to_string(),
-                entry_name: get_dict_string(dict, "entry_name")?.to_string(),
+                name: get_dict_string(dict, "entry_name")?.to_string(),
             })
         })
         .collect() // Returns all values if all Ok, or first Err

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -130,11 +130,10 @@ impl Interpreter {
             SourceMap::default()
         };
 
-        let interpreter =
-            stateful::Interpreter::new(true, sources, PackageType::Lib, target.into())
-                .map_py_err()?;
-
-        Ok(Self { interpreter })
+        match stateful::Interpreter::new(true, sources, PackageType::Lib, target.into()) {
+            Ok(interpreter) => Ok(Self { interpreter }),
+            Err(errors) => Err(QSharpError::new_err(format_errors(errors))),
+        }
     }
 
     /// Interprets Q# source code.

--- a/pip/tests/test_project.py
+++ b/pip/tests/test_project.py
@@ -23,6 +23,10 @@ def test_project(qsharp) -> None:
     result = qsharp.eval("Test.ReturnsFour()")
     assert result == 4
 
+def test_project_compile_error(qsharp) -> None:
+    with pytest.raises(Exception) as excinfo:
+        qsharp.init(project_root="/compile_error")
+    assert str(excinfo.value).startswith("Qsc.TypeCk.TyMismatch")
 
 def test_project_bad_qsharp_json(qsharp) -> None:
     with pytest.raises(Exception) as excinfo:
@@ -56,6 +60,10 @@ memfs = {
         },
         "unreadable_source": {
             "test.qs": OSError("could not read test.qs"),
+            "qsharp.json": "{}",
+        },
+        "compile_error": {
+            "test.qs": "namespace Test { operation ReturnsFour() : Int { 4.0 } }",
             "qsharp.json": "{}",
         },
     }


### PR DESCRIPTION
Format compilation errors when failing to compile project files provided to `qsharp.init()`.

Before:
![image](https://github.com/microsoft/qsharp/assets/10567287/4484cf7b-0847-4a0b-818a-90c858cafc16)

After:
![image](https://github.com/microsoft/qsharp/assets/10567287/10a6f01c-60c5-4b51-9c4e-879a4a17d546)
