### PR TITLE
Fix comment formatting in memory benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,10 +200,11 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   body: `_Change in memory usage detected by benchmark._
-                ## Memory Report for ${{ github.sha }}
-                | Test                        | This Branch | On Main  |
-                |-----------------------------|-------------|----------|
-                | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes |`
+            ## Memory Report for ${{ github.sha }}
+
+            | Test                        | This Branch | On Main  |
+            |-----------------------------|-------------|----------|
+            | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes |`
                 })
               } catch (err) {
                 core.warning(`Failed writing comment on GitHub issue: ${err}`)


### PR DESCRIPTION
I noticed in #1173 that the formatting for the memory benchmark is broken. This PR fixes that. See below comment for updated formatting.
