### PR TITLE
Only comment memory benchmark results if there is a difference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,13 +178,18 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## Memory Report for ${{ github.sha }}
-            | Test                        | This Branch | On Main  |
-            |-----------------------------|-------------|----------|
-            | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes |`
-            })
+            if (${{ env.BRANCH_MEASUREMENT }} !== ${{ env.MAIN_MEASUREMENT }}) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `_Change in memory usage detected by benchmark._
+              ## Memory Report for ${{ github.sha }}
+              | Test                        | This Branch | On Main  |
+              |-----------------------------|-------------|----------|
+              | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes |`
+              })
+            } else {
+              console.log("no change in memory usage detected by benchmark");
+            }
         if: ${{ github.base_ref != null }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            if (${{ env.BRANCH_MEASUREMENT }} !== ${{ env.MAIN_MEASUREMENT }}) {
+            if (1 !== ${{ env.MAIN_MEASUREMENT }}) {
               github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            if (1 !== ${{ env.MAIN_MEASUREMENT }}) {
+            if (${{ env.BRANCH_MEASUREMENT }} !== ${{ env.MAIN_MEASUREMENT }}) {
               github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,


### PR DESCRIPTION
With this change, our pipeline only comments about memory usage if there is a diff. If not, we omit the comment but log in the pipeline to confirm that there was no diff. I hope this reduces per-PR noise.