### PR TITLE
Enable breakpoints across all functors

### DIFF
--- a/vscode/src/debugger/session.ts
+++ b/vscode/src/debugger/session.ts
@@ -642,28 +642,11 @@ export class QscDebugSession extends LoggingDebugSession {
         ];
       });
 
-    // We should probably ensure we don't return duplicate
-    // spans from the debugger, but for now we'll just filter them out
-    const uniqOffsets: [
-      lo: number,
-      hi: number,
-      isLineBreakpoint: boolean,
-      uiLine: number,
-    ][] = [];
-    for (const bpOffset of desiredBpOffsets) {
-      if (
-        uniqOffsets.findIndex(
-          (u) => u[0] == bpOffset[0] && u[1] == bpOffset[1],
-        ) == -1
-      ) {
-        uniqOffsets.push(bpOffset);
-      }
-    }
     // Now that we have the mapped breakpoint span, get the actual breakpoints
     // with corresponding ids from the debugger
     const bps = [];
 
-    for (const bpOffset of uniqOffsets) {
+    for (const bpOffset of desiredBpOffsets) {
       const lo = bpOffset[0];
       const isLineBreakpoint = bpOffset[2];
       const uiLine = bpOffset[3];
@@ -677,9 +660,7 @@ export class QscDebugSession extends LoggingDebugSession {
       // is within the range of the location.
       for (const location of matchingLocations) {
         if (isLineBreakpoint) {
-          //
           bps.push(location.breakpoint);
-          break;
         } else {
           // column bp just has end of selection or cursor location in lo
           if (
@@ -687,7 +668,6 @@ export class QscDebugSession extends LoggingDebugSession {
             lo <= location.fileLocation.endOffset
           ) {
             bps.push(location.breakpoint);
-            break;
           }
         }
       }


### PR DESCRIPTION
- Old behavior
  - Line BP in operation only effects the body functor
  - Line BP on line with multiple statements puts BP on every statement in that line
  - Inline BP in operation will trigger on body functor for selected statement
- New behavior
  - Line BP in operation only effects all functors generated from body with BP
  - Line BP on line with multiple statements puts BP on every statement in that line
  - Inline BP in operation will trigger on all functors generated from the body BP