### PR TITLE
Added support for boolean exclusive disjunction in standard library

### DIFF
--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -23,6 +23,7 @@ pub const STD_LIB: &[(&str, &str)] = &[
     ("diagnostics.qs", include_str!("../std/diagnostics.qs")),
     ("internal.qs", include_str!("../std/internal.qs")),
     ("intrinsic.qs", include_str!("../std/intrinsic.qs")),
+    ("logical.qs", include_str!("../std/logical.qs")),
     ("math.qs", include_str!("../std/math.qs")),
     ("measurement.qs", include_str!("../std/measurement.qs")),
     ("qir.qs", include_str!("../std/qir.qs")),

--- a/library/src/tests.rs
+++ b/library/src/tests.rs
@@ -8,6 +8,7 @@ mod arrays;
 mod canon;
 mod convert;
 mod diagnostics;
+mod logical;
 mod math;
 mod measurement;
 mod table_lookup;

--- a/library/src/tests/logical.rs
+++ b/library/src/tests/logical.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::test_expression;
+use qsc::interpret::Value;
+
+// Tests for Microsoft.Quantum.Logical namespace
+
+#[test]
+fn check_xor() {
+    test_expression(
+        "Microsoft.Quantum.Logical.Xor(false, false)",
+        &Value::Bool(false),
+    );
+    test_expression(
+        "Microsoft.Quantum.Logical.Xor(false, true)",
+        &Value::Bool(true),
+    );
+    test_expression(
+        "Microsoft.Quantum.Logical.Xor(true, false)",
+        &Value::Bool(true),
+    );
+    test_expression(
+        "Microsoft.Quantum.Logical.Xor(true, true)",
+        &Value::Bool(false),
+    );
+}

--- a/library/std/logical.qs
+++ b/library/std/logical.qs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Logical {
+
+    /// # Summary
+    /// Returns the boolean exclusive disjunction (XOR) of two input boolean values.
+    ///
+    /// # Input
+    /// ## first
+    /// The first boolean value to be considered.
+    ///
+    /// ## second
+    /// The second boolean value to be considered.
+    ///
+    /// # Output
+    /// A `Bool` which is `true` if and only if exactly one of `first` and `second` is `true`.
+    ///
+    /// # Example
+    /// ```qsharp
+    ///
+    /// let result = Xor(true, false);
+    /// // result is true
+    /// ```
+    function Xor(first : Bool, second : Bool) : Bool {
+        (first or second) and ((not first) or (not second))
+    }
+}

--- a/library/std/logical.qs
+++ b/library/std/logical.qs
@@ -23,6 +23,6 @@ namespace Microsoft.Quantum.Logical {
     /// // result is true
     /// ```
     function Xor(first : Bool, second : Bool) : Bool {
-        (first or second) and ((not first) or (not second))
+        first != second
     }
 }


### PR DESCRIPTION
Fixes #1096 

The motivation is discussed in that issue as well. I put in the `Microsoft.Quantum.Logical` namespace, but we can move it into a different one if needed.