### PR TITLE
Remove qubit statements from FIR.

### DIFF
--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -558,10 +558,6 @@ impl<'a> Visitor<'a> for BreakpointCollector<'a> {
                 self.add_stmt(stmt_res);
                 visit::walk_expr(self, expr);
             }
-            qsc_fir::fir::StmtKind::Qubit(_, _, _, block) => match block {
-                Some(block) => visit::walk_block(self, block),
-                None => self.add_stmt(stmt_res),
-            },
             qsc_fir::fir::StmtKind::Item(_) | qsc_fir::fir::StmtKind::Semi(_) => {
                 self.add_stmt(stmt_res);
             }

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -871,7 +871,6 @@ impl State {
                 self.push_expr(*expr);
                 self.push_val(Value::unit());
             }
-            StmtKind::Qubit(..) => panic!("qubit use-stmt should be eliminated by passes"),
             StmtKind::Semi(expr) => {
                 self.push_action(Action::Consume);
                 self.push_expr(*expr);

--- a/compiler/qsc_eval/src/lower.rs
+++ b/compiler/qsc_eval/src/lower.rs
@@ -244,7 +244,7 @@ impl Lowerer {
                 self.lower_expr(expr),
             ),
             hir::StmtKind::Qubit(_, _, _, _) => {
-                panic!("qubit statements should have been elimiated by passes");
+                panic!("qubit statements should have been eliminated by passes");
             }
             hir::StmtKind::Semi(expr) => fir::StmtKind::Semi(self.lower_expr(expr)),
         };

--- a/compiler/qsc_eval/src/lower.rs
+++ b/compiler/qsc_eval/src/lower.rs
@@ -243,12 +243,9 @@ impl Lowerer {
                 self.lower_pat(pat),
                 self.lower_expr(expr),
             ),
-            hir::StmtKind::Qubit(source, pat, init, block) => fir::StmtKind::Qubit(
-                lower_qubit_source(*source),
-                self.lower_pat(pat),
-                self.lower_qubit_init(init),
-                block.as_ref().map(|b| self.lower_block(b)),
-            ),
+            hir::StmtKind::Qubit(_, _, _, _) => {
+                panic!("qubit statements should have been elimiated by passes");
+            }
             hir::StmtKind::Semi(expr) => fir::StmtKind::Semi(self.lower_expr(expr)),
         };
         let stmt = fir::Stmt {
@@ -401,26 +398,6 @@ impl Lowerer {
         };
         self.pats.insert(id, pat);
         id
-    }
-
-    fn lower_qubit_init(&mut self, init: &hir::QubitInit) -> fir::QubitInit {
-        let id = self.lower_id(init.id);
-        let ty = self.lower_ty(&init.ty);
-        let kind = match &init.kind {
-            hir::QubitInitKind::Array(length) => fir::QubitInitKind::Array(self.lower_expr(length)),
-            hir::QubitInitKind::Single => fir::QubitInitKind::Single,
-            hir::QubitInitKind::Tuple(items) => {
-                fir::QubitInitKind::Tuple(items.iter().map(|i| self.lower_qubit_init(i)).collect())
-            }
-            hir::QubitInitKind::Err => unreachable!("error qubit init should not be present"),
-        };
-
-        fir::QubitInit {
-            id,
-            span: init.span,
-            ty,
-            kind,
-        }
     }
 
     fn lower_id(&mut self, id: hir::NodeId) -> fir::NodeId {
@@ -675,13 +652,6 @@ fn lower_functor(functor: hir::Functor) -> fir::Functor {
     match functor {
         hir::Functor::Adj => fir::Functor::Adj,
         hir::Functor::Ctl => fir::Functor::Ctl,
-    }
-}
-
-fn lower_qubit_source(functor: hir::QubitSource) -> fir::QubitSource {
-    match functor {
-        hir::QubitSource::Dirty => fir::QubitSource::Dirty,
-        hir::QubitSource::Fresh => fir::QubitSource::Fresh,
     }
 }
 

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -885,8 +885,6 @@ pub enum StmtKind {
     Item(LocalItemId),
     /// A let or mutable binding: `let a = b;` or `mutable x = b;`.
     Local(Mutability, PatId, ExprId),
-    /// A use or borrow qubit allocation: `use a = b;` or `borrow a = b;`.
-    Qubit(QubitSource, PatId, QubitInit, Option<BlockId>),
     /// An expression with a trailing semicolon.
     Semi(ExprId),
 }
@@ -902,15 +900,6 @@ impl Display for StmtKind {
                 indent = set_indentation(indent, 1);
                 write!(indent, "\n{lhs}")?;
                 write!(indent, "\n{rhs}")?;
-            }
-            StmtKind::Qubit(s, lhs, rhs, block) => {
-                write!(indent, "Qubit ({s:?})")?;
-                indent = set_indentation(indent, 1);
-                write!(indent, "\n{lhs}")?;
-                write!(indent, "\n{rhs}")?;
-                if let Some(b) = block {
-                    write!(indent, "\n{b}")?;
-                }
             }
             StmtKind::Semi(e) => write!(indent, "Semi: {e}")?,
         }

--- a/compiler/qsc_fir/src/mut_visit.rs
+++ b/compiler/qsc_fir/src/mut_visit.rs
@@ -103,11 +103,6 @@ pub fn walk_stmt<'a>(vis: &mut impl MutVisitor<'a>, id: StmtId) {
             vis.visit_pat(*pat);
             vis.visit_expr(*value);
         }
-        StmtKind::Qubit(_, pat, init, block) => {
-            vis.visit_pat(*pat);
-            vis.visit_qubit_init(init);
-            block.iter().for_each(|b| vis.visit_block(*b));
-        }
     }
 }
 

--- a/compiler/qsc_fir/src/visit.rs
+++ b/compiler/qsc_fir/src/visit.rs
@@ -99,11 +99,6 @@ pub fn walk_stmt<'a>(vis: &mut impl Visitor<'a>, id: StmtId) {
             vis.visit_pat(*pat);
             vis.visit_expr(*value);
         }
-        StmtKind::Qubit(_, pat, init, block) => {
-            vis.visit_pat(*pat);
-            vis.visit_qubit_init(init);
-            block.iter().for_each(|b| vis.visit_block(*b));
-        }
     }
 }
 


### PR DESCRIPTION
This change removes qubit statements from FIR since those are eliminated by HIR passes.