### PR TITLE
Context specific comparison of code parameters in RE

### DIFF
--- a/resource_estimator/src/system/modeling/fault_tolerance.rs
+++ b/resource_estimator/src/system/modeling/fault_tolerance.rs
@@ -556,4 +556,8 @@ impl ErrorCorrection for Protocol {
     fn code_parameter_range(&self, lower_bound: Option<&u64>) -> impl Iterator<Item = u64> {
         (lower_bound.copied().unwrap_or(1)..=self.max_code_distance).step_by(2)
     }
+
+    fn code_parameter_cmp(&self, _qubit: &PhysicalQubit, p1: &u64, p2: &u64) -> std::cmp::Ordering {
+        p1.cmp(p2)
+    }
 }


### PR DESCRIPTION
In some applications, two code parameters cannot simply be compared without taking into account the context of the error correction method and the physical qubit. Therefore, instead of using `Ord` for `ErrorCorrection::Parameter`, I introduce a trait function `ErrorCorrection::code_parameter_cmp`, which compares two code parameters in the context of the error correction itself and the underlying physical qubit.

Further, I simplified the code and made some variable names and comments consistent to not refer to T states in particular, when referring to magic states.