### PR TITLE
Skip macOS in PR builds, include integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+        is_pr:
+          - ${{ github.event_name == 'pull_request' }}
+        exclude:
+          - os: macos-latest
+            is_pr: true
 
     runs-on: ${{matrix.os}}
 
@@ -105,11 +110,15 @@ jobs:
 
   integration-tests:
     name: Integration tests
-    if: ${{ ! github.event.pull_request }}
     timeout-minutes: 15
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+        is_pr:
+          - ${{ github.event_name == 'pull_request' }}
+        exclude:
+          - os: macos-latest
+            is_pr: true
 
     runs-on: ${{matrix.os}}
 
@@ -193,3 +202,13 @@ jobs:
               console.log("no change in memory usage detected by benchmark");
             }
         if: ${{ github.base_ref != null }}
+
+  status-check:
+    name: Status Check
+    needs: [format, clippy, web-check, build, integration-tests, runBenchmark]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - run: |
+          echo "::error Build failed"
+          exit 1


### PR DESCRIPTION
This change updates the logic for the build matrix to skip macOS when building for PRs and enables integration tests. This keeps the contentions and slower macOS runners reserved for merge queue to main.

To make this work nicely with branch protection rules, a "Status Check" task is introduced that depends on previous jobs, only executes on failure of dependencies, and always fails. Branch protection treats this job as required, and then PR build will require only those matrix combinations enabled in that context while merge queues will require the full matrix to run and pass.