### PR TITLE
Support setting classical and quantum random seeds

### DIFF
--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -48,6 +48,7 @@ pub fn generate_qir(
     let mut out = GenericReceiver::new(&mut stdout);
     let result = eval(
         package,
+        None,
         entry_expr.into(),
         &fir_store,
         &mut Env::default(),

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -4,6 +4,7 @@
 use num_bigint::BigUint;
 use num_complex::Complex;
 use quantum_sparse_sim::QuantumSim;
+use rand::RngCore;
 
 use crate::val::Value;
 
@@ -42,6 +43,8 @@ pub trait Backend {
     fn custom_intrinsic(&mut self, _name: &str, _arg: Value) -> Option<Result<Value, String>> {
         None
     }
+
+    fn set_seed(&mut self, _seed: Option<u64>) {}
 }
 
 /// Default backend used when targeting sparse simulation.
@@ -201,6 +204,13 @@ impl Backend for SparseSim {
             | "BeginRepeatEstimatesInternal"
             | "EndRepeatEstimatesInternal" => Some(Ok(Value::unit())),
             _ => None,
+        }
+    }
+
+    fn set_seed(&mut self, seed: Option<u64>) {
+        match seed {
+            Some(seed) => self.sim.set_rng_seed(seed),
+            None => self.sim.set_rng_seed(rand::thread_rng().next_u64()),
         }
     }
 }

--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -12,7 +12,7 @@ use crate::{
     Error,
 };
 use num_bigint::BigInt;
-use rand::Rng;
+use rand::{rngs::StdRng, Rng};
 use std::array;
 
 #[allow(clippy::too_many_lines)]
@@ -22,6 +22,7 @@ pub(crate) fn call(
     arg: Value,
     arg_span: PackageSpan,
     sim: &mut dyn Backend<ResultType = impl Into<val::Result>>,
+    rng: &mut StdRng,
     out: &mut dyn Receiver,
 ) -> Result<Value, Error> {
     match name {
@@ -66,7 +67,7 @@ pub(crate) fn call(
             if lo > hi {
                 Err(Error::EmptyRange(arg_span))
             } else {
-                Ok(Value::Int(rand::thread_rng().gen_range(lo..=hi)))
+                Ok(Value::Int(rng.gen_range(lo..=hi)))
             }
         }
         "DrawRandomDouble" => {
@@ -76,7 +77,7 @@ pub(crate) fn call(
             if lo > hi {
                 Err(Error::EmptyRange(arg_span))
             } else {
-                Ok(Value::Double(rand::thread_rng().gen_range(lo..=hi)))
+                Ok(Value::Double(rng.gen_range(lo..=hi)))
             }
         }
         #[allow(clippy::cast_possible_truncation)]

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -27,7 +27,7 @@ pub(super) fn eval_expr(
     package: PackageId,
     out: &mut impl Receiver,
 ) -> Result<Value, (Error, Vec<Frame>)> {
-    let mut state = State::new(package);
+    let mut state = State::new(package, None);
     let mut env = Env::default();
     state.push_expr(expr);
     let StepResult::Return(value) =

--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -7,6 +7,8 @@ from ._qsharp import (
     run,
     compile,
     estimate,
+    set_quantum_seed,
+    set_classical_seed,
     dump_machine,
 )
 
@@ -27,6 +29,8 @@ __all__ = [
     "init",
     "eval",
     "run",
+    "set_quantum_seed",
+    "set_classical_seed",
     "dump_machine",
     "compile",
     "estimate",

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -89,6 +89,22 @@ class Interpreter:
         :returns resources: The estimated resources.
         """
         ...
+    def set_quantum_seed(self, seed: Optional[int]) -> None:
+        """
+        Sets the seed for the quantum random number generator.
+
+        :param seed: The seed to use for the quantum random number generator. If None,
+            the seed will be generated from entropy.
+        """
+        ...
+    def set_classical_seed(self, seed: Optional[int]) -> None:
+        """
+        Sets the seed for the classical random number generator.
+
+        :param seed: The seed to use for the classical random number generator. If None,
+            the seed will be generated from entropy.
+        """
+        ...
     def dump_machine(self) -> StateDump:
         """
         Returns the sparse state vector of the simulator as a StateDump object.

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -247,7 +247,8 @@ def estimate(
 
 def set_quantum_seed(seed: Optional[int]) -> None:
     """
-    Sets the seed for the quantum random number generator used for measurements.
+    Sets the seed for the random number generator used for quantum measurements.
+    This applies to all Q# code executed, compiled, or estimated.
 
     :param seed: The seed to use for the quantum random number generator.
         If None, the seed will be generated from entropy.
@@ -256,8 +257,9 @@ def set_quantum_seed(seed: Optional[int]) -> None:
 
 def set_classical_seed(seed: Optional[int]) -> None:
     """
-    Sets the seed for the classical random number generator used for standard
-    library random number operations.
+    Sets the seed for the random number generator used for standard
+    library classical random number operations.
+    This applies to all Q# code executed, compiled, or estimated.
 
     :param seed: The seed to use for the classical random number generator.
         If None, the seed will be generated from entropy.

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -245,6 +245,24 @@ def estimate(
         json.loads(get_interpreter().estimate(entry_expr, json.dumps(params)))
     )
 
+def set_quantum_seed(seed: Optional[int]) -> None:
+    """
+    Sets the seed for the quantum random number generator used for measurements.
+
+    :param seed: The seed to use for the quantum random number generator.
+        If None, the seed will be generated from entropy.
+    """
+    get_interpreter().set_quantum_seed(seed)
+
+def set_classical_seed(seed: Optional[int]) -> None:
+    """
+    Sets the seed for the classical random number generator used for standard
+    library random number operations.
+
+    :param seed: The seed to use for the classical random number generator.
+        If None, the seed will be generated from entropy.
+    """
+    get_interpreter().set_classical_seed(seed)
 
 def dump_machine() -> StateDump:
     """

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -153,6 +153,16 @@ impl Interpreter {
         }
     }
 
+    /// Sets the quantum seed for the interpreter.
+    fn set_quantum_seed(&mut self, seed: Option<u64>) {
+        self.interpreter.set_quantum_seed(seed);
+    }
+
+    /// Sets the classical seed for the interpreter.
+    fn set_classical_seed(&mut self, seed: Option<u64>) {
+        self.interpreter.set_classical_seed(seed);
+    }
+
     /// Dumps the quantum state of the interpreter.
     /// Returns a tuple of (amplitudes, num_qubits), where amplitudes is a dictionary from integer indices to
     /// pairs of real and imaginary amplitudes.

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -49,6 +49,24 @@ def test_dump_output() -> None:
     )
     assert called
 
+def test_quantum_seed() -> None:
+    e = Interpreter(TargetProfile.Unrestricted)
+    e.set_quantum_seed(42)
+    value1 = e.interpret("{ use qs = Qubit[16]; for q in qs { H(q); }; Microsoft.Quantum.Measurement.MResetEachZ(qs) }")
+    e = Interpreter(TargetProfile.Unrestricted)
+    e.set_quantum_seed(42)
+    value2 = e.interpret("{ use qs = Qubit[16]; for q in qs { H(q); }; Microsoft.Quantum.Measurement.MResetEachZ(qs) }")
+    assert value1 == value2
+
+def test_classical_seed() -> None:
+    e = Interpreter(TargetProfile.Unrestricted)
+    e.set_classical_seed(42)
+    value1 = e.interpret("{ mutable res = []; for _ in 0..15{ set res += [Microsoft.Quantum.Random.DrawRandomInt(0, 100)]; }; res }")
+    e = Interpreter(TargetProfile.Unrestricted)
+    e.set_classical_seed(42)
+    value2 = e.interpret("{ mutable res = []; for _ in 0..15{ set res += [Microsoft.Quantum.Random.DrawRandomInt(0, 100)]; }; res }")
+    assert value1 == value2
+
 
 def test_dump_machine() -> None:
     e = Interpreter(TargetProfile.Unrestricted)

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -32,6 +32,32 @@ def test_stdout_multiple_lines() -> None:
 
     assert f.getvalue() == "STATE:\n|0⟩: 1.0000+0.0000𝑖\nHello!\n"
 
+def test_quantum_seed() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Unrestricted)
+    qsharp.set_quantum_seed(42)
+    value1 = qsharp.eval("{ use qs = Qubit[32]; for q in qs { H(q); }; Microsoft.Quantum.Measurement.MResetEachZ(qs) }")
+    qsharp.init(target_profile=qsharp.TargetProfile.Unrestricted)
+    qsharp.set_quantum_seed(42)
+    value2 = qsharp.eval("{ use qs = Qubit[32]; for q in qs { H(q); }; Microsoft.Quantum.Measurement.MResetEachZ(qs) }")
+    assert value1 == value2
+    qsharp.set_quantum_seed(None)
+    value3 = qsharp.eval("{ use qs = Qubit[32]; for q in qs { H(q); }; Microsoft.Quantum.Measurement.MResetEachZ(qs) }")
+    assert value1 != value3
+
+
+def test_classical_seed() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Unrestricted)
+    qsharp.set_classical_seed(42)
+    value1 = qsharp.eval("{ mutable res = []; for _ in 0..15{ set res += [(Microsoft.Quantum.Random.DrawRandomInt(0, 100), Microsoft.Quantum.Random.DrawRandomDouble(0.0, 1.0))]; }; res }")
+    qsharp.init(target_profile=qsharp.TargetProfile.Unrestricted)
+    qsharp.set_classical_seed(42)
+    value2 = qsharp.eval("{ mutable res = []; for _ in 0..15{ set res += [(Microsoft.Quantum.Random.DrawRandomInt(0, 100), Microsoft.Quantum.Random.DrawRandomDouble(0.0, 1.0))]; }; res }")
+    assert value1 == value2
+    qsharp.init(target_profile=qsharp.TargetProfile.Unrestricted)
+    qsharp.set_classical_seed(None)
+    value3 = qsharp.eval("{ mutable res = []; for _ in 0..15{ set res += [(Microsoft.Quantum.Random.DrawRandomInt(0, 100), Microsoft.Quantum.Random.DrawRandomDouble(0.0, 1.0))]; }; res }")
+    assert value1 != value3
+
 
 def test_dump_machine() -> None:
     qsharp.init(target_profile=qsharp.TargetProfile.Unrestricted)


### PR DESCRIPTION
This adds new Python APIs `qsharp.set_quantum_seed` and `qsharp.set_classical_seed` that allow users to fix the seed and sequence of random quantum measurements and/or random classical numbers generated from simulating Q#.

Fixes #1013