### PR TITLE
Refactor benches, add interpreter bench

### DIFF
--- a/compiler/qsc/benches/library.rs
+++ b/compiler/qsc/benches/library.rs
@@ -9,8 +9,10 @@ use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags};
 
 pub fn library(c: &mut Criterion) {
     c.bench_function("Core + Standard library compilation", |b| {
-        let store = PackageStore::new(compile::core());
-        b.iter(|| compile::std(&store, RuntimeCapabilityFlags::all()));
+        b.iter(|| {
+            let store = PackageStore::new(compile::core());
+            compile::std(&store, RuntimeCapabilityFlags::all())
+        });
     });
 }
 

--- a/compiler/qsc/benches/library.rs
+++ b/compiler/qsc/benches/library.rs
@@ -8,8 +8,8 @@ use qsc::compile;
 use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags};
 
 pub fn library(c: &mut Criterion) {
-    let store = PackageStore::new(compile::core());
-    c.bench_function("Standard library", |b| {
+    c.bench_function("Core + Standard library compilation", |b| {
+        let store = PackageStore::new(compile::core());
         b.iter(|| compile::std(&store, RuntimeCapabilityFlags::all()));
     });
 }


### PR DESCRIPTION
This change updates the benches in a few ways:
 - Include core library in library compilation bench
 - Don't include core and stdlib in large file compilation so only compilation of the user code is measured.
 - Introduce new bench for interpreter compilation of core + std + large file, which includes lowering to FIR in preparation for evalutation.