### PR TITLE
QSC: display the path when emitting HIR/QIR fails

### DIFF
--- a/compiler/qsc/src/bin/qsc.rs
+++ b/compiler/qsc/src/bin/qsc.rs
@@ -165,12 +165,12 @@ fn read_source(path: impl AsRef<Path>) -> miette::Result<(SourceName, SourceCont
 fn emit_hir(package: &Package, dir: impl AsRef<Path>) -> miette::Result<()> {
     let path = dir.as_ref().join("hir.txt");
     info!(
-        "Writing hir output file to: {}",
+        "Writing HIR output file to: {}",
         path.to_str().unwrap_or_default()
     );
-    fs::write(path, package.to_string())
+    fs::write(&path, package.to_string())
         .into_diagnostic()
-        .context("could not emit HIR")
+        .with_context(|| format!("could not emit HIR file `{}`", path.display()))
 }
 
 fn emit_qir(out_dir: &Path, store: &PackageStore, package_id: PackageId) -> Result<(), Report> {
@@ -179,13 +179,12 @@ fn emit_qir(out_dir: &Path, store: &PackageStore, package_id: PackageId) -> Resu
     match result {
         Ok(qir) => {
             info!(
-                "Writing qir output file to: {}",
+                "Writing QIR output file to: {}",
                 path.to_str().unwrap_or_default()
             );
-            fs::write(path, qir)
+            fs::write(&path, qir)
                 .into_diagnostic()
-                .context("could not emit QIR")?;
-            Ok(())
+                .with_context(|| format!("could not emit QIR file `{}`", path.display()))
         }
         Err((error, _)) => {
             let unit = store.get(package_id).expect("package should be in store");


### PR DESCRIPTION
I wasted a little time on this error as I could not figure out why the emit was failing for me, so I hope the change makes sense to everyone.

When emitting HIR/QIR fails (e.g. directory permissions or output path is invalid) it is not obvious where it failed because the code swallows the path:

```
Error:   × could not emit QIR
  ╰─▶ Permission denied (os error 13)
```

or 

```
Error:   × could not emit QIR
  ╰─▶ No such file or directory (os error 2)
```

With this change the path is also shown:

```
Error:   × could not emit QIR file `./../qir/qir.ll`
  ╰─▶ No such file or directory (os error 2)
```

This is symmetrical to how the path is already shown for source file errors

```
Error:   × could not read source file `../source/foo.qs`
  ╰─▶ No such file or directory (os error 2)
```