### PR TITLE
Format on Document Range

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -39,7 +39,7 @@ import { initCodegen } from "./qirGeneration.js";
 import { createReferenceProvider } from "./references.js";
 import { createRenameProvider } from "./rename.js";
 import { createSignatureHelpProvider } from "./signature.js";
-import { createFormatProvider } from "./format.js";
+import { createFormattingProvider } from "./format.js";
 import { activateTargetProfileStatusBarItem } from "./statusbar.js";
 import {
   EventType,
@@ -185,14 +185,20 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
   // format document
   const isFormattingEnabled = getEnableFormating();
   const formatterHandle = {
-    handle: undefined as vscode.Disposable | undefined,
+    DocumentFormattingHandle: undefined as vscode.Disposable | undefined,
+    DocumentRangeFormattingHandle: undefined as vscode.Disposable | undefined,
   };
   log.debug("Enable formatting set to: " + isFormattingEnabled);
   if (isFormattingEnabled) {
-    formatterHandle.handle =
+    formatterHandle.DocumentFormattingHandle =
       vscode.languages.registerDocumentFormattingEditProvider(
         qsharpLanguageId,
-        createFormatProvider(languageService),
+        createFormattingProvider(languageService),
+      );
+    formatterHandle.DocumentRangeFormattingHandle =
+      vscode.languages.registerDocumentRangeFormattingEditProvider(
+        qsharpLanguageId,
+        createFormattingProvider(languageService),
       );
   }
 
@@ -290,13 +296,19 @@ async function updateLanguageServiceEnableFormatting(
   const isFormattingEnabled = getEnableFormating();
   log.debug("Enable formatting set to: " + isFormattingEnabled);
   if (isFormattingEnabled) {
-    formatterHandle.handle =
+    formatterHandle.DocumentFormattingHandle =
       vscode.languages.registerDocumentFormattingEditProvider(
         qsharpLanguageId,
-        createFormatProvider(languageService),
+        createFormattingProvider(languageService),
+      );
+    formatterHandle.DocumentRangeFormattingHandle =
+      vscode.languages.registerDocumentRangeFormattingEditProvider(
+        qsharpLanguageId,
+        createFormattingProvider(languageService),
       );
   } else {
-    formatterHandle.handle?.dispose();
+    formatterHandle.DocumentFormattingHandle?.dispose();
+    formatterHandle.DocumentRangeFormattingHandle?.dispose();
   }
 }
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -308,7 +308,9 @@ async function updateLanguageServiceEnableFormatting(
       );
   } else {
     formatterHandle.DocumentFormattingHandle?.dispose();
+    formatterHandle.DocumentFormattingHandle = undefined;
     formatterHandle.DocumentRangeFormattingHandle?.dispose();
+    formatterHandle.DocumentRangeFormattingHandle = undefined;
   }
 }
 

--- a/vscode/src/telemetry.ts
+++ b/vscode/src/telemetry.ts
@@ -209,7 +209,7 @@ type EventTypes = {
     measurements: { timeToCompleteMs: number };
   };
   [EventType.FormatStart]: {
-    properties: { associationId: string };
+    properties: { associationId: string; event: FormatEvent };
     measurements: Empty;
   };
   [EventType.FormatEnd]: {
@@ -235,6 +235,12 @@ export enum UserFlowStatus {
 export enum DebugEvent {
   StepIn = "StepIn",
   Continue = "Continue",
+}
+
+export enum FormatEvent {
+  OnDocument = "OnDocument",
+  OnRange = "OnRange",
+  OnType = "OnType",
 }
 
 let reporter: TelemetryReporter | undefined;

--- a/vscode/test/suites/language-service/language-service.test.ts
+++ b/vscode/test/suites/language-service/language-service.test.ts
@@ -108,6 +108,57 @@ suite("Q# Language Service Tests", function suite() {
     );
   });
 
+  test("Format Document", async () => {
+    await vscode.workspace.openTextDocument(docUri);
+
+    const actualFormatEdits = (await vscode.commands.executeCommand(
+      "vscode.executeFormatDocumentProvider",
+      docUri,
+    )) as vscode.TextEdit[];
+
+    assert.lengthOf(actualFormatEdits, 1);
+    assert.equal(actualFormatEdits[0].range.start.line, 7);
+    assert.equal(actualFormatEdits[0].range.start.character, 27);
+    assert.equal(actualFormatEdits[0].range.end.line, 8);
+    assert.equal(actualFormatEdits[0].range.end.character, 4);
+    assert.equal(actualFormatEdits[0].newText, "");
+  });
+
+  test("Format Document Range", async () => {
+    await vscode.workspace.openTextDocument(docUri);
+
+    const noEditRange = new vscode.Range(
+      new vscode.Position(7, 24),
+      new vscode.Position(7, 27),
+    );
+    const editRange = new vscode.Range(
+      new vscode.Position(7, 27),
+      new vscode.Position(8, 4),
+    );
+
+    let actualFormatEdits = (await vscode.commands.executeCommand(
+      "vscode.executeFormatRangeProvider",
+      docUri,
+      noEditRange,
+    )) as vscode.TextEdit[];
+
+    // assert that edits outside the range aren't returned
+    assert.isUndefined(actualFormatEdits);
+
+    actualFormatEdits = (await vscode.commands.executeCommand(
+      "vscode.executeFormatRangeProvider",
+      docUri,
+      editRange,
+    )) as vscode.TextEdit[];
+
+    assert.lengthOf(actualFormatEdits, 1);
+    assert.equal(actualFormatEdits[0].range.start.line, 7);
+    assert.equal(actualFormatEdits[0].range.start.character, 27);
+    assert.equal(actualFormatEdits[0].range.end.line, 8);
+    assert.equal(actualFormatEdits[0].range.end.character, 4);
+    assert.equal(actualFormatEdits[0].newText, "");
+  });
+
   test("Code Lens", async () => {
     const doc = await vscode.workspace.openTextDocument(docUri);
 


### PR DESCRIPTION
Enables the feature to format highlighted Q# code, rather than formatting the whole file.