### PR TITLE
Fix BOM handling in Python

### DIFF
--- a/pip/qsharp/_fs.py
+++ b/pip/qsharp/_fs.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Tuple
 
 
 def read_file(path: str) -> Tuple[str, str]:
-    with open(path, mode="r", encoding="utf-8") as f:
+    with open(path, mode="r", encoding="utf-8-sig") as f:
         return (path, f.read())
 
 


### PR DESCRIPTION
Use `utf-8-sig` when opening a file to interpret the BOM if it exists.

Fixes #1099