### PR TITLE
RIR remap block id pass

### DIFF
--- a/compiler/qsc_rir/src/passes.rs
+++ b/compiler/qsc_rir/src/passes.rs
@@ -3,8 +3,10 @@
 
 mod defer_meas;
 mod reindex_qubits;
+mod remap_block_ids;
 mod unreachable_code_check;
 
 pub use defer_meas::defer_measurements;
 pub use reindex_qubits::reindex_qubits;
+pub use remap_block_ids::remap_block_ids;
 pub use unreachable_code_check::check_unreachable_code;

--- a/compiler/qsc_rir/src/passes/remap_block_ids.rs
+++ b/compiler/qsc_rir/src/passes/remap_block_ids.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::VecDeque;
+
+use rustc_hash::FxHashMap;
+
+use crate::{
+    rir::{BlockId, Instruction, Program},
+    utils::get_block_successors,
+};
+
+#[cfg(test)]
+mod tests;
+
+/// Remaps block IDs in the given program to be contiguous, starting from 0,
+/// and in a way that reflects control flow. Specifically, blocks in each new "layer" are
+/// given new IDs such that the graph will be ordered by control flow.
+/// This is useful for passes that need to iterate over all blocks in a program in a well-defined order.
+/// For example, the following graph would be remapped as follows:
+/// Entry: 2,
+/// 2 -> 1,
+/// 1 -> 0 or 3,
+/// 0 -> 4,
+/// 3 -> 4 or 6,
+/// 4 -> 5,
+/// 6 -> 5,
+/// becomes:
+/// Entry: 0,
+/// 0 -> 1,
+/// 1 -> 2 or 3,
+/// 2 -> 4,
+/// 3 -> 4 or 5,
+/// 4 -> 6,
+/// 5 -> 6
+pub fn remap_block_ids(program: &mut Program) {
+    // Only update the entry point.
+    let entry_block_id = program
+        .get_callable(program.entry)
+        .body
+        .expect("entry point should have a body block");
+
+    let mut block_id_map = FxHashMap::default();
+    let mut blocks_to_visit: VecDeque<BlockId> = vec![entry_block_id].into();
+    let mut next_block_id = 0_usize;
+    while let Some(block_id) = blocks_to_visit.pop_front() {
+        if block_id_map.contains_key(&block_id) {
+            continue;
+        }
+
+        block_id_map.insert(block_id, next_block_id);
+        next_block_id += 1;
+
+        blocks_to_visit.extend(get_block_successors(program.get_block(block_id)));
+    }
+
+    let blocks = program.blocks.drain().collect::<Vec<_>>();
+    for (old_block_id, mut block) in blocks {
+        let new_block_id = block_id_map[&old_block_id];
+        update_instr(
+            &block_id_map,
+            block
+                .0
+                .last_mut()
+                .expect("block should have at least one instruction"),
+        );
+        program.blocks.insert(new_block_id.into(), block);
+    }
+    program
+        .callables
+        .get_mut(program.entry)
+        .expect("entry should exist")
+        .body = Some(block_id_map[&entry_block_id].into());
+}
+
+fn update_instr(block_id_map: &FxHashMap<BlockId, usize>, instruction: &mut Instruction) {
+    match instruction {
+        Instruction::Jump(target) => {
+            *target = block_id_map[target].into();
+        }
+        Instruction::Branch(_, target1, target2) => {
+            *target1 = block_id_map[target1].into();
+            *target2 = block_id_map[target2].into();
+        }
+        _ => {}
+    }
+}

--- a/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
+++ b/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
@@ -1,0 +1,493 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(clippy::too_many_lines, clippy::needless_raw_string_hashes)]
+
+use expect_test::expect;
+
+use crate::rir::{
+    Block, BlockId, Callable, CallableId, CallableType, Instruction, Program, Ty, Value, Variable,
+    VariableId,
+};
+
+use super::remap_block_ids;
+
+#[test]
+fn test_remap_block_ids_no_changes() {
+    let mut program = Program::new();
+    program.callables.insert(
+        CallableId(0),
+        Callable {
+            name: "main".to_string(),
+            input_type: Vec::new(),
+            output_type: None,
+            body: Some(BlockId(0)),
+            call_type: CallableType::Regular,
+        },
+    );
+    program
+        .blocks
+        .insert(BlockId(0), Block(vec![Instruction::Jump(BlockId(1))]));
+    program
+        .blocks
+        .insert(BlockId(1), Block(vec![Instruction::Jump(BlockId(2))]));
+    program
+        .blocks
+        .insert(BlockId(2), Block(vec![Instruction::Return]));
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+            blocks:
+                Block 0: Block:
+                    Jump(1)
+                Block 1: Block:
+                    Jump(2)
+                Block 2: Block:
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    remap_block_ids(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+            blocks:
+                Block 0: Block:
+                    Jump(1)
+                Block 1: Block:
+                    Jump(2)
+                Block 2: Block:
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn test_remap_block_ids_out_of_order_no_branches() {
+    let mut program = Program::new();
+    program.callables.insert(
+        CallableId(0),
+        Callable {
+            name: "main".to_string(),
+            input_type: Vec::new(),
+            output_type: None,
+            body: Some(BlockId(5)),
+            call_type: CallableType::Regular,
+        },
+    );
+    program
+        .blocks
+        .insert(BlockId(5), Block(vec![Instruction::Jump(BlockId(3))]));
+    program
+        .blocks
+        .insert(BlockId(3), Block(vec![Instruction::Jump(BlockId(7))]));
+    program
+        .blocks
+        .insert(BlockId(7), Block(vec![Instruction::Return]));
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  5
+            blocks:
+                Block 3: Block:
+                    Jump(7)
+                Block 5: Block:
+                    Jump(3)
+                Block 7: Block:
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    remap_block_ids(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+            blocks:
+                Block 0: Block:
+                    Jump(1)
+                Block 1: Block:
+                    Jump(2)
+                Block 2: Block:
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn test_remap_block_ids_out_of_order_with_one_branch() {
+    let mut program = Program::new();
+    program.callables.insert(
+        CallableId(0),
+        Callable {
+            name: "main".to_string(),
+            input_type: Vec::new(),
+            output_type: None,
+            body: Some(BlockId(2)),
+            call_type: CallableType::Regular,
+        },
+    );
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![Instruction::Branch(
+            Value::Variable(Variable {
+                variable_id: VariableId(0),
+                ty: Ty::Boolean,
+            }),
+            BlockId(3),
+            BlockId(1),
+        )]),
+    );
+    program
+        .blocks
+        .insert(BlockId(1), Block(vec![Instruction::Jump(BlockId(0))]));
+    program
+        .blocks
+        .insert(BlockId(3), Block(vec![Instruction::Jump(BlockId(1))]));
+    program
+        .blocks
+        .insert(BlockId(0), Block(vec![Instruction::Return]));
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  2
+            blocks:
+                Block 0: Block:
+                    Return
+                Block 1: Block:
+                    Jump(0)
+                Block 2: Block:
+                    Branch Variable(0, Boolean), 3, 1
+                Block 3: Block:
+                    Jump(1)
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    remap_block_ids(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+            blocks:
+                Block 0: Block:
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Jump(2)
+                Block 2: Block:
+                    Jump(3)
+                Block 3: Block:
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn test_remap_block_ids_simple_loop() {
+    let mut program = Program::new();
+    program.callables.insert(
+        CallableId(0),
+        Callable {
+            name: "main".to_string(),
+            input_type: Vec::new(),
+            output_type: None,
+            body: Some(BlockId(4)),
+            call_type: CallableType::Regular,
+        },
+    );
+    program.blocks.insert(
+        BlockId(4),
+        Block(vec![Instruction::Branch(
+            Value::Variable(Variable {
+                variable_id: VariableId(0),
+                ty: Ty::Boolean,
+            }),
+            BlockId(6),
+            BlockId(2),
+        )]),
+    );
+    program
+        .blocks
+        .insert(BlockId(6), Block(vec![Instruction::Jump(BlockId(4))]));
+    program
+        .blocks
+        .insert(BlockId(2), Block(vec![Instruction::Return]));
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  4
+            blocks:
+                Block 2: Block:
+                    Return
+                Block 4: Block:
+                    Branch Variable(0, Boolean), 6, 2
+                Block 6: Block:
+                    Jump(4)
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    remap_block_ids(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+            blocks:
+                Block 0: Block:
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Jump(0)
+                Block 2: Block:
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn test_remap_block_ids_infinite_loop() {
+    let mut program = Program::new();
+    program.callables.insert(
+        CallableId(0),
+        Callable {
+            name: "main".to_string(),
+            input_type: Vec::new(),
+            output_type: None,
+            body: Some(BlockId(4)),
+            call_type: CallableType::Regular,
+        },
+    );
+    program
+        .blocks
+        .insert(BlockId(4), Block(vec![Instruction::Jump(BlockId(0))]));
+    program
+        .blocks
+        .insert(BlockId(0), Block(vec![Instruction::Jump(BlockId(4))]));
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  4
+            blocks:
+                Block 0: Block:
+                    Jump(4)
+                Block 4: Block:
+                    Jump(0)
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    remap_block_ids(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+            blocks:
+                Block 0: Block:
+                    Jump(1)
+                Block 1: Block:
+                    Jump(0)
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn test_remap_block_ids_nested_branching_loops() {
+    let mut program = Program::new();
+    program.callables.insert(
+        CallableId(0),
+        Callable {
+            name: "main".to_string(),
+            input_type: Vec::new(),
+            output_type: None,
+            body: Some(BlockId(4)),
+            call_type: CallableType::Regular,
+        },
+    );
+    program.blocks.insert(
+        BlockId(4),
+        Block(vec![Instruction::Branch(
+            Value::Variable(Variable {
+                variable_id: VariableId(0),
+                ty: Ty::Boolean,
+            }),
+            BlockId(6),
+            BlockId(2),
+        )]),
+    );
+    program.blocks.insert(
+        BlockId(6),
+        Block(vec![Instruction::Branch(
+            Value::Variable(Variable {
+                variable_id: VariableId(1),
+                ty: Ty::Boolean,
+            }),
+            BlockId(4),
+            BlockId(2),
+        )]),
+    );
+    program
+        .blocks
+        .insert(BlockId(2), Block(vec![Instruction::Return]));
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  4
+            blocks:
+                Block 2: Block:
+                    Return
+                Block 4: Block:
+                    Branch Variable(0, Boolean), 6, 2
+                Block 6: Block:
+                    Branch Variable(1, Boolean), 4, 2
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    remap_block_ids(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+            blocks:
+                Block 0: Block:
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Branch Variable(1, Boolean), 0, 2
+                Block 2: Block:
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}

--- a/compiler/qsc_rir/src/passes/unreachable_code_check/tests.rs
+++ b/compiler/qsc_rir/src/passes/unreachable_code_check/tests.rs
@@ -158,10 +158,9 @@ fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks_with_jump() {
             call_type: CallableType::Regular,
         },
     );
-    program.blocks.insert(
-        BlockId(0),
-        Block(vec![Instruction::Jump(BlockId(1)), Instruction::Return]),
-    );
+    program
+        .blocks
+        .insert(BlockId(0), Block(vec![Instruction::Jump(BlockId(1))]));
     program
         .blocks
         .insert(BlockId(1), Block(vec![Instruction::Return]));

--- a/compiler/qsc_rir/src/utils.rs
+++ b/compiler/qsc_rir/src/utils.rs
@@ -8,17 +8,20 @@ use rustc_hash::FxHashSet;
 #[must_use]
 pub fn get_block_successors(block: &Block) -> Vec<BlockId> {
     let mut successors = Vec::new();
-    for instr in &block.0 {
-        match instr {
-            Instruction::Jump(target) => {
-                successors.push(*target);
-            }
-            Instruction::Branch(_, target1, target2) => {
-                successors.push(*target1);
-                successors.push(*target2);
-            }
-            _ => {}
+    // Assume that the block is well-formed and that terminators only appear as the last instruction.
+    match block
+        .0
+        .last()
+        .expect("block should have at least one instruction")
+    {
+        Instruction::Jump(target) => {
+            successors.push(*target);
         }
+        Instruction::Branch(_, target1, target2) => {
+            successors.push(*target1);
+            successors.push(*target2);
+        }
+        _ => {}
     }
     successors
 }


### PR DESCRIPTION
This introduces a pass on RIR that takes the entry callable and remaps the block IDs such that they are sequentially ordered with a well-known pattern. This enables more efficient checks for later analysis passes.