### PR TITLE
Update type inference to constrain indexed container as an array

### DIFF
--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -312,9 +312,18 @@ impl<'a> Context<'a> {
                 )
             }
             ExprKind::Index(container, index) => {
+                let container_span = container.span;
                 let container = self.infer_expr(container);
                 let index = self.infer_expr(index);
                 let item_ty = self.inferrer.fresh_ty(TySource::not_divergent(expr.span));
+                let container_item_ty = self
+                    .inferrer
+                    .fresh_ty(TySource::not_divergent(container_span));
+                self.inferrer.eq(
+                    container_span,
+                    container.ty.clone(),
+                    Ty::Array(Box::new(container_item_ty)),
+                );
                 self.inferrer.class(
                     expr.span,
                     Class::HasIndex {

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -3630,3 +3630,34 @@ fn use_range_field_names_in_udt() {
         "#]],
     );
 }
+
+#[test]
+fn lambda_on_array_where_item_used_in_call_should_be_inferred() {
+    check(
+        indoc! {"
+            namespace A {
+                function B() : Unit {
+                    let f = qs => C(qs[0]);
+                }
+                operation C(q : Qubit) : Unit is Ctl + Adj { }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #6 28-30 "()" : Unit
+            #10 38-77 "{\n        let f = qs => C(qs[0]);\n    }" : Unit
+            #12 52-53 "f" : (Qubit[] => Unit)
+            #14 56-70 "qs => C(qs[0])" : (Qubit[] => Unit)
+            #15 56-58 "qs" : Qubit[]
+            #17 62-70 "C(qs[0])" : Unit
+            #18 62-63 "C" : (Qubit => Unit is Adj + Ctl)
+            #21 63-70 "(qs[0])" : Qubit
+            #22 64-69 "qs[0]" : Qubit
+            #23 64-66 "qs" : Qubit[]
+            #26 67-68 "0" : Int
+            #30 93-104 "(q : Qubit)" : Qubit
+            #31 94-103 "q : Qubit" : Qubit
+            #42 125-128 "{ }" : Unit
+        "##]],
+    );
+}


### PR DESCRIPTION
This change updates the type inference logic to have an additional constraint on indexed containers that they must be an array of a new inference type. This is enough to allow further inference to determine the type of the array if items from the array are used in places with inferred types. If any other types support the `HasIndex` class in the future this approach can be revisited.

This fixes an issue where certain code with inferrable types would produce type ambiguous errors, such as [this code](https://microsoft.github.io/qsharp/?code=H4sIAAAAAAAAEz3OMWvDMBAF4F2%2F4oEXe6k6t6R0aMkUiNsOBePhal8TgXVSpBMlhPz3YqX0xu8e785aiwbv5OPCxlqLLas6OSArJeV5teoNXjhPyUV1Qap8HF2GyyB4J87Tgr5BTOGQyEOPpJhI8MUomWdouFXiJ7l6oG8whZnvjJDnHGli7M59IdHi938tF2MA4PlVNJ33wYm2XZUQOdH6CXbkpO3wgDfOZdFhxKUm1llY8Y0NThmbJ3y2pzzcj93j%2Fz6xliQYxhtdzdX8Al5OMIEQAQAA):

```qsharp
let f = qs => X(qs[0);
```