### PR TITLE
Fix generated type in replace qubit allocation pass

### DIFF
--- a/compiler/qsc_passes/src/replace_qubit_allocation.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation.rs
@@ -480,10 +480,15 @@ fn create_qubit_alloc_call_expr(
     call_expr: Expr,
     array_size: Option<Expr>,
 ) -> Expr {
+    let ty = if array_size.is_none() {
+        Ty::Prim(Prim::Qubit)
+    } else {
+        Ty::Array(Box::new(Ty::Prim(Prim::Qubit)))
+    };
     Expr {
         id: assigner.next_node(),
         span,
-        ty: Ty::Prim(Prim::Qubit),
+        ty,
         kind: ExprKind::Call(
             Box::new(call_expr),
             Box::new(array_size.unwrap_or(Expr {

--- a/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
@@ -87,7 +87,7 @@ fn test_qubit_array() {
                             Block 4 [45-97] [Type Unit]:
                                 Stmt 18 [55-72]: Local (Immutable):
                                     Pat 19 [55-72] [Type Qubit[]]: Bind: Ident 7 [55-72] "q"
-                                    Expr 16 [55-72] [Type Qubit]: Call:
+                                    Expr 16 [55-72] [Type Qubit[]]: Call:
                                         Expr 15 [55-72] [Type (Int => Qubit[])]: Var: Item 6 (Package 0)
                                         Expr 9 [69-70] [Type Int]: Lit: Int(3)
                                 Stmt 10 [81-91]: Local (Immutable):
@@ -183,7 +183,7 @@ fn test_multiple_qubits_tuple() {
                                         Expr 27 [69-76] [Type Unit]: Unit
                                 Stmt 33 [78-86]: Local (Immutable):
                                     Pat 34 [78-86] [Type Qubit[]]: Bind: Ident 22 [78-86] "@generated_ident_22"
-                                    Expr 31 [78-86] [Type Qubit]: Call:
+                                    Expr 31 [78-86] [Type Qubit[]]: Call:
                                         Expr 30 [78-86] [Type (Int => Qubit[])]: Var: Item 6 (Package 0)
                                         Expr 14 [84-85] [Type Int]: Lit: Int(3)
                                 Stmt 35 [55-88]: Local (Immutable):
@@ -700,7 +700,7 @@ fn test_array_expr() {
                             Block 4 [45-150] [Type Unit]:
                                 Stmt 39 [55-125]: Local (Immutable):
                                     Pat 40 [55-125] [Type Qubit[]]: Bind: Ident 7 [55-125] "a"
-                                    Expr 37 [55-125] [Type Qubit]: Call:
+                                    Expr 37 [55-125] [Type Qubit[]]: Call:
                                         Expr 36 [55-125] [Type (Int => Qubit[])]: Var: Item 6 (Package 0)
                                         Expr 9 [69-123] [Type Int]: Expr Block: Block 10 [69-123] [Type Int]:
                                             Stmt 25 [83-99]: Local (Immutable):


### PR DESCRIPTION
During the replace qubit allocations pass, calls to qubit allocation operations are generated, but the type of the call expression was always set to `Qubit` regardless of whether the allocation was for a single qubit or multiple qubits.

This change sets the appropriate types for the qubit allocation call expression. `Qubit` for single qubit allocation and `Qubit[]` for multi-qubit allocation.