### PR TITLE
Skip mimalloc on Windows aarch64

### DIFF
--- a/allocator/Cargo.toml
+++ b/allocator/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license.workspace = true
 version.workspace = true
 
-[dependencies]
+[target.'cfg(all(not(target_family = "wasm"), not(all(system = "windows", target_arch = "arm"))))'.dependencies]
 mimalloc-sys = { path = "./mimalloc-sys" }
 
 [lints]

--- a/allocator/Cargo.toml
+++ b/allocator/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license.workspace = true
 version.workspace = true
 
-[target.'cfg(all(not(target_family = "wasm"), not(all(system = "windows", target_arch = "arm"))))'.dependencies]
+[target.'cfg(all(not(target_family = "wasm"), not(all(system = "windows", target_arch = "aarch64"))))'.dependencies]
 mimalloc-sys = { path = "./mimalloc-sys" }
 
 [lints]

--- a/allocator/Cargo.toml
+++ b/allocator/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license.workspace = true
 version.workspace = true
 
-[target.'cfg(all(not(target_family = "wasm"), not(all(system = "windows", target_arch = "aarch64"))))'.dependencies]
+[target.'cfg(not(any(target_family = "wasm", all(target_family = "windows", target_arch = "aarch64"))))'.dependencies]
 mimalloc-sys = { path = "./mimalloc-sys" }
 
 [lints]

--- a/allocator/src/lib.rs
+++ b/allocator/src/lib.rs
@@ -3,7 +3,7 @@
 
 #[cfg(all(
     not(target_family = "wasm"),
-    not(all(system = "windows", target_arch = "arm"))
+    not(all(system = "windows", target_arch = "aarch64"))
 ))]
 pub mod mimalloc;
 
@@ -13,7 +13,7 @@ macro_rules! assign_global {
     () => {
         #[cfg(all(
             not(target_family = "wasm"),
-            not(all(system = "windows", target_arch = "arm"))
+            not(all(system = "windows", target_arch = "aarch64"))
         ))]
         #[global_allocator]
         static GLOBAL: allocator::mimalloc::Mimalloc = allocator::mimalloc::Mimalloc;

--- a/allocator/src/lib.rs
+++ b/allocator/src/lib.rs
@@ -1,20 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#[cfg(all(
-    not(target_family = "wasm"),
-    not(all(system = "windows", target_arch = "aarch64"))
-))]
+#[cfg(not(any(
+    target_family = "wasm",
+    all(target_family = "windows", target_arch = "aarch64")
+)))]
 pub mod mimalloc;
 
 /// Declare a global allocator if the platform supports it.
 #[macro_export]
 macro_rules! assign_global {
     () => {
-        #[cfg(all(
-            not(target_family = "wasm"),
-            not(all(system = "windows", target_arch = "aarch64"))
-        ))]
+        #[cfg(not(any(
+            target_family = "wasm",
+            all(target_family = "windows", target_arch = "aarch64")
+        )))]
         #[global_allocator]
         static GLOBAL: allocator::mimalloc::Mimalloc = allocator::mimalloc::Mimalloc;
     };

--- a/allocator/src/lib.rs
+++ b/allocator/src/lib.rs
@@ -1,14 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(all(system = "windows", target_arch = "arm"))
+))]
 pub mod mimalloc;
 
 /// Declare a global allocator if the platform supports it.
 #[macro_export]
 macro_rules! assign_global {
     () => {
-        #[cfg(not(target_family = "wasm"))]
+        #[cfg(all(
+            not(target_family = "wasm"),
+            not(all(system = "windows", target_arch = "arm"))
+        ))]
         #[global_allocator]
         static GLOBAL: allocator::mimalloc::Mimalloc = allocator::mimalloc::Mimalloc;
     };


### PR DESCRIPTION
This adjusts the conditional compilation to skip mimalloc only on Windows aarch64, where cross-compilation needs some extra help.