### PR TITLE
More predictable init and better logging in VS Code tests

### DIFF
--- a/build.py
+++ b/build.py
@@ -410,6 +410,6 @@ if build_jupyterlab:
 
 if args.integration_tests:
     step_start("Running the VS Code integration tests")
-    vscode_args = [npm_cmd, "test", "--", "--verbose"]
+    vscode_args = [npm_cmd, "test"]
     subprocess.run(vscode_args, check=True, text=True, cwd=vscode_src)
     step_end()

--- a/npm/src/log.ts
+++ b/npm/src/log.ts
@@ -75,9 +75,8 @@ export const log = {
    * @param args - The format string and args to log, e.g. ["Index of %s is %i", str, index]
    */
   logWithLevel(level: number, target: string, ...args: any) {
-    // Convert to a format string containing the target (if present)
-    const [, ...trailingArgs] = args; // All but first element of args
-    const outArgs = [`[%s] ${args[0]}`, target || "", ...trailingArgs];
+    const [firstArg, ...trailingArgs] = args;
+    const outArgs = [`[${target || ""}] ${firstArg}`, ...trailingArgs];
     switch (level) {
       case 1:
         log.error(...outArgs);

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -52,11 +52,12 @@ export async function activate(
 ): Promise<ExtensionApi> {
   const api: ExtensionApi = {};
 
-  if (context.extensionMode !== vscode.ExtensionMode.Test) {
-    initOutputWindowLogger();
-  } else {
+  if (context.extensionMode === vscode.ExtensionMode.Test) {
     // Don't log to the output window in tests, forward to a listener instead
     api.logging = initLogForwarder();
+  } else {
+    // Direct logging to the output window
+    initOutputWindowLogger();
   }
 
   log.info("Q# extension activating.");

--- a/vscode/src/logging.ts
+++ b/vscode/src/logging.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { LogLevel, log } from "qsharp-lang";
+import * as vscode from "vscode";
+
+export interface Logging {
+  setListener(listener: LogFunction): void;
+  setLevel(level: LogLevel): void;
+}
+
+type LogFunction = (level: LogLevel, ...args: any[]) => void;
+
+export function initOutputWindowLogger() {
+  const output = vscode.window.createOutputChannel("Q#", { log: true });
+
+  // Override the global logger with functions that write to the output channel
+  log.error = output.error;
+  log.warn = output.warn;
+  log.info = output.info;
+  log.debug = output.debug;
+  log.trace = output.trace;
+
+  // The numerical log levels for VS Code and qsharp don't match.
+  function mapLogLevel(logLevel: vscode.LogLevel) {
+    switch (logLevel) {
+      case vscode.LogLevel.Off:
+        return "off";
+      case vscode.LogLevel.Trace:
+        return "trace";
+      case vscode.LogLevel.Debug:
+        return "debug";
+      case vscode.LogLevel.Info:
+        return "info";
+      case vscode.LogLevel.Warning:
+        return "warn";
+      case vscode.LogLevel.Error:
+        return "error";
+    }
+  }
+
+  log.setLogLevel(mapLogLevel(output.logLevel));
+  output.onDidChangeLogLevel((level) => {
+    log.setLogLevel(mapLogLevel(level));
+  });
+}
+
+export function initLogForwarder(): Logging {
+  log.error = (...args) => forwardLog("error", ...args);
+  log.warn = (...args) => forwardLog("warn", ...args);
+  log.info = (...args) => forwardLog("info", ...args);
+  log.debug = (...args) => forwardLog("debug", ...args);
+  log.trace = (...args) => forwardLog("trace", ...args);
+
+  // Collect all logs from source
+  log.setLogLevel("trace");
+
+  let listener: LogFunction | undefined = undefined;
+  const buffered: [LogLevel, any[]][] = [];
+  const levels: LogLevel[] = ["off", "error", "warn", "info", "debug", "trace"];
+  let logLevel = 0;
+
+  function forwardLog(level: LogLevel, ...args: any[]) {
+    if (listener) {
+      if (logLevel >= levels.indexOf(level)) {
+        listener(level, args);
+      }
+    } else {
+      // Buffer logs until a listener is hooked up
+      buffered.push([level, args]);
+    }
+  }
+
+  return {
+    setListener(newListener: LogFunction) {
+      listener = newListener;
+      // Forward the buffered events to the new listener
+      buffered.forEach(([level, args]) => forwardLog(level, args));
+      buffered.length = 0;
+    },
+    setLevel(level: LogLevel) {
+      logLevel = levels.indexOf(level);
+    },
+  };
+}

--- a/vscode/test/runTests.mjs
+++ b/vscode/test/runTests.mjs
@@ -22,6 +22,11 @@ const waitForDebugger = process.argv.find((arg) =>
   arg.startsWith(attachArgName),
 );
 const verboseArgName = "--verbose";
+/**
+ *  This controls the VS Code and test web server logging level.
+ *  Q# extension logs are usually more relevant for debugging tests.
+ *  To control the Q# extension log level see: suites/extensionUtils.ts
+ */
 const verbose = process.argv.includes(verboseArgName);
 
 try {

--- a/vscode/test/suites/extensionUtils.ts
+++ b/vscode/test/suites/extensionUtils.ts
@@ -19,13 +19,14 @@ export async function activateExtension() {
   const logForwarder = extensionApi.logging;
   if (!logForwarder) {
     throw new Error(`qsharp-tests: extension did not return a log forwarder`);
-  } else {
-    logForwarder.setLevel(extensionLogLevel);
-    logForwarder.setListener((level, ...args) => {
-      // Write extension logs to the console.
-      console.log(`qsharp: [${level}] ${args.join(" ")}`);
-    });
   }
+
+  logForwarder.setLevel(extensionLogLevel);
+  logForwarder.setListener((level, ...args) => {
+    // Write extension logs to the console.
+    console.log(`qsharp: [${level}] ${args.join(" ")}`);
+  });
+
   console.log(
     `qsharp-tests: activate() completed in ${performance.now() - start}ms`,
   );

--- a/vscode/test/suites/extensionUtils.ts
+++ b/vscode/test/suites/extensionUtils.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as vscode from "vscode";
+import { type ExtensionApi } from "../../src/extension";
+
+// Q# extension log level. Increase this for debugging.
+const extensionLogLevel = "warn";
+
+export async function activateExtension() {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const ext = vscode.extensions.getExtension("quantum.qsharp-lang-vscode-dev")!;
+  if (ext.isActive) {
+    return;
+  }
+
+  const start = performance.now();
+  const extensionApi: ExtensionApi = await ext.activate();
+  const logForwarder = extensionApi.logging;
+  if (!logForwarder) {
+    throw new Error(`qsharp-tests: extension did not return a log forwarder`);
+  } else {
+    logForwarder.setLevel(extensionLogLevel);
+    logForwarder.setListener((level, ...args) => {
+      // Write extension logs to the console.
+      console.log(`qsharp: [${level}] ${args.join(" ")}`);
+    });
+  }
+  console.log(
+    `qsharp-tests: activate() completed in ${performance.now() - start}ms`,
+  );
+}

--- a/vscode/test/suites/language-service/language-service.test.ts
+++ b/vscode/test/suites/language-service/language-service.test.ts
@@ -3,14 +3,19 @@
 
 import * as vscode from "vscode";
 import { assert } from "chai";
+import { activateExtension } from "../extensionUtils";
 
-suite("Q# Language Service Tests", () => {
+suite("Q# Language Service Tests", function suite() {
   const workspaceFolder =
     vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0];
   assert(workspaceFolder, "Expecting an open folder");
 
   const workspaceFolderUri = workspaceFolder.uri;
   const docUri = vscode.Uri.joinPath(workspaceFolderUri, "test.qs");
+
+  this.beforeAll(async () => {
+    await activateExtension();
+  });
 
   test("Q# language is registered", async () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
@@ -22,7 +27,6 @@ suite("Q# Language Service Tests", () => {
   });
 
   test("Completions", async () => {
-    await activate();
     const actualCompletionList = (await vscode.commands.executeCommand(
       "vscode.executeCompletionItemProvider",
       docUri,
@@ -36,7 +40,6 @@ suite("Q# Language Service Tests", () => {
   });
 
   test("Definition", async () => {
-    await activate();
     const doc = await vscode.workspace.openTextDocument(docUri);
     const text = doc.getText(
       new vscode.Range(new vscode.Position(4, 16), new vscode.Position(4, 19)),
@@ -57,8 +60,6 @@ suite("Q# Language Service Tests", () => {
   });
 
   test("Diagnostics", async () => {
-    await activate();
-
     const actualDiagnostics = vscode.languages.getDiagnostics(docUri);
     assert.lengthOf(actualDiagnostics, 1);
 
@@ -67,7 +68,6 @@ suite("Q# Language Service Tests", () => {
   });
 
   test("Hover", async () => {
-    await activate();
     const doc = await vscode.workspace.openTextDocument(docUri);
     const text = doc.getText(
       new vscode.Range(new vscode.Position(4, 16), new vscode.Position(4, 19)),
@@ -88,7 +88,6 @@ suite("Q# Language Service Tests", () => {
   });
 
   test("Signature Help", async () => {
-    await activate();
     const doc = await vscode.workspace.openTextDocument(docUri);
     const text = doc.getText(
       new vscode.Range(new vscode.Position(4, 16), new vscode.Position(4, 19)),
@@ -109,9 +108,3 @@ suite("Q# Language Service Tests", () => {
     );
   });
 });
-
-async function activate() {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const ext = vscode.extensions.getExtension("quantum.qsharp-lang-vscode-dev")!;
-  await ext.activate();
-}

--- a/vscode/test/suites/language-service/notebook.test.ts
+++ b/vscode/test/suites/language-service/notebook.test.ts
@@ -3,16 +3,20 @@
 
 import * as vscode from "vscode";
 import { assert } from "chai";
+import { activateExtension } from "../extensionUtils";
 
-suite("Q# Notebook Tests", () => {
+suite("Q# Notebook Tests", function suite() {
   const workspaceFolder =
     vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0];
   assert(workspaceFolder, "Expecting an open folder");
 
   const workspaceFolderUri = workspaceFolder.uri;
 
+  this.beforeAll(async () => {
+    await activateExtension();
+  });
+
   test("Cell language is set to Q#", async () => {
-    await activate();
     const notebook = await vscode.workspace.openNotebookDocument(
       vscode.Uri.joinPath(workspaceFolderUri, "test-no-lang-metadata.ipynb"),
     );
@@ -56,7 +60,6 @@ suite("Q# Notebook Tests", () => {
   });
 
   test("Diagnostics", async () => {
-    await activate();
     const notebook = await vscode.workspace.openNotebookDocument(
       vscode.Uri.joinPath(workspaceFolderUri, "test.ipynb"),
     );
@@ -72,7 +75,6 @@ suite("Q# Notebook Tests", () => {
   });
 
   test("Definition", async () => {
-    await activate();
     const notebook = await vscode.workspace.openNotebookDocument(
       vscode.Uri.joinPath(workspaceFolderUri, "test.ipynb"),
     );
@@ -95,9 +97,3 @@ suite("Q# Notebook Tests", () => {
     assert.equal(location.range.start.character, 10);
   });
 });
-
-async function activate() {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const ext = vscode.extensions.getExtension("quantum.qsharp-lang-vscode-dev")!;
-  await ext.activate();
-}

--- a/vscode/test/suites/run.ts
+++ b/vscode/test/suites/run.ts
@@ -27,10 +27,11 @@ export function runMochaTests(requireTestModules: () => void): Promise<void> {
       // Run the mocha test
       mocha.run((failures) => {
         if (failures > 0) {
-          e(new Error(`${failures} tests failed.`));
-        } else {
-          c();
+          console.error(
+            `[error] ${failures} vscode integration test(s) failed.`,
+          );
         }
+        c();
       });
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
This is an attempt at fixing or mitigating #963, but since I can't repro that one reliably, we won't be sure for a while.

* Product change: fix VS Code log formatting.

Before:
![Screenshot 2024-01-12 110423](https://github.com/microsoft/qsharp/assets/16928427/9444ff05-c8b4-4edf-8614-8f7db7fe35f3)
After:
![Screenshot 2024-01-12 110110](https://github.com/microsoft/qsharp/assets/16928427/b83f2674-784f-498a-95b0-dc940c102f56)

Test changes: 

* Explicitly activate the Q# extension before the tests start. This should eliminate issues where the activation itself is taking a long time for whatever reason and timing out the test cases, which have a reasonably conservative timeout of 2s.
* Write Q# logs to the console in the integration tests.
* Disable the ugly verbose vscode / webserver logs by default. They were helpful to debug infrastructure issues but we don't need them at the moment.