### PR TITLE
Doc Gen: Put Summary in Quotes for Metadata

### DIFF
--- a/compiler/qsc_doc_gen/src/generate_docs.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs.rs
@@ -230,7 +230,7 @@ ms.topic: {}
 qsharp.kind: {}
 qsharp.namespace: {}
 qsharp.name: {}
-qsharp.summary: {}
+qsharp.summary: \"{}\"
 ---",
             self.uid, self.title, self.topic, kind, self.namespace, self.name, self.summary
         )

--- a/compiler/qsc_doc_gen/src/generate_docs/tests.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs/tests.rs
@@ -24,7 +24,7 @@ fn docs_generation() {
         qsharp.kind: function
         qsharp.namespace: Microsoft.Quantum.Core
         qsharp.name: Length
-        qsharp.summary: Returns the number of elements in an array.
+        qsharp.summary: "Returns the number of elements in an array."
         ---
 
         # Length function


### PR DESCRIPTION
The summary field for the metadata needs to be wrapped in quotes.