### PR TITLE
Fix `documenttype` for `OpenedDocument` event

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -105,10 +105,10 @@ function registerDocumentUpdateHandlers(languageService: ILanguageService) {
   const subscriptions = [];
   subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {
-      const documentType = isQsharpDocument(document)
-        ? QsharpDocumentType.Qsharp
-        : isQsharpNotebookCell(document)
+      const documentType = isQsharpNotebookCell(document)
         ? QsharpDocumentType.JupyterCell
+        : isQsharpDocument(document)
+        ? QsharpDocumentType.Qsharp
         : QsharpDocumentType.Other;
       if (documentType !== QsharpDocumentType.Other) {
         sendTelemetryEvent(


### PR DESCRIPTION
The `OpenedDocument` event includes either `Qsharp` or `JupyterCell` for its document type, but the query was causing all documents to be treated as `Qsharp`. Swapping the ordering so we can correctly distinguish cells for this event.