### PR TITLE
Allow QEC to encode multiple logical qubits

### DIFF
--- a/resource_estimator/src/estimates.rs
+++ b/resource_estimator/src/estimates.rs
@@ -13,5 +13,5 @@ pub use physical_estimation::{
 mod layout;
 mod logical_qubit;
 pub use layout::Overhead;
-pub use logical_qubit::LogicalQubit;
+pub use logical_qubit::LogicalPatch;
 pub mod optimization;

--- a/resource_estimator/src/estimates/error.rs
+++ b/resource_estimator/src/estimates/error.rs
@@ -37,13 +37,20 @@ pub enum Error {
     #[error("No solution found for the provided maximum number of physical qubits.")]
     #[diagnostic(code("Qsc.Estimates.MaxPhysicalQubitsTooSmall"))]
     MaxPhysicalQubitsTooSmall,
-    /// The number of physical qubits per logical qubit cannot be computed.
+    /// The number of physical qubits required for a code cannot be computed.
     ///
     /// ✅ This does not contain user data and can be logged
     /// 🧑‍💻 This indicates a user error
-    #[error("The number of physical qubits per logical qubit cannot be computed: {0}")]
+    #[error("The number of physical qubits required for a code cannot be computed: {0}")]
     #[diagnostic(code("Qsc.Estimates.PhysicalQubitComputationFailed"))]
     PhysicalQubitComputationFailed(String),
+    /// The number of logical qubits provided by a code cannot be computed.
+    ///
+    /// ✅ This does not contain user data and can be logged
+    /// 🧑‍💻 This indicates a user error
+    #[error("The number of logical qubits provided by a code cannot be computed: {0}")]
+    #[diagnostic(code("Qsc.Estimates.LogicalQubitComputationFailed"))]
+    LogicalQubitComputationFailed(String),
     /// The logical cycle time cannot be computed.
     ///
     /// ✅ This does not contain user data and can be logged

--- a/resource_estimator/src/lib.rs
+++ b/resource_estimator/src/lib.rs
@@ -1,8 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/// A Q# backend to compute logical overheads to compute the overhead based on
+/// the PSSPC layout method.
 mod counts;
+/// Provides traits to define a fault-tolerant quantum computing architecture
+/// and functions to perform resource estimation on such architectures.
 pub mod estimates;
+/// Models a fault-tolerant quantum computing architecture based on
+/// customizaable gate-based and Majorana qubits, planar codes, and T-factories.
 pub mod system;
 
 pub use system::estimate_physical_resources_from_json;

--- a/resource_estimator/src/system/data/report.rs
+++ b/resource_estimator/src/system/data/report.rs
@@ -34,8 +34,8 @@ impl Report {
         let mut groups = vec![];
 
         let mut entries = vec![];
-        entries.push(ReportEntry::new("physicalCountsFormatted/runtime", "Runtime", r#"Total runtime"#, &format!(r#"This is a runtime estimate for the execution time of the algorithm.  In general, the execution time corresponds to the duration of one logical cycle ({} nanosecs) multiplied by the {} logical cycles to run the algorithm.  If however the duration of a single T factory (here: {} nanosecs) is larger than the algorithm runtime, we extend the number of logical cycles artificially in order to exceed the runtime of a single T factory."#, format_thousand_sep(&result.logical_qubit().logical_cycle_time()), format_thousand_sep(&result.algorithmic_logical_depth()), format_thousand_sep(&result.factory().map_or(0, TFactory::duration)))));
-        entries.push(ReportEntry::new("physicalCountsFormatted/rqops", "rQOPS", r#"Reliable quantum operations per second"#, &format!(r#"The value is computed as the number of logical qubits after layout ({}) (with a logical error rate of {}) multiplied by the clock frequency ({}), which is the number of logical cycles per second."#, format_thousand_sep(&result.layout_overhead().logical_qubits()), formatted_counts.required_logical_qubit_error_rate, format_thousand_sep_f64(result.logical_qubit().logical_cycles_per_second()))));
+        entries.push(ReportEntry::new("physicalCountsFormatted/runtime", "Runtime", r#"Total runtime"#, &format!(r#"This is a runtime estimate for the execution time of the algorithm.  In general, the execution time corresponds to the duration of one logical cycle ({} nanosecs) multiplied by the {} logical cycles to run the algorithm.  If however the duration of a single T factory (here: {} nanosecs) is larger than the algorithm runtime, we extend the number of logical cycles artificially in order to exceed the runtime of a single T factory."#, format_thousand_sep(&result.logical_patch().logical_cycle_time()), format_thousand_sep(&result.algorithmic_logical_depth()), format_thousand_sep(&result.factory().map_or(0, TFactory::duration)))));
+        entries.push(ReportEntry::new("physicalCountsFormatted/rqops", "rQOPS", r#"Reliable quantum operations per second"#, &format!(r#"The value is computed as the number of logical qubits after layout ({}) (with a logical error rate of {}) multiplied by the clock frequency ({}), which is the number of logical cycles per second."#, format_thousand_sep(&result.layout_overhead().logical_qubits()), formatted_counts.required_logical_qubit_error_rate, format_thousand_sep_f64(result.logical_patch().logical_cycles_per_second()))));
         entries.push(ReportEntry::new("physicalCountsFormatted/physicalQubits", "Physical qubits", r#"Number of physical qubits"#, &format!(r#"This value represents the total number of physical qubits, which is the sum of {} physical qubits to implement the algorithm logic, and {} physical qubits to execute the T factories that are responsible to produce the T states that are consumed by the algorithm."#, format_thousand_sep(&result.physical_qubits_for_algorithm()), format_thousand_sep(&result.physical_qubits_for_factories()))));
         groups.push(ReportEntryGroup {
             title: "Physical resource estimates".into(),
@@ -51,7 +51,7 @@ impl Report {
         entries.push(ReportEntry::new("physicalCountsFormatted/numTstates", "Number of T states", r#"Number of T states consumed by the algorithm"#, &format!(r#"To execute the algorithm, we require one T state for each of the {} T gates, four T states for each of the {} CCZ and {} CCiX gates, as well as {} for each of the {} single-qubit rotation gates with arbitrary angle rotation."#, format_thousand_sep(&logical_counts.t_count), format_thousand_sep(&logical_counts.ccz_count), format_thousand_sep(&logical_counts.ccix_count), formatted_counts.num_ts_per_rotation, format_thousand_sep(&logical_counts.rotation_count))));
         entries.push(ReportEntry::new("physicalCountsFormatted/numTfactories", "Number of T factories", &format!(r#"Number of T factories capable of producing the demanded {} T states during the algorithm's runtime"#, format_thousand_sep(&result.num_magic_states())), &format!(r#"The total number of T factories {} that are executed in parallel is computed as $\left\lceil\dfrac{{\text{{T states}}\cdot\text{{T factory duration}}}}{{\text{{T states per T factory}}\cdot\text{{algorithm runtime}}}}\right\rceil = \left\lceil\dfrac{{{} \cdot {}\;\text{{ns}}}}{{{} \cdot {}\;\text{{ns}}}}\right\rceil$"#, format_thousand_sep(&result.num_factories()), format_thousand_sep(&result.num_magic_states()), format_thousand_sep(&result.factory().map_or(0, TFactory::duration)), format_thousand_sep(&result.factory().map_or(0, TFactory::num_output_states)), format_thousand_sep(&result.runtime()))));
         entries.push(ReportEntry::new("physicalCountsFormatted/numTfactoryRuns", "Number of T factory invocations", r#"Number of times all T factories are invoked"#, &format!(r#"In order to prepare the {} T states, the {} copies of the T factory are repeatedly invoked {} times."#, format_thousand_sep(&result.num_magic_states()), format_thousand_sep(&result.num_factories()), format_thousand_sep(&result.num_factory_runs()))));
-        entries.push(ReportEntry::new("physicalCountsFormatted/physicalQubitsForAlgorithm", "Physical algorithmic qubits", r#"Number of physical qubits for the algorithm after layout"#, &format!(r#"The {} are the product of the {} logical qubits after layout and the {} physical qubits that encode a single logical qubit."#, format_thousand_sep(&result.physical_qubits_for_algorithm()), format_thousand_sep(&result.layout_overhead().logical_qubits()), format_thousand_sep(&result.logical_qubit().physical_qubits()))));
+        entries.push(ReportEntry::new("physicalCountsFormatted/physicalQubitsForAlgorithm", "Physical algorithmic qubits", r#"Number of physical qubits for the algorithm after layout"#, &format!(r#"The {} are the product of the {} logical qubits after layout and the {} physical qubits that encode a single logical qubit."#, format_thousand_sep(&result.physical_qubits_for_algorithm()), format_thousand_sep(&result.layout_overhead().logical_qubits()), format_thousand_sep(&result.logical_patch().physical_qubits()))));
         entries.push(ReportEntry::new("physicalCountsFormatted/physicalQubitsForTfactories", "Physical T factory qubits", r#"Number of physical qubits for the T factories"#, &format!(r#"Each T factory requires {} physical qubits and we run {} in parallel, therefore we need ${} = {} \cdot {}$ qubits."#, format_thousand_sep(&result.factory().map_or(0, TFactory::physical_qubits)), format_thousand_sep(&result.num_factories()), format_thousand_sep(&result.physical_qubits_for_factories()), format_thousand_sep(&result.factory().map_or(0, TFactory::physical_qubits)), format_thousand_sep(&result.num_factories()))));
         entries.push(ReportEntry::new("physicalCountsFormatted/requiredLogicalQubitErrorRate", "Required logical qubit error rate", r#"The minimum logical qubit error rate required to run the algorithm within the error budget"#, &format!(r#"The minimum logical qubit error rate is obtained by dividing the logical error probability {} by the product of {} logical qubits and the total cycle count {}."#, formatted_counts.error_budget_logical, format_thousand_sep(&result.layout_overhead().logical_qubits()), format_thousand_sep(&result.num_cycles()))));
         entries.push(ReportEntry::new("physicalCountsFormatted/requiredLogicalTstateErrorRate", "Required logical T state error rate", r#"The minimum T state error rate required for distilled T states"#, &format!(r#"The minimum T state error rate is obtained by dividing the T distillation error probability {} by the total number of T states {}."#, formatted_counts.error_budget_tstates, format_thousand_sep(&result.num_magic_states()))));
@@ -64,10 +64,10 @@ impl Report {
 
         let mut entries = vec![];
         entries.push(ReportEntry::new("jobParams/qecScheme/name", "QEC scheme", r#"Name of QEC scheme"#, r#"You can load pre-defined QEC schemes by using the name `surface_code` or `floquet_code`. The latter only works with Majorana qubits."#));
-        entries.push(ReportEntry::new("logicalQubit/codeDistance", "Code distance", r#"Required code distance for error correction"#, &format!(r#"The code distance is the smallest odd integer greater or equal to $\dfrac{{2\log({} / {})}}{{\log({}/{})}} - 1$"#, job_params.qec_scheme().crossing_prefactor.expect("crossing prefactor should be set"), result.required_logical_qubit_error_rate(), job_params.qec_scheme().error_correction_threshold.expect("error correction threshold should be set"), result.logical_qubit().physical_qubit().clifford_error_rate())));
+        entries.push(ReportEntry::new("logicalQubit/codeDistance", "Code distance", r#"Required code distance for error correction"#, &format!(r#"The code distance is the smallest odd integer greater or equal to $\dfrac{{2\log({} / {})}}{{\log({}/{})}} - 1$"#, job_params.qec_scheme().crossing_prefactor.expect("crossing prefactor should be set"), result.required_logical_patch_error_rate(), job_params.qec_scheme().error_correction_threshold.expect("error correction threshold should be set"), result.logical_patch().physical_qubit().clifford_error_rate())));
         entries.push(ReportEntry::new("physicalCountsFormatted/physicalQubitsPerLogicalQubit", "Physical qubits", r#"Number of physical qubits per logical qubit"#, &format!(r#"The number of physical qubits per logical qubit are evaluated using the formula {} that can be user-specified."#, job_params.qec_scheme().physical_qubits_per_logical_qubit.as_ref().expect("physical qubits per logical qubit should be set"))));
         entries.push(ReportEntry::new("physicalCountsFormatted/logicalCycleTime", "Logical cycle time", r#"Duration of a logical cycle in nanoseconds"#, &format!(r#"The runtime of one logical cycle in nanoseconds is evaluated using the formula {} that can be user-specified."#, job_params.qec_scheme().logical_cycle_time.as_ref().expect("logical cycle time should be set"))));
-        entries.push(ReportEntry::new("physicalCountsFormatted/logicalErrorRate", "Logical qubit error rate", r#"Logical qubit error rate"#, &format!(r#"The logical qubit error rate is computed as ${} \cdot \left(\dfrac{{{}}}{{{}}}\right)^\frac{{{} + 1}}{{2}}$"#, job_params.qec_scheme().crossing_prefactor.expect("crossing prefactor should be set"), result.logical_qubit().physical_qubit().clifford_error_rate(), job_params.qec_scheme().error_correction_threshold.expect("error correction threshold should be set"), result.logical_qubit().code_parameter())));
+        entries.push(ReportEntry::new("physicalCountsFormatted/logicalErrorRate", "Logical qubit error rate", r#"Logical qubit error rate"#, &format!(r#"The logical qubit error rate is computed as ${} \cdot \left(\dfrac{{{}}}{{{}}}\right)^\frac{{{} + 1}}{{2}}$"#, job_params.qec_scheme().crossing_prefactor.expect("crossing prefactor should be set"), result.logical_patch().physical_qubit().clifford_error_rate(), job_params.qec_scheme().error_correction_threshold.expect("error correction threshold should be set"), result.logical_patch().code_parameter())));
         entries.push(ReportEntry::new("jobParams/qecScheme/crossingPrefactor", "Crossing prefactor", r#"Crossing prefactor used in QEC scheme"#, r#"The crossing prefactor is usually extracted numerically from simulations when fitting an exponential curve to model the relationship between logical and physical error rate."#));
         entries.push(ReportEntry::new("jobParams/qecScheme/errorCorrectionThreshold", "Error correction threshold", r#"Error correction threshold used in QEC scheme"#, r#"The error correction threshold is the physical error rate below which the error rate of the logical qubit is less than the error rate of the physical qubit that constitute it.  This value is usually extracted numerically from simulations of the logical error rate."#));
         entries.push(ReportEntry::new(
@@ -76,10 +76,10 @@ impl Report {
             r#"QEC scheme formula used to compute logical cycle time"#,
             &format!(
                 r#"This is the formula that is used to compute the logical cycle time {} ns."#,
-                format_thousand_sep(&result.logical_qubit().logical_cycle_time())
+                format_thousand_sep(&result.logical_patch().logical_cycle_time())
             ),
         ));
-        entries.push(ReportEntry::new("jobParams/qecScheme/physicalQubitsPerLogicalQubit", "Physical qubits formula", r#"QEC scheme formula used to compute number of physical qubits per logical qubit"#, &format!(r#"This is the formula that is used to compute the number of physical qubits per logical qubits {}."#, format_thousand_sep(&result.logical_qubit().physical_qubits()))));
+        entries.push(ReportEntry::new("jobParams/qecScheme/physicalQubitsPerLogicalQubit", "Physical qubits formula", r#"QEC scheme formula used to compute number of physical qubits per logical qubit"#, &format!(r#"This is the formula that is used to compute the number of physical qubits per logical qubits {}."#, format_thousand_sep(&result.logical_patch().physical_qubits()))));
         groups.push(ReportEntryGroup {
             title: "Logical qubit parameters".into(),
             always_visible: false,
@@ -382,7 +382,7 @@ impl FormattedPhysicalResourceCounts {
         );
 
         let required_logical_qubit_error_rate =
-            format!("{:.2e}", result.required_logical_qubit_error_rate());
+            format!("{:.2e}", result.required_logical_patch_error_rate());
 
         let no_tstates_msg = "No T states in algorithm";
         let no_rotations_msg = "No rotations in algorithm";
@@ -396,15 +396,15 @@ impl FormattedPhysicalResourceCounts {
 
         // Logical qubit parameters
         let physical_qubits_per_logical_qubit =
-            format_metric_prefix(result.logical_qubit().physical_qubits());
+            format_metric_prefix(result.logical_patch().physical_qubits());
 
         let logical_cycle_time =
-            format_duration(result.logical_qubit().logical_cycle_time() as u128);
+            format_duration(result.logical_patch().logical_cycle_time() as u128);
 
         let clock_frequency =
-            format_metric_prefix(result.logical_qubit().logical_cycles_per_second().round() as u64);
+            format_metric_prefix(result.logical_patch().logical_cycles_per_second().round() as u64);
 
-        let logical_error_rate = format!("{:.2e}", result.logical_qubit().logical_error_rate());
+        let logical_error_rate = format!("{:.2e}", result.logical_patch().logical_error_rate());
 
         // T factory parameters
         let tfactory_physical_qubits = result

--- a/resource_estimator/src/system/data/result.rs
+++ b/resource_estimator/src/system/data/result.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::estimates::{ErrorBudget, LogicalQubit, Overhead, PhysicalResourceEstimationResult};
+use crate::estimates::{ErrorBudget, LogicalPatch, Overhead, PhysicalResourceEstimationResult};
 use crate::system::modeling::{Protocol, TFactory};
 
 use super::{
@@ -21,7 +21,7 @@ pub struct Success {
     #[serde(skip_serializing_if = "Option::is_none")]
     physical_counts_formatted: Option<FormattedPhysicalResourceCounts>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    logical_qubit: Option<LogicalQubit<Protocol>>,
+    logical_qubit: Option<LogicalPatch<Protocol>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tfactory: Option<TFactory>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -105,7 +105,7 @@ impl Success {
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct FrontierEntry {
-    pub logical_qubit: LogicalQubit<Protocol>,
+    pub logical_qubit: LogicalPatch<Protocol>,
     pub tfactory: Option<TFactory>,
     pub error_budget: ErrorBudget,
     pub physical_counts: PhysicalResourceCounts,
@@ -173,7 +173,7 @@ fn create_physical_resource_counts_breakdown<L: Overhead + Clone>(
             .layout_overhead()
             .logical_depth(num_ts_per_rotation.unwrap_or_default()),
         logical_depth: result.num_cycles(),
-        clock_frequency: result.logical_qubit().logical_cycles_per_second(),
+        clock_frequency: result.logical_patch().logical_cycles_per_second(),
         num_tstates: result
             .layout_overhead()
             .num_magic_states(num_ts_per_rotation.unwrap_or_default()),
@@ -181,11 +181,11 @@ fn create_physical_resource_counts_breakdown<L: Overhead + Clone>(
         num_tfactory_runs: result.num_factory_runs(),
         physical_qubits_for_tfactories: result.physical_qubits_for_factories(),
         physical_qubits_for_algorithm: result.physical_qubits_for_algorithm(),
-        required_logical_qubit_error_rate: result.required_logical_qubit_error_rate(),
+        required_logical_qubit_error_rate: result.required_logical_patch_error_rate(),
         required_logical_tstate_error_rate: result.required_logical_magic_state_error_rate(),
         num_ts_per_rotation,
         clifford_error_rate: result
-            .logical_qubit()
+            .logical_patch()
             .physical_qubit()
             .clifford_error_rate(),
     }
@@ -234,7 +234,7 @@ impl Serialize for Failure {
     }
 }
 
-impl Serialize for LogicalQubit<Protocol> {
+impl Serialize for LogicalPatch<Protocol> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/resource_estimator/src/system/error.rs
+++ b/resource_estimator/src/system/error.rs
@@ -109,7 +109,7 @@ pub enum Error {
     /// Handles various types of invalid input
     ///
     /// ✅ This does not contain user data and can be logged
-    /// (mostly user error, but check [InvalidInputError] for more details)
+    /// (mostly user error, but check InvalidInput for more details)
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidInput(InvalidInput),

--- a/resource_estimator/src/system/modeling/fault_tolerance.rs
+++ b/resource_estimator/src/system/modeling/fault_tolerance.rs
@@ -145,7 +145,7 @@ impl Protocol {
             // can you compute logical cycle time and number of physical qubits with code distance?
             ftp.logical_cycle_time(qubit, &code_distance)
                 .map_err(LogicalCycleTimeComputationFailed)?;
-            ftp.physical_qubits_per_logical_qubit(&code_distance)
+            ftp.physical_qubits(&code_distance)
                 .map_err(PhysicalQubitComputationFailed)?;
         }
 
@@ -464,11 +464,11 @@ impl ErrorCorrection for Protocol {
     type Qubit = PhysicalQubit;
     type Parameter = u64;
 
-    /// Computes the number of physical qubits required for one logical qubit
+    /// Computes the number of physical qubits required for this code
     ///
     /// The formula for this field has a default value of `2 * code_distance *
     /// code_distance`.
-    fn physical_qubits_per_logical_qubit(&self, code_distance: &u64) -> Result<u64, String> {
+    fn physical_qubits(&self, code_distance: &u64) -> Result<u64, String> {
         let mut context = Self::create_evaluation_context(None, *code_distance);
         let value = self
             .physical_qubits_per_logical_qubit
@@ -480,6 +480,11 @@ impl ErrorCorrection for Protocol {
         } else {
             Ok(value as u64)
         }
+    }
+
+    /// The planar codes considered in this system encode 1 logical qubit
+    fn logical_qubits(&self, _code_parameter: &Self::Parameter) -> Result<u64, String> {
+        Ok(1)
     }
 
     /// Returns the time of one logical cycle.

--- a/resource_estimator/src/system/modeling/physical_qubit/tests.rs
+++ b/resource_estimator/src/system/modeling/physical_qubit/tests.rs
@@ -4,7 +4,7 @@
 use std::rc::Rc;
 
 use crate::{
-    estimates::LogicalQubit,
+    estimates::LogicalPatch,
     system::{constants::FLOAT_COMPARISON_EPSILON, modeling::Protocol, Result},
 };
 
@@ -314,7 +314,7 @@ fn logical_qubit_from_fast_gate_based_and_surface_code() -> Result<()> {
 
     let ftp = Protocol::default();
 
-    let logical_qubit = LogicalQubit::new(&ftp, 7, physical_qubit)?;
+    let logical_qubit = LogicalPatch::new(&ftp, 7, physical_qubit)?;
 
     assert_eq!(logical_qubit.physical_qubits(), 98);
     assert!(

--- a/resource_estimator/src/system/modeling/tfactory.rs
+++ b/resource_estimator/src/system/modeling/tfactory.rs
@@ -10,7 +10,7 @@ use std::{collections::BTreeMap, vec};
 use probability::{distribution::Inverse, prelude::Binomial};
 use serde::{ser::SerializeMap, Serialize};
 
-use crate::estimates::{Factory, LogicalQubit};
+use crate::estimates::{Factory, LogicalPatch};
 use crate::system::modeling::PhysicalQubit;
 
 use super::super::{
@@ -20,7 +20,7 @@ use super::super::{
 use super::Protocol;
 
 pub enum TFactoryQubit<'a> {
-    Logical(&'a LogicalQubit<Protocol>),
+    Logical(&'a LogicalPatch<Protocol>),
     Physical(&'a PhysicalQubit),
 }
 
@@ -617,7 +617,7 @@ impl TFactory {
         TFactoryBuildStatus::Success
     }
 
-    pub fn default(logical_qubit: &LogicalQubit<Protocol>) -> Self {
+    pub fn default(logical_qubit: &LogicalPatch<Protocol>) -> Self {
         let tfactory_qubit = TFactoryQubit::Logical(logical_qubit);
         let template = TFactoryDistillationUnitTemplate::create_trivial_distillation_unit_1_to_1();
         let unit = TFactoryDistillationUnit::by_template(&template, &tfactory_qubit);

--- a/resource_estimator/src/system/modeling/tfactory/tests.rs
+++ b/resource_estimator/src/system/modeling/tfactory/tests.rs
@@ -6,7 +6,7 @@ use probability::prelude::Inverse;
 use super::*;
 use std::rc::Rc;
 
-use crate::estimates::LogicalQubit;
+use crate::estimates::LogicalPatch;
 
 use super::super::super::modeling::{PhysicalQubit, Protocol};
 use super::super::super::{constants::FLOAT_COMPARISON_EPSILON, Result};
@@ -85,11 +85,11 @@ fn single_physical_qubit() {
 
 fn create_logical_qubit_with_distance(
     code_distance: u64,
-) -> core::result::Result<LogicalQubit<Protocol>, crate::estimates::Error> {
+) -> core::result::Result<LogicalPatch<Protocol>, crate::estimates::Error> {
     let ftp = Protocol::default();
     let qubit = Rc::new(PhysicalQubit::default());
 
-    LogicalQubit::new(&ftp, code_distance, qubit)
+    LogicalPatch::new(&ftp, code_distance, qubit)
 }
 
 #[test]
@@ -264,7 +264,7 @@ fn expression_by_formula2() {
 fn default_t_factory() {
     let physical_qubit = PhysicalQubit::default();
     let ftp = Protocol::default();
-    let logical_qubit = LogicalQubit::new(&ftp, 15, Rc::new(physical_qubit))
+    let logical_qubit = LogicalPatch::new(&ftp, 15, Rc::new(physical_qubit))
         .expect("logical qubit contruction should succeed");
     let tfactory = TFactory::default(&logical_qubit);
 

--- a/resource_estimator/src/system/optimization/distillation_units_map.rs
+++ b/resource_estimator/src/system/optimization/distillation_units_map.rs
@@ -8,7 +8,7 @@ use std::cmp::max;
 
 use std::rc::Rc;
 
-use crate::estimates::LogicalQubit;
+use crate::estimates::LogicalPatch;
 use crate::system::modeling::{
     PhysicalQubit, Protocol, TFactoryDistillationUnit, TFactoryDistillationUnitTemplate,
     TFactoryDistillationUnitType, TFactoryQubit,
@@ -29,7 +29,7 @@ pub struct DistillationUnitsMap<'a> {
 impl<'a> DistillationUnitsMap<'a> {
     pub fn create(
         qubit: &PhysicalQubit,
-        qubits: &[Option<Rc<LogicalQubit<Protocol>>>],
+        qubits: &[Option<Rc<LogicalPatch<Protocol>>>],
         distances: Vec<u64>,
         distillation_unit_templates: &'a [TFactoryDistillationUnitTemplate],
     ) -> Self {

--- a/resource_estimator/src/system/optimization/distillation_units_map/tests.rs
+++ b/resource_estimator/src/system/optimization/distillation_units_map/tests.rs
@@ -4,7 +4,7 @@
 use rustc_hash::FxHashSet;
 use std::rc::Rc;
 
-use crate::estimates::LogicalQubit;
+use crate::estimates::LogicalPatch;
 
 use super::super::super::{
     data::{
@@ -53,7 +53,7 @@ fn create_default_map<'a>(
     let distances: Vec<_> = (min_code_distance..=max_code_distance).step_by(2).collect();
     let mut qubits = vec![None; max_code_distance as usize + 1];
     for &distance in &distances {
-        qubits[distance as usize] = LogicalQubit::new(ftp, distance, qubit.clone())
+        qubits[distance as usize] = LogicalPatch::new(ftp, distance, qubit.clone())
             .ok()
             .map(Rc::new);
     }

--- a/resource_estimator/src/system/optimization/tfactory_exhaustive.rs
+++ b/resource_estimator/src/system/optimization/tfactory_exhaustive.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use crate::estimates::{
     optimization::{Point, Point2D, Point4D, Population},
-    Factory, FactoryBuilder, LogicalQubit,
+    Factory, FactoryBuilder, LogicalPatch,
 };
 use crate::system::modeling::{
     PhysicalQubit, Protocol, TFactory, TFactoryBuildStatus, TFactoryDistillationUnit,
@@ -241,7 +241,7 @@ where
     if output_t_error_rate > qubit.t_gate_error_rate() {
         let mut population = Population::<P>::new();
 
-        if let Ok(logical_qubit) = LogicalQubit::new(ftp, max_code_distance, qubit.clone()) {
+        if let Ok(logical_qubit) = LogicalPatch::new(ftp, max_code_distance, qubit.clone()) {
             let factory = TFactory::default(&logical_qubit);
             let point = P::from(factory);
             population.push(point);
@@ -254,7 +254,7 @@ where
 
     let mut qubits = vec![None; max_code_distance as usize + 1];
     for &distance in &distances {
-        qubits[distance as usize] = LogicalQubit::new(ftp, distance, qubit.clone())
+        qubits[distance as usize] = LogicalPatch::new(ftp, distance, qubit.clone())
             .ok()
             .map(Rc::new);
     }

--- a/resource_estimator/src/system/tests.rs
+++ b/resource_estimator/src/system/tests.rs
@@ -226,7 +226,7 @@ fn validate_result_invariants<L: Overhead + Clone>(
     );
 
     assert!(
-        result.logical_qubit().logical_error_rate() <= result.required_logical_qubit_error_rate()
+        result.logical_patch().logical_error_rate() <= result.required_logical_patch_error_rate()
     );
 
     assert!(
@@ -255,7 +255,7 @@ pub fn test_hubbard_e2e() -> Result<()> {
 
     let result = estimation.estimate()?;
 
-    let logical_qubit = result.logical_qubit();
+    let logical_qubit = result.logical_patch();
     let tfactory = result.factory().expect("tfactory should be valid");
 
     assert_eq!(logical_qubit.code_parameter(), &17);
@@ -341,7 +341,7 @@ pub fn test_hubbard_e2e_measurement_based() -> Result<()> {
 
     let result = estimation.estimate()?;
 
-    let logical_qubit = result.logical_qubit();
+    let logical_qubit = result.logical_patch();
     let tfactory = result.factory().expect("tfactory should be valid");
 
     assert_eq!(logical_qubit.code_parameter(), &5);
@@ -523,7 +523,7 @@ pub fn test_chemistry_based_max_duration() -> Result<()> {
 
     let result = estimation.estimate_with_max_duration(max_duration_in_nanoseconds)?;
 
-    let logical_qubit = result.logical_qubit();
+    let logical_qubit = result.logical_patch();
     let tfactory = result.factory().expect("tfactory should be valid");
 
     // constraint is not violated
@@ -569,7 +569,7 @@ pub fn test_chemistry_based_max_duration() -> Result<()> {
     );
 
     assert!(
-        result.logical_qubit().logical_error_rate() <= result.required_logical_qubit_error_rate()
+        result.logical_patch().logical_error_rate() <= result.required_logical_patch_error_rate()
     );
 
     Ok(())
@@ -583,7 +583,7 @@ pub fn test_chemistry_based_max_num_qubits() -> Result<()> {
 
     let result = estimation.estimate_with_max_num_qubits(max_num_qubits)?;
 
-    let logical_qubit = result.logical_qubit();
+    let logical_qubit = result.logical_patch();
     let tfactory = result.factory().expect("tfactory should be valid");
 
     // constraint is not violated
@@ -628,7 +628,7 @@ pub fn test_chemistry_based_max_num_qubits() -> Result<()> {
     );
 
     assert!(
-        result.logical_qubit().logical_error_rate() <= result.required_logical_qubit_error_rate()
+        result.logical_patch().logical_error_rate() <= result.required_logical_patch_error_rate()
     );
 
     Ok(())
@@ -663,12 +663,12 @@ pub fn test_factorization_2048_max_duration_matches_regular_estimate() -> Result
 
     let result_no_max_duration = estimation.estimate_without_restrictions()?;
 
-    let logical_qubit_no_max_duration = result_no_max_duration.logical_qubit();
+    let logical_qubit_no_max_duration = result_no_max_duration.logical_patch();
 
     let max_duration_in_nanoseconds: u64 = result_no_max_duration.runtime();
     let result = estimation.estimate_with_max_duration(max_duration_in_nanoseconds)?;
 
-    let logical_qubit = result.logical_qubit();
+    let logical_qubit = result.logical_patch();
 
     assert_eq!(
         logical_qubit_no_max_duration.code_parameter(),
@@ -716,12 +716,12 @@ pub fn test_factorization_2048_max_num_qubits_matches_regular_estimate() -> Resu
 
     let result_no_max_num_qubits = estimation.estimate_without_restrictions()?;
 
-    let logical_qubit_no_max_num_qubits = result_no_max_num_qubits.logical_qubit();
+    let logical_qubit_no_max_num_qubits = result_no_max_num_qubits.logical_patch();
 
     let max_num_qubits = result_no_max_num_qubits.physical_qubits();
     let result = estimation.estimate_with_max_num_qubits(max_num_qubits)?;
 
-    let logical_qubit = result.logical_qubit();
+    let logical_qubit = result.logical_patch();
 
     assert_eq!(
         logical_qubit_no_max_num_qubits.code_parameter(),
@@ -800,8 +800,8 @@ fn build_frontier_test() {
         assert!(points[i].physical_qubits() >= points[i + 1].physical_qubits());
         assert!(points[i].num_factories() >= points[i + 1].num_factories());
         assert!(
-            points[i].logical_qubit().code_parameter()
-                <= points[i + 1].logical_qubit().code_parameter()
+            points[i].logical_patch().code_parameter()
+                <= points[i + 1].logical_patch().code_parameter()
         );
     }
 
@@ -816,8 +816,8 @@ fn build_frontier_test() {
         shortest_runtime_result.num_factories()
     );
     assert_eq!(
-        points[0].logical_qubit().code_parameter(),
-        shortest_runtime_result.logical_qubit().code_parameter()
+        points[0].logical_patch().code_parameter(),
+        shortest_runtime_result.logical_patch().code_parameter()
     );
 
     let mut max_duration = shortest_runtime_result.runtime();


### PR DESCRIPTION
This generalizes the `ErrorCorrection` trait to allow encoding multiple logical qubits, thereby enabling the modeling of codes such as LDPC. The change also lead to rename the `LogicalQubit` struct into `LogicalPatch` to account the possibility of multiple logical qubits in the name of the struct.

The system does not change, since all the planar codes modeled in it encode one logical qubit.