### PR TITLE
Make Base Profile result type check specific to entry expressions

### DIFF
--- a/compiler/qsc/src/incremental.rs
+++ b/compiler/qsc/src/incremental.rs
@@ -149,12 +149,12 @@ impl Compiler {
     /// get information about the newly added items, or do other modifications.
     /// It is then the caller's responsibility to merge
     /// these packages into the current `CompileUnit` using the `update()` method.
-    pub fn compile_expr(&mut self, expr: &str) -> Result<Increment, Errors> {
+    pub fn compile_entry_expr(&mut self, expr: &str) -> Result<Increment, Errors> {
         let (core, unit) = self.store.get_open_mut();
 
         let mut increment = self
             .frontend
-            .compile_expr(unit, "<entry>", expr)
+            .compile_entry_expr(unit, expr)
             .map_err(into_errors)?;
 
         let pass_errors = self.passes.run_default_passes(
@@ -173,6 +173,7 @@ impl Compiler {
 
     /// Updates the current compilation with the AST and HIR packages,
     /// and any associated context, returned from a previous incremental compilation.
+    /// Entry expressions are ignored.
     pub fn update(&mut self, new: Increment) {
         let (_, unit) = self.store.get_open_mut();
 

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -1044,6 +1044,20 @@ mod given_interpreter {
                 );
             }
         }
+
+        #[test]
+        fn base_prof_non_result_return() {
+            let mut interpreter = Interpreter::new(
+                true,
+                SourceMap::default(),
+                PackageType::Lib,
+                RuntimeCapabilityFlags::empty(),
+                LanguageFeatures::default(),
+            )
+            .expect("interpreter should be created");
+            let (result, output) = line(&mut interpreter, "123");
+            is_only_value(&result, &output, &Value::Int(123));
+        }
     }
 
     fn get_interpreter() -> Interpreter {

--- a/compiler/qsc_eval/src/lower.rs
+++ b/compiler/qsc_eval/src/lower.rs
@@ -81,6 +81,8 @@ impl Lowerer {
         fir_package: &mut fir::Package,
         hir_package: &hir::Package,
     ) -> Vec<StmtId> {
+        let new_entry = hir_package.entry.as_ref().map(|e| self.lower_expr(e));
+
         let items: IndexMap<LocalItemId, fir::Item> = hir_package
             .items
             .values()
@@ -99,6 +101,8 @@ impl Lowerer {
         for (k, v) in items {
             fir_package.items.insert(k, v);
         }
+
+        fir_package.entry = new_entry;
 
         qsc_fir::validate::validate(fir_package);
 

--- a/compiler/qsc_eval/src/lower.rs
+++ b/compiler/qsc_eval/src/lower.rs
@@ -81,8 +81,6 @@ impl Lowerer {
         fir_package: &mut fir::Package,
         hir_package: &hir::Package,
     ) -> Vec<StmtId> {
-        let new_entry = hir_package.entry.as_ref().map(|e| self.lower_expr(e));
-
         let items: IndexMap<LocalItemId, fir::Item> = hir_package
             .items
             .values()
@@ -96,13 +94,15 @@ impl Lowerer {
             .map(|s| self.lower_stmt(s))
             .collect();
 
+        let entry = hir_package.entry.as_ref().map(|e| self.lower_expr(e));
+
         self.update_package(fir_package);
 
         for (k, v) in items {
             fir_package.items.insert(k, v);
         }
 
-        fir_package.entry = new_entry;
+        fir_package.entry = entry;
 
         qsc_fir::validate::validate(fir_package);
 

--- a/compiler/qsc_passes/src/baseprofck.rs
+++ b/compiler/qsc_passes/src/baseprofck.rs
@@ -7,12 +7,9 @@ mod tests;
 use miette::Diagnostic;
 use qsc_data_structures::span::Span;
 use qsc_hir::{
-    hir::{
-        BinOp, CallableKind, Expr, ExprKind, Item, ItemKind, Lit, Package, SpecBody, SpecGen,
-        StmtKind,
-    },
+    hir::{BinOp, CallableKind, Expr, ExprKind, Item, ItemKind, Lit, Package, SpecBody, SpecGen},
     ty::{Prim, Ty},
-    visit::{walk_expr, walk_item, walk_package, Visitor},
+    visit::{walk_expr, walk_item, Visitor},
 };
 use thiserror::Error;
 
@@ -65,16 +62,6 @@ struct Checker {
 }
 
 impl<'a> Visitor<'a> for Checker {
-    fn visit_package(&mut self, package: &'a Package) {
-        if let Some(StmtKind::Expr(expr)) = &package.stmts.last().map(|stmt| &stmt.kind) {
-            if any_non_result_ty(&expr.ty) {
-                self.errors.push(Error::ReturnNonResult(expr.span));
-            }
-        }
-
-        walk_package(self, package);
-    }
-
     fn visit_item(&mut self, item: &'a Item) {
         match &item.kind {
             ItemKind::Callable(callable)


### PR DESCRIPTION
Fixes #1246

The current base profile result type check was overly broad, because it ran the check on all fragments (not just entry expressions). 

This was because during incremental compilation, entry expressions were added to the AST package as a top-level statement. After that point, the passes could not differentiate between the entry expression and a top-level statement.

We don't _actually_ have to convert the entry expression to a statement - we can just keep the entry expression in the `entry` field in the AST and HIR. So, now, if passes want to apply any special treatment to the entry expression, they have enough information to do so.