### PR TITLE
Switch syntax from Config(Full) to Config(Unrestricted)

### DIFF
--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -49,7 +49,7 @@ bitflags! {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ConfigAttr {
-    Full,
+    Unrestricted,
     Base,
 }
 
@@ -57,7 +57,7 @@ impl ConfigAttr {
     #[must_use]
     pub fn to_str(&self) -> &'static str {
         match self {
-            Self::Full => "Full",
+            Self::Unrestricted => "Unrestricted",
             Self::Base => "Base",
         }
     }
@@ -73,7 +73,7 @@ impl FromStr for ConfigAttr {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "Full" => Ok(ConfigAttr::Full),
+            "Unrestricted" => Ok(ConfigAttr::Unrestricted),
             "Base" => Ok(ConfigAttr::Base),
             _ => Err(()),
         }
@@ -83,7 +83,7 @@ impl FromStr for ConfigAttr {
 impl From<ConfigAttr> for RuntimeCapabilityFlags {
     fn from(value: ConfigAttr) -> Self {
         match value {
-            ConfigAttr::Full => Self::all(),
+            ConfigAttr::Unrestricted => Self::all(),
             ConfigAttr::Base => Self::empty(),
         }
     }

--- a/compiler/qsc_frontend/src/compile/preprocess.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess.rs
@@ -127,7 +127,7 @@ fn matches_config(attrs: &[Box<Attr>], capabilities: RuntimeCapabilityFlags) -> 
                     // the target. We can't do membership tests on the capabilities because
                     // Base is not a subset of any capabilities, it is a lack of capabilities.
                     ExprKind::Path(path) => match ConfigAttr::from_str(path.name.name.as_ref()) {
-                        Ok(ConfigAttr::Full) => capabilities.is_all(),
+                        Ok(ConfigAttr::Unrestricted) => capabilities.is_all(),
                         Ok(ConfigAttr::Base) => capabilities.is_empty(),
                         _ => true,
                     },

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -108,7 +108,7 @@ fn test_target_profile_full_attr_allowed() {
     check_errors(
         indoc! {"
             namespace input {
-                @Config(Full)
+                @Config(Unrestricted)
                 operation Foo() : Unit {
                     body ... {}
                 }

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -1977,13 +1977,13 @@ fn multiple_definition_dropped_is_not_found() {
     check(
         indoc! {"
             namespace A {
-                @Config(Full)
+                @Config(Unrestricted)
                 operation B() : Unit {}
                 @Config(Base)
                 operation B() : Unit {}
                 @Config(Base)
                 operation C() : Unit {}
-                @Config(Full)
+                @Config(Unrestricted)
                 operation C() : Unit {}
             }
             namespace D {
@@ -2000,13 +2000,13 @@ fn multiple_definition_dropped_is_not_found() {
         "},
         &expect![[r#"
             namespace item0 {
-                @Config(Full)
+                @Config(Unrestricted)
                 operation item1() : Unit {}
                 @Config(Base)
                 operation B() : Unit {}
                 @Config(Base)
                 operation C() : Unit {}
-                @Config(Full)
+                @Config(Unrestricted)
                 operation item2() : Unit {}
             }
             namespace item3 {
@@ -2021,8 +2021,8 @@ fn multiple_definition_dropped_is_not_found() {
                 }
             }
 
-            // NotFound("B", Span { lo: 249, hi: 250 })
-            // NotFound("C", Span { lo: 262, hi: 263 })
+            // NotFound("B", Span { lo: 265, hi: 266 })
+            // NotFound("C", Span { lo: 278, hi: 279 })
         "#]],
     );
 }

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool` representing the `input`.
-    @Config(Full)
+    @Config(Unrestricted)
     function ResultAsBool(input : Result) : Bool {
         input == One
     }
@@ -42,7 +42,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result` representing the `input`.
-    @Config(Full)
+    @Config(Unrestricted)
     function BoolAsResult(input : Bool) : Result {
         if input {One} else {Zero}
     }
@@ -142,7 +142,7 @@ namespace Microsoft.Quantum.Convert {
     /// // The following returns 1
     /// let int1 = ResultArrayAsInt([One,Zero])
     /// ```
-    @Config(Full)
+    @Config(Unrestricted)
     function ResultArrayAsInt(results : Result[]) : Int {
         let nBits = Length(results);
         Fact(nBits < 64, $"`Length(bits)` must be less than 64, but was {nBits}.");
@@ -167,7 +167,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool[]` representing the `input`.
-    @Config(Full)
+    @Config(Unrestricted)
     function ResultArrayAsBoolArray(input : Result[]) : Bool[] {
         mutable output = [];
         for r in input {
@@ -187,7 +187,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result[]` representing the `input`.
-    @Config(Full)
+    @Config(Unrestricted)
     function BoolArrayAsResultArray(input : Bool[]) : Result[] {
         mutable output = [];
         for b in input {

--- a/library/std/diagnostics.qs
+++ b/library/std/diagnostics.qs
@@ -8,12 +8,12 @@ namespace Microsoft.Quantum.Diagnostics {
         body intrinsic;
     }
 
-    @Config(Full)
+    @Config(Unrestricted)
     operation CheckZero(qubit : Qubit) : Bool {
         body intrinsic;
     }
 
-    @Config(Full)
+    @Config(Unrestricted)
     operation CheckAllZero(qubits : Qubit[]) : Bool {
         for q in qubits {
             if not CheckZero(q) {
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Diagnostics {
             fail message;
         }
     }
-    
+
     /// # Summary
     /// Given two operations, checks that they act identically for all input states.
     ///
@@ -59,7 +59,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// Operation defining the expected behavior for the operation under test.
     /// # Output
     /// True if operations are equal, false otherwise.
-    @Config(Full)
+    @Config(Unrestricted)
     operation CheckOperationsAreEqual (
         nQubits : Int,
         actual : (Qubit[] => Unit),

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -226,7 +226,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// Measure([PauliZ], [qubit]);
     /// ```
-    @Config(Full)
+    @Config(Unrestricted)
     operation M(qubit : Qubit) : Result {
         __quantum__qis__m__body(qubit)
     }
@@ -298,7 +298,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// If the basis array and qubit array are different lengths, then the
     /// operation will fail.
-    @Config(Full)
+    @Config(Unrestricted)
     operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
         if Length(bases) != Length(qubits) {
             fail "Arrays 'bases' and 'qubits' must be of the same length.";

--- a/library/std/measurement.qs
+++ b/library/std/measurement.qs
@@ -146,7 +146,7 @@ namespace Microsoft.Quantum.Measurement {
     /// # Remarks
     /// This operation resets its input register to the |00...0> state,
     /// suitable for releasing back to a target machine.
-    @Config(Full)
+    @Config(Unrestricted)
     operation MeasureInteger(target : Qubit[]) : Int {
         let nBits = Length(target);
         Fact(nBits < 64, $"`Length(target)` must be less than 64, but was {nBits}.");

--- a/library/std/random.qs
+++ b/library/std/random.qs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let roll = DrawRandomInt(1, 6);
     /// ```
-    @Config(Full)
+    @Config(Unrestricted)
     operation DrawRandomInt(min : Int, max : Int) : Int {
         body intrinsic;
     }
@@ -50,7 +50,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let angle = DrawRandomDouble(0.0, 2.0 * PI());
     /// ```
-    @Config(Full)
+    @Config(Unrestricted)
     operation DrawRandomDouble(min : Double, max : Double) : Double {
         body intrinsic;
     }

--- a/library/std/re.qs
+++ b/library/std/re.qs
@@ -33,7 +33,7 @@ namespace Microsoft.Quantum.ResourceEstimation {
     /// needs to be executed in order to collect and cache estimates.
     /// `false` indicates if cached estimates have been incorporated into the overall costs
     /// and the code fragment should be skipped.
-    @Config(Full)
+    @Config(Unrestricted)
     function BeginEstimateCaching(name: String, variant: Int): Bool {
         body intrinsic;
     }

--- a/library/std/unstable_arithmetic_internal.qs
+++ b/library/std/unstable_arithmetic_internal.qs
@@ -254,7 +254,7 @@ namespace Microsoft.Quantum.Unstable.Arithmetic {
     ///   Phys. Rev. A 87, 022328, 2013
     ///   [arXiv:1212.5069](https://arxiv.org/abs/1212.5069)
     ///   doi:10.1103/PhysRevA.87.022328
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation ApplyAndAssuming0Target(control1 : Qubit, control2 : Qubit, target: Qubit)
     : Unit is Adj { // NOTE: Eventually this operation will be public and intrinsic.
         body (...) {

--- a/library/std/unstable_table_lookup.qs
+++ b/library/std/unstable_table_lookup.qs
@@ -44,7 +44,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
     ///     "Windowed arithmetic"
     /// [3] [arXiv:2211.01133](https://arxiv.org/abs/2211.01133)
     ///     "Space-time optimized table lookup"
-    @Config(Full)
+    @Config(Unrestricted)
     operation Select(
         data : Bool[][],
         address : Qubit[],
@@ -97,7 +97,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
         }
     }
 
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation SinglyControlledSelect(
         ctl : Qubit,
         data : Bool[][],
@@ -163,7 +163,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
     /// # References
     /// - [arXiv:1905.07682](https://arxiv.org/abs/1905.07682)
     ///   "Windowed arithmetic"
-    @Config(Full)
+    @Config(Unrestricted)
     internal operation Unlookup(
         lookup : (Bool[][], Qubit[], Qubit[]) => Unit,
         data : Bool[][],


### PR DESCRIPTION
Doing my part in the renaming effort.

This PR changes the Q# syntax from `Config(Full)` to `Config(Unrestricted)`

