### PR TITLE
Add logic to detect missing comma token in array parsing

### DIFF
--- a/compiler/qsc_parse/src/expr.rs
+++ b/compiler/qsc_parse/src/expr.rs
@@ -280,7 +280,18 @@ fn expr_array_core(s: &mut ParserContext) -> Result<Box<ExprKind>> {
     };
 
     if token(s, TokenKind::Comma).is_err() {
-        return Ok(Box::new(ExprKind::Array(vec![first].into_boxed_slice())));
+        match s.peek().kind {
+            TokenKind::Eq | TokenKind::Close(Delim::Bracket) => {
+                return Ok(Box::new(ExprKind::Array(vec![first].into_boxed_slice())));
+            }
+            _missing_comma => {
+                return Err(Error(ErrorKind::Token(
+                    TokenKind::Comma,
+                    s.peek().kind,
+                    s.peek().span,
+                )));
+            }
+        }
     }
 
     let second = expr(s)?;

--- a/compiler/qsc_parse/src/expr/tests.rs
+++ b/compiler/qsc_parse/src/expr/tests.rs
@@ -978,6 +978,26 @@ fn array_pair() {
 }
 
 #[test]
+fn array_of_floats_missing_comma() {
+    check(
+        expr,
+        "[1. 0. 0.]",
+        &expect![[r#"
+        Error(
+            Token(
+                Comma,
+                Float,
+                Span {
+                    lo: 4,
+                    hi: 6,
+                },
+            ),
+        )
+    "#]],
+    )
+}
+
+#[test]
 fn array_repeat() {
     check(
         expr,


### PR DESCRIPTION
Closes #1114 

Adds a conditional arg to add better error handling when array elements are missing a comma. This may fall under the "parse don't validate" category, but it's a start. Welcoming any feedback on how to approach this otherwise, or happy to close if the current behavior is expected.