### PR TITLE
Use verbose flag when building wheels

### DIFF
--- a/build.py
+++ b/build.py
@@ -228,6 +228,7 @@ if build_pip:
         "wheel",
         "--wheel-dir",
         wheels_dir,
+        "-v",
         pip_src,
     ]
     subprocess.run(pip_build_args, check=True, text=True, cwd=pip_src, env=pip_env)


### PR DESCRIPTION
This adds the `-v` flag to the pip wheel command in the build script which will help with future diagnosability, expecially in the release pipeline. With this addition, the underlying Rust build for the Python wheel is displayed to console/log so we can confirm which components are being built on which platforms.