### PR TITLE
Update FIR data structures related to specializations to encode assumptions after running default passes

### DIFF
--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -782,6 +782,68 @@ impl Display for CallableDecl {
     }
 }
 
+/// The kinds of callable implementations.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CallableImplKind {
+    /// An intrinsic callable implementation.
+    Intrinsic(NodeId, Span),
+    /// A specialized callable implementation.
+    Specialized(CallableSpecImpl),
+}
+
+impl Display for CallableImplKind {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut indent = set_indentation(indented(f), 0);
+        match self {
+            CallableImplKind::Intrinsic(node_id, span) => {
+                write!(indent, "Instrinsic {node_id} {span}")?;
+            }
+            CallableImplKind::Specialized(spec_impl) => {
+                write!(indent, "Specialized:")?;
+                indent = set_indentation(indent, 1);
+                write!(indent, "\n{spec_impl}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// A callable specialized implementation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CallableSpecImpl {
+    /// The callable body.
+    pub body: SpecDecl,
+    /// The adjoint specialization.
+    pub adj: Option<SpecDecl>,
+    /// The controlled specialization.
+    pub ctl: Option<SpecDecl>,
+    /// The controlled adjoint specialization.
+    pub ctl_adj: Option<SpecDecl>,
+}
+
+impl Display for CallableSpecImpl {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut indent = set_indentation(indented(f), 0);
+        write!(indent, "CallableSpecDecl:",)?;
+        indent = set_indentation(indent, 1);
+        write!(indent, "\nbody: {}", self.body)?;
+        match &self.adj {
+            Some(spec) => write!(indent, "\nadj: {spec}")?,
+            None => write!(indent, "\nadj: <none>")?,
+        }
+        match &self.ctl {
+            Some(spec) => write!(indent, "\nctl: {spec}")?,
+            None => write!(indent, "\nctl: <none>")?,
+        }
+        match &self.ctl_adj {
+            Some(spec) => write!(indent, "\nctl-adj: {spec}")?,
+            None => write!(indent, "\nctl-adj: <none>")?,
+        }
+        Ok(())
+    }
+}
+
 /// A specialization declaration.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SpecDecl {

--- a/compiler/qsc_fir/src/mut_visit.rs
+++ b/compiler/qsc_fir/src/mut_visit.rs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 use crate::fir::{
-    Block, BlockId, CallableDecl, Expr, ExprId, ExprKind, Ident, Item, ItemKind, Package, Pat,
-    PatId, PatKind, QubitInit, QubitInitKind, SpecBody, SpecDecl, Stmt, StmtId, StmtKind,
-    StringComponent,
+    Block, BlockId, CallableDecl, CallableImplementation, Expr, ExprId, ExprKind, Ident, Item,
+    ItemKind, Package, Pat, PatId, PatKind, QubitInit, QubitInitKind, SpecDecl,
+    SpecializedImplementation, Stmt, StmtId, StmtKind, StringComponent,
 };
 
 pub trait MutVisitor<'a>: Sized {
@@ -18,6 +18,17 @@ pub trait MutVisitor<'a>: Sized {
 
     fn visit_callable_decl(&mut self, decl: &'a mut CallableDecl) {
         walk_callable_decl(self, decl);
+    }
+
+    fn visit_callable_implementation(&mut self, implementation: &'a mut CallableImplementation) {
+        walk_callable_implementation(self, implementation);
+    }
+
+    fn visit_specialized_implementation(
+        &mut self,
+        specialized_implementation: &'a mut SpecializedImplementation,
+    ) {
+        walk_specialized_implementation(self, specialized_implementation);
     }
 
     fn visit_spec_decl(&mut self, decl: &'a mut SpecDecl) {
@@ -61,32 +72,49 @@ pub fn walk_item<'a>(vis: &mut impl MutVisitor<'a>, item: &'a mut Item) {
     match &mut item.kind {
         ItemKind::Callable(decl) => vis.visit_callable_decl(decl),
         ItemKind::Namespace(name, _) | ItemKind::Ty(name, _) => vis.visit_ident(name),
-    }
+    };
 }
 
 pub fn walk_callable_decl<'a>(vis: &mut impl MutVisitor<'a>, decl: &'a mut CallableDecl) {
     vis.visit_ident(&mut decl.name);
     vis.visit_pat(decl.input);
-    vis.visit_spec_decl(&mut decl.body);
-    decl.adj
+    vis.visit_callable_implementation(&mut decl.implementation);
+}
+
+pub fn walk_callable_implementation<'a>(
+    vis: &mut impl MutVisitor<'a>,
+    implementation: &'a mut CallableImplementation,
+) {
+    match implementation {
+        CallableImplementation::Intrinsic(_, _) => {}
+        CallableImplementation::Specialized(specialized_implementation) => {
+            vis.visit_specialized_implementation(specialized_implementation);
+        }
+    }
+}
+
+pub fn walk_specialized_implementation<'a>(
+    vis: &mut impl MutVisitor<'a>,
+    specialized_implementation: &'a mut SpecializedImplementation,
+) {
+    vis.visit_spec_decl(&mut specialized_implementation.body);
+    specialized_implementation
+        .adj
         .iter_mut()
         .for_each(|spec| vis.visit_spec_decl(spec));
-    decl.ctl
+    specialized_implementation
+        .ctl
         .iter_mut()
         .for_each(|spec| vis.visit_spec_decl(spec));
-    decl.ctl_adj
+    specialized_implementation
+        .ctl_adj
         .iter_mut()
         .for_each(|spec| vis.visit_spec_decl(spec));
 }
 
 pub fn walk_spec_decl<'a>(vis: &mut impl MutVisitor<'a>, decl: &'a mut SpecDecl) {
-    match &mut decl.body {
-        SpecBody::Gen(_) => {}
-        SpecBody::Impl(pat, block) => {
-            pat.iter().for_each(|pat| vis.visit_pat(*pat));
-            vis.visit_block(*block);
-        }
-    }
+    decl.input.iter().for_each(|pat| vis.visit_pat(*pat));
+    vis.visit_block(decl.block);
 }
 
 pub fn walk_block<'a>(vis: &mut impl MutVisitor<'a>, block: BlockId) {


### PR DESCRIPTION
This change refactors FIR data structures related to callables' specializations to encode assumptions about what is expected of FIR after running default passes (specifically, the replace qubit allocations pass).

The assumptions are the following:
- Intrinsic callables do not have specializations.
- Specializations for callables that have them are implementations (no generators).