### PR TITLE
Optimize variable binding/access during runtime

### DIFF
--- a/compiler/qsc_eval/src/lower.rs
+++ b/compiler/qsc_eval/src/lower.rs
@@ -13,6 +13,7 @@ use std::{clone::Clone, rc::Rc};
 
 pub struct Lowerer {
     nodes: IndexMap<hir::NodeId, fir::NodeId>,
+    locals: IndexMap<hir::NodeId, fir::LocalVarId>,
     exprs: IndexMap<ExprId, Expr>,
     pats: IndexMap<PatId, Pat>,
     stmts: IndexMap<StmtId, Stmt>,
@@ -31,6 +32,7 @@ impl Lowerer {
     pub fn new() -> Self {
         Self {
             nodes: IndexMap::new(),
+            locals: IndexMap::new(),
             exprs: IndexMap::new(),
             pats: IndexMap::new(),
             stmts: IndexMap::new(),
@@ -179,6 +181,9 @@ impl Lowerer {
             };
             CallableImpl::Spec(specialized_implementation)
         };
+
+        self.assigner.reset_local();
+        self.locals.clear();
 
         fir::CallableDecl {
             id,
@@ -331,7 +336,7 @@ impl Lowerer {
                 fir::ExprKind::While(self.lower_expr(cond), self.lower_block(body))
             }
             hir::ExprKind::Closure(ids, id) => {
-                let ids = ids.iter().map(|id| self.lower_id(*id)).collect();
+                let ids = ids.iter().map(|id| self.lower_local_id(*id)).collect();
                 fir::ExprKind::Closure(ids, lower_local_item_id(*id))
             }
             hir::ExprKind::String(components) => fir::ExprKind::String(
@@ -413,17 +418,25 @@ impl Lowerer {
         })
     }
 
+    fn lower_local_id(&mut self, id: hir::NodeId) -> fir::LocalVarId {
+        self.locals.get(id).copied().unwrap_or_else(|| {
+            let new_id = self.assigner.next_local();
+            self.locals.insert(id, new_id);
+            new_id
+        })
+    }
+
     fn lower_res(&mut self, res: &hir::Res) -> fir::Res {
         match res {
             hir::Res::Item(item) => fir::Res::Item(lower_item_id(item)),
-            hir::Res::Local(node) => fir::Res::Local(self.lower_id(*node)),
+            hir::Res::Local(node) => fir::Res::Local(self.lower_local_id(*node)),
             hir::Res::Err => fir::Res::Err,
         }
     }
 
     fn lower_ident(&mut self, ident: &hir::Ident) -> fir::Ident {
         fir::Ident {
-            id: self.lower_id(ident.id),
+            id: self.lower_local_id(ident.id),
             span: ident.span,
             name: ident.name.clone(),
         }

--- a/compiler/qsc_fir/src/assigner.rs
+++ b/compiler/qsc_fir/src/assigner.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::fir::{BlockId, ExprId, NodeId, PatId, StmtId};
+use crate::fir::{BlockId, ExprId, LocalVarId, NodeId, PatId, StmtId};
 
 #[derive(Debug)]
 pub struct Assigner {
@@ -10,6 +10,7 @@ pub struct Assigner {
     next_expr: ExprId,
     next_pat: PatId,
     next_stmt: StmtId,
+    next_local: LocalVarId,
 }
 
 impl Assigner {
@@ -21,6 +22,7 @@ impl Assigner {
             next_expr: ExprId::default(),
             next_pat: PatId::default(),
             next_stmt: StmtId::default(),
+            next_local: LocalVarId::default(),
         }
     }
 
@@ -52,6 +54,16 @@ impl Assigner {
         let id = self.next_stmt;
         self.next_stmt = id.successor();
         id
+    }
+
+    pub fn next_local(&mut self) -> LocalVarId {
+        let id = self.next_local;
+        self.next_local = id.successor();
+        id
+    }
+
+    pub fn reset_local(&mut self) {
+        self.next_local = LocalVarId::default();
     }
 }
 

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -209,36 +209,7 @@ fir_id!(BlockId);
 fir_id!(ExprId);
 fir_id!(PatId);
 fir_id!(StmtId);
-
-/// A unique identifier for a local variable within a callable.
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct LocalVarId(u16);
-
-impl LocalVarId {
-    /// The successor of this ID.
-    #[must_use]
-    pub fn successor(self) -> Self {
-        Self(self.0 + 1)
-    }
-}
-
-impl Display for LocalVarId {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        Display::fmt(&self.0, f)
-    }
-}
-
-impl From<LocalVarId> for usize {
-    fn from(value: LocalVarId) -> Self {
-        value.0 as usize
-    }
-}
-
-impl From<usize> for LocalVarId {
-    fn from(value: usize) -> Self {
-        LocalVarId(value.try_into().expect("LocalVarId should fit into u32"))
-    }
-}
+fir_id!(LocalVarId);
 
 /// A unique identifier for a package within a package store.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -210,6 +210,36 @@ fir_id!(ExprId);
 fir_id!(PatId);
 fir_id!(StmtId);
 
+/// A unique identifier for a local variable within a callable.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LocalVarId(u16);
+
+impl LocalVarId {
+    /// The successor of this ID.
+    #[must_use]
+    pub fn successor(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+impl Display for LocalVarId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl From<LocalVarId> for usize {
+    fn from(value: LocalVarId) -> Self {
+        value.0 as usize
+    }
+}
+
+impl From<usize> for LocalVarId {
+    fn from(value: usize) -> Self {
+        LocalVarId(value.try_into().expect("LocalVarId should fit into u32"))
+    }
+}
+
 /// A unique identifier for a package within a package store.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PackageId(usize);
@@ -300,7 +330,7 @@ pub enum Res {
     /// A global item.
     Item(ItemId),
     /// A local variable.
-    Local(NodeId),
+    Local(LocalVarId),
 }
 
 impl Display for Res {
@@ -1006,7 +1036,7 @@ pub enum ExprKind {
     /// A call: `a(b)`.
     Call(ExprId, ExprId),
     /// A closure that fixes the vector of local variables as arguments to the callable item.
-    Closure(Vec<NodeId>, LocalItemId),
+    Closure(Vec<LocalVarId>, LocalItemId),
     /// A failure: `fail "message"`.
     Fail(ExprId),
     /// A field accessor: `a::F`.
@@ -1174,7 +1204,7 @@ fn display_call(mut indent: Indented<Formatter>, callable: ExprId, arg: ExprId) 
 
 fn display_closure(
     mut f: Indented<Formatter>,
-    args: &[NodeId],
+    args: &[LocalVarId],
     callable: LocalItemId,
 ) -> fmt::Result {
     f.write_str("Closure([")?;
@@ -1459,7 +1489,7 @@ impl Display for QubitInitKind {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Ident {
     /// The node ID.
-    pub id: NodeId,
+    pub id: LocalVarId,
     /// The span.
     pub span: Span,
     /// The identifier name.


### PR DESCRIPTION
This change improves performance by using an `IndexMap` for variable bindings at runtime. This is enabled by introducing a new identifier type in FIR specific to local variables that gets assigned contiguous IDs during lowering.