### PR TITLE
Fix panics on In-place update optimization

### DIFF
--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -1373,6 +1373,33 @@ fn assignop_add_expr() {
 }
 
 #[test]
+fn assignop_add_concat() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable x = [1, 2];
+            set x += [3, 4];
+            x
+        }"},
+        &expect!["[1, 2, 3, 4]"],
+    );
+}
+
+#[test]
+fn assignop_add_concat_copy() {
+    check_expr(
+        "",
+        indoc! {"{
+            let x = [1, 2];
+            mutable y = x;
+            set y += [3, 4];
+            y
+        }"},
+        &expect!["[1, 2, 3, 4]"],
+    );
+}
+
+#[test]
 fn assignop_sub_expr() {
     check_expr(
         "",
@@ -2252,6 +2279,20 @@ fn assignupdate_expr() {
             mutable x = [1, 2, 3];
             set x w/= 2 <- 4;
             x
+        }"},
+        &expect!["[1, 2, 4]"],
+    );
+}
+
+#[test]
+fn assignupdate_on_copy_should_work() {
+    check_expr(
+        "",
+        indoc! {"{
+            let x = [1, 2, 3];
+            mutable y = x;
+            set y w/= 2 <- 4;
+            y
         }"},
         &expect!["[1, 2, 4]"],
     );

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -1393,9 +1393,9 @@ fn assignop_add_concat_copy() {
             let x = [1, 2];
             mutable y = x;
             set y += [3, 4];
-            y
+            (x, y)
         }"},
-        &expect!["[1, 2, 3, 4]"],
+        &expect!["([1, 2], [1, 2, 3, 4])"],
     );
 }
 
@@ -2292,9 +2292,9 @@ fn assignupdate_on_copy_should_work() {
             let x = [1, 2, 3];
             mutable y = x;
             set y w/= 2 <- 4;
-            y
+            (x, y)
         }"},
-        &expect!["[1, 2, 4]"],
+        &expect!["([1, 2, 3], [1, 2, 4])"],
     );
 }
 


### PR DESCRIPTION
This checks ahead of time if the array we want to update in-place is uniquely referenced and correctly falls back to the previous, unoptimized path that makes a copy.

Fixes #1146