### PR TITLE
Use `macos-14` runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,11 @@ jobs:
     name: Build and test
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-14]
         is_pr:
           - ${{ github.event_name == 'pull_request' }}
         exclude:
-          - os: macos-latest
+          - os: macos-14
             is_pr: true
 
     runs-on: ${{matrix.os}}
@@ -95,7 +95,7 @@ jobs:
       - name: Add additional Rust targets
         run: |
           rustup target add aarch64-apple-darwin
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-14'
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -113,11 +113,11 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-14]
         is_pr:
           - ${{ github.event_name == 'pull_request' }}
         exclude:
-          - os: macos-latest
+          - os: macos-14
             is_pr: true
 
     runs-on: ${{matrix.os}}
@@ -134,7 +134,7 @@ jobs:
       - name: Add additional Rust targets
         run: |
           rustup target add aarch64-apple-darwin
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-14'
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           components: ${{ env.RUST_TOOLCHAIN_COMPONENTS }}
       - name: Add additional Rust targets
         run: |
-          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
         if: matrix.os == 'macos-14'
       - uses: actions/setup-python@v4
         with:
@@ -133,7 +133,7 @@ jobs:
           components: ${{ env.RUST_TOOLCHAIN_COMPONENTS }}
       - name: Add additional Rust targets
         run: |
-          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
         if: matrix.os == 'macos-14'
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Now that `macos-14` runners are available broadly, we can use those to get the must faster M1 based builds and actually test on arm64 Mac in CI.

See https://github.com/microsoft/qsharp/actions/runs/7721944262 for successful CI run that includes macOS.