### PR TITLE
Formally introduce an FIR `PackageStore` struct and consolidate lookups

### DIFF
--- a/compiler/qsc/src/interpret/debug.rs
+++ b/compiler/qsc/src/interpret/debug.rs
@@ -5,7 +5,7 @@
 mod tests;
 
 use qsc_eval::debug::{map_fir_package_to_hir, Frame};
-use qsc_fir::fir::{Global, ItemLookupId, PackageStoreLookup};
+use qsc_fir::fir::{Global, PackageStoreLookup, StoreItemId};
 use qsc_frontend::compile::PackageStore;
 use qsc_hir::hir;
 use qsc_hir::hir::{Item, ItemKind};
@@ -55,7 +55,7 @@ pub(crate) fn format_call_stack(
 }
 
 #[must_use]
-fn get_item_parent(store: &PackageStore, id: ItemLookupId) -> Option<Item> {
+fn get_item_parent(store: &PackageStore, id: StoreItemId) -> Option<Item> {
     let package = map_fir_package_to_hir(id.package);
     let item = hir::LocalItemId::from(usize::from(id.item));
     store.get(package).and_then(|unit| {
@@ -70,7 +70,7 @@ fn get_item_parent(store: &PackageStore, id: ItemLookupId) -> Option<Item> {
 }
 
 #[must_use]
-fn get_item_file_name(store: &PackageStore, id: ItemLookupId) -> Option<String> {
+fn get_item_file_name(store: &PackageStore, id: StoreItemId) -> Option<String> {
     let package = map_fir_package_to_hir(id.package);
     let item = hir::LocalItemId::from(usize::from(id.item));
     store.get(package).and_then(|unit| {

--- a/compiler/qsc/src/interpret/debug.rs
+++ b/compiler/qsc/src/interpret/debug.rs
@@ -5,16 +5,15 @@
 mod tests;
 
 use qsc_eval::debug::{map_fir_package_to_hir, Frame};
+use qsc_fir::fir::{Global, ItemLookupId, PackageStoreLookup};
 use qsc_frontend::compile::PackageStore;
-
-use qsc_eval::{val::GlobalId, Global, NodeLookup};
 use qsc_hir::hir;
 use qsc_hir::hir::{Item, ItemKind};
 
 #[must_use]
 pub(crate) fn format_call_stack(
     store: &PackageStore,
-    globals: &impl NodeLookup,
+    globals: &impl PackageStoreLookup,
     frames: Vec<Frame>,
     error: &dyn std::error::Error,
 ) -> String {
@@ -26,7 +25,7 @@ pub(crate) fn format_call_stack(
     frames.reverse();
 
     for frame in frames {
-        let Some(Global::Callable(call)) = globals.get(frame.id) else {
+        let Some(Global::Callable(call)) = globals.get_global(frame.id) else {
             panic!("missing global");
         };
 
@@ -56,7 +55,7 @@ pub(crate) fn format_call_stack(
 }
 
 #[must_use]
-fn get_item_parent(store: &PackageStore, id: GlobalId) -> Option<Item> {
+fn get_item_parent(store: &PackageStore, id: ItemLookupId) -> Option<Item> {
     let package = map_fir_package_to_hir(id.package);
     let item = hir::LocalItemId::from(usize::from(id.item));
     store.get(package).and_then(|unit| {
@@ -71,7 +70,7 @@ fn get_item_parent(store: &PackageStore, id: GlobalId) -> Option<Item> {
 }
 
 #[must_use]
-fn get_item_file_name(store: &PackageStore, id: GlobalId) -> Option<String> {
+fn get_item_file_name(store: &PackageStore, id: ItemLookupId) -> Option<String> {
     let package = map_fir_package_to_hir(id.package);
     let item = hir::LocalItemId::from(usize::from(id.item));
     store.get(package).and_then(|unit| {

--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -18,17 +18,18 @@ use miette::Diagnostic;
 use num_bigint::BigUint;
 use num_complex::Complex;
 use qsc_codegen::qir_base::BaseProfSim;
-use qsc_data_structures::{index_map::IndexMap, span::Span};
+use qsc_data_structures::span::Span;
 use qsc_eval::{
     backend::{Backend, SparseSim},
     debug::{map_fir_package_to_hir, map_hir_package_to_fir, Frame},
     eval_expr, eval_stmt,
     output::{GenericReceiver, Receiver},
-    val::{self, GlobalId, Value},
-    Env, Global, NodeLookup, State, StepAction, StepResult, VariableInfo,
+    val::{self, Value},
+    Env, State, StepAction, StepResult, VariableInfo,
 };
+use qsc_fir::fir::{self, Global, PackageStoreLookup};
 use qsc_fir::{
-    fir::{Block, BlockId, Expr, ExprId, ItemKind, Package, PackageId, Pat, PatId, Stmt, StmtId},
+    fir::{Block, BlockId, Expr, ExprId, Package, PackageId, Pat, PatId, Stmt, StmtId},
     visit::{self, Visitor},
 };
 use qsc_frontend::{
@@ -68,48 +69,6 @@ pub enum Error {
     UnsupportedRuntimeCapabilities,
 }
 
-struct Lookup<'a> {
-    fir_store: &'a IndexMap<PackageId, qsc_fir::fir::Package>,
-}
-
-impl<'a> Lookup<'a> {
-    fn get_package(&self, package: PackageId) -> &qsc_fir::fir::Package {
-        self.fir_store
-            .get(package)
-            .expect("Package should be in FIR store")
-    }
-}
-
-impl<'a> NodeLookup for Lookup<'a> {
-    fn get(&self, id: GlobalId) -> Option<Global<'a>> {
-        get_global(self.fir_store, id)
-    }
-    fn get_block(&self, package: PackageId, id: BlockId) -> &qsc_fir::fir::Block {
-        self.get_package(package)
-            .blocks
-            .get(id)
-            .expect("BlockId should have been lowered")
-    }
-    fn get_expr(&self, package: PackageId, id: ExprId) -> &qsc_fir::fir::Expr {
-        self.get_package(package)
-            .exprs
-            .get(id)
-            .expect("ExprId should have been lowered")
-    }
-    fn get_pat(&self, package: PackageId, id: PatId) -> &qsc_fir::fir::Pat {
-        self.get_package(package)
-            .pats
-            .get(id)
-            .expect("PatId should have been lowered")
-    }
-    fn get_stmt(&self, package: PackageId, id: StmtId) -> &qsc_fir::fir::Stmt {
-        self.get_package(package)
-            .stmts
-            .get(id)
-            .expect("StmtId should have been lowered")
-    }
-}
-
 /// A Q# interpreter.
 pub struct Interpreter {
     /// The incremental Q# compiler.
@@ -121,7 +80,7 @@ pub struct Interpreter {
     /// for each line evaluated with `eval_fragments`.
     lines: u32,
     // The FIR store
-    fir_store: IndexMap<PackageId, qsc_fir::fir::Package>,
+    fir_store: fir::PackageStore,
     /// FIR lowerer
     lowerer: qsc_eval::lower::Lowerer,
     /// The ID of the current package.
@@ -152,7 +111,7 @@ impl Interpreter {
         capabilities: RuntimeCapabilityFlags,
     ) -> Result<Self, Vec<Error>> {
         let mut lowerer = qsc_eval::lower::Lowerer::new();
-        let mut fir_store = IndexMap::new();
+        let mut fir_store = fir::PackageStore::new();
 
         let compiler =
             Compiler::new(std, sources, package_type, capabilities).map_err(into_errors)?;
@@ -201,13 +160,9 @@ impl Interpreter {
         breakpoints: &[StmtId],
         step: StepAction,
     ) -> Result<StepResult, Vec<Error>> {
-        let globals = Lookup {
-            fir_store: &self.fir_store,
-        };
-
         self.state
             .eval(
-                &globals,
+                &self.fir_store,
                 &mut self.env,
                 &mut self.sim,
                 receiver,
@@ -229,14 +184,10 @@ impl Interpreter {
     /// Returns a vector of errors if evaluating the entry point fails.
     pub fn eval_entry(&mut self, receiver: &mut impl Receiver) -> Result<Value, Vec<Error>> {
         let expr = self.get_entry_expr()?;
-        let globals = Lookup {
-            fir_store: &self.fir_store,
-        };
-
         eval_expr(
             &mut State::new(self.source_package),
             expr,
-            &globals,
+            &self.fir_store,
             &mut Env::with_empty_scope(),
             &mut self.sim,
             receiver,
@@ -259,14 +210,10 @@ impl Interpreter {
         receiver: &mut impl Receiver,
     ) -> Result<Value, Vec<Error>> {
         let expr = self.get_entry_expr()?;
-        let globals = Lookup {
-            fir_store: &self.fir_store,
-        };
-
         eval_expr(
             &mut State::new(self.source_package),
             expr,
-            &globals,
+            &self.fir_store,
             &mut Env::with_empty_scope(),
             sim,
             receiver,
@@ -321,13 +268,9 @@ impl Interpreter {
         let mut result = Value::unit();
 
         for stmt_id in stmts {
-            let globals = Lookup {
-                fir_store: &self.fir_store,
-            };
-
             match eval_stmt(
                 stmt_id,
-                &globals,
+                &self.fir_store,
                 &mut self.env,
                 &mut self.sim,
                 self.package,
@@ -405,16 +348,12 @@ impl Interpreter {
         stmt_id: StmtId,
         shots: u32,
     ) -> Vec<InterpretResult> {
-        let globals = Lookup {
-            fir_store: &self.fir_store,
-        };
-
         let mut results: Vec<InterpretResult> = Vec::new();
         for i in 0..shots {
             results.push(
                 match eval_stmt(
                     stmt_id,
-                    &globals,
+                    &self.fir_store,
                     &mut Env::with_empty_scope(),
                     sim,
                     self.package,
@@ -464,7 +403,6 @@ impl Interpreter {
             .fir_store
             .get_mut(self.package)
             .expect("package should be in store");
-
         self.lowerer
             .lower_and_update_package(fir_package, &unit_addition.hir)
     }
@@ -484,14 +422,14 @@ impl Interpreter {
 
     #[must_use]
     pub fn get_stack_frames(&self) -> Vec<StackFrame> {
-        let globals = Lookup {
-            fir_store: &self.fir_store,
-        };
         let frames = self.state.get_stack_frames();
         let stack_frames = frames
             .iter()
             .map(|frame| {
-                let callable = globals.get(frame.id).expect("frame should exist");
+                let callable = self
+                    .fir_store
+                    .get_global(frame.id)
+                    .expect("frame should exist");
                 let functor = format!("{}", frame.functor);
                 let name = match callable {
                     Global::Callable(decl) => decl.name.name.to_string(),
@@ -573,19 +511,6 @@ pub struct StackFrame {
     pub lo: u32,
     /// The end of the call site span in utf8 characters.
     pub hi: u32,
-}
-
-fn get_global(
-    fir_store: &IndexMap<PackageId, qsc_fir::fir::Package>,
-    id: GlobalId,
-) -> Option<Global<'_>> {
-    fir_store
-        .get(id.package)
-        .and_then(|package| match &package.items.get(id.item)?.kind {
-            ItemKind::Callable(callable) => Some(Global::Callable(callable)),
-            ItemKind::Namespace(..) => None,
-            ItemKind::Ty(..) => Some(Global::Udt),
-        })
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -683,7 +608,7 @@ impl<'a> Visitor<'a> for BreakpointCollector<'a> {
 
 fn eval_error(
     package_store: &PackageStore,
-    fir_store: &IndexMap<PackageId, qsc_fir::fir::Package>,
+    fir_store: &fir::PackageStore,
     call_stack: Vec<Frame>,
     error: qsc_eval::Error,
 ) -> Vec<Error> {
@@ -692,7 +617,7 @@ fn eval_error(
     } else {
         Some(format_call_stack(
             package_store,
-            &Lookup { fir_store },
+            fir_store,
             call_stack,
             &error,
         ))

--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -12,10 +12,10 @@ use qsc_eval::{
     debug::{map_hir_package_to_fir, Frame},
     eval_expr,
     output::GenericReceiver,
-    val::{GlobalId, Value},
-    Env, Error, Global, NodeLookup, State,
+    val::Value,
+    Env, Error, State,
 };
-use qsc_fir::fir::{BlockId, ExprId, ItemKind, PackageId, PatId, StmtId};
+use qsc_fir::fir;
 use qsc_frontend::compile::PackageStore;
 use qsc_hir::hir::{self};
 use std::fmt::{Display, Write};
@@ -31,10 +31,7 @@ pub fn generate_qir(
     package: hir::PackageId,
 ) -> std::result::Result<String, (Error, Vec<Frame>)> {
     let mut fir_lowerer = qsc_eval::lower::Lowerer::new();
-    let mut fir_store = IndexMap::new();
-    let package = map_hir_package_to_fir(package);
-    let mut sim = BaseProfSim::default();
-
+    let mut fir_store = fir::PackageStore::new();
     for (id, unit) in store {
         fir_store.insert(
             map_hir_package_to_fir(id),
@@ -42,17 +39,17 @@ pub fn generate_qir(
         );
     }
 
+    let package = map_hir_package_to_fir(package);
     let unit = fir_store.get(package).expect("store should have package");
     let entry_expr = unit.entry.expect("package should have entry");
 
+    let mut sim = BaseProfSim::default();
     let mut stdout = std::io::sink();
     let mut out = GenericReceiver::new(&mut stdout);
     let result = eval_expr(
         &mut State::new(package),
         entry_expr,
-        &Lookup {
-            fir_store: &fir_store,
-        },
+        &fir_store,
         &mut Env::with_empty_scope(),
         &mut sim,
         &mut out,
@@ -61,61 +58,6 @@ pub fn generate_qir(
         Ok(val) => Ok(sim.finish(&val)),
         Err((err, stack)) => Err((err, stack)),
     }
-}
-
-struct Lookup<'a> {
-    fir_store: &'a IndexMap<PackageId, qsc_fir::fir::Package>,
-}
-
-impl<'a> Lookup<'a> {
-    fn get_package(&self, package: PackageId) -> &qsc_fir::fir::Package {
-        self.fir_store
-            .get(package)
-            .expect("Package should be in FIR store")
-    }
-}
-
-impl<'a> NodeLookup for Lookup<'a> {
-    fn get(&self, id: GlobalId) -> Option<Global<'a>> {
-        get_global(self.fir_store, id)
-    }
-    fn get_block(&self, package: PackageId, id: BlockId) -> &qsc_fir::fir::Block {
-        self.get_package(package)
-            .blocks
-            .get(id)
-            .expect("BlockId should have been lowered")
-    }
-    fn get_expr(&self, package: PackageId, id: ExprId) -> &qsc_fir::fir::Expr {
-        self.get_package(package)
-            .exprs
-            .get(id)
-            .expect("ExprId should have been lowered")
-    }
-    fn get_pat(&self, package: PackageId, id: PatId) -> &qsc_fir::fir::Pat {
-        self.get_package(package)
-            .pats
-            .get(id)
-            .expect("PatId should have been lowered")
-    }
-    fn get_stmt(&self, package: PackageId, id: StmtId) -> &qsc_fir::fir::Stmt {
-        self.get_package(package)
-            .stmts
-            .get(id)
-            .expect("StmtId should have been lowered")
-    }
-}
-
-pub(super) fn get_global(
-    fir_store: &IndexMap<PackageId, qsc_fir::fir::Package>,
-    id: GlobalId,
-) -> Option<Global> {
-    fir_store
-        .get(id.package)
-        .and_then(|package| match &package.items.get(id.item)?.kind {
-            ItemKind::Callable(callable) => Some(Global::Callable(callable)),
-            ItemKind::Namespace(..) => None,
-            ItemKind::Ty(..) => Some(Global::Udt),
-        })
 }
 
 #[derive(Copy, Clone, Default)]

--- a/compiler/qsc_eval/src/debug.rs
+++ b/compiler/qsc_eval/src/debug.rs
@@ -5,13 +5,13 @@ use qsc_data_structures::span::Span;
 
 use crate::val::FunctorApp;
 use qsc_fir::fir;
-use qsc_fir::fir::{ItemLookupId, PackageId};
+use qsc_fir::fir::{PackageId, StoreItemId};
 use qsc_hir::hir;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Frame {
     pub span: Span,
-    pub id: ItemLookupId,
+    pub id: StoreItemId,
     pub caller: PackageId,
     pub functor: FunctorApp,
 }

--- a/compiler/qsc_eval/src/debug.rs
+++ b/compiler/qsc_eval/src/debug.rs
@@ -3,15 +3,15 @@
 
 use qsc_data_structures::span::Span;
 
-use crate::{val::FunctorApp, GlobalId};
+use crate::val::FunctorApp;
 use qsc_fir::fir;
-use qsc_fir::fir::PackageId;
+use qsc_fir::fir::{ItemLookupId, PackageId};
 use qsc_hir::hir;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Frame {
     pub span: Span,
-    pub id: GlobalId,
+    pub id: ItemLookupId,
     pub caller: PackageId,
     pub functor: FunctorApp,
 }

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -24,9 +24,9 @@ use num_bigint::BigInt;
 use output::Receiver;
 use qsc_data_structures::span::Span;
 use qsc_fir::fir::{
-    self, BinOp, BlockId, BlockLookupId, ExprId, ExprKind, ExprLookupId, Field, Functor, Global,
-    ItemLookupId, Lit, LocalItemId, Mutability, NodeId, PackageId, PackageStoreLookup, PatId,
-    PatKind, PatLookupId, PrimField, Res, SpecBody, SpecGen, StmtId, StmtKind, StmtLookupId,
+    self, BinOp, BlockId, ExprId, ExprKind, Field, Functor, Global, Lit, LocalItemId, Mutability,
+    NodeId, PackageId, PackageStoreLookup, PatId, PatKind, PrimField, Res, SpecBody, SpecGen,
+    StmtId, StmtKind, StoreBlockId, StoreExprId, StoreItemId, StorePatId, StoreStmtId,
     StringComponent, UnOp,
 };
 use qsc_fir::ty::Ty;
@@ -457,7 +457,7 @@ impl State {
         self.stack.push(Cont::Expr(expr));
     }
 
-    fn push_frame(&mut self, id: ItemLookupId, functor: FunctorApp) {
+    fn push_frame(&mut self, id: StoreItemId, functor: FunctorApp) {
         self.call_stack.push_frame(Frame {
             span: self.current_span,
             id,
@@ -489,7 +489,7 @@ impl State {
     }
 
     fn push_block(&mut self, env: &mut Env, globals: &impl PackageStoreLookup, block: BlockId) {
-        let block = globals.get_block(BlockLookupId::from(self.package, block));
+        let block = globals.get_block(StoreBlockId::from(self.package, block));
         self.push_scope(env);
         for stmt in block.stmts.iter().rev() {
             self.push_stmt(*stmt);
@@ -605,7 +605,7 @@ impl State {
         globals: &impl PackageStoreLookup,
         expr: ExprId,
     ) -> Result<(), Error> {
-        let expr = globals.get_expr(ExprLookupId::from(self.package, expr));
+        let expr = globals.get_expr(StoreExprId::from(self.package, expr));
         self.current_span = expr.span;
 
         match &expr.kind {
@@ -669,7 +669,7 @@ impl State {
     }
 
     fn cont_arr_repeat(&mut self, globals: &impl PackageStoreLookup, item: ExprId, size: ExprId) {
-        let size_expr = globals.get_expr(ExprLookupId::from(self.package, size));
+        let size_expr = globals.get_expr(StoreExprId::from(self.package, size));
         self.push_action(Action::ArrayRepeat(size_expr.span));
         self.push_expr(size);
         self.push_expr(item);
@@ -706,7 +706,7 @@ impl State {
         // If we know the assign op is an array append, as in `set arr += other;`, we should perform it in-place.
         if op == BinOp::Add
             && matches!(
-                globals.get_expr(ExprLookupId::from(self.package, lhs)).ty,
+                globals.get_expr(StoreExprId::from(self.package, lhs)).ty,
                 Ty::Array(_)
             )
         {
@@ -734,7 +734,7 @@ impl State {
         mid: ExprId,
         rhs: ExprId,
     ) {
-        let span = globals.get_expr(ExprLookupId::from(self.package, mid)).span;
+        let span = globals.get_expr(StoreExprId::from(self.package, mid)).span;
         self.push_action(Action::UpdateIndexInPlace(lhs, span));
         self.push_expr(rhs);
         self.push_expr(mid);
@@ -747,7 +747,7 @@ impl State {
     }
 
     fn cont_index(&mut self, globals: &impl PackageStoreLookup, arr: ExprId, index: ExprId) {
-        let index_expr = globals.get_expr(ExprLookupId::from(self.package, index));
+        let index_expr = globals.get_expr(StoreExprId::from(self.package, index));
         self.push_action(Action::Index(index_expr.span));
         self.push_expr(index);
         self.push_expr(arr);
@@ -791,8 +791,8 @@ impl State {
     }
 
     fn cont_call(&mut self, globals: &impl PackageStoreLookup, callee: ExprId, args: ExprId) {
-        let callee_expr = globals.get_expr(ExprLookupId::from(self.package, callee));
-        let args_expr = globals.get_expr(ExprLookupId::from(self.package, args));
+        let callee_expr = globals.get_expr(StoreExprId::from(self.package, callee));
+        let args_expr = globals.get_expr(StoreExprId::from(self.package, args));
         self.push_action(Action::Call(callee_expr.span, args_expr.span));
         self.push_expr(args);
         self.push_expr(callee);
@@ -805,7 +805,7 @@ impl State {
         rhs: ExprId,
         lhs: ExprId,
     ) {
-        let rhs_expr = globals.get_expr(ExprLookupId::from(self.package, rhs));
+        let rhs_expr = globals.get_expr(StoreExprId::from(self.package, rhs));
         match op {
             BinOp::Add
             | BinOp::AndB
@@ -842,7 +842,7 @@ impl State {
         mid: ExprId,
         rhs: ExprId,
     ) {
-        let span = globals.get_expr(ExprLookupId::from(self.package, mid)).span;
+        let span = globals.get_expr(StoreExprId::from(self.package, mid)).span;
         self.push_action(Action::UpdateIndex(span));
         self.push_expr(lhs);
         self.push_expr(rhs);
@@ -861,7 +861,7 @@ impl State {
     }
 
     fn cont_stmt(&mut self, globals: &impl PackageStoreLookup, stmt: StmtId) {
-        let stmt = globals.get_stmt(StmtLookupId::from(self.package, stmt));
+        let stmt = globals.get_stmt(StoreStmtId::from(self.package, stmt));
         self.current_span = stmt.span;
 
         match &stmt.kind {
@@ -942,7 +942,7 @@ impl State {
         globals: &impl PackageStoreLookup,
         lhs: ExprId,
     ) -> Result<(), Error> {
-        let lhs = globals.get_expr(ExprLookupId::from(self.package, lhs));
+        let lhs = globals.get_expr(StoreExprId::from(self.package, lhs));
         let rhs = self.pop_val();
         match (&lhs.kind, rhs) {
             (&ExprKind::Var(Res::Local(node), _), rhs) => match env.get_mut(node) {
@@ -1374,7 +1374,7 @@ impl State {
         val: Value,
         mutability: Mutability,
     ) {
-        let pat = globals.get_pat(PatLookupId::from(self.package, pat));
+        let pat = globals.get_pat(StorePatId::from(self.package, pat));
         match &pat.kind {
             PatKind::Bind(variable) => {
                 let scope = env.0.last_mut().expect("binding should have a scope");
@@ -1406,7 +1406,7 @@ impl State {
         lhs: ExprId,
         rhs: Value,
     ) -> Result<(), Error> {
-        let lhs = globals.get_expr(ExprLookupId::from(self.package, lhs));
+        let lhs = globals.get_expr(StoreExprId::from(self.package, lhs));
         match (&lhs.kind, rhs) {
             (ExprKind::Hole, _) => {}
             (&ExprKind::Var(Res::Local(node), _), rhs) => match env.get_mut(node) {
@@ -1437,7 +1437,7 @@ impl State {
         index: usize,
         rhs: Value,
     ) -> Result<(), Error> {
-        let lhs = globals.get_expr(ExprLookupId::from(self.package, lhs));
+        let lhs = globals.get_expr(StoreExprId::from(self.package, lhs));
         match &lhs.kind {
             &ExprKind::Var(Res::Local(node), _) => match env.get_mut(node) {
                 Some(var) if var.is_mutable() => {
@@ -1465,7 +1465,7 @@ impl State {
         range: &Value,
         update: Value,
     ) -> Result<(), Error> {
-        let lhs = globals.get_expr(ExprLookupId::from(self.package, lhs));
+        let lhs = globals.get_expr(StoreExprId::from(self.package, lhs));
         match &lhs.kind {
             &ExprKind::Var(Res::Local(node), _) => match env.get_mut(node) {
                 Some(var) if var.is_mutable() => {
@@ -1573,7 +1573,7 @@ fn resolve_binding(env: &Env, package: PackageId, res: Res, span: Span) -> Resul
     Ok(match res {
         Res::Err => panic!("resolution error"),
         Res::Item(item) => Value::Global(
-            ItemLookupId {
+            StoreItemId {
                 package: item.package.unwrap_or(package),
                 item: item.item,
             },
@@ -1614,7 +1614,7 @@ fn resolve_closure(
         package: map_fir_package_to_hir(package),
         span,
     }))?;
-    let callable = ItemLookupId {
+    let callable = StoreItemId {
         package,
         item: callable,
     };

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -24,10 +24,11 @@ use num_bigint::BigInt;
 use output::Receiver;
 use qsc_data_structures::span::Span;
 use qsc_fir::fir::{
-    self, BinOp, CallableDecl, ExprKind, Field, Functor, Lit, LocalItemId, Mutability, NodeId,
-    PackageId, PatKind, PrimField, Res, SpecBody, SpecGen, StmtKind, StringComponent, UnOp,
+    self, BinOp, BlockId, BlockLookupId, ExprId, ExprKind, ExprLookupId, Field, Functor, Global,
+    ItemLookupId, Lit, LocalItemId, Mutability, NodeId, PackageId, PackageStoreLookup, PatId,
+    PatKind, PatLookupId, PrimField, Res, SpecBody, SpecGen, StmtId, StmtKind, StmtLookupId,
+    StringComponent, UnOp,
 };
-use qsc_fir::fir::{BlockId, ExprId, PatId, StmtId};
 use qsc_fir::ty::Ty;
 use rustc_hash::FxHashMap;
 use std::{
@@ -38,7 +39,6 @@ use std::{
     rc::Rc,
 };
 use thiserror::Error;
-use val::GlobalId;
 
 #[derive(Clone, Debug, Diagnostic, Error)]
 pub enum Error {
@@ -179,7 +179,7 @@ impl Display for Spec {
 pub fn eval_expr(
     state: &mut State,
     expr: ExprId,
-    globals: &impl NodeLookup,
+    globals: &impl PackageStoreLookup,
     env: &mut Env,
     sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
     out: &mut impl Receiver,
@@ -199,7 +199,7 @@ pub fn eval_expr(
 /// On internal error where no result is returned.
 pub fn eval_stmt(
     stmt: StmtId,
-    globals: &impl NodeLookup,
+    globals: &impl PackageStoreLookup,
     env: &mut Env,
     sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
     package: PackageId,
@@ -306,19 +306,6 @@ impl Range {
             curr: start,
         }
     }
-}
-
-pub enum Global<'a> {
-    Callable(&'a CallableDecl),
-    Udt,
-}
-
-pub trait NodeLookup {
-    fn get(&self, id: GlobalId) -> Option<Global>;
-    fn get_block(&self, package: PackageId, id: BlockId) -> &qsc_fir::fir::Block;
-    fn get_expr(&self, package: PackageId, id: ExprId) -> &qsc_fir::fir::Expr;
-    fn get_pat(&self, package: PackageId, id: PatId) -> &qsc_fir::fir::Pat;
-    fn get_stmt(&self, package: PackageId, id: StmtId) -> &qsc_fir::fir::Stmt;
 }
 
 #[derive(Default)]
@@ -470,7 +457,7 @@ impl State {
         self.stack.push(Cont::Expr(expr));
     }
 
-    fn push_frame(&mut self, id: GlobalId, functor: FunctorApp) {
+    fn push_frame(&mut self, id: ItemLookupId, functor: FunctorApp) {
         self.call_stack.push_frame(Frame {
             span: self.current_span,
             id,
@@ -501,8 +488,8 @@ impl State {
         self.stack.push(Cont::Stmt(stmt));
     }
 
-    fn push_block(&mut self, env: &mut Env, globals: &impl NodeLookup, block: BlockId) {
-        let block = globals.get_block(self.package, block);
+    fn push_block(&mut self, env: &mut Env, globals: &impl PackageStoreLookup, block: BlockId) {
+        let block = globals.get_block(BlockLookupId::from(self.package, block));
         self.push_scope(env);
         for stmt in block.stmts.iter().rev() {
             self.push_stmt(*stmt);
@@ -544,7 +531,7 @@ impl State {
     /// When returning a value in the middle of execution.
     pub fn eval(
         &mut self,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         env: &mut Env,
         sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
         out: &mut impl Receiver,
@@ -615,10 +602,10 @@ impl State {
     fn cont_expr(
         &mut self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         expr: ExprId,
     ) -> Result<(), Error> {
-        let expr = globals.get_expr(self.package, expr);
+        let expr = globals.get_expr(ExprLookupId::from(self.package, expr));
         self.current_span = expr.span;
 
         match &expr.kind {
@@ -681,8 +668,8 @@ impl State {
         }
     }
 
-    fn cont_arr_repeat(&mut self, globals: &impl NodeLookup, item: ExprId, size: ExprId) {
-        let size_expr = globals.get_expr(self.package, size);
+    fn cont_arr_repeat(&mut self, globals: &impl PackageStoreLookup, item: ExprId, size: ExprId) {
+        let size_expr = globals.get_expr(ExprLookupId::from(self.package, size));
         self.push_action(Action::ArrayRepeat(size_expr.span));
         self.push_expr(size);
         self.push_expr(item);
@@ -709,9 +696,20 @@ impl State {
         self.push_val(Value::unit());
     }
 
-    fn cont_assign_op(&mut self, globals: &impl NodeLookup, op: BinOp, lhs: ExprId, rhs: ExprId) {
+    fn cont_assign_op(
+        &mut self,
+        globals: &impl PackageStoreLookup,
+        op: BinOp,
+        lhs: ExprId,
+        rhs: ExprId,
+    ) {
         // If we know the assign op is an array append, as in `set arr += other;`, we should perform it in-place.
-        if op == BinOp::Add && matches!(globals.get_expr(self.package, lhs).ty, Ty::Array(_)) {
+        if op == BinOp::Add
+            && matches!(
+                globals.get_expr(ExprLookupId::from(self.package, lhs)).ty,
+                Ty::Array(_)
+            )
+        {
             self.push_action(Action::ArrayAppendInPlace(lhs));
             self.push_expr(rhs);
             self.push_val(Value::unit());
@@ -731,12 +729,12 @@ impl State {
 
     fn cont_assign_index(
         &mut self,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         lhs: ExprId,
         mid: ExprId,
         rhs: ExprId,
     ) {
-        let span = globals.get_expr(self.package, mid).span;
+        let span = globals.get_expr(ExprLookupId::from(self.package, mid)).span;
         self.push_action(Action::UpdateIndexInPlace(lhs, span));
         self.push_expr(rhs);
         self.push_expr(mid);
@@ -748,8 +746,8 @@ impl State {
         self.push_expr(expr);
     }
 
-    fn cont_index(&mut self, globals: &impl NodeLookup, arr: ExprId, index: ExprId) {
-        let index_expr = globals.get_expr(self.package, index);
+    fn cont_index(&mut self, globals: &impl PackageStoreLookup, arr: ExprId, index: ExprId) {
+        let index_expr = globals.get_expr(ExprLookupId::from(self.package, index));
         self.push_action(Action::Index(index_expr.span));
         self.push_expr(index);
         self.push_expr(arr);
@@ -792,16 +790,22 @@ impl State {
         self.push_expr(cond_expr);
     }
 
-    fn cont_call(&mut self, globals: &impl NodeLookup, callee: ExprId, args: ExprId) {
-        let callee_expr = globals.get_expr(self.package, callee);
-        let args_expr = globals.get_expr(self.package, args);
+    fn cont_call(&mut self, globals: &impl PackageStoreLookup, callee: ExprId, args: ExprId) {
+        let callee_expr = globals.get_expr(ExprLookupId::from(self.package, callee));
+        let args_expr = globals.get_expr(ExprLookupId::from(self.package, args));
         self.push_action(Action::Call(callee_expr.span, args_expr.span));
         self.push_expr(args);
         self.push_expr(callee);
     }
 
-    fn cont_binop(&mut self, globals: &impl NodeLookup, op: BinOp, rhs: ExprId, lhs: ExprId) {
-        let rhs_expr = globals.get_expr(self.package, rhs);
+    fn cont_binop(
+        &mut self,
+        globals: &impl PackageStoreLookup,
+        op: BinOp,
+        rhs: ExprId,
+        lhs: ExprId,
+    ) {
+        let rhs_expr = globals.get_expr(ExprLookupId::from(self.package, rhs));
         match op {
             BinOp::Add
             | BinOp::AndB
@@ -831,8 +835,14 @@ impl State {
         }
     }
 
-    fn update_index(&mut self, globals: &impl NodeLookup, lhs: ExprId, mid: ExprId, rhs: ExprId) {
-        let span = globals.get_expr(self.package, mid).span;
+    fn update_index(
+        &mut self,
+        globals: &impl PackageStoreLookup,
+        lhs: ExprId,
+        mid: ExprId,
+        rhs: ExprId,
+    ) {
+        let span = globals.get_expr(ExprLookupId::from(self.package, mid)).span;
         self.push_action(Action::UpdateIndex(span));
         self.push_expr(lhs);
         self.push_expr(rhs);
@@ -850,8 +860,8 @@ impl State {
         self.push_expr(record);
     }
 
-    fn cont_stmt(&mut self, globals: &impl NodeLookup, stmt: StmtId) {
-        let stmt = globals.get_stmt(self.package, stmt);
+    fn cont_stmt(&mut self, globals: &impl PackageStoreLookup, stmt: StmtId) {
+        let stmt = globals.get_stmt(StmtLookupId::from(self.package, stmt));
         self.current_span = stmt.span;
 
         match &stmt.kind {
@@ -875,7 +885,7 @@ impl State {
         &mut self,
         env: &mut Env,
         sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         action: Action,
         out: &mut impl Receiver,
     ) -> Result<(), Error> {
@@ -929,10 +939,10 @@ impl State {
     fn eval_array_append_in_place(
         &mut self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         lhs: ExprId,
     ) -> Result<(), Error> {
-        let lhs = globals.get_expr(self.package, lhs);
+        let lhs = globals.get_expr(ExprLookupId::from(self.package, lhs));
         let rhs = self.pop_val();
         match (&lhs.kind, rhs) {
             (&ExprKind::Var(Res::Local(node), _), rhs) => match env.get_mut(node) {
@@ -966,7 +976,7 @@ impl State {
     fn eval_assign(
         &mut self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         lhs: ExprId,
     ) -> Result<(), Error> {
         let rhs = self.pop_val();
@@ -976,7 +986,7 @@ impl State {
     fn eval_bind(
         &mut self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         pat: PatId,
         mutability: Mutability,
     ) {
@@ -1051,7 +1061,7 @@ impl State {
         &mut self,
         env: &mut Env,
         sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         callee_span: Span,
         arg_span: Span,
         out: &mut impl Receiver,
@@ -1066,7 +1076,7 @@ impl State {
         let callee_span = self.to_global_span(callee_span);
         let arg_span = self.to_global_span(arg_span);
 
-        let callee = match globals.get(callee_id) {
+        let callee = match globals.get_global(callee_id) {
             Some(Global::Callable(callable)) => callable,
             Some(Global::Udt) => {
                 self.push_val(arg);
@@ -1257,7 +1267,7 @@ impl State {
     fn eval_update_index_in_place(
         &mut self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         lhs: ExprId,
         span: Span,
     ) -> Result<(), Error> {
@@ -1342,7 +1352,7 @@ impl State {
     fn eval_while(
         &mut self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         cond_expr: ExprId,
         block: BlockId,
     ) {
@@ -1359,12 +1369,12 @@ impl State {
     fn bind_value(
         &self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         pat: PatId,
         val: Value,
         mutability: Mutability,
     ) {
-        let pat = globals.get_pat(self.package, pat);
+        let pat = globals.get_pat(PatLookupId::from(self.package, pat));
         match &pat.kind {
             PatKind::Bind(variable) => {
                 let scope = env.0.last_mut().expect("binding should have a scope");
@@ -1392,11 +1402,11 @@ impl State {
     fn update_binding(
         &self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         lhs: ExprId,
         rhs: Value,
     ) -> Result<(), Error> {
-        let lhs = globals.get_expr(self.package, lhs);
+        let lhs = globals.get_expr(ExprLookupId::from(self.package, lhs));
         match (&lhs.kind, rhs) {
             (ExprKind::Hole, _) => {}
             (&ExprKind::Var(Res::Local(node), _), rhs) => match env.get_mut(node) {
@@ -1421,13 +1431,13 @@ impl State {
     fn update_array_index_single(
         &self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         lhs: ExprId,
         span: PackageSpan,
         index: usize,
         rhs: Value,
     ) -> Result<(), Error> {
-        let lhs = globals.get_expr(self.package, lhs);
+        let lhs = globals.get_expr(ExprLookupId::from(self.package, lhs));
         match &lhs.kind {
             &ExprKind::Var(Res::Local(node), _) => match env.get_mut(node) {
                 Some(var) if var.is_mutable() => {
@@ -1449,13 +1459,13 @@ impl State {
     fn update_array_index_range(
         &self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         lhs: ExprId,
         range_span: PackageSpan,
         range: &Value,
         update: Value,
     ) -> Result<(), Error> {
-        let lhs = globals.get_expr(self.package, lhs);
+        let lhs = globals.get_expr(ExprLookupId::from(self.package, lhs));
         match &lhs.kind {
             &ExprKind::Var(Res::Local(node), _) => match env.get_mut(node) {
                 Some(var) if var.is_mutable() => {
@@ -1494,7 +1504,7 @@ impl State {
     fn bind_args_for_spec(
         &self,
         env: &mut Env,
-        globals: &impl NodeLookup,
+        globals: &impl PackageStoreLookup,
         decl_pat: PatId,
         spec_pat: Option<PatId>,
         args_val: Value,
@@ -1563,7 +1573,7 @@ fn resolve_binding(env: &Env, package: PackageId, res: Res, span: Span) -> Resul
     Ok(match res {
         Res::Err => panic!("resolution error"),
         Res::Item(item) => Value::Global(
-            GlobalId {
+            ItemLookupId {
                 package: item.package.unwrap_or(package),
                 item: item.item,
             },
@@ -1604,7 +1614,7 @@ fn resolve_closure(
         package: map_fir_package_to_hir(package),
         span,
     }))?;
-    let callable = GlobalId {
+    let callable = ItemLookupId {
         package,
         item: callable,
     };

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -352,7 +352,7 @@ fn block_qubit_use_array_invalid_count_expr() {
                             lo: 1573,
                             hi: 1625,
                         },
-                        id: ItemLookupId {
+                        id: StoreItemId {
                             package: PackageId(
                                 0,
                             ),
@@ -2913,7 +2913,7 @@ fn call_adjoint_expr() {
                             lo: 190,
                             hi: 214,
                         },
-                        id: ItemLookupId {
+                        id: StoreItemId {
                             package: PackageId(
                                 2,
                             ),
@@ -2977,7 +2977,7 @@ fn call_adjoint_adjoint_expr() {
                             lo: 124,
                             hi: 145,
                         },
-                        id: ItemLookupId {
+                        id: StoreItemId {
                             package: PackageId(
                                 2,
                             ),
@@ -3036,7 +3036,7 @@ fn call_adjoint_self_expr() {
                             lo: 116,
                             hi: 137,
                         },
-                        id: ItemLookupId {
+                        id: StoreItemId {
                             package: PackageId(
                                 2,
                             ),

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use num_bigint::BigInt;
-use qsc_fir::fir::{ItemLookupId, Pauli};
+use qsc_fir::fir::{Pauli, StoreItemId};
 use std::{
     fmt::{self, Display, Formatter},
     iter,
@@ -16,9 +16,9 @@ pub enum Value {
     Array(Rc<Vec<Value>>),
     BigInt(BigInt),
     Bool(bool),
-    Closure(Rc<[Value]>, ItemLookupId, FunctorApp),
+    Closure(Rc<[Value]>, StoreItemId, FunctorApp),
     Double(f64),
-    Global(ItemLookupId, FunctorApp),
+    Global(StoreItemId, FunctorApp),
     Int(i64),
     Pauli(Pauli),
     Qubit(Qubit),
@@ -242,7 +242,7 @@ impl Value {
     /// # Panics
     /// This will panic if the [Value] is not a [`Value::Global`].
     #[must_use]
-    pub fn unwrap_global(self) -> (ItemLookupId, FunctorApp) {
+    pub fn unwrap_global(self) -> (StoreItemId, FunctorApp) {
         let Value::Global(id, functor) = self else {
             panic!("value should be Global, got {}", self.type_name());
         };

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use num_bigint::BigInt;
-use qsc_fir::fir::{LocalItemId, PackageId, Pauli};
+use qsc_fir::fir::{ItemLookupId, Pauli};
 use std::{
     fmt::{self, Display, Formatter},
     iter,
@@ -16,9 +16,9 @@ pub enum Value {
     Array(Rc<Vec<Value>>),
     BigInt(BigInt),
     Bool(bool),
-    Closure(Rc<[Value]>, GlobalId, FunctorApp),
+    Closure(Rc<[Value]>, ItemLookupId, FunctorApp),
     Double(f64),
-    Global(GlobalId, FunctorApp),
+    Global(ItemLookupId, FunctorApp),
     Int(i64),
     Pauli(Pauli),
     Qubit(Qubit),
@@ -67,18 +67,6 @@ impl From<bool> for Result {
 impl From<usize> for Result {
     fn from(val: usize) -> Self {
         Self::Id(val)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct GlobalId {
-    pub package: PackageId,
-    pub item: LocalItemId,
-}
-
-impl Display for GlobalId {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "<item {} in package {}>", self.item, self.package)
     }
 }
 
@@ -254,7 +242,7 @@ impl Value {
     /// # Panics
     /// This will panic if the [Value] is not a [`Value::Global`].
     #[must_use]
-    pub fn unwrap_global(self) -> (GlobalId, FunctorApp) {
+    pub fn unwrap_global(self) -> (ItemLookupId, FunctorApp) {
         let Value::Global(id, functor) = self else {
             panic!("value should be Global, got {}", self.type_name());
         };

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -320,21 +320,21 @@ pub enum Global<'a> {
 
 /// A unique identifier for an item within a package store.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ItemLookupId {
+pub struct StoreItemId {
     /// The package ID.
     pub package: PackageId,
     /// The item ID.
     pub item: LocalItemId,
 }
 
-impl Display for ItemLookupId {
+impl Display for StoreItemId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "<item {} in package {}>", self.item, self.package)
     }
 }
 
-impl ItemLookupId {
-    /// Creates a `ItemLookupId`.
+impl StoreItemId {
+    /// Creates a `StoreItemId`.
     #[must_use]
     pub fn from(package: PackageId, item: LocalItemId) -> Self {
         Self { package, item }
@@ -343,21 +343,21 @@ impl ItemLookupId {
 
 /// A unique identifier for a block within a package store.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct BlockLookupId {
+pub struct StoreBlockId {
     /// The package ID.
     pub package: PackageId,
     /// The item ID.
     pub block: BlockId,
 }
 
-impl Display for BlockLookupId {
+impl Display for StoreBlockId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "<block {} in package {}>", self.block, self.package)
     }
 }
 
-impl BlockLookupId {
-    /// Creates a `BlockLookupId`.
+impl StoreBlockId {
+    /// Creates a `StoreBlockId`.
     #[must_use]
     pub fn from(package: PackageId, block: BlockId) -> Self {
         Self { package, block }
@@ -366,21 +366,21 @@ impl BlockLookupId {
 
 /// A unique identifier for an expression within a package store.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ExprLookupId {
+pub struct StoreExprId {
     /// The package ID.
     pub package: PackageId,
     /// The expression ID.
     pub expr: ExprId,
 }
 
-impl Display for ExprLookupId {
+impl Display for StoreExprId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "<expression {} in package {}>", self.expr, self.package)
     }
 }
 
-impl ExprLookupId {
-    /// Creates an `ExprLookupId`.
+impl StoreExprId {
+    /// Creates an `StoreExprId`.
     #[must_use]
     pub fn from(package: PackageId, expr: ExprId) -> Self {
         Self { package, expr }
@@ -389,21 +389,21 @@ impl ExprLookupId {
 
 /// A unique identifier for a pattern within a package store.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct PatLookupId {
+pub struct StorePatId {
     /// The package ID.
     pub package: PackageId,
     /// The pat ID.
     pub pat: PatId,
 }
 
-impl Display for PatLookupId {
+impl Display for StorePatId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "<pattern {} in package {}>", self.pat, self.package)
     }
 }
 
-impl PatLookupId {
-    /// Creates a `PatLookupId`.
+impl StorePatId {
+    /// Creates a `StorePatId`.
     #[must_use]
     pub fn from(package: PackageId, pat: PatId) -> Self {
         Self { package, pat }
@@ -412,21 +412,21 @@ impl PatLookupId {
 
 /// A unique identifier for a statement within a package store.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct StmtLookupId {
+pub struct StoreStmtId {
     /// The package ID.
     pub package: PackageId,
     /// The statement ID.
     pub stmt: StmtId,
 }
 
-impl Display for StmtLookupId {
+impl Display for StoreStmtId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "<pattern {} in package {}>", self.stmt, self.package)
     }
 }
 
-impl StmtLookupId {
-    /// Creates a `StmtLookupId`.
+impl StoreStmtId {
+    /// Creates a `StoreStmtId`.
     #[must_use]
     pub fn from(package: PackageId, stmt: StmtId) -> Self {
         Self { package, stmt }
@@ -436,17 +436,17 @@ impl StmtLookupId {
 /// A trait to find elements in a package store.
 pub trait PackageStoreLookup {
     /// Gets a block.
-    fn get_block(&self, id: BlockLookupId) -> &Block;
+    fn get_block(&self, id: StoreBlockId) -> &Block;
     /// Gets an expression.
-    fn get_expr(&self, id: ExprLookupId) -> &Expr;
+    fn get_expr(&self, id: StoreExprId) -> &Expr;
     /// Gets a global.
-    fn get_global(&self, id: ItemLookupId) -> Option<Global>;
+    fn get_global(&self, id: StoreItemId) -> Option<Global>;
     /// Gets an item.
-    fn get_item(&self, id: ItemLookupId) -> &Item;
+    fn get_item(&self, id: StoreItemId) -> &Item;
     /// Gets a pat.
-    fn get_pat(&self, id: PatLookupId) -> &Pat;
+    fn get_pat(&self, id: StorePatId) -> &Pat;
     /// Gets a statement.
-    fn get_stmt(&self, id: StmtLookupId) -> &Stmt;
+    fn get_stmt(&self, id: StoreStmtId) -> &Stmt;
 }
 
 /// A FIR package store.
@@ -454,36 +454,36 @@ pub trait PackageStoreLookup {
 pub struct PackageStore(IndexMap<PackageId, Package>);
 
 impl PackageStoreLookup for PackageStore {
-    fn get_block(&self, id: BlockLookupId) -> &Block {
+    fn get_block(&self, id: StoreBlockId) -> &Block {
         self.get(id.package)
             .expect("Package not found")
             .get_block(id.block)
     }
 
-    fn get_expr(&self, id: ExprLookupId) -> &Expr {
+    fn get_expr(&self, id: StoreExprId) -> &Expr {
         self.get(id.package)
             .expect("Package not found")
             .get_expr(id.expr)
     }
 
-    fn get_global(&self, id: ItemLookupId) -> Option<Global> {
+    fn get_global(&self, id: StoreItemId) -> Option<Global> {
         self.get(id.package)
             .and_then(|package| package.get_global(id.item))
     }
 
-    fn get_item(&self, id: ItemLookupId) -> &Item {
+    fn get_item(&self, id: StoreItemId) -> &Item {
         self.get(id.package)
             .expect("Package not found")
             .get_item(id.item)
     }
 
-    fn get_pat(&self, id: PatLookupId) -> &Pat {
+    fn get_pat(&self, id: StorePatId) -> &Pat {
         self.get(id.package)
             .expect("Package not found")
             .get_pat(id.pat)
     }
 
-    fn get_stmt(&self, id: StmtLookupId) -> &Stmt {
+    fn get_stmt(&self, id: StoreStmtId) -> &Stmt {
         self.get(id.package)
             .expect("Package not found")
             .get_stmt(id.stmt)

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -449,8 +449,6 @@ pub trait PackageStoreLookup {
     fn get_expr(&self, id: StoreExprId) -> &Expr;
     /// Gets a global.
     fn get_global(&self, id: StoreItemId) -> Option<Global>;
-    /// Gets an item.
-    fn get_item(&self, id: StoreItemId) -> &Item;
     /// Gets a pat.
     fn get_pat(&self, id: StorePatId) -> &Pat;
     /// Gets a statement.
@@ -477,12 +475,6 @@ impl PackageStoreLookup for PackageStore {
     fn get_global(&self, id: StoreItemId) -> Option<Global> {
         self.get(id.package)
             .and_then(|package| package.get_global(id.item))
-    }
-
-    fn get_item(&self, id: StoreItemId) -> &Item {
-        self.get(id.package)
-            .expect("Package not found")
-            .get_item(id.item)
     }
 
     fn get_pat(&self, id: StorePatId) -> &Pat {
@@ -517,7 +509,6 @@ impl PackageStore {
     }
 
     /// Gets a package store iterator.
-    #[allow(clippy::iter_not_returning_iterator)]
     #[must_use]
     pub fn iter(&self) -> Iter<PackageId, Package> {
         self.0.iter()

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -11,7 +11,10 @@
 use crate::ty::{Arrow, FunctorSet, FunctorSetValue, GenericArg, GenericParam, Scheme, Ty, Udt};
 use indenter::{indented, Indented};
 use num_bigint::BigInt;
-use qsc_data_structures::{index_map::IndexMap, span::Span};
+use qsc_data_structures::{
+    index_map::{IndexMap, Iter},
+    span::Span,
+};
 use std::{
     cmp::Ordering,
     fmt::{self, Debug, Display, Formatter, Write},
@@ -506,6 +509,13 @@ impl PackageStore {
     /// Inserts a package to the store.
     pub fn insert(&mut self, id: PackageId, package: Package) {
         self.0.insert(id, package);
+    }
+
+    /// Gets a package store iterator.
+    #[allow(clippy::iter_not_returning_iterator)]
+    #[must_use]
+    pub fn iter(&self) -> Iter<PackageId, Package> {
+        self.0.iter()
     }
 
     /// Creates a package store.

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -359,6 +359,44 @@ pub struct StoreStmtId {
 #[derive(Debug)]
 pub struct PackageStore(IndexMap<PackageId, Package>);
 
+impl PackageStore {
+    /// Gets a block from the store.
+    #[must_use]
+    pub fn get_block(&self, id: StoreBlockId) -> &Block {
+        self.get_package(id.package).get_block(id.block)
+    }
+
+    /// Gets an expression from the store.
+    #[must_use]
+    pub fn get_expr(&self, id: StoreExprId) -> &Expr {
+        self.get_package(id.package).get_expr(id.expr)
+    }
+
+    /// Gets an item from the store.
+    #[must_use]
+    pub fn get_item(&self, id: StoreItemId) -> &Item {
+        self.get_package(id.package).get_item(id.item)
+    }
+
+    /// Gets a package from the store.
+    #[must_use]
+    pub fn get_package(&self, id: PackageId) -> &Package {
+        self.0.get(id).expect("Package not found")
+    }
+
+    /// Gets a pattern from the store.
+    #[must_use]
+    pub fn get_pat(&self, id: StorePatId) -> &Pat {
+        self.get_package(id.package).get_pat(id.pat)
+    }
+
+    /// Gets a statement from the store.
+    #[must_use]
+    pub fn get_stmt(&self, id: StoreStmtId) -> &Stmt {
+        self.get_package(id.package).get_stmt(id.stmt)
+    }
+}
+
 /// The root node of the FIR.
 /// ### Notes
 /// We maintain a dense map of ids within the package.
@@ -397,6 +435,38 @@ impl Display for Package {
             write!(indent, "\n{item}")?;
         }
         Ok(())
+    }
+}
+
+impl Package {
+    /// Gets a block from the package.
+    #[must_use]
+    pub fn get_block(&self, id: BlockId) -> &Block {
+        self.blocks.get(id).expect("Block not found")
+    }
+
+    /// Gets an expression from the package.
+    #[must_use]
+    pub fn get_expr(&self, id: ExprId) -> &Expr {
+        self.exprs.get(id).expect("Expression not found")
+    }
+
+    /// Gets a block from the package.
+    #[must_use]
+    pub fn get_item(&self, id: LocalItemId) -> &Item {
+        self.items.get(id).expect("Item not found")
+    }
+
+    /// Gets a pattern from the package.
+    #[must_use]
+    pub fn get_pat(&self, id: PatId) -> &Pat {
+        self.pats.get(id).expect("Pattern not found")
+    }
+
+    /// Gets a statement from the package.
+    #[must_use]
+    pub fn get_stmt(&self, id: StmtId) -> &Stmt {
+        self.stmts.get(id).expect("Statement not found")
     }
 }
 

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -336,11 +336,12 @@ impl Display for StoreItemId {
     }
 }
 
-impl StoreItemId {
-    /// Creates a `StoreItemId`.
-    #[must_use]
-    pub fn from(package: PackageId, item: LocalItemId) -> Self {
-        Self { package, item }
+impl From<(PackageId, LocalItemId)> for StoreItemId {
+    fn from(tuple: (PackageId, LocalItemId)) -> Self {
+        Self {
+            package: tuple.0,
+            item: tuple.1,
+        }
     }
 }
 
@@ -359,11 +360,12 @@ impl Display for StoreBlockId {
     }
 }
 
-impl StoreBlockId {
-    /// Creates a `StoreBlockId`.
-    #[must_use]
-    pub fn from(package: PackageId, block: BlockId) -> Self {
-        Self { package, block }
+impl From<(PackageId, BlockId)> for StoreBlockId {
+    fn from(tuple: (PackageId, BlockId)) -> Self {
+        Self {
+            package: tuple.0,
+            block: tuple.1,
+        }
     }
 }
 
@@ -382,11 +384,12 @@ impl Display for StoreExprId {
     }
 }
 
-impl StoreExprId {
-    /// Creates an `StoreExprId`.
-    #[must_use]
-    pub fn from(package: PackageId, expr: ExprId) -> Self {
-        Self { package, expr }
+impl From<(PackageId, ExprId)> for StoreExprId {
+    fn from(tuple: (PackageId, ExprId)) -> Self {
+        Self {
+            package: tuple.0,
+            expr: tuple.1,
+        }
     }
 }
 
@@ -405,11 +408,12 @@ impl Display for StorePatId {
     }
 }
 
-impl StorePatId {
-    /// Creates a `StorePatId`.
-    #[must_use]
-    pub fn from(package: PackageId, pat: PatId) -> Self {
-        Self { package, pat }
+impl From<(PackageId, PatId)> for StorePatId {
+    fn from(tuple: (PackageId, PatId)) -> Self {
+        Self {
+            package: tuple.0,
+            pat: tuple.1,
+        }
     }
 }
 
@@ -428,11 +432,12 @@ impl Display for StoreStmtId {
     }
 }
 
-impl StoreStmtId {
-    /// Creates a `StoreStmtId`.
-    #[must_use]
-    pub fn from(package: PackageId, stmt: StmtId) -> Self {
-        Self { package, stmt }
+impl From<(PackageId, StmtId)> for StoreStmtId {
+    fn from(tuple: (PackageId, StmtId)) -> Self {
+        Self {
+            package: tuple.0,
+            stmt: tuple.1,
+        }
     }
 }
 

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -310,6 +310,55 @@ impl Display for Res {
     }
 }
 
+/// A unique identifier for an item within a package store.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StoreItemId {
+    /// The package ID.
+    pub package: PackageId,
+    /// The item ID.
+    pub item: LocalItemId,
+}
+
+/// A unique identifier for a block within a package store.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StoreBlockId {
+    /// The package ID.
+    pub package: PackageId,
+    /// The item ID.
+    pub block: BlockId,
+}
+
+/// A unique identifier for an expression within a package store.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StoreExprId {
+    /// The package ID.
+    pub package: PackageId,
+    /// The expression ID.
+    pub expr: ExprId,
+}
+
+/// A unique identifier for a pattern within a package store.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StorePatId {
+    /// The package ID.
+    pub package: PackageId,
+    /// The pat ID.
+    pub pat: PatId,
+}
+
+/// A unique identifier for a statement within a package store.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StoreStmtId {
+    /// The package ID.
+    pub package: PackageId,
+    /// The statement ID.
+    pub stmt: StmtId,
+}
+
+/// A FIR package store.
+#[derive(Debug)]
+pub struct PackageStore(IndexMap<PackageId, Package>);
+
 /// The root node of the FIR.
 /// ### Notes
 /// We maintain a dense map of ids within the package.


### PR DESCRIPTION
This change formally introduces an FIR `PackageStore` such that it can be later used in runtime capabilities analysis (RCA).

It also refactors the way lookups are performed on an FIR package store in a consolidated way, reducing code duplication and making the lookup functionality available to the RCA implementation.