### PR TITLE
Local variable identifiers are incorrectly overridden in global scope used for fragments

### DIFF
--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -560,14 +560,18 @@ mod given_interpreter {
             is_only_value(&result, &output, &Value::unit());
             let (result, output) = line(&mut interpreter, "a");
             is_only_value(&result, &output, &Value::Int(1));
-            let (result, output) = line(&mut interpreter, "function B() : Unit {}");
+            let (result, output) = line(&mut interpreter, "function B() : Int { let inner_b = 3; inner_b }");
             is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "B()");
+            is_only_value(&result, &output, &Value::Int(3));
             let (result, output) = line(&mut interpreter, "let b = 2;");
             is_only_value(&result, &output, &Value::unit());
             let (result, output) = line(&mut interpreter, "b");
             is_only_value(&result, &output, &Value::Int(2));
             let (result, output) = line(&mut interpreter, "a");
             is_only_value(&result, &output, &Value::Int(1));
+            let (result, output) = line(&mut interpreter, "B()");
+            is_only_value(&result, &output, &Value::Int(3));
         }
 
         #[test]

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -547,6 +547,30 @@ mod given_interpreter {
         }
 
         #[test]
+        fn local_var_valid_after_item_definition() {
+            let mut interpreter = Interpreter::new(
+                true,
+                SourceMap::default(),
+                PackageType::Lib,
+                RuntimeCapabilityFlags::empty(),
+                LanguageFeatures::default(),
+            )
+            .expect("interpreter should be created");
+            let (result, output) = line(&mut interpreter, "let a = 1;");
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "a");
+            is_only_value(&result, &output, &Value::Int(1));
+            let (result, output) = line(&mut interpreter, "function B() : Unit {}");
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "let b = 2;");
+            is_only_value(&result, &output, &Value::unit());
+            let (result, output) = line(&mut interpreter, "b");
+            is_only_value(&result, &output, &Value::Int(2));
+            let (result, output) = line(&mut interpreter, "a");
+            is_only_value(&result, &output, &Value::Int(1));
+        }
+
+        #[test]
         fn normal_qirgen() {
             let mut interpreter = Interpreter::new(
                 true,

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -560,7 +560,10 @@ mod given_interpreter {
             is_only_value(&result, &output, &Value::unit());
             let (result, output) = line(&mut interpreter, "a");
             is_only_value(&result, &output, &Value::Int(1));
-            let (result, output) = line(&mut interpreter, "function B() : Int { let inner_b = 3; inner_b }");
+            let (result, output) = line(
+                &mut interpreter,
+                "function B() : Int { let inner_b = 3; inner_b }",
+            );
             is_only_value(&result, &output, &Value::unit());
             let (result, output) = line(&mut interpreter, "B()");
             is_only_value(&result, &output, &Value::Int(3));

--- a/compiler/qsc_eval/src/lower.rs
+++ b/compiler/qsc_eval/src/lower.rs
@@ -190,7 +190,7 @@ impl Lowerer {
         };
 
         self.assigner.reset_local();
-        // self.locals.clear();
+        self.locals.clear();
         for (k, v) in locals {
             self.locals.insert(k, v);
         }

--- a/compiler/qsc_eval/src/lower.rs
+++ b/compiler/qsc_eval/src/lower.rs
@@ -159,6 +159,9 @@ impl Lowerer {
     }
 
     fn lower_callable_decl(&mut self, decl: &hir::CallableDecl) -> fir::CallableDecl {
+        self.assigner.stash_local();
+        let locals = self.locals.drain().collect::<Vec<_>>();
+
         let id = self.lower_id(decl.id);
         let kind = lower_callable_kind(decl.kind);
         let name = self.lower_ident(&decl.name);
@@ -187,7 +190,10 @@ impl Lowerer {
         };
 
         self.assigner.reset_local();
-        self.locals.clear();
+        // self.locals.clear();
+        for (k, v) in locals {
+            self.locals.insert(k, v);
+        }
 
         fir::CallableDecl {
             id,

--- a/compiler/qsc_fir/src/assigner.rs
+++ b/compiler/qsc_fir/src/assigner.rs
@@ -11,6 +11,7 @@ pub struct Assigner {
     next_pat: PatId,
     next_stmt: StmtId,
     next_local: LocalVarId,
+    stashed_local: LocalVarId,
 }
 
 impl Assigner {
@@ -23,6 +24,7 @@ impl Assigner {
             next_pat: PatId::default(),
             next_stmt: StmtId::default(),
             next_local: LocalVarId::default(),
+            stashed_local: LocalVarId::default(),
         }
     }
 
@@ -62,8 +64,14 @@ impl Assigner {
         id
     }
 
-    pub fn reset_local(&mut self) {
+    pub fn stash_local(&mut self) {
+        self.stashed_local = self.next_local;
         self.next_local = LocalVarId::default();
+    }
+
+    pub fn reset_local(&mut self) {
+        self.next_local = self.stashed_local;
+        self.stashed_local = LocalVarId::default();
     }
 }
 

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -76,6 +76,12 @@ impl From<NodeId> for usize {
     }
 }
 
+impl From<usize> for NodeId {
+    fn from(value: usize) -> Self {
+        Self(value.try_into().expect("NodeId value should fit into u32"))
+    }
+}
+
 impl PartialEq for NodeId {
     fn eq(&self, other: &Self) -> bool {
         assert!(!self.is_default(), "default node ID should be replaced");


### PR DESCRIPTION
This fixes the logic on resetting local variable IDs to not lose global scope context, which ensures that variables defined at the global scope before an item defined in the global scope is still valid later in interpreter usage.

Fixes #1250