### PR TITLE
Fix left behind use of "Full" in error message

### DIFF
--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -231,9 +231,10 @@ impl With<'_> {
                     if matches!(inner.kind.as_ref(), ast::ExprKind::Path(path)
                         if ConfigAttr::from_str(path.name.name.as_ref()).is_ok()))
                 {
-                    self.lowerer
-                        .errors
-                        .push(Error::InvalidAttrArgs("Full or Base", attr.arg.span));
+                    self.lowerer.errors.push(Error::InvalidAttrArgs(
+                        "Unrestricted or Base",
+                        attr.arg.span,
+                    ));
                 }
                 None
             }

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -134,7 +134,7 @@ fn test_target_profile_attr_wrong_args() {
         &expect![[r#"
             [
                 InvalidAttrArgs(
-                    "Full or Base",
+                    "Unrestricted or Base",
                     Span {
                         lo: 29,
                         hi: 34,


### PR DESCRIPTION
We missed one instance of "Full" in an error message that needed to change to "Unrestricted" insetad.