### PR TITLE
Send OpenDocument telemetry event upon first opening of document

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -103,6 +103,21 @@ function registerDocumentUpdateHandlers(languageService: ILanguageService) {
     updateIfQsharpDocument(document);
   });
 
+  // we manually send an OpenDocument telemetry event if this is a Q# document, because the
+  // below subscriptions won't fire for documents that are already open when the extension is activated
+  vscode.workspace.textDocuments.forEach((document) => {
+    if (isQsharpDocument(document)) {
+      const documentType = isQsharpNotebookCell(document)
+        ? QsharpDocumentType.JupyterCell
+        : QsharpDocumentType.Qsharp;
+      sendTelemetryEvent(
+        EventType.OpenedDocument,
+        { documentType },
+        { linesOfCode: document.lineCount },
+      );
+    }
+  });
+
   const subscriptions = [];
   subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {


### PR DESCRIPTION
Closes #1253

We register subscriptions on first doc open, but that means we skip the telemetry event on first doc open, since the subscriptions aren't active yet.
