### PR TITLE
Fix notebook language service panics

### DIFF
--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -158,15 +158,10 @@ impl LanguageService {
     /// the notebook in the previous `update_notebook_document` call.
     ///
     /// LSP: notebookDocument/didClose
-    pub fn close_notebook_document<'b>(
-        &mut self,
-        notebook_uri: &str,
-        cell_uris: impl Iterator<Item = &'b str>,
-    ) {
+    pub fn close_notebook_document(&mut self, notebook_uri: &str) {
         trace!("close_notebook_document: {notebook_uri}");
         self.send_update(Update::CloseNotebookDocument {
             notebook_uri: notebook_uri.into(),
-            cell_uris: cell_uris.map(Into::into).collect(),
         });
     }
 
@@ -385,10 +380,9 @@ async fn apply_update(updater: &mut CompilationStateUpdater<'_>, update: Update)
                 .iter()
                 .map(|(uri, version, contents)| (uri.as_ref(), *version, contents.as_ref())),
         ),
-        Update::CloseNotebookDocument {
-            notebook_uri,
-            cell_uris,
-        } => updater.close_notebook_document(&notebook_uri, cell_uris.iter().map(AsRef::as_ref)),
+        Update::CloseNotebookDocument { notebook_uri } => {
+            updater.close_notebook_document(&notebook_uri);
+        }
         Update::Configuration { changed } => {
             updater.update_configuration(changed);
         }
@@ -414,6 +408,5 @@ enum Update {
     },
     CloseNotebookDocument {
         notebook_uri: String,
-        cell_uris: Vec<String>,
     },
 }

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -317,12 +317,14 @@ impl<'a> CompilationStateUpdater<'a> {
         self.with_state_mut(|state| {
             trace!("close_notebook_document: {notebook_uri}");
 
-            // First remove all the cells for the notebook
+            // Cells for the notebook are kept in the open documents map.
+            // First remove all the cells for the notebook from the open
+            // documents map.
             state
                 .open_documents
                 .retain(|_, open_doc| notebook_uri != open_doc.compilation.as_ref());
 
-            // Then remove the notebook itself
+            // Then remove the notebook itself from the compilations map
             state.compilations.remove(notebook_uri);
         });
 

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -717,7 +717,7 @@ fn close_notebook_clears_errors() {
         "#]],
     );
 
-    updater.close_notebook_document("notebook.ipynb", ["cell1", "cell2"].into_iter());
+    updater.close_notebook_document("notebook.ipynb");
 
     expect_errors(
         &errors,

--- a/npm/src/language-service/language-service.ts
+++ b/npm/src/language-service/language-service.ts
@@ -50,7 +50,7 @@ export interface ILanguageService {
     }[],
   ): Promise<void>;
   closeDocument(uri: string): Promise<void>;
-  closeNotebookDocument(notebookUri: string, cellUris: string[]): Promise<void>;
+  closeNotebookDocument(notebookUri: string): Promise<void>;
   getCompletions(documentUri: string, offset: number): Promise<ICompletionList>;
   getHover(documentUri: string, offset: number): Promise<IHover | undefined>;
   getDefinition(
@@ -177,12 +177,8 @@ export class QSharpLanguageService implements ILanguageService {
     this.languageService.close_document(documentUri);
   }
 
-  async closeNotebookDocument(
-    documentUri: string,
-    cellUris: string[],
-  ): Promise<void> {
-    cellUris.forEach((uri) => delete this.code[uri]);
-    this.languageService.close_notebook_document(documentUri, cellUris);
+  async closeNotebookDocument(documentUri: string): Promise<void> {
+    this.languageService.close_notebook_document(documentUri);
   }
 
   async getCompletions(

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {
-  DocumentFilter,
-  TextDocument,
-  Uri,
-  languages,
-  workspace,
-} from "vscode";
+import { DocumentFilter, TextDocument, Uri, workspace } from "vscode";
 
 export const qsharpLanguageId = "qsharp";
 
@@ -23,11 +17,14 @@ export const qsharpNotebookCellDocumentFilter: DocumentFilter = {
 };
 
 export function isQsharpDocument(document: TextDocument): boolean {
-  return languages.match(qsharpDocumentFilter, document) > 0;
+  return document.languageId === qsharpLanguageId;
 }
 
 export function isQsharpNotebookCell(document: TextDocument): boolean {
-  return languages.match(qsharpNotebookCellDocumentFilter, document) > 0;
+  return (
+    document.languageId === qsharpLanguageId &&
+    document.uri.scheme === "vscode-notebook-cell"
+  );
 }
 
 export const qsharpExtensionId = "qsharp-vscode";

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -1,25 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DocumentFilter, TextDocument, Uri, workspace } from "vscode";
+import { TextDocument, Uri, workspace } from "vscode";
 
 export const qsharpLanguageId = "qsharp";
 
-// Matches all Q# documents, including unsaved files, notebook cells, etc.
-export const qsharpDocumentFilter: DocumentFilter = {
-  language: qsharpLanguageId,
-};
-
-// Matches only Q# notebook cell documents.
-export const qsharpNotebookCellDocumentFilter: DocumentFilter = {
-  language: qsharpLanguageId,
-  notebookType: "jupyter-notebook",
-};
-
+// Returns true for all Q# documents, including unsaved files, notebook cells, etc.
 export function isQsharpDocument(document: TextDocument): boolean {
   return document.languageId === qsharpLanguageId;
 }
 
+// Returns true for only Q# notebook cell documents.
 export function isQsharpNotebookCell(document: TextDocument): boolean {
   return (
     document.languageId === qsharpLanguageId &&

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -13,7 +13,7 @@ import * as vscode from "vscode";
 import {
   isQsharpDocument,
   isQsharpNotebookCell,
-  qsharpDocumentFilter,
+  qsharpLanguageId,
 } from "./common.js";
 import { createCompletionItemProvider } from "./completion";
 import { activateDebugger } from "./debugger/activate";
@@ -182,7 +182,7 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
   // completions
   subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
-      qsharpDocumentFilter,
+      qsharpLanguageId,
       createCompletionItemProvider(languageService),
       "@", // for attribute completion
     ),
@@ -191,7 +191,7 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
   // hover
   subscriptions.push(
     vscode.languages.registerHoverProvider(
-      qsharpDocumentFilter,
+      qsharpLanguageId,
       createHoverProvider(languageService),
     ),
   );
@@ -199,7 +199,7 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
   // go to def
   subscriptions.push(
     vscode.languages.registerDefinitionProvider(
-      qsharpDocumentFilter,
+      qsharpLanguageId,
       createDefinitionProvider(languageService),
     ),
   );
@@ -207,7 +207,7 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
   // find references
   subscriptions.push(
     vscode.languages.registerReferenceProvider(
-      qsharpDocumentFilter,
+      qsharpLanguageId,
       createReferenceProvider(languageService),
     ),
   );
@@ -215,7 +215,7 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
   // signature help
   subscriptions.push(
     vscode.languages.registerSignatureHelpProvider(
-      qsharpDocumentFilter,
+      qsharpLanguageId,
       createSignatureHelpProvider(languageService),
       "(",
       ",",
@@ -225,7 +225,7 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
   // rename symbol
   subscriptions.push(
     vscode.languages.registerRenameProvider(
-      qsharpDocumentFilter,
+      qsharpLanguageId,
       createRenameProvider(languageService),
     ),
   );

--- a/vscode/src/notebook.ts
+++ b/vscode/src/notebook.ts
@@ -157,10 +157,7 @@ export function registerQSharpNotebookCellUpdateHandlers(
   function closeIfKnownQsharpNotebook(notebook: vscode.NotebookDocument) {
     const notebookUri = notebook.uri.toString();
     if (openQSharpNotebooks.has(notebookUri)) {
-      languageService.closeNotebookDocument(
-        notebookUri,
-        getQSharpCells(notebook).map((cell) => cell.document.uri.toString()),
-      );
+      languageService.closeNotebookDocument(notebookUri);
       openQSharpNotebooks.delete(notebook.uri.toString());
     }
   }

--- a/vscode/src/notebook.ts
+++ b/vscode/src/notebook.ts
@@ -3,7 +3,7 @@
 
 import { ILanguageService, log } from "qsharp-lang";
 import * as vscode from "vscode";
-import { qsharpDocumentFilter, qsharpLanguageId } from "./common.js";
+import { isQsharpNotebookCell, qsharpLanguageId } from "./common.js";
 import { WorkspaceTreeProvider } from "./azure/treeView.js";
 import { getPythonCodeForWorkspace } from "./azure/workspaceActions.js";
 import { notebookTemplate } from "./notebookTemplate.js";
@@ -165,9 +165,7 @@ export function registerQSharpNotebookCellUpdateHandlers(
   function getQSharpCells(notebook: vscode.NotebookDocument) {
     return notebook
       .getCells()
-      .filter((cell) =>
-        vscode.languages.match(qsharpDocumentFilter, cell.document),
-      );
+      .filter((cell) => isQsharpNotebookCell(cell.document));
   }
 
   function getQSharpText(document: vscode.TextDocument) {

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     serializable_type,
 };
-use js_sys::JsString;
 use qsc::{self, target::Profile, PackageType};
 use qsls::protocol::DiagnosticUpdate;
 use rustc_hash::FxHashMap;
@@ -131,13 +130,8 @@ impl LanguageService {
         );
     }
 
-    pub fn close_notebook_document(&mut self, notebook_uri: &str, cell_uris: Vec<JsString>) {
-        let cell_uris = cell_uris
-            .iter()
-            .map(|s| s.as_string().expect("expected string"))
-            .collect::<Vec<_>>();
-        self.0
-            .close_notebook_document(notebook_uri, cell_uris.iter().map(|s| s.as_str()));
+    pub fn close_notebook_document(&mut self, notebook_uri: &str) {
+        self.0.close_notebook_document(notebook_uri);
     }
 
     pub fn get_completions(&self, uri: &str, offset: u32) -> ICompletionList {


### PR DESCRIPTION
Fixes #873

ISSUE 1 (#873):

`close_notebook_document` takes both the notebook URI and a list of cell URIs, which is redundant, since we should already know in the language service which cells belong to the notebook. We still had an assert to verify that these two parameters were being sent consistently - and it turns out they weren't. When the last Q# cell in a notebook is deleted, we send `close_notebook_document` with _no_ Q# cells (instead of the last known list). That tripped the assert.

I'm just removing the redundant `cell_uris` parameter and using the open document map instead.

ISSUE 2 (new panic):

I'm 99.99% sure this is a change in VS Code, since this panic is so trivial to hit. All you have to do is close a notebook. I tried with builds of `qsharp` from September, and I still hit it. Basically, using `vscode.languages.match()` to determine whether a notebook cell is Q# is very unreliable, as it returns no match if the notebook is being closed. This leads to a panic in the language service. So instead I'm just using the `languageId` and `scheme` - same logic, much simpler.