### PR TITLE
Remove shots from statful interpreter `run` API

### DIFF
--- a/compiler/qsc/src/interpret/stateful.rs
+++ b/compiler/qsc/src/interpret/stateful.rs
@@ -295,9 +295,8 @@ impl Interpreter {
         &mut self,
         receiver: &mut impl Receiver,
         expr: &str,
-        shots: u32,
-    ) -> Result<Vec<InterpretResult>, Vec<Error>> {
-        self.run_with_sim(&mut SparseSim::new(), receiver, expr, shots)
+    ) -> Result<InterpretResult, Vec<Error>> {
+        self.run_with_sim(&mut SparseSim::new(), receiver, expr)
     }
 
     /// Gets the current quantum state of the simulator.
@@ -316,11 +315,7 @@ impl Interpreter {
         let mut stdout = std::io::sink();
         let mut out = GenericReceiver::new(&mut stdout);
 
-        let val = self
-            .run_with_sim(&mut sim, &mut out, expr, 1)?
-            .into_iter()
-            .last()
-            .expect("execution should have at least one result")?;
+        let val = self.run_with_sim(&mut sim, &mut out, expr)??;
 
         Ok(sim.finish(&val))
     }
@@ -332,11 +327,10 @@ impl Interpreter {
         sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
         receiver: &mut impl Receiver,
         expr: &str,
-        shots: u32,
-    ) -> Result<Vec<InterpretResult>, Vec<Error>> {
+    ) -> Result<InterpretResult, Vec<Error>> {
         let stmt_id = self.compile_expr_to_stmt(expr)?;
 
-        Ok(self.run_internal(sim, receiver, stmt_id, shots))
+        Ok(self.run_internal(sim, receiver, stmt_id))
     }
 
     fn run_internal(
@@ -344,37 +338,23 @@ impl Interpreter {
         sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
         receiver: &mut impl Receiver,
         stmt_id: StmtId,
-        shots: u32,
-    ) -> Vec<InterpretResult> {
-        let mut results: Vec<InterpretResult> = Vec::new();
-        for i in 0..shots {
-            results.push(
-                match eval_stmt(
-                    stmt_id,
-                    &self.fir_store,
-                    &mut Env::with_empty_scope(),
-                    sim,
-                    self.package,
-                    receiver,
-                ) {
-                    Ok(value) => Ok(value),
-                    Err((error, call_stack)) => Err(eval_error(
-                        self.compiler.package_store(),
-                        &self.fir_store,
-                        call_stack,
-                        error,
-                    )),
-                },
-            );
-
-            if i != 0 {
-                // If running more than one shot, re-initialize the simulator to start the next shot
-                // from a clean state.
-                sim.reinit();
-            }
+    ) -> InterpretResult {
+        match eval_stmt(
+            stmt_id,
+            &self.fir_store,
+            &mut Env::with_empty_scope(),
+            sim,
+            self.package,
+            receiver,
+        ) {
+            Ok(value) => Ok(value),
+            Err((error, call_stack)) => Err(eval_error(
+                self.compiler.package_store(),
+                &self.fir_store,
+                call_stack,
+                error,
+            )),
         }
-
-        results
     }
 
     fn compile_expr_to_stmt(&mut self, expr: &str) -> Result<StmtId, Vec<Error>> {

--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -437,10 +437,6 @@ impl Backend for BaseProfSim {
         // true to avoid a panic.
         true
     }
-
-    fn reinit(&mut self) {
-        *self = Self::default();
-    }
 }
 
 struct Qubit(HardwareId);

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -38,7 +38,6 @@ pub trait Backend {
     fn qubit_release(&mut self, q: usize);
     fn capture_quantum_state(&mut self) -> (Vec<(BigUint, Complex<f64>)>, usize);
     fn qubit_is_zero(&mut self, q: usize) -> bool;
-    fn reinit(&mut self);
 
     fn custom_intrinsic(&mut self, _name: &str, _arg: Value) -> Option<Result<Value, String>> {
         None
@@ -192,10 +191,6 @@ impl Backend for SparseSim {
 
     fn qubit_is_zero(&mut self, q: usize) -> bool {
         self.sim.qubit_is_zero(q)
-    }
-
-    fn reinit(&mut self) {
-        *self = Self::new();
     }
 
     fn custom_intrinsic(&mut self, name: &str, _arg: Value) -> Option<Result<Value, String>> {

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -134,10 +134,6 @@ impl Backend for CustomSim {
         self.sim.qubit_is_zero(q)
     }
 
-    fn reinit(&mut self) {
-        self.sim.reinit();
-    }
-
     fn custom_intrinsic(&mut self, name: &str, arg: Value) -> Option<Result<Value, String>> {
         match name {
             "Add1" => Some(Ok(Value::Int(arg.unwrap_int() + 1))),

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -57,17 +57,15 @@ class Interpreter:
         """
         ...
     def run(
-        self, entry_expr: str, shots: int, output_fn: Callable[[Output], None]
+        self, entry_expr: str, output_fn: Callable[[Output], None]
     ) -> Any:
         """
-        Runs the given Q# expressin for the given number of shots.
-        Each shot uses an independent instance of the simulator.
+        Runs the given Q# expressin with an independent instance of the simulator.
 
         :param entry_expr: The entry expression.
-        :param shots: The number of shots to run.
         :param output_fn: A callback function that will be called with each output.
 
-        :returns values: A list of results or runtime errors.
+        :returns values: A results or runtime errors.
 
         :raises QSharpError: If there is an error interpreting the input.
         """

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -60,12 +60,12 @@ class Interpreter:
         self, entry_expr: str, output_fn: Callable[[Output], None]
     ) -> Any:
         """
-        Runs the given Q# expressin with an independent instance of the simulator.
+        Runs the given Q# expression with an independent instance of the simulator.
 
         :param entry_expr: The entry expression.
         :param output_fn: A callback function that will be called with each output.
 
-        :returns values: A results or runtime errors.
+        :returns values: A result or runtime errors.
 
         :raises QSharpError: If there is an error interpreting the input.
         """

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -163,9 +163,9 @@ def run(
     for _ in range(shots):
         results.append({"result": None, "events": []})
         run_results = get_interpreter().run(
-            entry_expr, 1, on_save_events if save_events else print_output
+            entry_expr, on_save_events if save_events else print_output
         )
-        results[-1]["result"] = run_results[0]
+        results[-1]["result"] = run_results
         if on_result:
             on_result(results[-1])
 

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -167,19 +167,14 @@ impl Interpreter {
         &mut self,
         py: Python,
         entry_expr: &str,
-        shots: u32,
         callback: Option<PyObject>,
-    ) -> PyResult<Py<PyList>> {
+    ) -> PyResult<PyObject> {
         let mut receiver = OptionalCallbackReceiver { callback, py };
-        match self.interpreter.run(&mut receiver, entry_expr, shots) {
-            Ok(results) => Ok(PyList::new(
-                py,
-                results.into_iter().map(|res| match res {
-                    Ok(v) => ValueWrapper(v).into_py(py),
-                    Err(errors) => QSharpError::new_err(format_errors(errors)).into_py(py),
-                }),
-            )
-            .into_py(py)),
+        match self.interpreter.run(&mut receiver, entry_expr) {
+            Ok(result) => match result {
+                Ok(v) => Ok(ValueWrapper(v).into_py(py)),
+                Err(errors) => Err(QSharpError::new_err(format_errors(errors))),
+            },
             Err(errors) => Err(QSharpError::new_err(format_errors(errors))),
         }
     }

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -199,7 +199,9 @@ def test_run_with_shots() -> None:
     e.interpret('operation Foo() : Unit { Message("Hello, world!"); }', callback)
     assert called == 0
 
-    value = e.run("Foo()", 5, callback)
+    value = []
+    for _ in range(5):
+        value.append(e.run("Foo()", callback))
     assert called == 5
 
     assert value == [None, None, None, None, None]

--- a/resource_estimator/src/counts.rs
+++ b/resource_estimator/src/counts.rs
@@ -522,10 +522,6 @@ impl Backend for LogicalCounter {
         true
     }
 
-    fn reinit(&mut self) {
-        *self = Self::default();
-    }
-
     fn custom_intrinsic(&mut self, name: &str, arg: Value) -> Option<Result<Value, String>> {
         match name {
             "BeginEstimateCaching" => {

--- a/resource_estimator/src/lib.rs
+++ b/resource_estimator/src/lib.rs
@@ -53,11 +53,8 @@ pub fn estimate_expr(
     let mut stdout = std::io::sink();
     let mut out = GenericReceiver::new(&mut stdout);
     interpreter
-        .run_with_sim(&mut counter, &mut out, expr, 1)
+        .run_with_sim(&mut counter, &mut out, expr)
         .map_err(|e| e.into_iter().map(Error::Interpreter).collect::<Vec<_>>())?
-        .into_iter()
-        .last()
-        .expect("execution should have at least one result")
         .map_err(|e| vec![Error::Interpreter(e[0].clone())])?;
     estimate_physical_resources(&counter.logical_resources(), params)
         .map_err(|e| vec![Error::Estimation(e)])


### PR DESCRIPTION
This change removes the shots argument to the `run` API in stateful interpreter now that all callers pass 1. This avoids the need to wrap interpreter results in an additional vector and simplifies calling patterns. All consumers already passed 1 and had a shot loop around the call to `run` or utilized other APIs.

This also removes the need for a `reinit` function on the `Backend` trait, since now a simulator is only used once before being recreated.