### PR TITLE
anticipate docstrings after attributes

### DIFF
--- a/compiler/qsc_parse/src/item.rs
+++ b/compiler/qsc_parse/src/item.rs
@@ -289,6 +289,7 @@ fn ty_as_ident(ty: Ty) -> Result<Box<Ident>> {
 
 fn parse_callable_decl(s: &mut Scanner) -> Result<Box<CallableDecl>> {
     let lo = s.peek().span.lo;
+    let _doc = parse_doc(s);
     let kind = if token(s, TokenKind::Keyword(Keyword::Function)).is_ok() {
         CallableKind::Function
     } else if token(s, TokenKind::Keyword(Keyword::Operation)).is_ok() {

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -538,6 +538,25 @@ fn function_decl_doc() {
 }
 
 #[test]
+fn doc_between_attr_and_keyword() {
+    check(
+        parse,
+        "@EntryPoint()
+        /// doc comment.
+        function Foo() : () {}",
+        &expect![[r#"
+            Item _id_ [0-69]:
+                Attr _id_ [0-13] (Ident _id_ [1-11] "EntryPoint"):
+                    Expr _id_ [11-13]: Unit
+                Callable _id_ [22-69] (Function):
+                    name: Ident _id_ [56-59] "Foo"
+                    input: Pat _id_ [59-61]: Unit
+                    output: Type _id_ [64-66]: Unit
+                    body: Block: Block _id_ [67-69]: <empty>"#]],
+    );
+}
+
+#[test]
 fn operation_decl() {
     check(
         parse,


### PR DESCRIPTION
Closes #1086

Sequel to #982

See #941 for more context.
