### PR TITLE
Clean up Single-Qubit Measurements kata

### DIFF
--- a/katas/content/single_qubit_measurements/a_b_basis_measurements/Placeholder.qs
+++ b/katas/content/single_qubit_measurements/a_b_basis_measurements/Placeholder.qs
@@ -1,9 +1,7 @@
 namespace Kata {
-
     operation MeasureInABBasis(alpha : Double, q : Qubit) : Result {
         // Implement your solution here...
 
         return Zero;
     }
-
 }

--- a/katas/content/single_qubit_measurements/a_b_basis_measurements/Solution.qs
+++ b/katas/content/single_qubit_measurements/a_b_basis_measurements/Solution.qs
@@ -1,10 +1,8 @@
 namespace Kata {
-
     operation MeasureInABBasis(alpha : Double, q : Qubit) : Result {
         Rx(-2.0 * alpha, q);
         let measurementResult = M(q);
         Rx(2.0 * alpha, q);
         return measurementResult;
     }
-
 }

--- a/katas/content/single_qubit_measurements/a_b_basis_measurements/Verification.qs
+++ b/katas/content/single_qubit_measurements/a_b_basis_measurements/Verification.qs
@@ -5,7 +5,6 @@ namespace Kata.Verification {
     // Measure state in {|A❭, |B❭} basis
     // |A⟩ =   cos(alpha) * |0⟩ - i sin(alpha) * |1⟩,
     // |B⟩ = - i sin(alpha) * |0⟩ + cos(alpha) * |1⟩.
-
     operation StatePrep_IsQubitA (alpha : Double, q : Qubit, state : Int) : Unit is Adj {
         if state == 0 {
             // convert |0⟩ to |B⟩
@@ -27,11 +26,11 @@ namespace Kata.Verification {
                 [$"|B⟩=(-i sin({i}π/10)|0⟩ + cos({i}π/10)|1⟩)", $"|A⟩=(cos({i}π/10)|0⟩ + i sin({i}π/10)|1⟩)"],
                 true);
             if not isCorrect {
-                Message($"Test failes for alpha={alpha}");
+                Message($"Test fails for alpha={alpha}");
                 return false;
             }
         }
-        Message("All tests passed.");
+        Message("Correct!");
         true
     }
 

--- a/katas/content/single_qubit_measurements/distinguish_0_and_1/Placeholder.qs
+++ b/katas/content/single_qubit_measurements/distinguish_0_and_1/Placeholder.qs
@@ -1,16 +1,7 @@
 namespace Kata {
-
     operation IsQubitZero(q : Qubit) : Bool {
-        // The operation M will measure a qubit in the computational basis
-        // (|0⟩ and |1⟩ basis) and return Zero if the observed state was |0⟩
-        // or One if the state was |1⟩. Measuring a basis state will yield the
-        // result matching that state deterministically. To answer the
-        // question, you need to perform the measurement and check whether the
-        // result equals Zero.
-
         // Implement your solution here...
 
         return false;
     }
-
 }

--- a/katas/content/single_qubit_measurements/distinguish_0_and_1/Solution.qs
+++ b/katas/content/single_qubit_measurements/distinguish_0_and_1/Solution.qs
@@ -2,5 +2,4 @@ namespace Kata {
     operation IsQubitZero(q : Qubit) : Bool {
         return M(q) == Zero;
     }
-    
 }

--- a/katas/content/single_qubit_measurements/distinguish_0_and_1/Verification.qs
+++ b/katas/content/single_qubit_measurements/distinguish_0_and_1/Verification.qs
@@ -2,7 +2,6 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Intrinsic;
 
-    //Distinguish |0❭ and |1❭
     operation StatePrep_IsQubitZero (q : Qubit, state : Int) : Unit is Adj {
         if state == 0 {
             // convert |0⟩ to |1⟩
@@ -18,7 +17,9 @@ namespace Kata.Verification {
             ["|1⟩", "|0⟩"],
             false);
         if isCorrect {
-            Message("All tests passed.");
+            Message("Correct!");
+        } else {
+            Message("Incorrect.");
         }
         isCorrect
     }

--- a/katas/content/single_qubit_measurements/distinguish_0_and_1/solution.md
+++ b/katas/content/single_qubit_measurements/distinguish_0_and_1/solution.md
@@ -1,9 +1,9 @@
 The input qubit is guaranteed to be either in basis state $|0\rangle$ or $|1\rangle$. This means that when measuring the qubit in the computational basis, the measurement will report the input state without any doubt.
 
-In Q# the operation <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.m" target="_blank">`M`</a> can be used to measure a single qubit in the computational basis. The measurement result is a value of type `Result` - the operation `M` will return `One` if the input qubit was in the $|1\rangle$ state and `Zero` if the input qubit was in the $|0\rangle$ state. Since we need to encode the first case as `false` and the second one as `true`, we can return the result of equality comparison between measurement result and `Zero`.
+In Q# the operation `M` can be used to measure a single qubit in the computational basis. The measurement result is a value of type `Result` - the operation `M` will return `One` if the input qubit was in the $|1\rangle$ state and `Zero` if the input qubit was in the $|0\rangle$ state. Since we need to encode the first case as `false` and the second one as `true`, we can return the result of equality comparison between measurement result and `Zero`.
 
 @[solution]({
-"id": "single_qubit_measurements__distinguish_0_and_1_solution",
-"exerciseId": "distinguish_0_and_1",
-"codePath": "Solution.qs"
+    "id": "single_qubit_measurements__distinguish_0_and_1_solution",
+    "exerciseId": "distinguish_0_and_1",
+    "codePath": "Solution.qs"
 })

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/Placeholder.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/Placeholder.qs
@@ -6,5 +6,4 @@ namespace Kata {
 
         return false;
     }
-
 }

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/Solution.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/Solution.qs
@@ -5,5 +5,4 @@ namespace Kata {
         Ry(-2.0 * ArcTan2(0.8, 0.6), q);
         return M(q) == Zero;
     }
-
 }

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/Verification.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/Verification.qs
@@ -22,7 +22,9 @@ namespace Kata.Verification {
             ["|ψ₋⟩", "|ψ₊⟩"],
             false);
         if isCorrect {
-            Message("All tests passed.");
+            Message("Correct!");
+        } else {
+            Message("Incorrect.");
         }
         isCorrect
     }

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/index.md
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_1/index.md
@@ -4,5 +4,5 @@
 
 <details>
 <summary><strong>Need a hint?</strong></summary>
-A suitable $R_y$ rotation can be used to go from the computational basis ${ \ket 0, \ket 1 }$ to the ${ \ket{\psi_+}, \ket{\psi_-} }$ basis and vice versa.
+A suitable $R_y$ rotation can be used to go from the computational basis $\\{ \ket 0, \ket 1 \\}$ to the $\\{ \ket{\psi_+}, \ket{\psi_-} \\}$ basis and vice versa.
 </details>

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/Placeholder.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/Placeholder.qs
@@ -1,9 +1,7 @@
 namespace Kata {
-
     operation IsQubitA(alpha : Double, q : Qubit) : Bool {
         // Implement your solution here...
 
         return false;
     }
-
 }

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/Solution.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/Solution.qs
@@ -1,8 +1,6 @@
 namespace Kata {
-
     operation IsQubitA(alpha : Double, q : Qubit) : Bool {
         Rx(-2.0 * alpha, q);
         return M(q) == Zero;
     }
-
 }

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/Verification.qs
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/Verification.qs
@@ -26,10 +26,11 @@ namespace Kata.Verification {
                 [$"|B⟩ = -i sin({i}π/10)|0⟩ + cos({i}π/10)|1⟩", $"|A⟩ = cos({i}π/10)|0⟩ + i sin({i}π/10)|1⟩"],
                 false);
             if not isCorrect {
+                Message("Incorrect.");
                 return false;
             }
         }
-        Message("All tests passed.");
+        Message("Correct!");
         true
     }
 

--- a/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/solution.md
+++ b/katas/content/single_qubit_measurements/distinguish_orthogonal_states_2/solution.md
@@ -1,4 +1,4 @@
-We can distinguish between the states $\ket{A}$ and $\ket B$ if we implement a measurement in the $\{ \ket{A}, \ket{B}\}$ basis.
+We can distinguish between the states $\ket{A}$ and $\ket B$ if we implement a measurement in the $\\{ \ket{A}, \ket{B}\\}$ basis.
 
 We can notice that the $R_x$ rotation gate with $\theta = 2 \alpha$ is an appropriate transformation which maps the $\ket 0 $ state to the $\ket A$ state, and the $\ket 1$ state to the $\ket B$ state:
 

--- a/katas/content/single_qubit_measurements/distinguish_plus_and_minus/Placeholder.qs
+++ b/katas/content/single_qubit_measurements/distinguish_plus_and_minus/Placeholder.qs
@@ -1,9 +1,7 @@
 namespace Kata {
-
     operation IsQubitMinus(q : Qubit) : Bool {
         // Implement your solution here...
 
         return false;
     }
-
 }

--- a/katas/content/single_qubit_measurements/distinguish_plus_and_minus/Solution.qs
+++ b/katas/content/single_qubit_measurements/distinguish_plus_and_minus/Solution.qs
@@ -2,5 +2,4 @@ namespace Kata {
     operation IsQubitMinus(q : Qubit) : Bool {
         return Measure([PauliX], [q]) == One;
     }
-
 }

--- a/katas/content/single_qubit_measurements/distinguish_plus_and_minus/Verification.qs
+++ b/katas/content/single_qubit_measurements/distinguish_plus_and_minus/Verification.qs
@@ -20,7 +20,9 @@ namespace Kata.Verification {
             ["|+⟩", "|-⟩"],
             false);
         if isCorrect {
-            Message("All tests passed.");
+            Message("Correct!");
+        } else {
+            Message("Incorrect.");
         }
         isCorrect
     }

--- a/katas/content/single_qubit_measurements/distinguish_plus_and_minus/index.md
+++ b/katas/content/single_qubit_measurements/distinguish_plus_and_minus/index.md
@@ -1,6 +1,6 @@
 **Input**: A qubit which is guaranteed to be in either the $\ket +$ state, or the $\ket -$ state.
 
-**Output**: `true` if the qubit is in the $\ket -$ state, or `false` if it was in the $\ket +$ state.
+**Output**: `true` if the qubit is in the $\ket -$ state, or `false` if it was in the $\ket +$ state. The state of the qubit at the end of the operation does not matter.
 
 > To perform a single-qubit measurement in a certain Pauli basis using the `Measure` operation,
 > you need to pass it two parameters: first, an array of one `Pauli` constant (`PauliX`, `PauliY` or `PauliZ`), and second, an array of one qubit you want to measure.

--- a/katas/content/single_qubit_measurements/distinguish_plus_and_minus/solution.md
+++ b/katas/content/single_qubit_measurements/distinguish_plus_and_minus/solution.md
@@ -1,6 +1,6 @@
 The input qubit is guaranteed to be either in basis state $|+\rangle$ or $|-\rangle$. This means that when measuring the qubit in the Pauli X basis, the measurement will report the input state without any doubt. (Recall that these states are eigenstates for the Pauli X matrix).
 
-In Q# the operation <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.measure" target="_blank">`Measure`</a> can be used to measure a qubit in Pauli basis of the user's choice. The operation returns a value of type `Result` and is `Zero` if the measured state corresponds to the eigenvalue $+1$, and `One` if it corresponds to the eigenvalue $-1$ of the Pauli operator.
+In Q# the operation `Measure` can be used to measure a qubit in Pauli basis of the user's choice. The operation returns a value of type `Result` and is `Zero` if the measured state corresponds to the eigenvalue $+1$, and `One` if it corresponds to the eigenvalue $-1$ of the Pauli operator.
 
 Since the states $\ket +$ and $\ket -$ correspond to the eigenvalues $+1$ and $-1$ of the Pauli X operator, we can return the result of equality comparison between the measurement result and `One`.
 Note that since `Measure` operation generally works with multiple qubits to perform multi-qubit measurements, it takes array parameters. To do a single-qubit measurement, you need to pass two arrays of one element, `[PauliX]` and `[q]`, rather than individual values.

--- a/katas/content/single_qubit_measurements/implementing_measurement/Example.qs
+++ b/katas/content/single_qubit_measurements/implementing_measurement/Example.qs
@@ -5,16 +5,12 @@ namespace Kata {
     @EntryPoint()
     operation SimpleMeasurementDemo() : Unit {
         use q = Qubit();
-        // Prepare the qubit in the superposition state
-        // |𝜓❭ = 0.6 |0❭ + 0.8 |1❭
+        // Prepare the qubit in the superposition state |𝜓❭ = 0.6 |0❭ + 0.8 |1❭
         Ry(2.0 * ArcTan2(0.8, 0.6), q);
-
         Message("Qubit in state |𝜓❭:");
         DumpMachine();
 
-        Message("Measuring the qubit...");
-        let outcome = (M(q) == One ? 1 | 0);
-
+        let outcome = M(q) == One ? 1 | 0;
         Message($"The measurement outcome is {outcome}.");
         Message("Post-measurement state of the qubit:");
         DumpMachine();

--- a/katas/content/single_qubit_measurements/index.md
+++ b/katas/content/single_qubit_measurements/index.md
@@ -86,7 +86,7 @@ In this demo, we prepare a qubit in the state $0.6|0\rangle + 0.8|1\rangle$, and
 
 > If you run this code multiple times, you will notice that whenever the measurement outcome is $1$, the post-measurement state of the qubit is $\ket 1$, and similarly for outcome $0$ the final state is $\ket{0}$. This is in line with our expectation that after the measurement the wave function 'collapses' to the corresponding state.
 
-An alternative way to implement a computational basis measurement is `MResetZ` operation that measures the qubit and resets it to the $\ket{0}$ state. Remember that Q# requires you to reset all qubits to $\ket{0}$ before releasing them, so if you don't need to use the qubit after you measure it, it is convenient to use `MResetZ` right away rather than do the measurement using `M` and follow it with a separate call to `Reset`.
+An alternative way to implement a computational basis measurement is using the `MResetZ` operation that measures the qubit and resets it to the $\ket{0}$ state. Remember that Q# requires you to reset all qubits to $\ket{0}$ before releasing them, so if you don't need to use the qubit after you measure it, it is convenient to use `MResetZ` right away rather than do the measurement using `M` and follow it with a separate call to `Reset`.
 
 @[example]({
     "id": "single_qubit_measurements__implementing_measurement_demo",

--- a/katas/content/single_qubit_measurements/index.md
+++ b/katas/content/single_qubit_measurements/index.md
@@ -61,14 +61,14 @@ The outcomes of computational basis measurements and their probabilities are sum
     </tr>
 </table>
 
->Unlike quantum gates which are unitary and reversible operations, measurements are neither unitary nor reversible. Since the outcomes of a measurement are probabilistic, any two isolated qubits which are initially prepared in identical superposition states are in general not guaranteed to have the same measurement outcomes after each qubit has been measured separately. As we will see below, measurements are modeled by projection operators instead of unitary operators.
+>Unlike quantum gates, which are unitary and reversible operations, measurements are neither unitary nor reversible. Since the outcomes of a measurement are probabilistic, any two isolated qubits which are initially prepared in identical superposition states are in general not guaranteed to have the same measurement outcomes after each qubit has been measured separately. As we will see below, measurements are modeled by projection operators instead of unitary operators.
 >
 >Additionally, the assumption of the wave function being **normalized** is important, since the probability outcomes must sum up to $1$. If the wave function is not normalized, it is important to normalize it first in order to obtain the correct measurement probabilities.
 
 ## 🔎 Analyze
 
 The qubit is in the following state:
-$$\ket \psi = 0.6 \ket 0 + 0.8 \ket 1 \equiv \begin{bmatrix} 0.6 \\\ 0.8\end{bmatrix}.$$
+$$\ket \psi = 0.6 \ket 0 + 0.8 \ket 1 = \begin{bmatrix} 0.6 \\\ 0.8\end{bmatrix}$$
 
 If this qubit is measured in the computational basis, what are the outcome probabilities?
 
@@ -79,12 +79,14 @@ The given state $\ket \psi$ is normalized, since $0.6^2 + 0.8^2 = 1$. Hence, the
 
 @[section]({
     "id": "single_qubit_measurements__implementing_measurement",
-    "title": "Implementing Measurement In Q# Using The M Operation"
+    "title": "Implementing Measurement in Q# Using Operations M and MResetZ"
 })
 
-In this demo, we prepare a qubit in the state $0.6|0\rangle + 0.8|1\rangle$, and then measure it in the computational basis. In Q#, single-qubit measurements in the computational basis can be implemented using the <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.m" target="_blank">M operation</a>. It will return the constant `Zero` if measurement result was $0$ or the constant `One` if the measurement result was $1$. `Zero` and `One` are constants of type `Result`.
+In this demo, we prepare a qubit in the state $0.6|0\rangle + 0.8|1\rangle$, and then measure it in the computational basis. In Q#, single-qubit measurements in the computational basis can be implemented using the `M` operation. It will return the constant `Zero` if measurement result was $0$ or the constant `One` if the measurement result was $1$. `Zero` and `One` are constants of type `Result`.
 
-> If you run this code multiple times, you will notice that whenever the measurement outcome is $1$, the post-measurement state of the qubit is $\ket 1$, and similarly for $0$. This is in line with our expectation that after the measurement the wave function 'collapses' to the corresponding state.
+> If you run this code multiple times, you will notice that whenever the measurement outcome is $1$, the post-measurement state of the qubit is $\ket 1$, and similarly for outcome $0$ the final state is $\ket{0}$. This is in line with our expectation that after the measurement the wave function 'collapses' to the corresponding state.
+
+An alternative way to implement a computational basis measurement is `MResetZ` operation that measures the qubit and resets it to the $\ket{0}$ state. Remember that Q# requires you to reset all qubits to $\ket{0}$ before releasing them, so if you don't need to use the qubit after you measure it, it is convenient to use `MResetZ` right away rather than do the measurement using `M` and follow it with a separate call to `Reset`.
 
 @[example]({
     "id": "single_qubit_measurements__implementing_measurement_demo",
@@ -96,14 +98,14 @@ In this demo, we prepare a qubit in the state $0.6|0\rangle + 0.8|1\rangle$, and
     "title": "Measurement Statistics"
 })
 
-The following code demonstrates that the theoretical and experimental values of the probability outcomes indeed match with each other. We repeatedly prepare the same state $\ket \psi = 0.6 \ket 0 + 0.8 \ket 1$ and measure it in the computational basis $100$ times. At the end, we expect 0 to be measured approximately $|0.6 |^2 \cdot 100= 36$ times, and 1 to be measured approximately $|0.8|^2 \cdot 100= 64$ times. Note that since measurements are probabilistic, we do not expect the results to match these values exactly. As we repeat the measurements, the resulting distribution will align with the theoretical probabilities.
+The following code demonstrates that the theoretical and experimental values of the probability outcomes indeed match with each other. We repeatedly prepare the same state $\ket \psi = 0.6 \ket 0 + 0.8 \ket 1$ and measure it in the computational basis $100$ times. At the end, we expect $0$ to be measured approximately $|0.6 |^2 \cdot 100= 36$ times, and $1$ to be measured approximately $|0.8|^2 \cdot 100= 64$ times. Note that since measurements are probabilistic, we do not expect the results to match these values exactly. As we repeat the measurements, the resulting distribution will align with the theoretical probabilities.
 
 @[example]({
     "id": "single_qubit_measurements__measurement_statistics_demo",
     "codePath": "./measurement_statistics/Example.qs"
 })
 
-Measurements can be used to distinguish orthogonal states. We start with an exercise for distinguishing between the computational basis states and discuss the general case of arbitrary basis measurements later in the kata.
+Measurements can be used to distinguish orthogonal states. We start with an exercise for distinguishing between the computational basis states, and discuss the general case of arbitrary basis measurements later in the kata.
 
 @[exercise]({
     "id": "single_qubit_measurements__distinguish_0_and_1",
@@ -122,14 +124,14 @@ Measurements can be used to distinguish orthogonal states. We start with an exer
 
 So far, we have discussed measurements done in the computational basis, that is, the $\{ \ket 0, \ket 1\}$ basis.
 
-It is also possible to implement measurements in other orthogonal bases, such as the Pauli X basis, which consists of the two vectors $\ket + = \frac1{\sqrt2} \big(\ket 0 +\ket 1\big)$, and $\ket - = \frac1{\sqrt2} \big(\ket 0 -\ket 1\big)$. Q# has a built-in operation <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic.measure" target="_blank">`Measure`</a> for measurements in the Pauli bases.
+It is also possible to implement measurements in other orthogonal bases, such as the Pauli X basis, which consists of the two vectors $\ket + = \frac1{\sqrt2} \big(\ket 0 +\ket 1\big)$, and $\ket - = \frac1{\sqrt2} \big(\ket 0 -\ket 1\big)$. Q# has a built-in operation `Measure` for measurements in the Pauli bases.
 
-> The `Measure` operation can be used for measuring multiple qubits in a multi-qubit system; however, in this kata we only consider measurements for single-qubit systems.
+> The `Measure` operation can also be used for measuring multiple qubits in a multi-qubit system; however, in this kata we only consider measurements for single-qubit systems.
 
 The eigenvalues of a Pauli matrix are $\pm 1$, with one eigenvector corresponding to each eigenvalue. For any chosen Pauli basis, the `Measure` operation returns `Zero` if the measurement outcome corresponds to the eigenvalue $+1$, and returns `One` if the measurement outcome corresponds to the eigenvalue $-1$. As in the case of the computational basis measurements, the wave function of the qubit collapses to the corresponding state after the measurement is executed.
 
-The probabilities of the outcomes are defined using a similar rule: to measure a state $\ket \psi$ in a Pauli basis $\{ \ket {b_0}, \ket {b_1}\}$, we represent it as a linear combination of the basis vectors
-$$\ket \psi = c_0 \ket {b_0} + c_1 \ket {b_1}.$$
+The probabilities of the outcomes are defined using a similar rule: to measure a state $\ket \psi$ in a Pauli basis $\\{ \ket {b_0}, \ket {b_1} \\}$, we represent it as a linear combination of the basis vectors
+$$\ket \psi = c_0 \ket {b_0} + c_1 \ket {b_1}$$
 
 The probabilities of outcomes $\ket{b_0}$ and $\ket{b_1}$ will be defined as $|c_0|^2$, and $|c_1|^2$, respectively.
 
@@ -154,7 +156,7 @@ It is possible to measure a qubit in orthogonal bases other than the Pauli bases
 $$
 \ket \psi = c_0 \ket {b_0} + c_1 \ket {b_1}.
 $$
-The rule for obtaining the probabilities of measurement outcomes is exactly the same as that for the computation basis measurement. For a measurement in a $\{ b_0, b_1\}$ basis we get
+The rule for obtaining the probabilities of measurement outcomes is exactly the same as that for the computational basis measurement. For a measurement in a $\\{ b_0, b_1\\}$ basis we get
 
 - Outcome $b_0$ with probability $|c_0|^2$ and the post-measurement qubit state of $\ket {b_0}$
 - Outcome $b_1$ with probability $|c_1|^2$ and the post-measurement qubit state of $\ket {b_1}$
@@ -182,8 +184,8 @@ As before, the assumption of $\ket \psi$ being normalized is important, since it
 
 > As you may recall, a global phase is said to be hidden or unobservable.
 This is explained by the fact that global phases have no impact on quantum measurements. For example, consider two isolated qubits which are in (normalized) states $\ket \psi$ and $e^{i\theta}\ket \psi$.
-If both are measured in an orthogonal basis $\{ \ket{b_0},\ket{b_1}\}$, the probabilities of measuring $b_0$ or $b_1$ are identical in both cases, since $|\bra{b_i}\ket{\psi}|^2 = |\bra{b_i}e^{i\theta}\ket{\psi}|^2  $.
-Similarly, for either qubit, if $b_i$ is the measurement outcome, the post-measurement state of the qubit is $\ket{b_i}$ for both qubits. Hence, the measurements are independent of the global phase $\theta$.
+If both are measured in an orthogonal basis $\\{ \ket{b_0},\ket{b_1}\\}$, the probabilities of measuring $b_0$ or $b_1$ are identical in both cases, since $|\bra{b_i}\ket{\psi}|^2 = |\bra{b_i}e^{i\theta}\ket{\psi}|^2  $.
+Similarly, for either qubit, if $b_i$ is the measurement outcome, the post-measurement state of the qubit is $\ket{b_i}$. Hence, the measurements are independent of the global phase $\theta$.
 
 ## Measurements as Projection Operations
 
@@ -199,16 +201,15 @@ $$
 P = \ket 0 \bra 0 \equiv \begin{bmatrix} 1 & 0 \\\ 0 & 0\end{bmatrix}.
 $$
 
-A measurement in an orthogonal basis $\{ \ket{b_0}, \ket{b_1}\}$ is described by a pair of projectors $P_0 = \ket{b_0}\bra{b_0}$ and $P_1 = \ket{b_1}\bra{b_1}$. Since $\ket{b_0}$ and $\ket{b_1}$ are orthogonal, their projectors are also orthogonal, i.e., $P_0 P_1 = P_1 P_0 = 0$. The rules for measurements in this basis can then be summarized as follows:
+A measurement in an orthogonal basis $\\{ \ket{b_0}, \ket{b_1}\\}$ is described by a pair of projectors $P_0 = \ket{b_0}\bra{b_0}$ and $P_1 = \ket{b_1}\bra{b_1}$. Since $\ket{b_0}$ and $\ket{b_1}$ are orthogonal, their projectors are also orthogonal, i.e., $P_0 P_1 = P_1 P_0 = 0$. The rules for measurements in this basis can then be summarized as follows:
 
 - Measuring a qubit in a state $\ket \psi$ is done by picking one of these projection operators at random.
 - Projection $P_0$ is chosen with probability $|P_0 \ket{\psi}|^2$, and the projector $P_1$ is chosen with probability $|P_1\ket{\psi}|^2.$
 - If projector $P_0$ is chosen, the post-measurement state of the qubit is given by
-
-$$
-\frac1{|P_0 \ket{\psi}|}P_0 \ket\psi,
-$$
-and similarly for $P_1$.
+    $$
+    \frac1{|P_0 \ket{\psi}|}P_0 \ket\psi,
+    $$
+    and similarly for $P_1$.
 
 Although this formalism looks different from the previous sections, it is in fact equivalent. If $\ket \psi = c_0 \ket{b_0} + c_1 \ket{b_1}$, we have
 $$
@@ -219,15 +220,15 @@ $$
 P_1 \ket \psi = c_1 \ket{b_1}, \text{so that } |P_1\ket \psi| = c_1.
 $$
 
-Thus, as before, the probability of measuring $b_0$ is $|P_0\ket\psi|^2 = |c_0|^2$, and the probability of measuring $b_1$ is $|P_1\ket\psi|^2 = |c_1|^2$. Similarly, one can verify that the post-measurement outcomes are also $\ket{b_0}$ and $\ket{b_1}$ respectively (up to unobservable global phases).
+Thus, as before, the probability of measuring $b_0$ is $|P_0\ket\psi|^2 = |c_0|^2$, and the probability of measuring $b_1$ is $|P_1\ket\psi|^2 = |c_1|^2$. Similarly, one can verify that the post-measurement outcomes are also $\ket{b_0}$ and $\ket{b_1}$, respectively (up to unobservable global phases).
 
-Although the projector formalism for single-qubit systems may seem superfluous, its importance will become clear later while considering measurements for multi-qubit systems.
+Although the projector formalism for single-qubit systems may seem superfluous, its importance will become clear later, when we consider measurements for multi-qubit systems.
 
 ## Arbitrary Basis Measurements Implementation
 
 In the previous section, we discussed measurements in Pauli bases using the built-in `Measure` operation. We will now show that it is always possible to measure a qubit in any orthogonal basis using just unitary rotation matrices and computation basis measurements.
 
-Consider a state $ \ket \psi = c_0 \ket {b_0} + c_1 \ket {b_1} $ which we would like to measure in an orthonormal basis $\{ \ket{b_0}, \ket{b_1}\}$. First, we construct the following unitary matrix:
+Consider a state $ \ket \psi = c_0 \ket {b_0} + c_1 \ket {b_1} $ which we would like to measure in an orthonormal basis $\\{ \ket{b_0}, \ket{b_1}\\}$. First, we construct the following unitary matrix:
 $$
 U = \ket{0} \bra{b_0} + \ket{1} \bra{b_1}
 $$
@@ -240,12 +241,12 @@ $$
 (One may verify that $U$ is indeed a unitary matrix, by checking that $U^\dagger U = U U^\dagger = I$)
 
 Note that the effect of these matrices on the two bases is the following:
-$$U\ket{b_0} = \ket{0},$$
-$$U\ket{b_1} = \ket{1},$$
-$$U^\dagger \ket{0} = \ket{b_0},$$
-$$U^\dagger \ket 1 = \ket{b_1}.$$
+$$U\ket{b_0} = \ket{0}$$
+$$U\ket{b_1} = \ket{1}$$
+$$U^\dagger \ket{0} = \ket{b_0}$$
+$$U^\dagger \ket{1} = \ket{b_1}$$
 
-In order to implement a measurement in the ${ \ket{b_0}, \ket{b_1} }$ basis, we do the following:
+In order to implement a measurement in the $\\{ \ket{b_0}, \ket{b_1} \\}$ basis, we do the following:
 
 1. Apply $U$ to $\ket \psi$.  
    The resulting state is $U\ket \psi = c_0 \ket 0 + c_1 \ket 1 $.
@@ -333,9 +334,9 @@ This procedure can be used to distinguish arbitrary orthogonal states as well, a
 
 Congratulations! In this kata you learned how to apply measurements on single-qubit systems. Here are a few key concepts to keep in mind:
 
-- Measurements are always done in an orthogonal basis. By default, we choose the computational basis $\lbrace \ket{0}, \ket{1} \rbrace$.
-- Measurements are represented as projector operators, which are matrices.
 - Unlike quantum gates, measurements are neither unitary nor reversible. When we measure a qubit, the state of the qubit collapses to one of the basis states, and the initial state is lost.
-- In Q#, you can implement measurements in the computational basis using the `M` operation, and in the Pauli basis using the `Measure` operation.
+- Measurements are always done in an orthogonal basis. By default, we choose the computational basis ${{ \ket{0}, \ket{1} }}$.
+- Measurements are represented as sets of projector operators, which are matrices.
+- In Q#, you can implement measurements in the computational basis using the `M` operation, and in the Pauli basis using the `Measure` operation. You can also use `MResetZ` to measure a qubit in the computational basis and reset it to $\ket{0}$ right away.
 
 Next, you will learn about measurements in multi-qubit systems in the "Measurements in Multi-Qubit Systems" kata.

--- a/katas/content/single_qubit_measurements/measurement_statistics/Example.qs
+++ b/katas/content/single_qubit_measurements/measurement_statistics/Example.qs
@@ -1,7 +1,7 @@
 namespace Kata {
-
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Measurement;
 
     @EntryPoint()
     operation MeasumentStatisticsDemo() : Unit {
@@ -9,24 +9,19 @@ namespace Kata {
         let numRuns = 100;
         use q = Qubit();
         for i in 1 .. numRuns {
-            // Prepare the qubit in the superposition state
-            // |𝜓❭ = 0.6 |0❭ + 0.8 |1❭
+            // Prepare the qubit in the superposition state |𝜓❭ = 0.6 |0❭ + 0.8 |1❭
             Ry(2.0 * ArcTan2(0.8, 0.6), q);
 
-            // Measure in the computational basis, and update the counts according to the outcomes
-            if M(q) == Zero {
+            // Measure and update the counts according to the outcomes
+            if MResetZ(q) == Zero {
                 set countZero += 1;
             }
-            // Reset the qubit for use in the next iteration
-            Reset(q);
         }
         let countOne = numRuns - countZero;
 
         Message($"Simulated probability of measuring 0 is 0.{countZero}.");
         Message($"Theoretical probability of measuring 0 is 0.36.");
-
         Message($"Simulated probability of measuring 1 is 0.{countOne}.");
         Message($"Theoretical probability of measuring 1 is 0.64.");
     }
-
 }


### PR DESCRIPTION
Mostly making code snippets more compact, formatting, and adding info about MResetZ