### PR TITLE
Codegen for basic branching on measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,7 @@ name = "qsc_rir"
 version = "0.0.0"
 dependencies = [
  "qsc_data_structures",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -166,8 +166,8 @@ impl ToQir<String> for rir::Callable {
             return format!(
                 "declare {output_type} @{}({input_type}){}",
                 self.name,
-                if self.name == "__quantum__qis__mz__body" {
-                    // The mz callable is a special case that needs the irreversable attribute.
+                if self.is_measurement {
+                    // Measurement callables are a special case that needs the irreversable attribute.
                     " #1"
                 } else {
                     ""

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -162,10 +162,10 @@ impl ToQir<String> for rir::Callable {
             .collect::<Vec<_>>()
             .join(", ");
         let output_type = ToQir::<String>::to_qir(&self.output_type, program);
-        let signature = format!("{} @{}({})", output_type, self.name, input_type);
         let Some(entry_id) = self.body else {
             return format!(
-                "declare {signature}{}",
+                "declare {output_type} @{}({input_type}){}",
+                self.name,
                 if self.name == "__quantum__qis__mz__body" {
                     // The mz callable is a special case that needs the irreversable attribute.
                     " #1"
@@ -184,7 +184,11 @@ impl ToQir<String> for rir::Callable {
                 ToQir::<String>::to_qir(block, program)
             ));
         }
-        format!("define {signature} #0 {{\n{body}}}",)
+        assert!(
+            input_type.is_empty(),
+            "entry point should not have an input"
+        );
+        format!("define {output_type} @ENTRYPOINT__main() #0 {{\n{body}}}",)
     }
 }
 

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -6,7 +6,7 @@ mod rir_builder;
 #[cfg(test)]
 mod tests;
 
-use qsc_rir::rir;
+use qsc_rir::{rir, utils::get_all_block_successors};
 
 /// A trait for converting a type into QIR of type `T`.
 /// This can be used to generate QIR strings or other representations.
@@ -86,22 +86,41 @@ impl ToQir<String> for rir::Instruction {
     fn to_qir(&self, program: &rir::Program) -> String {
         match self {
             rir::Instruction::Store(_, _) => unimplemented!("store should be removed by pass"),
-            rir::Instruction::Call(call_id, args) => {
+            rir::Instruction::Call(call_id, args, output) => {
                 let args = args
                     .iter()
                     .map(|arg| ToQir::<String>::to_qir(arg, program))
                     .collect::<Vec<_>>()
                     .join(", ");
                 let callable = program.get_callable(*call_id);
+                if let Some(output) = output {
+                    format!(
+                        "  {} = call {} @{}({})",
+                        ToQir::<String>::to_qir(&output.variable_id, program),
+                        ToQir::<String>::to_qir(&callable.output_type, program),
+                        callable.name,
+                        args
+                    )
+                } else {
+                    format!(
+                        "  call {} @{}({})",
+                        ToQir::<String>::to_qir(&callable.output_type, program),
+                        callable.name,
+                        args
+                    )
+                }
+            }
+            rir::Instruction::Jump(block_id) => {
+                format!("  br label %{}", ToQir::<String>::to_qir(block_id, program))
+            }
+            rir::Instruction::Branch(cond, true_id, false_id) => {
                 format!(
-                    "  call {} @{}({})",
-                    ToQir::<String>::to_qir(&callable.output_type, program),
-                    callable.name,
-                    args
+                    "  br {}, label %{}, label %{}",
+                    ToQir::<String>::to_qir(cond, program),
+                    ToQir::<String>::to_qir(true_id, program),
+                    ToQir::<String>::to_qir(false_id, program)
                 )
             }
-            rir::Instruction::Jump(_) => todo!(),
-            rir::Instruction::Branch(_, _, _) => todo!(),
             rir::Instruction::Add(_, _, _) => todo!(),
             rir::Instruction::Sub(_, _, _) => todo!(),
             rir::Instruction::Mul(_, _, _) => todo!(),
@@ -115,6 +134,22 @@ impl ToQir<String> for rir::Instruction {
             rir::Instruction::BitwiseXor(_, _, _) => todo!(),
             rir::Instruction::Return => "  ret void".to_string(),
         }
+    }
+}
+
+impl ToQir<String> for rir::BlockId {
+    fn to_qir(&self, _program: &rir::Program) -> String {
+        format!("block_{}", self.0)
+    }
+}
+
+impl ToQir<String> for rir::Block {
+    fn to_qir(&self, program: &rir::Program) -> String {
+        self.0
+            .iter()
+            .map(|instr| ToQir::<String>::to_qir(instr, program))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }
 
@@ -139,18 +174,17 @@ impl ToQir<String> for rir::Callable {
                 }
             );
         };
-        // For now, assume a single block.
-        let block = program.get_block(entry_id);
-        let body = block
-            .0
-            .iter()
-            .map(|instr| ToQir::<String>::to_qir(instr, program))
-            .collect::<Vec<_>>()
-            .join("\n");
-        format!(
-            "define {signature} #0 {{\nblock_{}:\n{body}\n}}",
-            entry_id.0
-        )
+        let mut body = String::new();
+        let all_blocks = get_all_block_successors(entry_id, program);
+        for block_id in all_blocks {
+            let block = program.get_block(block_id);
+            body.push_str(&format!(
+                "{}:\n{}\n",
+                ToQir::<String>::to_qir(&block_id, program),
+                ToQir::<String>::to_qir(block, program)
+            ));
+        }
+        format!("define {signature} #0 {{\n{body}}}",)
     }
 }
 

--- a/compiler/qsc_codegen/src/qir/rir_builder.rs
+++ b/compiler/qsc_codegen/src/qir/rir_builder.rs
@@ -12,6 +12,15 @@ pub fn x_decl() -> rir::Callable {
     }
 }
 
+pub fn z_decl() -> rir::Callable {
+    rir::Callable {
+        name: "__quantum__qis__z__body".to_string(),
+        input_type: vec![rir::Ty::Qubit],
+        output_type: None,
+        body: None,
+    }
+}
+
 pub fn h_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__qis__h__body".to_string(),
@@ -48,9 +57,18 @@ pub fn mz_decl() -> rir::Callable {
     }
 }
 
+pub fn mresetz_decl() -> rir::Callable {
+    rir::Callable {
+        name: "__quantum__qis__mresetz__body".to_string(),
+        input_type: vec![rir::Ty::Qubit, rir::Ty::Result],
+        output_type: None,
+        body: None,
+    }
+}
+
 pub fn read_result_decl() -> rir::Callable {
     rir::Callable {
-        name: "__quantum__rt__read_result".to_string(),
+        name: "__quantum__qis__read_result__body".to_string(),
         input_type: vec![rir::Ty::Result],
         output_type: Some(rir::Ty::Boolean),
         body: None,
@@ -101,6 +119,7 @@ pub fn bell_program() -> rir::Program {
             rir::Instruction::Call(
                 rir::CallableId(0),
                 vec![rir::Value::Literal(rir::Literal::Qubit(0))],
+                None,
             ),
             rir::Instruction::Call(
                 rir::CallableId(1),
@@ -108,6 +127,7 @@ pub fn bell_program() -> rir::Program {
                     rir::Value::Literal(rir::Literal::Qubit(0)),
                     rir::Value::Literal(rir::Literal::Qubit(1)),
                 ],
+                None,
             ),
             rir::Instruction::Call(
                 rir::CallableId(2),
@@ -115,6 +135,7 @@ pub fn bell_program() -> rir::Program {
                     rir::Value::Literal(rir::Literal::Qubit(0)),
                     rir::Value::Literal(rir::Literal::Result(0)),
                 ],
+                None,
             ),
             rir::Instruction::Call(
                 rir::CallableId(2),
@@ -122,6 +143,7 @@ pub fn bell_program() -> rir::Program {
                     rir::Value::Literal(rir::Literal::Qubit(1)),
                     rir::Value::Literal(rir::Literal::Result(1)),
                 ],
+                None,
             ),
             rir::Instruction::Call(
                 rir::CallableId(3),
@@ -129,6 +151,7 @@ pub fn bell_program() -> rir::Program {
                     rir::Value::Literal(rir::Literal::Integer(2)),
                     rir::Value::Literal(rir::Literal::Pointer),
                 ],
+                None,
             ),
             rir::Instruction::Call(
                 rir::CallableId(4),
@@ -136,6 +159,7 @@ pub fn bell_program() -> rir::Program {
                     rir::Value::Literal(rir::Literal::Result(0)),
                     rir::Value::Literal(rir::Literal::Pointer),
                 ],
+                None,
             ),
             rir::Instruction::Call(
                 rir::CallableId(4),
@@ -143,6 +167,7 @@ pub fn bell_program() -> rir::Program {
                     rir::Value::Literal(rir::Literal::Result(1)),
                     rir::Value::Literal(rir::Literal::Pointer),
                 ],
+                None,
             ),
             rir::Instruction::Return,
         ]),
@@ -151,5 +176,166 @@ pub fn bell_program() -> rir::Program {
     program.num_results = 2;
     program.config.defer_measurements = true;
     program.config.remap_qubits_on_reuse = true;
+    program
+}
+
+#[allow(clippy::too_many_lines)]
+pub fn teleport_program() -> rir::Program {
+    let mut program = rir::Program::default();
+    program.callables.insert(rir::CallableId(0), h_decl());
+    program.callables.insert(rir::CallableId(1), z_decl());
+    program.callables.insert(rir::CallableId(2), x_decl());
+    program.callables.insert(rir::CallableId(3), cx_decl());
+    program.callables.insert(rir::CallableId(4), mresetz_decl());
+    program
+        .callables
+        .insert(rir::CallableId(5), read_result_decl());
+    program
+        .callables
+        .insert(rir::CallableId(6), result_record_decl());
+    program.callables.insert(
+        rir::CallableId(7),
+        rir::Callable {
+            name: "main".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+        },
+    );
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![
+            rir::Instruction::Call(
+                rir::CallableId(2),
+                vec![rir::Value::Literal(rir::Literal::Qubit(0))],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(0),
+                vec![rir::Value::Literal(rir::Literal::Qubit(2))],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(3),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(2)),
+                    rir::Value::Literal(rir::Literal::Qubit(1)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(3),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(0)),
+                    rir::Value::Literal(rir::Literal::Qubit(2)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(0),
+                vec![rir::Value::Literal(rir::Literal::Qubit(0))],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(4),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(0)),
+                    rir::Value::Literal(rir::Literal::Result(0)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(5),
+                vec![rir::Value::Literal(rir::Literal::Result(0))],
+                Some(rir::Variable {
+                    variable_id: rir::VariableId(0),
+                    ty: rir::Ty::Boolean,
+                }),
+            ),
+            rir::Instruction::Branch(
+                rir::Value::Variable(rir::Variable {
+                    variable_id: rir::VariableId(0),
+                    ty: rir::Ty::Boolean,
+                }),
+                rir::BlockId(1),
+                rir::BlockId(2),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        rir::BlockId(1),
+        rir::Block(vec![
+            rir::Instruction::Call(
+                rir::CallableId(1),
+                vec![rir::Value::Literal(rir::Literal::Qubit(1))],
+                None,
+            ),
+            rir::Instruction::Jump(rir::BlockId(2)),
+        ]),
+    );
+    program.blocks.insert(
+        rir::BlockId(2),
+        rir::Block(vec![
+            rir::Instruction::Call(
+                rir::CallableId(4),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(2)),
+                    rir::Value::Literal(rir::Literal::Result(1)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(5),
+                vec![rir::Value::Literal(rir::Literal::Result(1))],
+                Some(rir::Variable {
+                    variable_id: rir::VariableId(1),
+                    ty: rir::Ty::Boolean,
+                }),
+            ),
+            rir::Instruction::Branch(
+                rir::Value::Variable(rir::Variable {
+                    variable_id: rir::VariableId(1),
+                    ty: rir::Ty::Boolean,
+                }),
+                rir::BlockId(3),
+                rir::BlockId(4),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        rir::BlockId(3),
+        rir::Block(vec![
+            rir::Instruction::Call(
+                rir::CallableId(2),
+                vec![rir::Value::Literal(rir::Literal::Qubit(1))],
+                None,
+            ),
+            rir::Instruction::Jump(rir::BlockId(4)),
+        ]),
+    );
+    program.blocks.insert(
+        rir::BlockId(4),
+        rir::Block(vec![
+            rir::Instruction::Call(
+                rir::CallableId(4),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(1)),
+                    rir::Value::Literal(rir::Literal::Result(2)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(6),
+                vec![
+                    rir::Value::Literal(rir::Literal::Result(2)),
+                    rir::Value::Literal(rir::Literal::Pointer),
+                ],
+                None,
+            ),
+            rir::Instruction::Return,
+        ]),
+    );
+    program.num_qubits = 3;
+    program.num_results = 3;
     program
 }

--- a/compiler/qsc_codegen/src/qir/rir_builder.rs
+++ b/compiler/qsc_codegen/src/qir/rir_builder.rs
@@ -9,6 +9,7 @@ pub fn x_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit],
         output_type: None,
         body: None,
+        is_measurement: false,
     }
 }
 
@@ -18,6 +19,7 @@ pub fn z_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit],
         output_type: None,
         body: None,
+        is_measurement: false,
     }
 }
 
@@ -27,6 +29,7 @@ pub fn h_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit],
         output_type: None,
         body: None,
+        is_measurement: false,
     }
 }
 
@@ -36,6 +39,7 @@ pub fn cx_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit, rir::Ty::Qubit],
         output_type: None,
         body: None,
+        is_measurement: false,
     }
 }
 
@@ -45,6 +49,7 @@ pub fn rx_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Double, rir::Ty::Qubit],
         output_type: None,
         body: None,
+        is_measurement: false,
     }
 }
 
@@ -54,6 +59,7 @@ pub fn mz_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit, rir::Ty::Result],
         output_type: None,
         body: None,
+        is_measurement: true,
     }
 }
 
@@ -63,6 +69,7 @@ pub fn mresetz_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit, rir::Ty::Result],
         output_type: None,
         body: None,
+        is_measurement: true,
     }
 }
 
@@ -72,6 +79,7 @@ pub fn read_result_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Result],
         output_type: Some(rir::Ty::Boolean),
         body: None,
+        is_measurement: false,
     }
 }
 
@@ -81,6 +89,7 @@ pub fn result_record_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Result, rir::Ty::Pointer],
         output_type: None,
         body: None,
+        is_measurement: false,
     }
 }
 
@@ -90,6 +99,7 @@ pub fn array_record_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Integer, rir::Ty::Pointer],
         output_type: None,
         body: None,
+        is_measurement: false,
     }
 }
 
@@ -111,6 +121,7 @@ pub fn bell_program() -> rir::Program {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
+            is_measurement: false,
         },
     );
     program.blocks.insert(
@@ -200,6 +211,7 @@ pub fn teleport_program() -> rir::Program {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
+            is_measurement: false,
         },
     );
     program.blocks.insert(

--- a/compiler/qsc_codegen/src/qir/tests.rs
+++ b/compiler/qsc_codegen/src/qir/tests.rs
@@ -36,7 +36,7 @@ fn measurement_decl_works() {
 #[test]
 fn read_result_decl_works() {
     let decl = rir_builder::read_result_decl();
-    expect!["declare i1 @__quantum__rt__read_result(%Result*)"]
+    expect!["declare i1 @__quantum__qis__read_result__body(%Result*)"]
         .assert_eq(&decl.to_qir(&rir::Program::default()));
 }
 
@@ -56,6 +56,7 @@ fn single_qubit_call() {
     let call = rir::Instruction::Call(
         rir::CallableId(0),
         vec![rir::Value::Literal(rir::Literal::Qubit(0))],
+        None,
     );
     expect!["  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))"]
         .assert_eq(&call.to_qir(&program));
@@ -73,6 +74,7 @@ fn qubit_rotation_call() {
             rir::Value::Literal(rir::Literal::Double(std::f64::consts::PI)),
             rir::Value::Literal(rir::Literal::Qubit(0)),
         ],
+        None,
     );
     expect!["  call void @__quantum__qis__rx__body(double 3.141592653589793, %Qubit* inttoptr (i64 0 to %Qubit*))"]
         .assert_eq(&call.to_qir(&program));
@@ -90,6 +92,7 @@ fn qubit_rotation_round_number_call() {
             rir::Value::Literal(rir::Literal::Double(3.0)),
             rir::Value::Literal(rir::Literal::Qubit(0)),
         ],
+        None,
     );
     expect![
         "  call void @__quantum__qis__rx__body(double 3.0, %Qubit* inttoptr (i64 0 to %Qubit*))"
@@ -112,6 +115,7 @@ fn qubit_rotation_variable_angle_call() {
             }),
             rir::Value::Literal(rir::Literal::Qubit(0)),
         ],
+        None,
     );
     expect![
         "  call void @__quantum__qis__rx__body(double %var_0, %Qubit* inttoptr (i64 0 to %Qubit*))"
@@ -149,6 +153,67 @@ fn bell_program() {
         }
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="2" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+    "#]].assert_eq(&program.to_qir(&program));
+}
+
+#[test]
+fn teleport_program() {
+    let program = rir_builder::teleport_program();
+    expect![[r#"
+        %Result = type opaque
+        %Qubit = type opaque
+
+        declare void @__quantum__qis__h__body(%Qubit*)
+
+        declare void @__quantum__qis__z__body(%Qubit*)
+
+        declare void @__quantum__qis__x__body(%Qubit*)
+
+        declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*)
+
+        declare i1 @__quantum__qis__read_result__body(%Result*)
+
+        declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+        define void @main() #0 {
+        block_0:
+          call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 2 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          %var_0 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 0 to %Result*))
+          br i1 %var_0, label %block_1, label %block_2
+        block_1:
+          call void @__quantum__qis__z__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          br label %block_2
+        block_2:
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          %var_1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+          br i1 %var_1, label %block_3, label %block_4
+        block_3:
+          call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          br label %block_4
+        block_4:
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* null)
+          ret void
+        }
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="3" "required_num_results"="3" }
         attributes #1 = { "irreversible" }
 
         ; module flags

--- a/compiler/qsc_codegen/src/qir/tests.rs
+++ b/compiler/qsc_codegen/src/qir/tests.rs
@@ -181,7 +181,7 @@ fn teleport_program() {
 
         declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
-        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*)
+        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
 
         declare i1 @__quantum__qis__read_result__body(%Result*)
 

--- a/compiler/qsc_codegen/src/qir/tests.rs
+++ b/compiler/qsc_codegen/src/qir/tests.rs
@@ -140,7 +140,7 @@ fn bell_program() {
 
         declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-        define void @main() #0 {
+        define void @ENTRYPOINT__main() #0 {
         block_0:
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
@@ -187,7 +187,7 @@ fn teleport_program() {
 
         declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-        define void @main() #0 {
+        define void @ENTRYPOINT__main() #0 {
         block_0:
           call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 2 to %Qubit*))

--- a/compiler/qsc_rir/Cargo.toml
+++ b/compiler/qsc_rir/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 qsc_data_structures = { path = "../qsc_data_structures" }
+rustc-hash = { workspace = true }
 
 [lints]
 workspace = true

--- a/compiler/qsc_rir/src/lib.rs
+++ b/compiler/qsc_rir/src/lib.rs
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 
 pub mod rir;
+pub mod utils;

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -45,7 +45,7 @@ impl Config {
 }
 
 /// A unique identifier for a block in a RIR program.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct BlockId(pub u32);
 
 impl From<BlockId> for usize {
@@ -89,7 +89,7 @@ pub struct Callable {
 
 pub enum Instruction {
     Store(Value, Variable),
-    Call(CallableId, Vec<Value>),
+    Call(CallableId, Vec<Value>, Option<Variable>),
     Jump(BlockId),
     Branch(Value, BlockId, BlockId),
     Add(Value, Value, Variable),

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -85,6 +85,8 @@ pub struct Callable {
     /// The callable body.
     /// N.B. `None` bodys represent an intrinsic.
     pub body: Option<BlockId>,
+    /// Whether or not the callabe is a measurement.
+    pub is_measurement: bool,
 }
 
 pub enum Instruction {

--- a/compiler/qsc_rir/src/utils.rs
+++ b/compiler/qsc_rir/src/utils.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::rir::{Block, BlockId, Instruction, Program};
+use rustc_hash::FxHashSet;
+
+/// Given a block, return the block IDs of its successors.
+#[must_use]
+pub fn get_block_successors(block: &Block) -> Vec<BlockId> {
+    let mut successors = Vec::new();
+    for instr in &block.0 {
+        match instr {
+            Instruction::Jump(target) => {
+                successors.push(*target);
+            }
+            Instruction::Branch(_, target1, target2) => {
+                successors.push(*target1);
+                successors.push(*target2);
+            }
+            _ => {}
+        }
+    }
+    successors
+}
+
+/// Given a block ID and a containing program, return the block IDs of all blocks reachable from the given block including itself.
+/// The returned block IDs are sorted in ascending order.
+#[must_use]
+pub fn get_all_block_successors(block: BlockId, program: &Program) -> Vec<BlockId> {
+    let mut blocks_to_visit = vec![block];
+    let mut blocks_visited = FxHashSet::default();
+    while let Some(block_id) = blocks_to_visit.pop() {
+        if blocks_visited.contains(&block_id) {
+            continue;
+        }
+        blocks_visited.insert(block_id);
+        let block = program.get_block(block_id);
+        let block_successors = get_block_successors(block);
+        blocks_to_visit.extend(block_successors.clone());
+    }
+    let mut successors = blocks_visited.into_iter().collect::<Vec<_>>();
+    successors.sort_unstable();
+    successors
+}


### PR DESCRIPTION
This change upgrades RIR -> QIR to support basic branching on measurement results via `Jump` and `Branch` instructions. This does not include any support for mutable variables.