### PR TITLE
Formatter Indentation and Delimiter Logic

### DIFF
--- a/compiler/qsc_formatter/src/formatter.rs
+++ b/compiler/qsc_formatter/src/formatter.rs
@@ -14,6 +14,84 @@ use qsc_frontend::{
 #[cfg(test)]
 mod tests;
 
+// Public functions
+
+/// Applies formatting rules to the give code str and returns
+/// the formatted string.
+pub fn format_str(code: &str) -> String {
+    let mut edits = calculate_format_edits(code);
+    edits.sort_by_key(|edit| edit.span.hi); // sort edits by their span's hi value from lowest to highest
+    edits.reverse(); // sort from highest to lowest so that that as edits are applied they don't invalidate later applications of edits
+    let mut new_code = String::from(code);
+
+    for edit in edits {
+        let range = (edit.span.lo as usize)..(edit.span.hi as usize);
+        new_code.replace_range(range, &edit.new_text);
+    }
+
+    new_code
+}
+
+/// Applies formatting rules to the given code str, generating edits where
+/// the source code needs to be changed to comply with the format rules.
+pub fn calculate_format_edits(code: &str) -> Vec<TextEdit> {
+    let tokens = concrete::ConcreteTokenIterator::new(code);
+    let mut edits = vec![];
+
+    let mut formatter = Formatter {
+        code,
+        indent_level: 0,
+        delim_newlines_stack: vec![],
+        type_param_state: TypeParameterListState::NoState,
+    };
+
+    // The sliding window used is over three adjacent tokens
+    #[allow(unused_assignments)]
+    let mut one = None;
+    let mut two = None;
+    let mut three = None;
+
+    for token in tokens {
+        // Advance the token window
+        one = two;
+        two = three;
+        three = Some(token);
+
+        let mut edits_for_triple = match (&one, &two, &three) {
+            (Some(one), Some(two), Some(three)) => {
+                if matches!(one.kind, ConcreteTokenKind::WhiteSpace) {
+                    // first token is whitespace, continue scanning
+                    continue;
+                } else if matches!(two.kind, ConcreteTokenKind::WhiteSpace) {
+                    // whitespace in the middle
+                    formatter.apply_rules(one, get_token_contents(code, two), three)
+                } else {
+                    // one, two are adjacent tokens with no whitespace in the middle
+                    formatter.apply_rules(one, "", two)
+                }
+            }
+            (None, None, Some(three)) => {
+                // Remove any whitespace at the start of a file
+                if matches!(three.kind, ConcreteTokenKind::WhiteSpace) {
+                    vec![TextEdit::new("", three.span.lo, three.span.hi)]
+                } else {
+                    vec![]
+                }
+            }
+            _ => {
+                // not enough tokens to apply a rule
+                continue;
+            }
+        };
+
+        edits.append(&mut edits_for_triple);
+    }
+
+    edits
+}
+
+// Public types
+
 #[derive(Debug)]
 pub struct TextEdit {
     pub new_text: String,
@@ -28,6 +106,8 @@ impl TextEdit {
         }
     }
 }
+
+// Private types
 
 /// This is to keep track of whether the formatter is currently
 /// processing a sequence with newline separators or single-space
@@ -63,442 +143,426 @@ enum TypeParameterListState {
     InTypeParamList,
 }
 
-struct FormatterState<'a> {
+/// Enum for a token's status as a delimiter.
+/// `<` and `>` are delimiters only with type-parameter lists,
+/// which is determined using the TypeParameterListState enum.
+#[derive(Clone, Copy)]
+enum Delimiter {
+    // The token is an open delimiter. i.e. `{`, `[`, `(`, and sometimes `<`.
+    Open,
+    // The token is a close delimiter. i.e. `}`, `]`, `)`, and sometimes `>`.
+    Close,
+    // The token is not a delimiter.
+    NonDelim,
+}
+
+impl Delimiter {
+    /// Constructs a Delimiter from a token, given the current type-parameter state.
+    fn from_concrete_toke_kind(
+        kind: &ConcreteTokenKind,
+        type_param_state: TypeParameterListState,
+    ) -> Delimiter {
+        match kind {
+            ConcreteTokenKind::Syntax(TokenKind::Open(_)) => Delimiter::Open,
+            ConcreteTokenKind::Syntax(TokenKind::Lt)
+                if matches!(type_param_state, TypeParameterListState::InTypeParamList) =>
+            {
+                Delimiter::Open
+            }
+            ConcreteTokenKind::Syntax(TokenKind::Close(_)) => Delimiter::Close,
+            ConcreteTokenKind::Syntax(TokenKind::Gt)
+                if matches!(type_param_state, TypeParameterListState::InTypeParamList) =>
+            {
+                Delimiter::Close
+            }
+            _ => Delimiter::NonDelim,
+        }
+    }
+}
+
+struct Formatter<'a> {
     code: &'a str,
     indent_level: usize,
     delim_newlines_stack: Vec<NewlineContext>,
     type_param_state: TypeParameterListState,
 }
 
+impl<'a> Formatter<'a> {
+    fn apply_rules(
+        &mut self,
+        left: &ConcreteToken,
+        whitespace: &str,
+        right: &ConcreteToken,
+    ) -> Vec<TextEdit> {
+        use qsc_frontend::keyword::Keyword;
+        use qsc_frontend::lex::cooked::ClosedBinOp;
+        use ConcreteTokenKind::*;
+        use TokenKind::*;
+
+        let mut edits = vec![];
+        // when we get here, neither left nor right should be whitespace
+
+        let are_newlines_in_spaces = whitespace.contains('\n');
+        let does_right_required_newline = matches!(&right.kind, Syntax(cooked_right) if is_newline_keyword_or_ampersat(cooked_right));
+
+        let (left_delim_state, right_delim_state) =
+            self.update_type_param_state(&left.kind, &right.kind);
+
+        let newline_context = self.update_indent_level(
+            left_delim_state,
+            right_delim_state,
+            are_newlines_in_spaces,
+            does_right_required_newline,
+            matches!(right.kind, Comment),
+        );
+
+        match (&left.kind, &right.kind) {
+            (Comment | Syntax(DocComment), _) => {
+                // remove whitespace at the ends of comments
+                effect_trim_comment(left, &mut edits, self.code);
+                effect_correct_indentation(left, whitespace, right, &mut edits, self.indent_level);
+            }
+            (_, Comment) if matches!(left_delim_state, Delimiter::Open) => {
+                effect_correct_indentation(left, whitespace, right, &mut edits, self.indent_level);
+            }
+            (_, Comment) => {
+                if are_newlines_in_spaces {
+                    effect_correct_indentation(
+                        left,
+                        whitespace,
+                        right,
+                        &mut edits,
+                        self.indent_level,
+                    );
+                }
+                // else do nothing, preserving the user's spaces before the comment
+            }
+            (Syntax(cooked_left), Syntax(cooked_right)) => match (cooked_left, cooked_right) {
+                (ClosedBinOp(ClosedBinOp::Minus), _) | (_, ClosedBinOp(ClosedBinOp::Minus)) => {
+                    // This case is used to ignore the spacing around a `-`.
+                    // This is done because we currently don't have the architecture
+                    // to be able to differentiate between the unary `-` and the binary `-`
+                    // which would have different spacing rules.
+                }
+                (Semi, _) if matches!(newline_context, NewlineContext::Spaces) => {
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                (Semi, _) => {
+                    effect_correct_indentation(
+                        left,
+                        whitespace,
+                        right,
+                        &mut edits,
+                        self.indent_level,
+                    );
+                }
+                (_, Semi) => {
+                    effect_no_space(left, whitespace, right, &mut edits);
+                }
+                (Open(l), Close(r)) if l == r => {
+                    // close empty delimiter blocks, i.e. (), [], {}
+                    effect_no_space(left, whitespace, right, &mut edits);
+                }
+                (Lt, Gt)
+                    if matches!(
+                        self.type_param_state,
+                        TypeParameterListState::InTypeParamList
+                    ) =>
+                {
+                    // close empty delimiter blocks <>
+                    effect_no_space(left, whitespace, right, &mut edits);
+                }
+                (_, _)
+                    if matches!(left_delim_state, Delimiter::Open)
+                        && matches!(newline_context, NewlineContext::Newlines) =>
+                {
+                    effect_correct_indentation(
+                        left,
+                        whitespace,
+                        right,
+                        &mut edits,
+                        self.indent_level,
+                    );
+                }
+                (Comma, _) if matches!(newline_context, NewlineContext::Newlines) => {
+                    effect_correct_indentation(
+                        left,
+                        whitespace,
+                        right,
+                        &mut edits,
+                        self.indent_level,
+                    );
+                }
+                (Comma, _) => {
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                (_, _)
+                    if matches!(right_delim_state, Delimiter::Close)
+                        && matches!(newline_context, NewlineContext::Newlines) =>
+                {
+                    effect_correct_indentation(
+                        left,
+                        whitespace,
+                        right,
+                        &mut edits,
+                        self.indent_level,
+                    );
+                }
+                (Open(Delim::Bracket | Delim::Paren), _)
+                | (_, Close(Delim::Bracket | Delim::Paren)) => {
+                    effect_no_space(left, whitespace, right, &mut edits);
+                }
+                (Lt, _) | (_, Gt)
+                    if matches!(
+                        self.type_param_state,
+                        TypeParameterListState::InTypeParamList
+                    ) =>
+                {
+                    effect_no_space(left, whitespace, right, &mut edits);
+                }
+                (Open(Delim::Brace), _) | (_, Close(Delim::Brace)) => {
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                (At, Ident) => {
+                    effect_no_space(left, whitespace, right, &mut edits);
+                }
+                (Keyword(Keyword::Internal), _) => {
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                (Keyword(Keyword::Adjoint), Keyword(Keyword::Controlled))
+                | (Keyword(Keyword::Controlled), Keyword(Keyword::Adjoint)) => {
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                (_, _) if does_right_required_newline => {
+                    effect_correct_indentation(
+                        left,
+                        whitespace,
+                        right,
+                        &mut edits,
+                        self.indent_level,
+                    );
+                }
+                (_, Keyword(Keyword::Until))
+                | (_, Keyword(Keyword::In))
+                | (_, Keyword(Keyword::As))
+                | (_, Keyword(Keyword::Elif))
+                | (_, Keyword(Keyword::Else))
+                | (_, Keyword(Keyword::Apply)) => {
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                (_, Keyword(Keyword::Auto))
+                | (_, Keyword(Keyword::Distribute))
+                | (_, Keyword(Keyword::Intrinsic))
+                | (_, Keyword(Keyword::Invert))
+                | (_, Keyword(Keyword::Slf)) => {
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                (_, _) if are_newlines_in_spaces => {
+                    effect_trim_whitespace(left, whitespace, right, &mut edits);
+                    // Ignore the rest of the cases if the user has a newline in the whitespace.
+                    // This is done because we don't currently have logic for determining when
+                    // lines are too long and require newlines, and we don't have logic
+                    // for determining what the correct indentation should be in these cases,
+                    // so we put this do-nothing case in to leave user code unchanged.
+                }
+                (String(StringToken::Interpolated(_, InterpolatedEnding::LBrace)), _)
+                | (_, String(StringToken::Interpolated(InterpolatedStart::RBrace, _))) => {
+                    effect_no_space(left, whitespace, right, &mut edits);
+                }
+                (_, Open(Delim::Brace)) => {
+                    // Special-case braces to always have a leading single space
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                (_, _) if matches!(right_delim_state, Delimiter::Open) => {
+                    // Otherwise, all open delims have the same logic
+                    if is_value_token_left(cooked_left, left_delim_state) || is_prefix(cooked_left)
+                    {
+                        // i.e. foo() or { foo }[3]
+                        effect_no_space(left, whitespace, right, &mut edits);
+                    } else {
+                        // i.e. let x = (1, 2, 3);
+                        effect_single_space(left, whitespace, right, &mut edits);
+                    }
+                }
+                (_, DotDotDot) => {
+                    if is_value_token_left(cooked_left, left_delim_state) {
+                        effect_no_space(left, whitespace, right, &mut edits);
+                    } else {
+                        effect_single_space(left, whitespace, right, &mut edits);
+                    }
+                }
+                (_, Keyword(Keyword::Is))
+                | (_, Keyword(Keyword::For))
+                | (_, Keyword(Keyword::While))
+                | (_, Keyword(Keyword::Repeat))
+                | (_, Keyword(Keyword::If))
+                | (_, Keyword(Keyword::Within))
+                | (_, Keyword(Keyword::Return))
+                | (_, Keyword(Keyword::Fail)) => {
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                (_, _) if is_value_token_right(cooked_right, right_delim_state) => {
+                    if is_prefix(cooked_left) {
+                        effect_no_space(left, whitespace, right, &mut edits);
+                    } else {
+                        effect_single_space(left, whitespace, right, &mut edits);
+                    }
+                }
+                (_, _) if is_suffix(cooked_right) => {
+                    effect_no_space(left, whitespace, right, &mut edits);
+                }
+                (_, _) if is_prefix_with_space(cooked_right) => {
+                    if is_prefix(cooked_left) {
+                        effect_no_space(left, whitespace, right, &mut edits);
+                    } else {
+                        effect_single_space(left, whitespace, right, &mut edits);
+                    }
+                }
+                (_, _) if is_prefix_without_space(cooked_right) => {
+                    effect_no_space(left, whitespace, right, &mut edits);
+                }
+                (_, _) if is_bin_op(cooked_right) => {
+                    effect_single_space(left, whitespace, right, &mut edits);
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+        edits
+    }
+
+    /// Updates the type_param_state of the FormatterState based
+    /// on the left and right token kinds. Returns the delimiter
+    /// state of the left and right tokens.
+    fn update_type_param_state(
+        &mut self,
+        left_kind: &ConcreteTokenKind,
+        right_kind: &ConcreteTokenKind,
+    ) -> (Delimiter, Delimiter) {
+        use qsc_frontend::keyword::Keyword;
+        use ConcreteTokenKind::*;
+        use TokenKind::*;
+
+        // Save the left token's status as a delimiter before updating the delimiter state
+        let left_delim_state = Delimiter::from_concrete_toke_kind(left_kind, self.type_param_state);
+
+        // If we are leaving a type param list, reset the state
+        if matches!(left_kind, Syntax(Gt))
+            && matches!(
+                self.type_param_state,
+                TypeParameterListState::InTypeParamList
+            )
+        {
+            self.type_param_state = TypeParameterListState::NoState
+        }
+
+        match right_kind {
+            Comment => {
+                // comments don't update state
+            }
+            Syntax(Keyword(Keyword::Operation | Keyword::Function)) => {
+                self.type_param_state = TypeParameterListState::SeenCallableKeyword;
+            }
+            Syntax(Ident)
+                if matches!(
+                    self.type_param_state,
+                    TypeParameterListState::SeenCallableKeyword
+                ) =>
+            {
+                self.type_param_state = TypeParameterListState::SeenCallableName;
+            }
+            Syntax(Lt)
+                if matches!(
+                    self.type_param_state,
+                    TypeParameterListState::SeenCallableName
+                ) =>
+            {
+                self.type_param_state = TypeParameterListState::InTypeParamList;
+            }
+            Syntax(AposIdent | Comma | Gt)
+                if matches!(
+                    self.type_param_state,
+                    TypeParameterListState::InTypeParamList
+                ) =>
+            {
+                // type param identifiers and commas don't take us out of the type parameter list context
+                // Gt only takes us out of the list once we are past it (it is the left-hand token)
+            }
+            _ => {
+                self.type_param_state = TypeParameterListState::NoState;
+            }
+        }
+
+        // Save the right token's status as a delimiter after updating the delimiter state
+        let right_delim_state =
+            Delimiter::from_concrete_toke_kind(right_kind, self.type_param_state);
+
+        (left_delim_state, right_delim_state)
+    }
+
+    /// Updates the indent level and manages the `delim_newlines_stack`
+    /// of the FormatterState.
+    /// Returns the current newline context.
+    fn update_indent_level(
+        &mut self,
+        left_delim_state: Delimiter,
+        right_delim_state: Delimiter,
+        are_newlines_in_spaces: bool,
+        does_right_required_newline: bool,
+        is_right_comment: bool,
+    ) -> NewlineContext {
+        let mut newline_context = self
+            .delim_newlines_stack
+            .last()
+            .map_or(NewlineContext::NoContext, |b| *b);
+
+        match (left_delim_state, right_delim_state) {
+            (Delimiter::Open, Delimiter::Close) => {
+                // Don't change the indentation if empty sequence.
+            }
+            (Delimiter::Open, _) if are_newlines_in_spaces => {
+                newline_context = NewlineContext::Newlines;
+                self.delim_newlines_stack.push(newline_context);
+                self.indent_level += 1;
+            }
+            (Delimiter::Open, _) if does_right_required_newline => {
+                newline_context = NewlineContext::Newlines;
+                self.delim_newlines_stack.push(newline_context);
+                self.indent_level += 1;
+            }
+            (Delimiter::Open, _) if is_right_comment => {
+                newline_context = NewlineContext::Newlines;
+                self.delim_newlines_stack.push(newline_context);
+                self.indent_level += 1;
+            }
+            (Delimiter::Open, _) => {
+                newline_context = NewlineContext::Spaces;
+                self.delim_newlines_stack.push(newline_context);
+            }
+            (_, Delimiter::Close) => {
+                self.delim_newlines_stack.pop();
+                if matches!(newline_context, NewlineContext::Newlines) {
+                    self.indent_level = self.indent_level.saturating_sub(1);
+                }
+            }
+            _ => {}
+        }
+
+        newline_context
+    }
+}
+
+// Helper Functions
+
 fn make_indent_string(level: usize) -> String {
     "    ".repeat(level)
 }
 
-/// Applies formatting rules to the give code str and returns
-/// the formatted string.
-pub fn format_str(code: &str) -> String {
-    let mut edits = calculate_format_edits(code);
-    edits.sort_by_key(|edit| edit.span.hi); // sort edits by their span's hi value from lowest to highest
-    edits.reverse(); // sort from highest to lowest so that that as edits are applied they don't invalidate later applications of edits
-    let mut new_code = String::from(code);
-
-    for edit in edits {
-        let range = (edit.span.lo as usize)..(edit.span.hi as usize);
-        new_code.replace_range(range, &edit.new_text);
-    }
-
-    new_code
+fn get_token_contents<'a>(code: &'a str, token: &ConcreteToken) -> &'a str {
+    &code[token.span.lo as usize..token.span.hi as usize]
 }
 
-/// Applies formatting rules to the given code str, generating edits where
-/// the source code needs to be changed to comply with the format rules.
-pub fn calculate_format_edits(code: &str) -> Vec<TextEdit> {
-    let tokens = concrete::ConcreteTokenIterator::new(code);
-    let mut edits = vec![];
-
-    let mut state = FormatterState {
-        code,
-        indent_level: 0,
-        delim_newlines_stack: vec![],
-        type_param_state: TypeParameterListState::NoState,
-    };
-
-    // The sliding window used is over three adjacent tokens
-    #[allow(unused_assignments)]
-    let mut one = None;
-    let mut two = None;
-    let mut three = None;
-
-    for token in tokens {
-        // Advance the token window
-        one = two;
-        two = three;
-        three = Some(token);
-
-        let mut edits_for_triple = match (&one, &two, &three) {
-            (Some(one), Some(two), Some(three)) => {
-                if matches!(one.kind, ConcreteTokenKind::WhiteSpace) {
-                    // first token is whitespace, continue scanning
-                    continue;
-                } else if matches!(two.kind, ConcreteTokenKind::WhiteSpace) {
-                    // whitespace in the middle
-                    apply_rules(one, get_token_contents(code, two), three, &mut state)
-                } else {
-                    // one, two are adjacent tokens with no whitespace in the middle
-                    apply_rules(one, "", two, &mut state)
-                }
-            }
-            (None, None, Some(three)) => {
-                // Remove any whitespace at the start of a file
-                if matches!(three.kind, ConcreteTokenKind::WhiteSpace) {
-                    vec![TextEdit::new("", three.span.lo, three.span.hi)]
-                } else {
-                    vec![]
-                }
-            }
-            _ => {
-                // not enough tokens to apply a rule
-                continue;
-            }
-        };
-
-        edits.append(&mut edits_for_triple);
-    }
-
-    edits
-}
-
-fn apply_rules(
-    left: &ConcreteToken,
-    whitespace: &str,
-    right: &ConcreteToken,
-    state: &mut FormatterState,
-) -> Vec<TextEdit> {
-    let mut edits = vec![];
-    // when we get here, neither left nor right should be whitespace
-
-    let are_newlines_in_spaces = whitespace.contains('\n');
-    let does_right_required_newline =
-        matches!(&right.kind, Syntax(cooked_right) if is_newline_keyword_or_ampersat(cooked_right));
-
-    use qsc_frontend::keyword::Keyword;
-    use qsc_frontend::lex::cooked::ClosedBinOp;
-    use ConcreteTokenKind::*;
-    use TokenKind::*;
-
-    let (left_delim_state, right_delim_state) =
-        update_type_param_state(&left.kind, &right.kind, state);
-
-    let newline_context = update_indent_level(
-        left_delim_state,
-        right_delim_state,
-        state,
-        are_newlines_in_spaces,
-        does_right_required_newline,
-        matches!(right.kind, Comment),
-    );
-
-    match (&left.kind, &right.kind) {
-        (Comment | Syntax(DocComment), _) => {
-            // remove whitespace at the ends of comments
-            effect_trim_comment(left, &mut edits, state.code);
-            effect_correct_indentation(left, whitespace, right, &mut edits, state.indent_level);
-        }
-        (_, Comment) if matches!(left_delim_state, Delimiter::Open) => {
-            effect_correct_indentation(left, whitespace, right, &mut edits, state.indent_level);
-        }
-        (_, Comment) => {
-            if are_newlines_in_spaces {
-                effect_correct_indentation(left, whitespace, right, &mut edits, state.indent_level);
-            }
-            // else do nothing, preserving the user's spaces before the comment
-        }
-        (Syntax(cooked_left), Syntax(cooked_right)) => match (cooked_left, cooked_right) {
-            (ClosedBinOp(ClosedBinOp::Minus), _) | (_, ClosedBinOp(ClosedBinOp::Minus)) => {
-                // This case is used to ignore the spacing around a `-`.
-                // This is done because we currently don't have the architecture
-                // to be able to differentiate between the unary `-` and the binary `-`
-                // which would have different spacing rules.
-            }
-            (Semi, _) if matches!(newline_context, NewlineContext::Spaces) => {
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            (Semi, _) => {
-                effect_correct_indentation(left, whitespace, right, &mut edits, state.indent_level);
-            }
-            (_, Semi) => {
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (Open(l), Close(r)) if l == r => {
-                // close empty delimiter blocks, i.e. (), [], {}
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (Lt, Gt)
-                if matches!(
-                    state.type_param_state,
-                    TypeParameterListState::InTypeParamList
-                ) =>
-            {
-                // close empty delimiter blocks <>
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (_, _)
-                if matches!(left_delim_state, Delimiter::Open)
-                    && matches!(newline_context, NewlineContext::Newlines) =>
-            {
-                effect_correct_indentation(left, whitespace, right, &mut edits, state.indent_level);
-            }
-            (Comma, _) if matches!(newline_context, NewlineContext::Newlines) => {
-                effect_correct_indentation(left, whitespace, right, &mut edits, state.indent_level);
-            }
-            (Comma, _) => {
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            (_, _)
-                if matches!(right_delim_state, Delimiter::Close)
-                    && matches!(newline_context, NewlineContext::Newlines) =>
-            {
-                effect_correct_indentation(left, whitespace, right, &mut edits, state.indent_level);
-            }
-            (Open(Delim::Bracket | Delim::Paren), _)
-            | (_, Close(Delim::Bracket | Delim::Paren)) => {
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (Lt, _) | (_, Gt)
-                if matches!(
-                    state.type_param_state,
-                    TypeParameterListState::InTypeParamList
-                ) =>
-            {
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (Open(Delim::Brace), _) | (_, Close(Delim::Brace)) => {
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            (At, Ident) => {
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (Keyword(Keyword::Internal), _) => {
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            (Keyword(Keyword::Adjoint), Keyword(Keyword::Controlled))
-            | (Keyword(Keyword::Controlled), Keyword(Keyword::Adjoint)) => {
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            (_, _) if does_right_required_newline => {
-                effect_correct_indentation(left, whitespace, right, &mut edits, state.indent_level);
-            }
-            (_, TokenKind::Keyword(Keyword::Until))
-            | (_, TokenKind::Keyword(Keyword::In))
-            | (_, TokenKind::Keyword(Keyword::As))
-            | (_, TokenKind::Keyword(Keyword::Elif))
-            | (_, TokenKind::Keyword(Keyword::Else))
-            | (_, TokenKind::Keyword(Keyword::Apply)) => {
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            (_, TokenKind::Keyword(Keyword::Auto))
-            | (_, TokenKind::Keyword(Keyword::Distribute))
-            | (_, TokenKind::Keyword(Keyword::Intrinsic))
-            | (_, TokenKind::Keyword(Keyword::Invert))
-            | (_, TokenKind::Keyword(Keyword::Slf)) => {
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            (_, _) if are_newlines_in_spaces => {
-                effect_trim_whitespace(left, whitespace, right, &mut edits);
-                // Ignore the rest of the cases if the user has a newline in the whitespace.
-                // This is done because we don't currently have logic for determining when
-                // lines are too long and require newlines, and we don't have logic
-                // for determining what the correct indentation should be in these cases,
-                // so we put this do-nothing case in to leave user code unchanged.
-            }
-            (String(StringToken::Interpolated(_, InterpolatedEnding::LBrace)), _)
-            | (_, String(StringToken::Interpolated(InterpolatedStart::RBrace, _))) => {
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (_, Open(Delim::Brace)) => {
-                // Special-case braces to always have a leading single space
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            (_, _) if matches!(right_delim_state, Delimiter::Open) => {
-                // Otherwise, all open delims have the same logic
-                if is_value_token_left(cooked_left, left_delim_state) || is_prefix(cooked_left) {
-                    // i.e. foo() or { foo }[3]
-                    effect_no_space(left, whitespace, right, &mut edits);
-                } else {
-                    // i.e. let x = (1, 2, 3);
-                    effect_single_space(left, whitespace, right, &mut edits);
-                }
-            }
-            (_, TokenKind::DotDotDot) => {
-                if is_value_token_left(cooked_left, left_delim_state) {
-                    effect_no_space(left, whitespace, right, &mut edits);
-                } else {
-                    effect_single_space(left, whitespace, right, &mut edits);
-                }
-            }
-            (_, TokenKind::Keyword(Keyword::Is))
-            | (_, TokenKind::Keyword(Keyword::For))
-            | (_, TokenKind::Keyword(Keyword::While))
-            | (_, TokenKind::Keyword(Keyword::Repeat))
-            | (_, TokenKind::Keyword(Keyword::If))
-            | (_, TokenKind::Keyword(Keyword::Within))
-            | (_, TokenKind::Keyword(Keyword::Return))
-            | (_, TokenKind::Keyword(Keyword::Fail)) => {
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            (_, _) if is_value_token_right(cooked_right, right_delim_state) => {
-                if is_prefix(cooked_left) {
-                    effect_no_space(left, whitespace, right, &mut edits);
-                } else {
-                    effect_single_space(left, whitespace, right, &mut edits);
-                }
-            }
-            (_, _) if is_suffix(cooked_right) => {
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (_, _) if is_prefix_with_space(cooked_right) => {
-                if is_prefix(cooked_left) {
-                    effect_no_space(left, whitespace, right, &mut edits);
-                } else {
-                    effect_single_space(left, whitespace, right, &mut edits);
-                }
-            }
-            (_, _) if is_prefix_without_space(cooked_right) => {
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (_, _) if is_bin_op(cooked_right) => {
-                effect_single_space(left, whitespace, right, &mut edits);
-            }
-            _ => {}
-        },
-        _ => {}
-    }
-    edits
-}
-
-#[derive(Clone, Copy)]
-enum Delimiter {
-    Open,
-    Close,
-    NonDelim,
-}
-
-fn to_delim_enum(kind: &ConcreteTokenKind, type_param_state: TypeParameterListState) -> Delimiter {
-    match kind {
-        ConcreteTokenKind::Syntax(TokenKind::Open(_)) => Delimiter::Open,
-        ConcreteTokenKind::Syntax(TokenKind::Lt)
-            if matches!(type_param_state, TypeParameterListState::InTypeParamList) =>
-        {
-            Delimiter::Open
-        }
-        ConcreteTokenKind::Syntax(TokenKind::Close(_)) => Delimiter::Close,
-        ConcreteTokenKind::Syntax(TokenKind::Gt)
-            if matches!(type_param_state, TypeParameterListState::InTypeParamList) =>
-        {
-            Delimiter::Close
-        }
-        _ => Delimiter::NonDelim,
-    }
-}
-
-/// Updates the type_param_state of the FormatterState based
-/// on the left and right token kinds. Returns the delimiter
-/// state of the left and right tokens.
-fn update_type_param_state(
-    left_kind: &ConcreteTokenKind,
-    right_kind: &ConcreteTokenKind,
-    state: &mut FormatterState,
-) -> (Delimiter, Delimiter) {
-    use qsc_frontend::keyword::Keyword;
-    use ConcreteTokenKind::*;
-    use TokenKind::*;
-
-    // Save the left token's status as a delimiter before updating the delimiter state
-    let left_delim_state = to_delim_enum(left_kind, state.type_param_state);
-
-    // If we are leaving a type param list, reset the state
-    if matches!(left_kind, Syntax(Gt))
-        && matches!(
-            state.type_param_state,
-            TypeParameterListState::InTypeParamList
-        )
-    {
-        state.type_param_state = TypeParameterListState::NoState
-    }
-
-    match right_kind {
-        Comment => {
-            // comments don't update state
-        }
-        Syntax(Keyword(Keyword::Operation | Keyword::Function)) => {
-            state.type_param_state = TypeParameterListState::SeenCallableKeyword;
-        }
-        Syntax(Ident)
-            if matches!(
-                state.type_param_state,
-                TypeParameterListState::SeenCallableKeyword
-            ) =>
-        {
-            state.type_param_state = TypeParameterListState::SeenCallableName;
-        }
-        Syntax(Lt)
-            if matches!(
-                state.type_param_state,
-                TypeParameterListState::SeenCallableName
-            ) =>
-        {
-            state.type_param_state = TypeParameterListState::InTypeParamList;
-        }
-        Syntax(AposIdent | Comma | Gt)
-            if matches!(
-                state.type_param_state,
-                TypeParameterListState::InTypeParamList
-            ) =>
-        {
-            // type param identifiers and commas don't take us out of the type parameter list context
-            // Gt only takes us out of the list once we are past it (it is the left-hand token)
-        }
-        _ => {
-            state.type_param_state = TypeParameterListState::NoState;
-        }
-    }
-
-    // Save the right token's status as a delimiter after updating the delimiter state
-    let right_delim_state = to_delim_enum(right_kind, state.type_param_state);
-
-    (left_delim_state, right_delim_state)
-}
-
-/// Updates the indent level and manages the `delim_newlines_stack`
-/// of the FormatterState.
-/// Returns the current newline context.
-fn update_indent_level(
-    left_delim_state: Delimiter,
-    right_delim_state: Delimiter,
-    state: &mut FormatterState,
-    are_newlines_in_spaces: bool,
-    does_right_required_newline: bool,
-    is_right_comment: bool,
-) -> NewlineContext {
-    let mut newline_context = state
-        .delim_newlines_stack
-        .last()
-        .map_or(NewlineContext::NoContext, |b| *b);
-
-    match (left_delim_state, right_delim_state) {
-        (Delimiter::Open, Delimiter::Close) => {
-            // Don't change the indentation if empty sequence.
-        }
-        (Delimiter::Open, _) if are_newlines_in_spaces => {
-            newline_context = NewlineContext::Newlines;
-            state.delim_newlines_stack.push(newline_context);
-            state.indent_level += 1;
-        }
-        (Delimiter::Open, _) if does_right_required_newline => {
-            newline_context = NewlineContext::Newlines;
-            state.delim_newlines_stack.push(newline_context);
-            state.indent_level += 1;
-        }
-        (Delimiter::Open, _) if is_right_comment => {
-            newline_context = NewlineContext::Newlines;
-            state.delim_newlines_stack.push(newline_context);
-            state.indent_level += 1;
-        }
-        (Delimiter::Open, _) => {
-            newline_context = NewlineContext::Spaces;
-            state.delim_newlines_stack.push(newline_context);
-        }
-        (_, Delimiter::Close) => {
-            state.delim_newlines_stack.pop();
-            if matches!(newline_context, NewlineContext::Newlines) {
-                state.indent_level = state.indent_level.saturating_sub(1);
-            }
-        }
-        _ => {}
-    }
-
-    newline_context
-}
+// Rule Conditions
 
 fn is_bin_op(cooked: &TokenKind) -> bool {
     matches!(
@@ -628,6 +692,8 @@ fn is_value_token_right(cooked: &TokenKind, delim_state: Delimiter) -> bool {
     }
 }
 
+// Rule Effects
+
 fn effect_no_space(
     left: &ConcreteToken,
     whitespace: &str,
@@ -716,8 +782,4 @@ fn effect_correct_indentation(
             right.span.lo,
         ));
     }
-}
-
-fn get_token_contents<'a>(code: &'a str, token: &ConcreteToken) -> &'a str {
-    &code[token.span.lo as usize..token.span.hi as usize]
 }

--- a/compiler/qsc_formatter/src/formatter.rs
+++ b/compiler/qsc_formatter/src/formatter.rs
@@ -227,6 +227,13 @@ fn apply_rules(
             (_, Close(_)) if matches!(newline_context, NewlineContext::Newlines) => {
                 effect_correct_indentation(left, whitespace, right, &mut edits, *indent_level);
             }
+            (Open(Delim::Bracket | Delim::Paren), _)
+            | (_, Close(Delim::Bracket | Delim::Paren)) => {
+                effect_no_space(left, whitespace, right, &mut edits);
+            }
+            (Open(Delim::Brace), _) | (_, Close(Delim::Brace)) => {
+                effect_single_space(left, whitespace, right, &mut edits);
+            }
             (At, Ident) => {
                 effect_no_space(left, whitespace, right, &mut edits);
             }
@@ -266,13 +273,6 @@ fn apply_rules(
             (String(StringToken::Interpolated(_, InterpolatedEnding::LBrace)), _)
             | (_, String(StringToken::Interpolated(InterpolatedStart::RBrace, _))) => {
                 effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (Open(Delim::Bracket | Delim::Paren), _)
-            | (_, Close(Delim::Bracket | Delim::Paren)) => {
-                effect_no_space(left, whitespace, right, &mut edits);
-            }
-            (Open(Delim::Brace), _) | (_, Close(Delim::Brace)) => {
-                effect_single_space(left, whitespace, right, &mut edits);
             }
             (_, Open(Delim::Bracket | Delim::Paren)) => {
                 if is_value_token_left(cooked_left) || is_prefix(cooked_left) {

--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -723,6 +723,127 @@ fn delimiter_comments() {
 }
 
 #[test]
+fn brace_no_newlines() {
+    check(
+        indoc! {r#"
+        { Foo();
+            Bar(); Baz()
+        }
+    "#},
+        &expect![[r#"
+            { Foo(); Bar(); Baz() }
+        "#]],
+    );
+}
+
+#[test]
+fn brace_newlines() {
+    check(
+        indoc! {r#"
+        {
+            Foo(); Bar(); Baz() }
+    "#},
+        &expect![[r#"
+            {
+                Foo();
+                Bar();
+                Baz()
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn parens_no_newlines() {
+    check(
+        indoc! {r#"
+        ( Foo(),
+            Bar(), Baz()
+        )
+    "#},
+        &expect![[r#"
+            (Foo(), Bar(), Baz())
+        "#]],
+    );
+}
+
+#[test]
+fn parens_newlines() {
+    check(
+        indoc! {r#"
+        (
+            Foo(), Bar(), Baz() )
+    "#},
+        &expect![[r#"
+            (
+                Foo(),
+                Bar(),
+                Baz()
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn bracket_no_newlines() {
+    check(
+        indoc! {r#"
+        [ Foo(),
+            Bar(), Baz()
+        ]
+    "#},
+        &expect![[r#"
+            [Foo(), Bar(), Baz()]
+        "#]],
+    );
+}
+
+#[test]
+fn bracket_newlines() {
+    check(
+        indoc! {r#"
+        [
+            Foo(), Bar(), Baz() ]
+    "#},
+        &expect![[r#"
+            [
+                Foo(),
+                Bar(),
+                Baz()
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn semi_no_context_uses_newlines() {
+    check(
+        indoc! {r#"
+        Foo(); Bar(); Baz()
+    "#},
+        &expect![[r#"
+            Foo();
+            Bar();
+            Baz()
+        "#]],
+    );
+}
+
+#[test]
+fn comma_no_context_uses_space() {
+    check(
+        indoc! {r#"
+        Foo(),
+        Bar(),
+        Baz()
+    "#},
+        &expect![[r#"
+            Foo(), Bar(), Baz()
+        "#]],
+    );
+}
+
+#[test]
 fn test() {
     check(
         indoc! {r#"

--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -65,7 +65,8 @@ fn namespace_items_begin_on_their_own_lines() {
 #[test]
 fn functor_specs_begin_on_their_own_lines() {
     check(
-        "operation Foo() : Unit { body ... {} adjoint ... {} controlled (c, ...) {} controlled adjoint (c, ...) {} }",
+        "operation Foo() : Unit { body ... {} adjoint ... {} controlled (c, ...) {} controlled adjoint (c, ...) {}
+        }",
         &expect![[r#"
             operation Foo() : Unit {
                 body ... {}
@@ -520,13 +521,11 @@ fn single_space_before_open_brace_and_newline_after() {
                 let x = 3;
             }
             operation Bar() : Unit
-            {
-                {
-                    let x = 3;
-                } {
-                    let x = 4;
-                }
-            }
+            { {
+                let x = 3;
+            } {
+                let x = 4;
+            } }
         "#]],
     );
 }
@@ -605,8 +604,8 @@ fn single_space_before_literals() {
 #[test]
 fn single_space_before_types() {
     check(
-        "let x :   (Int,   Double,    String[],  (BigInt,  Unit),   ('T,)) =>   'T = foo;",
-        &expect![[r#"let x : (Int, Double, String[], (BigInt, Unit), ('T,)) => 'T = foo;"#]],
+        "let x :   (Int,   Double,    String[],  (BigInt,  Unit),   ('T, )) =>   'T = foo;",
+        &expect![[r#"let x : (Int, Double, String[], (BigInt, Unit), ('T, )) => 'T = foo;"#]],
     );
 }
 
@@ -682,6 +681,86 @@ fn formatting_corrects_indentation() {
                     return 5;
                 }
             }
+        "#]],
+    );
+}
+
+#[test]
+fn nested_delimiter_indentation() {
+    check(
+        indoc! {r#"
+        let x = [
+            (1)
+        ];
+            let y = 3;
+    "#},
+        &expect![[r#"
+            let x = [
+                (1)
+            ];
+            let y = 3;
+        "#]],
+    );
+}
+
+#[test]
+fn delimiter_comments() {
+    check(
+        indoc! {r#"
+        let x = [ // this is a comment
+            (1)
+        ];
+            let y = 3;
+    "#},
+        &expect![[r#"
+            let x = [
+                // this is a comment
+                (1)
+            ];
+            let y = 3;
+    "#]],
+    );
+}
+
+#[test]
+fn test() {
+    check(
+        indoc! {r#"
+        (
+            first, second)
+    "#},
+        &expect![[r#"
+            (
+                first,
+                second
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn delimiter_newlines_indentation() {
+    check(
+        r#"
+        let x = [ a,  b,  c ];
+        let y = [   a,
+            b,  c ];
+        let z = [
+
+
+            a,  b, c
+        ];
+"#,
+        &expect![[r#"
+            let x = [a, b, c];
+            let y = [a, b, c];
+            let z = [
+
+
+                a,
+                b,
+                c
+            ];
         "#]],
     );
 }

--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -643,7 +643,7 @@ fn formatter_does_not_crash_on_non_terminating_string() {
     super::calculate_format_edits("let x = \"Hello World");
 }
 
-// Correct indentation, which increases by four spaces when a brace-delimited block is opened and decreases when block is closed
+// Correct indentation, which increases by four spaces when a delimited block is opened and decreases when block is closed
 
 #[test]
 fn formatting_corrects_indentation() {
@@ -844,39 +844,25 @@ fn comma_no_context_uses_space() {
 }
 
 #[test]
-fn test() {
+fn type_param_lists_have_no_spaces_around_delims() {
     check(
         indoc! {r#"
         {
-            operation DrawMany<'TInput, 'TOutput>(op : ('TInput => 'TOutput), nSamples : Int, input : 'TInput) : 'TOutput[] {
-                mutable outputs = [];
-                for _ in 1 .. nSamples {
-                    set outputs += [op(input)];
-                }
-                outputs
-            }
+            operation Foo < 'A,
+            'B,   'C > (a : 'A, b : 'B, c : 'C) : Unit {}
         }
     "#},
         &expect![[r#"
-        {
-            operation DrawMany<'TInput, 'TOutput>(op : ('TInput => 'TOutput), nSamples : Int, input : 'TInput) : 'TOutput[] {
-                mutable outputs = [];
-                for _ in 1..nSamples {
-                    set outputs += [op(input)];
-                }
-                outputs
+            {
+                operation Foo<'A, 'B, 'C>(a : 'A, b : 'B, c : 'C) : Unit {}
             }
-        }
         "#]],
     );
 }
 
 #[test]
-fn test2() {
-    check(
-        indoc! {r#"1 > 0"#},
-        &expect!["1 > 0"],
-    )
+fn greater_than_and_less_than_bin_ops_have_spaces() {
+    check(indoc! {r#"x<y>z;"#}, &expect!["x < y > z;"])
 }
 
 #[test]
@@ -919,11 +905,6 @@ fn preserve_string_indentation() {
 #[test]
 fn preserve_user_newlines_in_expressions() {
     let input = indoc! {r#"
-        let x = [
-            thing1,
-            thing2,
-            thing3,
-        ];
         let y = 1 + 2 + 3 + 4 + 5 +
                 6 + 7 + 8 + 9 + 10;
         "#};

--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -847,16 +847,36 @@ fn comma_no_context_uses_space() {
 fn test() {
     check(
         indoc! {r#"
-        (
-            first, second)
+        {
+            operation DrawMany<'TInput, 'TOutput>(op : ('TInput => 'TOutput), nSamples : Int, input : 'TInput) : 'TOutput[] {
+                mutable outputs = [];
+                for _ in 1 .. nSamples {
+                    set outputs += [op(input)];
+                }
+                outputs
+            }
+        }
     "#},
         &expect![[r#"
-            (
-                first,
-                second
-            )
+        {
+            operation DrawMany<'TInput, 'TOutput>(op : ('TInput => 'TOutput), nSamples : Int, input : 'TInput) : 'TOutput[] {
+                mutable outputs = [];
+                for _ in 1..nSamples {
+                    set outputs += [op(input)];
+                }
+                outputs
+            }
+        }
         "#]],
     );
+}
+
+#[test]
+fn test2() {
+    check(
+        indoc! {r#"1 > 0"#},
+        &expect!["1 > 0"],
+    )
 }
 
 #[test]


### PR DESCRIPTION
Added some state to the formatter for the purposes of better handling of delimiters, i.e. `[]`, `()`, `{}`, and type parameter list delimiters `<>`. The formatting of delimited blocks will be determined by whether there is a newline in the whitespace following the open delimiter.
 - If there is a newline, then the indentation is increased for the length of the block, and separators, i.e. ',' and ';', require newlines after them, with the closing delimiter having a newline in front of it.
 - If there are no newlines, then delimiters have no spacing after the opening and before the closing delimiters, except the brace delimiters which have a singe space instead, and separators require a single space after them.