### PR TITLE
Move `FunctorApp` to a shared location

### DIFF
--- a/compiler/qsc_data_structures/src/display.rs
+++ b/compiler/qsc_data_structures/src/display.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::fmt::{self, Display, Formatter};
+
+/// Displays values separated by the provided string.
+pub fn join(
+    f: &mut Formatter,
+    mut vals: impl Iterator<Item = impl Display>,
+    sep: &str,
+) -> fmt::Result {
+    if let Some(v) = vals.next() {
+        v.fmt(f)?;
+    }
+    for v in vals {
+        write!(f, "{sep}")?;
+        v.fmt(f)?;
+    }
+    Ok(())
+}

--- a/compiler/qsc_data_structures/src/functor.rs
+++ b/compiler/qsc_data_structures/src/functor.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct FunctorApp {
+    /// An invocation is either adjoint or not, with each successive use of `Adjoint` functor switching
+    /// between the two, so a bool is sufficient to track.
+    pub adjoint: bool,
+
+    /// An invocation can have multiple `Controlled` functors with each one adding another layer of updates
+    /// to the argument tuple, so the functor application must be tracked with a count.
+    pub controlled: u8,
+}
+
+impl Display for FunctorApp {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let controlleds = iter::repeat("Controlled").take(self.controlled.into());
+        let adjoint = iter::once("Adjoint").filter(|_| self.adjoint);
+        join(f, controlleds.chain(adjoint), " ")
+    }
+}

--- a/compiler/qsc_data_structures/src/functors.rs
+++ b/compiler/qsc_data_structures/src/functors.rs
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::display::join;
+use std::{
+    fmt::{self, Display, Formatter},
+    iter,
+};
+
+/// A functor application.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FunctorApp {
     /// An invocation is either adjoint or not, with each successive use of `Adjoint` functor switching

--- a/compiler/qsc_data_structures/src/lib.rs
+++ b/compiler/qsc_data_structures/src/lib.rs
@@ -4,6 +4,8 @@
 #![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
+pub mod display;
+pub mod functors;
 pub mod index_map;
 pub mod line_column;
 pub mod span;

--- a/compiler/qsc_eval/src/debug.rs
+++ b/compiler/qsc_eval/src/debug.rs
@@ -3,7 +3,7 @@
 
 use qsc_data_structures::span::Span;
 
-use crate::val::FunctorApp;
+use qsc_data_structures::functors::FunctorApp;
 use qsc_fir::fir;
 use qsc_fir::fir::{PackageId, StoreItemId};
 use qsc_hir::hir;

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -15,15 +15,14 @@ pub mod lower;
 pub mod output;
 pub mod val;
 
-use crate::val::{FunctorApp, Value};
+use crate::val::Value;
 use backend::Backend;
 use debug::{map_fir_package_to_hir, CallStack, Frame};
 use error::PackageSpan;
 use miette::Diagnostic;
 use num_bigint::BigInt;
 use output::Receiver;
-use qsc_data_structures::index_map::IndexMap;
-use qsc_data_structures::span::Span;
+use qsc_data_structures::{functors::FunctorApp, index_map::IndexMap, span::Span};
 use qsc_fir::fir::{
     self, BinOp, BlockId, CallableImpl, Expr, ExprId, ExprKind, Field, Functor, Global, Lit,
     LocalItemId, LocalVarId, Mutability, PackageId, PackageStoreLookup, PatId, PatKind, PrimField,

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 use num_bigint::BigInt;
+use qsc_data_structures::{display::join, functors::FunctorApp};
 use qsc_fir::fir::{Pauli, StoreItemId};
 use std::{
     fmt::{self, Display, Formatter},
-    iter,
     rc::Rc,
 };
 
@@ -72,25 +72,6 @@ impl From<usize> for Result {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Qubit(pub usize);
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct FunctorApp {
-    /// An invocation is either adjoint or not, with each successive use of `Adjoint` functor switching
-    /// between the two, so a bool is sufficient to track.
-    pub adjoint: bool,
-
-    /// An invocation can have multiple `Controlled` functors with each one adding another layer of updates
-    /// to the argument tuple, so the functor application must be tracked with a count.
-    pub controlled: u8,
-}
-
-impl Display for FunctorApp {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let controlleds = iter::repeat("Controlled").take(self.controlled.into());
-        let adjoint = iter::once("Adjoint").filter(|_| self.adjoint);
-        join(f, controlleds.chain(adjoint), " ")
-    }
-}
 
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -344,15 +325,4 @@ impl Value {
             Value::Tuple(_) => "Tuple",
         }
     }
-}
-
-fn join(f: &mut Formatter, mut vals: impl Iterator<Item = impl Display>, sep: &str) -> fmt::Result {
-    if let Some(v) = vals.next() {
-        v.fmt(f)?;
-    }
-    for v in vals {
-        write!(f, "{sep}")?;
-        v.fmt(f)?;
-    }
-    Ok(())
 }


### PR DESCRIPTION
This change moves `FunctorApp` to a shared location so it can also be used by runtime capabilities analysis (RCA).