### PR TITLE
Wi12559 - Restore missing text.

### DIFF
--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -384,11 +384,7 @@ The identity gate is mostly here for completeness, at least for now. It will com
 </tr>
 <tr>
 <td style=\"text-align:center; border:1px solid\">$I$</td>
-<td style=\"text-align:center; border:1px solid\">
-$$
-\begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}
-$$
-</td>
+<td style=\"text-align:center; border:1px solid\">$\begin{bmatrix} 1 & 0 \ 0 & 1 \end{bmatrix}$</td>
 <td style=\"text-align:center; border:1px solid\">$|0\rangle\langle0| + |1\rangle\langle1|$</td>
 <td style=\"text-align:center; border:1px solid\">$I|\psi\rangle = |\psi\rangle$</td>
 <td style=\"text-align:center; border:1px solid\"><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.i\">I</a></td>

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -386,7 +386,7 @@ The identity gate is mostly here for completeness, at least for now. It will com
 <td style=\"text-align:center; border:1px solid\">$I$</td>
 <td style=\"text-align:center; border:1px solid\">
 $$
-\begin{bmatrix} 1 & 0 \ 0 & 1 \end{bmatrix}
+\begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}
 $$
 </td>
 <td style=\"text-align:center; border:1px solid\">$|0\rangle\langle0| + |1\rangle\langle1|$</td>

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -421,7 +421,7 @@ H|-i\rangle = e^{-i\pi/4}|i\rangle $</td>
 </tr>
 </table>
 
-> As a reminder, $e^{i\pi/4} = \frac{1}{\sqrt2} (1 + i)$ and $e^{-i\pi/4} = \frac{1}{\sqrt2} (1 - i)$. This is an application of Eulers formula, $e^{i\theta} = \cos \theta + i\sin \theta$, where $\theta$ is measured in radians.
+> As a reminder, $e^{i\pi/4} = \frac{1}{\sqrt2} (1 + i)$ and $e^{-i\pi/4} = \frac{1}{\sqrt2} (1 - i)$. This is an application of Euler's formula, $e^{i\theta} = \cos \theta + i\sin \theta$, where $\theta$ is measured in radians.
 > See this [Wikipedia article](https://en.wikipedia.org/wiki/Euler%27s_formula) for an explanation of Euler's formula and/or [this video](https://youtu.be/v0YEaeIClKY) for a more intuitive explanation.
 
 @[exercise]({

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -384,7 +384,11 @@ The identity gate is mostly here for completeness, at least for now. It will com
 </tr>
 <tr>
 <td style=\"text-align:center; border:1px solid\">$I$</td>
-<td style=\"text-align:center; border:1px solid\">$\begin{bmatrix} 1 & 0 \ 0 & 1 \end{bmatrix}$</td>
+<td style=\"text-align:center; border:1px solid\">
+$$
+\begin{bmatrix} 1 & 0 \ 0 & 1 \end{bmatrix}
+$$
+</td>
 <td style=\"text-align:center; border:1px solid\">$|0\rangle\langle0| + |1\rangle\langle1|$</td>
 <td style=\"text-align:center; border:1px solid\">$I|\psi\rangle = |\psi\rangle$</td>
 <td style=\"text-align:center; border:1px solid\"><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.i\">I</a></td>

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -421,8 +421,8 @@ H|-i\rangle = e^{-i\pi/4}|i\rangle $</td>
 </tr>
 </table>
 
-> As a reminder, $e^{i\pi/4} = \frac{1}{\sqrt2} (1 + i)$ and $e^{-i\pi/4} = \frac{1}{\sqrt2} (1 - i)$.
-> If you need a refresher on calculating expressions like $e^{i\theta}$, you should review the section on [complex exponentiation](../ComplexArithmetic/ComplexArithmetic.ipynb#Imaginary-Exponents).
+> As a reminder, $e^{i\pi/4} = \frac{1}{\sqrt2} (1 + i)$ and $e^{-i\pi/4} = \frac{1}{\sqrt2} (1 - i)$. This is an application of Eulers formula, $e^{i\theta} = \cos \theta + i\sin \theta$, where $\theta$ is measured in radians.
+> See this [Wikipedia article](https://en.wikipedia.org/wiki/Euler%27s_formula) for an explanation of Eulers formula and/or [this video](https://youtu.be/v0YEaeIClKY) for a more intuitive explanation.
 
 @[exercise]({
     "id": "single_qubit_gates__prepare_minus",

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -523,7 +523,11 @@ Note that for the first three gates the parameter $\theta$ is multiplied by $\fr
   </tr>
   <tr>
     <td>$R_x(\theta)$</td>
-    <td>$\begin{bmatrix} \cos\frac{\theta}{2} & -i\sin\frac{\theta}{2} \\\ -i\sin\frac{\theta}{2} & \cos\frac{\theta}{2} \end{bmatrix}$</td>
+    <td>
+    $$
+    \begin{bmatrix} \cos\frac{\theta}{2} & -i\sin\frac{\theta}{2} \\\ -i\sin\frac{\theta}{2} & \cos\frac{\theta}{2} \end{bmatrix}
+    $$
+    </td>
     <td>$R_x(\theta)|\psi\rangle = (\alpha\cos\frac{\theta}{2} - i\beta\sin\frac{\theta}{2})|0\rangle + (\beta\cos\frac{\theta}{2} - i\alpha\sin\frac{\theta}{2})|1\rangle$</td>
     <td>
       $R_x(\theta)|0\rangle = \cos\frac{\theta}{2}|0\rangle - i\sin\frac{\theta}{2}|1\rangle$<br>
@@ -563,7 +567,7 @@ Note that for the first three gates the parameter $\theta$ is multiplied by $\fr
   </tr>
 </table>
 
-You have already encountered some special cases of the $R_1$ gate: 
+You have already encountered some special cases of the $R_1$ gate:
 
 $$T = R_1(\frac{\pi}{4}), S = R_1(\frac{\pi}{2}), Z = R_1(\pi)$$
 

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -247,7 +247,6 @@ The Pauli gates, named after <a href="https://en.wikipedia.org/wiki/Wolfgang_Pau
     <th>Ket-Bra</th>
     <th>Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
     <th>Applying to basis states</th>
-    <th>Q# Documentation</th>
   </tr>
   <tr>
     <td>$X$</td>
@@ -262,7 +261,6 @@ The Pauli gates, named after <a href="https://en.wikipedia.org/wiki/Wolfgang_Pau
       $X|i\rangle = i|-i\rangle$<br>
       $X|-i\rangle = -i|i\rangle$
     </td>
-    <td><a href="https://learn.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.intrinsic.x" target="_blank">X</a></td>
   </tr>
   <tr>
     <td>$Y$</td>
@@ -277,7 +275,6 @@ The Pauli gates, named after <a href="https://en.wikipedia.org/wiki/Wolfgang_Pau
       $Y|i\rangle = |i\rangle$<br>
       $Y|-i\rangle = -|-i\rangle$<br>
     </td>
-    <td><a href="https://learn.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.intrinsic.y" target="_blank">Y</a></td>
   </tr>
   <tr>
     <td>$Z$</td>
@@ -292,7 +289,6 @@ The Pauli gates, named after <a href="https://en.wikipedia.org/wiki/Wolfgang_Pau
       $Z|i\rangle = |-i\rangle$<br>
       $Z|-i\rangle = |i\rangle$<br>
     </td>
-    <td><a href="https://learn.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.intrinsic.z" target="_blank">Z</a></td>
   </tr>
 </table>
 
@@ -325,7 +321,7 @@ X(q);
 Z(q);
 ```
 
-All the basic gates we will be covering in this kata are part of the <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic" target="_blank">Intrinsic</a> namespace. We're also using the function <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.diagnostics.dumpmachine" target="_blank">DumpMachine</a> to print the state of the quantum simulator.
+All the basic gates we will be covering in this kata are part of the Intrinsic namespace. We're also using the function DumpMachine to print the state of the quantum simulator.
 
 @[example]({"id": "single_qubit_gates__pauli_gates_in_qsharp_demo", "codePath": "./examples/PauliGates.qs"})
 
@@ -378,14 +374,12 @@ The identity gate is mostly here for completeness, at least for now. It will com
 <th>Matrix</th>
 <th>Ket-Bra</th>
 <th>Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
-<th>Q# Documentation</th>
 </tr>
 <tr>
 <td>$I$</td>
 <td>$\begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}$</td>
 <td>$|0\rangle\langle0| + |1\rangle\langle1|$</td>
 <td>$I|\psi\rangle = |\psi\rangle$</td>
-<td><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.i\">I</a></td>
 </tr>
 </table>
 
@@ -404,20 +398,18 @@ Like the Pauli gates, the Hadamard gate is self-adjoint.
 <th>Ket-Bra</th>
 <th>Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
 <th>Applying to basis states</th>
-<th>Q# Documentation</th>
 </tr>
 <tr>
 <td>$H$</td>
 <td>$\begin{bmatrix} \frac{1}{\sqrt{2}} & \frac{1}{\sqrt{2}} \\ \frac{1}{\sqrt{2}} & -\frac{1}{\sqrt{2}} \end{bmatrix} = \frac{1}{\sqrt{2}}\begin{bmatrix} 1 & 1 \\ 1 & -1 \end{bmatrix}$</td>
 <td>$|0\rangle\langle+| + |1\rangle\langle-|$</td>
 <td>$H|\psi\rangle = \alpha|+\rangle + \beta|-\rangle = \frac{\alpha + \beta}{\sqrt{2}}|0\rangle + \frac{\alpha - \beta}{\sqrt{2}}|1\rangle$</td>
-<td>$H|0\rangle = |+\rangle \\
-H|1\rangle = |-\rangle \\
-H|+\rangle = |0\rangle \\
-H|-\rangle = |1\rangle \\
-H|i\rangle = e^{i\pi/4}|-i\rangle \\
-H|-i\rangle = e^{-i\pi/4}|i\rangle $</td>
-<td><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.h\">H</a></td>
+<td>$H|0\rangle = |+\rangle$ <br>
+$H|1\rangle = |-\rangle$ <br>
+$H|+\rangle = |0\rangle$ <br>
+$H|-\rangle = |1\rangle$ <br>
+$H|i\rangle = e^{i\pi/4}|-i\rangle$ <br>
+$H|-i\rangle = e^{-i\pi/4}|i\rangle $ <br>
 </tr>
 </table>
 
@@ -450,11 +442,10 @@ The next two gates are known as phase shift gates. They apply a phase to the $|1
     <th>Ket-Bra</th>
     <th>Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
     <th>Applying to basis states</th>
-    <th>Q# Documentation</th>
-  </tr>
+    </tr>
   <tr>
     <td>$S$</td>
-    <td>$\begin{bmatrix} 1 & 0 \\\ 0 & i \end{bmatrix}$</td>
+    <td>$\begin{bmatrix} 1 & 0 \\ 0 & i \end{bmatrix}$</td>
     <td>$|0\rangle\langle0| + i|1\rangle\langle1|$</td>
     <td>$S|\psi\rangle = \alpha|0\rangle + i\beta|1\rangle$</td>
     <td>
@@ -465,8 +456,7 @@ The next two gates are known as phase shift gates. They apply a phase to the $|1
       $S|i\rangle = |-\rangle$<br>
       $S|-i\rangle = |+\rangle$<br>
     </td>
-    <td><a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.s" target="_blank">S</a></td>
-  </tr>
+    </tr>
   <tr>
     <td>$T$</td>
     <td>$\begin{bmatrix} 1 & 0 \\\ 0 & e^{i\pi/4} \end{bmatrix}$</td>
@@ -476,7 +466,6 @@ The next two gates are known as phase shift gates. They apply a phase to the $|1
       $T|0\rangle = |0\rangle$<br>
       $T|1\rangle = e^{i\pi/4}|1\rangle$
     </td>
-    <td><a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.t" target="_blank">T</a></td>
   </tr>
 </table>
 
@@ -514,8 +503,7 @@ Note that for the first three gates the parameter $\theta$ is multiplied by $\fr
     <th>Matrix</th>
     <th>Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
     <th>Applying to basis states</th>
-    <th>Q# Documentation</th>
-  </tr>
+   </tr>
   <tr>
     <td>$R_x(\theta)$</td>
     <td>
@@ -528,8 +516,7 @@ Note that for the first three gates the parameter $\theta$ is multiplied by $\fr
       $R_x(\theta)|0\rangle = \cos\frac{\theta}{2}|0\rangle - i\sin\frac{\theta}{2}|1\rangle$<br>
       $R_x(\theta)|1\rangle = \cos\frac{\theta}{2}|1\rangle - i\sin\frac{\theta}{2}|0\rangle$
     </td>
-    <td><a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.rx" target="_blank">Rx</a></td>
-  </tr>
+   </tr>
   <tr>
     <td>$R_y(\theta)$</td>
     <td>$\begin{bmatrix} \cos\frac{\theta}{2} & -\sin\frac{\theta}{2} \\\ \sin\frac{\theta}{2} & \cos\frac{\theta}{2} \end{bmatrix}$</td>
@@ -538,8 +525,7 @@ Note that for the first three gates the parameter $\theta$ is multiplied by $\fr
       $R_y(\theta)|0\rangle = \cos\frac{\theta}{2}|0\rangle + \sin\frac{\theta}{2}|1\rangle$<br>
       $R_y(\theta)|1\rangle = \cos\frac{\theta}{2}|1\rangle - \sin\frac{\theta}{2}|0\rangle$
     </td>
-    <td><a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.ry" target="_blank">Ry</a></td>
-  </tr>
+    </tr>
   <tr>
     <td>$R_z(\theta)$</td>
     <td>$\begin{bmatrix} e^{-i\theta/2} & 0 \\\ 0 & e^{i\theta/2} \end{bmatrix}$</td>
@@ -548,7 +534,6 @@ Note that for the first three gates the parameter $\theta$ is multiplied by $\fr
       $R_z(\theta)|0\rangle = e^{-i\theta/2}|0\rangle$<br>
       $R_z(\theta)|1\rangle = e^{i\theta/2}|1\rangle$
     </td>
-    <td><a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.rz" target="_blank">Rz</a></td>
   </tr>
   <tr>
     <td>$R_1(\theta)$</td>
@@ -558,7 +543,6 @@ Note that for the first three gates the parameter $\theta$ is multiplied by $\fr
       $R_1(\theta)|0\rangle = |0\rangle$<br>
       $R_1(\theta)|1\rangle = e^{i\theta}|1\rangle$
     </td>  
-    <td><a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.r1" target="_blank">R1</a></td>
   </tr>
 </table>
 

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -372,25 +372,20 @@ All the basic gates we will be covering in this kata are part of the <a href="ht
 
 The identity gate is mostly here for completeness, at least for now. It will come in handy when dealing with multi-qubit systems and multi-qubit gates. It is represented by the identity matrix, and does not affect the state of the qubit.
   
-<table style=\"border:1px solid\">
-<col width=50>
-<col width=50>
-<col width=150>
-<col width=200>
-<col width=50>
+<table>
 <tr>
-<th style=\"text-align:center; border:1px solid\">Gate</th>
-<th style=\"text-align:center; border:1px solid\">Matrix</th>
-<th style=\"text-align:center; border:1px solid\">Ket-Bra</th>
-<th style=\"text-align:center; border:1px solid\">Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
-<th style=\"text-align:center; border:1px solid\">Q# Documentation</th>
+<th>Gate</th>
+<th>Matrix</th>
+<th>Ket-Bra</th>
+<th>Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
+<th>Q# Documentation</th>
 </tr>
 <tr>
-<td style=\"text-align:center; border:1px solid\">$I$</td>
-<td style=\"text-align:center; border:1px solid\">$\begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}$</td>
-<td style=\"text-align:center; border:1px solid\">$|0\rangle\langle0| + |1\rangle\langle1|$</td>
-<td style=\"text-align:center; border:1px solid\">$I|\psi\rangle = |\psi\rangle$</td>
-<td style=\"text-align:center; border:1px solid\"><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.i\">I</a></td>
+<td>$I$</td>
+<td>$\begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}$</td>
+<td>$|0\rangle\langle0| + |1\rangle\langle1|$</td>
+<td>$I|\psi\rangle = |\psi\rangle$</td>
+<td><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.i\">I</a></td>
 </tr>
 </table>
 
@@ -402,33 +397,27 @@ The identity gate is mostly here for completeness, at least for now. It will com
 The **Hadamard** gate is an extremely important quantum gate. Unlike the previous gates, applying the Hadamard gate to a qubit in a computational basis state puts that qubit into a superposition.
 Like the Pauli gates, the Hadamard gate is self-adjoint.
 
-<table style=\"border:1px solid\">
-<col width=50>
-<col width=200>
-<col width=150>
-<col width=260>
-<col width=150>
-<col width=50>
+<table>
 <tr>
-<th style=\"text-align:center; border:1px solid\">Gate</th>
-<th style=\"text-align:center; border:1px solid\">Matrix</th>
-<th style=\"text-align:center; border:1px solid\">Ket-Bra</th>
-<th style=\"text-align:center; border:1px solid\">Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
-<th style=\"text-align:center; border:1px solid\">Applying to basis states</th>
-<th style=\"text-align:center; border:1px solid\">Q# Documentation</th>
+<th>Gate</th>
+<th>Matrix</th>
+<th>Ket-Bra</th>
+<th>Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
+<th>Applying to basis states</th>
+<th>Q# Documentation</th>
 </tr>
 <tr>
-<td style=\"text-align:center; border:1px solid\">$H$</td>
-<td style=\"text-align:center; border:1px solid\">$\begin{bmatrix} \frac{1}{\sqrt{2}} & \frac{1}{\sqrt{2}} \\ \frac{1}{\sqrt{2}} & -\frac{1}{\sqrt{2}} \end{bmatrix} = \frac{1}{\sqrt{2}}\begin{bmatrix} 1 & 1 \\ 1 & -1 \end{bmatrix}$</td>
-<td style=\"text-align:center; border:1px solid\">$|0\rangle\langle+| + |1\rangle\langle-|$</td>
-<td style=\"text-align:center; border:1px solid\">$H|\psi\rangle = \alpha|+\rangle + \beta|-\rangle = \frac{\alpha + \beta}{\sqrt{2}}|0\rangle + \frac{\alpha - \beta}{\sqrt{2}}|1\rangle$</td>
-<td style=\"text-align:center; border:1px solid\">$H|0\rangle = |+\rangle \\
+<td>$H$</td>
+<td>$\begin{bmatrix} \frac{1}{\sqrt{2}} & \frac{1}{\sqrt{2}} \\ \frac{1}{\sqrt{2}} & -\frac{1}{\sqrt{2}} \end{bmatrix} = \frac{1}{\sqrt{2}}\begin{bmatrix} 1 & 1 \\ 1 & -1 \end{bmatrix}$</td>
+<td>$|0\rangle\langle+| + |1\rangle\langle-|$</td>
+<td>$H|\psi\rangle = \alpha|+\rangle + \beta|-\rangle = \frac{\alpha + \beta}{\sqrt{2}}|0\rangle + \frac{\alpha - \beta}{\sqrt{2}}|1\rangle$</td>
+<td>$H|0\rangle = |+\rangle \\
 H|1\rangle = |-\rangle \\
 H|+\rangle = |0\rangle \\
 H|-\rangle = |1\rangle \\
 H|i\rangle = e^{i\pi/4}|-i\rangle \\
 H|-i\rangle = e^{-i\pi/4}|i\rangle $</td>
-<td style=\"text-align:center; border:1px solid\"><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.h\">H</a></td>
+<td><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.h\">H</a></td>
 </tr>
 </table>
 

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -365,7 +365,10 @@ All the basic gates we will be covering in this kata are part of the <a href="ht
     "solutionPath": "./sign_flip_on_zero/solution.md"
 })
 
-## Identity
+@[section]({
+    "id": "identity_gate",
+    "title": "Identity Gate"
+})
 
 The identity gate is mostly here for completeness, at least for now. It will come in handy when dealing with multi-qubit systems and multi-qubit gates. It is represented by the identity matrix, and does not affect the state of the qubit.
   
@@ -384,14 +387,17 @@ The identity gate is mostly here for completeness, at least for now. It will com
 </tr>
 <tr>
 <td style=\"text-align:center; border:1px solid\">$I$</td>
-<td style=\"text-align:center; border:1px solid\">$\begin{bmatrix} 1 & 0 \ 0 & 1 \end{bmatrix}$</td>
+<td style=\"text-align:center; border:1px solid\">$\begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}$</td>
 <td style=\"text-align:center; border:1px solid\">$|0\rangle\langle0| + |1\rangle\langle1|$</td>
 <td style=\"text-align:center; border:1px solid\">$I|\psi\rangle = |\psi\rangle$</td>
 <td style=\"text-align:center; border:1px solid\"><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.i\">I</a></td>
 </tr>
 </table>
 
-## Hadamard
+@[section]({
+    "id": "hadamard_gate",
+    "title": "Hadamard Gate"
+})
 
 The **Hadamard** gate is an extremely important quantum gate. Unlike the previous gates, applying the Hadamard gate to a qubit in a computational basis state puts that qubit into a superposition.
 Like the Pauli gates, the Hadamard gate is self-adjoint.

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -422,7 +422,7 @@ H|-i\rangle = e^{-i\pi/4}|i\rangle $</td>
 </table>
 
 > As a reminder, $e^{i\pi/4} = \frac{1}{\sqrt2} (1 + i)$ and $e^{-i\pi/4} = \frac{1}{\sqrt2} (1 - i)$. This is an application of Eulers formula, $e^{i\theta} = \cos \theta + i\sin \theta$, where $\theta$ is measured in radians.
-> See this [Wikipedia article](https://en.wikipedia.org/wiki/Euler%27s_formula) for an explanation of Eulers formula and/or [this video](https://youtu.be/v0YEaeIClKY) for a more intuitive explanation.
+> See this [Wikipedia article](https://en.wikipedia.org/wiki/Euler%27s_formula) for an explanation of Euler's formula and/or [this video](https://youtu.be/v0YEaeIClKY) for a more intuitive explanation.
 
 @[exercise]({
     "id": "single_qubit_gates__prepare_minus",

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -365,6 +365,70 @@ All the basic gates we will be covering in this kata are part of the <a href="ht
     "solutionPath": "./sign_flip_on_zero/solution.md"
 })
 
+## Identity
+
+The identity gate is mostly here for completeness, at least for now. It will come in handy when dealing with multi-qubit systems and multi-qubit gates. It is represented by the identity matrix, and does not affect the state of the qubit.
+  
+<table style=\"border:1px solid\">
+<col width=50>
+<col width=50>
+<col width=150>
+<col width=200>
+<col width=50>
+<tr>
+<th style=\"text-align:center; border:1px solid\">Gate</th>
+<th style=\"text-align:center; border:1px solid\">Matrix</th>
+<th style=\"text-align:center; border:1px solid\">Ket-Bra</th>
+<th style=\"text-align:center; border:1px solid\">Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
+<th style=\"text-align:center; border:1px solid\">Q# Documentation</th>
+</tr>
+<tr>
+<td style=\"text-align:center; border:1px solid\">$I$</td>
+<td style=\"text-align:center; border:1px solid\">$\begin{bmatrix} 1 & 0 \ 0 & 1 \end{bmatrix}$</td>
+<td style=\"text-align:center; border:1px solid\">$|0\rangle\langle0| + |1\rangle\langle1|$</td>
+<td style=\"text-align:center; border:1px solid\">$I|\psi\rangle = |\psi\rangle$</td>
+<td style=\"text-align:center; border:1px solid\"><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.i\">I</a></td>
+</tr>
+</table>
+
+## Hadamard
+
+The **Hadamard** gate is an extremely important quantum gate. Unlike the previous gates, applying the Hadamard gate to a qubit in a computational basis state puts that qubit into a superposition.
+Like the Pauli gates, the Hadamard gate is self-adjoint.
+
+<table style=\"border:1px solid\">
+<col width=50>
+<col width=200>
+<col width=150>
+<col width=260>
+<col width=150>
+<col width=50>
+<tr>
+<th style=\"text-align:center; border:1px solid\">Gate</th>
+<th style=\"text-align:center; border:1px solid\">Matrix</th>
+<th style=\"text-align:center; border:1px solid\">Ket-Bra</th>
+<th style=\"text-align:center; border:1px solid\">Applying to $|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$</th>
+<th style=\"text-align:center; border:1px solid\">Applying to basis states</th>
+<th style=\"text-align:center; border:1px solid\">Q# Documentation</th>
+</tr>
+<tr>
+<td style=\"text-align:center; border:1px solid\">$H$</td>
+<td style=\"text-align:center; border:1px solid\">$\begin{bmatrix} \frac{1}{\sqrt{2}} & \frac{1}{\sqrt{2}} \\ \frac{1}{\sqrt{2}} & -\frac{1}{\sqrt{2}} \end{bmatrix} = \frac{1}{\sqrt{2}}\begin{bmatrix} 1 & 1 \\ 1 & -1 \end{bmatrix}$</td>
+<td style=\"text-align:center; border:1px solid\">$|0\rangle\langle+| + |1\rangle\langle-|$</td>
+<td style=\"text-align:center; border:1px solid\">$H|\psi\rangle = \alpha|+\rangle + \beta|-\rangle = \frac{\alpha + \beta}{\sqrt{2}}|0\rangle + \frac{\alpha - \beta}{\sqrt{2}}|1\rangle$</td>
+<td style=\"text-align:center; border:1px solid\">$H|0\rangle = |+\rangle \\
+H|1\rangle = |-\rangle \\
+H|+\rangle = |0\rangle \\
+H|-\rangle = |1\rangle \\
+H|i\rangle = e^{i\pi/4}|-i\rangle \\
+H|-i\rangle = e^{-i\pi/4}|i\rangle $</td>
+<td style=\"text-align:center; border:1px solid\"><a href=\"https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.h\">H</a></td>
+</tr>
+</table>
+
+> As a reminder, $e^{i\pi/4} = \frac{1}{\sqrt2} (1 + i)$ and $e^{-i\pi/4} = \frac{1}{\sqrt2} (1 - i)$.
+> If you need a refresher on calculating expressions like $e^{i\theta}$, you should review the section on [complex exponentiation](../ComplexArithmetic/ComplexArithmetic.ipynb#Imaginary-Exponents).
+
 @[exercise]({
     "id": "single_qubit_gates__prepare_minus",
     "title": "Prepare Minus",


### PR DESCRIPTION
... here’s an issue with missing text in the SingleQubitGates tutorial (in the ADO, it’s https://dev.azure.com/ms-azurequantum/AzureQuantum/_workitems/edit/12559):

The file https://github.com/microsoft/qsharp/blob/main/katas/content/single_qubit_gates/index.md does not have the sections "Identity" and "Hadamard gate" before the exercise "Prepare Minus" from the original notebook https://github.com/microsoft/QuantumKatas/blob/main/tutorials/SingleQubitGates/SingleQubitGates.ipynb. ... 