### PR TITLE
Fix state ordering in Python

### DIFF
--- a/pip/src/displayable_output.rs
+++ b/pip/src/displayable_output.rs
@@ -7,11 +7,10 @@ mod tests;
 use num_bigint::BigUint;
 use num_complex::{Complex64, ComplexFloat};
 use qsc::{fmt_basis_state_label, fmt_complex, format_state_id, get_phase};
-use rustc_hash::FxHashMap;
 use std::fmt::Write;
 
 #[derive(Clone)]
-pub struct DisplayableState(pub FxHashMap<BigUint, Complex64>, pub usize);
+pub struct DisplayableState(pub Vec<(BigUint, Complex64)>, pub usize);
 
 impl DisplayableState {
     pub fn to_plain(&self) -> String {

--- a/pip/src/displayable_output/tests.rs
+++ b/pip/src/displayable_output/tests.rs
@@ -3,18 +3,12 @@
 
 use num_bigint::BigUint;
 use num_complex::Complex;
-use rustc_hash::FxHashMap;
 
 use crate::displayable_output::DisplayableState;
 
 #[test]
 fn display_neg_zero() {
-    let s = DisplayableState(
-        vec![(BigUint::default(), Complex::new(-0.0, -0.0))]
-            .into_iter()
-            .collect::<FxHashMap<_, _>>(),
-        1,
-    );
+    let s = DisplayableState(vec![(BigUint::default(), Complex::new(-0.0, -0.0))], 1);
     // -0 should be displayed as 0.0000 without a minus sign
     assert_eq!("STATE:\n|0⟩: 0.0000+0.0000𝑖", s.to_plain());
 }
@@ -22,11 +16,26 @@ fn display_neg_zero() {
 #[test]
 fn display_rounds_to_neg_zero() {
     let s = DisplayableState(
-        vec![(BigUint::default(), Complex::new(-0.00001, -0.00001))]
-            .into_iter()
-            .collect::<FxHashMap<_, _>>(),
+        vec![(BigUint::default(), Complex::new(-0.00001, -0.00001))],
         1,
     );
     // -0.00001 should be displayed as 0.0000 without a minus sign
     assert_eq!("STATE:\n|0⟩: 0.0000+0.0000𝑖", s.to_plain());
+}
+
+#[test]
+fn display_preserves_order() {
+    let s = DisplayableState(
+        vec![
+            (BigUint::from(0_u64), Complex::new(0.0, 0.0)),
+            (BigUint::from(1_u64), Complex::new(0.0, 1.0)),
+            (BigUint::from(2_u64), Complex::new(1.0, 0.0)),
+            (BigUint::from(3_u64), Complex::new(1.0, 1.0)),
+        ],
+        2,
+    );
+    assert_eq!(
+        "STATE:\n|00⟩: 0.0000+0.0000𝑖\n|01⟩: 0.0000+1.0000𝑖\n|10⟩: 1.0000+0.0000𝑖\n|11⟩: 1.0000+1.0000𝑖",
+        s.to_plain()
+    );
 }


### PR DESCRIPTION
This change uses the vector returned from the internals directly rather than converting into a hashmap so that the state ordering can be preserved for display.

Fixes #1119

Before:
![image](https://github.com/microsoft/qsharp/assets/10567287/4ff3d4d1-021b-4b27-b797-266312cc13cc)

After:
![image](https://github.com/microsoft/qsharp/assets/10567287/eff67e4e-a756-45e3-b246-16829f9befcf)
