### PR TITLE
Refactor common interpreter patterns

### DIFF
--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -193,7 +193,7 @@ impl Interpreter {
         let expr = self.get_entry_expr()?;
         eval(
             self.source_package,
-            &expr.into(),
+            expr.into(),
             self.compiler.package_store(),
             &self.fir_store,
             &mut Env::default(),
@@ -212,7 +212,7 @@ impl Interpreter {
         let expr = self.get_entry_expr()?;
         eval(
             self.source_package,
-            &expr.into(),
+            expr.into(),
             self.compiler.package_store(),
             &self.fir_store,
             &mut Env::default(),
@@ -263,7 +263,7 @@ impl Interpreter {
         for stmt_id in stmts {
             result = eval(
                 self.package,
-                &stmt_id.into(),
+                stmt_id.into(),
                 self.compiler.package_store(),
                 &self.fir_store,
                 &mut self.env,
@@ -318,7 +318,7 @@ impl Interpreter {
 
         Ok(eval(
             self.package,
-            &stmt_id.into(),
+            stmt_id.into(),
             self.compiler.package_store(),
             &self.fir_store,
             &mut Env::default(),
@@ -450,7 +450,7 @@ impl Interpreter {
 /// Wrapper function for `qsc_eval::eval` that handles error conversion.
 fn eval(
     package: PackageId,
-    id: &EvalId,
+    id: EvalId,
     package_store: &PackageStore,
     fir_store: &fir::PackageStore,
     env: &mut Env,

--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -29,10 +29,9 @@ use qsc_data_structures::span::Span;
 use qsc_eval::{
     backend::{Backend, SparseSim},
     debug::{map_fir_package_to_hir, map_hir_package_to_fir},
-    eval_expr, eval_stmt,
     output::Receiver,
     val::{self},
-    Env, State, VariableInfo,
+    Env, EvalId, State, VariableInfo,
 };
 use qsc_fir::fir::{self, Global, PackageStoreLookup};
 use qsc_fir::{
@@ -140,7 +139,7 @@ impl Interpreter {
             capabilities,
             fir_store,
             lowerer,
-            env: Env::with_empty_scope(),
+            env: Env::default(),
             sim: SparseSim::new(),
             state: State::new(map_hir_package_to_fir(source_package_id)),
             package: map_hir_package_to_fir(package_id),
@@ -192,22 +191,15 @@ impl Interpreter {
     /// Returns a vector of errors if evaluating the entry point fails.
     pub fn eval_entry(&mut self, receiver: &mut impl Receiver) -> Result<Value, Vec<Error>> {
         let expr = self.get_entry_expr()?;
-        eval_expr(
-            &mut State::new(self.source_package),
-            expr,
+        eval(
+            self.source_package,
+            &expr.into(),
+            self.compiler.package_store(),
             &self.fir_store,
-            &mut Env::with_empty_scope(),
+            &mut Env::default(),
             &mut self.sim,
             receiver,
         )
-        .map_err(|(error, call_stack)| {
-            eval_error(
-                self.compiler.package_store(),
-                &self.fir_store,
-                call_stack,
-                error,
-            )
-        })
     }
 
     /// Executes the entry expression until the end of execution, using the given simulator backend
@@ -218,22 +210,15 @@ impl Interpreter {
         receiver: &mut impl Receiver,
     ) -> Result<Value, Vec<Error>> {
         let expr = self.get_entry_expr()?;
-        eval_expr(
-            &mut State::new(self.source_package),
-            expr,
+        eval(
+            self.source_package,
+            &expr.into(),
+            self.compiler.package_store(),
             &self.fir_store,
-            &mut Env::with_empty_scope(),
+            &mut Env::default(),
             sim,
             receiver,
         )
-        .map_err(|(error, call_stack)| {
-            eval_error(
-                self.compiler.package_store(),
-                &self.fir_store,
-                call_stack,
-                error,
-            )
-        })
     }
 
     fn get_entry_expr(&self) -> Result<ExprId, Vec<Error>> {
@@ -276,24 +261,15 @@ impl Interpreter {
         let mut result = Value::unit();
 
         for stmt_id in stmts {
-            match eval_stmt(
-                stmt_id,
+            result = eval(
+                self.package,
+                &stmt_id.into(),
+                self.compiler.package_store(),
                 &self.fir_store,
                 &mut self.env,
                 &mut self.sim,
-                self.package,
                 receiver,
-            ) {
-                Ok(value) => result = value,
-                Err((error, call_stack)) => {
-                    return Err(eval_error(
-                        self.compiler.package_store(),
-                        &self.fir_store,
-                        call_stack,
-                        error,
-                    ))
-                }
-            }
+            )?;
         }
 
         Ok(result)
@@ -340,31 +316,15 @@ impl Interpreter {
     ) -> Result<InterpretResult, Vec<Error>> {
         let stmt_id = self.compile_expr_to_stmt(expr)?;
 
-        Ok(self.run_internal(sim, receiver, stmt_id))
-    }
-
-    fn run_internal(
-        &mut self,
-        sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
-        receiver: &mut impl Receiver,
-        stmt_id: StmtId,
-    ) -> InterpretResult {
-        match eval_stmt(
-            stmt_id,
-            &self.fir_store,
-            &mut Env::with_empty_scope(),
-            sim,
+        Ok(eval(
             self.package,
+            &stmt_id.into(),
+            self.compiler.package_store(),
+            &self.fir_store,
+            &mut Env::default(),
+            sim,
             receiver,
-        ) {
-            Ok(value) => Ok(value),
-            Err((error, call_stack)) => Err(eval_error(
-                self.compiler.package_store(),
-                &self.fir_store,
-                call_stack,
-                error,
-            )),
-        }
+        ))
     }
 
     fn compile_expr_to_stmt(&mut self, expr: &str) -> Result<StmtId, Vec<Error>> {
@@ -485,6 +445,20 @@ impl Interpreter {
             .filter(|v| !v.name.starts_with('@'))
             .collect()
     }
+}
+
+/// Wrapper function for `qsc_eval::eval` that handles error conversion.
+fn eval(
+    package: PackageId,
+    id: &EvalId,
+    package_store: &PackageStore,
+    fir_store: &fir::PackageStore,
+    env: &mut Env,
+    sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
+    receiver: &mut impl Receiver,
+) -> InterpretResult {
+    qsc_eval::eval(package, id, fir_store, env, sim, receiver)
+        .map_err(|(error, call_stack)| eval_error(package_store, fir_store, call_stack, error))
 }
 
 /// Represents a stack frame for debugging.

--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -10,10 +10,10 @@ use qsc_data_structures::index_map::IndexMap;
 use qsc_eval::{
     backend::Backend,
     debug::{map_hir_package_to_fir, Frame},
-    eval_expr,
+    eval,
     output::GenericReceiver,
     val::Value,
-    Env, Error, State,
+    Env, Error,
 };
 use qsc_fir::fir;
 use qsc_frontend::compile::PackageStore;
@@ -46,11 +46,11 @@ pub fn generate_qir(
     let mut sim = BaseProfSim::default();
     let mut stdout = std::io::sink();
     let mut out = GenericReceiver::new(&mut stdout);
-    let result = eval_expr(
-        &mut State::new(package),
-        entry_expr,
+    let result = eval(
+        package,
+        &entry_expr.into(),
         &fir_store,
-        &mut Env::with_empty_scope(),
+        &mut Env::default(),
         &mut sim,
         &mut out,
     );

--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -48,7 +48,7 @@ pub fn generate_qir(
     let mut out = GenericReceiver::new(&mut stdout);
     let result = eval(
         package,
-        &entry_expr.into(),
+        entry_expr.into(),
         &fir_store,
         &mut Env::default(),
         &mut sim,

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -170,45 +170,45 @@ impl Display for Spec {
     }
 }
 
-/// Evaluates the given expr with the given context.
-/// # Errors
-/// Returns the first error encountered during execution.
-/// # Panics
-/// On internal error where no result is returned.
-pub fn eval_expr(
-    state: &mut State,
-    expr: ExprId,
-    globals: &impl PackageStoreLookup,
-    env: &mut Env,
-    sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
-    out: &mut impl Receiver,
-) -> Result<Value, (Error, Vec<Frame>)> {
-    state.push_expr(expr);
-    let res = state.eval(globals, env, sim, out, &[], StepAction::Continue)?;
-    let StepResult::Return(value) = res else {
-        panic!("eval_expr should always return a value");
-    };
-    Ok(value)
+/// An id either representing a statement or an expression to be evaluated.
+pub enum EvalId {
+    Expr(ExprId),
+    Stmt(StmtId),
 }
 
-/// Evaluates the given stmt with the given context.
+impl From<ExprId> for EvalId {
+    fn from(expr: ExprId) -> Self {
+        Self::Expr(expr)
+    }
+}
+
+impl From<StmtId> for EvalId {
+    fn from(stmt: StmtId) -> Self {
+        Self::Stmt(stmt)
+    }
+}
+
+/// Evaluates the given code with the given context.
 /// # Errors
 /// Returns the first error encountered during execution.
 /// # Panics
 /// On internal error where no result is returned.
-pub fn eval_stmt(
-    stmt: StmtId,
+pub fn eval(
+    package: PackageId,
+    id: &EvalId,
     globals: &impl PackageStoreLookup,
     env: &mut Env,
     sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
-    package: PackageId,
     receiver: &mut impl Receiver,
 ) -> Result<Value, (Error, Vec<Frame>)> {
     let mut state = State::new(package);
-    state.push_stmt(stmt);
+    match id {
+        EvalId::Expr(expr) => state.push_expr(*expr),
+        EvalId::Stmt(stmt) => state.push_stmt(*stmt),
+    }
     let res = state.eval(globals, env, sim, receiver, &[], StepAction::Continue)?;
     let StepResult::Return(value) = res else {
-        panic!("eval_stmt should always return a value");
+        panic!("eval_expr should always return a value");
     };
     Ok(value)
 }
@@ -307,7 +307,6 @@ impl Range {
     }
 }
 
-#[derive(Default)]
 pub struct Env(Vec<Scope>);
 
 impl Env {
@@ -383,9 +382,9 @@ struct Scope {
     frame_id: usize,
 }
 
-impl Env {
+impl Default for Env {
     #[must_use]
-    pub fn with_empty_scope() -> Self {
+    fn default() -> Self {
         Self(vec![Scope::default()])
     }
 }

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -209,7 +209,7 @@ pub fn eval(
     }
     let res = state.eval(globals, env, sim, receiver, &[], StepAction::Continue)?;
     let StepResult::Return(value) = res else {
-        panic!("eval_expr should always return a value");
+        panic!("eval should always return a value");
     };
     Ok(value)
 }

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -171,6 +171,7 @@ impl Display for Spec {
 }
 
 /// An id either representing a statement or an expression to be evaluated.
+#[derive(Clone, Copy)]
 pub enum EvalId {
     Expr(ExprId),
     Stmt(StmtId),
@@ -195,7 +196,7 @@ impl From<StmtId> for EvalId {
 /// On internal error where no result is returned.
 pub fn eval(
     package: PackageId,
-    id: &EvalId,
+    id: EvalId,
     globals: &impl PackageStoreLookup,
     env: &mut Env,
     sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
@@ -203,8 +204,8 @@ pub fn eval(
 ) -> Result<Value, (Error, Vec<Frame>)> {
     let mut state = State::new(package);
     match id {
-        EvalId::Expr(expr) => state.push_expr(*expr),
-        EvalId::Stmt(stmt) => state.push_stmt(*stmt),
+        EvalId::Expr(expr) => state.push_expr(expr),
+        EvalId::Stmt(stmt) => state.push_stmt(stmt),
     }
     let res = state.eval(globals, env, sim, receiver, &[], StepAction::Continue)?;
     let StepResult::Return(value) = res else {

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -28,7 +28,7 @@ pub(super) fn eval_expr(
     out: &mut impl Receiver,
 ) -> Result<Value, (Error, Vec<Frame>)> {
     let mut state = State::new(package);
-    let mut env = Env::with_empty_scope();
+    let mut env = Env::default();
     state.push_expr(expr);
     let StepResult::Return(value) =
         state.eval(globals, &mut env, sim, out, &[], StepAction::Continue)?


### PR DESCRIPTION
This change refactors the interpreter API to unify around some common patterns and reduce places that look like exceptions. Several of the APIs used what appeared to be different patterns for how they invoked the evaluator when it turns out they were all minor, surface differences except for a few differences in input values. Using a wrapper function clarifies where the common patterns are and makes it easier for future updates to reuse them.