### PR TITLE
Fix generated type in loop unification pass

### DIFF
--- a/compiler/qsc_passes/src/loop_unification.rs
+++ b/compiler/qsc_passes/src/loop_unification.rs
@@ -147,7 +147,7 @@ impl LoopUni<'_> {
             Expr {
                 id: self.assigner.next_node(),
                 span: array_id.span,
-                ty: array_id.ty.clone(),
+                ty: Ty::Prim(Prim::Int),
                 kind: ExprKind::Call(
                     Box::new(len_callee),
                     Box::new(array_id.gen_local_ref(self.assigner)),

--- a/compiler/qsc_passes/src/loop_unification/tests.rs
+++ b/compiler/qsc_passes/src/loop_unification/tests.rs
@@ -62,7 +62,7 @@ fn convert_for_array() {
                                         Expr 10 [75-78] [Type Int[]]: Var: Local 3
                                     Stmt 24 [0-0]: Local (Immutable):
                                         Pat 25 [75-78] [Type Int]: Bind: Ident 21 [75-78] "@len_id_21"
-                                        Expr 22 [75-78] [Type Int[]]: Call:
+                                        Expr 22 [75-78] [Type Int]: Call:
                                             Expr 20 [75-78] [Type (Int[] -> Int)]: Var:
                                                 res: Item 1 (Package 0)
                                                 generics:
@@ -125,7 +125,7 @@ fn convert_for_array_deconstruct() {
                                         Expr 13 [90-93] [Type (Int, Double)[]]: Var: Local 3
                                     Stmt 27 [0-0]: Local (Immutable):
                                         Pat 28 [90-93] [Type Int]: Bind: Ident 24 [90-93] "@len_id_24"
-                                        Expr 25 [90-93] [Type (Int, Double)[]]: Call:
+                                        Expr 25 [90-93] [Type Int]: Call:
                                             Expr 23 [90-93] [Type ((Int, Double)[] -> Int)]: Var:
                                                 res: Item 1 (Package 0)
                                                 generics:
@@ -196,7 +196,7 @@ fn convert_for_slice() {
                                                 Expr 16 [86-87] [Type Int]: Lit: Int(2)
                                     Stmt 30 [0-0]: Local (Immutable):
                                         Pat 31 [75-88] [Type Int]: Bind: Ident 27 [75-88] "@len_id_27"
-                                        Expr 28 [75-88] [Type Int[]]: Call:
+                                        Expr 28 [75-88] [Type Int]: Call:
                                             Expr 26 [75-88] [Type (Int[] -> Int)]: Var:
                                                 res: Item 1 (Package 0)
                                                 generics:


### PR DESCRIPTION
During loop unification, new variable expressions are generated into the HIR that have types assigned after type inference. These types need to be correct for later analysis passes. One spot was using the type of the array rather than the hard-coded integer type for the length, creating a type mismatch that could confuse later analysis.