### PR TITLE
Fix required logical qubit error rate for multi-qubit patches

### DIFF
--- a/resource_estimator/src/estimates/factory.rs
+++ b/resource_estimator/src/estimates/factory.rs
@@ -15,6 +15,7 @@ pub trait DistillationUnit<P> {
     fn failure_probability(&self, input_error_rate: f64) -> f64;
 }
 
+#[derive(Debug)]
 pub enum FactoryBuildError {
     LowFailureProbability,
     HighFailureProbability,

--- a/resource_estimator/src/estimates/physical_estimation.rs
+++ b/resource_estimator/src/estimates/physical_estimation.rs
@@ -56,20 +56,95 @@ pub trait ErrorCorrection {
     /// the `Self::code_parameter_range` method and returns the first parameter
     /// for which the logical error rate is less or equal the required logical
     /// error rate.
+    ///
+    /// This method assumes that the code parameters that are returned from
+    /// `Self::code_parameter_range` are ordered by the logical error rate per
+    /// qubit, starting from the largest one.
     fn compute_code_parameter(
         &self,
         qubit: &Self::Qubit,
         required_logical_error_rate: f64,
     ) -> Result<Self::Parameter, String> {
         for parameter in self.code_parameter_range(None) {
-            if let Ok(probability) = self.logical_error_rate(qubit, &parameter) {
-                if probability <= required_logical_error_rate {
+            if let (Ok(probability), Ok(logical_qubits)) = (
+                self.logical_error_rate(qubit, &parameter),
+                self.logical_qubits(&parameter),
+            ) {
+                if probability / (logical_qubits as f64) <= required_logical_error_rate {
                     return Ok(parameter);
                 }
             }
         }
 
         Err("No code parameter achieves required logical error rate".into())
+    }
+
+    /// Computes the code parameter assignment that requires the fewest number
+    /// of physical qubits
+    ///
+    /// Compared to the default implementation `Self::compute_code_parameter`,
+    /// this method evaluates _all_ possible parameters, filters those which
+    /// fulfill the required logical error rate, and then chooses the one among
+    /// them, which requires the smallest number of physical qubits.
+    fn compute_code_parameter_for_smallest_size(
+        &self,
+        qubit: &Self::Qubit,
+        required_logical_error_rate: f64,
+    ) -> Result<Self::Parameter, String> {
+        let mut best: Option<(Self::Parameter, f64)> = None;
+
+        for parameter in self.code_parameter_range(None) {
+            if let (Ok(probability), Ok(logical_qubits), Ok(physical_qubits)) = (
+                self.logical_error_rate(qubit, &parameter),
+                self.logical_qubits(&parameter),
+                self.physical_qubits(&parameter),
+            ) {
+                let physical_qubits_per_logical_qubits =
+                    physical_qubits as f64 / logical_qubits as f64;
+                if (probability / (logical_qubits as f64) <= required_logical_error_rate)
+                    && best
+                        .as_ref()
+                        .map_or(true, |&(_, pq)| physical_qubits_per_logical_qubits < pq)
+                {
+                    best = Some((parameter, physical_qubits_per_logical_qubits));
+                }
+            }
+        }
+
+        best.map(|(p, _)| p)
+            .ok_or_else(|| "No code parameter achieves required logical error rate".into())
+    }
+
+    /// Computes the code parameter assignment that provides the fastest logical
+    /// cycle time
+    ///
+    /// Compared to the default implementation `Self::compute_code_parameter`,
+    /// this method evaluates _all_ possible parameters, filters those which
+    /// fulfill the required logical error rate, and then chooses the one among
+    /// them, which provides the fastest logical cycle time.
+    fn compute_code_parameter_for_smallest_runtime(
+        &self,
+        qubit: &Self::Qubit,
+        required_logical_error_rate: f64,
+    ) -> Result<Self::Parameter, String> {
+        let mut best: Option<(Self::Parameter, u64)> = None;
+
+        for parameter in self.code_parameter_range(None) {
+            if let (Ok(probability), Ok(logical_qubits), Ok(logical_cycle_time)) = (
+                self.logical_error_rate(qubit, &parameter),
+                self.logical_qubits(&parameter),
+                self.logical_cycle_time(qubit, &parameter),
+            ) {
+                if (probability / (logical_qubits as f64) <= required_logical_error_rate)
+                    && best.as_ref().map_or(true, |&(_, t)| logical_cycle_time < t)
+                {
+                    best = Some((parameter, logical_cycle_time));
+                }
+            }
+        }
+
+        best.map(|(p, _)| p)
+            .ok_or_else(|| "No code parameter achieves required logical error rate".into())
     }
 
     /// Returns an iterator of all possible code parameters
@@ -132,7 +207,7 @@ pub struct PhysicalResourceEstimationResult<E: ErrorCorrection, F, L> {
     num_cycles: u64,
     factory: Option<F>,
     num_factories: u64,
-    required_logical_patch_error_rate: f64,
+    required_logical_error_rate: f64,
     required_logical_magic_state_error_rate: Option<f64>,
     num_factory_runs: u64,
     physical_qubits_for_factories: u64,
@@ -156,7 +231,7 @@ impl<
         num_cycles: u64,
         factory: Option<F>,
         num_factories: u64,
-        required_logical_patch_error_rate: f64,
+        required_logical_error_rate: f64,
         required_logical_magic_state_error_rate: Option<f64>,
     ) -> Self {
         // Compute statistics for single factory
@@ -201,7 +276,7 @@ impl<
             num_cycles,
             factory,
             num_factories,
-            required_logical_patch_error_rate,
+            required_logical_error_rate,
             required_logical_magic_state_error_rate,
             num_factory_runs,
             physical_qubits_for_factories,
@@ -251,8 +326,10 @@ impl<
         self.num_factories
     }
 
-    pub fn required_logical_patch_error_rate(&self) -> f64 {
-        self.required_logical_patch_error_rate
+    /// The required logical error rate for one logical operation on one logical
+    /// qubit
+    pub fn required_logical_error_rate(&self) -> f64 {
+        self.required_logical_error_rate
     }
 
     pub fn required_logical_magic_state_error_rate(&self) -> Option<f64> {
@@ -556,11 +633,11 @@ impl<
             required_logical_patch_error_rate,
             required_logical_magic_state_error_rate,
         ) = loop {
-            let required_logical_patch_error_rate = self.required_logical_error_rate(num_cycles);
+            let required_logical_error_rate = self.required_logical_error_rate(num_cycles);
 
             let code_parameter = self
                 .ftp
-                .compute_code_parameter(&self.qubit, required_logical_patch_error_rate)
+                .compute_code_parameter(&self.qubit, required_logical_error_rate)
                 .map_err(Error::CodeParameterComputationFailed)?;
 
             let logical_patch =
@@ -574,13 +651,7 @@ impl<
                 .num_magic_states(num_magic_states_per_rotation.unwrap_or_default())
                 == 0
             {
-                break (
-                    logical_patch,
-                    None,
-                    0,
-                    required_logical_patch_error_rate,
-                    None,
-                );
+                break (logical_patch, None, 0, required_logical_error_rate, None);
             }
 
             // The required magic state error rate is computed by dividing the total
@@ -620,7 +691,7 @@ impl<
                         logical_patch,
                         Some(factory),
                         num_factories,
-                        required_logical_patch_error_rate,
+                        required_logical_error_rate,
                         Some(required_logical_magic_state_error_rate),
                     );
                 }
@@ -1189,9 +1260,10 @@ impl<
         self.num_logical_patches(patch) * patch.physical_qubits()
     }
 
-    /// Computes required logical error rate
+    /// Computes required logical error rate for a logical operation one one
+    /// qubit
     ///
-    /// The logical volume is the number of logical patches times the number of
+    /// The logical volume is the number of logical qubits times the number of
     /// cycles.  We obtain the required logical error rate by dividing the error
     /// budget for logical operations by the volume.
     fn required_logical_error_rate(&self, num_cycles: u64) -> f64 {

--- a/resource_estimator/src/system/data/report.rs
+++ b/resource_estimator/src/system/data/report.rs
@@ -71,7 +71,7 @@ impl Report {
 
         let mut entries = vec![];
         entries.push(ReportEntry::new("jobParams/qecScheme/name", "QEC scheme", r#"Name of QEC scheme"#, r#"You can load pre-defined QEC schemes by using the name `surface_code` or `floquet_code`. The latter only works with Majorana qubits."#));
-        entries.push(ReportEntry::new("logicalQubit/codeDistance", "Code distance", r#"Required code distance for error correction"#, &format!(r#"The code distance is the smallest odd integer greater or equal to $\dfrac{{2\log({} / {})}}{{\log({}/{})}} - 1$"#, job_params.qec_scheme().crossing_prefactor.expect("crossing prefactor should be set"), result.required_logical_patch_error_rate(), job_params.qec_scheme().error_correction_threshold.expect("error correction threshold should be set"), result.logical_patch().physical_qubit().clifford_error_rate())));
+        entries.push(ReportEntry::new("logicalQubit/codeDistance", "Code distance", r#"Required code distance for error correction"#, &format!(r#"The code distance is the smallest odd integer greater or equal to $\dfrac{{2\log({} / {})}}{{\log({}/{})}} - 1$"#, job_params.qec_scheme().crossing_prefactor.expect("crossing prefactor should be set"), result.required_logical_error_rate(), job_params.qec_scheme().error_correction_threshold.expect("error correction threshold should be set"), result.logical_patch().physical_qubit().clifford_error_rate())));
         entries.push(ReportEntry::new("physicalCountsFormatted/physicalQubitsPerLogicalQubit", "Physical qubits", r#"Number of physical qubits per logical qubit"#, &format!(r#"The number of physical qubits per logical qubit are evaluated using the formula {} that can be user-specified."#, job_params.qec_scheme().physical_qubits_per_logical_qubit.as_ref().expect("physical qubits per logical qubit should be set"))));
         entries.push(ReportEntry::new("physicalCountsFormatted/logicalCycleTime", "Logical cycle time", r#"Duration of a logical cycle in nanoseconds"#, &format!(r#"The runtime of one logical cycle in nanoseconds is evaluated using the formula {} that can be user-specified."#, job_params.qec_scheme().logical_cycle_time.as_ref().expect("logical cycle time should be set"))));
         entries.push(ReportEntry::new("physicalCountsFormatted/logicalErrorRate", "Logical qubit error rate", r#"Logical qubit error rate"#, &format!(r#"The logical qubit error rate is computed as ${} \cdot \left(\dfrac{{{}}}{{{}}}\right)^\frac{{{} + 1}}{{2}}$"#, job_params.qec_scheme().crossing_prefactor.expect("crossing prefactor should be set"), result.logical_patch().physical_qubit().clifford_error_rate(), job_params.qec_scheme().error_correction_threshold.expect("error correction threshold should be set"), result.logical_patch().code_parameter())));
@@ -391,7 +391,7 @@ impl FormattedPhysicalResourceCounts {
         );
 
         let required_logical_qubit_error_rate =
-            format!("{:.2e}", result.required_logical_patch_error_rate());
+            format!("{:.2e}", result.required_logical_error_rate());
 
         let no_tstates_msg = "No T states in algorithm";
         let no_rotations_msg = "No rotations in algorithm";

--- a/resource_estimator/src/system/data/result.rs
+++ b/resource_estimator/src/system/data/result.rs
@@ -175,7 +175,7 @@ fn create_physical_resource_counts_breakdown(
         num_tfactory_runs: result.num_factory_runs(),
         physical_qubits_for_tfactories: result.physical_qubits_for_factories(),
         physical_qubits_for_algorithm: result.physical_qubits_for_algorithm(),
-        required_logical_qubit_error_rate: result.required_logical_patch_error_rate(),
+        required_logical_qubit_error_rate: result.required_logical_error_rate(),
         required_logical_tstate_error_rate: result.required_logical_magic_state_error_rate(),
         num_ts_per_rotation,
         clifford_error_rate: result

--- a/resource_estimator/src/system/tests.rs
+++ b/resource_estimator/src/system/tests.rs
@@ -227,9 +227,7 @@ fn validate_result_invariants<L: Overhead>(
             * result.num_factories()
     );
 
-    assert!(
-        result.logical_patch().logical_error_rate() <= result.required_logical_patch_error_rate()
-    );
+    assert!(result.logical_patch().logical_error_rate() <= result.required_logical_error_rate());
 
     assert!(
         (result
@@ -591,9 +589,7 @@ pub fn test_chemistry_based_max_duration() -> Result<()> {
             * result.num_factories()
     );
 
-    assert!(
-        result.logical_patch().logical_error_rate() <= result.required_logical_patch_error_rate()
-    );
+    assert!(result.logical_patch().logical_error_rate() <= result.required_logical_error_rate());
 
     Ok(())
 }
@@ -653,9 +649,7 @@ pub fn test_chemistry_based_max_num_qubits() -> Result<()> {
             * result.num_factories()
     );
 
-    assert!(
-        result.logical_patch().logical_error_rate() <= result.required_logical_patch_error_rate()
-    );
+    assert!(result.logical_patch().logical_error_rate() <= result.required_logical_error_rate());
 
     Ok(())
 }


### PR DESCRIPTION
The required logical error rate is not correctly computed for logical patches which have more than one qubit. This PR fixes this. The problem had no impact on our system implementation for resource estimation, since it considers quantum error correction that encodes one logical qubit.