### PR TITLE
RIR defer measurements and unreachable code passes

### DIFF
--- a/compiler/qsc_codegen/src/lib.rs
+++ b/compiler/qsc_codegen/src/lib.rs
@@ -4,3 +4,9 @@
 pub mod qir;
 pub mod qir_base;
 pub mod remapper;
+pub mod rir_passes;
+
+#[cfg(test)]
+pub mod test_utils {
+    pub mod rir_builder;
+}

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -2,15 +2,13 @@
 // Licensed under the MIT License.
 
 #[cfg(test)]
-mod rir_builder;
-#[cfg(test)]
 mod tests;
 
 use qsc_rir::{rir, utils::get_all_block_successors};
 
 /// A trait for converting a type into QIR of type `T`.
 /// This can be used to generate QIR strings or other representations.
-trait ToQir<T> {
+pub trait ToQir<T> {
     fn to_qir(&self, program: &rir::Program) -> T;
 }
 
@@ -166,7 +164,7 @@ impl ToQir<String> for rir::Callable {
             return format!(
                 "declare {output_type} @{}({input_type}){}",
                 self.name,
-                if self.is_measurement {
+                if self.call_type == rir::CallableType::Measurement {
                     // Measurement callables are a special case that needs the irreversable attribute.
                     " #1"
                 } else {

--- a/compiler/qsc_codegen/src/qir/tests.rs
+++ b/compiler/qsc_codegen/src/qir/tests.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::{rir_builder, ToQir};
+use super::ToQir;
+use crate::test_utils::rir_builder;
 use expect_test::expect;
 use qsc_rir::rir;
 

--- a/compiler/qsc_codegen/src/rir_passes.rs
+++ b/compiler/qsc_codegen/src/rir_passes.rs
@@ -2,5 +2,9 @@
 // Licensed under the MIT License.
 
 mod defer_meas;
+mod unreachable_code_check;
 
 pub use defer_meas::defer_measurements;
+pub use unreachable_code_check::{
+    check_unreachable_blocks, check_unreachable_callable, check_unreachable_instrs,
+};

--- a/compiler/qsc_codegen/src/rir_passes.rs
+++ b/compiler/qsc_codegen/src/rir_passes.rs
@@ -5,6 +5,4 @@ mod defer_meas;
 mod unreachable_code_check;
 
 pub use defer_meas::defer_measurements;
-pub use unreachable_code_check::{
-    check_unreachable_blocks, check_unreachable_callable, check_unreachable_instrs,
-};
+pub use unreachable_code_check::check_unreachable_code;

--- a/compiler/qsc_codegen/src/rir_passes.rs
+++ b/compiler/qsc_codegen/src/rir_passes.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+mod defer_meas;
+
+pub use defer_meas::defer_measurements;

--- a/compiler/qsc_codegen/src/rir_passes/defer_meas.rs
+++ b/compiler/qsc_codegen/src/rir_passes/defer_meas.rs
@@ -29,7 +29,7 @@ pub fn defer_measurements(program: &mut Program) {
             CallableType::OutputRecording => {
                 output_recording_ids.insert(id);
             }
-            CallableType::Other => {}
+            CallableType::Regular => {}
         }
     }
 

--- a/compiler/qsc_codegen/src/rir_passes/defer_meas.rs
+++ b/compiler/qsc_codegen/src/rir_passes/defer_meas.rs
@@ -15,7 +15,7 @@ use rustc_hash::FxHashSet;
 /// 3. All output recordings.
 /// 4. Return, branch, and jump instructions (terminators).
 ///
-/// Releative ordering within each section is maintained. Note that the scope is limited to each
+/// Relative ordering within each section is maintained. Note that the scope is limited to each
 /// block, so measurements are not necessarily deferred to the end of the entire program unless the
 /// program consists of a single block.
 pub fn defer_measurements(program: &mut Program) {

--- a/compiler/qsc_codegen/src/rir_passes/defer_meas.rs
+++ b/compiler/qsc_codegen/src/rir_passes/defer_meas.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(test)]
+mod tests;
+
+use qsc_rir::rir::{CallableType, Instruction, Program};
+use rustc_hash::FxHashSet;
+
+/// Defers measurements in each block of a program to the end of that block.
+/// Specifically, this function reorders instructions within a block to follow the given order:
+///
+/// 1. All instructions except for measurements and output recordings.
+/// 2. All measurements.
+/// 3. All output recordings.
+/// 4. Return, branch, and jump instructions (terminators).
+///
+/// Releative ordering within each section is maintained. Note that the scope is limited to each
+/// block, so measurements are not necessarily deferred to the end of the entire program unless the
+/// program consists of a single block.
+pub fn defer_measurements(program: &mut Program) {
+    let mut measure_call_ids = FxHashSet::default();
+    let mut output_recording_ids = FxHashSet::default();
+    for (id, callable) in program.callables.iter() {
+        match callable.call_type {
+            CallableType::Measurement | CallableType::Readout => {
+                measure_call_ids.insert(id);
+            }
+            CallableType::OutputRecording => {
+                output_recording_ids.insert(id);
+            }
+            CallableType::Other => {}
+        }
+    }
+
+    for (_, block) in program.blocks.iter_mut() {
+        block.0.sort_by(|a, b| match (a, b) {
+            // Return, branch, and jump instructions are terminators and should come last.
+            (Instruction::Return | Instruction::Branch(..) | Instruction::Jump(..), _) => {
+                std::cmp::Ordering::Greater
+            }
+            (_, Instruction::Return | Instruction::Branch(..) | Instruction::Jump(..)) => {
+                std::cmp::Ordering::Less
+            }
+
+            // Measurements and output recordings should maintain their order relative to the same type.
+            (Instruction::Call(a_id, _, _), Instruction::Call(b_id, _, _))
+                if measure_call_ids.contains(a_id) && measure_call_ids.contains(b_id) =>
+            {
+                std::cmp::Ordering::Equal
+            }
+            (Instruction::Call(a_id, _, _), Instruction::Call(b_id, _, _))
+                if output_recording_ids.contains(a_id) && output_recording_ids.contains(b_id) =>
+            {
+                std::cmp::Ordering::Equal
+            }
+
+            // Output recording should come after any other instruction except for terminator instructions,
+            // which are handled above.
+            (Instruction::Call(a_id, _, _), _) if output_recording_ids.contains(a_id) => {
+                std::cmp::Ordering::Greater
+            }
+            (_, Instruction::Call(b_id, _, _)) if output_recording_ids.contains(b_id) => {
+                std::cmp::Ordering::Less
+            }
+
+            // Measurements should come after any other instruction except for terminator instructions,
+            // and output recording instructions, which are handled above.
+            (Instruction::Call(a_id, _, _), Instruction::Call(..))
+                if measure_call_ids.contains(a_id) =>
+            {
+                std::cmp::Ordering::Greater
+            }
+            (Instruction::Call(..), Instruction::Call(b_id, _, _))
+                if measure_call_ids.contains(b_id) =>
+            {
+                std::cmp::Ordering::Less
+            }
+
+            // All other instructions should maintain their relative order.
+            _ => std::cmp::Ordering::Equal,
+        });
+    }
+}

--- a/compiler/qsc_codegen/src/rir_passes/defer_meas/tests.rs
+++ b/compiler/qsc_codegen/src/rir_passes/defer_meas/tests.rs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(clippy::too_many_lines, clippy::needless_raw_string_hashes)]
+
+use crate::{qir::ToQir, test_utils::rir_builder};
+use expect_test::expect;
+use qsc_rir::rir;
+
+use super::defer_measurements;
+
+#[test]
+fn measurements_deferred_on_return_block() {
+    let mut program = rir::Program::default();
+    add_simple_measurement_block(&mut program);
+
+    // Before
+    expect![[r#"
+        block_0:
+          call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 3, i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* null)
+          ret void"#]].assert_eq(&format!("block_0:\n{}", program.blocks.get(0_usize.into()).expect("block should be present").to_qir(&program)));
+
+    // After
+    defer_measurements(&mut program);
+    expect![[r#"
+        block_0:
+          call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 3, i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* null)
+          ret void"#]].assert_eq(&format!("block_0:\n{}", program.blocks.get(0_usize.into()).expect("block should be present").to_qir(&program)));
+}
+
+#[test]
+fn branching_block_measurements_deferred_properly() {
+    let mut program = rir::Program::default();
+    add_branching_measurement_block(&mut program);
+
+    // Before
+    expect![[r#"
+        block_0:
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          %var_0 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 0 to %Result*))
+          br i1 %var_0, label %block_1, label %block_2"#]].assert_eq(&format!("block_0:\n{}", program.blocks.get(0_usize.into()).expect("block should be present").to_qir(&program)));
+
+    // After
+    defer_measurements(&mut program);
+    expect![[r#"
+        block_0:
+          call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          %var_0 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 0 to %Result*))
+          br i1 %var_0, label %block_1, label %block_2"#]].assert_eq(&format!("block_0:\n{}", program.blocks.get(0_usize.into()).expect("block should be present").to_qir(&program)));
+}
+
+fn add_simple_measurement_block(program: &mut rir::Program) {
+    program
+        .callables
+        .insert(rir::CallableId(0), rir_builder::mz_decl());
+    program
+        .callables
+        .insert(rir::CallableId(1), rir_builder::mresetz_decl());
+    program
+        .callables
+        .insert(rir::CallableId(2), rir_builder::x_decl());
+    program
+        .callables
+        .insert(rir::CallableId(3), rir_builder::array_record_decl());
+    program
+        .callables
+        .insert(rir::CallableId(4), rir_builder::result_record_decl());
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![
+            rir::Instruction::Call(
+                rir::CallableId(0),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(0)),
+                    rir::Value::Literal(rir::Literal::Result(0)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(2),
+                vec![rir::Value::Literal(rir::Literal::Qubit(1))],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(1),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(1)),
+                    rir::Value::Literal(rir::Literal::Result(1)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(1),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(0)),
+                    rir::Value::Literal(rir::Literal::Result(2)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(3),
+                vec![
+                    rir::Value::Literal(rir::Literal::Integer(3)),
+                    rir::Value::Literal(rir::Literal::Pointer),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(4),
+                vec![
+                    rir::Value::Literal(rir::Literal::Result(0)),
+                    rir::Value::Literal(rir::Literal::Pointer),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(4),
+                vec![
+                    rir::Value::Literal(rir::Literal::Result(1)),
+                    rir::Value::Literal(rir::Literal::Pointer),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(4),
+                vec![
+                    rir::Value::Literal(rir::Literal::Result(2)),
+                    rir::Value::Literal(rir::Literal::Pointer),
+                ],
+                None,
+            ),
+            rir::Instruction::Return,
+        ]),
+    );
+}
+
+fn add_branching_measurement_block(program: &mut rir::Program) {
+    program
+        .callables
+        .insert(rir::CallableId(0), rir_builder::mresetz_decl());
+    program
+        .callables
+        .insert(rir::CallableId(1), rir_builder::x_decl());
+    program
+        .callables
+        .insert(rir::CallableId(3), rir_builder::read_result_decl());
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![
+            rir::Instruction::Call(
+                rir::CallableId(0),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(1)),
+                    rir::Value::Literal(rir::Literal::Result(0)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(1),
+                vec![rir::Value::Literal(rir::Literal::Qubit(0))],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(0),
+                vec![
+                    rir::Value::Literal(rir::Literal::Qubit(0)),
+                    rir::Value::Literal(rir::Literal::Result(1)),
+                ],
+                None,
+            ),
+            rir::Instruction::Call(
+                rir::CallableId(3),
+                vec![rir::Value::Literal(rir::Literal::Result(0))],
+                Some(rir::Variable {
+                    variable_id: rir::VariableId(0),
+                    ty: rir::Ty::Boolean,
+                }),
+            ),
+            rir::Instruction::Branch(
+                rir::Value::Variable(rir::Variable {
+                    variable_id: rir::VariableId(0),
+                    ty: rir::Ty::Boolean,
+                }),
+                rir::BlockId(1),
+                rir::BlockId(2),
+            ),
+        ]),
+    );
+}

--- a/compiler/qsc_codegen/src/rir_passes/unreachable_code_check.rs
+++ b/compiler/qsc_codegen/src/rir_passes/unreachable_code_check.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use core::panic;
+use std::iter::once;
+
+use qsc_rir::{rir, utils};
+use rustc_hash::FxHashSet;
+
+#[cfg(test)]
+mod tests;
+
+/// Checks for unreachable instructions in each block of a program.
+/// Specifically, this function checks that no instruction follows a terminator instruction in a block,
+/// and that each block ends with a terminator instruction.
+pub fn check_unreachable_instrs(program: &mut rir::Program) {
+    for (block_id, block) in program.blocks.iter_mut() {
+        match block.0.iter().position(|i| {
+            matches!(
+                i,
+                rir::Instruction::Return
+                    | rir::Instruction::Jump(..)
+                    | rir::Instruction::Branch(..)
+            )
+        }) {
+            Some(idx) => {
+                assert!(
+                    idx == block.0.len() - 1,
+                    "{block_id:?} has unreachable instructions after a terminator",
+                );
+            }
+            None => panic!("{block_id:?} does not end with a terminator instruction"),
+        }
+    }
+}
+
+/// Checks for unreachable blocks in a program.
+/// Specifically, this function checks that all blocks are reachable from at least one callable in the program.
+pub fn check_unreachable_blocks(program: &mut rir::Program) {
+    let mut start_blocks = FxHashSet::default();
+    for (_, callable) in program.callables.iter() {
+        if let Some(block_id) = callable.body {
+            start_blocks.insert(block_id);
+        };
+    }
+    let mut live_blocks = FxHashSet::default();
+    for block in start_blocks {
+        live_blocks.insert(block);
+        live_blocks.extend(utils::get_all_block_successors(block, program).into_iter());
+    }
+    let mut dead_blocks = Vec::new();
+    for (block_id, _) in program.blocks.iter() {
+        if !live_blocks.contains(&block_id) {
+            dead_blocks.push(block_id);
+        }
+    }
+    assert!(
+        dead_blocks.is_empty(),
+        "Unreachable blocks found: {dead_blocks:?}"
+    );
+}
+
+/// Checks for unreachable callables in a program.
+/// Specifically, this function checks that all callables are reachable from the entry point of the program.
+/// Note that calls from unreachable blocks are not included as only succesor blocks are considered.
+pub fn check_unreachable_callable(program: &mut rir::Program) {
+    let mut live_callables = FxHashSet::default();
+    let mut callables_to_check = Vec::new();
+    callables_to_check.push(program.entry);
+    while let Some(callable_id) = callables_to_check.pop() {
+        if !live_callables.insert(callable_id) {
+            continue;
+        }
+        let callable = program.get_callable(callable_id);
+        let Some(body) = callable.body else {
+            continue;
+        };
+        for block_id in utils::get_all_block_successors(body, program)
+            .iter()
+            .chain(once(&body))
+        {
+            let block = program.get_block(*block_id);
+            for instr in &block.0 {
+                if let rir::Instruction::Call(callable_id, ..) = instr {
+                    callables_to_check.push(*callable_id);
+                }
+            }
+        }
+    }
+    let dead_callables = program
+        .callables
+        .iter()
+        .filter_map(|(callable_id, _)| {
+            if live_callables.contains(&callable_id) {
+                None
+            } else {
+                Some(callable_id)
+            }
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        dead_callables.is_empty(),
+        "Unreachable callables found: {dead_callables:?}"
+    );
+}

--- a/compiler/qsc_codegen/src/rir_passes/unreachable_code_check.rs
+++ b/compiler/qsc_codegen/src/rir_passes/unreachable_code_check.rs
@@ -10,11 +10,22 @@ use rustc_hash::FxHashSet;
 #[cfg(test)]
 mod tests;
 
+/// Checks for unreachable code in a program.
+/// This check first verifies that all callables are reachable from the entry point of the program.
+/// Then, it checks that all blocks are reachable from at least one callable in the program.
+/// Finally, it checks that no instruction follows a terminator instruction in a block,
+/// and that each block ends with a terminator instruction.
+pub fn check_unreachable_code(program: &rir::Program) {
+    check_unreachable_callable(program);
+    check_unreachable_blocks(program);
+    check_unreachable_instrs(program);
+}
+
 /// Checks for unreachable instructions in each block of a program.
 /// Specifically, this function checks that no instruction follows a terminator instruction in a block,
 /// and that each block ends with a terminator instruction.
-pub fn check_unreachable_instrs(program: &mut rir::Program) {
-    for (block_id, block) in program.blocks.iter_mut() {
+pub fn check_unreachable_instrs(program: &rir::Program) {
+    for (block_id, block) in program.blocks.iter() {
         match block.0.iter().position(|i| {
             matches!(
                 i,
@@ -36,7 +47,7 @@ pub fn check_unreachable_instrs(program: &mut rir::Program) {
 
 /// Checks for unreachable blocks in a program.
 /// Specifically, this function checks that all blocks are reachable from at least one callable in the program.
-pub fn check_unreachable_blocks(program: &mut rir::Program) {
+pub fn check_unreachable_blocks(program: &rir::Program) {
     let mut start_blocks = FxHashSet::default();
     for (_, callable) in program.callables.iter() {
         if let Some(block_id) = callable.body {
@@ -63,7 +74,7 @@ pub fn check_unreachable_blocks(program: &mut rir::Program) {
 /// Checks for unreachable callables in a program.
 /// Specifically, this function checks that all callables are reachable from the entry point of the program.
 /// Note that calls from unreachable blocks are not included as only succesor blocks are considered.
-pub fn check_unreachable_callable(program: &mut rir::Program) {
+pub fn check_unreachable_callable(program: &rir::Program) {
     let mut live_callables = FxHashSet::default();
     let mut callables_to_check = Vec::new();
     callables_to_check.push(program.entry);

--- a/compiler/qsc_codegen/src/rir_passes/unreachable_code_check/tests.rs
+++ b/compiler/qsc_codegen/src/rir_passes/unreachable_code_check/tests.rs
@@ -19,7 +19,7 @@ fn test_check_unreachable_instrs_panics_on_missing_terminator() {
             },
         )]),
     );
-    check_unreachable_instrs(&mut program);
+    check_unreachable_instrs(&program);
 }
 
 #[test]
@@ -28,7 +28,7 @@ fn test_check_unreachable_instrs_succeeds_on_terminator() {
     program
         .blocks
         .insert(rir::BlockId(0), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_instrs(&mut program);
+    check_unreachable_instrs(&program);
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn test_check_unreachable_instrs_succeeds_on_terminator_after_other_instrs() {
             rir::Instruction::Return,
         ]),
     );
-    check_unreachable_instrs(&mut program);
+    check_unreachable_instrs(&program);
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_check_unreachable_instrs_panics_on_unreachable_instrs_after_terminator()
             ),
         ]),
     );
-    check_unreachable_instrs(&mut program);
+    check_unreachable_instrs(&program);
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks() {
     program
         .blocks
         .insert(rir::BlockId(0), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_blocks(&mut program);
+    check_unreachable_blocks(&program);
 }
 
 #[test]
@@ -109,7 +109,7 @@ fn test_check_unreachable_blocks_panics_on_unreachable_block() {
     program
         .blocks
         .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_blocks(&mut program);
+    check_unreachable_blocks(&program);
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks_with_branch()
     program
         .blocks
         .insert(rir::BlockId(2), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_blocks(&mut program);
+    check_unreachable_blocks(&program);
 }
 
 #[test]
@@ -165,7 +165,7 @@ fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks_with_jump() {
     program
         .blocks
         .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_blocks(&mut program);
+    check_unreachable_blocks(&program);
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn test_check_unreachable_blocks_panics_on_unreachable_block_with_branch() {
     program
         .blocks
         .insert(rir::BlockId(2), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_blocks(&mut program);
+    check_unreachable_blocks(&program);
 }
 
 #[test]
@@ -216,7 +216,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables() {
     program
         .blocks
         .insert(rir::BlockId(0), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_callable(&mut program);
+    check_unreachable_callable(&program);
 }
 
 #[test]
@@ -250,7 +250,7 @@ fn test_check_unreachable_callable_panics_on_unreachable_callable() {
     program
         .blocks
         .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_callable(&mut program);
+    check_unreachable_callable(&program);
 }
 
 #[test]
@@ -288,7 +288,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_cal
     program
         .blocks
         .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_callable(&mut program);
+    check_unreachable_callable(&program);
 }
 
 #[test]
@@ -341,7 +341,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_nes
             None,
         )]),
     );
-    check_unreachable_callable(&mut program);
+    check_unreachable_callable(&program);
 }
 
 #[test]
@@ -390,7 +390,7 @@ fn test_check_unreachable_callable_panics_on_unreachable_callable_with_nested_ca
     program
         .blocks
         .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
-    check_unreachable_callable(&mut program);
+    check_unreachable_callable(&program);
 }
 
 #[test]
@@ -430,5 +430,5 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_cal
             None,
         )]),
     );
-    check_unreachable_callable(&mut program);
+    check_unreachable_callable(&program);
 }

--- a/compiler/qsc_codegen/src/rir_passes/unreachable_code_check/tests.rs
+++ b/compiler/qsc_codegen/src/rir_passes/unreachable_code_check/tests.rs
@@ -80,7 +80,7 @@ fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks() {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program
@@ -100,7 +100,7 @@ fn test_check_unreachable_blocks_panics_on_unreachable_block() {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program
@@ -122,7 +122,7 @@ fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks_with_branch()
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.blocks.insert(
@@ -152,7 +152,7 @@ fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks_with_jump() {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.blocks.insert(
@@ -179,7 +179,7 @@ fn test_check_unreachable_blocks_panics_on_unreachable_block_with_branch() {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.blocks.insert(
@@ -210,7 +210,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables() {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program
@@ -231,7 +231,7 @@ fn test_check_unreachable_callable_panics_on_unreachable_callable() {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.callables.insert(
@@ -241,7 +241,7 @@ fn test_check_unreachable_callable_panics_on_unreachable_callable() {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(1)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program
@@ -264,7 +264,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_cal
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.callables.insert(
@@ -274,7 +274,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_cal
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(1)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.blocks.insert(
@@ -302,7 +302,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_nes
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.callables.insert(
@@ -312,7 +312,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_nes
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(1)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.callables.insert(
@@ -322,7 +322,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_nes
             input_type: vec![],
             output_type: None,
             body: None,
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.blocks.insert(
@@ -356,7 +356,7 @@ fn test_check_unreachable_callable_panics_on_unreachable_callable_with_nested_ca
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.callables.insert(
@@ -366,7 +366,7 @@ fn test_check_unreachable_callable_panics_on_unreachable_callable_with_nested_ca
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(1)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.callables.insert(
@@ -376,7 +376,7 @@ fn test_check_unreachable_callable_panics_on_unreachable_callable_with_nested_ca
             input_type: vec![],
             output_type: None,
             body: None,
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.blocks.insert(
@@ -405,7 +405,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_cal
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.callables.insert(
@@ -415,7 +415,7 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_cal
             input_type: vec![],
             output_type: None,
             body: None,
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.blocks.insert(

--- a/compiler/qsc_codegen/src/rir_passes/unreachable_code_check/tests.rs
+++ b/compiler/qsc_codegen/src/rir_passes/unreachable_code_check/tests.rs
@@ -1,0 +1,434 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use qsc_rir::rir;
+
+use super::{check_unreachable_blocks, check_unreachable_callable, check_unreachable_instrs};
+
+#[test]
+#[should_panic(expected = "BlockId(0) does not end with a terminator instruction")]
+fn test_check_unreachable_instrs_panics_on_missing_terminator() {
+    let mut program = rir::Program::new();
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![rir::Instruction::BitwiseNot(
+            rir::Value::Literal(rir::Literal::Bool(true)),
+            rir::Variable {
+                variable_id: rir::VariableId(0),
+                ty: rir::Ty::Boolean,
+            },
+        )]),
+    );
+    check_unreachable_instrs(&mut program);
+}
+
+#[test]
+fn test_check_unreachable_instrs_succeeds_on_terminator() {
+    let mut program = rir::Program::new();
+    program
+        .blocks
+        .insert(rir::BlockId(0), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_instrs(&mut program);
+}
+
+#[test]
+fn test_check_unreachable_instrs_succeeds_on_terminator_after_other_instrs() {
+    let mut program = rir::Program::new();
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![
+            rir::Instruction::BitwiseNot(
+                rir::Value::Literal(rir::Literal::Bool(true)),
+                rir::Variable {
+                    variable_id: rir::VariableId(0),
+                    ty: rir::Ty::Boolean,
+                },
+            ),
+            rir::Instruction::Return,
+        ]),
+    );
+    check_unreachable_instrs(&mut program);
+}
+
+#[test]
+#[should_panic(expected = "BlockId(0) has unreachable instructions after a terminator")]
+fn test_check_unreachable_instrs_panics_on_unreachable_instrs_after_terminator() {
+    let mut program = rir::Program::new();
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![
+            rir::Instruction::Return,
+            rir::Instruction::BitwiseNot(
+                rir::Value::Literal(rir::Literal::Bool(true)),
+                rir::Variable {
+                    variable_id: rir::VariableId(0),
+                    ty: rir::Ty::Boolean,
+                },
+            ),
+        ]),
+    );
+    check_unreachable_instrs(&mut program);
+}
+
+#[test]
+fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks() {
+    let mut program = rir::Program::new();
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program
+        .blocks
+        .insert(rir::BlockId(0), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_blocks(&mut program);
+}
+
+#[test]
+#[should_panic(expected = "Unreachable blocks found: [BlockId(1)]")]
+fn test_check_unreachable_blocks_panics_on_unreachable_block() {
+    let mut program = rir::Program::new();
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program
+        .blocks
+        .insert(rir::BlockId(0), rir::Block(vec![rir::Instruction::Return]));
+    program
+        .blocks
+        .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_blocks(&mut program);
+}
+
+#[test]
+fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks_with_branch() {
+    let mut program = rir::Program::new();
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![rir::Instruction::Branch(
+            rir::Value::Literal(rir::Literal::Bool(true)),
+            rir::BlockId(1),
+            rir::BlockId(2),
+        )]),
+    );
+    program
+        .blocks
+        .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
+    program
+        .blocks
+        .insert(rir::BlockId(2), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_blocks(&mut program);
+}
+
+#[test]
+fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks_with_jump() {
+    let mut program = rir::Program::new();
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![
+            rir::Instruction::Jump(rir::BlockId(1)),
+            rir::Instruction::Return,
+        ]),
+    );
+    program
+        .blocks
+        .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_blocks(&mut program);
+}
+
+#[test]
+#[should_panic(expected = "Unreachable blocks found: [BlockId(2)]")]
+fn test_check_unreachable_blocks_panics_on_unreachable_block_with_branch() {
+    let mut program = rir::Program::new();
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![rir::Instruction::Branch(
+            rir::Value::Literal(rir::Literal::Bool(true)),
+            rir::BlockId(1),
+            rir::BlockId(1),
+        )]),
+    );
+    program
+        .blocks
+        .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
+    program
+        .blocks
+        .insert(rir::BlockId(2), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_blocks(&mut program);
+}
+
+#[test]
+fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables() {
+    let mut program = rir::Program::new();
+    program.entry = rir::CallableId(0);
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program
+        .blocks
+        .insert(rir::BlockId(0), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_callable(&mut program);
+}
+
+#[test]
+#[should_panic(expected = "Unreachable callables found: [CallableId(1)]")]
+fn test_check_unreachable_callable_panics_on_unreachable_callable() {
+    let mut program = rir::Program::new();
+    program.entry = rir::CallableId(0);
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.callables.insert(
+        rir::CallableId(1),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(1)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program
+        .blocks
+        .insert(rir::BlockId(0), rir::Block(vec![rir::Instruction::Return]));
+    program
+        .blocks
+        .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_callable(&mut program);
+}
+
+#[test]
+fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_call() {
+    let mut program = rir::Program::new();
+    program.entry = rir::CallableId(0);
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.callables.insert(
+        rir::CallableId(1),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(1)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![rir::Instruction::Call(
+            rir::CallableId(1),
+            Vec::new(),
+            None,
+        )]),
+    );
+    program
+        .blocks
+        .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_callable(&mut program);
+}
+
+#[test]
+fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_nested_call() {
+    let mut program = rir::Program::new();
+    program.entry = rir::CallableId(0);
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.callables.insert(
+        rir::CallableId(1),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(1)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.callables.insert(
+        rir::CallableId(2),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: None,
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![rir::Instruction::Call(
+            rir::CallableId(1),
+            Vec::new(),
+            None,
+        )]),
+    );
+    program.blocks.insert(
+        rir::BlockId(1),
+        rir::Block(vec![rir::Instruction::Call(
+            rir::CallableId(2),
+            Vec::new(),
+            None,
+        )]),
+    );
+    check_unreachable_callable(&mut program);
+}
+
+#[test]
+#[should_panic(expected = "Unreachable callables found: [CallableId(2)]")]
+fn test_check_unreachable_callable_panics_on_unreachable_callable_with_nested_call() {
+    let mut program = rir::Program::new();
+    program.entry = rir::CallableId(0);
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.callables.insert(
+        rir::CallableId(1),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(1)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.callables.insert(
+        rir::CallableId(2),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: None,
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![rir::Instruction::Call(
+            rir::CallableId(1),
+            Vec::new(),
+            None,
+        )]),
+    );
+    program
+        .blocks
+        .insert(rir::BlockId(1), rir::Block(vec![rir::Instruction::Return]));
+    check_unreachable_callable(&mut program);
+}
+
+#[test]
+fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_call_in_successor_block(
+) {
+    let mut program = rir::Program::new();
+    program.entry = rir::CallableId(0);
+    program.callables.insert(
+        rir::CallableId(0),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: Some(rir::BlockId(0)),
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.callables.insert(
+        rir::CallableId(1),
+        rir::Callable {
+            name: "test".to_string(),
+            input_type: vec![],
+            output_type: None,
+            body: None,
+            call_type: rir::CallableType::Other,
+        },
+    );
+    program.blocks.insert(
+        rir::BlockId(0),
+        rir::Block(vec![rir::Instruction::Jump(rir::BlockId(1))]),
+    );
+    program.blocks.insert(
+        rir::BlockId(1),
+        rir::Block(vec![rir::Instruction::Call(
+            rir::CallableId(1),
+            Vec::new(),
+            None,
+        )]),
+    );
+    check_unreachable_callable(&mut program);
+}

--- a/compiler/qsc_codegen/src/test_utils/rir_builder.rs
+++ b/compiler/qsc_codegen/src/test_utils/rir_builder.rs
@@ -10,7 +10,7 @@ pub fn x_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit],
         output_type: None,
         body: None,
-        call_type: rir::CallableType::Other,
+        call_type: rir::CallableType::Regular,
     }
 }
 
@@ -21,7 +21,7 @@ pub fn z_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit],
         output_type: None,
         body: None,
-        call_type: rir::CallableType::Other,
+        call_type: rir::CallableType::Regular,
     }
 }
 
@@ -32,7 +32,7 @@ pub fn h_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit],
         output_type: None,
         body: None,
-        call_type: rir::CallableType::Other,
+        call_type: rir::CallableType::Regular,
     }
 }
 
@@ -43,7 +43,7 @@ pub fn cx_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Qubit, rir::Ty::Qubit],
         output_type: None,
         body: None,
-        call_type: rir::CallableType::Other,
+        call_type: rir::CallableType::Regular,
     }
 }
 
@@ -54,7 +54,7 @@ pub fn rx_decl() -> rir::Callable {
         input_type: vec![rir::Ty::Double, rir::Ty::Qubit],
         output_type: None,
         body: None,
-        call_type: rir::CallableType::Other,
+        call_type: rir::CallableType::Regular,
     }
 }
 
@@ -132,7 +132,7 @@ pub fn bell_program() -> rir::Program {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.blocks.insert(
@@ -223,7 +223,7 @@ pub fn teleport_program() -> rir::Program {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            call_type: rir::CallableType::Other,
+            call_type: rir::CallableType::Regular,
         },
     );
     program.blocks.insert(

--- a/compiler/qsc_codegen/src/test_utils/rir_builder.rs
+++ b/compiler/qsc_codegen/src/test_utils/rir_builder.rs
@@ -3,106 +3,117 @@
 
 use qsc_rir::rir;
 
+#[must_use]
 pub fn x_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__qis__x__body".to_string(),
         input_type: vec![rir::Ty::Qubit],
         output_type: None,
         body: None,
-        is_measurement: false,
+        call_type: rir::CallableType::Other,
     }
 }
 
+#[must_use]
 pub fn z_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__qis__z__body".to_string(),
         input_type: vec![rir::Ty::Qubit],
         output_type: None,
         body: None,
-        is_measurement: false,
+        call_type: rir::CallableType::Other,
     }
 }
 
+#[must_use]
 pub fn h_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__qis__h__body".to_string(),
         input_type: vec![rir::Ty::Qubit],
         output_type: None,
         body: None,
-        is_measurement: false,
+        call_type: rir::CallableType::Other,
     }
 }
 
+#[must_use]
 pub fn cx_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__qis__cx__body".to_string(),
         input_type: vec![rir::Ty::Qubit, rir::Ty::Qubit],
         output_type: None,
         body: None,
-        is_measurement: false,
+        call_type: rir::CallableType::Other,
     }
 }
 
+#[must_use]
 pub fn rx_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__qis__rx__body".to_string(),
         input_type: vec![rir::Ty::Double, rir::Ty::Qubit],
         output_type: None,
         body: None,
-        is_measurement: false,
+        call_type: rir::CallableType::Other,
     }
 }
 
+#[must_use]
 pub fn mz_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__qis__mz__body".to_string(),
         input_type: vec![rir::Ty::Qubit, rir::Ty::Result],
         output_type: None,
         body: None,
-        is_measurement: true,
+        call_type: rir::CallableType::Measurement,
     }
 }
 
+#[must_use]
 pub fn mresetz_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__qis__mresetz__body".to_string(),
         input_type: vec![rir::Ty::Qubit, rir::Ty::Result],
         output_type: None,
         body: None,
-        is_measurement: true,
+        call_type: rir::CallableType::Measurement,
     }
 }
 
+#[must_use]
 pub fn read_result_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__qis__read_result__body".to_string(),
         input_type: vec![rir::Ty::Result],
         output_type: Some(rir::Ty::Boolean),
         body: None,
-        is_measurement: false,
+        call_type: rir::CallableType::Readout,
     }
 }
 
+#[must_use]
 pub fn result_record_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__rt__result_record_output".to_string(),
         input_type: vec![rir::Ty::Result, rir::Ty::Pointer],
         output_type: None,
         body: None,
-        is_measurement: false,
+        call_type: rir::CallableType::OutputRecording,
     }
 }
 
+#[must_use]
 pub fn array_record_decl() -> rir::Callable {
     rir::Callable {
         name: "__quantum__rt__array_record_output".to_string(),
         input_type: vec![rir::Ty::Integer, rir::Ty::Pointer],
         output_type: None,
         body: None,
-        is_measurement: false,
+        call_type: rir::CallableType::OutputRecording,
     }
 }
 
+#[must_use]
 pub fn bell_program() -> rir::Program {
     let mut program = rir::Program::default();
     program.callables.insert(rir::CallableId(0), h_decl());
@@ -121,7 +132,7 @@ pub fn bell_program() -> rir::Program {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            is_measurement: false,
+            call_type: rir::CallableType::Other,
         },
     );
     program.blocks.insert(
@@ -191,6 +202,7 @@ pub fn bell_program() -> rir::Program {
 }
 
 #[allow(clippy::too_many_lines)]
+#[must_use]
 pub fn teleport_program() -> rir::Program {
     let mut program = rir::Program::default();
     program.callables.insert(rir::CallableId(0), h_decl());
@@ -211,7 +223,7 @@ pub fn teleport_program() -> rir::Program {
             input_type: vec![],
             output_type: None,
             body: Some(rir::BlockId(0)),
-            is_measurement: false,
+            call_type: rir::CallableType::Other,
         },
     );
     program.blocks.insert(

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -45,7 +45,7 @@ impl Config {
 }
 
 /// A unique identifier for a block in a RIR program.
-#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct BlockId(pub u32);
 
 impl From<BlockId> for usize {
@@ -65,7 +65,7 @@ impl From<usize> for BlockId {
 pub struct Block(pub Vec<Instruction>);
 
 /// A unique identifier for a callable in a RIR program.
-#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct CallableId(pub u32);
 
 impl From<CallableId> for usize {

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -101,7 +101,7 @@ pub enum CallableType {
     Measurement,
     Readout,
     OutputRecording,
-    Other,
+    Regular,
 }
 
 pub enum Instruction {

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -54,12 +54,18 @@ impl From<BlockId> for usize {
     }
 }
 
+impl From<usize> for BlockId {
+    fn from(id: usize) -> BlockId {
+        BlockId(id.try_into().expect("block id should fit into u32"))
+    }
+}
+
 /// A block is a collection of instructions.
 #[derive(Default)]
 pub struct Block(pub Vec<Instruction>);
 
 /// A unique identifier for a callable in a RIR program.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct CallableId(pub u32);
 
 impl From<CallableId> for usize {
@@ -85,8 +91,17 @@ pub struct Callable {
     /// The callable body.
     /// N.B. `None` bodys represent an intrinsic.
     pub body: Option<BlockId>,
-    /// Whether or not the callabe is a measurement.
-    pub is_measurement: bool,
+    /// What type of callable this is.
+    pub call_type: CallableType,
+}
+
+/// The type of callable.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum CallableType {
+    Measurement,
+    Readout,
+    OutputRecording,
+    Other,
 }
 
 pub enum Instruction {


### PR DESCRIPTION
This change introduces two RIR -> RIR passes: the first that defers measurements within a block and a second that is a wrapper on a set of unreachable code checks. 

Deferring of measurements updates the RIR and preserves relative ordering of all instructions, leaving the block in the format of:

 1. Operations
 2. Measurements and readout
 3. Output recording
 4. Block terminator

For Base Profile programs where the whole program is a single block, this performs whole program measurement deferral. For programs with more complex control flow, this ensures that measurements appear at the end of the block in a way that could eventually support quantum logic separation.

The unreachable code pass does not modify the RIR, instead acting as a way to verify that RIR is well-formed and panicking on any unreachable callables, blocks, or instructions.

This change also refactors some test utilities to support code reuse across tests for QIR codegen and passes.