### PR TITLE
Return null if manifest is not parseable json

### DIFF
--- a/vscode/src/projectSystem.ts
+++ b/vscode/src/projectSystem.ts
@@ -21,6 +21,7 @@ export async function getManifest(uri: string): Promise<{
   }
 
   try {
+    updateQSharpJsonDiagnostics(manifestDocument.uri);
     JSON.parse(manifestDocument.content);
   } catch (e) {
     log.warn(
@@ -31,9 +32,8 @@ export async function getManifest(uri: string): Promise<{
       manifestDocument.uri,
       "Failed to parse Q# manifest. For a minimal Q# project manifest, try: {}",
     );
+    return null;
   }
-
-  updateQSharpJsonDiagnostics(manifestDocument.uri);
 
   const manifestDirectory = Utils.dirname(manifestDocument.uri);
 


### PR DESCRIPTION
This brings back the desirable and clear behavior of failing early when the Q# manifest fails to parse.
![image](https://github.com/microsoft/qsharp/assets/12157751/f56f386a-3146-4916-95e8-94f60176ac4f)
