### PR TITLE
Update lexer to accept captial letters for writing scientific notation

### DIFF
--- a/compiler/qsc_parse/src/lex/raw.rs
+++ b/compiler/qsc_parse/src/lex/raw.rs
@@ -246,11 +246,11 @@ impl<'a> Lexer<'a> {
             return None;
         }
 
-        let radix = if self.next_if_eq('b') {
+        let radix = if self.next_if_eq('b') || self.next_if_eq('B') {
             Radix::Binary
-        } else if self.next_if_eq('o') {
+        } else if self.next_if_eq('o') || self.next_if_eq('O') {
             Radix::Octal
-        } else if self.next_if_eq('x') {
+        } else if self.next_if_eq('x') || self.next_if_eq('X') {
             Radix::Hexadecimal
         } else {
             Radix::Decimal
@@ -295,7 +295,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn exp(&mut self) -> bool {
-        if self.next_if_eq('e') {
+        if self.next_if_eq('e') || self.next_if_eq('E') {
             self.chars.next_if(|i| i.1 == '+' || i.1 == '-');
             self.eat_while(|c| c.is_ascii_digit());
             true

--- a/compiler/qsc_parse/src/lex/raw/tests.rs
+++ b/compiler/qsc_parse/src/lex/raw/tests.rs
@@ -811,12 +811,42 @@ fn binary() {
             ]
         "#]],
     );
+    check(
+        "0B10110",
+        &expect![[r#"
+            [
+                Token {
+                    kind: Number(
+                        Int(
+                            Binary,
+                        ),
+                    ),
+                    offset: 0,
+                },
+            ]
+        "#]],
+    );
 }
 
 #[test]
 fn octal() {
     check(
         "0o70351",
+        &expect![[r#"
+            [
+                Token {
+                    kind: Number(
+                        Int(
+                            Octal,
+                        ),
+                    ),
+                    offset: 0,
+                },
+            ]
+        "#]],
+    );
+    check(
+        "0O70351",
         &expect![[r#"
             [
                 Token {
@@ -988,6 +1018,21 @@ fn dot_dot_dot_int() {
 fn hexadecimal() {
     check(
         "0x123abc",
+        &expect![[r#"
+            [
+                Token {
+                    kind: Number(
+                        Int(
+                            Hexadecimal,
+                        ),
+                    ),
+                    offset: 0,
+                },
+            ]
+        "#]],
+    );
+    check(
+        "0X123abc",
         &expect![[r#"
             [
                 Token {
@@ -1173,6 +1218,19 @@ fn trailing_point() {
 fn exp() {
     check(
         "1e23",
+        &expect![[r#"
+            [
+                Token {
+                    kind: Number(
+                        Float,
+                    ),
+                    offset: 0,
+                },
+            ]
+        "#]],
+    );
+    check(
+        "1E23",
         &expect![[r#"
             [
                 Token {


### PR DESCRIPTION
Closes #1179 

Adds extra conditional arguments to check for capital letters in binary, hexadecimal, octal and exp lexing methods.