### PR TITLE
Fix ordering of output from `DumpRegister`

### DIFF
--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -424,6 +424,33 @@ fn dump_register_qubits_reorder_output() {
 }
 
 #[test]
+fn dump_register_qubits_reorder_output_should_be_sorted() {
+    check_intrinsic_output(
+        "",
+        indoc! {"{
+            use qs = Qubit[5];
+            H(qs[0]);
+            H(qs[2]);
+            Microsoft.Quantum.Diagnostics.DumpMachine();
+            Microsoft.Quantum.Diagnostics.DumpRegister(qs[0..3]);
+            ResetAll(qs);
+        }"},
+        &expect![[r#"
+            STATE:
+            |00000⟩: 0.5000+0.0000𝑖
+            |00100⟩: 0.5000+0.0000𝑖
+            |10000⟩: 0.5000+0.0000𝑖
+            |10100⟩: 0.5000+0.0000𝑖
+            STATE:
+            |0000⟩: 0.5000+0.0000𝑖
+            |0010⟩: 0.5000+0.0000𝑖
+            |1000⟩: 0.5000+0.0000𝑖
+            |1010⟩: 0.5000+0.0000𝑖
+        "#]],
+    );
+}
+
+#[test]
 fn dump_register_qubits_not_unique_fails() {
     check_intrinsic_result(
         "",

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -432,7 +432,7 @@ fn dump_register_qubits_reorder_output_should_be_sorted() {
             H(qs[0]);
             H(qs[2]);
             Microsoft.Quantum.Diagnostics.DumpMachine();
-            Microsoft.Quantum.Diagnostics.DumpRegister(qs[0..3]);
+            Microsoft.Quantum.Diagnostics.DumpRegister(qs[0..2..3]);
             ResetAll(qs);
         }"},
         &expect![[r#"
@@ -442,10 +442,10 @@ fn dump_register_qubits_reorder_output_should_be_sorted() {
             |10000⟩: 0.5000+0.0000𝑖
             |10100⟩: 0.5000+0.0000𝑖
             STATE:
-            |0000⟩: 0.5000+0.0000𝑖
-            |0010⟩: 0.5000+0.0000𝑖
-            |1000⟩: 0.5000+0.0000𝑖
-            |1010⟩: 0.5000+0.0000𝑖
+            |00⟩: 0.5000+0.0000𝑖
+            |01⟩: 0.5000+0.0000𝑖
+            |10⟩: 0.5000+0.0000𝑖
+            |11⟩: 0.5000+0.0000𝑖
         "#]],
     );
 }

--- a/compiler/qsc_eval/src/intrinsic/utils.rs
+++ b/compiler/qsc_eval/src/intrinsic/utils.rs
@@ -39,12 +39,14 @@ pub fn split_state(
     }
 
     let dump_norm = 1.0 / dump_norm.sqrt();
-    Ok(dump_state
+    let mut dump_state = dump_state
         .into_iter()
         .filter_map(|(label, val)| {
             normalize_and_reorder(val, dump_norm, qubits, &label, qubit_count)
         })
-        .collect())
+        .collect::<Vec<_>>();
+    dump_state.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(dump_state)
 }
 
 /// From the qubit identifiers provided, compute the bit masks for the qubits to dump and the remaining qubits.


### PR DESCRIPTION
`DumpRegister` output was incorrectly non-deterministic and not ordered because it was coming from a hash map. This fixes that by sorting the reordered labels before returning the vector of results.