### PR TITLE
Allow satisfaction checks for functor support

### DIFF
--- a/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/compiler/qsc_frontend/src/typeck/infer.rs
@@ -570,7 +570,8 @@ impl Solver {
                 constraints.append(&mut self.unify(&arrow1.output, &arrow2.output, span));
 
                 match (arrow1.functors, arrow2.functors) {
-                    (FunctorSet::Value(value1), FunctorSet::Value(value2)) if value1 == value2 => {}
+                    (FunctorSet::Value(value1), FunctorSet::Value(value2))
+                        if value2.satisfies(&value1) => {}
                     (FunctorSet::Infer(infer1), FunctorSet::Infer(infer2)) if infer1 == infer2 => {}
                     (FunctorSet::Infer(infer), functors) | (functors, FunctorSet::Infer(infer)) => {
                         constraints.append(&mut self.bind_functor(infer, functors, span));

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -1709,30 +1709,30 @@ fn return_with_satisfying_specialization_succeeds() {
             #28 112-114 "{}" : Unit
             #32 131-133 "()" : Unit
             #39 154-156 "{}" : Unit
-            #43 184-186 "()" : Unit
-            #53 211-216 "{ A }" : (Unit => Unit is Adj)
-            #55 213-214 "A" : (Unit => Unit is Adj)
-            #61 245-247 "()" : Unit
-            #71 272-278 "{ AC }" : (Unit => Unit is Adj + Ctl)
-            #73 274-276 "AC" : (Unit => Unit is Adj + Ctl)
-            #79 307-309 "()" : Unit
-            #89 334-340 "{ AC }" : (Unit => Unit is Adj + Ctl)
-            #91 336-338 "AC" : (Unit => Unit is Adj + Ctl)
-            #97 368-370 "()" : Unit
-            #107 395-400 "{ C }" : (Unit => Unit is Ctl)
-            #109 397-398 "C" : (Unit => Unit is Ctl)
-            #115 429-431 "()" : Unit
-            #124 449-454 "{ A }" : (Unit => Unit is Adj)
-            #126 451-452 "A" : (Unit => Unit is Adj)
-            #132 483-485 "()" : Unit
-            #141 503-509 "{ AC }" : (Unit => Unit is Adj + Ctl)
-            #143 505-507 "AC" : (Unit => Unit is Adj + Ctl)
-            #149 537-539 "()" : Unit
-            #158 557-562 "{ C }" : (Unit => Unit is Ctl)
-            #160 559-560 "C" : (Unit => Unit is Ctl)
-            #166 590-592 "()" : Unit
-            #175 610-615 "{ E }" : (Unit => Unit)
-            #177 612-613 "E" : (Unit => Unit)
+            #43 185-187 "()" : Unit
+            #53 212-217 "{ A }" : (Unit => Unit is Adj)
+            #55 214-215 "A" : (Unit => Unit is Adj)
+            #61 246-248 "()" : Unit
+            #71 273-279 "{ AC }" : (Unit => Unit is Adj + Ctl)
+            #73 275-277 "AC" : (Unit => Unit is Adj + Ctl)
+            #79 309-311 "()" : Unit
+            #89 336-342 "{ AC }" : (Unit => Unit is Adj + Ctl)
+            #91 338-340 "AC" : (Unit => Unit is Adj + Ctl)
+            #97 370-372 "()" : Unit
+            #107 397-402 "{ C }" : (Unit => Unit is Ctl)
+            #109 399-400 "C" : (Unit => Unit is Ctl)
+            #115 431-433 "()" : Unit
+            #124 451-456 "{ A }" : (Unit => Unit is Adj)
+            #126 453-454 "A" : (Unit => Unit is Adj)
+            #132 485-487 "()" : Unit
+            #141 505-511 "{ AC }" : (Unit => Unit is Adj + Ctl)
+            #143 507-509 "AC" : (Unit => Unit is Adj + Ctl)
+            #149 539-541 "()" : Unit
+            #158 559-564 "{ C }" : (Unit => Unit is Ctl)
+            #160 561-562 "C" : (Unit => Unit is Ctl)
+            #166 592-594 "()" : Unit
+            #175 612-617 "{ E }" : (Unit => Unit)
+            #177 614-615 "E" : (Unit => Unit)
         "##]],
     );
 }

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -1678,6 +1678,26 @@ fn return_mismatch() {
 }
 
 #[test]
+fn return_with_more_specializations() {
+    check(
+        indoc! {"
+            namespace A {
+                operation B() : Unit is Adj + Ctl {}
+                function C() : (Unit => Unit is Adj) { B }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #6 29-31 "()" : Unit
+            #13 52-54 "{}" : Unit
+            #17 69-71 "()" : Unit
+            #27 96-101 "{ B }" : (Unit => Unit is Adj + Ctl)
+            #29 98-99 "B" : (Unit => Unit is Adj + Ctl)
+        "##]],
+    );
+}
+
+#[test]
 fn array_unknown_field_error() {
     check(
         indoc! {"
@@ -3215,8 +3235,6 @@ fn functors_in_array_mixed() {
             #47 180-183 "Foo" : (Qubit => Unit)
             #50 185-188 "Bar" : (Qubit => Unit is Adj)
             #53 190-193 "Baz" : (Qubit => Unit is Adj + Ctl)
-            Error(Type(Error(FunctorMismatch(Value(Empty), Value(Adj), Span { lo: 185, hi: 188 }))))
-            Error(Type(Error(FunctorMismatch(Value(Empty), Value(CtlAdj), Span { lo: 190, hi: 193 }))))
         "#]],
     );
 }
@@ -3337,7 +3355,6 @@ fn functors_in_arg_bound_to_let_becomes_monotype() {
             #63 232-235 "foo" : ((Qubit => Unit is Adj) => Unit)
             #66 235-240 "(Baz)" : (Qubit => Unit is Adj + Ctl)
             #67 236-239 "Baz" : (Qubit => Unit is Adj + Ctl)
-            Error(Type(Error(FunctorMismatch(Value(Adj), Value(CtlAdj), Span { lo: 232, hi: 240 }))))
         "#]],
     );
 }

--- a/compiler/qsc_hir/src/ty.rs
+++ b/compiler/qsc_hir/src/ty.rs
@@ -500,9 +500,9 @@ impl FunctorSetValue {
     }
 
     #[must_use]
-    pub fn satisfies(&self, required: &Self) -> bool {
+    pub fn satisfies(&self, other: &Self) -> bool {
         matches!(
-            (self, required),
+            (self, other),
             (_, Self::Empty)
                 | (Self::Adj | Self::CtlAdj, Self::Adj)
                 | (Self::Ctl | Self::CtlAdj, Self::Ctl)

--- a/compiler/qsc_hir/src/ty.rs
+++ b/compiler/qsc_hir/src/ty.rs
@@ -498,6 +498,17 @@ impl FunctorSetValue {
             | (Self::Ctl, Self::Adj) => Self::CtlAdj,
         }
     }
+
+    #[must_use]
+    pub fn satisfies(&self, required: &Self) -> bool {
+        matches!(
+            (self, required),
+            (_, Self::Empty)
+                | (Self::Adj | Self::CtlAdj, Self::Adj)
+                | (Self::Ctl | Self::CtlAdj, Self::Ctl)
+                | (Self::CtlAdj, Self::CtlAdj)
+        )
+    }
 }
 
 impl Display for FunctorSetValue {


### PR DESCRIPTION
This relaxes the equality check when unifying two arrow types such that the functors supported by the actual just need to satisfy the expected rather than be exactly equivalent.

Fixes #1241