### PR TITLE
Fixes Magic Getting Erased by Format in Notebooks

### DIFF
--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -965,6 +965,43 @@ fn format_with_crlf() {
 }
 
 #[test]
+fn format_does_not_edit_magic_comment() {
+    let content = indoc! {"\r\n\r\n    //qsharp    \r\n\r\noperation Foo() : Unit {\r\n\r\n}\r\n"};
+    check_edits(
+        content,
+        &expect![[r#"
+            [
+                TextEdit {
+                    new_text: "",
+                    span: Span {
+                        lo: 0,
+                        hi: 8,
+                    },
+                },
+                TextEdit {
+                    new_text: "//qsharp",
+                    span: Span {
+                        lo: 8,
+                        hi: 20,
+                    },
+                },
+                TextEdit {
+                    new_text: "",
+                    span: Span {
+                        lo: 48,
+                        hi: 52,
+                    },
+                },
+            ]
+        "#]],
+    );
+    check(
+        content,
+        &expect![["//qsharp\r\n\r\noperation Foo() : Unit {}\r\n"]],
+    );
+}
+
+#[test]
 fn sample_has_no_formatting_changes() {
     let input = indoc! {r#"
         /// # Sample

--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -960,11 +960,7 @@ fn format_with_crlf() {
     );
     check(
         content,
-        &expect![[r#"
-            //qsharp
-
-            operation Foo() : Unit {}
-        "#]],
+        &expect![["//qsharp\r\n\r\noperation Foo() : Unit {}\r\n"]],
     );
 }
 

--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -9,6 +9,11 @@ fn check(input: &str, expect: &Expect) {
     expect.assert_eq(&actual);
 }
 
+fn check_edits(input: &str, expect: &Expect) {
+    let actual = super::calculate_format_edits(input);
+    expect.assert_debug_eq(&actual);
+}
+
 // Removing trailing whitespace from lines
 
 #[test]
@@ -934,6 +939,33 @@ fn preserve_comments_at_start_of_file() {
         namespace Foo {}"#};
 
     assert!(super::calculate_format_edits(input).is_empty());
+}
+
+#[test]
+fn format_with_crlf() {
+    let content = indoc! {"//qsharp\r\n\r\noperation Foo() : Unit {\r\n\r\n}\r\n"};
+    check_edits(
+        content,
+        &expect![[r#"
+            [
+                TextEdit {
+                    new_text: "",
+                    span: Span {
+                        lo: 36,
+                        hi: 40,
+                    },
+                },
+            ]
+        "#]],
+    );
+    check(
+        content,
+        &expect![[r#"
+            //qsharp
+
+            operation Foo() : Unit {}
+        "#]],
+    );
 }
 
 #[test]

--- a/compiler/qsc_parse/src/lex/raw.rs
+++ b/compiler/qsc_parse/src/lex/raw.rs
@@ -233,7 +233,7 @@ impl<'a> Lexer<'a> {
                 CommentKind::Normal
             };
 
-            self.eat_while(|c| c != '\n');
+            self.eat_while(|c| c != '\n' && c != '\r');
             Some(kind)
         } else {
             None


### PR DESCRIPTION
This was caused by two different bugs that are addressed in this PR:
 - When the input Q# uses `\r\n` line endings, the raw token lexer would only consider the `\n` line ending, resulting in comment tokens with trailing `\r` characters in them.
 - In the notebooks, when there were newlines prior to the magic command, the offsets were not mapped correctly.

In order to preserve the magic command in the notebooks from getting removed as leading whitespace in a file (a formatter rule), the magic command is replaced by a comment instead of whitespace.

Fixes #1308 