### PR TITLE
Remove missing spec error case

### DIFF
--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -67,13 +67,6 @@ pub enum Error {
     #[diagnostic(code("Qsc.Eval.IntTooLarge"))]
     IntTooLarge(i64, #[label("this value is too large")] PackageSpan),
 
-    #[error("missing specialization: {0}")]
-    #[diagnostic(code("Qsc.Eval.MissingSpec"))]
-    MissingSpec(
-        String,
-        #[label("callable has no {0} specialization")] PackageSpan,
-    ),
-
     #[error("index out of range: {0}")]
     #[diagnostic(code("Qsc.Eval.IndexOutOfRange"))]
     IndexOutOfRange(i64, #[label("out of range")] PackageSpan),
@@ -141,7 +134,6 @@ impl Error {
             | Error::IntTooLarge(_, span)
             | Error::InvalidRotationAngle(_, span)
             | Error::InvalidNegativeInt(_, span)
-            | Error::MissingSpec(_, span)
             | Error::OutputFail(span)
             | Error::QubitUniqueness(span)
             | Error::RangeStepZero(span)
@@ -1141,7 +1133,7 @@ impl State {
                     Spec::Ctl => specialized_implementation.ctl.as_ref(),
                     Spec::CtlAdj => specialized_implementation.ctl_adj.as_ref(),
                 }
-                .ok_or(Error::MissingSpec(spec.to_string(), callee_span))?;
+                .expect("missing specialization should be a compilation error");
                 self.bind_args_for_spec(
                     env,
                     globals,


### PR DESCRIPTION
This error case caused the additional allocation of string, which could be avoided by switching `.ok_or` to `.ok_or_else`, but in practice this error case is no longer possible now that type checking verifies supported functors at compile time.