### PR TITLE
Fix to RCA panic when assigning call result to tuple

### DIFF
--- a/compiler/qsc_rca/tests/assigns.rs
+++ b/compiler/qsc_rca/tests/assigns.rs
@@ -134,7 +134,7 @@ fn check_rca_for_dynamic_double_assign_to_local() {
 }
 
 #[test]
-fn chec_rca_for_assign_call_result_to_tuple() {
+fn chec_rca_for_assign_call_result_to_tuple_of_vars() {
     let mut compilation_context = CompilationContext::default();
     compilation_context.update(
         r#"
@@ -157,7 +157,52 @@ fn chec_rca_for_assign_call_result_to_tuple() {
 }
 
 #[test]
-fn check_rca_for_assign_call_result_to_tuple_classic() {
+fn chec_rca_for_assign_var_binded_to_call_result_to_tuple_of_vars() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        function Foo() : (Int, Int) {
+            return (1,2);
+        }
+        let x = Foo();
+        mutable a = 1;
+        mutable b = 2;
+        set (a, b) = x;
+        "#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn chec_rca_for_assign_tuple_var_to_tuple_of_vars() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let x = (1, (2, 3));
+        mutable a = 4;
+        mutable b = (5, 6);
+        set (a, b) = x;
+        "#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_assign_classical_call_result_to_tuple_of_vars() {
     let mut compilation_context = CompilationContext::default();
     compilation_context.update(
         r#"
@@ -192,7 +237,7 @@ fn check_rca_for_assign_call_result_to_tuple_classic() {
 }
 
 #[test]
-fn check_rca_for_assign_call_result_to_tuple_dynamic() {
+fn check_rca_for_assign_dynamic_call_result_to_tuple_of_vars() {
     let mut compilation_context = CompilationContext::default();
     compilation_context.update(
         r#"


### PR DESCRIPTION
This change fixes #1357. 