### PR TITLE
Disallow branching on literal in RIR

### DIFF
--- a/compiler/qsc_rir/src/builder.rs
+++ b/compiler/qsc_rir/src/builder.rs
@@ -307,10 +307,10 @@ pub fn teleport_program() -> Program {
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(1),
                 BlockId(2),
             ),
@@ -347,10 +347,10 @@ pub fn teleport_program() -> Program {
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(1),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(3),
                 BlockId(4),
             ),

--- a/compiler/qsc_rir/src/passes/build_dominator_graph/tests.rs
+++ b/compiler/qsc_rir/src/passes/build_dominator_graph/tests.rs
@@ -10,8 +10,8 @@ use crate::{
     builder::new_program,
     passes::remap_block_ids,
     rir::{
-        Block, BlockId, Callable, CallableId, CallableType, Instruction, Operand, Program, Ty,
-        Variable, VariableId,
+        Block, BlockId, Callable, CallableId, CallableType, Instruction, Program, Ty, Variable,
+        VariableId,
     },
     utils::build_predecessors_map,
 };
@@ -104,10 +104,10 @@ fn dominator_graph_branching_blocks_dominated_by_common_predecessor() {
     program.blocks.insert(
         BlockId(1),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(2),
             BlockId(3),
         )]),
@@ -179,10 +179,10 @@ fn dominator_graph_branch_and_loop() {
     program.blocks.insert(
         BlockId(1),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(2),
             BlockId(3),
         )]),
@@ -243,10 +243,10 @@ fn dominator_graph_complex_structure_only_dominated_by_entry() {
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(5),
                 BlockId(4),
             ),
@@ -258,10 +258,10 @@ fn dominator_graph_complex_structure_only_dominated_by_entry() {
     program.blocks.insert(
         BlockId(4),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(2),
             BlockId(3),
         )]),
@@ -272,10 +272,10 @@ fn dominator_graph_complex_structure_only_dominated_by_entry() {
     program.blocks.insert(
         BlockId(2),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(3),
             BlockId(1),
         )]),
@@ -323,10 +323,10 @@ fn dominator_graph_with_node_having_many_predicates() {
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(1),
                 BlockId(2),
             ),
@@ -335,10 +335,10 @@ fn dominator_graph_with_node_having_many_predicates() {
     program.blocks.insert(
         BlockId(1),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(3),
             BlockId(4),
         )]),
@@ -346,10 +346,10 @@ fn dominator_graph_with_node_having_many_predicates() {
     program.blocks.insert(
         BlockId(2),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(5),
             BlockId(6),
         )]),

--- a/compiler/qsc_rir/src/passes/defer_meas/tests.rs
+++ b/compiler/qsc_rir/src/passes/defer_meas/tests.rs
@@ -198,10 +198,10 @@ fn add_branching_measurement_block(program: &mut Program) {
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(1),
                 BlockId(2),
             ),

--- a/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
+++ b/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
@@ -6,8 +6,8 @@
 use expect_test::expect;
 
 use crate::rir::{
-    Block, BlockId, Callable, CallableId, CallableType, Instruction, Operand, Program, Ty,
-    Variable, VariableId,
+    Block, BlockId, Callable, CallableId, CallableType, Instruction, Program, Ty, Variable,
+    VariableId,
 };
 
 use super::remap_block_ids;
@@ -176,10 +176,10 @@ fn test_remap_block_ids_out_of_order_with_one_branch() {
     program.blocks.insert(
         BlockId(2),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(3),
             BlockId(1),
         )]),
@@ -266,10 +266,10 @@ fn test_remap_block_ids_simple_loop() {
     program.blocks.insert(
         BlockId(4),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(6),
             BlockId(2),
         )]),
@@ -417,10 +417,10 @@ fn test_remap_block_ids_nested_branching_loops() {
     program.blocks.insert(
         BlockId(4),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(6),
             BlockId(2),
         )]),
@@ -428,10 +428,10 @@ fn test_remap_block_ids_nested_branching_loops() {
     program.blocks.insert(
         BlockId(6),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(1),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(4),
             BlockId(2),
         )]),

--- a/compiler/qsc_rir/src/passes/ssa_check.rs
+++ b/compiler/qsc_rir/src/passes/ssa_check.rs
@@ -158,7 +158,8 @@ fn get_variable_uses(program: &Program) -> IndexMap<VariableId, Vec<(BlockId, us
                 | Instruction::BitwiseOr(Operand::Variable(var), Operand::Literal(_), _)
                 | Instruction::BitwiseOr(Operand::Literal(_), Operand::Variable(var), _)
                 | Instruction::BitwiseXor(Operand::Variable(var), Operand::Literal(_), _)
-                | Instruction::BitwiseXor(Operand::Literal(_), Operand::Variable(var), _) => {
+                | Instruction::BitwiseXor(Operand::Literal(_), Operand::Variable(var), _)
+                | Instruction::Branch(var, _, _) => {
                     add_use(var.variable_id, block_id, idx);
                 }
 
@@ -199,7 +200,7 @@ fn get_variable_uses(program: &Program) -> IndexMap<VariableId, Vec<(BlockId, us
                     }
                 }
 
-                // No variables
+                // If an instruction has no variables, it should have been inlined by partial eval.
                 Instruction::Add(Operand::Literal(_), Operand::Literal(_), _)
                 | Instruction::Sub(Operand::Literal(_), Operand::Literal(_), _)
                 | Instruction::Mul(Operand::Literal(_), Operand::Literal(_), _)
@@ -218,7 +219,7 @@ fn get_variable_uses(program: &Program) -> IndexMap<VariableId, Vec<(BlockId, us
                     panic!("{block_id:?}, instruction {idx} has no variables: {instr}")
                 }
 
-                Instruction::Jump(..) | Instruction::Branch(..) | Instruction::Return => {}
+                Instruction::Jump(..) | Instruction::Return => {}
 
                 Instruction::Store(..) => {
                     panic!("Unexpected Store at {block_id:?}, instruction {idx}")

--- a/compiler/qsc_rir/src/passes/ssa_check/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_check/tests.rs
@@ -237,10 +237,10 @@ fn test_ssa_check_passes_for_variable_that_dominates_usage() {
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(1),
                 BlockId(2),
             ),
@@ -317,10 +317,10 @@ fn test_ssa_check_fails_when_definition_does_not_dominates_usage() {
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(1),
                 BlockId(2),
             ),
@@ -407,10 +407,10 @@ fn test_ssa_check_succeeds_when_phi_handles_multiple_values_from_branches() {
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(1),
                 BlockId(2),
             ),
@@ -519,10 +519,10 @@ fn test_ssa_check_succeeds_when_phi_handles_value_from_dominator_of_predecessor(
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(1),
                 BlockId(2),
             ),
@@ -638,10 +638,10 @@ fn test_ssa_check_fails_when_phi_handles_value_from_non_dominator_of_predecessor
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(1),
                 BlockId(2),
             ),
@@ -679,10 +679,10 @@ fn test_ssa_check_fails_when_phi_handles_value_from_non_dominator_of_predecessor
                 },
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(4),
                 BlockId(5),
             ),
@@ -783,10 +783,10 @@ fn test_ssa_check_fails_when_phi_lists_non_predecessor_block() {
                 }),
             ),
             Instruction::Branch(
-                Operand::Variable(Variable {
+                Variable {
                     variable_id: VariableId(0),
                     ty: Ty::Boolean,
-                }),
+                },
                 BlockId(1),
                 BlockId(2),
             ),

--- a/compiler/qsc_rir/src/passes/unreachable_code_check/tests.rs
+++ b/compiler/qsc_rir/src/passes/unreachable_code_check/tests.rs
@@ -131,10 +131,10 @@ fn test_check_unreachable_blocks_succeeds_on_no_unreachable_blocks_with_branch()
     program.blocks.insert(
         BlockId(0),
         Block(vec![Instruction::Branch(
-            Operand::Variable(Variable {
+            Variable {
                 variable_id: VariableId(0),
                 ty: Ty::Boolean,
-            }),
+            },
             BlockId(1),
             BlockId(2),
         )]),
@@ -187,7 +187,10 @@ fn test_check_unreachable_blocks_panics_on_unreachable_block_with_branch() {
     program.blocks.insert(
         BlockId(0),
         Block(vec![Instruction::Branch(
-            Operand::Literal(Literal::Bool(true)),
+            Variable {
+                variable_id: VariableId(0),
+                ty: Ty::Boolean,
+            },
             BlockId(1),
             BlockId(1),
         )]),
@@ -412,36 +415,4 @@ fn test_check_unreachable_callable_succeeds_on_no_unreachable_callables_with_cal
         Block(vec![Instruction::Call(CallableId(1), Vec::new(), None)]),
     );
     check_unreachable_callable(&program);
-}
-
-#[test]
-#[should_panic(expected = "Unreachable blocks found: [BlockId(2)]")]
-fn constant_branches_lead_to_unreachable_blocks() {
-    let mut program = Program::new();
-    program.entry = CallableId(0);
-    program.callables.insert(
-        CallableId(0),
-        Callable {
-            name: "test".to_string(),
-            input_type: vec![],
-            output_type: None,
-            body: Some(BlockId(0)),
-            call_type: CallableType::Regular,
-        },
-    );
-    program.blocks.insert(
-        BlockId(0),
-        Block(vec![Instruction::Branch(
-            Operand::Literal(Literal::Bool(true)),
-            BlockId(1),
-            BlockId(2),
-        )]),
-    );
-    program
-        .blocks
-        .insert(BlockId(1), Block(vec![Instruction::Return]));
-    program
-        .blocks
-        .insert(BlockId(2), Block(vec![Instruction::Return]));
-    check_unreachable_blocks(&program);
 }

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -252,7 +252,7 @@ pub enum Instruction {
     Store(Operand, Variable),
     Call(CallableId, Vec<Operand>, Option<Variable>),
     Jump(BlockId),
-    Branch(Operand, BlockId, BlockId),
+    Branch(Variable, BlockId, BlockId),
     Add(Operand, Operand, Variable),
     Sub(Operand, Operand, Variable),
     Mul(Operand, Operand, Variable),
@@ -289,7 +289,7 @@ impl Display for Instruction {
 
         fn write_branch(
             f: &mut Formatter,
-            condition: &Operand,
+            condition: Variable,
             if_true: BlockId,
             if_false: BlockId,
         ) -> fmt::Result {
@@ -360,7 +360,7 @@ impl Display for Instruction {
                 write_call(f, *callable_id, args, *variable)?;
             }
             Self::Branch(condition, if_true, if_false) => {
-                write_branch(f, condition, *if_true, *if_false)?;
+                write_branch(f, *condition, *if_true, *if_false)?;
             }
             Self::Add(lhs, rhs, variable) => {
                 write_binary_instruction(f, "Add", lhs, rhs, *variable)?;

--- a/compiler/qsc_rir/src/utils.rs
+++ b/compiler/qsc_rir/src/utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::rir::{Block, BlockId, Instruction, Literal, Operand, Program};
+use crate::rir::{Block, BlockId, Instruction, Program};
 use qsc_data_structures::index_map::IndexMap;
 use rustc_hash::FxHashSet;
 
@@ -15,15 +15,11 @@ pub fn get_block_successors(block: &Block) -> Vec<BlockId> {
         .last()
         .expect("block should have at least one instruction")
     {
-        Instruction::Branch(Operand::Variable(_), target1, target2) => {
+        Instruction::Branch(_, target1, target2) => {
             successors.push(*target1);
             successors.push(*target2);
         }
-        Instruction::Jump(target)
-        | Instruction::Branch(Operand::Literal(Literal::Bool(true)), target, _)
-        | Instruction::Branch(Operand::Literal(Literal::Bool(false)), _, target) => {
-            successors.push(*target);
-        }
+        Instruction::Jump(target) => successors.push(*target),
         _ => {}
     }
     successors


### PR DESCRIPTION
Since branching on literal values is disallowed by dead code checks and should have been simplified by RIR, this change updates `Instruction::Branch` to only have a `Variable` for its condition rather than an operand.