### PR TITLE
Fix spelling: s/ciclyc/cyclic

### DIFF
--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -5,9 +5,9 @@
 
 use super::tests_common::{
     check, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
-    CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
+    CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
     LOOP_WITH_DYNAMIC_CONDITION, MEASUREMENT_WITHIN_DYNAMIC_SCOPE, MINIMAL,
     RETURN_WITHIN_DYNAMIC_SCOPE, USE_CLOSURE_FUNCTION, USE_DYNAMICALLY_SIZED_ARRAY,
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
@@ -267,7 +267,7 @@ fn use_of_dynamic_operation_yields_errors() {
 #[test]
 fn call_cyclic_function_with_classical_argument_yields_no_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             []
         "#]],
@@ -277,7 +277,7 @@ fn call_cyclic_function_with_classical_argument_yields_no_errors() {
 #[test]
 fn call_cyclic_function_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 UseOfDynamicInt(
@@ -300,7 +300,7 @@ fn call_cyclic_function_with_dynamic_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_classical_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(
@@ -329,7 +329,7 @@ fn call_cyclic_operation_with_classical_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -7,9 +7,9 @@ use crate::capabilitiesck::tests_common::USE_DYNAMIC_RANGE;
 
 use super::tests_common::{
     check, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
-    CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
+    CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
     LOOP_WITH_DYNAMIC_CONDITION, MEASUREMENT_WITHIN_DYNAMIC_SCOPE, MINIMAL,
     RETURN_WITHIN_DYNAMIC_SCOPE, USE_CLOSURE_FUNCTION, USE_DYNAMICALLY_SIZED_ARRAY,
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
@@ -222,7 +222,7 @@ fn use_of_dynamic_operation_yields_errors() {
 #[test]
 fn call_cyclic_function_with_classical_argument_yields_no_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             []
         "#]],
@@ -232,7 +232,7 @@ fn call_cyclic_function_with_classical_argument_yields_no_errors() {
 #[test]
 fn call_cyclic_function_with_dynamic_argument_yields_error() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 CallToCyclicFunctionWithDynamicArg(
@@ -249,7 +249,7 @@ fn call_cyclic_function_with_dynamic_argument_yields_error() {
 #[test]
 fn call_cyclic_operation_with_classical_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(
@@ -272,7 +272,7 @@ fn call_cyclic_operation_with_classical_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(

--- a/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -5,9 +5,9 @@
 
 use super::tests_common::{
     check, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
-    CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
-    CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
+    CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+    CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
     LOOP_WITH_DYNAMIC_CONDITION, MEASUREMENT_WITHIN_DYNAMIC_SCOPE, MINIMAL,
     RETURN_WITHIN_DYNAMIC_SCOPE, USE_CLOSURE_FUNCTION, USE_DYNAMICALLY_SIZED_ARRAY,
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
@@ -331,7 +331,7 @@ fn use_of_dynamic_operation_yields_errors() {
 #[test]
 fn call_cyclic_function_with_classical_argument_yields_no_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             []
         "#]],
@@ -341,7 +341,7 @@ fn call_cyclic_function_with_classical_argument_yields_no_errors() {
 #[test]
 fn call_cyclic_function_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 UseOfDynamicBool(
@@ -370,7 +370,7 @@ fn call_cyclic_function_with_dynamic_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_classical_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(
@@ -399,7 +399,7 @@ fn call_cyclic_operation_with_classical_argument_yields_errors() {
 #[test]
 fn call_cyclic_operation_with_dynamic_argument_yields_errors() {
     check_profile(
-        CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT,
+        CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT,
         &expect![[r#"
             [
                 CyclicOperationSpec(

--- a/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -196,7 +196,7 @@ pub const USE_DYNAMIC_OPERATION: &str = r#"
         }
     }"#;
 
-pub const CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT: &str = r#"
+pub const CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT: &str = r#"
     function GaussSum(n : Int) : Int {
         if n == 0 {
             0
@@ -208,7 +208,7 @@ pub const CALL_TO_CICLYC_FUNCTION_WITH_CLASSICAL_ARGUMENT: &str = r#"
         let sum = GaussSum(10);
     }"#;
 
-pub const CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT: &str = r#"
+pub const CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT: &str = r#"
     function GaussSum(n : Int) : Int {
         if n == 0 {
             0
@@ -221,7 +221,7 @@ pub const CALL_TO_CICLYC_FUNCTION_WITH_DYNAMIC_ARGUMENT: &str = r#"
         let sum = GaussSum(M(q) == Zero ? 10 | 20);
     }"#;
 
-pub const CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT: &str = r#"
+pub const CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT: &str = r#"
     operation GaussSum(n : Int) : Int {
         if n == 0 {
             0
@@ -233,7 +233,7 @@ pub const CALL_TO_CICLYC_OPERATION_WITH_CLASSICAL_ARGUMENT: &str = r#"
         let sum = GaussSum(10);
     }"#;
 
-pub const CALL_TO_CICLYC_OPERATION_WITH_DYNAMIC_ARGUMENT: &str = r#"
+pub const CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT: &str = r#"
     operation GaussSum(n : Int) : Int {
         if n == 0 {
             0


### PR DESCRIPTION
Noticed this while working on something else, figured I'd put it in a separate PR to reduce noise in my main feature.
