### PR TITLE
Remove debug with circuit menu item; more helpful handling for result comparison error

### DIFF
--- a/npm/ux/circuit.tsx
+++ b/npm/ux/circuit.tsx
@@ -13,6 +13,8 @@ const MAX_QUBITS = 1000;
 
 /* This component is shared by the Python widget and the VS Code panel */
 export function Circuit(props: { circuit: qviz.Circuit }) {
+  const circuitDiv = useRef<HTMLDivElement>(null);
+
   const errorDiv =
     props.circuit.qubits.length === 0 ? (
       <div>
@@ -42,13 +44,12 @@ export function Circuit(props: { circuit: qviz.Circuit }) {
       </div>
     ) : undefined;
 
-  if (errorDiv) {
-    return <div class=".qs-circuit-error">{errorDiv}</div>;
-  }
-
-  const circuitDiv = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
+    if (errorDiv !== undefined) {
+      circuitDiv.current!.innerHTML = "";
+      return;
+    }
+
     qviz.draw(props.circuit, circuitDiv.current!);
 
     // quantum-viz hardcodes the styles in the SVG.
@@ -57,7 +58,12 @@ export function Circuit(props: { circuit: qviz.Circuit }) {
     styleElements?.forEach((tag) => tag.remove());
   }, [props.circuit]);
 
-  return <div class="qs-circuit" ref={circuitDiv}></div>;
+  return (
+    <div>
+      <div class="qs-circuit-error">{errorDiv}</div>
+      <div class="qs-circuit" ref={circuitDiv}></div>
+    </div>
+  );
 }
 
 /* This component is exclusive to the VS Code panel */

--- a/npm/ux/circuit.tsx
+++ b/npm/ux/circuit.tsx
@@ -3,6 +3,7 @@
 
 import * as qviz from "@microsoft/quantum-viz.js/lib";
 import { useEffect, useRef } from "preact/hooks";
+import { CircuitProps } from "./data";
 
 // For perf reasons we set a limit on how many gates/qubits
 // we attempt to render. This is still a lot higher than a human would
@@ -67,31 +68,39 @@ export function Circuit(props: { circuit: qviz.Circuit }) {
 }
 
 /* This component is exclusive to the VS Code panel */
-export function CircuitPanel(props: {
-  title: string;
-  subtitle: string;
-  circuit?: qviz.Circuit;
-  errorHtml?: string;
-}) {
+export function CircuitPanel(props: CircuitProps) {
+  const error = props.errorHtml ? (
+    <div>
+      <p>
+        {props.circuit
+          ? "The program encountered a failure. See the error(s) below."
+          : "A circuit could not be generated for this program. See the error(s) below."}
+        <br />
+      </p>
+      <div dangerouslySetInnerHTML={{ __html: props.errorHtml }}></div>
+    </div>
+  ) : null;
+
   return (
     <div class="qs-circuit-panel">
       <div>
         <h1>{props.title}</h1>
       </div>
       {props.circuit ? <Circuit circuit={props.circuit}></Circuit> : null}
-      <div class="qs-circuit-error">
-        {props.errorHtml ? (
-          <div>
-            <p>
-              A circuit could not be generated for this program. See the
-              error(s) below.
-              <br />
-            </p>
-            <div dangerouslySetInnerHTML={{ __html: props.errorHtml }}></div>
-          </div>
-        ) : null}
-      </div>
-      <p>{props.subtitle /* target profile */}</p>
+      <div class="qs-circuit-error">{error}</div>
+      <p>{props.targetProfile /* target profile */}</p>
+      {props.simulating ? (
+        <p>
+          This circuit diagram was generated while running the program in the
+          simulator.
+          <br />
+          <br />
+          If your program contains behavior that is conditional on a qubit
+          measurement result, note that this circuit only shows the outcome that
+          was encountered during this simulation. Running the program again may
+          result in a different circuit being generated.
+        </p>
+      ) : null}
       <p>
         <a href="https://github.com/microsoft/qsharp/wiki/Circuit-Diagrams-from-Q%23-Code">
           Learn more
@@ -100,5 +109,3 @@ export function CircuitPanel(props: {
     </div>
   );
 }
-
-export type CircuitData = qviz.Circuit;

--- a/npm/ux/circuit.tsx
+++ b/npm/ux/circuit.tsx
@@ -3,7 +3,7 @@
 
 import * as qviz from "@microsoft/quantum-viz.js/lib";
 import { useEffect, useRef } from "preact/hooks";
-import { CircuitProps } from "./data";
+import { CircuitProps } from "./data.js";
 
 // For perf reasons we set a limit on how many gates/qubits
 // we attempt to render. This is still a lot higher than a human would

--- a/npm/ux/circuit.tsx
+++ b/npm/ux/circuit.tsx
@@ -20,12 +20,6 @@ export function Circuit(props: { circuit: qviz.Circuit }) {
     props.circuit.qubits.length === 0 ? (
       <div>
         <p>No circuit to display. No qubits have been allocated.</p>
-        <p>
-          <em>
-            Tip: you can generate a circuit diagram for any operation that takes
-            qubits or arrays of qubits as input.
-          </em>
-        </p>
       </div>
     ) : props.circuit.operations.length > MAX_OPERATIONS ? (
       <div>
@@ -88,7 +82,7 @@ export function CircuitPanel(props: CircuitProps) {
       </div>
       {props.circuit ? <Circuit circuit={props.circuit}></Circuit> : null}
       <div class="qs-circuit-error">{error}</div>
-      <p>{props.targetProfile /* target profile */}</p>
+      <p>{props.targetProfile}</p>
       {props.simulating ? (
         <p>
           This circuit diagram was generated while running the program in the
@@ -101,6 +95,19 @@ export function CircuitPanel(props: CircuitProps) {
           result in a different circuit being generated.
         </p>
       ) : null}
+      {
+        // show tip when the circuit is empty and we didn't run under the simulator (i.e. debugging)
+        !props.simulating &&
+        !props.errorHtml &&
+        props.circuit?.qubits.length === 0 ? (
+          <p>
+            <em>
+              Tip: you can generate a circuit diagram for any operation that
+              takes qubits or arrays of qubits as input.
+            </em>
+          </p>
+        ) : null
+      }
       <p>
         <a href="https://github.com/microsoft/qsharp/wiki/Circuit-Diagrams-from-Q%23-Code">
           Learn more

--- a/npm/ux/data.ts
+++ b/npm/ux/data.ts
@@ -63,3 +63,13 @@ export function CreateSingleEstimateResult(
     };
   }
 }
+
+export type CircuitProps = {
+  title: string;
+  circuit?: CircuitData;
+  errorHtml?: string;
+  targetProfile: string;
+  simulating: boolean;
+};
+
+export type CircuitData = import("@microsoft/quantum-viz.js/lib").Circuit;

--- a/npm/ux/index.ts
+++ b/npm/ux/index.ts
@@ -6,11 +6,16 @@
 import "./qsharp-ux.css";
 import "./qsharp-circuit.css";
 
-export { CreateSingleEstimateResult, type ReData } from "./data.js";
+export {
+  CreateSingleEstimateResult,
+  type ReData,
+  type CircuitData,
+  type CircuitProps,
+} from "./data.js";
 export { Histogram } from "./histogram.js";
 export { ReTable } from "./reTable.js";
 export { SpaceChart } from "./spaceChart.js";
 export { ScatterChart } from "./scatterChart.js";
 export { EstimatesOverview } from "./estimatesOverview.js";
 export { EstimatesPanel } from "./estimatesPanel.js";
-export { Circuit, CircuitPanel, type CircuitData } from "./circuit.js";
+export { Circuit, CircuitPanel } from "./circuit.js";

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -282,9 +282,7 @@
       {
         "command": "qsharp-vscode.runEditorContentsWithCircuit",
         "title": "Run file and show circuit diagram",
-        "category": "Debug",
-        "enablement": "!inDebugMode",
-        "icon": "$(play)"
+        "category": "Q#"
       },
       {
         "command": "qsharp-vscode.showHistogram",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -132,11 +132,6 @@
           "command": "qsharp-vscode.debugEditorContents",
           "when": "resourceLangId == qsharp",
           "group": "navigation@2"
-        },
-        {
-          "command": "qsharp-vscode.debugEditorContentsWithCircuit",
-          "when": "resourceLangId == qsharp",
-          "group": "navigation@2"
         }
       ],
       "commandPalette": [
@@ -149,7 +144,7 @@
           "when": "resourceLangId == qsharp"
         },
         {
-          "command": "qsharp-vscode.debugEditorContentsWithCircuit",
+          "command": "qsharp-vscode.runEditorContentsWithCircuit",
           "when": "resourceLangId == qsharp"
         },
         {
@@ -285,11 +280,11 @@
         "icon": "$(play)"
       },
       {
-        "command": "qsharp-vscode.debugEditorContentsWithCircuit",
-        "title": "Debug Q# File with Circuit Diagram",
+        "command": "qsharp-vscode.runEditorContentsWithCircuit",
+        "title": "Run file and show circuit diagram",
         "category": "Debug",
         "enablement": "!inDebugMode",
-        "icon": "$(debug-alt)"
+        "icon": "$(play)"
       },
       {
         "command": "qsharp-vscode.showHistogram",

--- a/vscode/src/circuit.ts
+++ b/vscode/src/circuit.ts
@@ -65,6 +65,7 @@ export async function showCircuitCommand(
       targetProfile,
       editor.document.uri.path,
       circuit,
+      true, // reveal
       operation,
     );
 
@@ -95,6 +96,7 @@ export async function showCircuitCommand(
       targetProfile,
       editor.document.uri.path,
       errorHtml,
+      false, // reveal
       operation,
     );
   } finally {
@@ -107,6 +109,7 @@ export function updateCircuitPanel(
   targetProfile: string,
   docPath: string,
   circuitOrErrorHtml: CircuitData | string,
+  reveal: boolean,
   operation?: IOperationInfo | undefined,
 ) {
   let title;
@@ -128,7 +131,7 @@ export function updateCircuitPanel(
     errorHtml:
       typeof circuitOrErrorHtml === "string" ? circuitOrErrorHtml : undefined,
   };
-  sendMessageToPanel("circuit", false, message);
+  sendMessageToPanel("circuit", reveal, message);
 }
 
 /**

--- a/vscode/src/debugger/activate.ts
+++ b/vscode/src/debugger/activate.ts
@@ -55,13 +55,17 @@ function registerCommands(context: vscode.ExtensionContext) {
         startDebugging(resource, { name: "Debug Q# File", stopOnEntry: true }),
     ),
     vscode.commands.registerCommand(
-      `${qsharpExtensionId}.debugEditorContentsWithCircuit`,
+      `${qsharpExtensionId}.runEditorContentsWithCircuit`,
       (resource: vscode.Uri) =>
-        startDebugging(resource, {
-          name: "Debug Q# File",
-          stopOnEntry: true,
-          showCircuit: true,
-        }),
+        startDebugging(
+          resource,
+          {
+            name: "Run file and show circuit diagram",
+            stopOnEntry: false,
+            showCircuit: true,
+          },
+          { noDebug: true },
+        ),
     ),
   );
 
@@ -76,12 +80,8 @@ function registerCommands(context: vscode.ExtensionContext) {
     }
 
     if (targetResource) {
-      // We'll omit config.program and let the configuration
-      // resolver fill it in with the currently open editor's URI.
-      // This will also let us correctly handle untitled files
-      // where the save prompt pops up before the debugger is launched,
-      // potentially causing the active editor URI to change if
-      // the file is saved with a different name.
+      config.programUri = targetResource.toString();
+
       vscode.debug.startDebugging(
         undefined,
         {
@@ -90,7 +90,11 @@ function registerCommands(context: vscode.ExtensionContext) {
           shots: 1,
           ...config,
         },
-        options,
+        {
+          // no need to save the file, in fact better not to, since it may cause the document uri to change
+          suppressSaveBeforeStart: true,
+          ...options,
+        },
       );
     }
   }
@@ -137,7 +141,11 @@ class QsDebugConfigProvider implements vscode.DebugConfigurationProvider {
           path: fileUri.path,
         })
         .toString();
-    } else {
+    } else if (!config.programUri) {
+      // We shouldn't hit this in practice
+      log.warn(
+        "Cannot find a Q# program to debug, defaulting to active editor",
+      );
       // Use the active editor if no program is specified.
       const editor = vscode.window.activeTextEditor;
       if (editor && isQsharpDocument(editor.document)) {

--- a/vscode/src/webview/webview.tsx
+++ b/vscode/src/webview/webview.tsx
@@ -8,6 +8,7 @@ const vscodeApi = acquireVsCodeApi();
 import { render } from "preact";
 import {
   CircuitPanel,
+  CircuitProps,
   EstimatesPanel,
   Histogram,
   type ReData,
@@ -18,7 +19,6 @@ import { HelpPage } from "./help";
 // @ts-ignore - there are no types for this
 import mk from "@vscode/markdown-it-katex";
 import markdownIt from "markdown-it";
-import { CircuitData } from "qsharp-lang/ux/circuit";
 const md = markdownIt();
 md.use(mk);
 
@@ -46,10 +46,7 @@ type EstimatesState = {
 
 type CircuitState = {
   viewType: "circuit";
-  title: string;
-  subtitle: string;
-  circuit?: CircuitData;
-  errorHtml?: string;
+  props: CircuitProps;
 };
 
 type State =
@@ -179,14 +176,7 @@ function App({ state }: { state: State }) {
         />
       );
     case "circuit":
-      return (
-        <CircuitPanel
-          title={state.title}
-          subtitle={state.subtitle}
-          circuit={state.circuit}
-          errorHtml={state.errorHtml}
-        ></CircuitPanel>
-      );
+      return <CircuitPanel {...state.props}></CircuitPanel>;
     case "help":
       return <HelpPage />;
     default:


### PR DESCRIPTION
More UX improvements and an attempt to be more helpful with known error conditions.

## "Show circuit" command (or Code Lens)

![image](https://github.com/microsoft/qsharp/assets/16928427/b30b79e3-2d9f-444a-b203-d7b4043d52c8)


## "Run file and show circuit diagram" command (i.e. running in simulator)

![image](https://github.com/microsoft/qsharp/assets/16928427/787f925c-5a75-4d16-af9d-9af06069c105)


## Program that compares measurement results, Target Profile = Unrestricted

![image](https://github.com/microsoft/qsharp/assets/16928427/b40dd857-3452-4cd8-ac72-1d08ecef298b)


## Same program, but with "Run file and show circuit diagram" 

![image](https://github.com/microsoft/qsharp/assets/16928427/5674be51-6f73-4770-8ad5-b00c17797755)


## Same program, but with Target Profile = Base

![image](https://github.com/microsoft/qsharp/assets/16928427/3a9af968-75fd-4760-80b1-3d372ac27b55)
