### PR TITLE
use relevant icon for locals completion

### DIFF
--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -228,6 +228,9 @@ function registerMonacoLanguageServiceProviders(
             case "variable":
               kind = monaco.languages.CompletionItemKind.Variable;
               break;
+            case "typeParameter":
+              kind = monaco.languages.CompletionItemKind.TypeParameter;
+              break;
             case "module":
               kind = monaco.languages.CompletionItemKind.Module;
               break;

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -225,6 +225,9 @@ function registerMonacoLanguageServiceProviders(
             case "keyword":
               kind = monaco.languages.CompletionItemKind.Keyword;
               break;
+            case "variable":
+              kind = monaco.languages.CompletionItemKind.Variable;
+              break;
             case "module":
               kind = monaco.languages.CompletionItemKind.Module;
               break;

--- a/vscode/src/completion.ts
+++ b/vscode/src/completion.ts
@@ -61,6 +61,9 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
         case "keyword":
           kind = vscode.CompletionItemKind.Keyword;
           break;
+        case "variable":
+          kind = vscode.CompletionItemKind.Variable;
+          break;
         case "module":
           kind = vscode.CompletionItemKind.Module;
           break;

--- a/vscode/src/completion.ts
+++ b/vscode/src/completion.ts
@@ -64,6 +64,9 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
         case "variable":
           kind = vscode.CompletionItemKind.Variable;
           break;
+        case "typeParameter":
+          kind = vscode.CompletionItemKind.TypeParameter;
+          break;
         case "module":
           kind = vscode.CompletionItemKind.Module;
           break;


### PR DESCRIPTION
https://github.com/microsoft/qsharp/pull/880 added support for locals in completion list. 
What was still missing in the Monaco playground and VS Code extension is mapping to the relevant icon.

Before:
<img width="607" alt="Bildschirmfoto 2024-02-02 um 15 59 11" src="https://github.com/microsoft/qsharp/assets/1710369/2759d98c-e528-4510-9fb0-b25e145e5032">

After:
<img width="538" alt="Bildschirmfoto 2024-02-02 um 15 58 35" src="https://github.com/microsoft/qsharp/assets/1710369/d5e043b5-fbb5-4335-95cb-57655cf19b4d">
