### PR TITLE
Fix "initializeruntime" telemetry error

### DIFF
--- a/vscode/src/debugger/session.ts
+++ b/vscode/src/debugger/session.ts
@@ -142,7 +142,13 @@ export class QscDebugSession extends LoggingDebugSession {
     }
     sendTelemetryEvent(
       EventType.InitializeRuntimeEnd,
-      { associationId, flowStatus: UserFlowStatus.Succeeded },
+      {
+        associationId,
+        flowStatus:
+          this.failureMessage === ""
+            ? UserFlowStatus.Succeeded
+            : UserFlowStatus.Failed,
+      },
       { timeToCompleteMs: performance.now() - start },
     );
   }


### PR DESCRIPTION
We are currently oversending initialize runtime end events. This was because 
we incorrectly updated the telemetry when the project system was added. So,
there are currently far more _End_ events than _Start_ events in our metrics.

This PR fixes that by only sending one _End_ event per initialization.
