### PR TITLE
Explicitly allow commenting permissions for CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,9 @@ jobs:
   runBenchmark:
     name: run benchmark
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: boa-dev/criterion-compare-action@v3
@@ -161,6 +164,9 @@ jobs:
   runMemoryProfile:
     name: run memory profile
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This change adapts to the recent GitHub default token permissions update by allowing our CI actions the right permissions to write back to PRs.