### PR TITLE
Use optimized AND for decomposition 

### DIFF
--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -49,7 +49,7 @@ pub trait Backend {
 
 /// Default backend used when targeting sparse simulation.
 pub struct SparseSim {
-    sim: QuantumSim,
+    pub sim: QuantumSim,
 }
 
 impl Default for SparseSim {

--- a/library/src/tests.rs
+++ b/library/src/tests.rs
@@ -9,6 +9,7 @@ mod canon;
 mod convert;
 mod core;
 mod diagnostics;
+mod intrinsic;
 mod logical;
 mod math;
 mod measurement;
@@ -17,9 +18,9 @@ mod table_lookup;
 
 use indoc::indoc;
 use qsc::{
-    interpret::{GenericReceiver, Interpreter, Value},
+    interpret::{GenericReceiver, Interpreter, Result, Value},
     target::Profile,
-    PackageType, SourceMap,
+    Backend, PackageType, SourceMap, SparseSim,
 };
 
 /// # Panics
@@ -41,6 +42,17 @@ pub fn test_expression_with_lib_and_profile(
     profile: Profile,
     expected: &Value,
 ) -> String {
+    let mut sim = SparseSim::default();
+    test_expression_with_lib_and_profile_and_sim(expr, lib, profile, &mut sim, expected)
+}
+
+pub fn test_expression_with_lib_and_profile_and_sim(
+    expr: &str,
+    lib: &str,
+    profile: Profile,
+    sim: &mut impl Backend<ResultType = impl Into<Result>>,
+    expected: &Value,
+) -> String {
     let mut stdout = vec![];
     let mut out = GenericReceiver::new(&mut stdout);
 
@@ -49,7 +61,7 @@ pub fn test_expression_with_lib_and_profile(
     let mut interpreter = Interpreter::new(true, sources, PackageType::Exe, profile.into())
         .expect("test should compile");
     let result = interpreter
-        .eval_entry(&mut out)
+        .eval_entry_with_sim(sim, &mut out)
         .expect("test should run successfully");
 
     match (&expected, result) {

--- a/library/src/tests/intrinsic.rs
+++ b/library/src/tests/intrinsic.rs
@@ -634,7 +634,1245 @@ fn test_mcry_1_control() {
     }
 }
 
-// TODO: tests for mcs, mcsadj, mct, and mctadj with 1 and 2 controls unrestricted and 3 and 4 controls unrestricted + base
+#[test]
+fn test_mcs_1_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(2);
+            let aux = QIR.Runtime.AllocateQubitArray(2);
+            for i in 0..1 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled S(qs[0..0], qs[1]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000⟩: 0.5000+0.0000𝑖
+        |0101⟩: 0.5000+0.0000𝑖
+        |1010⟩: 0.5000+0.0000𝑖
+        |1111⟩: 0.0000+0.5000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcsadj(&[0], 1);
+    for i in 0..2 {
+        sim.sim.mcx(&[i + 2], i);
+        sim.sim.h(i + 2);
+        assert!(sim.sim.qubit_is_zero(i + 2), "qubit {} is not zero", i + 2);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mcs_2_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(3);
+            let aux = QIR.Runtime.AllocateQubitArray(3);
+            for i in 0..2 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled S(qs[0..1], qs[2]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |000000⟩: 0.3468−0.0690𝑖
+        |001001⟩: 0.3468−0.0690𝑖
+        |010010⟩: 0.3468−0.0690𝑖
+        |011011⟩: 0.3468−0.0690𝑖
+        |100100⟩: 0.3468−0.0690𝑖
+        |101101⟩: 0.3468−0.0690𝑖
+        |110110⟩: 0.3468−0.0690𝑖
+        |111111⟩: 0.0690+0.3468𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcsadj(&[0, 1], 2);
+    for i in 0..3 {
+        sim.sim.mcx(&[i + 3], i);
+        sim.sim.h(i + 3);
+        assert!(sim.sim.qubit_is_zero(i + 3), "qubit {} is not zero", i + 3);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcs_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled S(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2452−0.0488𝑖
+        |00010001⟩: 0.2452−0.0488𝑖
+        |00100010⟩: 0.2452−0.0488𝑖
+        |00110011⟩: 0.2452−0.0488𝑖
+        |01000100⟩: 0.2452−0.0488𝑖
+        |01010101⟩: 0.2452−0.0488𝑖
+        |01100110⟩: 0.2452−0.0488𝑖
+        |01110111⟩: 0.2452−0.0488𝑖
+        |10001000⟩: 0.2452−0.0488𝑖
+        |10011001⟩: 0.2452−0.0488𝑖
+        |10101010⟩: 0.2452−0.0488𝑖
+        |10111011⟩: 0.2452−0.0488𝑖
+        |11001100⟩: 0.2452−0.0488𝑖
+        |11011101⟩: 0.2452−0.0488𝑖
+        |11101110⟩: 0.2452−0.0488𝑖
+        |11111111⟩: 0.0488+0.2452𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcsadj(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcs_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled S(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2452−0.0488𝑖
+        |00010001⟩: 0.2452−0.0488𝑖
+        |00100010⟩: 0.2452−0.0488𝑖
+        |00110011⟩: 0.2452−0.0488𝑖
+        |01000100⟩: 0.2452−0.0488𝑖
+        |01010101⟩: 0.2452−0.0488𝑖
+        |01100110⟩: 0.2452−0.0488𝑖
+        |01110111⟩: 0.2452−0.0488𝑖
+        |10001000⟩: 0.2452−0.0488𝑖
+        |10011001⟩: 0.2452−0.0488𝑖
+        |10101010⟩: 0.2452−0.0488𝑖
+        |10111011⟩: 0.2452−0.0488𝑖
+        |11001100⟩: 0.2452−0.0488𝑖
+        |11011101⟩: 0.2452−0.0488𝑖
+        |11101110⟩: 0.2452−0.0488𝑖
+        |11111111⟩: 0.0488+0.2452𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcsadj(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcs_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled S(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1734−0.0345𝑖
+        |0000100001⟩: 0.1734−0.0345𝑖
+        |0001000010⟩: 0.1734−0.0345𝑖
+        |0001100011⟩: 0.1734−0.0345𝑖
+        |0010000100⟩: 0.1734−0.0345𝑖
+        |0010100101⟩: 0.1734−0.0345𝑖
+        |0011000110⟩: 0.1734−0.0345𝑖
+        |0011100111⟩: 0.1734−0.0345𝑖
+        |0100001000⟩: 0.1734−0.0345𝑖
+        |0100101001⟩: 0.1734−0.0345𝑖
+        |0101001010⟩: 0.1734−0.0345𝑖
+        |0101101011⟩: 0.1734−0.0345𝑖
+        |0110001100⟩: 0.1734−0.0345𝑖
+        |0110101101⟩: 0.1734−0.0345𝑖
+        |0111001110⟩: 0.1734−0.0345𝑖
+        |0111101111⟩: 0.1734−0.0345𝑖
+        |1000010000⟩: 0.1734−0.0345𝑖
+        |1000110001⟩: 0.1734−0.0345𝑖
+        |1001010010⟩: 0.1734−0.0345𝑖
+        |1001110011⟩: 0.1734−0.0345𝑖
+        |1010010100⟩: 0.1734−0.0345𝑖
+        |1010110101⟩: 0.1734−0.0345𝑖
+        |1011010110⟩: 0.1734−0.0345𝑖
+        |1011110111⟩: 0.1734−0.0345𝑖
+        |1100011000⟩: 0.1734−0.0345𝑖
+        |1100111001⟩: 0.1734−0.0345𝑖
+        |1101011010⟩: 0.1734−0.0345𝑖
+        |1101111011⟩: 0.1734−0.0345𝑖
+        |1110011100⟩: 0.1734−0.0345𝑖
+        |1110111101⟩: 0.1734−0.0345𝑖
+        |1111011110⟩: 0.1734−0.0345𝑖
+        |1111111111⟩: 0.0345+0.1734𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcsadj(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcs_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled S(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1734−0.0345𝑖
+        |0000100001⟩: 0.1734−0.0345𝑖
+        |0001000010⟩: 0.1734−0.0345𝑖
+        |0001100011⟩: 0.1734−0.0345𝑖
+        |0010000100⟩: 0.1734−0.0345𝑖
+        |0010100101⟩: 0.1734−0.0345𝑖
+        |0011000110⟩: 0.1734−0.0345𝑖
+        |0011100111⟩: 0.1734−0.0345𝑖
+        |0100001000⟩: 0.1734−0.0345𝑖
+        |0100101001⟩: 0.1734−0.0345𝑖
+        |0101001010⟩: 0.1734−0.0345𝑖
+        |0101101011⟩: 0.1734−0.0345𝑖
+        |0110001100⟩: 0.1734−0.0345𝑖
+        |0110101101⟩: 0.1734−0.0345𝑖
+        |0111001110⟩: 0.1734−0.0345𝑖
+        |0111101111⟩: 0.1734−0.0345𝑖
+        |1000010000⟩: 0.1734−0.0345𝑖
+        |1000110001⟩: 0.1734−0.0345𝑖
+        |1001010010⟩: 0.1734−0.0345𝑖
+        |1001110011⟩: 0.1734−0.0345𝑖
+        |1010010100⟩: 0.1734−0.0345𝑖
+        |1010110101⟩: 0.1734−0.0345𝑖
+        |1011010110⟩: 0.1734−0.0345𝑖
+        |1011110111⟩: 0.1734−0.0345𝑖
+        |1100011000⟩: 0.1734−0.0345𝑖
+        |1100111001⟩: 0.1734−0.0345𝑖
+        |1101011010⟩: 0.1734−0.0345𝑖
+        |1101111011⟩: 0.1734−0.0345𝑖
+        |1110011100⟩: 0.1734−0.0345𝑖
+        |1110111101⟩: 0.1734−0.0345𝑖
+        |1111011110⟩: 0.1734−0.0345𝑖
+        |1111111111⟩: 0.0345+0.1734𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcsadj(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mcsadj_1_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(2);
+            let aux = QIR.Runtime.AllocateQubitArray(2);
+            for i in 0..1 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint S(qs[0..0], qs[1]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000⟩: 0.5000+0.0000𝑖
+        |0101⟩: 0.5000+0.0000𝑖
+        |1010⟩: 0.5000+0.0000𝑖
+        |1111⟩: 0.0000−0.5000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcs(&[0], 1);
+    for i in 0..2 {
+        sim.sim.mcx(&[i + 2], i);
+        sim.sim.h(i + 2);
+        assert!(sim.sim.qubit_is_zero(i + 2), "qubit {} is not zero", i + 2);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mcsadj_2_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(3);
+            let aux = QIR.Runtime.AllocateQubitArray(3);
+            for i in 0..2 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint S(qs[0..1], qs[2]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |000000⟩: 0.3468+0.0690𝑖
+        |001001⟩: 0.3468+0.0690𝑖
+        |010010⟩: 0.3468+0.0690𝑖
+        |011011⟩: 0.3468+0.0690𝑖
+        |100100⟩: 0.3468+0.0690𝑖
+        |101101⟩: 0.3468+0.0690𝑖
+        |110110⟩: 0.3468+0.0690𝑖
+        |111111⟩: 0.0690−0.3468𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcs(&[0, 1], 2);
+    for i in 0..3 {
+        sim.sim.mcx(&[i + 3], i);
+        sim.sim.h(i + 3);
+        assert!(sim.sim.qubit_is_zero(i + 3), "qubit {} is not zero", i + 3);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcsadj_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint S(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2452+0.0488𝑖
+        |00010001⟩: 0.2452+0.0488𝑖
+        |00100010⟩: 0.2452+0.0488𝑖
+        |00110011⟩: 0.2452+0.0488𝑖
+        |01000100⟩: 0.2452+0.0488𝑖
+        |01010101⟩: 0.2452+0.0488𝑖
+        |01100110⟩: 0.2452+0.0488𝑖
+        |01110111⟩: 0.2452+0.0488𝑖
+        |10001000⟩: 0.2452+0.0488𝑖
+        |10011001⟩: 0.2452+0.0488𝑖
+        |10101010⟩: 0.2452+0.0488𝑖
+        |10111011⟩: 0.2452+0.0488𝑖
+        |11001100⟩: 0.2452+0.0488𝑖
+        |11011101⟩: 0.2452+0.0488𝑖
+        |11101110⟩: 0.2452+0.0488𝑖
+        |11111111⟩: 0.0488−0.2452𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcs(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcsadj_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint S(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2452+0.0488𝑖
+        |00010001⟩: 0.2452+0.0488𝑖
+        |00100010⟩: 0.2452+0.0488𝑖
+        |00110011⟩: 0.2452+0.0488𝑖
+        |01000100⟩: 0.2452+0.0488𝑖
+        |01010101⟩: 0.2452+0.0488𝑖
+        |01100110⟩: 0.2452+0.0488𝑖
+        |01110111⟩: 0.2452+0.0488𝑖
+        |10001000⟩: 0.2452+0.0488𝑖
+        |10011001⟩: 0.2452+0.0488𝑖
+        |10101010⟩: 0.2452+0.0488𝑖
+        |10111011⟩: 0.2452+0.0488𝑖
+        |11001100⟩: 0.2452+0.0488𝑖
+        |11011101⟩: 0.2452+0.0488𝑖
+        |11101110⟩: 0.2452+0.0488𝑖
+        |11111111⟩: 0.0488−0.2452𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcs(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcsadj_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint S(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1734+0.0345𝑖
+        |0000100001⟩: 0.1734+0.0345𝑖
+        |0001000010⟩: 0.1734+0.0345𝑖
+        |0001100011⟩: 0.1734+0.0345𝑖
+        |0010000100⟩: 0.1734+0.0345𝑖
+        |0010100101⟩: 0.1734+0.0345𝑖
+        |0011000110⟩: 0.1734+0.0345𝑖
+        |0011100111⟩: 0.1734+0.0345𝑖
+        |0100001000⟩: 0.1734+0.0345𝑖
+        |0100101001⟩: 0.1734+0.0345𝑖
+        |0101001010⟩: 0.1734+0.0345𝑖
+        |0101101011⟩: 0.1734+0.0345𝑖
+        |0110001100⟩: 0.1734+0.0345𝑖
+        |0110101101⟩: 0.1734+0.0345𝑖
+        |0111001110⟩: 0.1734+0.0345𝑖
+        |0111101111⟩: 0.1734+0.0345𝑖
+        |1000010000⟩: 0.1734+0.0345𝑖
+        |1000110001⟩: 0.1734+0.0345𝑖
+        |1001010010⟩: 0.1734+0.0345𝑖
+        |1001110011⟩: 0.1734+0.0345𝑖
+        |1010010100⟩: 0.1734+0.0345𝑖
+        |1010110101⟩: 0.1734+0.0345𝑖
+        |1011010110⟩: 0.1734+0.0345𝑖
+        |1011110111⟩: 0.1734+0.0345𝑖
+        |1100011000⟩: 0.1734+0.0345𝑖
+        |1100111001⟩: 0.1734+0.0345𝑖
+        |1101011010⟩: 0.1734+0.0345𝑖
+        |1101111011⟩: 0.1734+0.0345𝑖
+        |1110011100⟩: 0.1734+0.0345𝑖
+        |1110111101⟩: 0.1734+0.0345𝑖
+        |1111011110⟩: 0.1734+0.0345𝑖
+        |1111111111⟩: 0.0345−0.1734𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcs(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcsadj_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint S(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1734+0.0345𝑖
+        |0000100001⟩: 0.1734+0.0345𝑖
+        |0001000010⟩: 0.1734+0.0345𝑖
+        |0001100011⟩: 0.1734+0.0345𝑖
+        |0010000100⟩: 0.1734+0.0345𝑖
+        |0010100101⟩: 0.1734+0.0345𝑖
+        |0011000110⟩: 0.1734+0.0345𝑖
+        |0011100111⟩: 0.1734+0.0345𝑖
+        |0100001000⟩: 0.1734+0.0345𝑖
+        |0100101001⟩: 0.1734+0.0345𝑖
+        |0101001010⟩: 0.1734+0.0345𝑖
+        |0101101011⟩: 0.1734+0.0345𝑖
+        |0110001100⟩: 0.1734+0.0345𝑖
+        |0110101101⟩: 0.1734+0.0345𝑖
+        |0111001110⟩: 0.1734+0.0345𝑖
+        |0111101111⟩: 0.1734+0.0345𝑖
+        |1000010000⟩: 0.1734+0.0345𝑖
+        |1000110001⟩: 0.1734+0.0345𝑖
+        |1001010010⟩: 0.1734+0.0345𝑖
+        |1001110011⟩: 0.1734+0.0345𝑖
+        |1010010100⟩: 0.1734+0.0345𝑖
+        |1010110101⟩: 0.1734+0.0345𝑖
+        |1011010110⟩: 0.1734+0.0345𝑖
+        |1011110111⟩: 0.1734+0.0345𝑖
+        |1100011000⟩: 0.1734+0.0345𝑖
+        |1100111001⟩: 0.1734+0.0345𝑖
+        |1101011010⟩: 0.1734+0.0345𝑖
+        |1101111011⟩: 0.1734+0.0345𝑖
+        |1110011100⟩: 0.1734+0.0345𝑖
+        |1110111101⟩: 0.1734+0.0345𝑖
+        |1111011110⟩: 0.1734+0.0345𝑖
+        |1111111111⟩: 0.0345−0.1734𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcs(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mct_1_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(2);
+            let aux = QIR.Runtime.AllocateQubitArray(2);
+            for i in 0..1 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled T(qs[0..0], qs[1]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000⟩: 0.4904−0.0975𝑖
+        |0101⟩: 0.4904−0.0975𝑖
+        |1010⟩: 0.4904−0.0975𝑖
+        |1111⟩: 0.4157+0.2778𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mctadj(&[0], 1);
+    for i in 0..2 {
+        sim.sim.mcx(&[i + 2], i);
+        sim.sim.h(i + 2);
+        assert!(sim.sim.qubit_is_zero(i + 2), "qubit {} is not zero", i + 2);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mct_2_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(3);
+            let aux = QIR.Runtime.AllocateQubitArray(3);
+            for i in 0..2 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled T(qs[0..1], qs[2]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |000000⟩: 0.3468−0.0690𝑖
+        |001001⟩: 0.3468−0.0690𝑖
+        |010010⟩: 0.3468−0.0690𝑖
+        |011011⟩: 0.3468−0.0690𝑖
+        |100100⟩: 0.3468−0.0690𝑖
+        |101101⟩: 0.3468−0.0690𝑖
+        |110110⟩: 0.3468−0.0690𝑖
+        |111111⟩: 0.2940+0.1964𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mctadj(&[0, 1], 2);
+    for i in 0..3 {
+        sim.sim.mcx(&[i + 3], i);
+        sim.sim.h(i + 3);
+        assert!(sim.sim.qubit_is_zero(i + 3), "qubit {} is not zero", i + 3);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mct_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled T(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2452−0.0488𝑖
+        |00010001⟩: 0.2452−0.0488𝑖
+        |00100010⟩: 0.2452−0.0488𝑖
+        |00110011⟩: 0.2452−0.0488𝑖
+        |01000100⟩: 0.2452−0.0488𝑖
+        |01010101⟩: 0.2452−0.0488𝑖
+        |01100110⟩: 0.2452−0.0488𝑖
+        |01110111⟩: 0.2452−0.0488𝑖
+        |10001000⟩: 0.2452−0.0488𝑖
+        |10011001⟩: 0.2452−0.0488𝑖
+        |10101010⟩: 0.2452−0.0488𝑖
+        |10111011⟩: 0.2452−0.0488𝑖
+        |11001100⟩: 0.2452−0.0488𝑖
+        |11011101⟩: 0.2452−0.0488𝑖
+        |11101110⟩: 0.2452−0.0488𝑖
+        |11111111⟩: 0.2079+0.1389𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mctadj(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mct_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled T(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2452−0.0488𝑖
+        |00010001⟩: 0.2452−0.0488𝑖
+        |00100010⟩: 0.2452−0.0488𝑖
+        |00110011⟩: 0.2452−0.0488𝑖
+        |01000100⟩: 0.2452−0.0488𝑖
+        |01010101⟩: 0.2452−0.0488𝑖
+        |01100110⟩: 0.2452−0.0488𝑖
+        |01110111⟩: 0.2452−0.0488𝑖
+        |10001000⟩: 0.2452−0.0488𝑖
+        |10011001⟩: 0.2452−0.0488𝑖
+        |10101010⟩: 0.2452−0.0488𝑖
+        |10111011⟩: 0.2452−0.0488𝑖
+        |11001100⟩: 0.2452−0.0488𝑖
+        |11011101⟩: 0.2452−0.0488𝑖
+        |11101110⟩: 0.2452−0.0488𝑖
+        |11111111⟩: 0.2079+0.1389𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mctadj(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mct_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled T(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1734−0.0345𝑖
+        |0000100001⟩: 0.1734−0.0345𝑖
+        |0001000010⟩: 0.1734−0.0345𝑖
+        |0001100011⟩: 0.1734−0.0345𝑖
+        |0010000100⟩: 0.1734−0.0345𝑖
+        |0010100101⟩: 0.1734−0.0345𝑖
+        |0011000110⟩: 0.1734−0.0345𝑖
+        |0011100111⟩: 0.1734−0.0345𝑖
+        |0100001000⟩: 0.1734−0.0345𝑖
+        |0100101001⟩: 0.1734−0.0345𝑖
+        |0101001010⟩: 0.1734−0.0345𝑖
+        |0101101011⟩: 0.1734−0.0345𝑖
+        |0110001100⟩: 0.1734−0.0345𝑖
+        |0110101101⟩: 0.1734−0.0345𝑖
+        |0111001110⟩: 0.1734−0.0345𝑖
+        |0111101111⟩: 0.1734−0.0345𝑖
+        |1000010000⟩: 0.1734−0.0345𝑖
+        |1000110001⟩: 0.1734−0.0345𝑖
+        |1001010010⟩: 0.1734−0.0345𝑖
+        |1001110011⟩: 0.1734−0.0345𝑖
+        |1010010100⟩: 0.1734−0.0345𝑖
+        |1010110101⟩: 0.1734−0.0345𝑖
+        |1011010110⟩: 0.1734−0.0345𝑖
+        |1011110111⟩: 0.1734−0.0345𝑖
+        |1100011000⟩: 0.1734−0.0345𝑖
+        |1100111001⟩: 0.1734−0.0345𝑖
+        |1101011010⟩: 0.1734−0.0345𝑖
+        |1101111011⟩: 0.1734−0.0345𝑖
+        |1110011100⟩: 0.1734−0.0345𝑖
+        |1110111101⟩: 0.1734−0.0345𝑖
+        |1111011110⟩: 0.1734−0.0345𝑖
+        |1111111111⟩: 0.1470+0.0982𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mctadj(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mct_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled T(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1734−0.0345𝑖
+        |0000100001⟩: 0.1734−0.0345𝑖
+        |0001000010⟩: 0.1734−0.0345𝑖
+        |0001100011⟩: 0.1734−0.0345𝑖
+        |0010000100⟩: 0.1734−0.0345𝑖
+        |0010100101⟩: 0.1734−0.0345𝑖
+        |0011000110⟩: 0.1734−0.0345𝑖
+        |0011100111⟩: 0.1734−0.0345𝑖
+        |0100001000⟩: 0.1734−0.0345𝑖
+        |0100101001⟩: 0.1734−0.0345𝑖
+        |0101001010⟩: 0.1734−0.0345𝑖
+        |0101101011⟩: 0.1734−0.0345𝑖
+        |0110001100⟩: 0.1734−0.0345𝑖
+        |0110101101⟩: 0.1734−0.0345𝑖
+        |0111001110⟩: 0.1734−0.0345𝑖
+        |0111101111⟩: 0.1734−0.0345𝑖
+        |1000010000⟩: 0.1734−0.0345𝑖
+        |1000110001⟩: 0.1734−0.0345𝑖
+        |1001010010⟩: 0.1734−0.0345𝑖
+        |1001110011⟩: 0.1734−0.0345𝑖
+        |1010010100⟩: 0.1734−0.0345𝑖
+        |1010110101⟩: 0.1734−0.0345𝑖
+        |1011010110⟩: 0.1734−0.0345𝑖
+        |1011110111⟩: 0.1734−0.0345𝑖
+        |1100011000⟩: 0.1734−0.0345𝑖
+        |1100111001⟩: 0.1734−0.0345𝑖
+        |1101011010⟩: 0.1734−0.0345𝑖
+        |1101111011⟩: 0.1734−0.0345𝑖
+        |1110011100⟩: 0.1734−0.0345𝑖
+        |1110111101⟩: 0.1734−0.0345𝑖
+        |1111011110⟩: 0.1734−0.0345𝑖
+        |1111111111⟩: 0.1470+0.0982𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mctadj(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mctadj_1_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(2);
+            let aux = QIR.Runtime.AllocateQubitArray(2);
+            for i in 0..1 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint T(qs[0..0], qs[1]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000⟩: 0.4904+0.0975𝑖
+        |0101⟩: 0.4904+0.0975𝑖
+        |1010⟩: 0.4904+0.0975𝑖
+        |1111⟩: 0.4157−0.2778𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mct(&[0], 1);
+    for i in 0..2 {
+        sim.sim.mcx(&[i + 2], i);
+        sim.sim.h(i + 2);
+        assert!(sim.sim.qubit_is_zero(i + 2), "qubit {} is not zero", i + 2);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mctadj_2_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(3);
+            let aux = QIR.Runtime.AllocateQubitArray(3);
+            for i in 0..2 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint T(qs[0..1], qs[2]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |000000⟩: 0.3468+0.0690𝑖
+        |001001⟩: 0.3468+0.0690𝑖
+        |010010⟩: 0.3468+0.0690𝑖
+        |011011⟩: 0.3468+0.0690𝑖
+        |100100⟩: 0.3468+0.0690𝑖
+        |101101⟩: 0.3468+0.0690𝑖
+        |110110⟩: 0.3468+0.0690𝑖
+        |111111⟩: 0.2940−0.1964𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mct(&[0, 1], 2);
+    for i in 0..3 {
+        sim.sim.mcx(&[i + 3], i);
+        sim.sim.h(i + 3);
+        assert!(sim.sim.qubit_is_zero(i + 3), "qubit {} is not zero", i + 3);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mctadj_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint T(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2452+0.0488𝑖
+        |00010001⟩: 0.2452+0.0488𝑖
+        |00100010⟩: 0.2452+0.0488𝑖
+        |00110011⟩: 0.2452+0.0488𝑖
+        |01000100⟩: 0.2452+0.0488𝑖
+        |01010101⟩: 0.2452+0.0488𝑖
+        |01100110⟩: 0.2452+0.0488𝑖
+        |01110111⟩: 0.2452+0.0488𝑖
+        |10001000⟩: 0.2452+0.0488𝑖
+        |10011001⟩: 0.2452+0.0488𝑖
+        |10101010⟩: 0.2452+0.0488𝑖
+        |10111011⟩: 0.2452+0.0488𝑖
+        |11001100⟩: 0.2452+0.0488𝑖
+        |11011101⟩: 0.2452+0.0488𝑖
+        |11101110⟩: 0.2452+0.0488𝑖
+        |11111111⟩: 0.2079−0.1389𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mct(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mctadj_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint T(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2452+0.0488𝑖
+        |00010001⟩: 0.2452+0.0488𝑖
+        |00100010⟩: 0.2452+0.0488𝑖
+        |00110011⟩: 0.2452+0.0488𝑖
+        |01000100⟩: 0.2452+0.0488𝑖
+        |01010101⟩: 0.2452+0.0488𝑖
+        |01100110⟩: 0.2452+0.0488𝑖
+        |01110111⟩: 0.2452+0.0488𝑖
+        |10001000⟩: 0.2452+0.0488𝑖
+        |10011001⟩: 0.2452+0.0488𝑖
+        |10101010⟩: 0.2452+0.0488𝑖
+        |10111011⟩: 0.2452+0.0488𝑖
+        |11001100⟩: 0.2452+0.0488𝑖
+        |11011101⟩: 0.2452+0.0488𝑖
+        |11101110⟩: 0.2452+0.0488𝑖
+        |11111111⟩: 0.2079−0.1389𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mct(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mctadj_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint T(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1734+0.0345𝑖
+        |0000100001⟩: 0.1734+0.0345𝑖
+        |0001000010⟩: 0.1734+0.0345𝑖
+        |0001100011⟩: 0.1734+0.0345𝑖
+        |0010000100⟩: 0.1734+0.0345𝑖
+        |0010100101⟩: 0.1734+0.0345𝑖
+        |0011000110⟩: 0.1734+0.0345𝑖
+        |0011100111⟩: 0.1734+0.0345𝑖
+        |0100001000⟩: 0.1734+0.0345𝑖
+        |0100101001⟩: 0.1734+0.0345𝑖
+        |0101001010⟩: 0.1734+0.0345𝑖
+        |0101101011⟩: 0.1734+0.0345𝑖
+        |0110001100⟩: 0.1734+0.0345𝑖
+        |0110101101⟩: 0.1734+0.0345𝑖
+        |0111001110⟩: 0.1734+0.0345𝑖
+        |0111101111⟩: 0.1734+0.0345𝑖
+        |1000010000⟩: 0.1734+0.0345𝑖
+        |1000110001⟩: 0.1734+0.0345𝑖
+        |1001010010⟩: 0.1734+0.0345𝑖
+        |1001110011⟩: 0.1734+0.0345𝑖
+        |1010010100⟩: 0.1734+0.0345𝑖
+        |1010110101⟩: 0.1734+0.0345𝑖
+        |1011010110⟩: 0.1734+0.0345𝑖
+        |1011110111⟩: 0.1734+0.0345𝑖
+        |1100011000⟩: 0.1734+0.0345𝑖
+        |1100111001⟩: 0.1734+0.0345𝑖
+        |1101011010⟩: 0.1734+0.0345𝑖
+        |1101111011⟩: 0.1734+0.0345𝑖
+        |1110011100⟩: 0.1734+0.0345𝑖
+        |1110111101⟩: 0.1734+0.0345𝑖
+        |1111011110⟩: 0.1734+0.0345𝑖
+        |1111111111⟩: 0.1470−0.0982𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mct(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mctadj_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Adjoint T(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1734+0.0345𝑖
+        |0000100001⟩: 0.1734+0.0345𝑖
+        |0001000010⟩: 0.1734+0.0345𝑖
+        |0001100011⟩: 0.1734+0.0345𝑖
+        |0010000100⟩: 0.1734+0.0345𝑖
+        |0010100101⟩: 0.1734+0.0345𝑖
+        |0011000110⟩: 0.1734+0.0345𝑖
+        |0011100111⟩: 0.1734+0.0345𝑖
+        |0100001000⟩: 0.1734+0.0345𝑖
+        |0100101001⟩: 0.1734+0.0345𝑖
+        |0101001010⟩: 0.1734+0.0345𝑖
+        |0101101011⟩: 0.1734+0.0345𝑖
+        |0110001100⟩: 0.1734+0.0345𝑖
+        |0110101101⟩: 0.1734+0.0345𝑖
+        |0111001110⟩: 0.1734+0.0345𝑖
+        |0111101111⟩: 0.1734+0.0345𝑖
+        |1000010000⟩: 0.1734+0.0345𝑖
+        |1000110001⟩: 0.1734+0.0345𝑖
+        |1001010010⟩: 0.1734+0.0345𝑖
+        |1001110011⟩: 0.1734+0.0345𝑖
+        |1010010100⟩: 0.1734+0.0345𝑖
+        |1010110101⟩: 0.1734+0.0345𝑖
+        |1011010110⟩: 0.1734+0.0345𝑖
+        |1011110111⟩: 0.1734+0.0345𝑖
+        |1100011000⟩: 0.1734+0.0345𝑖
+        |1100111001⟩: 0.1734+0.0345𝑖
+        |1101011010⟩: 0.1734+0.0345𝑖
+        |1101111011⟩: 0.1734+0.0345𝑖
+        |1110011100⟩: 0.1734+0.0345𝑖
+        |1110111101⟩: 0.1734+0.0345𝑖
+        |1111011110⟩: 0.1734+0.0345𝑖
+        |1111111111⟩: 0.1470−0.0982𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mct(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
 
 #[test]
 fn test_unrestricted_mcx_3_control() {

--- a/library/src/tests/intrinsic.rs
+++ b/library/src/tests/intrinsic.rs
@@ -1,0 +1,1333 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use expect_test::expect;
+use indoc::indoc;
+use qsc::{interpret::Value, target::Profile, SparseSim};
+
+use super::test_expression_with_lib_and_profile_and_sim;
+
+// These tests verify multi-controlled decomposition logic for gate operations. Each test
+// manually allocates 2N qubits, performs the decomposed operation from the library on the first N,
+// verifies the resulting state via dump, and then uncomputes the operation via simulator-native
+// multi-controlled operations to verify via Choi-Jamiolkowski isomorphism that the decomposition
+// was correct.
+
+#[test]
+fn test_mch_1_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(2);
+            let aux = QIR.Runtime.AllocateQubitArray(2);
+            for i in 0..1 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled H(qs[0..0], qs[1]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000⟩: 0.5000+0.0000𝑖
+        |0101⟩: 0.5000+0.0000𝑖
+        |1010⟩: 0.3536+0.0000𝑖
+        |1011⟩: 0.3536+0.0000𝑖
+        |1110⟩: 0.3536+0.0000𝑖
+        |1111⟩: −0.3536+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mch(&[0], 1);
+    for i in 0..2 {
+        sim.sim.mcx(&[i + 2], i);
+        sim.sim.h(i + 2);
+        assert!(sim.sim.qubit_is_zero(i + 2), "qubit {} is not zero", i + 2);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mch_2_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(3);
+            let aux = QIR.Runtime.AllocateQubitArray(3);
+            for i in 0..2 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled H(qs[0..1], qs[2]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |000000⟩: 0.3536+0.0000𝑖
+        |001001⟩: 0.3536+0.0000𝑖
+        |010010⟩: 0.3536+0.0000𝑖
+        |011011⟩: 0.3536+0.0000𝑖
+        |100100⟩: 0.3536+0.0000𝑖
+        |101101⟩: 0.3536+0.0000𝑖
+        |110110⟩: 0.2500+0.0000𝑖
+        |110111⟩: 0.2500+0.0000𝑖
+        |111110⟩: 0.2500+0.0000𝑖
+        |111111⟩: −0.2500+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mch(&[0, 1], 2);
+    for i in 0..3 {
+        sim.sim.mcx(&[i + 3], i);
+        sim.sim.h(i + 3);
+        assert!(sim.sim.qubit_is_zero(i + 3), "qubit {} is not zero", i + 3);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mch_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled H(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101110⟩: 0.1768+0.0000𝑖
+        |11101111⟩: 0.1768+0.0000𝑖
+        |11111110⟩: 0.1768+0.0000𝑖
+        |11111111⟩: −0.1768+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mch(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mch_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled H(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101110⟩: 0.1768+0.0000𝑖
+        |11101111⟩: 0.1768+0.0000𝑖
+        |11111110⟩: 0.1768+0.0000𝑖
+        |11111111⟩: −0.1768+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mch(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mch_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled H(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1768+0.0000𝑖
+        |0000100001⟩: 0.1768+0.0000𝑖
+        |0001000010⟩: 0.1768+0.0000𝑖
+        |0001100011⟩: 0.1768+0.0000𝑖
+        |0010000100⟩: 0.1768+0.0000𝑖
+        |0010100101⟩: 0.1768+0.0000𝑖
+        |0011000110⟩: 0.1768+0.0000𝑖
+        |0011100111⟩: 0.1768+0.0000𝑖
+        |0100001000⟩: 0.1768+0.0000𝑖
+        |0100101001⟩: 0.1768+0.0000𝑖
+        |0101001010⟩: 0.1768+0.0000𝑖
+        |0101101011⟩: 0.1768+0.0000𝑖
+        |0110001100⟩: 0.1768+0.0000𝑖
+        |0110101101⟩: 0.1768+0.0000𝑖
+        |0111001110⟩: 0.1768+0.0000𝑖
+        |0111101111⟩: 0.1768+0.0000𝑖
+        |1000010000⟩: 0.1768+0.0000𝑖
+        |1000110001⟩: 0.1768+0.0000𝑖
+        |1001010010⟩: 0.1768+0.0000𝑖
+        |1001110011⟩: 0.1768+0.0000𝑖
+        |1010010100⟩: 0.1768+0.0000𝑖
+        |1010110101⟩: 0.1768+0.0000𝑖
+        |1011010110⟩: 0.1768+0.0000𝑖
+        |1011110111⟩: 0.1768+0.0000𝑖
+        |1100011000⟩: 0.1768+0.0000𝑖
+        |1100111001⟩: 0.1768+0.0000𝑖
+        |1101011010⟩: 0.1768+0.0000𝑖
+        |1101111011⟩: 0.1768+0.0000𝑖
+        |1110011100⟩: 0.1768+0.0000𝑖
+        |1110111101⟩: 0.1768+0.0000𝑖
+        |1111011110⟩: 0.1250+0.0000𝑖
+        |1111011111⟩: 0.1250+0.0000𝑖
+        |1111111110⟩: 0.1250+0.0000𝑖
+        |1111111111⟩: −0.1250+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mch(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mch_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled H(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1768+0.0000𝑖
+        |0000100001⟩: 0.1768+0.0000𝑖
+        |0001000010⟩: 0.1768+0.0000𝑖
+        |0001100011⟩: 0.1768+0.0000𝑖
+        |0010000100⟩: 0.1768+0.0000𝑖
+        |0010100101⟩: 0.1768+0.0000𝑖
+        |0011000110⟩: 0.1768+0.0000𝑖
+        |0011100111⟩: 0.1768+0.0000𝑖
+        |0100001000⟩: 0.1768+0.0000𝑖
+        |0100101001⟩: 0.1768+0.0000𝑖
+        |0101001010⟩: 0.1768+0.0000𝑖
+        |0101101011⟩: 0.1768+0.0000𝑖
+        |0110001100⟩: 0.1768+0.0000𝑖
+        |0110101101⟩: 0.1768+0.0000𝑖
+        |0111001110⟩: 0.1768+0.0000𝑖
+        |0111101111⟩: 0.1768+0.0000𝑖
+        |1000010000⟩: 0.1768+0.0000𝑖
+        |1000110001⟩: 0.1768+0.0000𝑖
+        |1001010010⟩: 0.1768+0.0000𝑖
+        |1001110011⟩: 0.1768+0.0000𝑖
+        |1010010100⟩: 0.1768+0.0000𝑖
+        |1010110101⟩: 0.1768+0.0000𝑖
+        |1011010110⟩: 0.1768+0.0000𝑖
+        |1011110111⟩: 0.1768+0.0000𝑖
+        |1100011000⟩: 0.1768+0.0000𝑖
+        |1100111001⟩: 0.1768+0.0000𝑖
+        |1101011010⟩: 0.1768+0.0000𝑖
+        |1101111011⟩: 0.1768+0.0000𝑖
+        |1110011100⟩: 0.1768+0.0000𝑖
+        |1110111101⟩: 0.1768+0.0000𝑖
+        |1111011110⟩: 0.1250+0.0000𝑖
+        |1111011111⟩: 0.1250+0.0000𝑖
+        |1111111110⟩: 0.1250+0.0000𝑖
+        |1111111111⟩: −0.1250+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mch(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mcrz_1_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(2);
+            let aux = QIR.Runtime.AllocateQubitArray(2);
+            for i in 0..1 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Rz(qs[0..0], (Microsoft.Quantum.Math.PI() / 7.0, qs[1]));
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000⟩: 0.5000+0.0000𝑖
+        |0101⟩: 0.5000+0.0000𝑖
+        |1010⟩: 0.4875−0.1113𝑖
+        |1111⟩: 0.4875+0.1113𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcrz(&[0], std::f64::consts::PI / -7.0, 1);
+    for i in 0..2 {
+        sim.sim.mcx(&[i + 2], i);
+        sim.sim.h(i + 2);
+        assert!(sim.sim.qubit_is_zero(i + 2), "qubit {} is not zero", i + 2);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcrz_2_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(3);
+            let aux = QIR.Runtime.AllocateQubitArray(3);
+            for i in 0..2 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Rz(qs[0..1], (Microsoft.Quantum.Math.PI() / 7.0, qs[2]));
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |000000⟩: 0.3536+0.0000𝑖
+        |001001⟩: 0.3536+0.0000𝑖
+        |010010⟩: 0.3536+0.0000𝑖
+        |011011⟩: 0.3536+0.0000𝑖
+        |100100⟩: 0.3536+0.0000𝑖
+        |101101⟩: 0.3536+0.0000𝑖
+        |110110⟩: 0.3447−0.0787𝑖
+        |111111⟩: 0.3447+0.0787𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcrz(&[0, 1], std::f64::consts::PI / -7.0, 2);
+    for i in 0..3 {
+        sim.sim.mcx(&[i + 3], i);
+        sim.sim.h(i + 3);
+        assert!(sim.sim.qubit_is_zero(i + 3), "qubit {} is not zero", i + 3);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcrz_2_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(3);
+            let aux = QIR.Runtime.AllocateQubitArray(3);
+            for i in 0..2 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Rz(qs[0..1], (Microsoft.Quantum.Math.PI() / 7.0, qs[2]));
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |000000⟩: 0.3536+0.0000𝑖
+        |001001⟩: 0.3536+0.0000𝑖
+        |010010⟩: 0.3536+0.0000𝑖
+        |011011⟩: 0.3536+0.0000𝑖
+        |100100⟩: 0.3536+0.0000𝑖
+        |101101⟩: 0.3536+0.0000𝑖
+        |110110⟩: 0.3447−0.0787𝑖
+        |111111⟩: 0.3447+0.0787𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcrz(&[0, 1], std::f64::consts::PI / -7.0, 2);
+    for i in 0..3 {
+        sim.sim.mcx(&[i + 3], i);
+        sim.sim.h(i + 3);
+        assert!(sim.sim.qubit_is_zero(i + 3), "qubit {} is not zero", i + 3);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcrz_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Rz(qs[0..2], (Microsoft.Quantum.Math.PI() / 7.0, qs[3]));
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101110⟩: 0.2437−0.0556𝑖
+        |11111111⟩: 0.2437+0.0556𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcrz(&[0, 1, 2], std::f64::consts::PI / -7.0, 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcrz_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Rz(qs[0..2], (Microsoft.Quantum.Math.PI() / 7.0, qs[3]));
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101110⟩: 0.2437−0.0556𝑖
+        |11111111⟩: 0.2437+0.0556𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcrz(&[0, 1, 2], std::f64::consts::PI / -7.0, 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mcrx_1_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(2);
+            let aux = QIR.Runtime.AllocateQubitArray(2);
+            for i in 0..1 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Rx(qs[0..0], (Microsoft.Quantum.Math.PI() / 7.0, qs[1]));
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000⟩: 0.5000+0.0000𝑖
+        |0101⟩: 0.5000+0.0000𝑖
+        |1010⟩: 0.4875+0.0000𝑖
+        |1011⟩: 0.0000−0.1113𝑖
+        |1110⟩: 0.0000−0.1113𝑖
+        |1111⟩: 0.4875+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcrx(&[0], std::f64::consts::PI / -7.0, 1);
+    for i in 0..2 {
+        sim.sim.mcx(&[i + 2], i);
+        sim.sim.h(i + 2);
+        assert!(sim.sim.qubit_is_zero(i + 2), "qubit {} is not zero", i + 2);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_mcry_1_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(2);
+            let aux = QIR.Runtime.AllocateQubitArray(2);
+            for i in 0..1 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Ry(qs[0..0], (Microsoft.Quantum.Math.PI() / 7.0, qs[1]));
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000⟩: 0.5000+0.0000𝑖
+        |0101⟩: 0.5000+0.0000𝑖
+        |1010⟩: 0.4875+0.0000𝑖
+        |1011⟩: −0.1113+0.0000𝑖
+        |1110⟩: 0.1113+0.0000𝑖
+        |1111⟩: 0.4875+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcry(&[0], std::f64::consts::PI / -7.0, 1);
+    for i in 0..2 {
+        sim.sim.mcx(&[i + 2], i);
+        sim.sim.h(i + 2);
+        assert!(sim.sim.qubit_is_zero(i + 2), "qubit {} is not zero", i + 2);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+// TODO: tests for mcs, mcsadj, mct, and mctadj with 1 and 2 controls unrestricted and 3 and 4 controls unrestricted + base
+
+#[test]
+fn test_unrestricted_mcx_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled X(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101111⟩: 0.2500+0.0000𝑖
+        |11111110⟩: 0.2500+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcx(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcx_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled X(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101111⟩: 0.2500+0.0000𝑖
+        |11111110⟩: 0.2500+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcx(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcx_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled X(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1768+0.0000𝑖
+        |0000100001⟩: 0.1768+0.0000𝑖
+        |0001000010⟩: 0.1768+0.0000𝑖
+        |0001100011⟩: 0.1768+0.0000𝑖
+        |0010000100⟩: 0.1768+0.0000𝑖
+        |0010100101⟩: 0.1768+0.0000𝑖
+        |0011000110⟩: 0.1768+0.0000𝑖
+        |0011100111⟩: 0.1768+0.0000𝑖
+        |0100001000⟩: 0.1768+0.0000𝑖
+        |0100101001⟩: 0.1768+0.0000𝑖
+        |0101001010⟩: 0.1768+0.0000𝑖
+        |0101101011⟩: 0.1768+0.0000𝑖
+        |0110001100⟩: 0.1768+0.0000𝑖
+        |0110101101⟩: 0.1768+0.0000𝑖
+        |0111001110⟩: 0.1768+0.0000𝑖
+        |0111101111⟩: 0.1768+0.0000𝑖
+        |1000010000⟩: 0.1768+0.0000𝑖
+        |1000110001⟩: 0.1768+0.0000𝑖
+        |1001010010⟩: 0.1768+0.0000𝑖
+        |1001110011⟩: 0.1768+0.0000𝑖
+        |1010010100⟩: 0.1768+0.0000𝑖
+        |1010110101⟩: 0.1768+0.0000𝑖
+        |1011010110⟩: 0.1768+0.0000𝑖
+        |1011110111⟩: 0.1768+0.0000𝑖
+        |1100011000⟩: 0.1768+0.0000𝑖
+        |1100111001⟩: 0.1768+0.0000𝑖
+        |1101011010⟩: 0.1768+0.0000𝑖
+        |1101111011⟩: 0.1768+0.0000𝑖
+        |1110011100⟩: 0.1768+0.0000𝑖
+        |1110111101⟩: 0.1768+0.0000𝑖
+        |1111011111⟩: 0.1768+0.0000𝑖
+        |1111111110⟩: 0.1768+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcx(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcx_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled X(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1768+0.0000𝑖
+        |0000100001⟩: 0.1768+0.0000𝑖
+        |0001000010⟩: 0.1768+0.0000𝑖
+        |0001100011⟩: 0.1768+0.0000𝑖
+        |0010000100⟩: 0.1768+0.0000𝑖
+        |0010100101⟩: 0.1768+0.0000𝑖
+        |0011000110⟩: 0.1768+0.0000𝑖
+        |0011100111⟩: 0.1768+0.0000𝑖
+        |0100001000⟩: 0.1768+0.0000𝑖
+        |0100101001⟩: 0.1768+0.0000𝑖
+        |0101001010⟩: 0.1768+0.0000𝑖
+        |0101101011⟩: 0.1768+0.0000𝑖
+        |0110001100⟩: 0.1768+0.0000𝑖
+        |0110101101⟩: 0.1768+0.0000𝑖
+        |0111001110⟩: 0.1768+0.0000𝑖
+        |0111101111⟩: 0.1768+0.0000𝑖
+        |1000010000⟩: 0.1768+0.0000𝑖
+        |1000110001⟩: 0.1768+0.0000𝑖
+        |1001010010⟩: 0.1768+0.0000𝑖
+        |1001110011⟩: 0.1768+0.0000𝑖
+        |1010010100⟩: 0.1768+0.0000𝑖
+        |1010110101⟩: 0.1768+0.0000𝑖
+        |1011010110⟩: 0.1768+0.0000𝑖
+        |1011110111⟩: 0.1768+0.0000𝑖
+        |1100011000⟩: 0.1768+0.0000𝑖
+        |1100111001⟩: 0.1768+0.0000𝑖
+        |1101011010⟩: 0.1768+0.0000𝑖
+        |1101111011⟩: 0.1768+0.0000𝑖
+        |1110011100⟩: 0.1768+0.0000𝑖
+        |1110111101⟩: 0.1768+0.0000𝑖
+        |1111011111⟩: 0.1768+0.0000𝑖
+        |1111111110⟩: 0.1768+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcx(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcy_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Y(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101111⟩: 0.0000−0.2500𝑖
+        |11111110⟩: 0.0000+0.2500𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcy(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcy_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Y(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101111⟩: 0.0000−0.2500𝑖
+        |11111110⟩: 0.0000+0.2500𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcy(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcy_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Y(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1768+0.0000𝑖
+        |0000100001⟩: 0.1768+0.0000𝑖
+        |0001000010⟩: 0.1768+0.0000𝑖
+        |0001100011⟩: 0.1768+0.0000𝑖
+        |0010000100⟩: 0.1768+0.0000𝑖
+        |0010100101⟩: 0.1768+0.0000𝑖
+        |0011000110⟩: 0.1768+0.0000𝑖
+        |0011100111⟩: 0.1768+0.0000𝑖
+        |0100001000⟩: 0.1768+0.0000𝑖
+        |0100101001⟩: 0.1768+0.0000𝑖
+        |0101001010⟩: 0.1768+0.0000𝑖
+        |0101101011⟩: 0.1768+0.0000𝑖
+        |0110001100⟩: 0.1768+0.0000𝑖
+        |0110101101⟩: 0.1768+0.0000𝑖
+        |0111001110⟩: 0.1768+0.0000𝑖
+        |0111101111⟩: 0.1768+0.0000𝑖
+        |1000010000⟩: 0.1768+0.0000𝑖
+        |1000110001⟩: 0.1768+0.0000𝑖
+        |1001010010⟩: 0.1768+0.0000𝑖
+        |1001110011⟩: 0.1768+0.0000𝑖
+        |1010010100⟩: 0.1768+0.0000𝑖
+        |1010110101⟩: 0.1768+0.0000𝑖
+        |1011010110⟩: 0.1768+0.0000𝑖
+        |1011110111⟩: 0.1768+0.0000𝑖
+        |1100011000⟩: 0.1768+0.0000𝑖
+        |1100111001⟩: 0.1768+0.0000𝑖
+        |1101011010⟩: 0.1768+0.0000𝑖
+        |1101111011⟩: 0.1768+0.0000𝑖
+        |1110011100⟩: 0.1768+0.0000𝑖
+        |1110111101⟩: 0.1768+0.0000𝑖
+        |1111011111⟩: 0.0000−0.1768𝑖
+        |1111111110⟩: 0.0000+0.1768𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcy(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcy_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Y(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1768+0.0000𝑖
+        |0000100001⟩: 0.1768+0.0000𝑖
+        |0001000010⟩: 0.1768+0.0000𝑖
+        |0001100011⟩: 0.1768+0.0000𝑖
+        |0010000100⟩: 0.1768+0.0000𝑖
+        |0010100101⟩: 0.1768+0.0000𝑖
+        |0011000110⟩: 0.1768+0.0000𝑖
+        |0011100111⟩: 0.1768+0.0000𝑖
+        |0100001000⟩: 0.1768+0.0000𝑖
+        |0100101001⟩: 0.1768+0.0000𝑖
+        |0101001010⟩: 0.1768+0.0000𝑖
+        |0101101011⟩: 0.1768+0.0000𝑖
+        |0110001100⟩: 0.1768+0.0000𝑖
+        |0110101101⟩: 0.1768+0.0000𝑖
+        |0111001110⟩: 0.1768+0.0000𝑖
+        |0111101111⟩: 0.1768+0.0000𝑖
+        |1000010000⟩: 0.1768+0.0000𝑖
+        |1000110001⟩: 0.1768+0.0000𝑖
+        |1001010010⟩: 0.1768+0.0000𝑖
+        |1001110011⟩: 0.1768+0.0000𝑖
+        |1010010100⟩: 0.1768+0.0000𝑖
+        |1010110101⟩: 0.1768+0.0000𝑖
+        |1011010110⟩: 0.1768+0.0000𝑖
+        |1011110111⟩: 0.1768+0.0000𝑖
+        |1100011000⟩: 0.1768+0.0000𝑖
+        |1100111001⟩: 0.1768+0.0000𝑖
+        |1101011010⟩: 0.1768+0.0000𝑖
+        |1101111011⟩: 0.1768+0.0000𝑖
+        |1110011100⟩: 0.1768+0.0000𝑖
+        |1110111101⟩: 0.1768+0.0000𝑖
+        |1111011111⟩: 0.0000−0.1768𝑖
+        |1111111110⟩: 0.0000+0.1768𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcy(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcz_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Z(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101110⟩: 0.2500+0.0000𝑖
+        |11111111⟩: −0.2500+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcz(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcz_3_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(4);
+            let aux = QIR.Runtime.AllocateQubitArray(4);
+            for i in 0..3 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Z(qs[0..2], qs[3]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |00000000⟩: 0.2500+0.0000𝑖
+        |00010001⟩: 0.2500+0.0000𝑖
+        |00100010⟩: 0.2500+0.0000𝑖
+        |00110011⟩: 0.2500+0.0000𝑖
+        |01000100⟩: 0.2500+0.0000𝑖
+        |01010101⟩: 0.2500+0.0000𝑖
+        |01100110⟩: 0.2500+0.0000𝑖
+        |01110111⟩: 0.2500+0.0000𝑖
+        |10001000⟩: 0.2500+0.0000𝑖
+        |10011001⟩: 0.2500+0.0000𝑖
+        |10101010⟩: 0.2500+0.0000𝑖
+        |10111011⟩: 0.2500+0.0000𝑖
+        |11001100⟩: 0.2500+0.0000𝑖
+        |11011101⟩: 0.2500+0.0000𝑖
+        |11101110⟩: 0.2500+0.0000𝑖
+        |11111111⟩: −0.2500+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcz(&[0, 1, 2], 3);
+    for i in 0..4 {
+        sim.sim.mcx(&[i + 4], i);
+        sim.sim.h(i + 4);
+        assert!(sim.sim.qubit_is_zero(i + 4), "qubit {} is not zero", i + 4);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_unrestricted_mcz_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Z(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+        }"},
+        "",
+        Profile::Unrestricted,
+        &mut sim,
+        &Value::unit(),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1768+0.0000𝑖
+        |0000100001⟩: 0.1768+0.0000𝑖
+        |0001000010⟩: 0.1768+0.0000𝑖
+        |0001100011⟩: 0.1768+0.0000𝑖
+        |0010000100⟩: 0.1768+0.0000𝑖
+        |0010100101⟩: 0.1768+0.0000𝑖
+        |0011000110⟩: 0.1768+0.0000𝑖
+        |0011100111⟩: 0.1768+0.0000𝑖
+        |0100001000⟩: 0.1768+0.0000𝑖
+        |0100101001⟩: 0.1768+0.0000𝑖
+        |0101001010⟩: 0.1768+0.0000𝑖
+        |0101101011⟩: 0.1768+0.0000𝑖
+        |0110001100⟩: 0.1768+0.0000𝑖
+        |0110101101⟩: 0.1768+0.0000𝑖
+        |0111001110⟩: 0.1768+0.0000𝑖
+        |0111101111⟩: 0.1768+0.0000𝑖
+        |1000010000⟩: 0.1768+0.0000𝑖
+        |1000110001⟩: 0.1768+0.0000𝑖
+        |1001010010⟩: 0.1768+0.0000𝑖
+        |1001110011⟩: 0.1768+0.0000𝑖
+        |1010010100⟩: 0.1768+0.0000𝑖
+        |1010110101⟩: 0.1768+0.0000𝑖
+        |1011010110⟩: 0.1768+0.0000𝑖
+        |1011110111⟩: 0.1768+0.0000𝑖
+        |1100011000⟩: 0.1768+0.0000𝑖
+        |1100111001⟩: 0.1768+0.0000𝑖
+        |1101011010⟩: 0.1768+0.0000𝑖
+        |1101111011⟩: 0.1768+0.0000𝑖
+        |1110011100⟩: 0.1768+0.0000𝑖
+        |1110111101⟩: 0.1768+0.0000𝑖
+        |1111011110⟩: 0.1768+0.0000𝑖
+        |1111111111⟩: −0.1768+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcz(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}
+
+#[test]
+fn test_base_mcz_4_control() {
+    let mut sim = SparseSim::default();
+    let dump = test_expression_with_lib_and_profile_and_sim(
+        indoc! {"{
+            let qs = QIR.Runtime.AllocateQubitArray(5);
+            let aux = QIR.Runtime.AllocateQubitArray(5);
+            for i in 0..4 {
+                H(aux[i]);
+                CNOT(aux[i], qs[i]);
+            }
+            Controlled Z(qs[0..3], qs[4]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            let result : Result[] = [];
+            result
+        }"},
+        "",
+        Profile::Base,
+        &mut sim,
+        &Value::Array(Vec::new().into()),
+    );
+    expect![[r#"
+        STATE:
+        |0000000000⟩: 0.1768+0.0000𝑖
+        |0000100001⟩: 0.1768+0.0000𝑖
+        |0001000010⟩: 0.1768+0.0000𝑖
+        |0001100011⟩: 0.1768+0.0000𝑖
+        |0010000100⟩: 0.1768+0.0000𝑖
+        |0010100101⟩: 0.1768+0.0000𝑖
+        |0011000110⟩: 0.1768+0.0000𝑖
+        |0011100111⟩: 0.1768+0.0000𝑖
+        |0100001000⟩: 0.1768+0.0000𝑖
+        |0100101001⟩: 0.1768+0.0000𝑖
+        |0101001010⟩: 0.1768+0.0000𝑖
+        |0101101011⟩: 0.1768+0.0000𝑖
+        |0110001100⟩: 0.1768+0.0000𝑖
+        |0110101101⟩: 0.1768+0.0000𝑖
+        |0111001110⟩: 0.1768+0.0000𝑖
+        |0111101111⟩: 0.1768+0.0000𝑖
+        |1000010000⟩: 0.1768+0.0000𝑖
+        |1000110001⟩: 0.1768+0.0000𝑖
+        |1001010010⟩: 0.1768+0.0000𝑖
+        |1001110011⟩: 0.1768+0.0000𝑖
+        |1010010100⟩: 0.1768+0.0000𝑖
+        |1010110101⟩: 0.1768+0.0000𝑖
+        |1011010110⟩: 0.1768+0.0000𝑖
+        |1011110111⟩: 0.1768+0.0000𝑖
+        |1100011000⟩: 0.1768+0.0000𝑖
+        |1100111001⟩: 0.1768+0.0000𝑖
+        |1101011010⟩: 0.1768+0.0000𝑖
+        |1101111011⟩: 0.1768+0.0000𝑖
+        |1110011100⟩: 0.1768+0.0000𝑖
+        |1110111101⟩: 0.1768+0.0000𝑖
+        |1111011110⟩: 0.1768+0.0000𝑖
+        |1111111111⟩: −0.1768+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+
+    sim.sim.mcz(&[0, 1, 2, 3], 4);
+    for i in 0..5 {
+        sim.sim.mcx(&[i + 5], i);
+        sim.sim.h(i + 5);
+        assert!(sim.sim.qubit_is_zero(i + 5), "qubit {} is not zero", i + 5);
+        assert!(sim.sim.qubit_is_zero(i), "qubit {i} is not zero");
+    }
+}

--- a/library/std/internal.qs
+++ b/library/std/internal.qs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Intrinsic {
+    open Microsoft.Quantum.Measurement;
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Core;
     open Microsoft.Quantum.Math;
@@ -125,13 +126,13 @@ namespace Microsoft.Quantum.Intrinsic {
     internal operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
         // First collect the controls into the first part of the auxiliary list.
         for i in 0..2..(Length(ctls) - 2) {
-            PhaseCCX(ctls[i], ctls[i + 1], aux[i / 2]);
+            AND(ctls[i], ctls[i + 1], aux[i / 2]);
         }
         // Then collect the auxiliary qubits in the first part of the list forward into the last
         // qubit of the auxiliary list. The adjustment is used to allow the caller to reduce or increase
         // the number of times this is run based on the eventual number of control qubits needed.
         for i in 0..((Length(ctls) / 2) - 2 - adjustment) {
-            PhaseCCX(aux[i * 2], aux[(i * 2) + 1], aux[i + Length(ctls) / 2]);
+            AND(aux[i * 2], aux[(i * 2) + 1], aux[i + Length(ctls) / 2]);
         }
     }
 
@@ -139,8 +140,26 @@ namespace Microsoft.Quantum.Intrinsic {
     /// last control and the second to last auxiliary will be collected into the last auxiliary.
     internal operation AdjustForSingleControl(ctls : Qubit[], aux : Qubit[]) : Unit is Adj {
         if Length(ctls) % 2 != 0 {
-            PhaseCCX(ctls[Length(ctls) - 1], aux[Length(ctls) - 3], aux[Length(ctls) - 2]);
+            AND(ctls[Length(ctls) - 1], aux[Length(ctls) - 3], aux[Length(ctls) - 2]);
         }
+    }
+
+    @Config(Unrestricted)
+    internal operation AND(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
+        body ... {
+            CCNOT(control1, control2, target);
+        }
+        adjoint ... {
+            H(target);
+            if MResetZ(target) == One {
+                Controlled Z([control1], control2);
+            }
+        }
+    }
+
+    @Config(Base)
+    internal operation AND(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
+        PhaseCCX(control1, control2, target);
     }
 
     internal operation PhaseCCX(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {


### PR DESCRIPTION
This allows the "unrestricted" configuration to use an optimized `AND` for multi-controlled decomposition that relies on measurement-based adjoint. The existing `PhaseCCX` will still be used for "base" configuration since branching measurement is not allowed there.

Fixes #1137