### PR TITLE
Output DumpMachine as one message

### DIFF
--- a/vscode/src/debugger/output.ts
+++ b/vscode/src/debugger/output.ts
@@ -39,7 +39,6 @@ export function createDebugConsoleEventTarget(out: (message: string) => void) {
         4,
       )}%     | ${phase.toFixed(4)}\n`;
     });
-    out_str += "\n";
     out(out_str);
   });
 

--- a/vscode/src/debugger/output.ts
+++ b/vscode/src/debugger/output.ts
@@ -25,25 +25,22 @@ export function createDebugConsoleEventTarget(out: (message: string) => void) {
     }
 
     const dump = evt.detail;
-    out("");
-    out("DumpMachine:");
-    out("");
-    out("  Basis | Amplitude     | Probability   | Phase");
-    out("  ---------------------------------------------");
+    let out_str = "\n";
+    out_str += "DumpMachine:\n\n";
+    out_str += "  Basis | Amplitude     | Probability   | Phase\n";
+    out_str += "  ---------------------------------------------\n";
     Object.keys(dump).map((basis) => {
       const [real, imag] = dump[basis];
       const complex = formatComplex(real, imag);
       const probabilityPercent = probability(real, imag) * 100;
       const phase = Math.atan2(imag, real);
 
-      out(
-        `  ${basis}  | ${complex} | ${probabilityPercent.toFixed(
-          4,
-        )}%     | ${phase.toFixed(4)}`,
-      );
+      out_str += `  ${basis}  | ${complex} | ${probabilityPercent.toFixed(
+        4,
+      )}%     | ${phase.toFixed(4)}\n`;
     });
-    out("");
-    out("");
+    out_str += "\n";
+    out(out_str);
   });
 
   eventTarget.addEventListener("Result", (evt) => {


### PR DESCRIPTION
Each DumpMachine line was being written as it's own message, causing duplicate lines (such as blank lines) to be collapsed and counted with a grey circle. This gives the impression duplicate DumpMachine state was reported and collapsed. With this change, it's one message.

BEFORE

<img width="242" alt="image" src="https://github.com/microsoft/qsharp/assets/993909/106f1299-8793-4d16-8959-f8e53ee4ec0b">

AFTER

<img width="538" alt="image" src="https://github.com/microsoft/qsharp/assets/993909/e87bd28d-c3a5-4177-b155-f480ee994de5">
