### PR TITLE
Fix error reporting in vscode integration tests

### DIFF
--- a/vscode/test/suites/run.ts
+++ b/vscode/test/suites/run.ts
@@ -30,8 +30,10 @@ export function runMochaTests(requireTestModules: () => void): Promise<void> {
           console.error(
             `[error] ${failures} vscode integration test(s) failed.`,
           );
+          e(new Error(`${failures} vscode integration test(s) failed.`));
+        } else {
+          c();
         }
-        c();
       });
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
I accidentally broke VS Code integration test error reporting with #1015. `run()` should raise an error if any tests fail, but it was swallowing the error after writing to console.

This made it so that CI would succeed even when tests failed. I did manually look through the last few days' runs and didn't see any actual failures.