### PR TITLE
Mark qubit value kind as dynamic when allocated within a dynamic scope

### DIFF
--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -313,14 +313,6 @@ impl<'a> Analyzer<'a> {
 
             // If the call expression type is either a result or a qubit, it uses dynamic allocation runtime features.
             if let Ty::Prim(Prim::Qubit) = expr_type {
-                compute_kind = compute_kind.aggregate_runtime_features(
-                    ComputeKind::new_with_runtime_features(
-                        RuntimeFeatureFlags::DynamicQubitAllocation,
-                        default_value_kind,
-                    ),
-                    default_value_kind,
-                );
-
                 // We consider this qubit dynamic so the value kind of this expression must be dynamic.
                 let ComputeKind::Quantum(quantum_properties) = &mut compute_kind else {
                     panic!("compute kind is expected to be of the quantum variant");

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -740,18 +740,16 @@ bitflags! {
         const CallToUnresolvedCallee = 1 << 16;
         /// Forward branching on dynamic value.
         const ForwardBranchingOnDynamicValue = 1 << 17;
-        /// Qubit allocation that happens within a dynamic scope.
-        const DynamicQubitAllocation = 1 << 18;
         /// Result allocation that happens within a dynamic scope.
-        const DynamicResultAllocation = 1 << 19;
+        const DynamicResultAllocation = 1 << 18;
         /// Use of a dynamic index to access or update an array.
-        const UseOfDynamicIndex = 1 << 20;
+        const UseOfDynamicIndex = 1 << 19;
         /// A return expression withing a dynamic scope.
-        const ReturnWithinDynamicScope = 1 << 21;
+        const ReturnWithinDynamicScope = 1 << 20;
         /// A loop with a dynamic condition.
-        const LoopWithDynamicCondition = 1 << 22;
+        const LoopWithDynamicCondition = 1 << 21;
         /// Use of a closure.
-        const UseOfClosure = 1 << 23;
+        const UseOfClosure = 1 << 22;
     }
 }
 
@@ -829,9 +827,6 @@ impl RuntimeFeatureFlags {
         }
         if self.contains(RuntimeFeatureFlags::ForwardBranchingOnDynamicValue) {
             runtume_capabilities |= RuntimeCapabilityFlags::ForwardBranching;
-        }
-        if self.contains(RuntimeFeatureFlags::DynamicQubitAllocation) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::DynamicResultAllocation) {
             runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;

--- a/compiler/qsc_rca/tests/qubits.rs
+++ b/compiler/qsc_rca/tests/qubits.rs
@@ -57,7 +57,7 @@ fn check_rca_for_dynamic_single_qubit_allcation() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ForwardBranchingOnDynamicValue | DynamicQubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit | ForwardBranchingOnDynamicValue | DynamicQubitAllocation)
                         value_kind: Element(Static)
                     dynamic_param_applications: <empty>
                 adj: <none>

--- a/compiler/qsc_rca/tests/qubits.rs
+++ b/compiler/qsc_rca/tests/qubits.rs
@@ -57,7 +57,7 @@ fn check_rca_for_dynamic_single_qubit_allcation() {
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit | ForwardBranchingOnDynamicValue | DynamicQubitAllocation)
+                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit | ForwardBranchingOnDynamicValue)
                         value_kind: Element(Static)
                     dynamic_param_applications: <empty>
                 adj: <none>
@@ -106,7 +106,7 @@ fn check_rca_for_dynamic_multi_qubit_allcation() {
             r#"
             ApplicationsGeneratorSet:
                 inherent: Quantum: QuantumProperties:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicQubit | UseOfDynamicallySizedArray | ForwardBranchingOnDynamicValue | DynamicQubitAllocation | LoopWithDynamicCondition)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicQubit | UseOfDynamicallySizedArray | ForwardBranchingOnDynamicValue | LoopWithDynamicCondition)
                     value_kind: Array(Content: Dynamic, Size: Dynamic)
                 dynamic_param_applications: <empty>"#
         ],


### PR DESCRIPTION
When a qubit is allocated within a dynamic scope, its value kind should be dynamic. This change fixes this and removes the redundant "dynamic qubit allocation" runtime feature.