### PR TITLE
Put macOS back into PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,6 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-14]
-        is_pr:
-          - ${{ github.event_name == 'pull_request' }}
-        exclude:
-          - os: macos-14
-            is_pr: true
 
     runs-on: ${{matrix.os}}
 
@@ -114,11 +109,6 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-14]
-        is_pr:
-          - ${{ github.event_name == 'pull_request' }}
-        exclude:
-          - os: macos-14
-            is_pr: true
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
Now that we have mac-14 runners the performance and reliability seems high enough to start including them in PR builds again. This will help with verifying native code dependencies and build changes that are in flight.