### PR TITLE
Add keywords to dynamic fields in pyproject

### DIFF
--- a/jupyterlab/pyproject.toml
+++ b/jupyterlab/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["description", "authors", "urls", "keywords"]
 source = "nodejs"
 
 [tool.hatch.metadata.hooks.nodejs]
-fields = ["description", "authors", "urls"]
+fields = ["description", "authors", "urls", "keywords"]
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["qsharp-jupyterlab/labextension"]


### PR DESCRIPTION
It's listed as 'dynamic' in line 27, so adding in line 33 to indicate it should come from the package.json.