### PR TITLE
Support generating QIR with custom intrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,7 @@ dependencies = [
  "qsc_frontend",
  "qsc_hir",
  "qsc_passes",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/compiler/qsc_codegen/Cargo.toml
+++ b/compiler/qsc_codegen/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 [dependencies]
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
+rustc-hash = { workspace = true }
 qsc_eval = { path = "../qsc_eval" }
 qsc_data_structures = { path = "../qsc_data_structures" }
 qsc_frontend = { path = "../qsc_frontend" }

--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -18,6 +18,7 @@ use qsc_eval::{
 use qsc_fir::fir;
 use qsc_frontend::compile::PackageStore;
 use qsc_hir::hir::{self};
+use rustc_hash::FxHashSet;
 use std::fmt::{Display, Write};
 
 /// # Errors
@@ -71,6 +72,8 @@ pub struct BaseProfSim {
     qubit_map: IndexMap<usize, HardwareId>,
     instrs: String,
     measurements: String,
+    decls: String,
+    decl_names: FxHashSet<String>,
 }
 
 impl Default for BaseProfSim {
@@ -89,6 +92,8 @@ impl BaseProfSim {
             qubit_map: IndexMap::new(),
             instrs: String::new(),
             measurements: String::new(),
+            decls: String::new(),
+            decl_names: FxHashSet::default(),
         };
         sim.instrs.push_str(include_str!("./qir_base/prefix.ll"));
         sim
@@ -103,7 +108,7 @@ impl BaseProfSim {
         write!(
             self.instrs,
             include_str!("./qir_base/postfix.ll"),
-            self.next_qubit_hardware_id.0, self.next_meas_id
+            self.decls, self.next_qubit_hardware_id.0, self.next_meas_id
         )
         .expect("writing to string should succeed");
 
@@ -171,6 +176,53 @@ impl BaseProfSim {
             self.instrs,
             "  call void @__quantum__rt__array_record_output(i64 {size}, i8* null)"
         )
+    }
+
+    fn write_arg(&mut self, arg: &Value) -> std::result::Result<(), String> {
+        match arg {
+            Value::Qubit(q) => {
+                let q = self.map(q.0);
+                write!(self.instrs, "{}", Qubit(q))
+            }
+            Value::Double(d) => write!(self.instrs, "{}", Double(*d)),
+            Value::Bool(b) => write!(self.instrs, "{}", Bool(*b)),
+            Value::Int(i) => write!(self.instrs, "{}", Int(*i)),
+            _ => return Err(format!("unsupported argument type: {}", arg.type_name())),
+        }
+        .expect("writing to string should succeed");
+        Ok(())
+    }
+
+    fn write_decl_type(&mut self, ty: &Value) -> std::result::Result<(), String> {
+        match ty {
+            Value::Qubit(_) => write!(self.decls, "%Qubit*"),
+            Value::Double(_) => write!(self.decls, "double"),
+            Value::Bool(_) => write!(self.decls, "i1"),
+            Value::Int(_) => write!(self.decls, "i64"),
+            _ => return Err(format!("unsupported argument type: {}", ty.type_name())),
+        }
+        .expect("writing to string should succeed");
+        Ok(())
+    }
+
+    fn write_decl(&mut self, name: &str, arg: &Value) -> std::result::Result<(), String> {
+        if self.decl_names.insert(name.to_string()) {
+            write!(self.decls, "declare void @{name}(").expect("writing to string should succeed");
+            if let Value::Tuple(args) = arg {
+                if let Some((first, rest)) = args.split_first() {
+                    self.write_decl_type(first)?;
+                    for arg in rest {
+                        write!(self.decls, ", ").expect("writing to string should succeed");
+                        self.write_decl_type(arg)?;
+                    }
+                }
+            } else {
+                self.write_decl_type(arg)?;
+            }
+            writeln!(self.decls, ")").expect("writing to string should succeed");
+        }
+
+        Ok(())
     }
 }
 
@@ -438,6 +490,42 @@ impl Backend for BaseProfSim {
         // true to avoid a panic.
         true
     }
+
+    fn custom_intrinsic(
+        &mut self,
+        name: &str,
+        arg: Value,
+    ) -> Option<std::result::Result<Value, String>> {
+        match self.write_decl(name, &arg) {
+            Ok(()) => {}
+            Err(e) => return Some(Err(e)),
+        }
+        write!(self.instrs, "  call void @{name}(").expect("writing to string should succeed");
+
+        if let Value::Tuple(args) = arg {
+            if let Some((first, rest)) = args.split_first() {
+                match self.write_arg(first) {
+                    Ok(()) => {}
+                    Err(e) => return Some(Err(e)),
+                }
+                for arg in rest {
+                    write!(self.instrs, ", ").expect("writing to string should succeed");
+                    match self.write_arg(arg) {
+                        Ok(()) => {}
+                        Err(e) => return Some(Err(e)),
+                    }
+                }
+            }
+        } else {
+            match self.write_arg(&arg) {
+                Ok(()) => {}
+                Err(e) => return Some(Err(e)),
+            }
+        }
+
+        writeln!(self.instrs, ")").expect("writing to string should succeed");
+        Some(Ok(Value::unit()))
+    }
 }
 
 struct Qubit(HardwareId);
@@ -468,5 +556,25 @@ impl Display for Double {
         } else {
             write!(f, "double {v}")
         }
+    }
+}
+
+struct Bool(bool);
+
+impl Display for Bool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0 {
+            write!(f, "i1 true")
+        } else {
+            write!(f, "i1 false")
+        }
+    }
+}
+
+struct Int(i64);
+
+impl Display for Int {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "i64 {}", self.0)
     }
 }

--- a/compiler/qsc_codegen/src/qir_base/postfix.ll
+++ b/compiler/qsc_codegen/src/qir_base/postfix.ll
@@ -24,7 +24,7 @@ declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
 declare void @__quantum__rt__result_record_output(%Result*, i8*)
 declare void @__quantum__rt__array_record_output(i64, i8*)
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
-
+{}
 attributes #0 = {{ "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="{}" "required_num_results"="{}" }}
 attributes #1 = {{ "irreversible" }}
 

--- a/compiler/qsc_codegen/src/qir_base/tests.rs
+++ b/compiler/qsc_codegen/src/qir_base/tests.rs
@@ -1000,7 +1000,7 @@ fn qubit_ids_properly_reused() {
 }
 
 #[test]
-fn custom_itrinsic_on_single_qubit() {
+fn custom_intrinsic_on_single_qubit() {
     check(
         indoc! {"
         namespace Test {
@@ -1058,6 +1058,93 @@ fn custom_itrinsic_on_single_qubit() {
             declare void @__quantum__rt__array_record_output(i64, i8*)
             declare void @__quantum__rt__tuple_record_output(i64, i8*)
             declare void @MyCustomGate(%Qubit*)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="2" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}
+
+#[test]
+fn multiple_custom_intrinsic_calls() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : (Result, Result) {
+                use (q0, q1) = (Qubit(), Qubit());
+                MySecondCustomGate(q0, q1);
+                MyCustomGate(q0);
+                MyCustomFunc(42);
+                return (MResetZ(q0), MResetZ(q1));
+            }
+
+            operation MyCustomGate(q : Qubit) : Unit {
+                body intrinsic;
+            }
+
+            operation MySecondCustomGate(q0 : Qubit, q1 : Qubit) : Unit {
+                body intrinsic;
+            }
+
+            function MyCustomFunc(n : Int) : Unit {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+              call void @MySecondCustomGate(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @MyCustomGate(%Qubit* inttoptr (i64 0 to %Qubit*))
+              call void @MyCustomFunc(i64 42)
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*)) #1
+              call void @__quantum__rt__tuple_record_output(i64 2, i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__rx__body(double, %Qubit*)
+            declare void @__quantum__qis__rxx__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+            declare void @__quantum__qis__ryy__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__rz__body(double, %Qubit*)
+            declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__h__body(%Qubit*)
+            declare void @__quantum__qis__s__body(%Qubit*)
+            declare void @__quantum__qis__s__adj(%Qubit*)
+            declare void @__quantum__qis__t__body(%Qubit*)
+            declare void @__quantum__qis__t__adj(%Qubit*)
+            declare void @__quantum__qis__x__body(%Qubit*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+            declare void @__quantum__qis__z__body(%Qubit*)
+            declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__rt__array_record_output(i64, i8*)
+            declare void @__quantum__rt__tuple_record_output(i64, i8*)
+            declare void @MySecondCustomGate(%Qubit*, %Qubit*)
+            declare void @MyCustomGate(%Qubit*)
+            declare void @MyCustomFunc(i64)
 
             attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="2" }
             attributes #1 = { "irreversible" }

--- a/compiler/qsc_codegen/src/qir_base/tests.rs
+++ b/compiler/qsc_codegen/src/qir_base/tests.rs
@@ -925,7 +925,7 @@ fn qubit_ids_properly_reused() {
             }
         }
         "},
-        Some("Test.IntrinsicCNOT()"),
+        None,
         &expect![[r#"
             %Result = type opaque
             %Qubit = type opaque
@@ -995,6 +995,520 @@ fn qubit_ids_properly_reused() {
             !1 = !{i32 7, !"qir_minor_version", i32 0}
             !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
             !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}
+
+#[test]
+fn custom_itrinsic_on_single_qubit() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : (Result, Result) {
+                use (q1, q2) = (Qubit(), Qubit());
+                MyCustomGate(q1);
+                MyCustomGate(q2);
+                return (MResetZ(q1), MResetZ(q2));
+            }
+
+            operation MyCustomGate(q : Qubit) : Unit {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+              call void @MyCustomGate(%Qubit* inttoptr (i64 0 to %Qubit*))
+              call void @MyCustomGate(%Qubit* inttoptr (i64 1 to %Qubit*))
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*)) #1
+              call void @__quantum__rt__tuple_record_output(i64 2, i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__rx__body(double, %Qubit*)
+            declare void @__quantum__qis__rxx__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+            declare void @__quantum__qis__ryy__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__rz__body(double, %Qubit*)
+            declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__h__body(%Qubit*)
+            declare void @__quantum__qis__s__body(%Qubit*)
+            declare void @__quantum__qis__s__adj(%Qubit*)
+            declare void @__quantum__qis__t__body(%Qubit*)
+            declare void @__quantum__qis__t__adj(%Qubit*)
+            declare void @__quantum__qis__x__body(%Qubit*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+            declare void @__quantum__qis__z__body(%Qubit*)
+            declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__rt__array_record_output(i64, i8*)
+            declare void @__quantum__rt__tuple_record_output(i64, i8*)
+            declare void @MyCustomGate(%Qubit*)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="2" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}
+
+#[test]
+fn custom_intrinsic_on_qubit_and_double() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : Result {
+                use q = Qubit();
+                let d = 3.14;
+                MyCustomGate(q, d);
+                return MResetZ(q);
+            }
+
+            operation MyCustomGate(q : Qubit, d : Double) : Unit {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+              call void @MyCustomGate(%Qubit* inttoptr (i64 0 to %Qubit*), double 3.14)
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__rx__body(double, %Qubit*)
+            declare void @__quantum__qis__rxx__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+            declare void @__quantum__qis__ryy__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__rz__body(double, %Qubit*)
+            declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__h__body(%Qubit*)
+            declare void @__quantum__qis__s__body(%Qubit*)
+            declare void @__quantum__qis__s__adj(%Qubit*)
+            declare void @__quantum__qis__t__body(%Qubit*)
+            declare void @__quantum__qis__t__adj(%Qubit*)
+            declare void @__quantum__qis__x__body(%Qubit*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+            declare void @__quantum__qis__z__body(%Qubit*)
+            declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__rt__array_record_output(i64, i8*)
+            declare void @__quantum__rt__tuple_record_output(i64, i8*)
+            declare void @MyCustomGate(%Qubit*, double)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="1" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}
+
+#[test]
+fn custom_intrinsic_on_qubit_and_bool() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : Result {
+                use q = Qubit();
+                let b = true;
+                MyCustomGate(q, b);
+                return MResetZ(q);
+            }
+
+            operation MyCustomGate(q : Qubit, b : Bool) : Unit {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+              call void @MyCustomGate(%Qubit* inttoptr (i64 0 to %Qubit*), i1 true)
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__rx__body(double, %Qubit*)
+            declare void @__quantum__qis__rxx__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+            declare void @__quantum__qis__ryy__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__rz__body(double, %Qubit*)
+            declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__h__body(%Qubit*)
+            declare void @__quantum__qis__s__body(%Qubit*)
+            declare void @__quantum__qis__s__adj(%Qubit*)
+            declare void @__quantum__qis__t__body(%Qubit*)
+            declare void @__quantum__qis__t__adj(%Qubit*)
+            declare void @__quantum__qis__x__body(%Qubit*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+            declare void @__quantum__qis__z__body(%Qubit*)
+            declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__rt__array_record_output(i64, i8*)
+            declare void @__quantum__rt__tuple_record_output(i64, i8*)
+            declare void @MyCustomGate(%Qubit*, i1)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="1" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}
+
+#[test]
+fn custom_intrinsic_on_qubit_and_int() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : Result {
+                use q = Qubit();
+                let i = 42;
+                MyCustomGate(q, i);
+                return MResetZ(q);
+            }
+
+            operation MyCustomGate(q : Qubit, i : Int) : Unit {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+              call void @MyCustomGate(%Qubit* inttoptr (i64 0 to %Qubit*), i64 42)
+              call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*)) #1
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cy__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__rx__body(double, %Qubit*)
+            declare void @__quantum__qis__rxx__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__ry__body(double, %Qubit*)
+            declare void @__quantum__qis__ryy__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__rz__body(double, %Qubit*)
+            declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+            declare void @__quantum__qis__h__body(%Qubit*)
+            declare void @__quantum__qis__s__body(%Qubit*)
+            declare void @__quantum__qis__s__adj(%Qubit*)
+            declare void @__quantum__qis__t__body(%Qubit*)
+            declare void @__quantum__qis__t__adj(%Qubit*)
+            declare void @__quantum__qis__x__body(%Qubit*)
+            declare void @__quantum__qis__y__body(%Qubit*)
+            declare void @__quantum__qis__z__body(%Qubit*)
+            declare void @__quantum__qis__swap__body(%Qubit*, %Qubit*)
+            declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__rt__array_record_output(i64, i8*)
+            declare void @__quantum__rt__tuple_record_output(i64, i8*)
+            declare void @MyCustomGate(%Qubit*, i64)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="1" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        "#]],
+    );
+}
+
+#[test]
+fn custom_intrinsic_fail_on_result_arg() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : Result {
+                use q = Qubit();
+                let r = MResetZ(q);
+                MyCustomGate(q, r);
+                return r;
+            }
+
+            operation MyCustomGate(q : Qubit, r : Result) : Unit {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            IntrinsicFail(
+                "MyCustomGate",
+                "unsupported argument type: Result",
+                PackageSpan {
+                    package: PackageId(
+                        2,
+                    ),
+                    span: Span {
+                        lo: 217,
+                        hi: 301,
+                    },
+                },
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn custom_intrinsic_fail_on_bigint_arg() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : Result {
+                use q = Qubit();
+                let i = 42L;
+                MyCustomGate(q, i);
+                return MResetZ(q);
+            }
+
+            operation MyCustomGate(q : Qubit, i : BigInt) : Unit {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            IntrinsicFail(
+                "MyCustomGate",
+                "unsupported argument type: BigInt",
+                PackageSpan {
+                    package: PackageId(
+                        2,
+                    ),
+                    span: Span {
+                        lo: 219,
+                        hi: 303,
+                    },
+                },
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn custom_intrinsic_fail_on_string_arg() {
+    check(
+        indoc! {r#"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : Result {
+                use q = Qubit();
+                let s = "hello, world";
+                MyCustomGate(q, s);
+                return MResetZ(q);
+            }
+
+            operation MyCustomGate(q : Qubit, s : String) : Unit {
+                body intrinsic;
+            }
+        }
+        "#},
+        None,
+        &expect![[r#"
+            IntrinsicFail(
+                "MyCustomGate",
+                "unsupported argument type: String",
+                PackageSpan {
+                    package: PackageId(
+                        2,
+                    ),
+                    span: Span {
+                        lo: 230,
+                        hi: 314,
+                    },
+                },
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn custom_intrinsic_fail_on_array_arg() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : Result {
+                use q = Qubit();
+                let a = [1, 2, 3];
+                MyCustomGate(q, a);
+                return MResetZ(q);
+            }
+
+            operation MyCustomGate(q : Qubit, a : Int[]) : Unit {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            IntrinsicFail(
+                "MyCustomGate",
+                "unsupported argument type: Array",
+                PackageSpan {
+                    package: PackageId(
+                        2,
+                    ),
+                    span: Span {
+                        lo: 225,
+                        hi: 308,
+                    },
+                },
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn custom_intrinsic_fail_on_tuple_arg() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : Result {
+                use q = Qubit();
+                let t = (1, 2, 3);
+                MyCustomGate(q, t);
+                return MResetZ(q);
+            }
+
+            operation MyCustomGate(q : Qubit, t : (Int, Int, Int)) : Unit {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            IntrinsicFail(
+                "MyCustomGate",
+                "unsupported argument type: Tuple",
+                PackageSpan {
+                    package: PackageId(
+                        2,
+                    ),
+                    span: Span {
+                        lo: 225,
+                        hi: 318,
+                    },
+                },
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn custom_intrinsic_fail_on_non_unit_return() {
+    check(
+        indoc! {"
+        namespace Test {
+            open Microsoft.Quantum.Measurement;
+            @EntryPoint()
+            operation Test() : Result {
+                use q = Qubit();
+                MyCustomGate(q);
+                return MResetZ(q);
+            }
+
+            function MyCustomGate(q : Qubit) : Int {
+                body intrinsic;
+            }
+        }
+        "},
+        None,
+        &expect![[r#"
+            UnsupportedIntrinsicType(
+                "MyCustomGate",
+                PackageSpan {
+                    package: PackageId(
+                        2,
+                    ),
+                    span: Span {
+                        lo: 195,
+                        hi: 265,
+                    },
+                },
+            )
         "#]],
     );
 }


### PR DESCRIPTION
This change adds support for generating QIR with custom intrinsic callables. Any Q# operation or function declared as `body intrinsic` that is not part of the recognized built-in callables will be inserted as a call to an extern function in the QIR declared with the provided arguments and with a `void` return (see limitations below). These functions must be recognized and supported by the consumer of the QIR or it may cause compilation or linking failure further down the pipeline. Note that custom intrinsics will still fail simulation.

This fixes #825.

### Limitations
 - A custom intrinsic that returns types other than `Unit` causes a runtime error during code generation with help text that advises the use of `Unit`: 
![image](https://github.com/microsoft/qsharp/assets/10567287/b1c536e8-72f2-45b3-b17a-0775896ba429)

 - Passing complex, memory backed types to custom intrinsics (`BigInt`, arrays, tuples) will cause code generation to fail with a runtime error mentioning the unsupported type: 
![image](https://github.com/microsoft/qsharp/assets/10567287/908df8ac-7c86-4ad1-b90f-b5706a369bcc)

 - While not a memory backed type, `Result` also cannot be used as an argument or return because it would break logic used for deferring measurements and potentially violate requirements of the Base Profile spec (results should be write-only and tagged as such except in measurements, for example). These cases are rejected with the same runtime errors shown above.