### PR TITLE
Make FIR package store queries return `&Package` instead of `Option<&Package>`

### DIFF
--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -204,10 +204,7 @@ impl Interpreter {
     }
 
     fn get_entry_expr(&self) -> Result<ExprId, Vec<Error>> {
-        let unit = self
-            .fir_store
-            .get(self.source_package)
-            .expect("store should have package");
+        let unit = self.fir_store.get(self.source_package);
         if let Some(entry) = unit.entry {
             return Ok(entry);
         };
@@ -334,10 +331,7 @@ impl Interpreter {
     }
 
     fn lower(&mut self, unit_addition: &qsc_frontend::incremental::Increment) -> Vec<StmtId> {
-        let fir_package = self
-            .fir_store
-            .get_mut(self.package)
-            .expect("package should be in store");
+        let fir_package = self.fir_store.get_mut(self.package);
         self.lowerer
             .lower_and_update_package(fir_package, &unit_addition.hir)
     }
@@ -469,8 +463,7 @@ impl Debugger {
             let package = self
                 .interpreter
                 .fir_store
-                .get(self.interpreter.source_package)
-                .expect("package should have been lowered");
+                .get(self.interpreter.source_package);
             let mut collector = BreakpointCollector::new(
                 &unit.sources,
                 source.offset,

--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -41,7 +41,7 @@ pub fn generate_qir(
     }
 
     let package = map_hir_package_to_fir(package);
-    let unit = fir_store.get(package).expect("store should have package");
+    let unit = fir_store.get(package);
     let entry_expr = unit.entry.expect("package should have entry");
 
     let mut sim = BaseProfSim::default();

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -462,46 +462,37 @@ pub struct PackageStore(IndexMap<PackageId, Package>);
 
 impl PackageStoreLookup for PackageStore {
     fn get_block(&self, id: StoreBlockId) -> &Block {
-        self.get(id.package)
-            .expect("Package not found")
-            .get_block(id.block)
+        self.get(id.package).get_block(id.block)
     }
 
     fn get_expr(&self, id: StoreExprId) -> &Expr {
-        self.get(id.package)
-            .expect("Package not found")
-            .get_expr(id.expr)
+        self.get(id.package).get_expr(id.expr)
     }
 
     fn get_global(&self, id: StoreItemId) -> Option<Global> {
-        self.get(id.package)
-            .and_then(|package| package.get_global(id.item))
+        self.get(id.package).get_global(id.item)
     }
 
     fn get_pat(&self, id: StorePatId) -> &Pat {
-        self.get(id.package)
-            .expect("Package not found")
-            .get_pat(id.pat)
+        self.get(id.package).get_pat(id.pat)
     }
 
     fn get_stmt(&self, id: StoreStmtId) -> &Stmt {
-        self.get(id.package)
-            .expect("Package not found")
-            .get_stmt(id.stmt)
+        self.get(id.package).get_stmt(id.stmt)
     }
 }
 
 impl PackageStore {
     /// Gets a package from the store.
     #[must_use]
-    pub fn get(&self, id: PackageId) -> Option<&Package> {
-        self.0.get(id)
+    pub fn get(&self, id: PackageId) -> &Package {
+        self.0.get(id).expect("store should have package")
     }
 
     /// Gets a mutable package from the store.
     #[must_use]
-    pub fn get_mut(&mut self, id: PackageId) -> Option<&mut Package> {
-        self.0.get_mut(id)
+    pub fn get_mut(&mut self, id: PackageId) -> &mut Package {
+        self.0.get_mut(id).expect("store should have package")
     }
 
     /// Inserts a package to the store.


### PR DESCRIPTION
When we query a package from an FIR package store, we always expect the package to be present in the store. Therefore, there is no need to return an option (we always use `expect` to extract the package reference from the option).

This change modifies the `get` and `get_mut` methods for `fir::PackageStore` such that they return a reference to a package instead of an option.