### PR TITLE
Skip running memtest in merge groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
           branchName: ${{ github.base_ref }}
           cwd: "compiler/qsc"
         if: ${{ github.base_ref != null }}
+
   runMemoryProfile:
     name: run memory profile
     runs-on: ubuntu-latest
@@ -186,3 +187,4 @@ jobs:
             |-----------------------------|-------------|----------|
             | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes |`
             })
+        if: ${{ github.base_ref != null }}


### PR DESCRIPTION
The memtest task was causing spurious failures during merge group builds because it failed to write back a comment even though it ran successfully (merge group builds do not associate back to a signle issue/PR). This skips the comment step if `github.base_ref` is null, so will still run but not try to write back specific results.