### PR TITLE
Use workspace lint settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,14 @@ quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", rev =
 async-trait = "0.1"
 tokio = { version = "1.35", features = ["macros", "rt"] }
 
+[workspace.lints.clippy]
+mod_module_files = "warn"
+pedantic = "warn"
+unwrap_used = "warn"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+
 [profile.release]
 debug = 1
 strip = true

--- a/compiler/qsc/Cargo.toml
+++ b/compiler/qsc/Cargo.toml
@@ -34,6 +34,9 @@ criterion = { workspace = true, features = ["cargo_bench_support"] }
 expect-test = { workspace = true }
 indoc = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 bench = false
 doctest = false

--- a/compiler/qsc/benches/eval.rs
+++ b/compiler/qsc/benches/eval.rs
@@ -28,7 +28,7 @@ pub fn teleport(c: &mut Criterion) {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);
             assert!(evaluator.eval_entry(&mut rec).is_ok());
-        })
+        });
     });
 }
 
@@ -47,7 +47,7 @@ pub fn deutsch_jozsa(c: &mut Criterion) {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);
             assert!(evaluator.eval_entry(&mut rec).is_ok());
-        })
+        });
     });
 }
 
@@ -66,7 +66,7 @@ pub fn large_file(c: &mut Criterion) {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);
             assert!(evaluator.eval_entry(&mut rec).is_ok());
-        })
+        });
     });
 }
 
@@ -97,7 +97,7 @@ pub fn array_append(c: &mut Criterion) {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);
             assert!(evaluator.eval_entry(&mut rec).is_ok());
-        })
+        });
     });
 }
 
@@ -128,7 +128,7 @@ pub fn array_update(c: &mut Criterion) {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);
             assert!(evaluator.eval_entry(&mut rec).is_ok());
-        })
+        });
     });
 }
 
@@ -147,7 +147,7 @@ pub fn array_literal(c: &mut Criterion) {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);
             assert!(evaluator.eval_entry(&mut rec).is_ok());
-        })
+        });
     });
 }
 
@@ -183,7 +183,7 @@ pub fn large_nested_iteration(c: &mut Criterion) {
             let mut out = Vec::new();
             let mut rec = GenericReceiver::new(&mut out);
             assert!(evaluator.eval_entry(&mut rec).is_ok());
-        })
+        });
     });
 }
 

--- a/compiler/qsc/benches/large.rs
+++ b/compiler/qsc/benches/large.rs
@@ -24,7 +24,7 @@ pub fn large_file(c: &mut Criterion) {
                 LanguageFeatures::default(),
             );
             assert!(reports.is_empty());
-        })
+        });
     });
 }
 

--- a/compiler/qsc/benches/library.rs
+++ b/compiler/qsc/benches/library.rs
@@ -8,7 +8,7 @@ use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags};
 pub fn library(c: &mut Criterion) {
     let store = PackageStore::new(compile::core());
     c.bench_function("Standard library", |b| {
-        b.iter(|| compile::std(&store, RuntimeCapabilityFlags::all()))
+        b.iter(|| compile::std(&store, RuntimeCapabilityFlags::all()));
     });
 }
 

--- a/compiler/qsc/build.rs
+++ b/compiler/qsc/build.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 use std::process::Command;
 
 fn main() {

--- a/compiler/qsc/src/bin/memtest.rs
+++ b/compiler/qsc/src/bin/memtest.rs
@@ -45,6 +45,7 @@ impl<A: GlobalAlloc> AllocationCounter<A> {
 #[global_allocator]
 static ALLOCATOR: AllocationCounter<System> = AllocationCounter::new(System);
 
+#[must_use]
 pub fn compile_stdlib() -> CompileUnit {
     let store = PackageStore::new(compile::core());
     compile::std(&store, RuntimeCapabilityFlags::all())

--- a/compiler/qsc/src/bin/qsc.rs
+++ b/compiler/qsc/src/bin/qsc.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 use clap::{crate_version, ArgGroup, Parser, ValueEnum};
 use log::info;
 use miette::{Context, IntoDiagnostic, Report};

--- a/compiler/qsc/src/bin/qsi.rs
+++ b/compiler/qsc/src/bin/qsi.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 use clap::{crate_version, Parser};
 use miette::{Context, IntoDiagnostic, Report, Result};
 use num_bigint::BigUint;

--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -113,7 +113,6 @@ pub struct Interpreter {
     env: Env,
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub type InterpretResult = std::result::Result<Value, Vec<Error>>;
 
 impl Interpreter {

--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 pub mod compile;
 pub mod error;
 pub mod incremental;

--- a/compiler/qsc_ast/Cargo.toml
+++ b/compiler/qsc_ast/Cargo.toml
@@ -14,5 +14,8 @@ miette = { workspace = true }
 num-bigint = { workspace = true }
 qsc_data_structures = { path = "../qsc_data_structures" }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_ast/src/lib.rs
+++ b/compiler/qsc_ast/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 pub mod assigner;
 pub mod ast;
 pub mod mut_visit;

--- a/compiler/qsc_codegen/Cargo.toml
+++ b/compiler/qsc_codegen/Cargo.toml
@@ -23,5 +23,8 @@ expect-test = { workspace = true }
 indoc = { workspace = true }
 qsc_passes = { path = "../qsc_passes" }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_codegen/src/lib.rs
+++ b/compiler/qsc_codegen/src/lib.rs
@@ -1,7 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 pub mod qir_base;

--- a/compiler/qsc_data_structures/Cargo.toml
+++ b/compiler/qsc_data_structures/Cargo.toml
@@ -16,5 +16,8 @@ bitflags = { workspace = true }
 [dev-dependencies]
 expect-test = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_data_structures/src/lib.rs
+++ b/compiler/qsc_data_structures/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 pub mod display;
 pub mod functors;
 pub mod index_map;

--- a/compiler/qsc_data_structures/src/span.rs
+++ b/compiler/qsc_data_structures/src/span.rs
@@ -75,7 +75,6 @@ impl From<Span> for SourceSpan {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub trait WithSpan {
     #[must_use]
     fn with_span(self, span: Span) -> Self;

--- a/compiler/qsc_doc_gen/Cargo.toml
+++ b/compiler/qsc_doc_gen/Cargo.toml
@@ -18,5 +18,8 @@ qsc_ast = { path = "../qsc_ast" }
 qsc_hir = { path = "../qsc_hir" }
 rustc-hash = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_doc_gen/src/display.rs
+++ b/compiler/qsc_doc_gen/src/display.rs
@@ -56,10 +56,12 @@ pub struct CodeDisplay<'a> {
 
 #[allow(clippy::unused_self)]
 impl<'a> CodeDisplay<'a> {
+    #[must_use]
     pub fn hir_callable_decl(&self, decl: &'a hir::CallableDecl) -> impl Display + '_ {
         HirCallableDecl { decl }
     }
 
+    #[must_use]
     pub fn ast_callable_decl(&self, decl: &'a ast::CallableDecl) -> impl Display + '_ {
         AstCallableDecl {
             lookup: self.compilation,
@@ -67,6 +69,7 @@ impl<'a> CodeDisplay<'a> {
         }
     }
 
+    #[must_use]
     pub fn name_ty_id(&self, name: &'a str, ty_id: ast::NodeId) -> impl Display + '_ {
         NameTyId {
             lookup: self.compilation,
@@ -75,22 +78,27 @@ impl<'a> CodeDisplay<'a> {
         }
     }
 
+    #[must_use]
     pub fn ident_ty(&self, ident: &'a ast::Ident, ty: &'a ast::Ty) -> impl Display + '_ {
         IdentTy { ident, ty }
     }
 
+    #[must_use]
     pub fn ident_ty_def(&self, ident: &'a ast::Ident, def: &'a ast::TyDef) -> impl Display + 'a {
         IdentTyDef { ident, def }
     }
 
+    #[must_use]
     pub fn hir_udt(&self, udt: &'a ty::Udt) -> impl Display + '_ {
         HirUdt { udt }
     }
 
+    #[must_use]
     pub fn hir_pat(&self, pat: &'a hir::Pat) -> impl Display + '_ {
         HirPat { pat }
     }
 
+    #[must_use]
     pub fn get_param_offset(&self, decl: &hir::CallableDecl) -> u32 {
         HirCallableDecl { decl }.get_param_offset()
     }
@@ -601,6 +609,7 @@ fn eval_functor_expr(expr: &ast::FunctorExpr) -> ty::FunctorSetValue {
 
 /// Takes a doc string from Q# and increases all of the markdown header levels by one level.
 /// i.e. `# Summary` becomes `## Summary`
+#[must_use]
 pub fn increase_header_level(doc: &str) -> String {
     let re = Regex::new(r"(?mi)^(#+)( [\s\S]+?)$").expect("Invalid regex");
     re.replace_all(doc, "$1#$2").to_string()
@@ -608,6 +617,7 @@ pub fn increase_header_level(doc: &str) -> String {
 
 /// Takes a doc string from Q# and returns the contents of the `# Summary` section. If no
 /// such section can be found, returns the original doc string.
+#[must_use]
 pub fn parse_doc_for_summary(doc: &str) -> String {
     let re = Regex::new(r"(?mi)(?:^# Summary$)([\s\S]*?)(?:(^# .*)|\z)").expect("Invalid regex");
     match re.captures(doc) {
@@ -626,6 +636,7 @@ pub fn parse_doc_for_summary(doc: &str) -> String {
 /// Takes a doc string from a Q# callable and the name of a parameter of
 /// that callable. Returns the description of that parameter found in the
 /// doc string. If no description is found, returns the empty string.
+#[must_use]
 pub fn parse_doc_for_param(doc: &str, param: &str) -> String {
     let re = Regex::new(r"(?mi)(?:^# Input$)([\s\S]*?)(?:(^# .*)|\z)").expect("Invalid regex");
     let input = match re.captures(doc) {

--- a/compiler/qsc_doc_gen/src/generate_docs.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs.rs
@@ -102,6 +102,7 @@ impl Lookup for Compilation {
     }
 }
 
+#[must_use]
 pub fn generate_docs() -> Files {
     let compilation = Compilation::new();
     let mut files: Files = vec![];

--- a/compiler/qsc_eval/Cargo.toml
+++ b/compiler/qsc_eval/Cargo.toml
@@ -27,5 +27,8 @@ indoc = { workspace = true }
 qsc_frontend = { path = "../qsc_frontend" }
 qsc_passes = { path = "../qsc_passes" }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 #[cfg(test)]
 mod tests;
 

--- a/compiler/qsc_eval/src/lower.rs
+++ b/compiler/qsc_eval/src/lower.rs
@@ -683,7 +683,6 @@ fn lower_functor_set_value(value: qsc_hir::ty::FunctorSetValue) -> qsc_fir::ty::
 }
 
 #[must_use]
-#[allow(clippy::module_name_repetitions)]
 fn lower_local_item_id(id: qsc_hir::hir::LocalItemId) -> LocalItemId {
     LocalItemId::from(usize::from(id))
 }

--- a/compiler/qsc_fir/Cargo.toml
+++ b/compiler/qsc_fir/Cargo.toml
@@ -14,5 +14,8 @@ num-bigint = { workspace = true }
 qsc_data_structures = { path = "../qsc_data_structures" }
 rustc-hash = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_fir/src/lib.rs
+++ b/compiler/qsc_fir/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 pub mod assigner;
 pub mod fir;
 pub mod global;

--- a/compiler/qsc_frontend/Cargo.toml
+++ b/compiler/qsc_frontend/Cargo.toml
@@ -23,5 +23,8 @@ thiserror = { workspace = true }
 expect-test = { workspace = true }
 indoc = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -90,7 +90,6 @@ impl From<ConfigAttr> for RuntimeCapabilityFlags {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Default)]
 pub struct CompileUnit {
     pub package: hir::Package,

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1216,38 +1216,6 @@ fn reject_use_qubit_block_syntax_if_preview_feature_is_on() {
                     ),
                 ),
             ),
-            Error(
-                Parse(
-                    Error(
-                        Token(
-                            Close(
-                                Brace,
-                            ),
-                            Semi,
-                            Span {
-                                lo: 303,
-                                hi: 304,
-                            },
-                        ),
-                    ),
-                ),
-            ),
-            Error(
-                Parse(
-                    Error(
-                        Token(
-                            Eof,
-                            Close(
-                                Brace,
-                            ),
-                            Span {
-                                lo: 320,
-                                hi: 321,
-                            },
-                        ),
-                    ),
-                ),
-            ),
         ]
     "#]]
     .assert_debug_eq(&unit.errors);

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1216,6 +1216,38 @@ fn reject_use_qubit_block_syntax_if_preview_feature_is_on() {
                     ),
                 ),
             ),
+            Error(
+                Parse(
+                    Error(
+                        Token(
+                            Close(
+                                Brace,
+                            ),
+                            Semi,
+                            Span {
+                                lo: 303,
+                                hi: 304,
+                            },
+                        ),
+                    ),
+                ),
+            ),
+            Error(
+                Parse(
+                    Error(
+                        Token(
+                            Eof,
+                            Close(
+                                Brace,
+                            ),
+                            Span {
+                                lo: 320,
+                                hi: 321,
+                            },
+                        ),
+                    ),
+                ),
+            ),
         ]
     "#]]
     .assert_debug_eq(&unit.errors);

--- a/compiler/qsc_frontend/src/lib.rs
+++ b/compiler/qsc_frontend/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 mod closure;
 pub mod compile;
 pub mod error;

--- a/compiler/qsc_hir/Cargo.toml
+++ b/compiler/qsc_hir/Cargo.toml
@@ -14,5 +14,8 @@ num-bigint = { workspace = true }
 qsc_data_structures = { path = "../qsc_data_structures" }
 rustc-hash = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_hir/src/lib.rs
+++ b/compiler/qsc_hir/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 pub mod assigner;
 pub mod global;
 pub mod hir;

--- a/compiler/qsc_parse/Cargo.toml
+++ b/compiler/qsc_parse/Cargo.toml
@@ -20,5 +20,8 @@ thiserror = { workspace = true }
 [dev-dependencies]
 expect-test = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_parse/src/expr.rs
+++ b/compiler/qsc_parse/src/expr.rs
@@ -667,7 +667,7 @@ fn range_op(s: &mut ParserContext, start: Box<Expr>) -> Result<Box<ExprKind>> {
 
 fn op_name(s: &ParserContext) -> OpName {
     match Keyword::from_str(s.read()) {
-        Ok(Keyword::And | Keyword::Or) | Err(_) => OpName::Token(s.peek().kind),
+        Ok(Keyword::And | Keyword::Or) | Err(()) => OpName::Token(s.peek().kind),
         Ok(keyword) => OpName::Keyword(keyword),
     }
 }

--- a/compiler/qsc_parse/src/expr/tests.rs
+++ b/compiler/qsc_parse/src/expr/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::expr;
 use crate::tests::check;
 use expect_test::expect;

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::{parse, parse_attr, parse_spec_decl};
 use crate::{
     scan::ParserContext,
@@ -1463,7 +1465,7 @@ fn callable_missing_parens() {
                     ),
                 ),
             ]"#]],
-    )
+    );
 }
 
 #[test]
@@ -1492,7 +1494,7 @@ fn callable_missing_close_parens() {
                     ),
                 ),
             ]"#]],
-    )
+    );
 }
 
 #[test]
@@ -1517,7 +1519,7 @@ fn callable_missing_open_parens() {
                     ),
                 ),
             ]"#]],
-    )
+    );
 }
 
 #[test]

--- a/compiler/qsc_parse/src/lex/cooked/tests.rs
+++ b/compiler/qsc_parse/src/lex/cooked/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::{Lexer, Token, TokenKind};
 use crate::lex::Delim;
 use expect_test::{expect, Expect};

--- a/compiler/qsc_parse/src/lex/raw/tests.rs
+++ b/compiler/qsc_parse/src/lex/raw/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::Lexer;
 use crate::lex::raw::{Single, Token, TokenKind};
 use expect_test::{expect, Expect};

--- a/compiler/qsc_parse/src/lib.rs
+++ b/compiler/qsc_parse/src/lib.rs
@@ -30,6 +30,7 @@ use thiserror::Error;
 pub struct Error(ErrorKind);
 
 impl Error {
+    #[must_use]
     pub fn with_offset(self, offset: u32) -> Self {
         Self(self.0.with_offset(offset))
     }
@@ -100,6 +101,7 @@ trait Parser<T>: FnMut(&mut ParserContext) -> Result<T> {}
 
 impl<T, F: FnMut(&mut ParserContext) -> Result<T>> Parser<T> for F {}
 
+#[must_use]
 pub fn namespaces(
     input: &str,
     language_features: LanguageFeatures,
@@ -115,6 +117,7 @@ pub fn namespaces(
     }
 }
 
+#[must_use]
 pub fn top_level_nodes(
     input: &str,
     language_features: LanguageFeatures,
@@ -130,6 +133,7 @@ pub fn top_level_nodes(
     }
 }
 
+#[must_use]
 pub fn expr(input: &str, language_features: LanguageFeatures) -> (Box<Expr>, Vec<Error>) {
     let mut scanner = ParserContext::new(input, language_features);
     match expr::expr_eof(&mut scanner) {

--- a/compiler/qsc_parse/src/prim.rs
+++ b/compiler/qsc_parse/src/prim.rs
@@ -222,25 +222,17 @@ pub(super) fn recovering<T>(
     }
 }
 
-pub(super) fn recovering_semi(s: &mut ParserContext) -> Result<()> {
-    match token(s, TokenKind::Semi) {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            s.push_error(error);
-            // no recovery, just move on to the next token
-            Ok(())
-        }
+pub(super) fn recovering_semi(s: &mut ParserContext) {
+    if let Err(error) = token(s, TokenKind::Semi) {
+        s.push_error(error);
+        s.recover(&[TokenKind::Semi]);
     }
 }
 
-pub(super) fn recovering_token(s: &mut ParserContext, t: TokenKind) -> Result<()> {
-    match token(s, t) {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            s.push_error(error);
-            s.recover(&[t]);
-            Ok(())
-        }
+pub(super) fn recovering_token(s: &mut ParserContext, t: TokenKind) {
+    if let Err(error) = token(s, t) {
+        s.push_error(error);
+        s.recover(&[t]);
     }
 }
 

--- a/compiler/qsc_parse/src/prim.rs
+++ b/compiler/qsc_parse/src/prim.rs
@@ -224,8 +224,8 @@ pub(super) fn recovering<T>(
 
 pub(super) fn recovering_semi(s: &mut ParserContext) {
     if let Err(error) = token(s, TokenKind::Semi) {
+        // no recovery, just move on to the next token
         s.push_error(error);
-        s.recover(&[TokenKind::Semi]);
     }
 }
 

--- a/compiler/qsc_parse/src/prim/tests.rs
+++ b/compiler/qsc_parse/src/prim/tests.rs
@@ -10,7 +10,7 @@ use crate::{
     Error, ErrorKind,
 };
 use expect_test::expect;
-use qsc_data_structures::span::Span;
+use qsc_data_structures::{language_features::LanguageFeatures, span::Span};
 
 #[test]
 fn ident_basic() {
@@ -52,7 +52,7 @@ fn ident_num_prefix() {
 #[test]
 fn ident_keyword() {
     for keyword in enum_iterator::all::<Keyword>() {
-        let mut scanner = ParserContext::new(keyword.as_str(), Default::default());
+        let mut scanner = ParserContext::new(keyword.as_str(), LanguageFeatures::default());
         let actual = ident(&mut scanner);
         let span = Span {
             lo: 0,

--- a/compiler/qsc_parse/src/scan.rs
+++ b/compiler/qsc_parse/src/scan.rs
@@ -151,11 +151,11 @@ impl<'a> Scanner<'a> {
             if contains(peek, tokens) {
                 self.advance();
                 break;
-            } else if peek == TokenKind::Eof || self.barriers.iter().any(|&b| contains(peek, b)) {
-                break;
-            } else {
-                self.advance();
             }
+            if peek == TokenKind::Eof || self.barriers.iter().any(|&b| contains(peek, b)) {
+                break;
+            }
+            self.advance();
         }
     }
 

--- a/compiler/qsc_parse/src/stmt.rs
+++ b/compiler/qsc_parse/src/stmt.rs
@@ -58,7 +58,7 @@ pub(super) fn parse_block(s: &mut ParserContext) -> Result<Box<Block>> {
     token(s, TokenKind::Open(Delim::Brace))?;
     let stmts = barrier(s, &[TokenKind::Close(Delim::Brace)], parse_many)?;
     check_semis(s, &stmts);
-    recovering_token(s, TokenKind::Close(Delim::Brace))?;
+    recovering_token(s, TokenKind::Close(Delim::Brace));
     Ok(Box::new(Block {
         id: NodeId::default(),
         span: s.span(lo),
@@ -66,6 +66,7 @@ pub(super) fn parse_block(s: &mut ParserContext) -> Result<Box<Block>> {
     }))
 }
 
+#[allow(clippy::unnecessary_box_returns)]
 fn default(span: Span) -> Box<Stmt> {
     Box::new(Stmt {
         id: NodeId::default(),
@@ -91,7 +92,7 @@ fn parse_local(s: &mut ParserContext) -> Result<Box<StmtKind>> {
     let lhs = pat(s)?;
     token(s, TokenKind::Eq)?;
     let rhs = expr(s)?;
-    recovering_semi(s)?;
+    recovering_semi(s);
     Ok(Box::new(StmtKind::Local(mutability, lhs, rhs)))
 }
 
@@ -118,7 +119,7 @@ fn parse_qubit(s: &mut ParserContext) -> Result<Box<StmtKind>> {
     };
 
     if block.is_none() {
-        recovering_semi(s)?;
+        recovering_semi(s);
     }
 
     Ok(Box::new(StmtKind::Qubit(source, lhs, rhs, block)))

--- a/compiler/qsc_parse/src/stmt/tests.rs
+++ b/compiler/qsc_parse/src/stmt/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::needless_raw_string_hashes)]
+
 use super::{parse, parse_block};
 use crate::tests::check;
 use expect_test::expect;

--- a/compiler/qsc_parse/src/tests.rs
+++ b/compiler/qsc_parse/src/tests.rs
@@ -84,7 +84,7 @@ fn check_map<T>(
     expect: &Expect,
     f: impl FnOnce(&T) -> String,
 ) {
-    let mut scanner = ParserContext::new(input, Default::default());
+    let mut scanner = ParserContext::new(input, LanguageFeatures::default());
     let result = parser(&mut scanner);
     let errors = scanner.into_errors();
     match result {

--- a/compiler/qsc_passes/Cargo.toml
+++ b/compiler/qsc_passes/Cargo.toml
@@ -20,5 +20,8 @@ thiserror = { workspace = true }
 expect-test = { workspace = true }
 indoc = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 mod baseprofck;
 mod borrowck;
 mod callable_limits;

--- a/compiler/qsc_project/Cargo.toml
+++ b/compiler/qsc_project/Cargo.toml
@@ -25,5 +25,8 @@ qsc_project = { path = ".", features = ["fs"] }
 fs = []
 async = ["async-trait"]
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/compiler/qsc_project/src/fs.rs
+++ b/compiler/qsc_project/src/fs.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! This module contains a project implementation using [std::fs].
+//! This module contains a project implementation using [`std::fs`].
 //! Only a sync API is provided for now, because our binary targets
 //! are only sync at the time of writing this (qsi and qsc).
 
@@ -12,7 +12,7 @@ use std::fs::DirEntry as StdEntry;
 use std::path::Path;
 use std::{path::PathBuf, sync::Arc};
 
-/// This struct represents management of Q# projects from the [std::fs] filesystem implementation.
+/// This struct represents management of Q# projects from the [`std::fs`] filesystem implementation.
 #[derive(Default)]
 pub struct StdFs;
 

--- a/compiler/qsc_project/src/manifest.rs
+++ b/compiler/qsc_project/src/manifest.rs
@@ -33,6 +33,7 @@ pub struct ManifestDescriptor {
 
 impl ManifestDescriptor {
     /// Generate a canonical compilation URI for the project associated with this manifest
+    #[must_use]
     pub fn compilation_uri(&self) -> Arc<str> {
         Arc::from(format!(
             "{}/qsharp.json",
@@ -59,8 +60,8 @@ impl Manifest {
         Self::load_from_path(dir)
     }
 
-    /// Given a [PathBuf], traverse [PathBuf::ancestors] until a Manifest is found.
-    /// Returns [None] if no manifest named [MANIFEST_FILE_NAME] is found.
+    /// Given a [`PathBuf`], traverse [`PathBuf::ancestors`] until a Manifest is found.
+    /// Returns [None] if no manifest named [`MANIFEST_FILE_NAME`] is found.
     /// Returns an error if a manifest is found, but is not parsable into the
     /// expected format.
     pub fn load_from_path(path: PathBuf) -> std::result::Result<Option<ManifestDescriptor>, Error> {
@@ -96,7 +97,7 @@ impl Manifest {
     }
 }
 
-/// Utility function which filters out any [DirEntry] which is not a valid file or
+/// Utility function which filters out any [`DirEntry`] which is not a valid file or
 /// was unable to be read.
 #[cfg(feature = "fs")]
 fn only_valid_files(item: std::result::Result<DirEntry, std::io::Error>) -> Option<DirEntry> {

--- a/compiler/qsc_project/src/project.rs
+++ b/compiler/qsc_project/src/project.rs
@@ -14,7 +14,7 @@ pub struct Project {
     pub manifest: crate::Manifest,
 }
 
-/// This enum represents a filesystem object type. It is analogous to [std::fs::FileType].
+/// This enum represents a filesystem object type. It is analogous to [`std::fs::FileType`].
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum EntryType {
     File,
@@ -23,7 +23,7 @@ pub enum EntryType {
     Unknown,
 }
 
-/// This trait represents a filesystem object. It is analogous to [std::fs::DirEntry].
+/// This trait represents a filesystem object. It is analogous to [`std::fs::DirEntry`].
 pub trait DirEntry {
     type Error: Send + Sync;
     fn entry_type(&self) -> Result<EntryType, Self::Error>;
@@ -90,7 +90,7 @@ pub trait FileSystemAsync {
             match item.entry_type() {
                 Ok(EntryType::File) if item.entry_extension() == "qs" => files.push(item),
                 Ok(EntryType::Folder) => {
-                    files.append(&mut self.collect_project_sources_inner(&item.path()).await?)
+                    files.append(&mut self.collect_project_sources_inner(&item.path()).await?);
                 }
                 _ => (),
             }
@@ -130,12 +130,12 @@ fn filter_hidden_files<Entry: DirEntry>(
 /// for the Q# project system to function correctly.
 pub trait FileSystem {
     type Entry: DirEntry;
-    /// Given a path, parse its contents and return a tuple representing (FileName, FileContents).
+    /// Given a path, parse its contents and return a tuple representing (`FileName`, `FileContents`).
     fn read_file(&self, path: &Path) -> miette::Result<(Arc<str>, Arc<str>)>;
 
     /// Given a path, list its directory contents (if any).
     fn list_directory(&self, path: &Path) -> miette::Result<Vec<Self::Entry>>;
-    /// Given an initial path, fetch files matching <initial_path>/**/*.qs
+    /// Given an initial path, fetch files matching <`initial_path`>/**/*.qs
     fn collect_project_sources(&self, initial_path: &Path) -> miette::Result<Vec<Self::Entry>> {
         let listing = self.list_directory(initial_path)?;
         if let Some(src_dir) = listing.into_iter().find(|x| {
@@ -162,7 +162,7 @@ pub trait FileSystem {
             match item.entry_type() {
                 Ok(EntryType::File) if item.entry_extension() == "qs" => files.push(item),
                 Ok(EntryType::Folder) => {
-                    files.append(&mut self.collect_project_sources_inner(&item.path())?)
+                    files.append(&mut self.collect_project_sources_inner(&item.path())?);
                 }
                 _ => (),
             }
@@ -170,7 +170,7 @@ pub trait FileSystem {
         Ok(files)
     }
 
-    /// Given a [ManifestDescriptor], load project sources.
+    /// Given a [`ManifestDescriptor`], load project sources.
     fn load_project(&self, manifest: &ManifestDescriptor) -> miette::Result<Project> {
         let project_path = manifest.manifest_dir.clone();
         let qs_files = self.collect_project_sources(&project_path)?;

--- a/compiler/qsc_project/tests/harness.rs
+++ b/compiler/qsc_project/tests/harness.rs
@@ -6,21 +6,24 @@ use std::{path::PathBuf, sync::Arc};
 use expect_test::Expect;
 use qsc_project::{FileSystem, Manifest, StdFs};
 
-pub fn check(project_path: PathBuf, expect: &Expect) {
+pub fn check(project_path: &PathBuf, expect: &Expect) {
     let mut root_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     root_path.push(PathBuf::from("tests/projects"));
     let mut absolute_project_path = root_path.clone();
-    absolute_project_path.push(project_path.clone());
+    absolute_project_path.push(project_path);
     let manifest = Manifest::load_from_path(absolute_project_path)
-        .unwrap()
-        .unwrap();
+        .expect("manifest should load")
+        .expect("manifest should contain descriptor");
     let fs = StdFs;
-    let mut project = fs.load_project(&manifest).unwrap();
+    let mut project = fs.load_project(&manifest).expect("project should load");
 
     // remove the prefix absolute path
-    for (path, _contents) in project.sources.iter_mut() {
+    for (path, _contents) in &mut project.sources {
         let new_path = PathBuf::from(path.to_string());
-        let new_path = new_path.strip_prefix(&root_path).unwrap().to_string_lossy();
+        let new_path = new_path
+            .strip_prefix(&root_path)
+            .expect("prefix should be present")
+            .to_string_lossy();
         let new_path = new_path.replace(std::path::MAIN_SEPARATOR, "/");
         *path = Arc::from(new_path);
     }

--- a/compiler/qsc_project/tests/tests.rs
+++ b/compiler/qsc_project/tests/tests.rs
@@ -13,7 +13,7 @@ use harness::check;
 #[test]
 fn basic_manifest() {
     check(
-        "basic_manifest".into(),
+        &"basic_manifest".into(),
         &expect![[r#"
             Project {
                 sources: [
@@ -38,13 +38,13 @@ fn basic_manifest() {
                     language_features: [],
                 },
             }"#]],
-    )
+    );
 }
 
 #[test]
 fn circular_imports() {
     check(
-        "circular_imports".into(),
+        &"circular_imports".into(),
         &expect![[r#"
             Project {
                 sources: [
@@ -69,13 +69,13 @@ fn circular_imports() {
                     language_features: [],
                 },
             }"#]],
-    )
+    );
 }
 
 #[test]
 fn different_files_same_manifest() {
     check(
-        "different_files_same_manifest".into(),
+        &"different_files_same_manifest".into(),
         &expect![[r#"
             Project {
                 sources: [
@@ -100,13 +100,13 @@ fn different_files_same_manifest() {
                     language_features: [],
                 },
             }"#]],
-    )
+    );
 }
 
 #[test]
 fn empty_manifest() {
     check(
-        "empty_manifest".into(),
+        &"empty_manifest".into(),
         &expect![[r#"
             Project {
                 sources: [
@@ -121,13 +121,13 @@ fn empty_manifest() {
                     language_features: [],
                 },
             }"#]],
-    )
+    );
 }
 
 #[test]
 fn folder_structure() {
     check(
-        "folder_structure".into(),
+        &"folder_structure".into(),
         &expect![[r#"
             Project {
                 sources: [
@@ -154,12 +154,12 @@ fn folder_structure() {
                     language_features: [],
                 },
             }"#]],
-    )
+    );
 }
 #[test]
 fn hidden_files() {
     check(
-        "hidden_files".into(),
+        &"hidden_files".into(),
         &expect![[r#"
             Project {
                 sources: [
@@ -182,12 +182,12 @@ fn hidden_files() {
                     language_features: [],
                 },
             }"#]],
-    )
+    );
 }
 #[test]
 fn peer_file() {
     check(
-        "peer_file".into(),
+        &"peer_file".into(),
         &expect![[r#"
             Project {
                 sources: [
@@ -214,13 +214,13 @@ fn peer_file() {
                     language_features: [],
                 },
             }"#]],
-    )
+    );
 }
 
 #[test]
 fn language_feature() {
     check(
-        "language_feature".into(),
+        &"language_feature".into(),
         &expect![[r#"
             Project {
                 sources: [
@@ -237,5 +237,5 @@ fn language_feature() {
                     ],
                 },
             }"#]],
-    )
+    );
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,6 +19,9 @@ qsc = { path = "../compiler/qsc" }
 [features]
 do_fuzz = [ "dep:libfuzzer-sys" ]
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "compile"
 path = "fuzz_targets/compile.rs"

--- a/katas/Cargo.toml
+++ b/katas/Cargo.toml
@@ -11,5 +11,8 @@ license.workspace = true
 [dependencies]
 qsc = { path = "../compiler/qsc" }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/katas/src/lib.rs
+++ b/katas/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 #[cfg(test)]
 mod tests;
 

--- a/language_service/Cargo.toml
+++ b/language_service/Cargo.toml
@@ -23,5 +23,8 @@ rustc-hash = { workspace = true }
 qsc_project = { path = "../compiler/qsc_project", features = ["async"] }
 async-trait = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 pub mod code_lens;
 mod compilation;
 pub mod completion;

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -19,7 +19,6 @@ pub struct DiagnosticUpdate {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[allow(clippy::module_name_repetitions)]
 pub enum CompletionItemKind {
     // It would have been nice to match the numeric values to the ones used by
     // VS Code and Monaco, but unfortunately those two disagree on the values.
@@ -34,13 +33,11 @@ pub enum CompletionItemKind {
 }
 
 #[derive(Debug, Default)]
-#[allow(clippy::module_name_repetitions)]
 pub struct CompletionList {
     pub items: Vec<CompletionItem>,
 }
 
 #[derive(Debug)]
-#[allow(clippy::module_name_repetitions)]
 pub struct CompletionItem {
     pub label: String,
     pub kind: CompletionItemKind,

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -14,5 +14,8 @@ num-bigint = { workspace = true }
 expect-test = { workspace = true }
 qsc = { path = "../compiler/qsc" }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false

--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 #[cfg(test)]
 mod tests;
 

--- a/pip/Cargo.toml
+++ b/pip/Cargo.toml
@@ -17,6 +17,9 @@ resource_estimator = { path = "../resource_estimator" }
 miette = { workspace = true, features = ["fancy"] }
 rustc-hash = { workspace = true }
 
+[lints]
+workspace = true
+
 [target.'cfg(not(any(target_os = "windows")))'.dependencies]
 pyo3 = { workspace = true, features = ["abi3-py37", "extension-module", "num-bigint"] }
 

--- a/pip/src/lib.rs
+++ b/pip/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 mod displayable_output;
 mod fs;
 mod interpreter;

--- a/resource_estimator/Cargo.toml
+++ b/resource_estimator/Cargo.toml
@@ -25,3 +25,6 @@ fasteval = { workspace = true }
 [dev-dependencies]
 expect-test = { workspace = true }
 indoc = { workspace = true }
+
+[lints]
+workspace = true

--- a/resource_estimator/src/counts.rs
+++ b/resource_estimator/src/counts.rs
@@ -358,9 +358,6 @@ impl LogicalCounter {
 
             1
         } else {
-            #[allow(clippy::cast_possible_truncation)]
-            #[allow(clippy::cast_sign_loss)]
-            #[allow(clippy::cast_precision_loss)]
             if r_depth < (r_count as f64 / qubits.len() as f64).ceil() as usize {
                 return Err(format!(
                     "Rotation depth {r_depth} is too small for rotation count {r_count} and {} qubits.", qubits.len()
@@ -458,7 +455,6 @@ impl Backend for LogicalCounter {
     fn rz(&mut self, theta: f64, q: usize) {
         let multiple = (theta / (PI / 4.0)).round();
         if ((multiple * (PI / 4.0)) - theta).abs() <= EPSILON {
-            #[allow(clippy::cast_possible_truncation)]
             let multiple = (multiple as i64).rem_euclid(8) as u64;
             if multiple & 1 == 1 {
                 self.t(q);

--- a/resource_estimator/src/estimates/error_budget.rs
+++ b/resource_estimator/src/estimates/error_budget.rs
@@ -12,6 +12,7 @@ pub struct ErrorBudget {
 }
 
 impl ErrorBudget {
+    #[must_use]
     pub fn new(logical: f64, magic_states: f64, rotations: f64) -> Self {
         Self {
             logical,
@@ -21,16 +22,19 @@ impl ErrorBudget {
     }
 
     /// Get the error budget's plogical.
+    #[must_use]
     pub fn logical(&self) -> f64 {
         self.logical
     }
 
     /// Get the error budget's tstates.
+    #[must_use]
     pub fn magic_states(&self) -> f64 {
         self.magic_states
     }
 
     /// Get the error budget's rotations.
+    #[must_use]
     pub fn rotations(&self) -> f64 {
         self.rotations
     }

--- a/resource_estimator/src/estimates/optimization/population.rs
+++ b/resource_estimator/src/estimates/optimization/population.rs
@@ -165,6 +165,7 @@ where
 {
     const MAX_NONEXECUTED_ATTEMPTS_TO_FILTER_OUT_DOMINATED: usize = 1000;
 
+    #[must_use]
     pub fn new() -> Self {
         Self {
             items: Vec::new(),
@@ -172,6 +173,7 @@ where
         }
     }
 
+    #[must_use]
     pub fn items(&self) -> &[P] {
         &self.items
     }

--- a/resource_estimator/src/estimates/physical_estimation.rs
+++ b/resource_estimator/src/estimates/physical_estimation.rs
@@ -462,15 +462,11 @@ impl<
             // ensures that the first code parameter is always tried. After
             // that, the last code parameter governs the reuse of the magic
             // state factory.
-            if last_code_parameter
-                .as_ref()
-                .map(|d| {
-                    self.ftp
-                        .code_parameter_cmp(self.qubit.as_ref(), d, &code_parameter)
-                        .is_gt()
-                })
-                .unwrap_or(true)
-            {
+            if last_code_parameter.as_ref().map_or(true, |d| {
+                self.ftp
+                    .code_parameter_cmp(self.qubit.as_ref(), d, &code_parameter)
+                    .is_gt()
+            }) {
                 last_factories = self.factory_builder.find_factories(
                     &self.ftp,
                     &self.qubit,
@@ -786,15 +782,11 @@ impl<
             // ensures that the first code parameter is always tried. After
             // that, the last code parameter governs the reuse of the magic
             // state factory.
-            if last_code_parameter
-                .as_ref()
-                .map(|d| {
-                    self.ftp
-                        .code_parameter_cmp(self.qubit.as_ref(), d, &code_parameter)
-                        .is_gt()
-                })
-                .unwrap_or(true)
-            {
+            if last_code_parameter.as_ref().map_or(true, |d| {
+                self.ftp
+                    .code_parameter_cmp(self.qubit.as_ref(), d, &code_parameter)
+                    .is_gt()
+            }) {
                 last_factories = self.factory_builder.find_factories(
                     &self.ftp,
                     &self.qubit,
@@ -925,15 +917,11 @@ impl<
             // ensures that the first code parameter is always tried. After
             // that, the last code parameter governs the reuse of the magic
             // state factory.
-            if last_code_parameter
-                .as_ref()
-                .map(|d| {
-                    self.ftp
-                        .code_parameter_cmp(self.qubit.as_ref(), d, &code_parameter)
-                        .is_gt()
-                })
-                .unwrap_or(true)
-            {
+            if last_code_parameter.as_ref().map_or(true, |d| {
+                self.ftp
+                    .code_parameter_cmp(self.qubit.as_ref(), d, &code_parameter)
+                    .is_gt()
+            }) {
                 last_factories = self.factory_builder.find_factories(
                     &self.ftp,
                     &self.qubit,
@@ -998,7 +986,7 @@ impl<
         best_estimation_result.ok_or(Error::MaxPhysicalQubitsTooSmall)
     }
 
-    /// Based on num_factories, we compute the number of cycles required which
+    /// Based on `num_factories`, we compute the number of cycles required which
     /// must be smaller than the maximum number of cycles allowed by the
     /// duration constraint (and the error rate).
     fn compute_num_cycles_required_for_magic_states(
@@ -1178,7 +1166,7 @@ impl<
     fn find_highest_code_parameter(&self, factories: &[Builder::Factory]) -> Option<E::Parameter> {
         factories
             .iter()
-            .map(|p| p.max_code_parameter())
+            .map(Factory::max_code_parameter)
             .max_by(|a, b| self.ftp.code_parameter_cmp(self.qubit.as_ref(), a, b))
     }
 

--- a/resource_estimator/src/lib.rs
+++ b/resource_estimator/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-/// A Q# backend to compute logical overheads to compute the overhead based on
-/// the PSSPC layout method.
+//! A Q# backend to compute logical overheads to compute the overhead based on
+//! the PSSPC layout method.
 
 // This crate uses lots of converstions between floating point numbers and integers, so this helps
 // avoid many needed allow statements. Comment out individual lines to see where they are needed.

--- a/resource_estimator/src/lib.rs
+++ b/resource_estimator/src/lib.rs
@@ -3,6 +3,16 @@
 
 /// A Q# backend to compute logical overheads to compute the overhead based on
 /// the PSSPC layout method.
+
+// This crate uses lots of converstions between floating point numbers and integers, so this helps
+// avoid many needed allow statements. Comment out individual lines to see where they are needed.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::cast_lossless
+)]
+
 mod counts;
 /// Provides traits to define a fault-tolerant quantum computing architecture
 /// and functions to perform resource estimation on such architectures.

--- a/resource_estimator/src/system.rs
+++ b/resource_estimator/src/system.rs
@@ -115,13 +115,15 @@ fn estimate_single(
                 ));
             }
 
-            let estimation_result = estimation.build_frontier().map_err(|err| err.into());
+            let estimation_result = estimation
+                .build_frontier()
+                .map_err(std::convert::Into::into);
             estimation_result.map(|result| {
                 data::Success::new_from_multiple(logical_resources, job_params, result)
             })
         }
         EstimateType::SinglePoint => {
-            let estimation_result = estimation.estimate().map_err(|err| err.into());
+            let estimation_result = estimation.estimate().map_err(std::convert::Into::into);
             estimation_result
                 .map(|result| data::Success::new(logical_resources, job_params, result))
         }

--- a/resource_estimator/src/system/data/report.rs
+++ b/resource_estimator/src/system/data/report.rs
@@ -350,14 +350,13 @@ pub struct FormattedPhysicalResourceCounts {
 }
 
 impl FormattedPhysicalResourceCounts {
-    #[allow(clippy::too_many_lines, clippy::cast_lossless)]
+    #[allow(clippy::too_many_lines)]
     pub fn new<L: Overhead + Clone>(
         result: &PhysicalResourceEstimationResult<Protocol, TFactory, L>,
         logical_resources: &LogicalResourceCounts,
         job_params: &JobParams,
     ) -> Self {
         // Physical resource estimates
-        #[allow(clippy::cast_lossless)]
         let runtime = format_duration(result.runtime().into());
         let rqops = format_metric_prefix(result.rqops());
         let physical_qubits = format_metric_prefix(result.physical_qubits());

--- a/resource_estimator/src/system/modeling/fault_tolerance.rs
+++ b/resource_estimator/src/system/modeling/fault_tolerance.rs
@@ -532,7 +532,6 @@ impl ErrorCorrection for Protocol {
             )
             .to_string())
         } else {
-            #[allow(clippy::cast_possible_truncation)]
             Ok(self.crossing_prefactor()
                 * ((physical_error_rate / self.error_correction_threshold())
                     .powi((*code_distance as i32 + 1) / 2)))

--- a/resource_estimator/src/system/modeling/physical_qubit.rs
+++ b/resource_estimator/src/system/modeling/physical_qubit.rs
@@ -112,7 +112,6 @@ impl PhysicalQubit {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct GateBasedPhysicalQubit {

--- a/resource_estimator/src/system/modeling/tfactory.rs
+++ b/resource_estimator/src/system/modeling/tfactory.rs
@@ -228,7 +228,7 @@ impl TFactoryDistillationUnitTemplate {
     fn failure_probability(
         input_error_rate: f64,
         clifford_error_rate: f64,
-        #[allow(unused_variables)] readout_error_rate: f64,
+        _readout_error_rate: f64,
     ) -> f64 {
         15.0 * input_error_rate + 356.0 * clifford_error_rate
     }
@@ -236,23 +236,23 @@ impl TFactoryDistillationUnitTemplate {
     fn output_error_rate(
         input_error_rate: f64,
         clifford_error_rate: f64,
-        #[allow(unused_variables)] readout_error_rate: f64,
+        _readout_error_rate: f64,
     ) -> f64 {
         35.0 * input_error_rate.powi(3) + 7.1 * clifford_error_rate
     }
 
     fn trivial_failutre_probability(
-        #[allow(unused_variables)] input_error_rate: f64,
-        #[allow(unused_variables)] clifford_error_rate: f64,
-        #[allow(unused_variables)] readout_error_rate: f64,
+        _input_error_rate: f64,
+        _clifford_error_rate: f64,
+        _readout_error_rate: f64,
     ) -> f64 {
         0.0
     }
 
     fn trivial_error_rate(
         input_error_rate: f64,
-        #[allow(unused_variables)] clifford_error_rate: f64,
-        #[allow(unused_variables)] readout_error_rate: f64,
+        _clifford_error_rate: f64,
+        _readout_error_rate: f64,
     ) -> f64 {
         input_error_rate
     }
@@ -533,7 +533,6 @@ impl TFactoryDistillationRound {
         self.duration
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn compute_num_output_ts(&self, failure_probability: f64) -> u64 {
         // special case when not necessary to run actual distillation:
         // the physcial qubit error rate is already below the threshold

--- a/resource_estimator/src/system/tests.rs
+++ b/resource_estimator/src/system/tests.rs
@@ -932,7 +932,6 @@ fn build_frontier_bit_flip_code_test() {
     );
 }
 
-#[allow(clippy::cast_lossless)]
 #[test]
 fn code_distance_tests() {
     let params = JobParams::default();

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -42,3 +42,6 @@ getrandom = { workspace = true, features = ["js"] }
 [dev-dependencies]
 expect-test = { workspace = true }
 indoc = { workspace = true }
+
+[lints]
+workspace = true

--- a/wasm/build.rs
+++ b/wasm/build.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![warn(clippy::mod_module_files, clippy::pedantic, clippy::unwrap_used)]
-#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-
 use std::process::Command;
 
 fn main() {

--- a/wasm/src/debug_service.rs
+++ b/wasm/src/debug_service.rs
@@ -27,22 +27,23 @@ impl DebugService {
         Self::default()
     }
 
+    #[allow(clippy::needless_pass_by_value)] // needed for wasm_bindgen
     pub fn load_source(
         &mut self,
         sources: Vec<js_sys::Array>,
-        target_profile: String,
+        target_profile: &str,
         entry: Option<String>,
         language_features: Vec<String>,
     ) -> String {
-        let source_map = get_source_map(sources, entry);
-        let target = Profile::from_str(&target_profile)
-            .unwrap_or_else(|_| panic!("Invalid target : {}", target_profile));
+        let source_map = get_source_map(sources, &entry);
+        let target = Profile::from_str(target_profile)
+            .unwrap_or_else(|()| panic!("Invalid target : {target_profile}"));
         let features = LanguageFeatures::from_iter(language_features);
         match Debugger::new(source_map, target.into(), Encoding::Utf16, features) {
             Ok(debugger) => {
                 self.debugger = Some(debugger);
                 match self.debugger_mut().set_entry() {
-                    Ok(()) => "".to_string(),
+                    Ok(()) => String::new(),
                     Err(e) => render_errors(e),
                 }
             }
@@ -174,7 +175,7 @@ impl DebugService {
 
         match result {
             Ok(value) => Ok(value),
-            Err(errors) => Err(Vec::from_iter(errors.iter().cloned())),
+            Err(errors) => Err(errors.clone()),
         }
     }
 

--- a/wasm/src/diagnostic.rs
+++ b/wasm/src/diagnostic.rs
@@ -48,32 +48,33 @@ impl VSDiagnostic {
         serde_json::to_value(self).expect("serializing VSDiagnostic should succeed")
     }
 
-    /// Creates a [VSDiagnostic] from an interpreter error. See `VSDiagnostic::new()` for details.
+    /// Creates a [`VSDiagnostic`] from an interpreter error. See `VSDiagnostic::new()` for details.
     pub(crate) fn from_interpret_error(source_name: &str, err: &interpret::Error) -> Self {
         let labels = match err {
             interpret::Error::Compile(e) => error_labels(e),
             interpret::Error::Pass(e) => error_labels(e),
             interpret::Error::Eval(e) => error_labels(e.error()),
-            interpret::Error::NoEntryPoint => Vec::new(),
-            interpret::Error::UnsupportedRuntimeCapabilities => Vec::new(),
+            interpret::Error::NoEntryPoint | interpret::Error::UnsupportedRuntimeCapabilities => {
+                Vec::new()
+            }
         };
 
         Self::new(labels, source_name, err)
     }
 
-    /// Creates a [VSDiagnostic] from a compiler error. See `VSDiagnostic::new()` for details.
+    /// Creates a [`VSDiagnostic`] from a compiler error. See `VSDiagnostic::new()` for details.
     pub(crate) fn from_compile_error(source_name: &str, err: &qsc::compile::Error) -> Self {
         let labels = error_labels(err);
 
         Self::new(labels, source_name, err)
     }
 
-    /// Creates a [VSDiagnostic] using the information from a [miette::Diagnostic].
+    /// Creates a [`VSDiagnostic`] using the information from a [`miette::Diagnostic`].
     /// The error message, code and severity are straightforwardly generated,
     /// while mapping label spans is a little trickier.
     ///
-    /// While a [miette::Diagnostic] can be associated with zero or more spans,
-    /// a [VSDiagnostic] is intended to be shown as a squiggle in a specific document,
+    /// While a [`miette::Diagnostic`] can be associated with zero or more spans,
+    /// a [`VSDiagnostic`] is intended to be shown as a squiggle in a specific document,
     /// and therefore needs to have at least one span that falls in the current document.
     ///
     /// If the first label's span falls in the current document, that span will be
@@ -83,7 +84,7 @@ impl VSDiagnostic {
     /// used just to make the squiggle visible in the current document.
     ///
     /// Any labels with associated messages are included as "related information"
-    /// objects in the [VSDiagnostic], whether they fall in the current document or not.
+    /// objects in the [`VSDiagnostic`], whether they fall in the current document or not.
     /// Editors can display these as links to other source locations.
     fn new<T>(labels: Vec<Label>, source_name: &str, err: &T) -> VSDiagnostic
     where

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -99,7 +99,7 @@ impl LanguageService {
                     "exe" => PackageType::Exe,
                     _ => panic!("invalid package type"),
                 }),
-            })
+            });
     }
 
     pub fn update_document(&mut self, uri: &str, version: u32, text: &str) {
@@ -116,7 +116,7 @@ impl LanguageService {
         notebook_metadata: INotebookMetadata,
         cells: Vec<ICell>,
     ) {
-        let cells: Vec<Cell> = cells.into_iter().map(|c| c.into()).collect();
+        let cells: Vec<Cell> = cells.into_iter().map(std::convert::Into::into).collect();
         let notebook_metadata: NotebookMetadata = notebook_metadata.into();
         self.0.update_notebook_document(
             notebook_uri,
@@ -241,15 +241,15 @@ impl LanguageService {
         let locations = self.0.get_rename(uri, position.into());
 
         let mut renames: FxHashMap<String, Vec<TextEdit>> = FxHashMap::default();
-        locations.into_iter().for_each(|l| {
+        for l in locations {
             renames
                 .entry(l.source.to_string())
                 .or_default()
                 .push(TextEdit {
                     range: l.range.into(),
                     newText: new_name.to_string(),
-                })
-        });
+                });
+        }
 
         let workspace_edit = WorkspaceEdit {
             changes: renames.into_iter().collect(),

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -7,7 +7,7 @@ use diagnostic::VSDiagnostic;
 use katas::check_solution;
 use num_bigint::BigUint;
 use num_complex::Complex64;
-use project_system::*;
+use project_system::into_async_rust_fn_with;
 use qsc::{
     compile,
     hir::PackageId,
@@ -45,6 +45,7 @@ thread_local! {
 }
 
 #[wasm_bindgen]
+#[must_use]
 pub fn git_hash() -> String {
     let git_hash = env!("QSHARP_GIT_HASH");
     git_hash.into()
@@ -54,7 +55,8 @@ pub fn git_hash() -> String {
 // so we have to manually assert length of the interior
 // array and the content type in the function body
 // `sources` should be Vec<[String; 2]> though
-pub fn get_source_map(sources: Vec<js_sys::Array>, entry: Option<String>) -> SourceMap {
+#[must_use]
+pub fn get_source_map(sources: Vec<js_sys::Array>, entry: &Option<String>) -> SourceMap {
     let sources = sources.into_iter().map(|js_arr| {
         // map the inner arr elements into (String, String)
         let elem_0 = js_arr.get(0).as_string();
@@ -64,7 +66,7 @@ pub fn get_source_map(sources: Vec<js_sys::Array>, entry: Option<String>) -> Sou
             Arc::from(elem_1.unwrap_or_default()),
         )
     });
-    SourceMap::new(sources, entry.as_deref().map(|value| value.into()))
+    SourceMap::new(sources, entry.as_deref().map(std::convert::Into::into))
 }
 
 #[wasm_bindgen]
@@ -73,7 +75,7 @@ pub fn get_qir(
     language_features: Vec<String>,
 ) -> Result<String, String> {
     let language_features = LanguageFeatures::from_iter(language_features);
-    let sources = get_source_map(sources, None);
+    let sources = get_source_map(sources, &None);
     _get_qir(sources, language_features)
 }
 
@@ -111,7 +113,7 @@ pub fn get_estimates(
     params: &str,
     language_features: Vec<String>,
 ) -> Result<String, String> {
-    let sources = get_source_map(sources, None);
+    let sources = get_source_map(sources, &None);
 
     let language_features = LanguageFeatures::from_iter(language_features);
 
@@ -132,6 +134,7 @@ pub fn get_estimates(
 }
 
 #[wasm_bindgen]
+#[must_use]
 pub fn get_library_source_content(name: &str) -> Option<String> {
     STORE_CORE_STD.with(|(store, std)| {
         for id in [PackageId::CORE, *std] {
@@ -286,7 +289,7 @@ pub fn run(
 
     let language_features = LanguageFeatures::from_iter(language_features);
 
-    let sources = get_source_map(sources, Some(expr.into()));
+    let sources = get_source_map(sources, &Some(expr.into()));
     match run_internal_with_features(
         sources,
         |msg: &str| {
@@ -333,6 +336,7 @@ fn check_exercise_solution_internal(
 }
 
 #[wasm_bindgen]
+#[must_use]
 pub fn check_exercise_solution(
     solution_code: &str,
     exercise_sources_js: JsValue,
@@ -357,6 +361,7 @@ struct DocFile {
 }
 
 #[wasm_bindgen]
+#[must_use]
 pub fn generate_docs() -> JsValue {
     let docs = qsc_doc_gen::generate_docs::generate_docs();
     let mut result: Vec<DocFile> = vec![];

--- a/wasm/src/logging.rs
+++ b/wasm/src/logging.rs
@@ -84,7 +84,7 @@ pub fn init_logging(callback: JsValue, level: i32) -> Result<(), JsError> {
         return Err(JsError::new("Invalid logging level"));
     }
 
-    let thefn: Function = callback.dyn_into().expect("shoudl already be a function");
+    let thefn: Function = callback.dyn_into().expect("should already be a function");
     LOG_JS_FN.with(|f| {
         *f.borrow_mut() = Option::Some(thefn);
     });

--- a/wasm/src/logging.rs
+++ b/wasm/src/logging.rs
@@ -70,7 +70,7 @@ pub fn hook(info: &std::panic::PanicInfo) {
     msg.push_str(&stack);
     msg.push_str("\n\n");
 
-    let err_text = format!("Wasm panic occurred: {}", msg);
+    let err_text = format!("Wasm panic occurred: {msg}");
     log::error!(target: "wasm", "{}", &err_text);
 }
 
@@ -84,7 +84,7 @@ pub fn init_logging(callback: JsValue, level: i32) -> Result<(), JsError> {
         return Err(JsError::new("Invalid logging level"));
     }
 
-    let thefn: Function = callback.dyn_into().unwrap(); // Already checked it was a function
+    let thefn: Function = callback.dyn_into().expect("shoudl already be a function");
     LOG_JS_FN.with(|f| {
         *f.borrow_mut() = Option::Some(thefn);
     });

--- a/wasm/src/project_system.rs
+++ b/wasm/src/project_system.rs
@@ -44,7 +44,7 @@ extern "C" {
 
 impl From<ManifestDescriptorObject> for Option<ManifestDescriptor> {
     fn from(value: ManifestDescriptorObject) -> Self {
-        get_manifest_transformer(value.obj, Default::default())
+        get_manifest_transformer(value.obj, String::default())
     }
 }
 
@@ -90,14 +90,13 @@ pub(crate) fn to_js_function(val: JsValue, help_text_panic: &'static str) -> js_
     let js_ty = val.js_typeof();
     assert!(
         val.is_function(),
-        "expected a valid JS function ({help_text_panic}), received {:?}",
-        js_ty
+        "expected a valid JS function ({help_text_panic}), received {js_ty:?}"
     );
     Into::<js_sys::Function>::into(val)
 }
 pub(crate) use into_async_rust_fn_with;
 
-/// Given a [JsValue] representing the result of a call to a list_directory function,
+/// Given a [`JsValue`] representing the result of a call to a `list_directory` function,
 /// and an unused `String` parameter for API compatibility, assert that `js_val`
 /// matches our expected return type of `[string, number][]` and transform that
 /// JS data into a [Vec<JSFileEntry>]
@@ -111,9 +110,10 @@ pub(crate) fn list_directory_transformer(js_val: JsValue, _: String) -> Vec<JSFi
             })
             .filter_map(|js_arr| {
                 let mut arr = js_arr.into_iter().take(2);
+                #[allow(clippy::cast_possible_truncation)]
                 match (
-                    arr.next().unwrap().as_string(),
-                    arr.next().unwrap().as_f64(),
+                    arr.next().expect("should be string").as_string(),
+                    arr.next().expect("should be float").as_f64(),
                 ) {
                     (Some(a), Some(b)) => Some((a, b as i32)),
                     _ => None,
@@ -134,25 +134,27 @@ pub(crate) fn list_directory_transformer(js_val: JsValue, _: String) -> Vec<JSFi
     }
 }
 
-/// Given a [JsValue] representing the result of a call to a read file function,
+/// Given a [`JsValue`] representing the result of a call to a read file function,
 /// and a `String` representing the path that was originally passed in as an
 /// argument to that function, assert that `js_val` matches our expected return type of
 /// `string` and transform it into a tuple representing the path and the file contents.
+#[allow(clippy::needless_pass_by_value)]
 pub(crate) fn read_file_transformer(
     js_val: JsValue,
     path_buf_string: String,
 ) -> (Arc<str>, Arc<str>) {
     match js_val.as_string() {
-        Some(res) => return (Arc::from(path_buf_string.as_str()), Arc::from(res)),
+        Some(res) => (Arc::from(path_buf_string), Arc::from(res)),
         // this can happen if the document is completely empty
-        None if js_val.is_null() => (Arc::from(path_buf_string.as_str()), Arc::from("")),
+        None if js_val.is_null() => (Arc::from(path_buf_string), Arc::from("")),
         None => unreachable!("Expected string from JS callback, received {js_val:?}"),
     }
 }
-/// Given a [JsValue] representing the result of a call to a get_manifest function,
+/// Given a [`JsValue`] representing the result of a call to a `get_manifest` function,
 /// and an unused `String` parameter for API compatibility, assert that `js_val`
-/// matches our expected return object shape  and transform it into a [ManifestDescriptor],
+/// matches our expected return object shape  and transform it into a [`ManifestDescriptor`],
 /// or `None`
+#[allow(clippy::needless_pass_by_value)]
 pub(crate) fn get_manifest_transformer(js_val: JsValue, _: String) -> Option<ManifestDescriptor> {
     if js_val.is_null() {
         return None;
@@ -162,8 +164,7 @@ pub(crate) fn get_manifest_transformer(js_val: JsValue, _: String) -> Option<Man
     {
         Ok(v) => v.as_string().unwrap_or_else(|| {
             panic!(
-                "manifest callback returned {:?}, but we expected a string representing its URI",
-                v
+                "manifest callback returned {v:?}, but we expected a string representing its URI"
             )
         }),
         Err(_) => unreachable!("our typescript bindings should guarantee that an object with a manifestDirectory property is returned here"),
@@ -176,14 +177,13 @@ pub(crate) fn get_manifest_transformer(js_val: JsValue, _: String) -> Option<Man
                 .map(|x| {
                     x.as_string().unwrap_or_else(|| {
                         panic!(
-                            "manifest callback returned {:?}, but we expected a string representing a language feature",
-                            x
+                            "manifest callback returned {x:?}, but we expected a string representing a language feature"
                         )
                     })
                 }).collect::<Vec<_>>(),
-                Err(_) => Default::default(),
+                Err(_) => Vec::new(),
         },
-        _ => Default::default(),
+        _ => Vec::new(),
 
     };
 
@@ -231,20 +231,24 @@ impl ProjectLoader {
     pub async fn load_project(&self, manifest: ManifestDescriptorObject) -> ProjectSources {
         let manifest: Option<ManifestDescriptor> = manifest.into();
         match manifest {
+            #[allow(clippy::from_iter_instead_of_collect)]
             Some(manifest) => {
                 let res = qsc_project::FileSystemAsync::load_project(self, &manifest)
                     .await
-                    .map(|proj| {
-                        proj.sources
-                            .into_iter()
-                            .map(|(path, contents)| {
-                                js_sys::Array::from_iter::<std::slice::Iter<'_, JsString>>(
-                                    [path.to_string().into(), contents.to_string().into()].iter(),
-                                )
-                            })
-                            .collect::<js_sys::Array>()
-                    })
-                    .unwrap_or_else(|_| js_sys::Array::new());
+                    .map_or_else(
+                        |_| js_sys::Array::new(),
+                        |proj| {
+                            proj.sources
+                                .into_iter()
+                                .map(|(path, contents)| {
+                                    js_sys::Array::from_iter::<std::slice::Iter<'_, JsString>>(
+                                        [path.to_string().into(), contents.to_string().into()]
+                                            .iter(),
+                                    )
+                                })
+                                .collect::<_>()
+                        },
+                    );
                 ProjectSources { obj: res.into() }
             }
             None => ProjectSources {

--- a/wasm/src/tests.rs
+++ b/wasm/src/tests.rs
@@ -60,8 +60,8 @@ fn test_run_two_shots() {
 
     let _result = run_internal(
         SourceMap::new([("test.qs".into(), code.into())], Some(expr.into())),
-        |_msg| {
-            assert!(_msg.contains("42"));
+        |msg| {
+            assert!(msg.contains("42"));
             count.set(count.get() + 1);
         },
         2,
@@ -106,8 +106,8 @@ fn test_message() {
     let expr = "Sample.main()";
     let result = run_internal(
         SourceMap::new([("test.qs".into(), code.into())], Some(expr.into())),
-        |_msg_| {
-            assert!(_msg_.contains("hi") || _msg_.contains("result"));
+        |msg| {
+            assert!(msg.contains("hi") || msg.contains("result"));
         },
         1,
     );
@@ -127,8 +127,8 @@ fn message_with_escape_sequences() {
     let expr = "Sample.main()";
     let result = run_internal(
         SourceMap::new([("test.qs".into(), code.into())], Some(expr.into())),
-        |_msg_| {
-            assert!(_msg_.contains(r"\ta\n\t") || _msg_.contains("result"));
+        |msg| {
+            assert!(msg.contains(r"\ta\n\t") || msg.contains("result"));
         },
         1,
     );
@@ -149,11 +149,11 @@ fn message_with_backslashes() {
     let expr = "Sample.main()";
     let result = run_internal(
         SourceMap::new([("test.qs".into(), code.into())], Some(expr.into())),
-        |_msg_| {
+        |msg| {
             assert!(
-                _msg_.contains("hello { \\\\World [")
-                    || _msg_.contains("hi \\\\World")
-                    || _msg_.contains("result")
+                msg.contains("hello { \\\\World [")
+                    || msg.contains("hi \\\\World")
+                    || msg.contains("result")
             );
         },
         1,
@@ -173,8 +173,8 @@ fn test_entrypoint() {
     let expr = "";
     let result = run_internal(
         SourceMap::new([("test.qs".into(), code.into())], Some(expr.into())),
-        |_msg_| {
-            assert!(_msg_.contains("hi") || _msg_.contains("result"));
+        |msg| {
+            assert!(msg.contains("hi") || msg.contains("result"));
         },
         1,
     );
@@ -194,7 +194,7 @@ fn test_missing_entrypoint() {
     let result = run_internal(
         SourceMap::new([("test.qs".into(), code.into())], Some(expr.into())),
         |msg| {
-            expect![[r#"{"result":{"code":"Qsc.EntryPoint.NotFound","message":"entry point not found\n\nhelp: a single callable with the `@EntryPoint()` attribute must be present if no entry expression is provided","range":{"end":{"character":1,"line":0},"start":{"character":0,"line":0}},"severity":"error"},"success":false,"type":"Result"}"#]].assert_eq(msg)
+            expect![[r#"{"result":{"code":"Qsc.EntryPoint.NotFound","message":"entry point not found\n\nhelp: a single callable with the `@EntryPoint()` attribute must be present if no entry expression is provided","range":{"end":{"character":1,"line":0},"start":{"character":0,"line":0}},"severity":"error"},"success":false,"type":"Result"}"#]].assert_eq(msg);
         },
         1,
     );
@@ -306,13 +306,13 @@ fn test_runtime_error_with_span() {
 #[test]
 fn test_runtime_error_in_another_file_with_project() {
     let mut output = Vec::new();
-    let first = indoc! {r#"
+    let first = indoc! {r"
             namespace Test {
                 @EntryPoint()
                 operation Main() : Unit {
                     Test.other()
                 }
-            }"#
+            }"
     };
     let second = indoc! {r#"
             namespace Test {
@@ -351,12 +351,12 @@ fn test_runtime_error_with_failure_in_main_file_project() {
                 }
             }"#
     };
-    let second = indoc! {r#"
+    let second = indoc! {r"
             namespace Test {
                 operation other() : Unit {
                     Test.failing_call()
                 }
-            }"#
+            }"
     };
     run_internal(
         SourceMap::new(
@@ -377,7 +377,7 @@ fn test_runtime_error_with_failure_in_main_file_project() {
 #[test]
 fn test_compile_error_related_spans() {
     let mut output = Vec::new();
-    let code = indoc! {r#"
+    let code = indoc! {r"
             namespace Other { operation DumpMachine() : Unit { } }
             namespace Test {
                 open Other;
@@ -387,7 +387,7 @@ fn test_compile_error_related_spans() {
                     DumpMachine()
                 }
             }
-        "#
+        "
     };
     run_internal(
         SourceMap::new([("test.qs".into(), code.into())], None),
@@ -402,7 +402,7 @@ fn test_compile_error_related_spans() {
 #[test]
 fn test_runtime_error_related_spans() {
     let mut output = Vec::new();
-    let code = indoc! {r#"
+    let code = indoc! {r"
             namespace Test {
                 @EntryPoint()
                 operation Main() : Unit {
@@ -410,7 +410,7 @@ fn test_runtime_error_related_spans() {
                     X(q);
                 }
             }
-        "#
+        "
     };
     run_internal(
         SourceMap::new([("test.qs".into(), code.into())], None),
@@ -425,14 +425,14 @@ fn test_runtime_error_related_spans() {
 #[test]
 fn test_runtime_error_default_span() {
     let mut output = Vec::new();
-    let code = indoc! {r#"
+    let code = indoc! {r"
             namespace Test {
                 @EntryPoint()
                 operation Main() : Unit {
                     use qs = Qubit[-1];
                 }
             }
-        "#
+        "
     };
     run_internal(
         SourceMap::new([("test.qs".into(), code.into())], None),
@@ -456,7 +456,9 @@ fn test_doc_gen() {
         if filename.eq("toc.yml") {
             assert!(text.contains("uid: Qdk.Microsoft.Quantum.Core"));
         } else {
-            assert!(filename.ends_with(".md"));
+            assert!(std::path::Path::new(&filename)
+                .extension()
+                .map_or(false, |ext| ext.eq_ignore_ascii_case("md")));
             assert!(text.starts_with("---\n"));
         }
     }


### PR DESCRIPTION
This change shifts from having common lints described at the top of each crate's lib.rs to having them in a single top-level lints section of the workspace Cargo.toml. This feature was new as of Rust 1.74, but we hadn't switched to it ahead of the initial release.
Of note, a few crates were missing the top-level lints, so had lots of fixup to do to get them up to the bar of the rest of code.