### PR TITLE
Add version check to Python package

### DIFF
--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -36,3 +36,27 @@ __all__ = [
     "TargetProfile",
     "StateDump",
 ]
+
+__version__ = "0.0.0"
+
+# Check if there is a newer published version of the package
+# and warn the user if there is. This is best effort only.
+
+try:
+    import urllib.request
+    import json
+    import sys
+    from packaging.version import parse as parse_version
+
+    url = 'https://pypi.org/pypi/qsharp-lang/json'
+    with urllib.request.urlopen(url, timeout=3) as f:
+        pypi_info = json.loads(f.read().decode('utf-8'))
+    latest_version = pypi_info['info']['version']
+
+    if parse_version(latest_version) > parse_version(__version__):
+        print(
+            f'You are using qsharp {__version__}, but version {latest_version} is available.\n'
+            'Consider upgrading via the "pip install --upgrade qsharp" command.',
+            file=sys.stderr)
+except:
+    pass

--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -37,7 +37,8 @@ __all__ = [
     "StateDump",
 ]
 
-__version__ = "0.0.0"
+import importlib.metadata
+__version__ = importlib.metadata.version("qsharp-lang")
 
 # Check if there is a newer published version of the package
 # and warn the user if there is. This is best effort only.

--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -54,7 +54,7 @@ try:
         pypi_info = json.loads(f.read().decode('utf-8'))
     latest_version = pypi_info['info']['version']
 
-    if parse_version(latest_version) > parse_version(__version__):
+    if __version__ != "0.0.0" and parse_version(latest_version) > parse_version(__version__):
         print(
             f'You are using qsharp {__version__}, but version {latest_version} is available.\n'
             'Consider upgrading via the "pip install --upgrade qsharp" command.',

--- a/version.py
+++ b/version.py
@@ -55,6 +55,11 @@ update_file(
     r'version = "{}"'.format(pip_version),
 )
 update_file(
+    os.path.join(root_dir, "pip/qsharp/__init__.py"),
+    r'__version__ = "0.0.0"',
+    r'__version__ = "{}"'.format(pip_version),
+)
+update_file(
     os.path.join(root_dir, "widgets/pyproject.toml"),
     r'version = "0.0.0"',
     r'version = "{}"'.format(pip_version),

--- a/version.py
+++ b/version.py
@@ -55,11 +55,6 @@ update_file(
     r'version = "{}"'.format(pip_version),
 )
 update_file(
-    os.path.join(root_dir, "pip/qsharp/__init__.py"),
-    r'__version__ = "0.0.0"',
-    r'__version__ = "{}"'.format(pip_version),
-)
-update_file(
     os.path.join(root_dir, "widgets/pyproject.toml"),
     r'version = "0.0.0"',
     r'version = "{}"'.format(pip_version),


### PR DESCRIPTION
This adds a best effort version check to the Python package. On import it will try to check pypi.org for the latest version and compare it to the metadata for the currently installed version. It uses a 3 second timeout for the check and will catch and ignore any failures so that it doesn't interfere with using the package. The message to users is displayed on stderr to avoid having it show up along with normal script output while still showing on first import in a jupyter environment.