### PR TITLE
Sample for resource estimation extension based on arXiv:2302.06639

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anbrc"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "num-bigint",
+ "num-complex",
+ "num-traits",
+ "qsc",
+ "resource_estimator",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +98,12 @@ dependencies = [
  "anstyle",
  "windows-sys",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "library",
     "pip",
     "resource_estimator",
+    "samples/estimation/extension/anbrc",
     "wasm",
 ]
 resolver = "2"

--- a/samples/estimation/extension/anbrc/Cargo.toml
+++ b/samples/estimation/extension/anbrc/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "anbrc"
+edition.workspace = true
+
+[dependencies]
+anyhow = "1.0.81"
+num-bigint.workspace = true
+num-complex.workspace = true
+num-traits.workspace = true
+qsc = { path = "../../../../compiler/qsc" }
+resource_estimator = { path = "../../../../resource_estimator" }
+
+[lints]
+workspace = true

--- a/samples/estimation/extension/anbrc/qsharp/Adder.qs
+++ b/samples/estimation/extension/anbrc/qsharp/Adder.qs
@@ -1,0 +1,13 @@
+namespace Samples {
+    open Microsoft.Quantum.Unstable.Arithmetic;
+
+    @EntryPoint()
+    operation EstimateAdder() : Unit {
+        let bitsize = 128;
+
+        use xs = Qubit[bitsize];
+        use ys = Qubit[bitsize];
+
+        RippleCarryCGIncByLE(xs, ys);
+    }
+}

--- a/samples/estimation/extension/anbrc/src/code.rs
+++ b/samples/estimation/extension/anbrc/src/code.rs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use num_traits::{FromPrimitive, ToPrimitive};
+use std::{cmp::Ordering, fmt::Display};
+
+use resource_estimator::estimates::ErrorCorrection;
+
+use crate::qubit::CatQubit;
+
+pub struct RepetitionCode {
+    p_threshold: f64,
+}
+
+impl RepetitionCode {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // arXiv:2302.06639 (p. 28, eq. E1)
+    #[must_use]
+    fn logical_phaseflip_probability(
+        &self,
+        physical_qubit: &CatQubit,
+        parameter: &CodeParameter,
+    ) -> Option<f64> {
+        // arXiv:2302.06639 (p. 29, Fig. 26)
+        let prefactor = 5.6e-2;
+        let exponent = (i32::from_u64(parameter.distance)? + 1) / 2;
+
+        Some(
+            prefactor
+                * ((parameter.alpha_sq.powf(0.86) * physical_qubit.k1_k2) / self.p_threshold)
+                    .powi(exponent),
+        )
+    }
+
+    #[allow(clippy::similar_names)]
+    #[must_use]
+    fn logical_bitflip_probability(parameter: &CodeParameter) -> Option<f64> {
+        // number of CX gates in a repetition code cycle
+        let ncx = 2 * (parameter.distance - 1);
+
+        // bitflip error probability of a CX gate (numerically estimates using
+        // full process tomography), arXiv:2302.06639 (p. 26, eq. D8)
+        let pcx = 0.5 * (-2.0 * parameter.alpha_sq).exp();
+
+        Some(f64::from_u64(ncx)? * pcx)
+    }
+}
+
+impl Default for RepetitionCode {
+    fn default() -> Self {
+        // arXiv:2302.06639 (p. 4, p. 28, Fig. 26)
+        let p_threshold = 0.013;
+
+        Self { p_threshold }
+    }
+}
+
+#[derive(Clone)]
+pub struct CodeParameter {
+    distance: u64,
+    // amplitude ɑ arXiv:2302.06639 (p. 3)
+    // average number of photons ɑ²
+    alpha_sq: f64,
+}
+
+impl CodeParameter {
+    #[must_use]
+    pub fn new(distance: u64, alpha_sq: f64) -> Self {
+        Self { distance, alpha_sq }
+    }
+}
+
+impl Display for CodeParameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (ɑ = {})", self.distance, self.alpha_sq)
+    }
+}
+
+struct CodeParameterRange {
+    distance: u64,
+    alpha_sq: u64,
+    max_distance: u64,
+    max_alpha_sq: u64,
+}
+
+impl CodeParameterRange {
+    pub fn new(lower_bound: Option<&CodeParameter>, max_distance: u64, max_alpha_sq: f64) -> Self {
+        let lower_bound = lower_bound.cloned().unwrap_or(CodeParameter::new(1, 1.0));
+
+        Self {
+            distance: lower_bound.distance,
+            alpha_sq: lower_bound
+                .alpha_sq
+                .to_u64()
+                .expect("alpha can be represented as u64"),
+            max_distance,
+            max_alpha_sq: max_alpha_sq
+                .to_u64()
+                .expect("max_alpha can be represented as u64"),
+        }
+    }
+}
+
+impl Iterator for CodeParameterRange {
+    type Item = CodeParameter;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.distance > self.max_distance {
+            None
+        } else {
+            let result = CodeParameter::new(
+                self.distance,
+                self.alpha_sq.to_f64().expect("alpha fits in f64"),
+            );
+
+            if self.alpha_sq == self.max_alpha_sq {
+                self.distance += 2;
+                self.alpha_sq = 1;
+            } else {
+                self.alpha_sq += 1;
+            }
+
+            Some(result)
+        }
+    }
+}
+
+impl ErrorCorrection for RepetitionCode {
+    type Qubit = CatQubit;
+    type Parameter = CodeParameter;
+
+    fn code_parameter_range(
+        &self,
+        lower_bound: Option<&Self::Parameter>,
+    ) -> impl Iterator<Item = Self::Parameter> {
+        CodeParameterRange::new(lower_bound, 49, 30.0)
+    }
+
+    fn physical_qubits(&self, parameter: &Self::Parameter) -> Result<u64, String> {
+        // arXiv:2302.06639 (p. 27)
+        Ok(2 * parameter.distance - 1)
+    }
+
+    fn logical_qubits(&self, _parameter: &Self::Parameter) -> Result<u64, String> {
+        Ok(1)
+    }
+
+    fn logical_cycle_time(
+        &self,
+        _qubit: &Self::Qubit,
+        parameter: &Self::Parameter,
+    ) -> Result<u64, String> {
+        // arXiv:2302.06639 (p. 28, repetition code cycle time in d code cycles)
+        Ok(500 * parameter.distance)
+    }
+
+    fn logical_error_rate(
+        &self,
+        qubit: &Self::Qubit,
+        parameter: &Self::Parameter,
+    ) -> Result<f64, String> {
+        if let (Some(code_distance_f64), Some(lzp), Some(lxp)) = (
+            f64::from_u64(parameter.distance),
+            self.logical_phaseflip_probability(qubit, parameter),
+            Self::logical_bitflip_probability(parameter),
+        ) {
+            // arXiv:2302.06639 (p. 4, eq. 3)
+            Ok(code_distance_f64 * (lzp + lxp))
+        } else {
+            Err("cannot compute logical failure probability".into())
+        }
+    }
+
+    fn compute_code_parameter(
+        &self,
+        qubit: &Self::Qubit,
+        required_logical_error_rate: f64,
+    ) -> Result<Self::Parameter, String> {
+        self.compute_code_parameter_for_smallest_size(qubit, required_logical_error_rate)
+    }
+
+    fn code_parameter_cmp(
+        &self,
+        qubit: &Self::Qubit,
+        p1: &Self::Parameter,
+        p2: &Self::Parameter,
+    ) -> std::cmp::Ordering {
+        if let (
+            Ok(num_qubits1),
+            Ok(logical_cycle_time1),
+            Ok(num_qubits2),
+            Ok(logical_cycle_time2),
+        ) = (
+            self.physical_qubits(p1),
+            self.logical_cycle_time(qubit, p1),
+            self.physical_qubits(p2),
+            self.logical_cycle_time(qubit, p2),
+        ) {
+            num_qubits1
+                .cmp(&num_qubits2)
+                .then(logical_cycle_time1.cmp(&logical_cycle_time2))
+        } else {
+            Ordering::Equal
+        }
+    }
+}

--- a/samples/estimation/extension/anbrc/src/counter.rs
+++ b/samples/estimation/extension/anbrc/src/counter.rs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::{fs::read_to_string, path::Path};
+
+use num_bigint::BigUint;
+use num_complex::Complex;
+use num_traits::ToPrimitive;
+use qsc::{
+    interpret::{GenericReceiver, Interpreter},
+    Backend, LanguageFeatures, RuntimeCapabilityFlags, SourceMap,
+};
+use resource_estimator::estimates::{ErrorBudget, Overhead};
+
+#[allow(clippy::struct_field_names)]
+#[derive(Clone, Default)]
+pub struct LogicalCounts {
+    pub(crate) qubit_count: u64,
+    pub(crate) cx_count: u64,
+    pub(crate) ccx_count: u64,
+
+    free_list: Vec<usize>,
+}
+
+impl LogicalCounts {
+    #[allow(clippy::similar_names)]
+    pub fn new(qubit_count: u64, cx_count: u64, ccx_count: u64) -> Self {
+        Self {
+            qubit_count,
+            cx_count,
+            ccx_count,
+            free_list: vec![],
+        }
+    }
+
+    #[allow(clippy::similar_names)]
+    #[must_use]
+    pub fn from_elliptic_curve_crypto(bit_size: u64, window_size: u64) -> Self {
+        let qubit_count = 9 * bit_size + window_size + 4;
+        let cx_count = (448 * bit_size.pow(3)).div_ceil(window_size);
+        let ccx_count = (348 * bit_size.pow(3)).div_ceil(window_size);
+
+        Self::new(qubit_count, cx_count, ccx_count)
+    }
+
+    pub fn from_qsharp(filename: impl AsRef<Path>) -> Result<Self, String> {
+        let content = read_to_string(filename).map_err(|_| String::from("Cannot read filename"))?;
+
+        let sources = SourceMap::new([("source".into(), content.into())], None);
+
+        let mut interpreter = Interpreter::new(
+            true,
+            sources,
+            qsc::PackageType::Exe,
+            RuntimeCapabilityFlags::all(),
+            LanguageFeatures::default(),
+        )
+        .map_err(|_| String::from("Cannot create interpreter"))?;
+
+        let mut counter = Self::default();
+        let mut stdout = std::io::stdout();
+        let mut out = GenericReceiver::new(&mut stdout);
+
+        interpreter
+            .eval_entry_with_sim(&mut counter, &mut out)
+            .map_err(|_| String::from("Cannot estimate Q# code"))?;
+
+        Ok(counter)
+    }
+}
+
+impl Overhead for LogicalCounts {
+    fn logical_qubits(&self) -> u64 {
+        let horizontal_routing_qubits = self.qubit_count.div_ceil(2) + 1;
+
+        self.qubit_count + horizontal_routing_qubits
+    }
+
+    #[allow(clippy::similar_names)]
+    fn logical_depth(&self, _: &ErrorBudget) -> u64 {
+        let cx_f = self.cx_count.to_f64().expect("#CX is convertible to f64");
+        let ccx_f = self.ccx_count.to_f64().expect("#CCX is convertible to f64");
+
+        // arXiv:2302.06639 (p. 30, Fig. 27); measurement is countes as 0.2
+        // cycles according to open source code
+        let cx_cycles = 2.2;
+
+        // arXiv:2302.06639 (p. 36, Fig. 33); the cost is approximates as 3
+        // CNOT (3 * 2.2), then 1.5 CNOT subject to measurement outcome (1.5
+        // * 2.2), and measurement (0.2)
+        let ccx_cycles = 10.1;
+
+        ((cx_f * cx_cycles) + (ccx_f * ccx_cycles))
+            .ceil()
+            .to_u64()
+            .expect("logical depth is not too large")
+    }
+
+    fn num_magic_states(&self, _: &ErrorBudget, _: usize) -> u64 {
+        self.ccx_count
+    }
+}
+
+impl Backend for LogicalCounts {
+    type ResultType = bool;
+
+    fn ccx(&mut self, _ctl0: usize, _ctl1: usize, _q: usize) {
+        self.ccx_count += 1;
+    }
+
+    fn cx(&mut self, _ctl: usize, _q: usize) {
+        self.cx_count += 1;
+    }
+
+    fn cy(&mut self, _ctl: usize, _q: usize) {
+        self.cx_count += 1;
+    }
+
+    fn cz(&mut self, _ctl: usize, _q: usize) {
+        self.cx_count += 1;
+    }
+
+    fn h(&mut self, _q: usize) {}
+
+    fn m(&mut self, _q: usize) -> Self::ResultType {
+        false
+    }
+
+    fn mresetz(&mut self, _q: usize) -> Self::ResultType {
+        false
+    }
+
+    fn reset(&mut self, _q: usize) {}
+
+    fn sadj(&mut self, _q: usize) {}
+
+    fn s(&mut self, _q: usize) {}
+
+    fn swap(&mut self, _q0: usize, _q1: usize) {
+        self.cx_count += 3;
+    }
+
+    fn x(&mut self, _q: usize) {}
+
+    fn y(&mut self, _q: usize) {}
+
+    fn z(&mut self, _q: usize) {}
+
+    fn qubit_allocate(&mut self) -> usize {
+        if let Some(qubit) = self.free_list.pop() {
+            qubit
+        } else {
+            let qubit = self.qubit_count;
+            self.qubit_count += 1;
+            qubit.to_usize().expect("qubit is not too large")
+        }
+    }
+
+    fn qubit_release(&mut self, q: usize) {
+        self.free_list.push(q);
+    }
+
+    fn capture_quantum_state(&mut self) -> (Vec<(BigUint, Complex<f64>)>, usize) {
+        (vec![], 0)
+    }
+
+    fn qubit_is_zero(&mut self, _q: usize) -> bool {
+        true
+    }
+}

--- a/samples/estimation/extension/anbrc/src/estimates.rs
+++ b/samples/estimation/extension/anbrc/src/estimates.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::{fmt::Display, ops::Deref};
+
+use num_traits::{FromPrimitive, ToPrimitive};
+use resource_estimator::estimates::{FactoryPart, Overhead, PhysicalResourceEstimationResult};
+
+use crate::{code::RepetitionCode, counter::LogicalCounts, factories::ToffoliFactory};
+
+pub struct AliceAndBobEstimates(
+    PhysicalResourceEstimationResult<RepetitionCode, ToffoliFactory, LogicalCounts>,
+);
+
+impl AliceAndBobEstimates {
+    pub fn toffoli_factory_part(&self) -> Option<&FactoryPart<ToffoliFactory>> {
+        self.factory_parts()[0].as_ref()
+    }
+
+    pub fn physical_qubits(&self) -> u64 {
+        let additional_routing_qubits = 2
+            * ((3 * self.layout_overhead().logical_qubits()
+                + self.toffoli_factory_part().map_or(0, FactoryPart::copies) * 6)
+                - 1);
+        self.0.physical_qubits() + additional_routing_qubits
+    }
+
+    pub fn factory_fraction(&self) -> f64 {
+        (self
+            .physical_qubits_for_factories()
+            .to_f64()
+            .expect("can convert")
+            / self.physical_qubits().to_f64().expect("can convert"))
+            * 100.0
+    }
+
+    pub fn total_error(&self) -> f64 {
+        let logical = (self.num_cycles() * self.layout_overhead().logical_qubits())
+            .to_f64()
+            .expect("can convert volume as f64")
+            * self.logical_patch().logical_error_rate();
+        let magic_states = self.toffoli_factory_part().map_or(0.0, |p| {
+            self.num_magic_states(0)
+                .to_f64()
+                .expect("can convert number of magic states as f64")
+                * p.factory().error_probability()
+        });
+
+        logical + magic_states
+    }
+}
+
+impl Deref for AliceAndBobEstimates {
+    type Target = PhysicalResourceEstimationResult<RepetitionCode, ToffoliFactory, LogicalCounts>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<PhysicalResourceEstimationResult<RepetitionCode, ToffoliFactory, LogicalCounts>>
+    for AliceAndBobEstimates
+{
+    fn from(
+        value: PhysicalResourceEstimationResult<RepetitionCode, ToffoliFactory, LogicalCounts>,
+    ) -> Self {
+        Self(value)
+    }
+}
+
+impl Display for AliceAndBobEstimates {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f,)?;
+        writeln!(f, "─────────────────────────────")?;
+        writeln!(f, "#physical qubits:    {}", self.physical_qubits())?;
+        writeln!(
+            f,
+            "runtime:             {:.2} hrs",
+            f64::from_u64(self.runtime()).expect("runtime is not too large") / 1e9 / 3600.0
+        )?;
+        writeln!(f, "total error:         {:.5}", self.total_error())?;
+        writeln!(f, "─────────────────────────────")?;
+        writeln!(
+            f,
+            "code distance:       {}",
+            self.logical_patch().code_parameter()
+        )?;
+        writeln!(
+            f,
+            "#factories:          {}",
+            self.toffoli_factory_part().map_or(0, FactoryPart::copies)
+        )?;
+        writeln!(f, "factory fraction:    {:.2}%", self.factory_fraction())?;
+        writeln!(f, "─────────────────────────────")
+    }
+}

--- a/samples/estimation/extension/anbrc/src/factories.rs
+++ b/samples/estimation/extension/anbrc/src/factories.rs
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use num_traits::FromPrimitive;
+use resource_estimator::estimates::{self, FactoryBuilder};
+use std::{borrow::Cow, rc::Rc};
+
+use crate::{code::CodeParameter, CatQubit, RepetitionCode};
+
+#[derive(Clone, PartialEq)]
+pub struct ToffoliFactory {
+    code_distance: usize,
+    alpha_sq: f64,
+    error_probability: f64,
+    steps: usize,
+    acceptance_probability: f64,
+}
+
+impl ToffoliFactory {
+    pub fn error_probability(&self) -> f64 {
+        self.error_probability
+    }
+
+    pub fn normalized_volume(&self) -> u64 {
+        use estimates::Factory;
+
+        assert_eq!(self.num_output_states(), 1);
+
+        self.physical_qubits() * self.duration()
+    }
+}
+
+impl estimates::Factory for ToffoliFactory {
+    type Parameter = CodeParameter;
+
+    fn physical_qubits(&self) -> u64 {
+        // A Toffoli factory requires 4 logical qubits, arXiv:2302.06639 (p. 27)
+        let num_logical_qubits: u64 = 4;
+        let horizontal_routing_qubits = num_logical_qubits.div_ceil(4) + 1;
+
+        (num_logical_qubits + horizontal_routing_qubits) * (2 * self.code_distance as u64 - 1)
+    }
+
+    fn duration(&self) -> u64 {
+        let t = 100.0; // 1/κ₂
+
+        // the more accurate time 89.2 was taken from the Github code
+        let gate_time = (89.2 * t / self.alpha_sq) / self.acceptance_probability;
+
+        f64::from_usize(self.steps)
+            .map(|steps| (gate_time * steps).round())
+            .and_then(u64::from_f64)
+            .expect("cannot compute runtime of factory")
+    }
+
+    fn num_output_states(&self) -> u64 {
+        1
+    }
+    fn max_code_parameter(&self) -> Option<Cow<Self::Parameter>> {
+        Some(Cow::Owned(CodeParameter::new(
+            self.code_distance as u64,
+            self.alpha_sq.sqrt(),
+        )))
+    }
+}
+
+impl Eq for ToffoliFactory {}
+
+impl Ord for ToffoliFactory {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.normalized_volume().cmp(&other.normalized_volume())
+    }
+}
+
+impl PartialOrd for ToffoliFactory {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub struct ToffoliBuilder {
+    factories: Vec<ToffoliFactory>,
+    lowest_error_probability: f64,
+}
+
+impl Default for ToffoliBuilder {
+    #[allow(clippy::too_many_lines)]
+    fn default() -> Self {
+        // arXiv:2302.06639 (p. 35, Table 3)
+        let factories = vec![
+            ToffoliFactory {
+                code_distance: 3,
+                alpha_sq: 3.75,
+                error_probability: 1.05e-3,
+                steps: 23,
+                acceptance_probability: 0.84,
+            },
+            ToffoliFactory {
+                code_distance: 3,
+                alpha_sq: 3.93,
+                error_probability: 1.02e-4,
+                steps: 29,
+                acceptance_probability: 0.745,
+            },
+            ToffoliFactory {
+                code_distance: 3,
+                alpha_sq: 5.32,
+                error_probability: 8.14e-5,
+                steps: 35,
+                acceptance_probability: 0.66,
+            },
+            ToffoliFactory {
+                code_distance: 5,
+                alpha_sq: 7.15,
+                error_probability: 4.62e-6,
+                steps: 46,
+                acceptance_probability: 0.456,
+            },
+            ToffoliFactory {
+                code_distance: 5,
+                alpha_sq: 8.18,
+                error_probability: 7.00e-7,
+                steps: 53,
+                acceptance_probability: 0.362,
+            },
+            ToffoliFactory {
+                code_distance: 5,
+                alpha_sq: 8.38,
+                error_probability: 5.36e-7,
+                steps: 60,
+                acceptance_probability: 0.288,
+            },
+            ToffoliFactory {
+                code_distance: 7,
+                alpha_sq: 9.71,
+                error_probability: 6.14e-8,
+                steps: 73,
+                acceptance_probability: 0.148,
+            },
+            ToffoliFactory {
+                code_distance: 7,
+                alpha_sq: 10.76,
+                error_probability: 8.40e-9,
+                steps: 81,
+                acceptance_probability: 0.105,
+            },
+            ToffoliFactory {
+                code_distance: 7,
+                alpha_sq: 11.06,
+                error_probability: 5.16e-9,
+                steps: 89,
+                acceptance_probability: 0.0727,
+            },
+            ToffoliFactory {
+                code_distance: 9,
+                alpha_sq: 11.64,
+                error_probability: 2.28e-9,
+                steps: 104,
+                acceptance_probability: 0.0262,
+            },
+            ToffoliFactory {
+                code_distance: 9,
+                alpha_sq: 12.83,
+                error_probability: 2.30e-10,
+                steps: 113,
+                acceptance_probability: 0.0154,
+            },
+            ToffoliFactory {
+                code_distance: 9,
+                alpha_sq: 13.44,
+                error_probability: 7.36e-11,
+                steps: 122,
+                acceptance_probability: 0.00975,
+            },
+            ToffoliFactory {
+                code_distance: 19,
+                alpha_sq: 17.35,
+                error_probability: 7.90e-12,
+                steps: 9576,
+                acceptance_probability: 1.0,
+            },
+            ToffoliFactory {
+                code_distance: 21,
+                alpha_sq: 18.94,
+                error_probability: 5.40e-13,
+                steps: 14112,
+                acceptance_probability: 1.0,
+            },
+            ToffoliFactory {
+                code_distance: 23,
+                alpha_sq: 20.53,
+                error_probability: 3.74e-14,
+                steps: 21344,
+                acceptance_probability: 1.0,
+            },
+        ];
+
+        let lowest_error_probability = factories
+            .iter()
+            .map(|f| f.error_probability)
+            .min_by(f64::total_cmp)
+            .unwrap_or_default();
+
+        Self {
+            factories,
+            lowest_error_probability,
+        }
+    }
+}
+
+impl FactoryBuilder<RepetitionCode> for ToffoliBuilder {
+    type Factory = ToffoliFactory;
+
+    fn find_factories(
+        &self,
+        _ftp: &RepetitionCode,
+        _qubit: &Rc<CatQubit>,
+        _magic_state_type: usize,
+        output_error_rate: f64,
+        _max_code_parameter: &CodeParameter,
+    ) -> Vec<Cow<Self::Factory>> {
+        assert!(
+            output_error_rate > self.lowest_error_probability,
+            "Requested error probability is too low"
+        );
+
+        let mut factories: Vec<_> = self
+            .factories
+            .iter()
+            .filter_map(|factory| {
+                (factory.error_probability <= output_error_rate).then_some(Cow::Borrowed(factory))
+            })
+            .collect();
+        factories.sort_unstable();
+        factories
+    }
+
+    fn num_magic_state_types(&self) -> usize {
+        1
+    }
+}

--- a/samples/estimation/extension/anbrc/src/main.rs
+++ b/samples/estimation/extension/anbrc/src/main.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::rc::Rc;
+
+use code::RepetitionCode;
+use counter::LogicalCounts;
+use estimates::AliceAndBobEstimates;
+use factories::ToffoliBuilder;
+use qubit::CatQubit;
+use resource_estimator::estimates::{ErrorBudget, PhysicalResourceEstimation};
+
+/// Repetition code for biased error correction with a focus on phase flips
+mod code;
+/// Computes logical space-time volume overhead for resource estimation from Q#
+/// files or formulas for ECC application
+mod counter;
+/// Convenience structure to display resource estimation results
+mod estimates;
+/// Toffoli magic state factories
+mod factories;
+/// Model for cat qubits
+mod qubit;
+
+fn main() -> Result<(), anyhow::Error> {
+    // ECC pre-computed counts
+    // -----------------------
+
+    // This value can be changed to investigate other key sizes, e.g., those in
+    // arXiv:2302.06639 (Table IV, p. 37)
+    let bit_size = 256;
+    // Value w_e as reported in arXiv:2302.06639 (Table IV, p. 37)
+    let window_size = 18;
+
+    let qubit = CatQubit::new();
+    let qec = RepetitionCode::new();
+    let builder = ToffoliBuilder::default();
+    let overhead = Rc::new(LogicalCounts::from_elliptic_curve_crypto(
+        bit_size,
+        window_size,
+    ));
+    let budget = ErrorBudget::new(0.333 * 0.5, 0.333 * 0.5, 0.0);
+
+    let estimation =
+        PhysicalResourceEstimation::new(qec, Rc::new(qubit), builder, overhead, budget);
+    let result: AliceAndBobEstimates = estimation.estimate()?.into();
+    println!("{result}");
+
+    let results = estimation.build_frontier()?;
+
+    println!("----------------------------------------");
+    for r in results {
+        println!("{}", AliceAndBobEstimates::from(r));
+    }
+    println!("----------------------------------------");
+
+    // Resource estimation from Q#
+    // ---------------------------
+
+    let filename = format!("{}/qsharp/Adder.qs", env!("CARGO_MANIFEST_DIR"));
+
+    let qubit = CatQubit::new();
+    let qec = RepetitionCode::new();
+    let builder = ToffoliBuilder::default();
+    let overhead = Rc::new(LogicalCounts::from_qsharp(filename).map_err(anyhow::Error::msg)?);
+    let budget = ErrorBudget::new(0.001 * 0.5, 0.001 * 0.5, 0.0);
+
+    let estimation =
+        PhysicalResourceEstimation::new(qec, Rc::new(qubit), builder, overhead, budget);
+    let result: AliceAndBobEstimates = estimation.estimate()?.into();
+    println!("{result}");
+
+    Ok(())
+}

--- a/samples/estimation/extension/anbrc/src/qubit.rs
+++ b/samples/estimation/extension/anbrc/src/qubit.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+pub struct CatQubit {
+    // physical error rate is computed as κ₁/κ₂
+    pub(crate) k1_k2: f64,
+}
+
+impl Default for CatQubit {
+    fn default() -> Self {
+        // By default, we assume k1_k2 of 1e-5, arXiv:2302.06639 (p. 2).
+        Self { k1_k2: 1e-5 }
+    }
+}
+
+impl CatQubit {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}


### PR DESCRIPTION
This sample shows how to use the resource estimation extension API to model the architecture presented in arXiv:2302.06639, which has cat qubits, a biased repetition code, and Toffoli factories.

Items left to do:
- [ ] Add README
- [ ] Improve code documentation
