### PR TITLE
RIR qubit reindex pass

### DIFF
--- a/compiler/qsc_data_structures/src/index_map.rs
+++ b/compiler/qsc_data_structures/src/index_map.rs
@@ -63,6 +63,27 @@ impl<K, V> IndexMap<K, V> {
             base: self.values.iter_mut(),
         }
     }
+
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(K, &V) -> bool,
+        K: From<usize>,
+    {
+        for (k, v) in self.values.iter_mut().enumerate() {
+            let remove = if let Some(value) = v {
+                !f(K::from(k), value)
+            } else {
+                false
+            };
+            if remove {
+                *v = None;
+            }
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.values.clear();
+    }
 }
 
 impl<K: Into<usize>, V> IndexMap<K, V> {
@@ -94,10 +115,6 @@ impl<K: Into<usize>, V> IndexMap<K, V> {
         if index < self.values.len() {
             self.values[index] = None;
         }
-    }
-
-    pub fn clear(&mut self) {
-        self.values.clear();
     }
 }
 

--- a/compiler/qsc_rir/src/builder.rs
+++ b/compiler/qsc_rir/src/builder.rs
@@ -84,6 +84,17 @@ pub fn mresetz_decl() -> Callable {
 }
 
 #[must_use]
+pub fn reset_decl() -> Callable {
+    Callable {
+        name: "__quantum__qis__reset__body".to_string(),
+        input_type: vec![Ty::Qubit],
+        output_type: None,
+        body: None,
+        call_type: CallableType::Reset,
+    }
+}
+
+#[must_use]
 pub fn read_result_decl() -> Callable {
     Callable {
         name: "__quantum__qis__read_result__body".to_string(),

--- a/compiler/qsc_rir/src/passes.rs
+++ b/compiler/qsc_rir/src/passes.rs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 mod defer_meas;
+mod reindex_qubits;
 mod unreachable_code_check;
 
 pub use defer_meas::defer_measurements;
+pub use reindex_qubits::reindex_qubits;
 pub use unreachable_code_check::check_unreachable_code;

--- a/compiler/qsc_rir/src/passes/defer_meas.rs
+++ b/compiler/qsc_rir/src/passes/defer_meas.rs
@@ -30,6 +30,9 @@ pub fn defer_measurements(program: &mut Program) {
                 output_recording_ids.insert(id);
             }
             CallableType::Regular => {}
+            CallableType::Reset => panic!(
+                "Reset callables should not be present in the RIR when deferring measurements"
+            ),
         }
     }
 

--- a/compiler/qsc_rir/src/passes/reindex_qubits.rs
+++ b/compiler/qsc_rir/src/passes/reindex_qubits.rs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(test)]
+mod tests;
+
+use rustc_hash::FxHashMap;
+
+use crate::rir::{
+    Block, Callable, CallableId, CallableType, Instruction, Literal, Program, Ty, Value,
+};
+
+/// Reindexes qubits after they have been measured or reset. This ensures there is no qubit reuse in
+/// the program. As part of the pass, reset callables are removed and mresetz calls are replaced with
+/// mz calls.
+/// Note that this pass has several assumptions:
+/// 1. Only one callable has a body, which is the entry point callable.
+/// 2. The entry point callable has a single block.
+/// 3. No dynamic qubits are used.
+/// The pass will panic if the input program violates any of these assumptions.
+pub fn reindex_qubits(program: &mut Program) {
+    validate_assumptions(program);
+
+    let (mut used_mz, mz_id) = match find_measurement_callable(program, "__quantum__qis__mz__body")
+    {
+        Some(id) => (true, id),
+        None => (false, add_mz(program)),
+    };
+    let mresetz_id = find_measurement_callable(program, "__quantum__qis__mresetz__body");
+
+    let mut qubit_map = FxHashMap::default();
+    let mut next_qubit_id = program.num_qubits;
+    let mut highest_used_id = next_qubit_id - 1;
+    let mut new_block = Vec::new();
+    let (block_id, block) = program
+        .blocks
+        .drain()
+        .next()
+        .expect("program should have at least one block");
+    for instr in &block.0 {
+        // Assume qubits only appear in void call instructions.
+        match instr {
+            Instruction::Call(call_id, args, _)
+                if program.get_callable(*call_id).call_type == CallableType::Reset =>
+            {
+                // Generate any new qubit ids and skip adding the instruction.
+                for arg in args {
+                    if let Value::Literal(Literal::Qubit(qubit_id)) = arg {
+                        qubit_map.insert(*qubit_id, next_qubit_id);
+                        next_qubit_id += 1;
+                    }
+                }
+            }
+            Instruction::Call(call_id, args, None) => {
+                // Map the qubit args, if any, and copy over the instruction.
+                let new_args = args
+                    .iter()
+                    .map(|arg| match arg {
+                        Value::Literal(Literal::Qubit(qubit_id)) => {
+                            if let Some(mapped_id) = qubit_map.get(qubit_id) {
+                                highest_used_id = highest_used_id.max(*mapped_id);
+                                Value::Literal(Literal::Qubit(*mapped_id))
+                            } else {
+                                *arg
+                            }
+                        }
+                        _ => *arg,
+                    })
+                    .collect::<Vec<_>>();
+
+                // If the call was to mresetz, replace with mz.
+                let call_id = if Some(*call_id) == mresetz_id {
+                    used_mz = true;
+                    mz_id
+                } else {
+                    *call_id
+                };
+
+                new_block.push(Instruction::Call(call_id, new_args, None));
+
+                if program.get_callable(call_id).call_type == CallableType::Measurement {
+                    // Generate any new qubit ids after a measurement.
+                    for arg in args {
+                        if let Value::Literal(Literal::Qubit(qubit_id)) = arg {
+                            qubit_map.insert(*qubit_id, next_qubit_id);
+                            next_qubit_id += 1;
+                        }
+                    }
+                }
+            }
+            _ => {
+                // Copy over the instruction.
+                new_block.push(instr.clone());
+            }
+        }
+    }
+
+    program.num_qubits = highest_used_id + 1;
+    program.blocks.clear();
+    program.blocks.insert(block_id, Block(new_block));
+
+    // All reset function calls should be removed, so remove them from the callables.
+    let mut callables_to_remove = Vec::new();
+    for (callable_id, callable) in program.callables.iter() {
+        if callable.call_type == CallableType::Reset || Some(callable_id) == mresetz_id {
+            callables_to_remove.push(callable_id);
+        }
+    }
+    for callable_id in callables_to_remove {
+        program.callables.remove(callable_id);
+    }
+
+    // If mz was added but not used, remove it.
+    if !used_mz {
+        program.callables.remove(mz_id);
+    }
+}
+
+fn validate_assumptions(program: &Program) {
+    // Ensure only one callable with a body exists.
+    for (callable_id, callable) in program.callables.iter() {
+        assert!(
+            callable.body.is_none() || callable_id == program.entry,
+            "Only the entry point callable should have a body"
+        );
+    }
+
+    // Ensure entry point callable has a single block.
+    // Future enhancements may allow multiple blocks in the entry point callable.
+    assert!(
+        program.blocks.iter().count() == 1,
+        "Entry point callable must have a single block"
+    );
+
+    // Ensure that no dynamic qubits are used.
+    let Some((_, block)) = program.blocks.iter().next() else {
+        panic!("No blocks found in the program");
+    };
+    for instr in &block.0 {
+        assert!(
+            !matches!(instr, Instruction::Store(_, var) if var.ty == Ty::Qubit),
+            "Dynamic qubits are not supported"
+        );
+    }
+}
+
+fn find_measurement_callable(program: &Program, name: &str) -> Option<CallableId> {
+    for (callable_id, callable) in program.callables.iter() {
+        if callable.call_type == CallableType::Measurement && callable.name == name {
+            return Some(callable_id);
+        }
+    }
+    None
+}
+
+fn add_mz(program: &mut Program) -> CallableId {
+    let mz_id = CallableId(
+        program
+            .callables
+            .iter()
+            .map(|(id, _)| id.0)
+            .max()
+            .expect("should be at least one callable")
+            + 1,
+    );
+    program.callables.insert(
+        mz_id,
+        Callable {
+            name: "__quantum__qis__mz__body".to_string(),
+            input_type: vec![Ty::Qubit, Ty::Result],
+            output_type: None,
+            body: None,
+            call_type: CallableType::Measurement,
+        },
+    );
+    mz_id
+}

--- a/compiler/qsc_rir/src/passes/reindex_qubits.rs
+++ b/compiler/qsc_rir/src/passes/reindex_qubits.rs
@@ -100,15 +100,9 @@ pub fn reindex_qubits(program: &mut Program) {
     program.blocks.insert(block_id, Block(new_block));
 
     // All reset function calls should be removed, so remove them from the callables.
-    let mut callables_to_remove = Vec::new();
-    for (callable_id, callable) in program.callables.iter() {
-        if callable.call_type == CallableType::Reset || Some(callable_id) == mresetz_id {
-            callables_to_remove.push(callable_id);
-        }
-    }
-    for callable_id in callables_to_remove {
-        program.callables.remove(callable_id);
-    }
+    program
+        .callables
+        .retain(|id, callable| callable.call_type != CallableType::Reset && Some(id) != mresetz_id);
 
     // If mz was added but not used, remove it.
     if !used_mz {

--- a/compiler/qsc_rir/src/passes/reindex_qubits/tests.rs
+++ b/compiler/qsc_rir/src/passes/reindex_qubits/tests.rs
@@ -1,0 +1,286 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(clippy::too_many_lines, clippy::needless_raw_string_hashes)]
+
+use expect_test::expect;
+
+use crate::{
+    builder::{cx_decl, h_decl, mresetz_decl, mz_decl, reset_decl, x_decl},
+    rir::{Block, BlockId, CallableId, CallableType, Instruction, Literal, Program, Value},
+};
+
+use super::reindex_qubits;
+
+#[test]
+fn qubit_reindexed_after_reset_removes_reset() {
+    let mut program = Program::new();
+    program.num_qubits = 1;
+    program.callables.insert(CallableId(0), x_decl());
+    program.callables.insert(CallableId(1), reset_decl());
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(CallableId(1), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(CallableId(1), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+
+    // After
+    reindex_qubits(&mut program);
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(0), args( Qubit(1), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+    assert_eq!(program.num_qubits, 2);
+
+    // Reset callable should be removed.
+    for callable in program.callables.values() {
+        assert_ne!(callable.call_type, CallableType::Reset);
+    }
+}
+
+#[test]
+fn qubit_reindexed_after_mz() {
+    let mut program = Program::new();
+    program.num_qubits = 1;
+    program.callables.insert(CallableId(0), x_decl());
+    program.callables.insert(CallableId(1), mz_decl());
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(
+                CallableId(1),
+                vec![
+                    Value::Literal(Literal::Qubit(0)),
+                    Value::Literal(Literal::Result(0)),
+                ],
+                None,
+            ),
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(
+                CallableId(1),
+                vec![
+                    Value::Literal(Literal::Qubit(0)),
+                    Value::Literal(Literal::Result(1)),
+                ],
+                None,
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(1), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+
+    // After
+    reindex_qubits(&mut program);
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(0), args( Qubit(1), )
+            Call id(1), args( Qubit(1), Result(1), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+    assert_eq!(program.num_qubits, 2);
+}
+
+#[test]
+fn qubit_reindexed_after_mresetz_and_changed_to_mz() {
+    let mut program = Program::new();
+    program.num_qubits = 1;
+    program.callables.insert(CallableId(0), x_decl());
+    program.callables.insert(CallableId(1), mresetz_decl());
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(
+                CallableId(1),
+                vec![
+                    Value::Literal(Literal::Qubit(0)),
+                    Value::Literal(Literal::Result(0)),
+                ],
+                None,
+            ),
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(
+                CallableId(1),
+                vec![
+                    Value::Literal(Literal::Qubit(0)),
+                    Value::Literal(Literal::Result(1)),
+                ],
+                None,
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(1), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+
+    // After
+    reindex_qubits(&mut program);
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(2), args( Qubit(0), Result(0), )
+            Call id(0), args( Qubit(1), )
+            Call id(2), args( Qubit(1), Result(1), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+    assert_eq!(program.num_qubits, 2);
+}
+
+#[test]
+fn multiple_qubit_reindex() {
+    let mut program = Program::new();
+    program.num_qubits = 2;
+    program.callables.insert(CallableId(0), h_decl());
+    program.callables.insert(CallableId(1), mresetz_decl());
+    program.callables.insert(CallableId(2), cx_decl());
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(
+                CallableId(1),
+                vec![
+                    Value::Literal(Literal::Qubit(0)),
+                    Value::Literal(Literal::Result(0)),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                CallableId(2),
+                vec![
+                    Value::Literal(Literal::Qubit(1)),
+                    Value::Literal(Literal::Qubit(0)),
+                ],
+                None,
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(2), args( Qubit(1), Qubit(0), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+
+    // After
+    reindex_qubits(&mut program);
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(3), args( Qubit(0), Result(0), )
+            Call id(2), args( Qubit(1), Qubit(2), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+    assert_eq!(program.num_qubits, 3);
+}
+
+#[test]
+fn qubit_reindexed_multiple_times() {
+    let mut program = Program::new();
+    program.num_qubits = 1;
+    program.callables.insert(CallableId(0), x_decl());
+    program.callables.insert(CallableId(1), mz_decl());
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(
+                CallableId(1),
+                vec![
+                    Value::Literal(Literal::Qubit(0)),
+                    Value::Literal(Literal::Result(0)),
+                ],
+                None,
+            ),
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(
+                CallableId(1),
+                vec![
+                    Value::Literal(Literal::Qubit(0)),
+                    Value::Literal(Literal::Result(1)),
+                ],
+                None,
+            ),
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(
+                CallableId(1),
+                vec![
+                    Value::Literal(Literal::Qubit(0)),
+                    Value::Literal(Literal::Result(2)),
+                ],
+                None,
+            ),
+            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(
+                CallableId(1),
+                vec![
+                    Value::Literal(Literal::Qubit(0)),
+                    Value::Literal(Literal::Result(3)),
+                ],
+                None,
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(1), )
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(2), )
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(3), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+
+    // After
+    reindex_qubits(&mut program);
+    expect![[r#"
+        Block:
+            Call id(0), args( Qubit(0), )
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(0), args( Qubit(1), )
+            Call id(1), args( Qubit(1), Result(1), )
+            Call id(0), args( Qubit(2), )
+            Call id(1), args( Qubit(2), Result(2), )
+            Call id(0), args( Qubit(3), )
+            Call id(1), args( Qubit(3), Result(3), )
+            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+    assert_eq!(program.num_qubits, 4);
+}

--- a/compiler/qsc_rir/src/passes/reindex_qubits/tests.rs
+++ b/compiler/qsc_rir/src/passes/reindex_qubits/tests.rs
@@ -36,7 +36,8 @@ fn qubit_reindexed_after_reset_removes_reset() {
             Call id(1), args( Qubit(0), )
             Call id(0), args( Qubit(0), )
             Call id(1), args( Qubit(0), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
 
     // After
     reindex_qubits(&mut program);
@@ -44,7 +45,8 @@ fn qubit_reindexed_after_reset_removes_reset() {
         Block:
             Call id(0), args( Qubit(0), )
             Call id(0), args( Qubit(1), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
     assert_eq!(program.num_qubits, 2);
 
     // Reset callable should be removed.
@@ -91,7 +93,8 @@ fn qubit_reindexed_after_mz() {
             Call id(1), args( Qubit(0), Result(0), )
             Call id(0), args( Qubit(0), )
             Call id(1), args( Qubit(0), Result(1), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
 
     // After
     reindex_qubits(&mut program);
@@ -101,7 +104,8 @@ fn qubit_reindexed_after_mz() {
             Call id(1), args( Qubit(0), Result(0), )
             Call id(0), args( Qubit(1), )
             Call id(1), args( Qubit(1), Result(1), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
     assert_eq!(program.num_qubits, 2);
 }
 
@@ -143,7 +147,8 @@ fn qubit_reindexed_after_mresetz_and_changed_to_mz() {
             Call id(1), args( Qubit(0), Result(0), )
             Call id(0), args( Qubit(0), )
             Call id(1), args( Qubit(0), Result(1), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
 
     // After
     reindex_qubits(&mut program);
@@ -153,7 +158,8 @@ fn qubit_reindexed_after_mresetz_and_changed_to_mz() {
             Call id(2), args( Qubit(0), Result(0), )
             Call id(0), args( Qubit(1), )
             Call id(2), args( Qubit(1), Result(1), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
     assert_eq!(program.num_qubits, 2);
 }
 
@@ -194,7 +200,8 @@ fn multiple_qubit_reindex() {
             Call id(0), args( Qubit(0), )
             Call id(1), args( Qubit(0), Result(0), )
             Call id(2), args( Qubit(1), Qubit(0), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
 
     // After
     reindex_qubits(&mut program);
@@ -203,7 +210,8 @@ fn multiple_qubit_reindex() {
             Call id(0), args( Qubit(0), )
             Call id(3), args( Qubit(0), Result(0), )
             Call id(2), args( Qubit(1), Qubit(2), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
     assert_eq!(program.num_qubits, 3);
 }
 
@@ -267,7 +275,8 @@ fn qubit_reindexed_multiple_times() {
             Call id(1), args( Qubit(0), Result(2), )
             Call id(0), args( Qubit(0), )
             Call id(1), args( Qubit(0), Result(3), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
 
     // After
     reindex_qubits(&mut program);
@@ -281,6 +290,7 @@ fn qubit_reindexed_multiple_times() {
             Call id(1), args( Qubit(2), Result(2), )
             Call id(0), args( Qubit(3), )
             Call id(1), args( Qubit(3), Result(3), )
-            Return"#]].assert_eq(&program.get_block(BlockId(0)).to_string());
+            Return"#]]
+    .assert_eq(&program.get_block(BlockId(0)).to_string());
     assert_eq!(program.num_qubits, 4);
 }

--- a/compiler/qsc_rir/src/passes/reindex_qubits/tests.rs
+++ b/compiler/qsc_rir/src/passes/reindex_qubits/tests.rs
@@ -14,17 +14,19 @@ use super::reindex_qubits;
 
 #[test]
 fn qubit_reindexed_after_reset_removes_reset() {
+    const X: CallableId = CallableId(0);
+    const RESET: CallableId = CallableId(1);
     let mut program = Program::new();
     program.num_qubits = 1;
-    program.callables.insert(CallableId(0), x_decl());
-    program.callables.insert(CallableId(1), reset_decl());
+    program.callables.insert(X, x_decl());
+    program.callables.insert(RESET, reset_decl());
     program.blocks.insert(
         BlockId(0),
         Block(vec![
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
-            Instruction::Call(CallableId(1), vec![Value::Literal(Literal::Qubit(0))], None),
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
-            Instruction::Call(CallableId(1), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(RESET, vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(RESET, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Return,
         ]),
     );
@@ -57,25 +59,27 @@ fn qubit_reindexed_after_reset_removes_reset() {
 
 #[test]
 fn qubit_reindexed_after_mz() {
+    const X: CallableId = CallableId(0);
+    const MZ: CallableId = CallableId(1);
     let mut program = Program::new();
     program.num_qubits = 1;
-    program.callables.insert(CallableId(0), x_decl());
-    program.callables.insert(CallableId(1), mz_decl());
+    program.callables.insert(X, x_decl());
+    program.callables.insert(MZ, mz_decl());
     program.blocks.insert(
         BlockId(0),
         Block(vec![
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Call(
-                CallableId(1),
+                MZ,
                 vec![
                     Value::Literal(Literal::Qubit(0)),
                     Value::Literal(Literal::Result(0)),
                 ],
                 None,
             ),
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Call(
-                CallableId(1),
+                MZ,
                 vec![
                     Value::Literal(Literal::Qubit(0)),
                     Value::Literal(Literal::Result(1)),
@@ -111,6 +115,8 @@ fn qubit_reindexed_after_mz() {
 
 #[test]
 fn qubit_reindexed_after_mresetz_and_changed_to_mz() {
+    const X: CallableId = CallableId(0);
+    const MRESETZ: CallableId = CallableId(1);
     let mut program = Program::new();
     program.num_qubits = 1;
     program.callables.insert(CallableId(0), x_decl());
@@ -118,18 +124,18 @@ fn qubit_reindexed_after_mresetz_and_changed_to_mz() {
     program.blocks.insert(
         BlockId(0),
         Block(vec![
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Call(
-                CallableId(1),
+                MRESETZ,
                 vec![
                     Value::Literal(Literal::Qubit(0)),
                     Value::Literal(Literal::Result(0)),
                 ],
                 None,
             ),
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Call(
-                CallableId(1),
+                MRESETZ,
                 vec![
                     Value::Literal(Literal::Qubit(0)),
                     Value::Literal(Literal::Result(1)),
@@ -165,17 +171,20 @@ fn qubit_reindexed_after_mresetz_and_changed_to_mz() {
 
 #[test]
 fn multiple_qubit_reindex() {
+    const H: CallableId = CallableId(0);
+    const MRESETZ: CallableId = CallableId(1);
+    const CX: CallableId = CallableId(2);
     let mut program = Program::new();
     program.num_qubits = 2;
-    program.callables.insert(CallableId(0), h_decl());
-    program.callables.insert(CallableId(1), mresetz_decl());
-    program.callables.insert(CallableId(2), cx_decl());
+    program.callables.insert(H, h_decl());
+    program.callables.insert(MRESETZ, mresetz_decl());
+    program.callables.insert(CX, cx_decl());
     program.blocks.insert(
         BlockId(0),
         Block(vec![
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(H, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Call(
-                CallableId(1),
+                MRESETZ,
                 vec![
                     Value::Literal(Literal::Qubit(0)),
                     Value::Literal(Literal::Result(0)),
@@ -183,7 +192,7 @@ fn multiple_qubit_reindex() {
                 None,
             ),
             Instruction::Call(
-                CallableId(2),
+                CX,
                 vec![
                     Value::Literal(Literal::Qubit(1)),
                     Value::Literal(Literal::Qubit(0)),
@@ -217,6 +226,8 @@ fn multiple_qubit_reindex() {
 
 #[test]
 fn qubit_reindexed_multiple_times() {
+    const X: CallableId = CallableId(0);
+    const MZ: CallableId = CallableId(1);
     let mut program = Program::new();
     program.num_qubits = 1;
     program.callables.insert(CallableId(0), x_decl());
@@ -224,36 +235,36 @@ fn qubit_reindexed_multiple_times() {
     program.blocks.insert(
         BlockId(0),
         Block(vec![
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Call(
-                CallableId(1),
+                MZ,
                 vec![
                     Value::Literal(Literal::Qubit(0)),
                     Value::Literal(Literal::Result(0)),
                 ],
                 None,
             ),
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Call(
-                CallableId(1),
+                MZ,
                 vec![
                     Value::Literal(Literal::Qubit(0)),
                     Value::Literal(Literal::Result(1)),
                 ],
                 None,
             ),
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Call(
-                CallableId(1),
+                MZ,
                 vec![
                     Value::Literal(Literal::Qubit(0)),
                     Value::Literal(Literal::Result(2)),
                 ],
                 None,
             ),
-            Instruction::Call(CallableId(0), vec![Value::Literal(Literal::Qubit(0))], None),
+            Instruction::Call(X, vec![Value::Literal(Literal::Qubit(0))], None),
             Instruction::Call(
-                CallableId(1),
+                MZ,
                 vec![
                     Value::Literal(Literal::Qubit(0)),
                     Value::Literal(Literal::Result(3)),

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -187,9 +187,10 @@ impl Display for Callable {
 }
 
 /// The type of callable.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallableType {
     Measurement,
+    Reset,
     Readout,
     OutputRecording,
     Regular,
@@ -202,11 +203,13 @@ impl Display for CallableType {
             Self::Readout => write!(f, "Readout")?,
             Self::OutputRecording => write!(f, "OutputRecording")?,
             Self::Regular => write!(f, "Regular")?,
+            Self::Reset => write!(f, "Reset")?,
         };
         Ok(())
     }
 }
 
+#[derive(Clone)]
 pub enum Instruction {
     Store(Value, Variable),
     Call(CallableId, Vec<Value>, Option<Variable>),
@@ -330,6 +333,7 @@ impl Display for Instruction {
 #[derive(Clone, Copy, Default)]
 pub struct VariableId(pub u32);
 
+#[derive(Clone, Copy)]
 pub struct Variable {
     pub variable_id: VariableId,
     pub ty: Ty,
@@ -343,6 +347,7 @@ impl Display for Variable {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Ty {
     Qubit,
     Result,
@@ -366,6 +371,7 @@ impl Display for Ty {
     }
 }
 
+#[derive(Clone, Copy)]
 pub enum Value {
     Literal(Literal),
     Variable(Variable),

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -237,7 +237,7 @@ impl Display for Instruction {
             instruction: &str,
             lhs: &Value,
             rhs: &Value,
-            variable: &Variable,
+            variable: Variable,
         ) -> fmt::Result {
             let mut indent = set_indentation(indented(f), 0);
             write!(indent, "{variable} = {instruction} {lhs}, {rhs}")?;
@@ -259,7 +259,7 @@ impl Display for Instruction {
             f: &mut Formatter,
             callable_id: CallableId,
             args: &[Value],
-            variable: &Option<Variable>,
+            variable: Option<Variable>,
         ) -> fmt::Result {
             let mut indent = set_indentation(indented(f), 0);
             if let Some(variable) = variable {
@@ -277,7 +277,7 @@ impl Display for Instruction {
             f: &mut Formatter,
             instruction: &str,
             value: &Value,
-            variable: &Variable,
+            variable: Variable,
         ) -> fmt::Result {
             let mut indent = set_indentation(indented(f), 0);
             write!(indent, "{variable} = {instruction} {value}")?;
@@ -285,44 +285,46 @@ impl Display for Instruction {
         }
 
         match &self {
-            Self::Store(value, variable) => write_unary_instruction(f, "Store", value, variable)?,
+            Self::Store(value, variable) => write_unary_instruction(f, "Store", value, *variable)?,
             Self::Jump(block_id) => write!(f, "Jump({})", block_id.0)?,
-            Self::Call(callable_id, args, variable) => write_call(f, *callable_id, args, variable)?,
+            Self::Call(callable_id, args, variable) => {
+                write_call(f, *callable_id, args, *variable)?;
+            }
             Self::Branch(condition, if_true, if_false) => {
                 write_branch(f, condition, *if_true, *if_false)?;
             }
             Self::Add(lhs, rhs, variable) => {
-                write_binary_instruction(f, "Add", lhs, rhs, variable)?;
+                write_binary_instruction(f, "Add", lhs, rhs, *variable)?;
             }
             Self::Sub(lhs, rhs, variable) => {
-                write_binary_instruction(f, "Sub", lhs, rhs, variable)?;
+                write_binary_instruction(f, "Sub", lhs, rhs, *variable)?;
             }
             Self::Mul(lhs, rhs, variable) => {
-                write_binary_instruction(f, "Mul", lhs, rhs, variable)?;
+                write_binary_instruction(f, "Mul", lhs, rhs, *variable)?;
             }
             Self::Div(lhs, rhs, variable) => {
-                write_binary_instruction(f, "Div", lhs, rhs, variable)?;
+                write_binary_instruction(f, "Div", lhs, rhs, *variable)?;
             }
             Self::LogicalNot(value, variable) => {
-                write_unary_instruction(f, "LogicalNot", value, variable)?;
+                write_unary_instruction(f, "LogicalNot", value, *variable)?;
             }
             Self::LogicalAnd(lhs, rhs, variable) => {
-                write_binary_instruction(f, "LogicalAnd", lhs, rhs, variable)?;
+                write_binary_instruction(f, "LogicalAnd", lhs, rhs, *variable)?;
             }
             Self::LogicalOr(lhs, rhs, variable) => {
-                write_binary_instruction(f, "LogicalOr", lhs, rhs, variable)?;
+                write_binary_instruction(f, "LogicalOr", lhs, rhs, *variable)?;
             }
             Self::BitwiseNot(value, variable) => {
-                write_unary_instruction(f, "BitwiseNot", value, variable)?;
+                write_unary_instruction(f, "BitwiseNot", value, *variable)?;
             }
             Self::BitwiseAnd(lhs, rhs, variable) => {
-                write_binary_instruction(f, "BitwiseAnd", lhs, rhs, variable)?;
+                write_binary_instruction(f, "BitwiseAnd", lhs, rhs, *variable)?;
             }
             Self::BitwiseOr(lhs, rhs, variable) => {
-                write_binary_instruction(f, "BitwiseOr", lhs, rhs, variable)?;
+                write_binary_instruction(f, "BitwiseOr", lhs, rhs, *variable)?;
             }
             Self::BitwiseXor(lhs, rhs, variable) => {
-                write_binary_instruction(f, "BitwiseXor", lhs, rhs, variable)?;
+                write_binary_instruction(f, "BitwiseXor", lhs, rhs, *variable)?;
             }
             Self::Return => write!(f, "Return")?,
         };

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -321,11 +321,7 @@ impl Display for Instruction {
             variable: Variable,
         ) -> fmt::Result {
             let mut indent = set_indentation(indented(f), 0);
-            write!(indent, "Icmp ({op}):")?;
-            indent = set_indentation(indent, 1);
-            write!(indent, "\nlhs: {lhs}")?;
-            write!(indent, "\nrhs: {rhs}")?;
-            write!(indent, "\nvariable: {variable}")?;
+            write!(indent, "{variable} = Icmp {op}, {lhs}, {rhs}")?;
             Ok(())
         }
 
@@ -335,18 +331,11 @@ impl Display for Instruction {
             variable: Variable,
         ) -> fmt::Result {
             let mut indent = set_indentation(indented(f), 0);
-            write!(indent, "Phi:")?;
-            indent = set_indentation(indent, 1);
-            write!(indent, "\nargs:")?;
-            if args.is_empty() {
-                write!(indent, " <empty>")?;
-            } else {
-                indent = set_indentation(indent, 2);
-                for (index, (arg, block_id)) in args.iter().enumerate() {
-                    write!(indent, "\n[{index}]: {arg} from block {}", block_id.0)?;
-                }
+            write!(indent, "{variable} = Phi ( ")?;
+            for (val, block_id) in args {
+                write!(indent, "[{val}, {}], ", block_id.0)?;
             }
-            write!(indent, "\nvariable: {variable}")?;
+            write!(indent, ")")?;
             Ok(())
         }
 


### PR DESCRIPTION
This pass reindexes qubits after measurement or reset, ensuring there is no qubit reuse in the program.