### PR TITLE
Fixed a bunch of typos in Q# standard lib documentation

### DIFF
--- a/library/std/arrays.qs
+++ b/library/std/arrays.qs
@@ -962,7 +962,7 @@ namespace Microsoft.Quantum.Arrays {
     ///
     /// # Input
     /// ## partitionSizes
-    /// Number of elements in each splitted part of array.
+    /// Number of elements in each split part of array.
     /// ## array
     /// Input array to be split.
     ///

--- a/library/std/diagnostics.qs
+++ b/library/std/diagnostics.qs
@@ -80,7 +80,7 @@ namespace Microsoft.Quantum.Diagnostics {
             Adjoint expected(target);
         }
 
-        // Check and resturn result.
+        // Check and return result.
         let areEqual = CheckAllZero(reference) and CheckAllZero(target);
         ResetAll(target);
         ResetAll(reference);

--- a/library/std/internal.qs
+++ b/library/std/internal.qs
@@ -114,9 +114,9 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    /// Collects the given list of control qubits into one or two of the given auxiliarly qubits, using
+    /// Collects the given list of control qubits into one or two of the given auxiliary qubits, using
     /// all but the last qubits in the auxiliary list as scratch qubits. The auxiliary list must be
-    /// big enough to accomodate the data, so it is usually smaller than controls list by number of
+    /// big enough to accommodate the data, so it is usually smaller than controls list by number of
     /// qubits needed for the eventual controlled unitary application. The passed adjustment value is
     /// used to ensure the right number of auxiliary qubits are processed.
     ///

--- a/library/std/math.qs
+++ b/library/std/math.qs
@@ -12,7 +12,7 @@ namespace Microsoft.Quantum.Math {
     /// # Summary
     /// Represents the ratio of the circumference of a circle to its diameter.
     ///
-    /// # Ouptut
+    /// # Output
     /// A double-precision approximation of the the circumference of a circle
     /// to its diameter, π ≈ 3.14159265358979323846.
     ///
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.Math {
     /// Returns the natural logarithmic base to double-precision.
     ///
     /// # Output
-    /// A double-precision approximation of the natural logarithic base,
+    /// A double-precision approximation of the natural logarithmic base,
     /// e ≈ 2.7182818284590452354.
     ///
     /// # See Also
@@ -71,7 +71,7 @@ namespace Microsoft.Quantum.Math {
     /// ## d
     /// The floating-point value to be checked.
     ///
-    /// # Ouput
+    /// # Output
     /// `true` if and only if `d` is either positive or negative infinity.
     ///
     /// # Remarks

--- a/library/std/re.qs
+++ b/library/std/re.qs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.ResourceEstimation {
     /// variant for which they were collected and the current variant is the same.
     ///
     /// # Output
-    /// `true` indicated that the cached estimates are not yet avialable and the code fragment
+    /// `true` indicated that the cached estimates are not yet available and the code fragment
     /// needs to be executed in order to collect and cache estimates.
     /// `false` indicates if cached estimates have been incorporated into the overall costs
     /// and the code fragment should be skipped.
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.ResourceEstimation {
 
     /// # Summary
     /// Returns a tuple that can be passed to the `AccountForEstimates` operation
-    /// to specify that the number of auxilliary qubits is equal to the `amount`.
+    /// to specify that the number of auxiliary qubits is equal to the `amount`.
     function AuxQubitCount(amount : Int) : (Int, Int) {
         return (0, amount);
     }
@@ -104,7 +104,7 @@ namespace Microsoft.Quantum.ResourceEstimation {
 
     /// # Summary
     /// Account for the resource estimates of an unimplemented operation,
-    /// which were obtainted separately. This operation is only available
+    /// which were obtained separately. This operation is only available
     /// when using resource estimator execution target.
     /// # Input
     /// ## cost

--- a/library/std/unstable_arithmetic.qs
+++ b/library/std/unstable_arithmetic.qs
@@ -267,7 +267,7 @@ namespace Microsoft.Quantum.Unstable.Arithmetic {
         Fact(zsLen >= xsLen, "Register `zs` must be no shorter than register `xs`.");
 
         // Since zs is zero-initialized, its bits at indexes higher than
-        // xsLen remain unsued as there will be no carry into them.
+        // xsLen remain unused as there will be no carry into them.
         let top = MinI(zsLen-2, xsLen-1);
         for k in 0 .. top {
             FullAdder(zs[k], xs[k], ys[k], zs[k + 1]);


### PR DESCRIPTION
Found and corrected a bunch of typos and misspellings in the doc strings.