### PR TITLE
Switch to `x-ms-useragent` in Azure requests

### DIFF
--- a/vscode/src/azure/networkRequests.ts
+++ b/vscode/src/azure/networkRequests.ts
@@ -24,7 +24,7 @@ export async function azureRequest(
   const headers: [string, string][] = [
     ["Authorization", `Bearer ${token}`],
     ["Content-Type", "application/json"],
-    ["User-Agent", getUserAgent()],
+    ["x-ms-useragent", getUserAgent()],
   ];
 
   try {
@@ -81,7 +81,7 @@ export async function storageRequest(
   const headers: [string, string][] = [
     ["x-ms-version", "2023-01-03"],
     ["x-ms-date", new Date().toUTCString()],
-    ["User-Agent", getUserAgent()],
+    ["x-ms-useragent", getUserAgent()],
   ];
   if (token) headers.push(["Authorization", `Bearer ${token}`]);
 

--- a/vscode/src/telemetry.ts
+++ b/vscode/src/telemetry.ts
@@ -266,7 +266,7 @@ function getBrowserRelease(): string {
       navigator.userAgentData.brands[navigator.userAgentData.brands.length - 1];
     return `${browser.brand}/${browser.version}`;
   } else {
-    return "";
+    return navigator.userAgent;
   }
 }
 


### PR DESCRIPTION
Also: default to full user agent string if `userAgentData` is unavailable