### PR TITLE
Initial integration of RCA, preview QIR gen, and adaptive profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ dependencies = [
  "qsc_frontend",
  "qsc_hir",
  "qsc_linter",
+ "qsc_lowerer",
  "qsc_passes",
  "qsc_project",
  "qsc_rca",
@@ -980,7 +981,10 @@ dependencies = [
  "qsc_fir",
  "qsc_frontend",
  "qsc_hir",
+ "qsc_lowerer",
+ "qsc_partial_eval",
  "qsc_passes",
+ "qsc_rca",
  "qsc_rir",
  "rustc-hash",
 ]
@@ -1021,6 +1025,7 @@ dependencies = [
  "qsc_fir",
  "qsc_frontend",
  "qsc_hir",
+ "qsc_lowerer",
  "qsc_passes",
  "quantum-sparse-sim",
  "rand",
@@ -1095,6 +1100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "qsc_lowerer"
+version = "0.0.0"
+dependencies = [
+ "qsc_data_structures",
+ "qsc_fir",
+ "qsc_hir",
+]
+
+[[package]]
 name = "qsc_parse"
 version = "0.0.0"
 dependencies = [
@@ -1121,9 +1135,11 @@ dependencies = [
  "qsc_eval",
  "qsc_fir",
  "qsc_frontend",
+ "qsc_lowerer",
  "qsc_rca",
  "qsc_rir",
  "rustc-hash",
+ "thiserror",
 ]
 
 [[package]]
@@ -1139,6 +1155,7 @@ dependencies = [
  "qsc_fir",
  "qsc_frontend",
  "qsc_hir",
+ "qsc_lowerer",
  "qsc_rca",
  "rustc-hash",
  "thiserror",
@@ -1168,9 +1185,9 @@ dependencies = [
  "indenter",
  "qsc",
  "qsc_data_structures",
- "qsc_eval",
  "qsc_fir",
  "qsc_frontend",
+ "qsc_lowerer",
  "qsc_passes",
  "rustc-hash",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "compiler/qsc_frontend",
     "compiler/qsc_hir",
     "compiler/qsc_linter",
+    "compiler/qsc_lowerer",
     "compiler/qsc_parse",
     "compiler/qsc_partial_eval",
     "compiler/qsc_passes",

--- a/compiler/qsc/Cargo.toml
+++ b/compiler/qsc/Cargo.toml
@@ -23,6 +23,7 @@ qsc_formatter = { path = "../qsc_formatter" }
 qsc_eval = { path = "../qsc_eval" }
 qsc_frontend = { path = "../qsc_frontend" }
 qsc_linter = { path = "../qsc_linter" }
+qsc_lowerer = { path = "../qsc_lowerer" }
 qsc_ast = { path = "../qsc_ast" }
 qsc_fir = { path = "../qsc_fir" }
 qsc_hir = { path = "../qsc_hir" }

--- a/compiler/qsc/benches/rca.rs
+++ b/compiler/qsc/benches/rca.rs
@@ -4,9 +4,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use qsc::incremental::Compiler;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_eval::{debug::map_hir_package_to_fir, lower::Lowerer};
 use qsc_fir::fir::PackageStore;
 use qsc_frontend::compile::{PackageStore as HirPackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_lowerer::{map_hir_package_to_fir, Lowerer};
 use qsc_passes::PackageType;
 use qsc_rca::{Analyzer, PackageStoreComputeProperties};
 

--- a/compiler/qsc/src/codegen.rs
+++ b/compiler/qsc/src/codegen.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use qsc_codegen::qir::hir_to_qir;
+use qsc_data_structures::language_features::LanguageFeatures;
+use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_passes::{PackageType, PassContext};
+
+use crate::compile;
+
+pub fn get_qir(
+    sources: SourceMap,
+    language_features: LanguageFeatures,
+    capabilities: RuntimeCapabilityFlags,
+) -> Result<String, String> {
+    let core = compile::core();
+    let mut package_store = PackageStore::new(core);
+    let std = compile::std(&package_store, capabilities);
+    let std = package_store.insert(std);
+
+    let (unit, errors) = crate::compile::compile(
+        &package_store,
+        &[std],
+        sources,
+        PackageType::Exe,
+        capabilities,
+        language_features,
+    );
+
+    // Ensure it compiles before trying to add it to the store.
+    if !errors.is_empty() {
+        // This should never happen, as the program should be checked for errors before trying to
+        // generate code for it. But just in case, simply report the failure.
+        return Err("Failed to generate QIR".to_string());
+    }
+
+    let package_id = package_store.insert(unit);
+
+    let caps_results = PassContext::run_fir_passes_on_hir(&package_store, package_id, capabilities);
+    // Ensure it compiles before trying to add it to the store.
+    match caps_results {
+        Ok(compute_properties) => hir_to_qir(
+            &package_store,
+            package_id,
+            capabilities,
+            Some(compute_properties),
+        )
+        .map_err(|e| e.to_string()),
+        Err(_) => {
+            // This should never happen, as the program should be checked for errors before trying to
+            // generate code for it. But just in case, simply report the failure.
+            Err("Failed to generate QIR".to_string())
+        }
+    }
+}

--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -23,6 +23,7 @@ pub use qsc_eval::{
     val::Value,
     StepAction, StepResult,
 };
+use qsc_lowerer::{map_fir_package_to_hir, map_hir_package_to_fir};
 
 use crate::{
     error::{self, WithStack},
@@ -46,7 +47,6 @@ use qsc_data_structures::{
 };
 use qsc_eval::{
     backend::{Backend, Chain as BackendChain, SparseSim},
-    debug::{map_fir_package_to_hir, map_hir_package_to_fir},
     output::Receiver,
     val, Env, State, VariableInfo,
 };
@@ -59,7 +59,7 @@ use qsc_frontend::{
     compile::{CompileUnit, PackageStore, RuntimeCapabilityFlags, Source, SourceMap},
     error::WithSource,
 };
-use qsc_passes::PackageType;
+use qsc_passes::{PackageType, PassContext};
 use rustc_hash::FxHashSet;
 use thiserror::Error;
 
@@ -112,7 +112,7 @@ pub struct Interpreter {
     // The FIR store
     fir_store: fir::PackageStore,
     /// FIR lowerer
-    lowerer: qsc_eval::lower::Lowerer,
+    lowerer: qsc_lowerer::Lowerer,
     /// The ID of the current package.
     /// This ID is valid both for the FIR store and the `PackageStore`.
     package: PackageId,
@@ -190,7 +190,7 @@ impl Interpreter {
         for (id, unit) in compiler.package_store() {
             fir_store.insert(
                 map_hir_package_to_fir(id),
-                qsc_eval::lower::Lowerer::new()
+                qsc_lowerer::Lowerer::new()
                     .with_debug(dbg)
                     .lower_package(&unit.package),
             );
@@ -203,7 +203,7 @@ impl Interpreter {
             lines: 0,
             capabilities,
             fir_store,
-            lowerer: qsc_eval::lower::Lowerer::new().with_debug(dbg),
+            lowerer: qsc_lowerer::Lowerer::new().with_debug(dbg),
             env: Env::default(),
             sim: BackendChain::new(
                 SparseSim::new(),
@@ -300,7 +300,7 @@ impl Interpreter {
             .compile_fragments_fail_fast(&label, fragments)
             .map_err(into_errors)?;
 
-        let (_, graph) = self.lower(&increment);
+        let (_, graph) = self.lower(&increment)?;
 
         // Updating the compiler state with the new AST/HIR nodes
         // is not necessary for the interpreter to function, as all
@@ -432,7 +432,7 @@ impl Interpreter {
 
         // `lower` will update the entry expression in the FIR store,
         // and it will always return an empty list of statements.
-        let (_, graph) = self.lower(&increment);
+        let (_, graph) = self.lower(&increment)?;
 
         // The AST and HIR packages in `increment` only contain an entry
         // expression and no statements. The HIR *can* contain items if the entry
@@ -454,13 +454,56 @@ impl Interpreter {
     fn lower(
         &mut self,
         unit_addition: &qsc_frontend::incremental::Increment,
-    ) -> (Vec<StmtId>, Vec<ExecGraphNode>) {
+    ) -> core::result::Result<(Vec<StmtId>, Vec<ExecGraphNode>), Vec<Error>> {
+        if self.capabilities != RuntimeCapabilityFlags::all() {
+            return self.run_fir_passes(unit_addition);
+        }
         let fir_package = self.fir_store.get_mut(self.package);
-        (
+        Ok((
             self.lowerer
                 .lower_and_update_package(fir_package, &unit_addition.hir),
             self.lowerer.take_exec_graph(),
-        )
+        ))
+    }
+
+    fn run_fir_passes(
+        &mut self,
+        unit: &qsc_frontend::incremental::Increment,
+    ) -> core::result::Result<(Vec<StmtId>, Vec<ExecGraphNode>), Vec<Error>> {
+        let mut fir_store = self.fir_store.clone();
+        let mut lowerer = self.lowerer.clone();
+
+        let fir_package = fir_store.get_mut(self.package);
+        let stmts = lowerer.lower_and_update_package(fir_package, &unit.hir);
+
+        let caps_errors =
+            PassContext::run_fir_passes_on_fir(&fir_store, self.package, self.capabilities);
+        // if there are no errors, update the interpreter state
+        // with the updated FIR store and lowerer so that we
+        // don't have to do this twice.
+        if caps_errors.is_empty() {
+            self.fir_store = fir_store;
+            let graph = lowerer.take_exec_graph();
+            self.lowerer = lowerer;
+            return Ok((stmts, graph));
+        }
+        // if there are errors, convert them to interpreter errors
+        // and don't update the lowerer or FIR store.
+        let mut errors = Vec::with_capacity(caps_errors.len());
+        let source_package = self
+            .compiler
+            .package_store()
+            .get(map_fir_package_to_hir(self.package))
+            .expect("package should exist in the package store");
+
+        for error in caps_errors {
+            errors.push(Error::Pass(WithSource::from_map(
+                &source_package.sources,
+                error,
+            )));
+        }
+
+        Err(errors)
     }
 
     fn next_line_label(&mut self) -> String {

--- a/compiler/qsc/src/interpret/debug.rs
+++ b/compiler/qsc/src/interpret/debug.rs
@@ -4,11 +4,12 @@
 #[cfg(test)]
 mod tests;
 
-use qsc_eval::debug::{map_fir_package_to_hir, Frame};
+use qsc_eval::debug::Frame;
 use qsc_fir::fir::{Global, PackageStoreLookup, StoreItemId};
 use qsc_frontend::compile::PackageStore;
 use qsc_hir::hir;
 use qsc_hir::hir::{Item, ItemKind};
+use qsc_lowerer::map_fir_package_to_hir;
 
 #[must_use]
 pub(crate) fn format_call_stack(

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -507,6 +507,74 @@ mod given_interpreter {
         }
 
         #[test]
+        fn callables_failing_profile_validation_are_still_registered() {
+            fn verify_same_error<E>(result: &Result<Value, Vec<E>>, output: &str)
+            where
+                E: Diagnostic,
+            {
+                is_only_error(
+                    result,
+                    output,
+                    &expect![[r#"
+                    cannot use a dynamic integer value
+                       [line_0] [set x = 2]
+                    cannot use a dynamic integer value
+                       [line_0] [x]
+                "#]],
+                );
+            }
+            let mut interpreter =
+                get_interpreter_with_capbilities(RuntimeCapabilityFlags::ForwardBranching);
+            let (result, output) = line(
+                &mut interpreter,
+                indoc! {r#"
+                    operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }
+                "#},
+            );
+            verify_same_error(&result, &output);
+            // do something innocuous
+            let (result, output) = line(&mut interpreter, indoc! {r#"Foo()"#});
+            // if the callable wasn't registered, this would panic instead of returning an error.
+            verify_same_error(&result, &output);
+        }
+
+        #[test]
+        fn once_rca_validation_fails_following_calls_also_fail_by_design() {
+            fn verify_same_error<E>(result: &Result<Value, Vec<E>>, output: &str)
+            where
+                E: Diagnostic,
+            {
+                is_only_error(
+                    result,
+                    output,
+                    &expect![[r#"
+                    cannot use a dynamic integer value
+                       [line_0] [set x = 2]
+                    cannot use a dynamic integer value
+                       [line_0] [x]
+                "#]],
+                );
+            }
+            let mut interpreter =
+                get_interpreter_with_capbilities(RuntimeCapabilityFlags::ForwardBranching);
+            let (result, output) = line(
+                &mut interpreter,
+                indoc! {r#"
+                    operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }
+                "#},
+            );
+            verify_same_error(&result, &output);
+            // do something innocuous
+            let (result, output) = line(
+                &mut interpreter,
+                indoc! {r#"
+                    let y = 7;
+                "#},
+            );
+            verify_same_error(&result, &output);
+        }
+
+        #[test]
         fn namespace_usable_before_definition() {
             let mut interpreter = get_interpreter();
             let (result, output) = line(
@@ -1097,6 +1165,17 @@ mod given_interpreter {
             SourceMap::default(),
             PackageType::Lib,
             RuntimeCapabilityFlags::all(),
+            LanguageFeatures::default(),
+        )
+        .expect("interpreter should be created")
+    }
+
+    fn get_interpreter_with_capbilities(capabilities: RuntimeCapabilityFlags) -> Interpreter {
+        Interpreter::new(
+            true,
+            SourceMap::default(),
+            PackageType::Lib,
+            capabilities,
             LanguageFeatures::default(),
         )
         .expect("interpreter should be created")

--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+pub mod codegen;
 pub mod compile;
 pub mod error;
 pub mod incremental;

--- a/compiler/qsc/src/target.rs
+++ b/compiler/qsc/src/target.rs
@@ -9,6 +9,7 @@ use qsc_frontend::compile::RuntimeCapabilityFlags;
 pub enum Profile {
     Unrestricted,
     Base,
+    Adaptive,
 }
 
 impl Profile {
@@ -17,6 +18,7 @@ impl Profile {
         match self {
             Self::Unrestricted => "Unrestricted",
             Self::Base => "Base",
+            Self::Adaptive => "Adaptive",
         }
     }
 }
@@ -26,6 +28,7 @@ impl From<Profile> for RuntimeCapabilityFlags {
         match value {
             Profile::Unrestricted => Self::all(),
             Profile::Base => Self::empty(),
+            Profile::Adaptive => Self::ForwardBranching,
         }
     }
 }
@@ -35,8 +38,9 @@ impl FromStr for Profile {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "Unrestricted" | "unrestricted" => Ok(Self::Unrestricted),
+            "Adaptive" | "adaptive" => Ok(Self::Adaptive),
             "Base" | "base" => Ok(Self::Base),
+            "Unrestricted" | "unrestricted" => Ok(Self::Unrestricted),
             _ => Err(()),
         }
     }

--- a/compiler/qsc_codegen/Cargo.toml
+++ b/compiler/qsc_codegen/Cargo.toml
@@ -12,11 +12,14 @@ license.workspace = true
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
 rustc-hash = { workspace = true }
-qsc_eval = { path = "../qsc_eval" }
 qsc_data_structures = { path = "../qsc_data_structures" }
-qsc_frontend = { path = "../qsc_frontend" }
+qsc_eval = { path = "../qsc_eval" }
 qsc_fir = { path = "../qsc_fir" }
+qsc_frontend = { path = "../qsc_frontend" }
 qsc_hir = { path = "../qsc_hir" }
+qsc_lowerer = { path = "../qsc_lowerer" }
+qsc_partial_eval = { path = "../qsc_partial_eval" }
+qsc_rca = { path = "../qsc_rca" }
 qsc_rir = { path = "../qsc_rir" }
 
 [dev-dependencies]

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -42,7 +42,6 @@ pub fn fir_to_qir(
     fir_package_id: qsc_fir::fir::PackageId,
     capabilities: RuntimeCapabilityFlags,
 ) -> Result<String, qsc_partial_eval::Error> {
-    let program = get_rir_from_compilation(fir_store, fir_package_id, capabilities)?;
     let mut program = get_rir_from_compilation(fir_store, fir_package_id, capabilities)?;
     check_and_transform(&mut program);
     if capabilities.is_empty() {

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -42,7 +42,13 @@ pub fn fir_to_qir(
     capabilities: RuntimeCapabilityFlags,
 ) -> Result<String, qsc_partial_eval::Error> {
     let program = get_rir_from_compilation(fir_store, fir_package_id, capabilities)?;
+    let mut program = get_rir_from_compilation(fir_store, fir_package_id, capabilities)?;
+    check_and_transform(&mut program);
+    if capabilities.is_empty() {
+        defer_quantum_measurements(&mut program);
+    }
     Ok(ToQir::<String>::to_qir(&program, &program))
+
 }
 
 fn get_rir_from_compilation(

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -26,15 +26,22 @@ fn lower_store(package_store: &qsc_frontend::compile::PackageStore) -> qsc_fir::
 }
 
 /// converts the given sources to QIR using the given language features.
-pub fn to_qir(
+pub fn hir_to_qir(
     package_store: &qsc_frontend::compile::PackageStore,
     package_id: hir::PackageId,
     capabilities: RuntimeCapabilityFlags,
 ) -> Result<String, qsc_partial_eval::Error> {
     let fir_store = lower_store(package_store);
-
     let fir_package_id = map_hir_package_to_fir(package_id);
-    let program = get_rir_from_compilation(&fir_store, fir_package_id, capabilities)?;
+    fir_to_qir(&fir_store, fir_package_id, capabilities)
+}
+
+pub fn fir_to_qir(
+    fir_store: &qsc_fir::fir::PackageStore,
+    fir_package_id: qsc_fir::fir::PackageId,
+    capabilities: RuntimeCapabilityFlags,
+) -> Result<String, qsc_partial_eval::Error> {
+    let program = get_rir_from_compilation(fir_store, fir_package_id, capabilities)?;
     Ok(ToQir::<String>::to_qir(&program, &program))
 }
 

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -12,6 +12,7 @@ use qsc_hir::hir;
 use qsc_lowerer::map_hir_package_to_fir;
 use qsc_partial_eval::partially_evaluate;
 use qsc_rir::{
+    passes::{check_and_transform, defer_quantum_measurements},
     rir::{self, ConditionCode},
     utils::get_all_block_successors,
 };
@@ -48,7 +49,6 @@ pub fn fir_to_qir(
         defer_quantum_measurements(&mut program);
     }
     Ok(ToQir::<String>::to_qir(&program, &program))
-
 }
 
 fn get_rir_from_compilation(

--- a/compiler/qsc_codegen/src/qir_base.rs
+++ b/compiler/qsc_codegen/src/qir_base.rs
@@ -8,16 +8,12 @@ use crate::remapper::{HardwareId, Remapper};
 use num_bigint::BigUint;
 use num_complex::Complex;
 use qsc_eval::{
-    backend::Backend,
-    debug::{map_hir_package_to_fir, Frame},
-    eval,
-    output::GenericReceiver,
-    val::Value,
-    Env, Error,
+    backend::Backend, debug::Frame, eval, output::GenericReceiver, val::Value, Env, Error,
 };
 use qsc_fir::fir;
 use qsc_frontend::compile::PackageStore;
 use qsc_hir::hir::{self};
+use qsc_lowerer::map_hir_package_to_fir;
 use rustc_hash::FxHashSet;
 use std::fmt::{Display, Write};
 
@@ -35,7 +31,7 @@ pub fn generate_qir(
     for (id, unit) in store {
         fir_store.insert(
             map_hir_package_to_fir(id),
-            qsc_eval::lower::Lowerer::new().lower_package(&unit.package),
+            qsc_lowerer::Lowerer::new().lower_package(&unit.package),
         );
     }
 

--- a/compiler/qsc_data_structures/src/language_features.rs
+++ b/compiler/qsc_data_structures/src/language_features.rs
@@ -11,7 +11,7 @@ bitflags! {
     impl LanguageFeatures: u8 {
         const V2PreviewSyntax = 0b1;
         const PreviewQirGen = 0b10;
-        const AdaptiveProfileQirGen = 0b100;
+        const AdaptiveProfile = 0b100;
     }
 }
 
@@ -36,7 +36,7 @@ where
             acc | match x.as_ref() {
                 "v2-preview-syntax" => LanguageFeatures::V2PreviewSyntax,
                 "preview-qir-gen" => LanguageFeatures::PreviewQirGen,
-                "adaptive-qir-gen" => LanguageFeatures::AdaptiveProfileQirGen,
+                "adaptive-profile" => LanguageFeatures::AdaptiveProfile,
                 _ => LanguageFeatures::empty(),
             }
         })

--- a/compiler/qsc_data_structures/src/language_features.rs
+++ b/compiler/qsc_data_structures/src/language_features.rs
@@ -10,6 +10,8 @@ pub struct LanguageFeatures(u8);
 bitflags! {
     impl LanguageFeatures: u8 {
         const V2PreviewSyntax = 0b1;
+        const QirGenPreview = 0b10;
+        const AdaptiveProfileQirGen = 0b100;
     }
 }
 
@@ -33,6 +35,8 @@ where
         iter.into_iter().fold(LanguageFeatures::empty(), |acc, x| {
             acc | match x.as_ref() {
                 "v2-preview-syntax" => LanguageFeatures::V2PreviewSyntax,
+                "qir-gen-preview" => LanguageFeatures::QirGenPreview,
+                "adaptive-qir-gen" => LanguageFeatures::AdaptiveProfileQirGen,
                 _ => LanguageFeatures::empty(),
             }
         })

--- a/compiler/qsc_data_structures/src/language_features.rs
+++ b/compiler/qsc_data_structures/src/language_features.rs
@@ -11,7 +11,6 @@ bitflags! {
     impl LanguageFeatures: u8 {
         const V2PreviewSyntax = 0b1;
         const PreviewQirGen = 0b10;
-        const AdaptiveProfile = 0b100;
     }
 }
 
@@ -36,7 +35,6 @@ where
             acc | match x.as_ref() {
                 "v2-preview-syntax" => LanguageFeatures::V2PreviewSyntax,
                 "preview-qir-gen" => LanguageFeatures::PreviewQirGen,
-                "adaptive-profile" => LanguageFeatures::AdaptiveProfile,
                 _ => LanguageFeatures::empty(),
             }
         })

--- a/compiler/qsc_data_structures/src/language_features.rs
+++ b/compiler/qsc_data_structures/src/language_features.rs
@@ -10,7 +10,7 @@ pub struct LanguageFeatures(u8);
 bitflags! {
     impl LanguageFeatures: u8 {
         const V2PreviewSyntax = 0b1;
-        const QirGenPreview = 0b10;
+        const PreviewQirGen = 0b10;
         const AdaptiveProfileQirGen = 0b100;
     }
 }
@@ -35,7 +35,7 @@ where
         iter.into_iter().fold(LanguageFeatures::empty(), |acc, x| {
             acc | match x.as_ref() {
                 "v2-preview-syntax" => LanguageFeatures::V2PreviewSyntax,
-                "qir-gen-preview" => LanguageFeatures::QirGenPreview,
+                "preview-qir-gen" => LanguageFeatures::PreviewQirGen,
                 "adaptive-qir-gen" => LanguageFeatures::AdaptiveProfileQirGen,
                 _ => LanguageFeatures::empty(),
             }

--- a/compiler/qsc_eval/Cargo.toml
+++ b/compiler/qsc_eval/Cargo.toml
@@ -17,6 +17,7 @@ quantum-sparse-sim = { workspace = true }
 qsc_data_structures = { path = "../qsc_data_structures" }
 qsc_fir = { path = "../qsc_fir" }
 qsc_hir = { path = "../qsc_hir" }
+qsc_lowerer = { path = "../qsc_lowerer" }
 rand =  { workspace = true }
 rustc-hash = { workspace = true }
 thiserror = { workspace = true }

--- a/compiler/qsc_eval/src/debug.rs
+++ b/compiler/qsc_eval/src/debug.rs
@@ -4,9 +4,7 @@
 use qsc_data_structures::span::Span;
 
 use qsc_data_structures::functors::FunctorApp;
-use qsc_fir::fir;
 use qsc_fir::fir::{PackageId, StoreItemId};
-use qsc_hir::hir;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Frame {
@@ -44,14 +42,4 @@ impl CallStack {
     pub fn pop_frame(&mut self) -> Option<Frame> {
         self.frames.pop()
     }
-}
-
-#[must_use]
-pub fn map_hir_package_to_fir(package: hir::PackageId) -> fir::PackageId {
-    fir::PackageId::from(<hir::PackageId as Into<usize>>::into(package))
-}
-
-#[must_use]
-pub fn map_fir_package_to_hir(package: fir::PackageId) -> hir::PackageId {
-    hir::PackageId::from(<fir::PackageId as Into<usize>>::into(package))
 }

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -6,7 +6,6 @@
 use std::f64::consts;
 
 use crate::backend::{Backend, SparseSim};
-use crate::debug::map_hir_package_to_fir;
 use crate::tests::eval_graph;
 use crate::Env;
 use crate::{
@@ -20,6 +19,7 @@ use num_bigint::BigInt;
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_fir::fir;
 use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_lowerer::map_hir_package_to_fir;
 use qsc_passes::{run_core_passes, run_default_passes, PackageType};
 
 #[derive(Default)]
@@ -148,7 +148,7 @@ impl Backend for CustomSim {
 fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Value, Error> {
     let mut core = compile::core();
     run_core_passes(&mut core);
-    let core_fir = crate::lower::Lowerer::new().lower_package(&core.package);
+    let core_fir = qsc_lowerer::Lowerer::new().lower_package(&core.package);
     let mut store = PackageStore::new(core);
 
     let mut std = compile::std(&store, RuntimeCapabilityFlags::all());
@@ -160,7 +160,7 @@ fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Va
         RuntimeCapabilityFlags::all()
     )
     .is_empty());
-    let std_fir = crate::lower::Lowerer::new().lower_package(&std.package);
+    let std_fir = qsc_lowerer::Lowerer::new().lower_package(&std.package);
     let std_id = store.insert(std);
 
     let sources = SourceMap::new([("test".into(), file.into())], Some(expr.into()));
@@ -179,7 +179,7 @@ fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Va
         RuntimeCapabilityFlags::all()
     )
     .is_empty());
-    let unit_fir = crate::lower::Lowerer::new().lower_package(&unit.package);
+    let unit_fir = qsc_lowerer::Lowerer::new().lower_package(&unit.package);
     let entry = unit_fir.entry_exec_graph.clone();
 
     let id = store.insert(unit);

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -21,14 +21,13 @@ pub mod backend;
 pub mod debug;
 mod error;
 mod intrinsic;
-pub mod lower;
 pub mod output;
 pub mod state;
 pub mod val;
 
 use crate::val::Value;
 use backend::Backend;
-use debug::{map_fir_package_to_hir, CallStack, Frame};
+use debug::{CallStack, Frame};
 use error::PackageSpan;
 use miette::Diagnostic;
 use num_bigint::BigInt;
@@ -40,6 +39,7 @@ use qsc_fir::fir::{
     StoreItemId, StringComponent, UnOp,
 };
 use qsc_fir::ty::Ty;
+use qsc_lowerer::map_fir_package_to_hir;
 use rand::{rngs::StdRng, SeedableRng};
 use std::ops;
 use std::{

--- a/compiler/qsc_fir/src/assigner.rs
+++ b/compiler/qsc_fir/src/assigner.rs
@@ -3,7 +3,7 @@
 
 use crate::fir::{BlockId, ExprId, LocalVarId, NodeId, PatId, StmtId};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Assigner {
     next_node: NodeId,
     next_block: BlockId,

--- a/compiler/qsc_fir/src/assigner.rs
+++ b/compiler/qsc_fir/src/assigner.rs
@@ -3,7 +3,7 @@
 
 use crate::fir::{BlockId, ExprId, LocalVarId, NodeId, PatId, StmtId};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Assigner {
     next_node: NodeId,
     next_block: BlockId,

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -458,7 +458,7 @@ pub trait PackageStoreLookup {
 }
 
 /// A FIR package store.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PackageStore(IndexMap<PackageId, Package>);
 
 impl PackageStoreLookup for PackageStore {

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -458,7 +458,7 @@ pub trait PackageStoreLookup {
 }
 
 /// A FIR package store.
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct PackageStore(IndexMap<PackageId, Package>);
 
 impl PackageStoreLookup for PackageStore {
@@ -549,7 +549,7 @@ pub trait PackageLookup {
 /// within the containing node. Node ids are used to identify nodes within
 /// the package and require mapping from the HIR node id to the new FIR node id.
 /// `PackageId`s and `LocalItemId`s are 1:1 from the HIR and are not remapped.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Package {
     /// The items in the package.
     pub items: IndexMap<LocalItemId, Item>,

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -52,6 +52,7 @@ bitflags! {
 pub enum ConfigAttr {
     Unrestricted,
     Base,
+    Adaptive,
 }
 
 impl ConfigAttr {
@@ -60,6 +61,7 @@ impl ConfigAttr {
         match self {
             Self::Unrestricted => "Unrestricted",
             Self::Base => "Base",
+            Self::Adaptive => "Adaptive",
         }
     }
 
@@ -76,6 +78,7 @@ impl FromStr for ConfigAttr {
         match s {
             "Unrestricted" => Ok(ConfigAttr::Unrestricted),
             "Base" => Ok(ConfigAttr::Base),
+            "Adaptive" => Ok(ConfigAttr::Adaptive),
             _ => Err(()),
         }
     }
@@ -86,6 +89,7 @@ impl From<ConfigAttr> for RuntimeCapabilityFlags {
         match value {
             ConfigAttr::Unrestricted => Self::all(),
             ConfigAttr::Base => Self::empty(),
+            ConfigAttr::Adaptive => Self::ForwardBranching,
         }
     }
 }

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -50,18 +50,18 @@ bitflags! {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ConfigAttr {
-    Unrestricted,
-    Base,
     Adaptive,
+    Base,
+    Unrestricted,
 }
 
 impl ConfigAttr {
     #[must_use]
     pub fn to_str(&self) -> &'static str {
         match self {
-            Self::Unrestricted => "Unrestricted",
-            Self::Base => "Base",
             Self::Adaptive => "Adaptive",
+            Self::Base => "Base",
+            Self::Unrestricted => "Unrestricted",
         }
     }
 
@@ -76,9 +76,9 @@ impl FromStr for ConfigAttr {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "Unrestricted" => Ok(ConfigAttr::Unrestricted),
-            "Base" => Ok(ConfigAttr::Base),
             "Adaptive" => Ok(ConfigAttr::Adaptive),
+            "Base" => Ok(ConfigAttr::Base),
+            "Unrestricted" => Ok(ConfigAttr::Unrestricted),
             _ => Err(()),
         }
     }

--- a/compiler/qsc_frontend/src/compile/preprocess.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess.rs
@@ -119,7 +119,10 @@ impl MutVisitor for Conditional {
 }
 
 fn matches_config(attrs: &[Box<Attr>], capabilities: RuntimeCapabilityFlags) -> bool {
-    attrs.iter().all(|attr| {
+    if attrs.is_empty() {
+        return true;
+    }
+    attrs.iter().any(|attr| {
         if hir::Attr::from_str(attr.name.name.as_ref()) == Ok(hir::Attr::Config) {
             if let ExprKind::Paren(inner) = attr.arg.kind.as_ref() {
                 match inner.kind.as_ref() {
@@ -129,6 +132,9 @@ fn matches_config(attrs: &[Box<Attr>], capabilities: RuntimeCapabilityFlags) -> 
                     ExprKind::Path(path) => match ConfigAttr::from_str(path.name.name.as_ref()) {
                         Ok(ConfigAttr::Unrestricted) => capabilities.is_all(),
                         Ok(ConfigAttr::Base) => capabilities.is_empty(),
+                        Ok(ConfigAttr::Adaptive) => {
+                            capabilities == RuntimeCapabilityFlags::ForwardBranching
+                        }
                         _ => true,
                     },
                     _ => true, // Unknown config attribute, so we assume it matches

--- a/compiler/qsc_lowerer/Cargo.toml
+++ b/compiler/qsc_lowerer/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "qsc_lowerer"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+qsc_data_structures = { path = "../qsc_data_structures" }
+qsc_fir = { path = "../qsc_fir" }
+qsc_hir = { path = "../qsc_hir" }
+
+[lints]
+workspace = true

--- a/compiler/qsc_lowerer/src/lib.rs
+++ b/compiler/qsc_lowerer/src/lib.rs
@@ -19,7 +19,7 @@ pub fn map_hir_package_to_fir(package: hir::PackageId) -> fir::PackageId {
 
 #[must_use]
 pub fn map_fir_package_to_hir(package: fir::PackageId) -> hir::PackageId {
-    hir::PackageId::from(<fir::PackageId as Into<usize>>::into(package))
+    hir::PackageId::from(Into::<usize>::into(package))
 }
 
 #[derive(Clone)]

--- a/compiler/qsc_lowerer/src/lib.rs
+++ b/compiler/qsc_lowerer/src/lib.rs
@@ -12,6 +12,17 @@ use qsc_hir::hir::{self, SpecBody, SpecGen};
 use std::iter::once;
 use std::{clone::Clone, rc::Rc};
 
+#[must_use]
+pub fn map_hir_package_to_fir(package: hir::PackageId) -> fir::PackageId {
+    fir::PackageId::from(<hir::PackageId as Into<usize>>::into(package))
+}
+
+#[must_use]
+pub fn map_fir_package_to_hir(package: fir::PackageId) -> hir::PackageId {
+    hir::PackageId::from(<fir::PackageId as Into<usize>>::into(package))
+}
+
+#[derive(Clone)]
 pub struct Lowerer {
     nodes: IndexMap<hir::NodeId, fir::NodeId>,
     locals: IndexMap<hir::NodeId, fir::LocalVarId>,

--- a/compiler/qsc_lowerer/src/lib.rs
+++ b/compiler/qsc_lowerer/src/lib.rs
@@ -14,7 +14,7 @@ use std::{clone::Clone, rc::Rc};
 
 #[must_use]
 pub fn map_hir_package_to_fir(package: hir::PackageId) -> fir::PackageId {
-    fir::PackageId::from(<hir::PackageId as Into<usize>>::into(package))
+    fir::PackageId::from(Into::<usize>::into(package))
 }
 
 #[must_use]

--- a/compiler/qsc_lowerer/src/lib.rs
+++ b/compiler/qsc_lowerer/src/lib.rs
@@ -22,7 +22,6 @@ pub fn map_fir_package_to_hir(package: fir::PackageId) -> hir::PackageId {
     hir::PackageId::from(Into::<usize>::into(package))
 }
 
-#[derive(Clone)]
 pub struct Lowerer {
     nodes: IndexMap<hir::NodeId, fir::NodeId>,
     locals: IndexMap<hir::NodeId, fir::LocalVarId>,

--- a/compiler/qsc_partial_eval/Cargo.toml
+++ b/compiler/qsc_partial_eval/Cargo.toml
@@ -14,8 +14,10 @@ rustc-hash = { workspace = true }
 qsc_data_structures = { path = "../qsc_data_structures" }
 qsc_eval = { path = "../qsc_eval" }
 qsc_fir = { path = "../qsc_fir" }
+qsc_lowerer = { path = "../qsc_lowerer" }
 qsc_rca = { path = "../qsc_rca" }
 qsc_rir = { path = "../qsc_rir" }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 expect-test = { workspace = true }

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -4,6 +4,7 @@
 #[cfg(test)]
 mod tests;
 
+use miette::Diagnostic;
 use qsc_data_structures::functors::FunctorApp;
 use qsc_eval::{
     self, backend::Backend, exec_graph_section, output::GenericReceiver, val::Value, Env, State,
@@ -22,6 +23,7 @@ use qsc_rca::{ComputeKind, ComputePropertiesLookup, PackageStoreComputePropertie
 use qsc_rir::rir::{self, Callable, CallableId, CallableType, Instruction, Literal, Program};
 use rustc_hash::FxHashMap;
 use std::{collections::hash_map::Entry, rc::Rc, result::Result};
+use thiserror::Error;
 
 pub fn partially_evaluate(
     package_id: PackageId,
@@ -32,7 +34,10 @@ pub fn partially_evaluate(
     partial_evaluator.eval()
 }
 
+#[derive(Clone, Debug, Diagnostic, Error)]
 pub enum Error {
+    #[error("partial evaluation error: {0}")]
+    #[diagnostic(code("Qsc.Partial.Eval"))]
     EvaluationFailed(qsc_eval::Error),
 }
 

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -37,7 +37,7 @@ pub fn partially_evaluate(
 #[derive(Clone, Debug, Diagnostic, Error)]
 pub enum Error {
     #[error("partial evaluation error: {0}")]
-    #[diagnostic(code("Qsc.Partial.Eval"))]
+    #[diagnostic(code("Qsc.PartialEval.EvaluationFailed"))]
     EvaluationFailed(qsc_eval::Error),
 }
 

--- a/compiler/qsc_partial_eval/src/tests.rs
+++ b/compiler/qsc_partial_eval/src/tests.rs
@@ -8,9 +8,10 @@ use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc::{incremental::Compiler, PackageType};
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_eval::{debug::map_hir_package_to_fir, lower::Lowerer};
 use qsc_fir::fir::{PackageId, PackageStore};
 use qsc_frontend::compile::{PackageStore as HirPackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_lowerer::map_hir_package_to_fir;
+use qsc_lowerer::Lowerer;
 use qsc_rca::{Analyzer, PackageStoreComputeProperties};
 
 #[test]
@@ -29,9 +30,9 @@ fn empty_entry_point() {
                     Callable 0: Callable:
                         name: main
                         call_type: Regular
-                        input_type:  <VOID>
-                        output_type:  <VOID>
-                        body:  0
+                        input_type: <VOID>
+                        output_type: <VOID>
+                        body: 0
                 blocks:
                     Block 0: Block:
                         Return
@@ -62,9 +63,9 @@ fn allocate_one_qubit() {
                     Callable 0: Callable:
                         name: main
                         call_type: Regular
-                        input_type:  <VOID>
-                        output_type:  <VOID>
-                        body:  0
+                        input_type: <VOID>
+                        output_type: <VOID>
+                        body: 0
                 blocks:
                     Block 0: Block:
                         Return
@@ -96,16 +97,16 @@ fn call_to_single_qubit_operation() {
                     Callable 0: Callable:
                         name: main
                         call_type: Regular
-                        input_type:  <VOID>
-                        output_type:  <VOID>
-                        body:  0
+                        input_type: <VOID>
+                        output_type: <VOID>
+                        body: 0
                     Callable 1: Callable:
                         name: __quantum__qis__h__body
                         call_type: Regular
-                        input_type: 
+                        input_type:
                             [0]: Qubit
-                        output_type:  <VOID>
-                        body:  <NONE>
+                        output_type: <VOID>
+                        body: <NONE>
                 blocks:
                     Block 0: Block:
                         Call id(1), args( Qubit(0), )
@@ -144,30 +145,30 @@ fn call_to_many_single_qubit_operations() {
                     Callable 0: Callable:
                         name: main
                         call_type: Regular
-                        input_type:  <VOID>
-                        output_type:  <VOID>
-                        body:  0
+                        input_type: <VOID>
+                        output_type: <VOID>
+                        body: 0
                     Callable 1: Callable:
                         name: __quantum__qis__h__body
                         call_type: Regular
-                        input_type: 
+                        input_type:
                             [0]: Qubit
-                        output_type:  <VOID>
-                        body:  <NONE>
+                        output_type: <VOID>
+                        body: <NONE>
                     Callable 2: Callable:
                         name: __quantum__qis__x__body
                         call_type: Regular
-                        input_type: 
+                        input_type:
                             [0]: Qubit
-                        output_type:  <VOID>
-                        body:  <NONE>
+                        output_type: <VOID>
+                        body: <NONE>
                     Callable 3: Callable:
                         name: __quantum__qis__y__body
                         call_type: Regular
-                        input_type: 
+                        input_type:
                             [0]: Qubit
-                        output_type:  <VOID>
-                        body:  <NONE>
+                        output_type: <VOID>
+                        body: <NONE>
                 blocks:
                     Block 0: Block:
                         Call id(1), args( Qubit(0), )
@@ -203,17 +204,17 @@ fn call_to_rotation_operation_using_literal() {
                     Callable 0: Callable:
                         name: main
                         call_type: Regular
-                        input_type:  <VOID>
-                        output_type:  <VOID>
-                        body:  0
+                        input_type: <VOID>
+                        output_type: <VOID>
+                        body: 0
                     Callable 1: Callable:
                         name: __quantum__qis__rx__body
                         call_type: Regular
-                        input_type: 
+                        input_type:
                             [0]: Double
                             [1]: Qubit
-                        output_type:  <VOID>
-                        body:  <NONE>
+                        output_type: <VOID>
+                        body: <NONE>
                 blocks:
                     Block 0: Block:
                         Call id(1), args( Double(1), Qubit(0), )
@@ -248,17 +249,17 @@ fn calls_to_rotation_operation_using_inline_expressions() {
                     Callable 0: Callable:
                         name: main
                         call_type: Regular
-                        input_type:  <VOID>
-                        output_type:  <VOID>
-                        body:  0
+                        input_type: <VOID>
+                        output_type: <VOID>
+                        body: 0
                     Callable 1: Callable:
                         name: __quantum__qis__ry__body
                         call_type: Regular
-                        input_type: 
+                        input_type:
                             [0]: Double
                             [1]: Qubit
-                        output_type:  <VOID>
-                        body:  <NONE>
+                        output_type: <VOID>
+                        body: <NONE>
                 blocks:
                     Block 0: Block:
                         Call id(1), args( Double(0), Qubit(0), )
@@ -298,17 +299,17 @@ fn calls_to_rotation_operation_using_variables() {
                     Callable 0: Callable:
                         name: main
                         call_type: Regular
-                        input_type:  <VOID>
-                        output_type:  <VOID>
-                        body:  0
+                        input_type: <VOID>
+                        output_type: <VOID>
+                        body: 0
                     Callable 1: Callable:
                         name: __quantum__qis__rz__body
                         call_type: Regular
-                        input_type: 
+                        input_type:
                             [0]: Double
                             [1]: Qubit
-                        output_type:  <VOID>
-                        body:  <NONE>
+                        output_type: <VOID>
+                        body: <NONE>
                 blocks:
                     Block 0: Block:
                         Call id(1), args( Double(2), Qubit(0), )

--- a/compiler/qsc_passes/Cargo.toml
+++ b/compiler/qsc_passes/Cargo.toml
@@ -11,9 +11,11 @@ license.workspace = true
 [dependencies]
 miette = { workspace = true }
 qsc_data_structures = { path = "../qsc_data_structures" }
+qsc_eval = { path = "../qsc_eval" }
 qsc_fir = { path = "../qsc_fir" }
 qsc_frontend = { path = "../qsc_frontend" }
 qsc_hir = { path = "../qsc_hir" }
+qsc_lowerer = { path = "../qsc_lowerer" }
 qsc_rca = { path = "../qsc_rca" }
 rustc-hash = { workspace = true }
 thiserror = { workspace = true }

--- a/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/compiler/qsc_passes/src/capabilitiesck.rs
@@ -172,6 +172,7 @@ pub enum Error {
     UseOfClosure(#[label] Span),
 }
 
+/// Lower a package store from `qsc_frontend` HIR store to a `qsc_fir` FIR store.
 pub fn lower_store(
     package_store: &qsc_frontend::compile::PackageStore,
 ) -> qsc_fir::fir::PackageStore {

--- a/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/compiler/qsc_passes/src/capabilitiesck.rs
@@ -15,6 +15,7 @@ pub mod tests_common;
 
 use miette::Diagnostic;
 use qsc_data_structures::span::Span;
+
 use qsc_fir::{
     fir::{
         Block, BlockId, CallableImpl, Expr, ExprId, ExprKind, Global, Ident, Item, ItemKind,
@@ -25,7 +26,10 @@ use qsc_fir::{
     visit::Visitor,
 };
 use qsc_frontend::compile::RuntimeCapabilityFlags;
-use qsc_rca::{ComputeKind, ItemComputeProperties, PackageComputeProperties, RuntimeFeatureFlags};
+use qsc_lowerer::map_hir_package_to_fir;
+use qsc_rca::{
+    Analyzer, ComputeKind, ItemComputeProperties, PackageComputeProperties, RuntimeFeatureFlags,
+};
 use rustc_hash::FxHashMap;
 use thiserror::Error;
 
@@ -166,6 +170,32 @@ pub enum Error {
     #[diagnostic(help("closures are not supported by the current target"))]
     #[diagnostic(code("Qsc.CapabilitiesCk.UseOfClosure"))]
     UseOfClosure(#[label] Span),
+}
+
+pub fn lower_store(
+    package_store: &qsc_frontend::compile::PackageStore,
+) -> qsc_fir::fir::PackageStore {
+    let mut fir_store = qsc_fir::fir::PackageStore::new();
+    for (id, unit) in package_store {
+        let package = qsc_lowerer::Lowerer::new().lower_package(&unit.package);
+        fir_store.insert(map_hir_package_to_fir(id), package);
+    }
+    fir_store
+}
+
+pub fn run_rca_pass(
+    fir_store: &qsc_fir::fir::PackageStore,
+    package_id: qsc_fir::fir::PackageId,
+    capabilities: RuntimeCapabilityFlags,
+) -> Vec<crate::Error> {
+    let analyzer = Analyzer::init(fir_store);
+    let compute_properties = analyzer.analyze_all();
+    let fir_package = fir_store.get(package_id);
+
+    let package_compute_properties = compute_properties.get(package_id);
+    let mut errors =
+        check_supported_capabilities(fir_package, package_compute_properties, capabilities);
+    errors.drain(..).map(crate::Error::CapabilitiesCk).collect()
 }
 
 #[must_use]

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -5,9 +5,9 @@
 
 use super::tests_common::{
     check, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
-    CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
+    CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
     LOOP_WITH_DYNAMIC_CONDITION, MEASUREMENT_WITHIN_DYNAMIC_SCOPE, MINIMAL,
     RETURN_WITHIN_DYNAMIC_SCOPE, USE_CLOSURE_FUNCTION, USE_DYNAMICALLY_SIZED_ARRAY,
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
@@ -267,7 +267,7 @@ fn use_of_dynamic_operation_yields_errors() {
 #[test]
 fn call_cyclic_function_with_classical_argument_yields_no_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             []
         "#]],
@@ -277,7 +277,7 @@ fn call_cyclic_function_with_classical_argument_yields_no_errors() {
 #[test]
 fn call_cyclic_function_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 UseOfDynamicInt(
@@ -300,7 +300,7 @@ fn call_cyclic_function_with_dynamic_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_classical_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(
@@ -329,7 +329,7 @@ fn call_cyclic_operation_with_classical_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -7,9 +7,9 @@ use crate::capabilitiesck::tests_common::USE_DYNAMIC_RANGE;
 
 use super::tests_common::{
     check, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
-    CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
+    CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
     LOOP_WITH_DYNAMIC_CONDITION, MEASUREMENT_WITHIN_DYNAMIC_SCOPE, MINIMAL,
     RETURN_WITHIN_DYNAMIC_SCOPE, USE_CLOSURE_FUNCTION, USE_DYNAMICALLY_SIZED_ARRAY,
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
@@ -222,7 +222,7 @@ fn use_of_dynamic_operation_yields_errors() {
 #[test]
 fn call_cyclic_function_with_classical_argument_yields_no_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             []
         "#]],
@@ -232,7 +232,7 @@ fn call_cyclic_function_with_classical_argument_yields_no_errors() {
 #[test]
 fn call_cyclic_function_with_dynamic_argument_yields_error() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 CallToCyclicFunctionWithDynamicArg(
@@ -249,7 +249,7 @@ fn call_cyclic_function_with_dynamic_argument_yields_error() {
 #[test]
 fn call_cyclic_operation_with_classical_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(
@@ -272,7 +272,7 @@ fn call_cyclic_operation_with_classical_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(

--- a/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -5,9 +5,9 @@
 
 use super::tests_common::{
     check, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
-    CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
+    CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
     LOOP_WITH_DYNAMIC_CONDITION, MEASUREMENT_WITHIN_DYNAMIC_SCOPE, MINIMAL,
     RETURN_WITHIN_DYNAMIC_SCOPE, USE_CLOSURE_FUNCTION, USE_DYNAMICALLY_SIZED_ARRAY,
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
@@ -331,7 +331,7 @@ fn use_of_dynamic_operation_yields_errors() {
 #[test]
 fn call_cyclic_function_with_classical_argument_yields_no_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             []
         "#]],
@@ -341,7 +341,7 @@ fn call_cyclic_function_with_classical_argument_yields_no_errors() {
 #[test]
 fn call_cyclic_function_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 UseOfDynamicBool(
@@ -370,7 +370,7 @@ fn call_cyclic_function_with_dynamic_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_classical_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(
@@ -399,7 +399,7 @@ fn call_cyclic_operation_with_classical_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(

--- a/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -8,9 +8,9 @@ use expect_test::Expect;
 use crate::capabilitiesck::check_supported_capabilities;
 use qsc::{incremental::Compiler, PackageType};
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_eval::{debug::map_hir_package_to_fir, lower::Lowerer};
 use qsc_fir::fir::{Package, PackageId, PackageStore};
 use qsc_frontend::compile::{PackageStore as HirPackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_lowerer::{map_hir_package_to_fir, Lowerer};
 use qsc_rca::{Analyzer, PackageComputeProperties, PackageStoreComputeProperties};
 
 pub fn check(source: &str, expect: &Expect, capabilities: RuntimeCapabilityFlags) {
@@ -196,7 +196,7 @@ pub const USE_DYNAMIC_OPERATION: &str = r#"
         }
     }"#;
 
-pub const CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT: &str = r#"
+pub const CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT: &str = r#"
     function GaussSum(n : Int) : Int {
         if n == 0 {
             0
@@ -208,7 +208,7 @@ pub const CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT: &str = r#"
         let sum = GaussSum(10);
     }"#;
 
-pub const CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT: &str = r#"
+pub const CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT: &str = r#"
     function GaussSum(n : Int) : Int {
         if n == 0 {
             0
@@ -221,7 +221,7 @@ pub const CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT: &str = r#"
         let sum = GaussSum(M(q) == Zero ? 10 | 20);
     }"#;
 
-pub const CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT: &str = r#"
+pub const CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT: &str = r#"
     operation GaussSum(n : Int) : Int {
         if n == 0 {
             0
@@ -233,7 +233,7 @@ pub const CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT: &str = r#"
         let sum = GaussSum(10);
     }"#;
 
-pub const CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT: &str = r#"
+pub const CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT: &str = r#"
     operation GaussSum(n : Int) : Int {
         if n == 0 {
             0

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -31,7 +31,7 @@ use qsc_hir::{
     visit::Visitor,
 };
 use qsc_lowerer::map_hir_package_to_fir;
-use qsc_rca::PackageComputeProperties;
+use qsc_rca::{PackageComputeProperties, PackageStoreComputeProperties};
 use replace_qubit_allocation::ReplaceQubitAllocation;
 use thiserror::Error;
 
@@ -120,23 +120,21 @@ impl PassContext {
             .collect()
     }
 
-    #[must_use]
     pub fn run_fir_passes_on_hir(
         package_store: &qsc_frontend::compile::PackageStore,
         package_id: qsc_hir::hir::PackageId,
         capabilities: RuntimeCapabilityFlags,
-    ) -> Vec<Error> {
+    ) -> Result<PackageStoreComputeProperties, Vec<Error>> {
         let fir_store = lower_store(package_store);
         let fir_package_id = map_hir_package_to_fir(package_id);
         Self::run_fir_passes_on_fir(&fir_store, fir_package_id, capabilities)
     }
 
-    #[must_use]
     pub fn run_fir_passes_on_fir(
         fir_store: &qsc_fir::fir::PackageStore,
         package_id: qsc_fir::fir::PackageId,
         capabilities: RuntimeCapabilityFlags,
-    ) -> Vec<Error> {
+    ) -> Result<PackageStoreComputeProperties, Vec<Error>> {
         run_rca_pass(fir_store, package_id, capabilities)
     }
 }

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -16,7 +16,7 @@ mod replace_qubit_allocation;
 mod spec_gen;
 
 use callable_limits::CallableLimits;
-use capabilitiesck::check_supported_capabilities;
+use capabilitiesck::{check_supported_capabilities, lower_store, run_rca_pass};
 use entry_point::generate_entry_expr;
 use loop_unification::LoopUni;
 use miette::Diagnostic;
@@ -30,6 +30,7 @@ use qsc_hir::{
     validate::Validator,
     visit::Visitor,
 };
+use qsc_lowerer::map_hir_package_to_fir;
 use qsc_rca::PackageComputeProperties;
 use replace_qubit_allocation::ReplaceQubitAllocation;
 use thiserror::Error;
@@ -117,6 +118,26 @@ impl PassContext {
             .chain(entry_point_errors)
             .chain(base_prof_errors.into_iter().map(Error::BaseProfCk))
             .collect()
+    }
+
+    #[must_use]
+    pub fn run_fir_passes_on_hir(
+        package_store: &qsc_frontend::compile::PackageStore,
+        package_id: qsc_hir::hir::PackageId,
+        capabilities: RuntimeCapabilityFlags,
+    ) -> Vec<Error> {
+        let fir_store = lower_store(package_store);
+        let fir_package_id = map_hir_package_to_fir(package_id);
+        Self::run_fir_passes_on_fir(&fir_store, fir_package_id, capabilities)
+    }
+
+    #[must_use]
+    pub fn run_fir_passes_on_fir(
+        fir_store: &qsc_fir::fir::PackageStore,
+        package_id: qsc_fir::fir::PackageId,
+        capabilities: RuntimeCapabilityFlags,
+    ) -> Vec<Error> {
+        run_rca_pass(fir_store, package_id, capabilities)
     }
 }
 

--- a/compiler/qsc_rca/Cargo.toml
+++ b/compiler/qsc_rca/Cargo.toml
@@ -15,12 +15,12 @@ indenter = { workspace = true }
 qsc_data_structures = { path = "../qsc_data_structures" }
 qsc_fir = { path = "../qsc_fir" }
 qsc_frontend = { path = "../qsc_frontend" }
+qsc_lowerer = { path = "../qsc_lowerer" }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]
 expect-test = { workspace = true }
 qsc = { path = "../qsc" }
-qsc_eval = { path = "../qsc_eval" }
 qsc_passes = { path = "../qsc_passes" }
 
 [lints]

--- a/compiler/qsc_rca/tests/test_utils.rs
+++ b/compiler/qsc_rca/tests/test_utils.rs
@@ -4,9 +4,9 @@
 use expect_test::Expect;
 use qsc::incremental::Compiler;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_eval::{debug::map_hir_package_to_fir, lower::Lowerer};
 use qsc_fir::fir::{ItemKind, LocalItemId, Package, PackageStore, StoreItemId};
 use qsc_frontend::compile::{PackageStore as HirPackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_lowerer::{map_hir_package_to_fir, Lowerer};
 use qsc_passes::PackageType;
 use qsc_rca::{Analyzer, ComputePropertiesLookup, PackageStoreComputeProperties};
 

--- a/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
+++ b/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
@@ -43,9 +43,9 @@ fn remap_block_ids_no_changes() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
             blocks:
                 Block 0: Block:
                     Jump(1)
@@ -68,9 +68,9 @@ fn remap_block_ids_no_changes() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
             blocks:
                 Block 0: Block:
                     Jump(1)
@@ -117,9 +117,9 @@ fn remap_block_ids_out_of_order_no_branches() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  5
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 5
             blocks:
                 Block 3: Block:
                     Jump(7)
@@ -142,9 +142,9 @@ fn remap_block_ids_out_of_order_no_branches() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
             blocks:
                 Block 0: Block:
                     Jump(1)
@@ -202,9 +202,9 @@ fn remap_block_ids_out_of_order_with_one_branch() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  2
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 2
             blocks:
                 Block 0: Block:
                     Return
@@ -230,9 +230,9 @@ fn remap_block_ids_out_of_order_with_one_branch() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
             blocks:
                 Block 0: Block:
                     Branch Variable(0, Boolean), 1, 2
@@ -289,9 +289,9 @@ fn remap_block_ids_simple_loop() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  4
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 4
             blocks:
                 Block 2: Block:
                     Return
@@ -315,9 +315,9 @@ fn remap_block_ids_simple_loop() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
             blocks:
                 Block 0: Block:
                     Branch Variable(0, Boolean), 1, 2
@@ -361,9 +361,9 @@ fn remap_block_ids_infinite_loop() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  4
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 4
             blocks:
                 Block 0: Block:
                     Jump(4)
@@ -385,9 +385,9 @@ fn remap_block_ids_infinite_loop() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
             blocks:
                 Block 0: Block:
                     Jump(1)
@@ -448,9 +448,9 @@ fn remap_block_ids_nested_branching_loops() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  4
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 4
             blocks:
                 Block 2: Block:
                     Return
@@ -474,9 +474,9 @@ fn remap_block_ids_nested_branching_loops() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
             blocks:
                 Block 0: Block:
                     Branch Variable(0, Boolean), 1, 2

--- a/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
+++ b/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
@@ -566,9 +566,9 @@ fn remap_block_ids_ensures_acyclic_program_gets_topological_ordering() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  4
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 4
             blocks:
                 Block 0: Block:
                     Jump(8)
@@ -604,9 +604,9 @@ fn remap_block_ids_ensures_acyclic_program_gets_topological_ordering() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
             blocks:
                 Block 0: Block:
                     Branch Variable(0, Boolean), 1, 2

--- a/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
@@ -103,15 +103,15 @@ fn ssa_transform_removes_store_in_single_block_program() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -134,15 +134,15 @@ fn ssa_transform_removes_store_in_single_block_program() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -253,15 +253,15 @@ fn ssa_transform_removes_multiple_stores_in_single_block_program() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -288,15 +288,15 @@ fn ssa_transform_removes_multiple_stores_in_single_block_program() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -414,15 +414,15 @@ fn ssa_transform_store_dominating_usage_propagates_to_successor_blocks() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -453,15 +453,15 @@ fn ssa_transform_store_dominating_usage_propagates_to_successor_blocks() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -560,15 +560,15 @@ fn ssa_transform_store_dominating_usage_propagates_to_successor_blocks_without_i
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -597,15 +597,15 @@ fn ssa_transform_store_dominating_usage_propagates_to_successor_blocks_without_i
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -747,15 +747,15 @@ fn ssa_transform_inserts_phi_for_store_not_dominating_usage() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -788,15 +788,15 @@ fn ssa_transform_inserts_phi_for_store_not_dominating_usage() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -917,15 +917,15 @@ fn ssa_transform_inserts_phi_for_store_not_dominating_usage_in_one_branch() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -956,15 +956,15 @@ fn ssa_transform_inserts_phi_for_store_not_dominating_usage_in_one_branch() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -1156,15 +1156,15 @@ fn ssa_transform_inserts_phi_for_node_with_many_predecessors() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -1207,15 +1207,15 @@ fn ssa_transform_inserts_phi_for_node_with_many_predecessors() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -1388,15 +1388,15 @@ fn ssa_transform_inserts_phi_for_multiple_stored_values() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -1431,15 +1431,15 @@ fn ssa_transform_inserts_phi_for_multiple_stored_values() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -1696,15 +1696,15 @@ fn ssa_transform_inserts_phi_nodes_in_successive_blocks_for_chained_branches() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -1753,15 +1753,15 @@ fn ssa_transform_inserts_phi_nodes_in_successive_blocks_for_chained_branches() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -1993,15 +1993,15 @@ fn ssa_transform_inerts_phi_nodes_for_early_return_graph_pattern() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
@@ -2045,15 +2045,15 @@ fn ssa_transform_inerts_phi_nodes_for_early_return_graph_pattern() {
                 Callable 0: Callable:
                     name: main
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  <VOID>
-                    body:  0
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
                 Callable 1: Callable:
                     name: dynamic_bool
                     call_type: Regular
-                    input_type:  <VOID>
-                    output_type:  Boolean
-                    body:  <NONE>
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
             blocks:
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -174,7 +174,7 @@ impl Display for Callable {
         indent = set_indentation(indent, 1);
         write!(indent, "\nname: {}", self.name)?;
         write!(indent, "\ncall_type: {}", self.call_type)?;
-        write!(indent, "\ninput_type: ")?;
+        write!(indent, "\ninput_type:")?;
         if self.input_type.is_empty() {
             write!(indent, " <VOID>")?;
         } else {
@@ -184,13 +184,13 @@ impl Display for Callable {
             }
             indent = set_indentation(indent, 1);
         }
-        write!(indent, "\noutput_type: ")?;
+        write!(indent, "\noutput_type:")?;
         if let Some(output_type) = &self.output_type {
             write!(indent, " {output_type}")?;
         } else {
             write!(indent, " <VOID>")?;
         }
-        write!(indent, "\nbody: ")?;
+        write!(indent, "\nbody:")?;
         if let Some(body_block_id) = self.body {
             write!(indent, " {}", body_block_id.0)?;
         } else {

--- a/language_service/Cargo.toml
+++ b/language_service/Cargo.toml
@@ -16,15 +16,15 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dependencies]
+async-trait = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }
 miette = { workspace = true }
 qsc = { path = "../compiler/qsc" }
-rustc-hash = { workspace = true }
 qsc_linter = { path = "../compiler/qsc_linter" }
 qsc_project = { path = "../compiler/qsc_project", features = ["async"] }
-async-trait = { workspace = true }
+rustc-hash = { workspace = true }
 
 [lints]
 workspace = true

--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -12,7 +12,7 @@ use qsc::{
     line_column::{Encoding, Position},
     resolve,
     target::Profile,
-    CompileUnit, LanguageFeatures, PackageStore, PackageType, SourceMap, Span,
+    CompileUnit, LanguageFeatures, PackageStore, PackageType, PassContext, SourceMap, Span,
 };
 use qsc_linter::LintConfig;
 use std::sync::Arc;
@@ -72,14 +72,32 @@ impl Compilation {
             language_features,
         );
 
-        let lints = qsc::linter::run_lints(&unit, Some(lints_config));
-        let mut lints = lints
-            .into_iter()
-            .map(|lint| WithSource::from_map(&unit.sources, qsc::compile::ErrorKind::Lint(lint)))
-            .collect();
-        errors.append(&mut lints);
-
         let package_id = package_store.insert(unit);
+        let unit = package_store
+            .get(package_id)
+            .expect("expected to find user package");
+
+        if errors.is_empty() && target_profile != Profile::Unrestricted {
+            let caps_errors = PassContext::run_fir_passes_on_hir(
+                &package_store,
+                package_id,
+                target_profile.into(),
+            );
+            for err in caps_errors {
+                errors.push(WithSource::from_map(
+                    &unit.sources,
+                    compile::ErrorKind::Pass(err),
+                ));
+            }
+        }
+
+        let lints = qsc::linter::run_lints(unit, Some(lints_config));
+        for lint in lints {
+            errors.push(WithSource::from_map(
+                &unit.sources,
+                qsc::compile::ErrorKind::Lint(lint),
+            ));
+        }
 
         Self {
             package_store,

--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -78,16 +78,18 @@ impl Compilation {
             .expect("expected to find user package");
 
         if errors.is_empty() && target_profile != Profile::Unrestricted {
-            let caps_errors = PassContext::run_fir_passes_on_hir(
+            let cap_results = PassContext::run_fir_passes_on_hir(
                 &package_store,
                 package_id,
                 target_profile.into(),
             );
-            for err in caps_errors {
-                errors.push(WithSource::from_map(
-                    &unit.sources,
-                    compile::ErrorKind::Pass(err),
-                ));
+            if let Err(caps_errors) = cap_results {
+                for err in caps_errors {
+                    errors.push(WithSource::from_map(
+                        &unit.sources,
+                        compile::ErrorKind::Pass(err),
+                    ));
+                }
             }
         }
 

--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -77,7 +77,11 @@ impl Compilation {
             .get(package_id)
             .expect("expected to find user package");
 
-        if errors.is_empty() && target_profile != Profile::Unrestricted {
+        // baseprofchk will handle the case where the target profile is Base
+        if errors.is_empty()
+            && target_profile != Profile::Unrestricted
+            && target_profile != Profile::Base
+        {
             let cap_results = PassContext::run_fir_passes_on_hir(
                 &package_store,
                 package_id,

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -27,6 +27,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool` representing the `input`.
+    @Config(Adaptive)
     @Config(Unrestricted)
     function ResultAsBool(input : Result) : Bool {
         input == One
@@ -42,6 +43,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result` representing the `input`.
+    @Config(Adaptive)
     @Config(Unrestricted)
     function BoolAsResult(input : Bool) : Result {
         if input { One } else { Zero }
@@ -168,6 +170,7 @@ namespace Microsoft.Quantum.Convert {
     /// // The following returns 1
     /// let int1 = ResultArrayAsInt([One,Zero])
     /// ```
+    @Config(Adaptive)
     @Config(Unrestricted)
     function ResultArrayAsInt(results : Result[]) : Int {
         let nBits = Length(results);
@@ -193,6 +196,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool[]` representing the `input`.
+    @Config(Adaptive)
     @Config(Unrestricted)
     function ResultArrayAsBoolArray(input : Result[]) : Bool[] {
         mutable output = [];
@@ -213,6 +217,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result[]` representing the `input`.
+    @Config(Adaptive)
     @Config(Unrestricted)
     function BoolArrayAsResultArray(input : Bool[]) : Result[] {
         mutable output = [];

--- a/library/std/diagnostics.qs
+++ b/library/std/diagnostics.qs
@@ -69,11 +69,13 @@ namespace Microsoft.Quantum.Diagnostics {
         body intrinsic;
     }
 
+    @Config(Adaptive)
     @Config(Unrestricted)
     operation CheckZero(qubit : Qubit) : Bool {
         body intrinsic;
     }
 
+    @Config(Adaptive)
     @Config(Unrestricted)
     operation CheckAllZero(qubits : Qubit[]) : Bool {
         for q in qubits {
@@ -120,6 +122,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// Operation defining the expected behavior for the operation under test.
     /// # Output
     /// True if operations are equal, false otherwise.
+    @Config(Adaptive)
     @Config(Unrestricted)
     operation CheckOperationsAreEqual(
         nQubits : Int,

--- a/library/std/internal.qs
+++ b/library/std/internal.qs
@@ -131,6 +131,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
+    @Config(Adaptive)
     @Config(Unrestricted)
     internal operation AND(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         body ... {

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -218,6 +218,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// Measure([PauliZ], [qubit]);
     /// ```
+    @Config(Adaptive)
     @Config(Unrestricted)
     operation M(qubit : Qubit) : Result {
         __quantum__qis__m__body(qubit)
@@ -290,6 +291,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// If the basis array and qubit array are different lengths, then the
     /// operation will fail.
+    @Config(Adaptive)
     @Config(Unrestricted)
     operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
         if Length(bases) != Length(qubits) {

--- a/library/std/measurement.qs
+++ b/library/std/measurement.qs
@@ -146,6 +146,7 @@ namespace Microsoft.Quantum.Measurement {
     /// # Remarks
     /// This operation resets its input register to the |00...0> state,
     /// suitable for releasing back to a target machine.
+    @Config(Adaptive)
     @Config(Unrestricted)
     operation MeasureInteger(target : Qubit[]) : Int {
         let nBits = Length(target);

--- a/library/std/random.qs
+++ b/library/std/random.qs
@@ -24,6 +24,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let roll = DrawRandomInt(1, 6);
     /// ```
+    @Config(Adaptive)
     @Config(Unrestricted)
     operation DrawRandomInt(min : Int, max : Int) : Int {
         body intrinsic;
@@ -50,6 +51,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let angle = DrawRandomDouble(0.0, 2.0 * PI());
     /// ```
+    @Config(Adaptive)
     @Config(Unrestricted)
     operation DrawRandomDouble(min : Double, max : Double) : Double {
         body intrinsic;

--- a/library/std/re.qs
+++ b/library/std/re.qs
@@ -33,6 +33,7 @@ namespace Microsoft.Quantum.ResourceEstimation {
     /// needs to be executed in order to collect and cache estimates.
     /// `false` indicates if cached estimates have been incorporated into the overall costs
     /// and the code fragment should be skipped.
+    @Config(Adaptive)
     @Config(Unrestricted)
     function BeginEstimateCaching(name : String, variant : Int) : Bool {
         body intrinsic;

--- a/library/std/unstable_arithmetic_internal.qs
+++ b/library/std/unstable_arithmetic_internal.qs
@@ -243,6 +243,7 @@ namespace Microsoft.Quantum.Unstable.Arithmetic {
     ///   Phys. Rev. A 87, 022328, 2013
     ///   [arXiv:1212.5069](https://arxiv.org/abs/1212.5069)
     ///   doi:10.1103/PhysRevA.87.022328
+    @Config(Adaptive)
     @Config(Unrestricted)
     internal operation ApplyAndAssuming0Target(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         // NOTE: Eventually this operation will be public and intrinsic.

--- a/library/std/unstable_table_lookup.qs
+++ b/library/std/unstable_table_lookup.qs
@@ -43,6 +43,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
     ///     "Windowed arithmetic"
     /// [3] [arXiv:2211.01133](https://arxiv.org/abs/2211.01133)
     ///     "Space-time optimized table lookup"
+    @Config(Adaptive)
     @Config(Unrestricted)
     operation Select(
         data : Bool[][],
@@ -97,6 +98,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
         }
     }
 
+    @Config(Adaptive)
     @Config(Unrestricted)
     internal operation SinglyControlledSelect(
         ctl : Qubit,
@@ -166,6 +168,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
     /// # References
     /// - [arXiv:1905.07682](https://arxiv.org/abs/1905.07682)
     ///   "Windowed arithmetic"
+    @Config(Adaptive)
     @Config(Unrestricted)
     internal operation Unlookup(
         lookup : (Bool[][], Qubit[], Qubit[]) => Unit,

--- a/npm/qsharp/src/browser.ts
+++ b/npm/qsharp/src/browser.ts
@@ -170,7 +170,7 @@ export type {
   VSDiagnostic,
 } from "../lib/web/qsc_wasm.js";
 export { type Dump, type ShotResult } from "./compiler/common.js";
-export { type CompilerState } from "./compiler/compiler.js";
+export { type CompilerState, type ProgramConfig } from "./compiler/compiler.js";
 export { QscEventTarget } from "./compiler/events.js";
 export {
   getAllKatas,

--- a/npm/qsharp/src/compiler/compiler.ts
+++ b/npm/qsharp/src/compiler/compiler.ts
@@ -94,6 +94,8 @@ export type ProgramConfig = {
   sources: [string, string][];
   /** An array of language features to be opted in to in this compilation. */
   languageFeatures?: string[];
+  /** Target compilation profile. */
+  profile?: TargetProfile;
 };
 
 // WebWorker also support being explicitly terminated to tear down the worker thread
@@ -138,22 +140,24 @@ export class Compiler implements ICompiler {
     if (Array.isArray(sourcesOrConfig)) {
       return this.deprecatedGetQir(sourcesOrConfig, languageFeatures || []);
     } else {
-      return this.newGetQir(sourcesOrConfig);
+      const config = sourcesOrConfig as ProgramConfig;
+      return this.newGetQir(config);
     }
   }
 
   async newGetQir({
     sources,
     languageFeatures = [],
+    profile = "base",
   }: ProgramConfig): Promise<string> {
-    return this.wasm.get_qir(sources, languageFeatures);
+    return this.wasm.get_qir(sources, languageFeatures, profile);
   }
 
   async deprecatedGetQir(
     sources: [string, string][],
     languageFeatures: string[],
   ): Promise<string> {
-    return this.wasm.get_qir(sources, languageFeatures);
+    return this.wasm.get_qir(sources, languageFeatures, "base");
   }
 
   async getEstimates(

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -12,9 +12,12 @@ class TargetProfile:
     The target profile is a description of a target's capabilities.
     """
 
-    Unrestricted: ClassVar[Any]
+    Adaptive: ClassVar[Any]
     """
-    Describes the unrestricted set of capabilities required to run any Q# program.
+    Target supports the core set of adaptive.
+
+    This option maps to the Adaptive Profile as defined by the QIR specification
+    without any extensions.
     """
 
     Base: ClassVar[Any]
@@ -23,6 +26,11 @@ class TargetProfile:
     program.
 
     This option maps to the Base Profile as defined by the QIR specification.
+    """
+
+    Unrestricted: ClassVar[Any]
+    """
+    Describes the unrestricted set of capabilities required to run any Q# program.
     """
 
 class Interpreter:

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -27,6 +27,7 @@ class Config:
         if target_profile == TargetProfile.Adaptive:
             self._config = {"targetProfile": "adaptive"}
             warn("The adaptive target profile is a preview feature.")
+            warn("Functionality may be incomplete or incorrect.")
         elif target_profile == TargetProfile.Base:
             self._config = {"targetProfile": "base"}
         elif target_profile == TargetProfile.Unrestricted:

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -9,6 +9,7 @@ from ._native import (
     Output,
     Circuit,
 )
+from warnings import warn
 from typing import Any, Callable, Dict, Optional, TypedDict, Union, List
 from .estimator._estimator import EstimatorResult, EstimatorParams
 import json
@@ -23,10 +24,14 @@ class Config:
     """
 
     def __init__(self, target_profile: TargetProfile, language_features: List[str]):
-        if target_profile == TargetProfile.Unrestricted:
-            self._config = {"targetProfile": "unrestricted"}
+        if target_profile == TargetProfile.Adaptive:
+            self._config = {"targetProfile": "adaptive"}
+            warn("The adaptive target profile is a preview feature.")
         elif target_profile == TargetProfile.Base:
             self._config = {"targetProfile": "base"}
+        elif target_profile == TargetProfile.Unrestricted:
+            self._config = {"targetProfile": "unrestricted"}
+
         self._config["languageFeatures"] = language_features
 
     def __repr__(self) -> str:

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -51,14 +51,18 @@ fn _native(py: Python, m: &PyModule) -> PyResult<()> {
 /// A target profile describes the capabilities of the hardware or simulator
 /// which will be used to run the Q# program.
 pub(crate) enum TargetProfile {
-    /// Target supports the full set of capabilities required to run any Q# program.
+    /// Target supports the core set of adaptive.
     ///
-    /// This option maps to the Full Profile as defined by the QIR specification.
-    Unrestricted,
+    /// This option maps to the Adaptive Profile as defined by the QIR specification without any extensions.
+    Adaptive,
     /// Target supports the minimal set of capabilities required to run a quantum program.
     ///
     /// This option maps to the Base Profile as defined by the QIR specification.
     Base,
+    /// Target supports the full set of capabilities required to run any Q# program.
+    ///
+    /// This option maps to the Full Profile as defined by the QIR specification.
+    Unrestricted,
 }
 
 #[pyclass(unsendable)]
@@ -110,8 +114,9 @@ impl Interpreter {
         list_directory: Option<PyObject>,
     ) -> PyResult<Self> {
         let target = match target {
-            TargetProfile::Unrestricted => Profile::Unrestricted,
+            TargetProfile::Adaptive => Profile::Adaptive,
             TargetProfile::Base => Profile::Base,
+            TargetProfile::Unrestricted => Profile::Unrestricted,
         };
         let language_features = language_features.unwrap_or_default();
 

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -272,6 +272,21 @@ def test_entry_expr_circuit() -> None:
     )
 
 
+def test_adaptive_errors_are_raised_when_interpreting() -> None:
+    e = Interpreter(TargetProfile.Adaptive)
+    with pytest.raises(Exception) as excinfo:
+        e.interpret("operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }")
+    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+
+
+def test_adaptive_errors_are_raised_when_running() -> None:
+    e = Interpreter(TargetProfile.Adaptive)
+    with pytest.raises(Exception) as excinfo:
+        e.run("{use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; }}")
+    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+
+
+
 def test_operation_circuit() -> None:
     e = Interpreter(TargetProfile.Unrestricted)
     e.interpret("operation Foo(q: Qubit) : Result { H(q); return M(q) }")

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -272,6 +272,7 @@ def test_entry_expr_circuit() -> None:
     )
 
 
+# this is by design
 def test_callables_failing_profile_validation_are_still_registered() -> None:
     e = Interpreter(TargetProfile.Adaptive)
     with pytest.raises(Exception) as excinfo:
@@ -284,6 +285,7 @@ def test_callables_failing_profile_validation_are_still_registered() -> None:
     assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
 
 
+# this is by design
 def test_once_rca_validation_fails_following_calls_also_fail() -> None:
     e = Interpreter(TargetProfile.Adaptive)
     with pytest.raises(Exception) as excinfo:

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -272,10 +272,36 @@ def test_entry_expr_circuit() -> None:
     )
 
 
+def test_callables_failing_profile_validation_are_still_registered() -> None:
+    e = Interpreter(TargetProfile.Adaptive)
+    with pytest.raises(Exception) as excinfo:
+        e.interpret(
+            "operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }"
+        )
+    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+    with pytest.raises(Exception) as excinfo:
+        e.interpret("Foo()")
+    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+
+
+def test_once_rca_validation_fails_following_calls_also_fail() -> None:
+    e = Interpreter(TargetProfile.Adaptive)
+    with pytest.raises(Exception) as excinfo:
+        e.interpret(
+            "operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }"
+        )
+    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+    with pytest.raises(Exception) as excinfo:
+        e.interpret("let x = 5;")
+    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+
+
 def test_adaptive_errors_are_raised_when_interpreting() -> None:
     e = Interpreter(TargetProfile.Adaptive)
     with pytest.raises(Exception) as excinfo:
-        e.interpret("operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }")
+        e.interpret(
+            "operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }"
+        )
     assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
 
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -101,8 +101,8 @@
           "default": "unrestricted",
           "enum": [
             "unrestricted",
-            "adaptive",
-            "base"
+            "base",
+            "adaptive"
           ],
           "enumDescriptions": [
             "The set of all capabilities required to run any Q# program.",
@@ -120,7 +120,7 @@
           "default": true,
           "description": "Enables the Circuit code lens to synthesize circuit diagrams for Q# programs and operations."
         },
-        "Q#.useQirGenPreview": {
+        "Q#.enablePreviewQirGen": {
           "type": "boolean",
           "default": false,
           "description": "Enables the preview QIR code generation functionality."

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -101,6 +101,7 @@
           "default": "unrestricted",
           "enum": [
             "unrestricted",
+            "adaptive",
             "base"
           ],
           "enumDescriptions": [
@@ -118,6 +119,16 @@
           "type": "boolean",
           "default": true,
           "description": "Enables the Circuit code lens to synthesize circuit diagrams for Q# programs and operations."
+        },
+        "Q#.useQirGenPreview": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables the preview QIR code generation functionality."
+        },
+        "Q#.enableAdaptiveProfile": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables Adaptive as a target profile."
         }
       }
     },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -106,7 +106,8 @@
           ],
           "enumDescriptions": [
             "The set of all capabilities required to run any Q# program.",
-            "The minimal set of capabilities required to run a quantum program. This option maps to the Base Profile as defined by the QIR specification."
+            "The minimal set of capabilities required to run a quantum program. This option maps to the Base Profile as defined by the QIR specification.",
+            "The set of capabilities required to run an adaptive quantum program. This option maps to the Adaptive Profile as defined by the QIR specification."
           ],
           "description": "Setting the target profile allows the Q# extension to generate programs that are compatible with a specific target. The target is the hardware or simulator which will be used to run the Q# program. The target profile is a description of a target's capabilities."
         },

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -30,10 +30,10 @@ export async function setTarget(target: TargetProfile) {
 
 export function getTargetFriendlyName(targetProfile?: string) {
   switch (targetProfile) {
-    case "base":
-      return "Q#: QIR base";
     case "adaptive":
       return "Q#: QIR adaptive";
+    case "base":
+      return "Q#: QIR base";
     case "unrestricted":
       return "Q#: unrestricted";
     default:
@@ -56,9 +56,9 @@ export function getShowCircuitCodeLens(): boolean {
   );
 }
 
-export function getUseQirGenPreview(): boolean {
+export function getEnablePreviewQirGen(): boolean {
   return vscode.workspace.getConfiguration("Q#").get<boolean>(
-    "useQirGenPreview",
+    "enablePreviewQirGen",
     false, // The default value should be set in `package.json` as well.
   );
 }

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -9,6 +9,7 @@ export function getTarget(): TargetProfile {
     .getConfiguration("Q#")
     .get<TargetProfile>("targetProfile", "unrestricted");
   switch (target) {
+    case "adaptive":
     case "base":
     case "unrestricted":
       return target;
@@ -31,6 +32,8 @@ export function getTargetFriendlyName(targetProfile?: string) {
   switch (targetProfile) {
     case "base":
       return "Q#: QIR base";
+    case "adaptive":
+      return "Q#: QIR adaptive";
     case "unrestricted":
       return "Q#: unrestricted";
     default:
@@ -50,5 +53,19 @@ export function getShowCircuitCodeLens(): boolean {
   return vscode.workspace.getConfiguration("Q#").get<boolean>(
     "showCircuitCodeLens",
     true, // The default value should be set in `package.json` as well.
+  );
+}
+
+export function getUseQirGenPreview(): boolean {
+  return vscode.workspace.getConfiguration("Q#").get<boolean>(
+    "useQirGenPreview",
+    false, // The default value should be set in `package.json` as well.
+  );
+}
+
+export function getEnableAdaptiveProfile(): boolean {
+  return vscode.workspace.getConfiguration("Q#").get<boolean>(
+    "enableAdaptiveProfile",
+    false, // The default value should be set in `package.json` as well.
   );
 }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -278,6 +278,7 @@ async function updateLanguageServiceProfile(languageService: ILanguageService) {
   const targetProfile = getTarget();
 
   switch (targetProfile) {
+    case "adaptive":
     case "base":
     case "unrestricted":
       break;

--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -86,7 +86,7 @@ export async function getQirForActiveWindow(): Promise<string> {
     }
     if (getTarget() === "adaptive") {
       // if the target is adaptive, we already know adaptive is enabled
-      languageFeatures.push("adaptive-qir-gen");
+      languageFeatures.push("adaptive-profile");
     }
     result = await worker.getQir({ sources, languageFeatures });
 

--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -6,7 +6,7 @@ import { getCompilerWorker, log } from "qsharp-lang";
 import { isQsharpDocument } from "./common";
 import { EventType, sendTelemetryEvent } from "./telemetry";
 import { getRandomGuid } from "./utils";
-import { getTarget, getUseQirGenPreview, setTarget } from "./config";
+import { getTarget, getEnablePreviewQirGen, setTarget } from "./config";
 import { loadProject } from "./projectSystem";
 
 const generateQirTimeoutMs = 30000;
@@ -32,9 +32,10 @@ export async function getQirForActiveWindow(): Promise<string> {
 
   // Check that the current target is base profile, and current doc has no errors.
   const targetProfile = getTarget();
+  const enablePreviewQirGen = getEnablePreviewQirGen();
   const allowed =
     targetProfile === "base" ||
-    (targetProfile === "adaptive" && getUseQirGenPreview());
+    (targetProfile === "adaptive" && enablePreviewQirGen);
   if (!allowed) {
     const result = await vscode.window.showWarningMessage(
       "Submitting to Azure is only supported when targeting the QIR base profile.",
@@ -80,8 +81,8 @@ export async function getQirForActiveWindow(): Promise<string> {
     const associationId = getRandomGuid();
     const start = performance.now();
     sendTelemetryEvent(EventType.GenerateQirStart, { associationId }, {});
-    if (getUseQirGenPreview()) {
-      languageFeatures.push("qir-gen-preview");
+    if (enablePreviewQirGen) {
+      languageFeatures.push("preview-qir-gen");
     }
     if (getTarget() === "adaptive") {
       // if the target is adaptive, we already know adaptive is enabled

--- a/vscode/src/statusbar.ts
+++ b/vscode/src/statusbar.ts
@@ -121,10 +121,10 @@ function getTargetProfiles(): {
 
 function getTargetProfileSetting(uiText: string): TargetProfile {
   switch (uiText) {
-    case "Q#: QIR base":
-      return "base";
     case "Q#: QIR adaptive":
       return "adaptive";
+    case "Q#: QIR base":
+      return "base";
     case "Q#: unrestricted":
       return "unrestricted";
     default:

--- a/vscode/src/statusbar.ts
+++ b/vscode/src/statusbar.ts
@@ -4,7 +4,12 @@
 import { log, TargetProfile } from "qsharp-lang";
 import * as vscode from "vscode";
 import { isQsharpDocument } from "./common";
-import { getTarget, getTargetFriendlyName, setTarget } from "./config";
+import {
+  getEnableAdaptiveProfile,
+  getTarget,
+  getTargetFriendlyName,
+  setTarget,
+} from "./config";
 
 export function activateTargetProfileStatusBarItem(): vscode.Disposable[] {
   const disposables = [];
@@ -81,7 +86,7 @@ function registerTargetProfileCommand() {
     "qsharp-vscode.setTargetProfile",
     async () => {
       const target = await vscode.window.showQuickPick(
-        targetProfiles.map((profile) => ({
+        getTargetProfiles().map((profile) => ({
           label: profile.uiText,
         })),
         { placeHolder: "Select the QIR target profile" },
@@ -95,14 +100,31 @@ function registerTargetProfileCommand() {
 }
 
 const targetProfiles = [
+  { configName: "adaptive", uiText: "Q#: QIR adaptive" },
   { configName: "base", uiText: "Q#: QIR base" },
   { configName: "unrestricted", uiText: "Q#: unrestricted" },
 ];
+
+function getTargetProfiles(): {
+  configName: string;
+  uiText: string;
+}[] {
+  const allow_adaptive = getEnableAdaptiveProfile();
+  if (allow_adaptive) {
+    return targetProfiles;
+  } else {
+    return targetProfiles.filter(
+      (profile) => profile.configName !== "adaptive",
+    );
+  }
+}
 
 function getTargetProfileSetting(uiText: string): TargetProfile {
   switch (uiText) {
     case "Q#: QIR base":
       return "base";
+    case "Q#: QIR adaptive":
+      return "adaptive";
     case "Q#: unrestricted":
       return "unrestricted";
     default:

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -489,7 +489,7 @@ serializable_type! {
         pub languageFeatures: Option<Vec<String>>
     },
     r#"export interface INotebookMetadata {
-        targetProfile?: "unrestricted" | "base";
+        targetProfile?: "adaptive" | "base" | "unrestricted";
         languageFeatures?: "v2-preview-syntax"[];
     }"#,
     INotebookMetadata

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -21,7 +21,7 @@ use qsc::{
     LanguageFeatures, PackageStore, PackageType, PassContext, SourceContents, SourceMap,
     SourceName, SparseSim,
 };
-use qsc_codegen::{qir::to_qir, qir_base::generate_qir};
+use qsc_codegen::{qir::hir_to_qir, qir_base::generate_qir};
 use resource_estimator::{self as re, estimate_entry};
 use serde::Serialize;
 use serde_json::json;
@@ -79,7 +79,11 @@ pub fn get_qir(
 ) -> Result<String, String> {
     let language_features = LanguageFeatures::from_iter(language_features);
     let sources = get_source_map(sources, &None);
-    if language_features.contains(LanguageFeatures::QirGenPreview) {
+    if language_features.contains(LanguageFeatures::PreviewQirGen) {
+        // the use of AdaptiveProfileQirGen is currently being used to
+        // determine what profile to target as the get_qir interface doesn't
+        // have a way to specify the profile to target and the old codegen
+        // is hardcoded to use the Base profile.
         let profile = if language_features.contains(LanguageFeatures::AdaptiveProfileQirGen) {
             Profile::Adaptive
         } else {
@@ -155,7 +159,7 @@ fn _get_qir_preview(
         return Err("Failed to generate QIR".to_string());
     }
 
-    to_qir(&package_store, package_id, profile.into()).map_err(|e| e.to_string())
+    hir_to_qir(&package_store, package_id, profile.into()).map_err(|e| e.to_string())
 }
 
 #[wasm_bindgen]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -84,7 +84,7 @@ pub fn get_qir(
         // determine what profile to target as the get_qir interface doesn't
         // have a way to specify the profile to target and the old codegen
         // is hardcoded to use the Base profile.
-        let profile = if language_features.contains(LanguageFeatures::AdaptiveProfileQirGen) {
+        let profile = if language_features.contains(LanguageFeatures::AdaptiveProfile) {
             Profile::Adaptive
         } else {
             Profile::Base

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -76,19 +76,13 @@ pub fn get_source_map(sources: Vec<js_sys::Array>, entry: &Option<String>) -> So
 pub fn get_qir(
     sources: Vec<js_sys::Array>,
     language_features: Vec<String>,
+    profile: &str,
 ) -> Result<String, String> {
     let language_features = LanguageFeatures::from_iter(language_features);
     let sources = get_source_map(sources, &None);
+    let profile =
+        Profile::from_str(profile).map_err(|()| format!("Invalid target profile {profile}"))?;
     if language_features.contains(LanguageFeatures::PreviewQirGen) {
-        // the use of AdaptiveProfileQirGen is currently being used to
-        // determine what profile to target as the get_qir interface doesn't
-        // have a way to specify the profile to target and the old codegen
-        // is hardcoded to use the Base profile.
-        let profile = if language_features.contains(LanguageFeatures::AdaptiveProfile) {
-            Profile::Adaptive
-        } else {
-            Profile::Base
-        };
         _get_qir_preview(sources, language_features, profile)
     } else {
         _get_qir(sources, language_features)

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -154,13 +154,20 @@ fn _get_qir_preview(
     let caps_results =
         PassContext::run_fir_passes_on_hir(&package_store, package_id, profile.into());
     // Ensure it compiles before trying to add it to the store.
-    if caps_results.is_err() {
-        // This should never happen, as the program should be checked for errors before trying to
-        // generate code for it. But just in case, simply report the failure.
-        return Err("Failed to generate QIR".to_string());
+    match caps_results {
+        Ok(compute_properties) => hir_to_qir(
+            &package_store,
+            package_id,
+            profile.into(),
+            Some(compute_properties),
+        )
+        .map_err(|e| e.to_string()),
+        Err(_) => {
+            // This should never happen, as the program should be checked for errors before trying to
+            // generate code for it. But just in case, simply report the failure.
+            Err("Failed to generate QIR".to_string())
+        }
     }
-
-    hir_to_qir(&package_store, package_id, profile.into()).map_err(|e| e.to_string())
 }
 
 #[wasm_bindgen]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -18,10 +18,9 @@ use qsc::{
         CircuitEntryPoint,
     },
     target::Profile,
-    LanguageFeatures, PackageStore, PackageType, PassContext, SourceContents, SourceMap,
-    SourceName, SparseSim,
+    LanguageFeatures, PackageStore, PackageType, SourceContents, SourceMap, SourceName, SparseSim,
 };
-use qsc_codegen::{qir::hir_to_qir, qir_base::generate_qir};
+use qsc_codegen::qir_base::generate_qir;
 use resource_estimator::{self as re, estimate_entry};
 use serde::Serialize;
 use serde_json::json;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -151,9 +151,10 @@ fn _get_qir_preview(
 
     let package_id = package_store.insert(unit);
 
-    let errors = PassContext::run_fir_passes_on_hir(&package_store, package_id, profile.into());
+    let caps_results =
+        PassContext::run_fir_passes_on_hir(&package_store, package_id, profile.into());
     // Ensure it compiles before trying to add it to the store.
-    if !errors.is_empty() {
+    if caps_results.is_err() {
         // This should never happen, as the program should be checked for errors before trying to
         // generate code for it. But just in case, simply report the failure.
         return Err("Failed to generate QIR".to_string());

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -83,7 +83,7 @@ pub fn get_qir(
     let profile =
         Profile::from_str(profile).map_err(|()| format!("Invalid target profile {profile}"))?;
     if language_features.contains(LanguageFeatures::PreviewQirGen) {
-        _get_qir_preview(sources, language_features, profile)
+        qsc::codegen::get_qir(sources, language_features, profile.into())
     } else {
         _get_qir(sources, language_features)
     }
@@ -115,53 +115,6 @@ fn _get_qir(sources: SourceMap, language_features: LanguageFeatures) -> Result<S
     let package = store.insert(unit);
 
     generate_qir(&store, package).map_err(|e| e.0.to_string())
-}
-
-fn _get_qir_preview(
-    sources: SourceMap,
-    language_features: LanguageFeatures,
-    profile: Profile,
-) -> Result<String, String> {
-    let core = compile::core();
-    let mut package_store = PackageStore::new(core);
-    let std = compile::std(&package_store, profile.into());
-    let std = package_store.insert(std);
-
-    let (unit, errors) = qsc::compile::compile(
-        &package_store,
-        &[std],
-        sources,
-        PackageType::Exe,
-        profile.into(),
-        language_features,
-    );
-
-    // Ensure it compiles before trying to add it to the store.
-    if !errors.is_empty() {
-        // This should never happen, as the program should be checked for errors before trying to
-        // generate code for it. But just in case, simply report the failure.
-        return Err("Failed to generate QIR".to_string());
-    }
-
-    let package_id = package_store.insert(unit);
-
-    let caps_results =
-        PassContext::run_fir_passes_on_hir(&package_store, package_id, profile.into());
-    // Ensure it compiles before trying to add it to the store.
-    match caps_results {
-        Ok(compute_properties) => hir_to_qir(
-            &package_store,
-            package_id,
-            profile.into(),
-            Some(compute_properties),
-        )
-        .map_err(|e| e.to_string()),
-        Err(_) => {
-            // This should never happen, as the program should be checked for errors before trying to
-            // generate code for it. But just in case, simply report the failure.
-            Err("Failed to generate QIR".to_string())
-        }
-    }
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
In order to support adaptive profile selection in VS we have to add `Adaptive` as a compilation attribute in the std lib. This is a workaround until we design a full solution to address #996. This PR adds adaptive as a profile.

Functionality to enable adaptive profile VSCode is hidden behind a config value, as is using the preview QIR code generation from VSCode.

QIR generation for Adaptive/Unrestricted from Python will continue to raise exceptions.

Adaptive is a profile allowed in the Python APIs, but warnings will be issued to users indicating that this functionality is in preview.

The language service will surface RCA errors in VSCode and Python, but not the Notebooks (will be handled in a follow up PR).
Other integration features are being tracked in #1294 and this PR is not expected to have all functionality enabled.