### PR TITLE
Move the Location struct to a more common place

### DIFF
--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -8,6 +8,7 @@ pub mod compile;
 pub mod error;
 pub mod incremental;
 pub mod interpret;
+pub mod location;
 pub mod target;
 
 pub use qsc_frontend::compile::{

--- a/compiler/qsc/src/location.rs
+++ b/compiler/qsc/src/location.rs
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::sync::Arc;
+
+use qsc_data_structures::{
+    line_column::{Encoding, Range},
+    span::Span,
+};
+use qsc_frontend::compile::PackageStore;
+use qsc_hir::hir::PackageId;
+
+pub const QSHARP_LIBRARY_URI_SCHEME: &str = "qsharp-library-source";
+
+/// Describes a location in source code in terms of a source name and [`Range`].
+#[derive(Debug, PartialEq, Clone)]
+pub struct Location {
+    pub source: Arc<str>,
+    pub range: Range,
+}
+
+impl Location {
+    /// Creates a [`Location`] from a package ID and a SourceMap-relative span.
+    ///
+    /// To differentiate user sources from library sources, this function takes
+    /// a `user_package_id` parameter which denotes the user package.
+    /// All other packages in the package store are assumed to be library packages.
+    /// Source names from library packages are prepended with a unique URI scheme.
+    #[must_use]
+    pub fn from(
+        span: Span,
+        package_id: PackageId,
+        package_store: &PackageStore,
+        user_package_id: PackageId,
+        position_encoding: Encoding,
+    ) -> Self {
+        let source = package_store
+            .get(package_id)
+            .expect("package id must exist in store")
+            .sources
+            .find_by_offset(span.lo)
+            .expect("source should exist for offset");
+
+        let source_name = if package_id == user_package_id {
+            source.name.clone()
+        } else {
+            // Currently the only supported external packages are our library packages,
+            // URI's to which need to include our custom library scheme.
+            format!("{}:{}", QSHARP_LIBRARY_URI_SCHEME, source.name).into()
+        };
+
+        Location {
+            source: source_name,
+            range: Range::from_span(position_encoding, &source.contents, &(span - source.offset)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compile;
+    use expect_test::expect;
+    use qsc_data_structures::{line_column::Encoding, span::Span};
+    use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags, SourceMap};
+    use qsc_hir::hir::PackageId;
+    use qsc_passes::PackageType;
+
+    use super::Location;
+
+    #[test]
+    fn from_std_span() {
+        let (store, std_package_id, user_package_id) = compile_package();
+
+        let location = Location::from(
+            Span { lo: 0, hi: 1 },
+            std_package_id,
+            &store,
+            user_package_id,
+            Encoding::Utf8,
+        );
+
+        expect![[r#"
+            Location {
+                source: "qsharp-library-source:arrays.qs",
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        column: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        column: 1,
+                    },
+                },
+            }
+        "#]]
+        .assert_debug_eq(&location);
+    }
+
+    #[test]
+    fn from_core_span() {
+        let (store, _, user_package_id) = compile_package();
+
+        let location = Location::from(
+            Span { lo: 0, hi: 1 },
+            PackageId::CORE,
+            &store,
+            user_package_id,
+            Encoding::Utf8,
+        );
+
+        expect![[r#"
+            Location {
+                source: "qsharp-library-source:core/core.qs",
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        column: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        column: 1,
+                    },
+                },
+            }
+        "#]]
+        .assert_debug_eq(&location);
+    }
+
+    #[test]
+    fn from_user_span() {
+        let (store, _, user_package_id) = compile_package();
+
+        let bar_start_offset = store
+            .get(user_package_id)
+            .expect("expected to find user package")
+            .sources
+            .find_by_name("bar.qs")
+            .expect("expected to find source")
+            .offset;
+
+        let location = Location::from(
+            Span {
+                lo: bar_start_offset,
+                hi: bar_start_offset + 1,
+            },
+            user_package_id,
+            &store,
+            user_package_id,
+            Encoding::Utf8,
+        );
+
+        expect![[r#"
+            Location {
+                source: "bar.qs",
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        column: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        column: 1,
+                    },
+                },
+            }
+        "#]]
+        .assert_debug_eq(&location);
+    }
+
+    #[test]
+    fn from_out_of_bounds_lo() {
+        let (store, _, user_package_id) = compile_package();
+
+        let location = Location::from(
+            Span { lo: 1000, hi: 2000 },
+            user_package_id,
+            &store,
+            user_package_id,
+            Encoding::Utf8,
+        );
+
+        // Per [`Range`] spec, out of bounds positions map to EOF
+        expect![[r#"
+            Location {
+                source: "bar.qs",
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        column: 17,
+                    },
+                    end: Position {
+                        line: 0,
+                        column: 17,
+                    },
+                },
+            }
+        "#]]
+        .assert_debug_eq(&location);
+    }
+
+    #[test]
+    fn from_out_of_bounds_hi() {
+        let (store, _, user_package_id) = compile_package();
+
+        let location = Location::from(
+            Span { lo: 0, hi: 2000 },
+            user_package_id,
+            &store,
+            user_package_id,
+            Encoding::Utf8,
+        );
+
+        // Per [`Range`] spec, out of bounds positions map to EOF
+        expect![[r#"
+            Location {
+                source: "foo.qs",
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        column: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        column: 17,
+                    },
+                },
+            }
+        "#]]
+        .assert_debug_eq(&location);
+    }
+
+    fn compile_package() -> (PackageStore, PackageId, PackageId) {
+        let mut store = PackageStore::new(compile::core());
+        let mut dependencies = Vec::new();
+
+        let (package_type, capabilities) = (PackageType::Lib, RuntimeCapabilityFlags::all());
+
+        let std = compile::std(&store, capabilities);
+        let std_package_id = store.insert(std);
+
+        dependencies.push(std_package_id);
+        let sources = SourceMap::new(
+            [
+                ("foo.qs".into(), "namespace Foo { }".into()),
+                ("bar.qs".into(), "namespace Bar { }".into()),
+            ],
+            None,
+        );
+        let (unit, _) =
+            compile::compile(&store, &dependencies, sources, package_type, capabilities);
+        let user_package_id = store.insert(unit);
+
+        (store, std_package_id, user_package_id)
+    }
+}

--- a/language_service/src/definition.rs
+++ b/language_service/src/definition.rs
@@ -6,11 +6,11 @@ mod tests;
 
 use crate::compilation::Compilation;
 use crate::name_locator::{Handler, Locator, LocatorContext};
-use crate::protocol::Location;
 use crate::qsc_utils::into_location;
 use qsc::ast::visit::Visitor;
 use qsc::hir::PackageId;
 use qsc::line_column::{Encoding, Position};
+use qsc::location::Location;
 use qsc::{ast, hir, Span};
 
 pub(crate) fn get_definition(

--- a/language_service/src/definition/tests.rs
+++ b/language_service/src/definition/tests.rs
@@ -4,10 +4,10 @@
 #![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::{expect, Expect};
+use qsc::location::Location;
 
 use super::get_definition;
 use crate::{
-    protocol::Location,
     test_utils::{
         compile_notebook_with_fake_stdlib_and_markers, compile_with_fake_stdlib_and_markers,
     },
@@ -26,8 +26,8 @@ fn assert_definition(source_with_markers: &str) {
         None
     } else {
         Some(Location {
-            source: "<source>".to_string(),
-            span: target_spans[0],
+            source: "<source>".into(),
+            range: target_spans[0],
         })
     };
     assert_eq!(&expected_definition, &actual_definition);
@@ -40,10 +40,7 @@ fn assert_definition_notebook(cells_with_markers: &[(&str, &str)]) {
     let expected_definition = if target_spans.is_empty() {
         None
     } else {
-        Some(Location {
-            source: target_spans[0].0.clone(),
-            span: target_spans[0].1,
-        })
+        Some(target_spans[0].clone())
     };
     assert_eq!(&expected_definition, &actual_definition);
 }
@@ -302,7 +299,7 @@ fn std_call() {
             Some(
                 Location {
                     source: "qsharp-library-source:<std>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 1,
                             column: 26,
@@ -410,7 +407,7 @@ fn std_udt() {
             Some(
                 Location {
                     source: "qsharp-library-source:<std>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 4,
                             column: 24,
@@ -442,7 +439,7 @@ fn std_udt_udt_field() {
             Some(
                 Location {
                     source: "qsharp-library-source:<std>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 4,
                             column: 31,

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -37,7 +37,7 @@ fn check_notebook(cells_with_markers: &[(&str, &str)], expect: &Expect) {
 
     let actual =
         get_hover(&compilation, &cell_uri, position, Encoding::Utf8).expect("Expected a hover.");
-    assert_eq!(&actual.span, &target_spans[0].1);
+    assert_eq!(&actual.span, &target_spans[0].range);
     expect.assert_eq(&actual.contents);
 }
 

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -27,10 +27,13 @@ use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures_util::StreamExt;
 use log::{trace, warn};
 use protocol::{
-    CompletionList, DiagnosticUpdate, Hover, Location, NotebookMetadata, SignatureHelp,
+    CompletionList, DiagnosticUpdate, Hover, NotebookMetadata, SignatureHelp,
     WorkspaceConfigurationUpdate,
 };
-use qsc::line_column::{Encoding, Position, Range};
+use qsc::{
+    line_column::{Encoding, Position, Range},
+    location::Location,
+};
 use qsc_project::JSFileEntry;
 use state::{CompilationState, CompilationStateUpdater};
 use std::{cell::RefCell, fmt::Debug, future::Future, pin::Pin, rc::Rc, sync::Arc};

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -87,12 +87,6 @@ impl Hash for CompletionItem {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Location {
-    pub source: String,
-    pub span: Range,
-}
-
-#[derive(Debug, PartialEq)]
 pub struct Hover {
     pub contents: String,
     pub span: Range,

--- a/language_service/src/references.rs
+++ b/language_service/src/references.rs
@@ -8,12 +8,12 @@ use std::rc::Rc;
 
 use crate::compilation::{Compilation, Lookup};
 use crate::name_locator::{Handler, Locator, LocatorContext};
-use crate::protocol::Location;
 use crate::qsc_utils::into_location;
 use qsc::ast::visit::{walk_callable_decl, walk_expr, walk_ty, Visitor};
 use qsc::hir::ty::Ty;
 use qsc::hir::{PackageId, Res};
 use qsc::line_column::{Encoding, Position};
+use qsc::location::Location;
 use qsc::{ast, hir, resolve, Span};
 
 pub(crate) fn get_references(

--- a/language_service/src/references/tests.rs
+++ b/language_service/src/references/tests.rs
@@ -5,7 +5,6 @@
 
 use super::get_references;
 use crate::{
-    protocol,
     test_utils::{
         compile_notebook_with_fake_stdlib_and_markers, compile_with_fake_stdlib_and_markers,
     },
@@ -43,7 +42,7 @@ fn check(source_with_markers: &str, include_declaration: bool) {
         include_declaration,
     )
     .into_iter()
-    .map(|l| l.span)
+    .map(|l| l.range)
     .collect::<Vec<_>>();
     for target in &target_spans {
         assert!(
@@ -71,10 +70,7 @@ fn check_notebook_exclude_decl(cells_with_markers: &[(&str, &str)]) {
         .collect::<Vec<_>>();
     for target in &target_spans {
         assert!(
-            actual.contains(&protocol::Location {
-                source: target.0.clone(),
-                span: target.1
-            }),
+            actual.contains(target),
             "expected {actual:?} to contain {target:?}"
         );
     }
@@ -98,7 +94,7 @@ fn std_callable_ref() {
             [
                 Location {
                     source: "qsharp-library-source:<std>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 1,
                             column: 26,
@@ -111,7 +107,7 @@ fn std_callable_ref() {
                 },
                 Location {
                     source: "<source>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 3,
                             column: 8,
@@ -124,7 +120,7 @@ fn std_callable_ref() {
                 },
                 Location {
                     source: "<source>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 5,
                             column: 8,
@@ -255,7 +251,7 @@ fn std_udt_ref() {
             [
                 Location {
                     source: "qsharp-library-source:<std>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 4,
                             column: 24,
@@ -268,7 +264,7 @@ fn std_udt_ref() {
                 },
                 Location {
                     source: "<source>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 2,
                             column: 22,
@@ -345,7 +341,7 @@ fn std_field_ref() {
             [
                 Location {
                     source: "qsharp-library-source:<std>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 4,
                             column: 31,
@@ -358,7 +354,7 @@ fn std_field_ref() {
                 },
                 Location {
                     source: "<source>",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 4,
                             column: 23,

--- a/language_service/src/rename.rs
+++ b/language_service/src/rename.rs
@@ -6,11 +6,11 @@ mod tests;
 
 use crate::compilation::{Compilation, Lookup};
 use crate::name_locator::{Handler, Locator, LocatorContext};
-use crate::protocol::Location;
 use crate::qsc_utils::into_range;
 use crate::references::ReferenceFinder;
 use qsc::ast::visit::Visitor;
 use qsc::line_column::{Encoding, Position, Range};
+use qsc::location::Location;
 use qsc::{ast, hir, resolve, Span};
 
 pub(crate) fn prepare_rename(
@@ -126,9 +126,9 @@ impl<'a> Rename<'a> {
                 .for_ty_param(param_id, current_callable)
                 .into_iter()
                 .map(|l| {
-                    assert!(!l.span.empty(), "Type parameter name is empty");
+                    assert!(!l.range.empty(), "Type parameter name is empty");
                     Location {
-                        span: type_param_ident_range(l.span),
+                        range: type_param_ident_range(l.range),
                         ..l
                     }
                 })

--- a/language_service/src/rename/tests.rs
+++ b/language_service/src/rename/tests.rs
@@ -20,7 +20,7 @@ fn check(source_with_markers: &str) {
         compile_with_fake_stdlib_and_markers(source_with_markers);
     let actual = get_rename(&compilation, "<source>", cursor_position, Encoding::Utf8)
         .into_iter()
-        .map(|l| l.span)
+        .map(|l| l.range)
         .collect::<Vec<_>>();
     for target in &target_spans {
         assert!(actual.contains(target));
@@ -391,7 +391,7 @@ fn notebook_rename_across_cells() {
             [
                 Location {
                     source: "cell1",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 0,
                             column: 10,
@@ -404,7 +404,7 @@ fn notebook_rename_across_cells() {
                 },
                 Location {
                     source: "cell2",
-                    span: Range {
+                    range: Range {
                         start: Position {
                             line: 0,
                             column: 0,

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -239,10 +239,13 @@ impl LanguageService {
 
         let mut renames: FxHashMap<String, Vec<TextEdit>> = FxHashMap::default();
         locations.into_iter().for_each(|l| {
-            renames.entry(l.source).or_default().push(TextEdit {
-                range: l.span.into(),
-                newText: new_name.to_string(),
-            })
+            renames
+                .entry(l.source.to_string())
+                .or_default()
+                .push(TextEdit {
+                    range: l.range.into(),
+                    newText: new_name.to_string(),
+                })
         });
 
         let workspace_edit = WorkspaceEdit {
@@ -262,15 +265,6 @@ impl LanguageService {
             }
             .into()
         })
-    }
-}
-
-impl From<qsls::protocol::Location> for Location {
-    fn from(location: qsls::protocol::Location) -> Self {
-        Location {
-            source: location.source,
-            span: location.span.into(),
-        }
     }
 }
 

--- a/wasm/src/line_column.rs
+++ b/wasm/src/line_column.rs
@@ -70,3 +70,12 @@ impl From<qsc::line_column::Range> for Range {
         }
     }
 }
+
+impl From<qsc::location::Location> for Location {
+    fn from(location: qsc::location::Location) -> Self {
+        Location {
+            source: location.source.to_string(),
+            span: location.range.into(),
+        }
+    }
+}


### PR DESCRIPTION
A `Location` refers to a span within a specific source file. It's expressed as a source name and `Range`. See: https://github.com/microsoft/vscode/blob/7923151da4b3567636c1346df9e8ba682744bbf3/src/vscode-dts/vscode.d.ts#L6581

It was defined in the language service protocol, but I'm moving it to a more common location in `compiler/qsc` since I need the debugger to use it in #1107.

To summarize this PR and #1038, here's how locations are represented in the compiler vs. higher-level components that interface with VS Code (debugger, language service):
 
| Compiler representation | Line/column representation |
|---|---|
| `u32` offset (into `SourceMap`) | `Position` (into specific source file) |
| `Span` | `Range` |
| (`PackageId`, `Span`) | `Location` |

