### PR TITLE
Fix Typo in Docs Metadata

### DIFF
--- a/compiler/qsc_doc_gen/src/generate_docs.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs.rs
@@ -216,7 +216,7 @@ impl Display for Metadata {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let kind = match &self.kind {
             MetadataKind::Function => "function",
-            MetadataKind::Operation => "opeartion",
+            MetadataKind::Operation => "operation",
             MetadataKind::Udt => "udt",
         };
         write!(


### PR DESCRIPTION
Fixes "opeartion" to "operation" in the generated docs' metadata.