### PR TITLE
Check for duplicate intrinsics globally

### DIFF
--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1051,3 +1051,54 @@ fn unimplemented_attribute_avoids_ambiguous_error_with_duplicate_names_in_scope(
     "#]]
     .assert_debug_eq(&unit.errors);
 }
+
+#[test]
+fn duplicate_intrinsic_from_dependency() {
+    let lib_sources = SourceMap::new(
+        [(
+            "lib".into(),
+            indoc! {"
+                namespace Foo {
+                    operation Bar() : Unit { body intrinsic; }
+                }
+            "}
+            .into(),
+        )],
+        None,
+    );
+
+    let mut store = PackageStore::new(super::core());
+    let lib = compile(&store, &[], lib_sources, RuntimeCapabilityFlags::all());
+    assert!(lib.errors.is_empty(), "{:#?}", lib.errors);
+    let lib = store.insert(lib);
+
+    let sources = SourceMap::new(
+        [(
+            "test".into(),
+            indoc! {"
+                namespace Test {
+                    operation Bar() : Unit { body intrinsic; }
+                }
+            "}
+            .into(),
+        )],
+        None,
+    );
+
+    let unit = compile(&store, &[lib], sources, RuntimeCapabilityFlags::all());
+    expect![[r#"
+        [
+            Error(
+                Resolve(
+                    DuplicateIntrinsic(
+                        "Bar",
+                        Span {
+                            lo: 31,
+                            hi: 34,
+                        },
+                    ),
+                ),
+            ),
+        ]
+    "#]].assert_debug_eq(&unit.errors);
+}

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1100,5 +1100,6 @@ fn duplicate_intrinsic_from_dependency() {
                 ),
             ),
         ]
-    "#]].assert_debug_eq(&unit.errors);
+    "#]]
+    .assert_debug_eq(&unit.errors);
 }

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -2027,6 +2027,39 @@ fn multiple_definition_dropped_is_not_found() {
     );
 }
 
+#[test]
+fn disallow_duplicate_intrinsic() {
+    check(
+        indoc! {"
+            namespace A {
+                operation B() : Unit {
+                    body intrinsic;
+                }
+            }
+            namespace B {
+                operation B() : Unit {
+                    body intrinsic;
+                }
+            }
+        "},
+        &expect![[r#"
+            namespace item0 {
+                operation item1() : Unit {
+                    body intrinsic;
+                }
+            }
+            namespace item2 {
+                operation item3() : Unit {
+                    body intrinsic;
+                }
+            }
+
+            // DuplicateIntrinsic("B", Span { lo: 101, hi: 102 })
+        "#]],
+    );
+
+}
+
 #[allow(clippy::cast_possible_truncation)]
 fn check_locals(input: &str, expect: &Expect) {
     let parts = input.split('↘').collect::<Vec<_>>();

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -2057,7 +2057,6 @@ fn disallow_duplicate_intrinsic() {
             // DuplicateIntrinsic("B", Span { lo: 101, hi: 102 })
         "#]],
     );
-
 }
 
 #[allow(clippy::cast_possible_truncation)]

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -2059,6 +2059,46 @@ fn disallow_duplicate_intrinsic() {
     );
 }
 
+#[test]
+fn disallow_duplicate_intrinsic_and_non_intrinsic_collision() {
+    check(
+        indoc! {"
+            namespace A {
+                operation C() : Unit {
+                    body intrinsic;
+                }
+            }
+            namespace B {
+                operation C() : Unit {}
+            }
+            namespace B {
+                operation C() : Unit {
+                    body intrinsic;
+                }
+            }
+        "},
+        &expect![[r#"
+            namespace item0 {
+                operation item1() : Unit {
+                    body intrinsic;
+                }
+            }
+            namespace item2 {
+                operation item3() : Unit {}
+            }
+            namespace item4 {
+                operation item5() : Unit {
+                    body intrinsic;
+                }
+            }
+
+            // Duplicate("C", "B", Span { lo: 145, hi: 146 })
+            // DuplicateIntrinsic("C", Span { lo: 145, hi: 146 })
+        "#]],
+    );
+
+}
+
 #[allow(clippy::cast_possible_truncation)]
 fn check_locals(input: &str, expect: &Expect) {
     let parts = input.split('↘').collect::<Vec<_>>();

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -2064,7 +2064,7 @@ fn disallow_duplicate_intrinsic_and_non_intrinsic_collision() {
     check(
         indoc! {"
             namespace A {
-                operation C() : Unit {
+                internal operation C() : Unit {
                     body intrinsic;
                 }
             }
@@ -2079,7 +2079,7 @@ fn disallow_duplicate_intrinsic_and_non_intrinsic_collision() {
         "},
         &expect![[r#"
             namespace item0 {
-                operation item1() : Unit {
+                internal operation item1() : Unit {
                     body intrinsic;
                 }
             }
@@ -2092,8 +2092,8 @@ fn disallow_duplicate_intrinsic_and_non_intrinsic_collision() {
                 }
             }
 
-            // Duplicate("C", "B", Span { lo: 145, hi: 146 })
-            // DuplicateIntrinsic("C", Span { lo: 145, hi: 146 })
+            // Duplicate("C", "B", Span { lo: 154, hi: 155 })
+            // DuplicateIntrinsic("C", Span { lo: 154, hi: 155 })
         "#]],
     );
 

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -2096,7 +2096,6 @@ fn disallow_duplicate_intrinsic_and_non_intrinsic_collision() {
             // DuplicateIntrinsic("C", Span { lo: 154, hi: 155 })
         "#]],
     );
-
 }
 
 #[allow(clippy::cast_possible_truncation)]

--- a/compiler/qsc_hir/src/global.rs
+++ b/compiler/qsc_hir/src/global.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
-    hir::{Item, ItemId, ItemKind, ItemStatus, Package, PackageId, Visibility},
+    hir::{Item, ItemId, ItemKind, ItemStatus, Package, PackageId, SpecBody, SpecGen, Visibility},
     ty::Scheme,
 };
 use qsc_data_structures::index_map;
@@ -30,6 +30,7 @@ pub struct Ty {
 pub struct Term {
     pub id: ItemId,
     pub scheme: Scheme,
+    pub intrinsic: bool,
 }
 
 #[derive(Default)]
@@ -107,6 +108,7 @@ impl PackageIter<'_> {
                 kind: Kind::Term(Term {
                     id,
                     scheme: decl.scheme(),
+                    intrinsic: decl.body.body == SpecBody::Gen(SpecGen::Intrinsic),
                 }),
             }),
             (ItemKind::Ty(name, def), Some(ItemKind::Namespace(namespace, _))) => {
@@ -118,6 +120,7 @@ impl PackageIter<'_> {
                     kind: Kind::Term(Term {
                         id,
                         scheme: def.cons_scheme(id),
+                        intrinsic: false,
                     }),
                 });
 


### PR DESCRIPTION
This adds new logic to name resolution to verify that any callable declared as `body intrinsic` has a globally unique name.

This fixes #1130.