### PR TITLE
Ignore failed PR comment when PRs are from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
                 | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes |`
                 })
               } catch (err) {
-                core.warning(`Failed writting comment to GitHub issue: ${err}`)
+                core.warning(`Failed writing comment on GitHub issue: ${err}`)
               }
             } else {
               console.log("no change in memory usage detected by benchmark");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,17 +178,22 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
+            const core = require('@actions/core');
             if (${{ env.BRANCH_MEASUREMENT }} !== ${{ env.MAIN_MEASUREMENT }}) {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `_Change in memory usage detected by benchmark._
-              ## Memory Report for ${{ github.sha }}
-              | Test                        | This Branch | On Main  |
-              |-----------------------------|-------------|----------|
-              | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes |`
-              })
+              try {
+                github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: `_Change in memory usage detected by benchmark._
+                ## Memory Report for ${{ github.sha }}
+                | Test                        | This Branch | On Main  |
+                |-----------------------------|-------------|----------|
+                | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes |`
+                })
+              } catch (err) {
+                core.warning(`Failed writting comment to GitHub issue.`)
+              }
             } else {
               console.log("no change in memory usage detected by benchmark");
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
 
   status-check:
     name: Status Check
-    needs: [format, clippy, web-check, build, integration-tests, runBenchmark]
+    needs: [format, clippy, web-check, build, integration-tests, runBenchmark, runMemoryProfile]
     runs-on: ubuntu-latest
     if: failure()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,6 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const core = require('@actions/core');
             if (${{ env.BRANCH_MEASUREMENT }} !== ${{ env.MAIN_MEASUREMENT }}) {
               try {
                 github.rest.issues.createComment({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
                 | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes |`
                 })
               } catch (err) {
-                core.warning(`Failed writting comment to GitHub issue.`)
+                core.warning(`Failed writting comment to GitHub issue: ${err}`)
               }
             } else {
               console.log("no change in memory usage detected by benchmark");


### PR DESCRIPTION
`github.rest.issues.createComment({ ... })` is throwing an error when running the memory profile on PRs from forks. We want to treat this failure as warning instead of an error.