### PR TITLE
Prefer open file contents to disk contents

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -397,7 +397,12 @@
           }
         }
       }
-    ]
+    ],
+    "configurationDefaults": {
+      "[qsharp]": {
+        "debug.saveBeforeStart": "none"
+      }
+    }
   },
   "scripts": {
     "build": "npm run tsc:check && node build.mjs",


### PR DESCRIPTION
This seems like what we should be doing anyway, but has the benefit that when using the language service or the debugger in a multi-file project, then everything just works even if the files haven't been saved to disk yet.

Putting up early for review, but in initial testing looked to behave as expected.