### PR TITLE
FIR non-mutable visitor does not need mutable getters

### DIFF
--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -590,25 +590,25 @@ impl<'a> Visitor<'a> for BreakpointCollector<'a> {
         };
     }
 
-    fn get_block(&mut self, id: BlockId) -> &'a Block {
+    fn get_block(&self, id: BlockId) -> &'a Block {
         self.package
             .blocks
             .get(id)
             .expect("couldn't find block in FIR")
     }
 
-    fn get_expr(&mut self, id: ExprId) -> &'a Expr {
+    fn get_expr(&self, id: ExprId) -> &'a Expr {
         self.package
             .exprs
             .get(id)
             .expect("couldn't find expr in FIR")
     }
 
-    fn get_pat(&mut self, id: PatId) -> &'a Pat {
+    fn get_pat(&self, id: PatId) -> &'a Pat {
         self.package.pats.get(id).expect("couldn't find pat in FIR")
     }
 
-    fn get_stmt(&mut self, id: StmtId) -> &'a Stmt {
+    fn get_stmt(&self, id: StmtId) -> &'a Stmt {
         self.package
             .stmts
             .get(id)

--- a/compiler/qsc_fir/src/validate.rs
+++ b/compiler/qsc_fir/src/validate.rs
@@ -24,19 +24,19 @@ impl Validator<'_> {
 }
 
 impl<'a> Visitor<'a> for Validator<'a> {
-    fn get_block(&mut self, id: BlockId) -> &'a Block {
+    fn get_block(&self, id: BlockId) -> &'a Block {
         self.package.blocks.get(id).expect("block not found")
     }
 
-    fn get_expr(&mut self, id: ExprId) -> &'a Expr {
+    fn get_expr(&self, id: ExprId) -> &'a Expr {
         self.package.exprs.get(id).expect("expr not found")
     }
 
-    fn get_pat(&mut self, id: PatId) -> &'a Pat {
+    fn get_pat(&self, id: PatId) -> &'a Pat {
         self.package.pats.get(id).expect("pat not found")
     }
 
-    fn get_stmt(&mut self, id: StmtId) -> &'a Stmt {
+    fn get_stmt(&self, id: StmtId) -> &'a Stmt {
         self.package.stmts.get(id).expect("stmt not found")
     }
 }

--- a/compiler/qsc_fir/src/visit.rs
+++ b/compiler/qsc_fir/src/visit.rs
@@ -54,10 +54,10 @@ pub trait Visitor<'a>: Sized {
 
     fn visit_ident(&mut self, _: &'a Ident) {}
 
-    fn get_block(&mut self, id: BlockId) -> &'a Block;
-    fn get_expr(&mut self, id: ExprId) -> &'a Expr;
-    fn get_pat(&mut self, id: PatId) -> &'a Pat;
-    fn get_stmt(&mut self, id: StmtId) -> &'a Stmt;
+    fn get_block(&self, id: BlockId) -> &'a Block;
+    fn get_expr(&self, id: ExprId) -> &'a Expr;
+    fn get_pat(&self, id: PatId) -> &'a Pat;
+    fn get_stmt(&self, id: StmtId) -> &'a Stmt;
 }
 
 pub fn walk_package<'a>(vis: &mut impl Visitor<'a>, package: &'a Package) {


### PR DESCRIPTION
This change updates the `get_*` methods to use an immutable reference to `self` rather than a mutable one.

Note: this helps when implementing callable cycle detection on FIR using the visitor pattern.