### PR TITLE
RIR SSA transformation pass

### DIFF
--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -463,7 +463,8 @@ impl ToQir<String> for rir::Callable {
             );
         };
         let mut body = String::new();
-        let all_blocks = get_all_block_successors(entry_id, program);
+        let mut all_blocks = vec![entry_id];
+        all_blocks.extend(get_all_block_successors(entry_id, program));
         for block_id in all_blocks {
             let block = program.get_block(block_id);
             body.push_str(&format!(

--- a/compiler/qsc_rir/src/passes.rs
+++ b/compiler/qsc_rir/src/passes.rs
@@ -6,11 +6,38 @@ mod defer_meas;
 mod reindex_qubits;
 mod remap_block_ids;
 mod ssa_check;
+mod ssa_transform;
 mod unreachable_code_check;
 
-pub use build_dominator_graph::build_dominator_graph;
-pub use defer_meas::defer_measurements;
-pub use reindex_qubits::reindex_qubits;
-pub use remap_block_ids::remap_block_ids;
-pub use ssa_check::check_ssa_form;
+use build_dominator_graph::build_dominator_graph;
+use defer_meas::defer_measurements;
+use reindex_qubits::reindex_qubits;
+use remap_block_ids::remap_block_ids;
+use ssa_check::check_ssa_form;
+use ssa_transform::transform_to_ssa;
 pub use unreachable_code_check::check_unreachable_code;
+
+use crate::{rir::Program, utils::build_predecessors_map};
+
+/// Run the default set of RIR check and transformation passes.
+/// This includes:
+/// - Checking for unreachable code
+/// - Remapping block IDs
+/// - Transforming the program to SSA form
+/// - Checking that the program is in SSA form
+pub fn check_and_transform(program: &mut Program) {
+    check_unreachable_code(program);
+    remap_block_ids(program);
+    let preds = build_predecessors_map(program);
+    transform_to_ssa(program, &preds);
+    let doms = build_dominator_graph(program, &preds);
+    check_ssa_form(program, &preds, &doms);
+}
+
+/// Run the RIR passes that are necessary for targets with no mid-program measurement.
+/// This requires that qubits are not reused after measurement or reset, so qubit ids must be reindexed.
+/// This also requires that the program is a single block and will panic otherwise.
+pub fn defer_quantum_measurements(program: &mut Program) {
+    reindex_qubits(program);
+    defer_measurements(program);
+}

--- a/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
+++ b/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
@@ -592,7 +592,8 @@ fn remap_block_ids_ensures_acyclic_program_gets_topological_ordering() {
                 remap_qubits_on_reuse: false
                 defer_measurements: false
             num_qubits: 0
-            num_results: 0"#]].assert_eq(&program.to_string());
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
 
     // After
     remap_block_ids(&mut program);
@@ -629,5 +630,6 @@ fn remap_block_ids_ensures_acyclic_program_gets_topological_ordering() {
                 remap_qubits_on_reuse: false
                 defer_measurements: false
             num_qubits: 0
-            num_results: 0"#]].assert_eq(&program.to_string());
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
 }

--- a/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
+++ b/compiler/qsc_rir/src/passes/remap_block_ids/tests.rs
@@ -13,7 +13,7 @@ use crate::rir::{
 use super::remap_block_ids;
 
 #[test]
-fn test_remap_block_ids_no_changes() {
+fn remap_block_ids_no_changes() {
     let mut program = Program::new();
     program.callables.insert(
         CallableId(0),
@@ -87,7 +87,7 @@ fn test_remap_block_ids_no_changes() {
 }
 
 #[test]
-fn test_remap_block_ids_out_of_order_no_branches() {
+fn remap_block_ids_out_of_order_no_branches() {
     let mut program = Program::new();
     program.callables.insert(
         CallableId(0),
@@ -161,7 +161,7 @@ fn test_remap_block_ids_out_of_order_no_branches() {
 }
 
 #[test]
-fn test_remap_block_ids_out_of_order_with_one_branch() {
+fn remap_block_ids_out_of_order_with_one_branch() {
     let mut program = Program::new();
     program.callables.insert(
         CallableId(0),
@@ -251,7 +251,7 @@ fn test_remap_block_ids_out_of_order_with_one_branch() {
 }
 
 #[test]
-fn test_remap_block_ids_simple_loop() {
+fn remap_block_ids_simple_loop() {
     let mut program = Program::new();
     program.callables.insert(
         CallableId(0),
@@ -334,7 +334,7 @@ fn test_remap_block_ids_simple_loop() {
 }
 
 #[test]
-fn test_remap_block_ids_infinite_loop() {
+fn remap_block_ids_infinite_loop() {
     let mut program = Program::new();
     program.callables.insert(
         CallableId(0),
@@ -402,7 +402,7 @@ fn test_remap_block_ids_infinite_loop() {
 }
 
 #[test]
-fn test_remap_block_ids_nested_branching_loops() {
+fn remap_block_ids_nested_branching_loops() {
     let mut program = Program::new();
     program.callables.insert(
         CallableId(0),
@@ -490,4 +490,144 @@ fn test_remap_block_ids_nested_branching_loops() {
             num_qubits: 0
             num_results: 0"#]]
     .assert_eq(&program.to_string());
+}
+
+#[test]
+fn remap_block_ids_ensures_acyclic_program_gets_topological_ordering() {
+    let mut program = Program::new();
+    program.callables.insert(
+        CallableId(0),
+        Callable {
+            name: "main".to_string(),
+            input_type: Vec::new(),
+            output_type: None,
+            body: Some(BlockId(4)),
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(4),
+        Block(vec![Instruction::Branch(
+            Variable {
+                variable_id: VariableId(0),
+                ty: Ty::Boolean,
+            },
+            BlockId(6),
+            BlockId(2),
+        )]),
+    );
+    program
+        .blocks
+        .insert(BlockId(6), Block(vec![Instruction::Jump(BlockId(2))]));
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![Instruction::Branch(
+            Variable {
+                variable_id: VariableId(1),
+                ty: Ty::Boolean,
+            },
+            BlockId(1),
+            BlockId(3),
+        )]),
+    );
+    program
+        .blocks
+        .insert(BlockId(1), Block(vec![Instruction::Jump(BlockId(7))]));
+    program.blocks.insert(
+        BlockId(3),
+        Block(vec![Instruction::Branch(
+            Variable {
+                variable_id: VariableId(2),
+                ty: Ty::Boolean,
+            },
+            BlockId(5),
+            BlockId(0),
+        )]),
+    );
+    program
+        .blocks
+        .insert(BlockId(5), Block(vec![Instruction::Jump(BlockId(8))]));
+    program
+        .blocks
+        .insert(BlockId(0), Block(vec![Instruction::Jump(BlockId(8))]));
+    program
+        .blocks
+        .insert(BlockId(8), Block(vec![Instruction::Jump(BlockId(7))]));
+    program
+        .blocks
+        .insert(BlockId(7), Block(vec![Instruction::Return]));
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  4
+            blocks:
+                Block 0: Block:
+                    Jump(8)
+                Block 1: Block:
+                    Jump(7)
+                Block 2: Block:
+                    Branch Variable(1, Boolean), 1, 3
+                Block 3: Block:
+                    Branch Variable(2, Boolean), 5, 0
+                Block 4: Block:
+                    Branch Variable(0, Boolean), 6, 2
+                Block 5: Block:
+                    Jump(8)
+                Block 6: Block:
+                    Jump(2)
+                Block 7: Block:
+                    Return
+                Block 8: Block:
+                    Jump(7)
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
+
+    // After
+    remap_block_ids(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+            blocks:
+                Block 0: Block:
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Jump(2)
+                Block 2: Block:
+                    Branch Variable(1, Boolean), 3, 4
+                Block 3: Block:
+                    Jump(8)
+                Block 4: Block:
+                    Branch Variable(2, Boolean), 5, 6
+                Block 5: Block:
+                    Jump(7)
+                Block 6: Block:
+                    Jump(7)
+                Block 7: Block:
+                    Jump(8)
+                Block 8: Block:
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
 }

--- a/compiler/qsc_rir/src/passes/ssa_check/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_check/tests.rs
@@ -611,7 +611,7 @@ fn ssa_check_succeeds_when_phi_handles_value_from_dominator_of_predecessor() {
 
 #[test]
 #[should_panic(
-    expected = "Definition of VariableId(3) in BlockId(5) does not dominate use in BlockId(6), instruction 18446744073709551615"
+    expected = "Definition of VariableId(3) in BlockId(4) does not dominate use in BlockId(5), instruction 18446744073709551615"
 )]
 fn ssa_check_fails_when_phi_handles_value_from_non_dominator_of_predecessor() {
     let mut program = new_program();
@@ -844,7 +844,7 @@ fn ssa_check_fails_when_phi_lists_non_predecessor_block() {
                             variable_id: VariableId(2),
                             ty: Ty::Boolean,
                         }),
-                        BlockId(4),
+                        BlockId(1),
                     ),
                 ],
                 Variable {

--- a/compiler/qsc_rir/src/passes/ssa_check/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_check/tests.rs
@@ -23,14 +23,14 @@ fn perform_ssa_check(program: &mut Program) {
 }
 
 #[test]
-fn test_ssa_check_passes_for_base_profile_program() {
+fn ssa_check_passes_for_base_profile_program() {
     let mut program = bell_program();
 
     perform_ssa_check(&mut program);
 }
 
 #[test]
-fn test_ssa_check_passes_for_adaptive_program_with_all_literals() {
+fn ssa_check_passes_for_adaptive_program_with_all_literals() {
     let mut program = teleport_program();
 
     perform_ssa_check(&mut program);
@@ -40,7 +40,7 @@ fn test_ssa_check_passes_for_adaptive_program_with_all_literals() {
 #[should_panic(
     expected = "BlockId(0), instruction 0 has no variables: Variable(0, Boolean) = LogicalNot Bool(true)"
 )]
-fn test_ssa_check_fails_for_instruction_on_literal_values() {
+fn ssa_check_fails_for_instruction_on_literal_values() {
     let mut program = new_program();
 
     program.blocks.insert(
@@ -64,7 +64,7 @@ fn test_ssa_check_fails_for_instruction_on_literal_values() {
 #[should_panic(
     expected = "VariableId(1) is used before it is assigned in BlockId(0), instruction 0"
 )]
-fn test_ssa_check_fails_for_use_before_assignment_in_single_block() {
+fn ssa_check_fails_for_use_before_assignment_in_single_block() {
     let mut program = new_program();
 
     program.blocks.insert(
@@ -99,7 +99,7 @@ fn test_ssa_check_fails_for_use_before_assignment_in_single_block() {
 
 #[test]
 #[should_panic(expected = "VariableId(4) is used but not assigned")]
-fn test_ssa_check_fails_for_use_without_assignment_in_single_block() {
+fn ssa_check_fails_for_use_without_assignment_in_single_block() {
     let mut program = new_program();
 
     program.blocks.insert(
@@ -136,7 +136,7 @@ fn test_ssa_check_fails_for_use_without_assignment_in_single_block() {
 #[should_panic(
     expected = "Definition of VariableId(1) in BlockId(1) does not dominate use in BlockId(0), instruction 0"
 )]
-fn test_ssa_check_fails_for_use_before_assignment_across_sequential_blocks() {
+fn ssa_check_fails_for_use_before_assignment_across_sequential_blocks() {
     let mut program = new_program();
 
     program.blocks.insert(
@@ -178,7 +178,7 @@ fn test_ssa_check_fails_for_use_before_assignment_across_sequential_blocks() {
 
 #[test]
 #[should_panic(expected = "Duplicate assignment to VariableId(0) in BlockId(0), instruction 1")]
-fn test_ssa_check_fails_for_multiple_assignment_in_single_block() {
+fn ssa_check_fails_for_multiple_assignment_in_single_block() {
     let mut program = new_program();
 
     program.blocks.insert(
@@ -212,7 +212,7 @@ fn test_ssa_check_fails_for_multiple_assignment_in_single_block() {
 }
 
 #[test]
-fn test_ssa_check_passes_for_variable_that_dominates_usage() {
+fn ssa_check_passes_for_variable_that_dominates_usage() {
     let mut program = new_program();
     program.callables.insert(
         CallableId(1),
@@ -292,7 +292,7 @@ fn test_ssa_check_passes_for_variable_that_dominates_usage() {
 #[should_panic(
     expected = "Definition of VariableId(2) in BlockId(2) does not dominate use in BlockId(3), instruction 0"
 )]
-fn test_ssa_check_fails_when_definition_does_not_dominates_usage() {
+fn ssa_check_fails_when_definition_does_not_dominates_usage() {
     let mut program = new_program();
     program.callables.insert(
         CallableId(1),
@@ -382,7 +382,7 @@ fn test_ssa_check_fails_when_definition_does_not_dominates_usage() {
 }
 
 #[test]
-fn test_ssa_check_succeeds_when_phi_handles_multiple_values_from_branches() {
+fn ssa_check_succeeds_when_phi_handles_multiple_values_from_branches() {
     let mut program = new_program();
     program.callables.insert(
         CallableId(1),
@@ -494,7 +494,7 @@ fn test_ssa_check_succeeds_when_phi_handles_multiple_values_from_branches() {
 }
 
 #[test]
-fn test_ssa_check_succeeds_when_phi_handles_value_from_dominator_of_predecessor() {
+fn ssa_check_succeeds_when_phi_handles_value_from_dominator_of_predecessor() {
     let mut program = new_program();
     program.callables.insert(
         CallableId(1),
@@ -613,7 +613,7 @@ fn test_ssa_check_succeeds_when_phi_handles_value_from_dominator_of_predecessor(
 #[should_panic(
     expected = "Definition of VariableId(3) in BlockId(5) does not dominate use in BlockId(6), instruction 18446744073709551615"
 )]
-fn test_ssa_check_fails_when_phi_handles_value_from_non_dominator_of_predecessor() {
+fn ssa_check_fails_when_phi_handles_value_from_non_dominator_of_predecessor() {
     let mut program = new_program();
     program.callables.insert(
         CallableId(1),
@@ -758,7 +758,7 @@ fn test_ssa_check_fails_when_phi_handles_value_from_non_dominator_of_predecessor
 
 #[test]
 #[should_panic(expected = "Phi node in BlockId(3) references a non-predecessor BlockId(0)")]
-fn test_ssa_check_fails_when_phi_lists_non_predecessor_block() {
+fn ssa_check_fails_when_phi_lists_non_predecessor_block() {
     let mut program = new_program();
     program.callables.insert(
         CallableId(1),
@@ -847,6 +847,222 @@ fn test_ssa_check_fails_when_phi_lists_non_predecessor_block() {
                         BlockId(4),
                     ),
                 ],
+                Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    perform_ssa_check(&mut program);
+}
+
+#[test]
+#[should_panic(expected = "Phi node in BlockId(3) assigns to VariableId(3) to itself")]
+fn ssa_check_fails_when_phi_assigns_to_itself() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+
+    program.blocks.insert(
+        BlockId(1),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+
+    program.blocks.insert(
+        BlockId(3),
+        Block(vec![
+            Instruction::Phi(
+                vec![
+                    (
+                        Operand::Variable(Variable {
+                            variable_id: VariableId(1),
+                            ty: Ty::Boolean,
+                        }),
+                        BlockId(1),
+                    ),
+                    (
+                        Operand::Variable(Variable {
+                            variable_id: VariableId(3),
+                            ty: Ty::Boolean,
+                        }),
+                        BlockId(2),
+                    ),
+                ],
+                Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+        ]),
+    );
+
+    perform_ssa_check(&mut program);
+}
+
+#[test]
+#[should_panic(expected = "Phi node in BlockId(3) has 1 arguments but 2 predecessors")]
+fn ssa_check_fails_when_phi_blocks_have_different_predecessors() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+
+    program.blocks.insert(
+        BlockId(1),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+
+    program.blocks.insert(
+        BlockId(3),
+        Block(vec![
+            Instruction::Phi(
+                vec![(
+                    Operand::Variable(Variable {
+                        variable_id: VariableId(1),
+                        ty: Ty::Boolean,
+                    }),
+                    BlockId(1),
+                )],
                 Variable {
                     variable_id: VariableId(3),
                     ty: Ty::Boolean,

--- a/compiler/qsc_rir/src/passes/ssa_transform.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform.rs
@@ -1,0 +1,343 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    rir::{Block, BlockId, Instruction, Literal, Operand, Program, Ty, Variable, VariableId},
+    utils::get_variable_assignments,
+};
+use qsc_data_structures::index_map::IndexMap;
+use rustc_hash::FxHashMap;
+
+/// Transforms the program into Single Static Assignment (SSA) form by inserting phi nodes
+/// at the beginning of blocks where necessary, allowing the removal of store instructions.
+pub fn transform_to_ssa(program: &mut Program, preds: &IndexMap<BlockId, Vec<BlockId>>) {
+    // Ensure that the graph is acyclic before proceeding. Current approach does not support cycles.
+    ensure_acyclic(preds);
+
+    // First, remove store instructions and propagate variables through individual blocks.
+    // This produces a per-block map of dynamic variables to their values.
+    // Orphan variables may be left behind where a variable is defined in one block and used in another, which
+    // will be resolved by inserting phi nodes.
+    let mut block_var_map = map_store_to_dominated_ssa(program, preds);
+
+    // Get the next available variable ID for use in newly generated phi nodes.
+    let mut next_var_id = get_variable_assignments(program)
+        .iter()
+        .last()
+        .map(|(var_id, _)| var_id.successor())
+        .unwrap_or_default();
+
+    // Insert phi nodes where necessary, mapping any remaining orphaned uses to the new variable
+    // created by the phi node.
+    // This can be done in one pass because the graph is assumed to be acyclic.
+    for (block_id, block) in program.blocks.iter_mut() {
+        let Some(block_preds) = preds.get(block_id) else {
+            // The block with no predecessors is the entry block and has no phi nodes.
+            continue;
+        };
+
+        // Use a map to track updates to the variable map for the block. These will be applied after
+        // any phi nodes are inserted and will replace any orphaned variables.
+        let mut var_map_updates = FxHashMap::default();
+
+        let (first_pred, rest_preds) = block_preds
+            .split_first()
+            .expect("block should have at least one predecessor");
+
+        // The block is only a candidate for phi nodes if it has multiple predecessors.
+        if !rest_preds.is_empty() {
+            // Check each variable in the first predecessor's variable map, and if any other
+            // predecessor has a different value for the variable, a phi node is needed.
+            for (var_id, operand) in block_var_map
+                .get(*first_pred)
+                .expect("block should have variable map")
+            {
+                let mut phi_nodes = FxHashMap::default();
+
+                if rest_preds.iter().any(|pred| {
+                    block_var_map
+                        .get(*pred)
+                        .expect("block should have variable map")
+                        .get(var_id)
+                        != Some(operand)
+                }) {
+                    // Some predecessors have different values for this variable, so a phi node is needed.
+                    // Start with the first predecessor's value and block id, then add the values from the other predecessors.
+                    let mut phi_args = vec![(*operand, *first_pred)];
+                    for pred in rest_preds {
+                        phi_args.push((
+                            block_var_map
+                                .get(*pred)
+                                .expect("block should have variable map")
+                                .get(var_id)
+                                .copied()
+                                .expect("variable should be defined in all predecessors"),
+                            *pred,
+                        ));
+                    }
+                    phi_nodes.insert(*var_id, phi_args);
+                } else {
+                    // If all predecessors have the same value for this variable, the value can be propagated.
+                    // Update the block variable map with the common operand.
+                    var_map_updates.insert(*var_id, *operand);
+                }
+
+                // For any phi nodes that need to be inserted, create a new variable and insert
+                // the phi node at the beginning of the block. The new variable will be used to replace
+                // the original variable in the block's variable map, which will take care of any orphaned uses.
+                for (variable_id, args) in phi_nodes {
+                    let new_var = Variable {
+                        variable_id: next_var_id,
+                        ty: operand.get_type(),
+                    };
+                    let phi_node = Instruction::Phi(args, new_var);
+                    block.0.insert(0, phi_node);
+                    var_map_updates.insert(variable_id, Operand::Variable(new_var));
+                    next_var_id = next_var_id.successor();
+                }
+            }
+
+            // Now that the block has finished processing, apply any updates to the variable map,
+            // and use the updated map to propagate variables through the block.
+            for (var_id, operand) in var_map_updates {
+                let var_map = block_var_map
+                    .get_mut(block_id)
+                    .expect("block should have variable map");
+                var_map.entry(var_id).or_insert(operand);
+                map_variable_use_in_block(block, var_map);
+            }
+        }
+    }
+}
+
+// For now, SSA transform assumes the graph is acyclic, so verify that no block has a predecessor with
+// a block id less than itself, which would indicate a cycle.
+fn ensure_acyclic(preds: &IndexMap<BlockId, Vec<BlockId>>) {
+    for (block_id, block_preds) in preds.iter() {
+        assert!(
+            !block_preds.iter().any(|pred| *pred >= block_id),
+            "block {block_id:?} has a cycle in its predecessors"
+        );
+    }
+}
+
+// Remove store instructions and propagate variables through individual blocks.
+// This produces a per-block map of dynamic variables to their values.
+// Any block with a single predecessor inherits that predecessor's mapped variables, since those
+// are live across the block.
+fn map_store_to_dominated_ssa(
+    program: &mut Program,
+    preds: &IndexMap<BlockId, Vec<BlockId>>,
+) -> IndexMap<BlockId, FxHashMap<VariableId, Operand>> {
+    let mut block_var_map = IndexMap::default();
+    for (block_id, block) in program.blocks.iter_mut() {
+        let mut var_map: FxHashMap<VariableId, Operand> = match preds.get(block_id) {
+            Some(block_preds) if block_preds.len() == 1 => {
+                // Any block with a single predecessor inherits those mapped variables.
+                block_var_map
+                    .get(block_preds[0])
+                    .cloned()
+                    .unwrap_or_default()
+            }
+            _ => FxHashMap::default(),
+        };
+        map_variable_use_in_block(block, &mut var_map);
+        block_var_map.insert(block_id, var_map);
+    }
+    block_var_map
+}
+
+// Propagates stored variables through a block, tracking the latest stored value and replacing
+// usage of the variable with the stored value.
+#[allow(clippy::too_many_lines)]
+fn map_variable_use_in_block(block: &mut Block, var_map: &mut impl VariableMapper) {
+    let instrs = block.0.drain(..).collect::<Vec<_>>();
+
+    for instr in instrs {
+        match instr {
+            // Track the new value of the variable and omit the store instruction.
+            Instruction::Store(operand, var) => {
+                var_map.insert(var, operand);
+            }
+
+            // Replace any arguments with the new values of stored variables.
+            Instruction::Call(call_id, args, out) => {
+                let new_args = args
+                    .into_iter()
+                    .map(|arg| match arg {
+                        Operand::Variable(var) => var_map.to_operand(var),
+                        Operand::Literal(_) => arg,
+                    })
+                    .collect();
+                block.0.push(Instruction::Call(call_id, new_args, out));
+            }
+            Instruction::Branch(var, true_block, false_block) => {
+                block.0.push(Instruction::Branch(
+                    var_map.to_variable(var),
+                    true_block,
+                    false_block,
+                ));
+            }
+            Instruction::Add(lhs, rhs, out) => {
+                block.0.push(Instruction::Add(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::Sub(lhs, rhs, out) => {
+                block.0.push(Instruction::Sub(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::Mul(lhs, rhs, out) => {
+                block.0.push(Instruction::Mul(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::Sdiv(lhs, rhs, out) => {
+                block.0.push(Instruction::Sdiv(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::Srem(lhs, rhs, out) => {
+                block.0.push(Instruction::Srem(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::Shl(lhs, rhs, out) => {
+                block.0.push(Instruction::Shl(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::Ashr(lhs, rhs, out) => {
+                block.0.push(Instruction::Ashr(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::Icmp(cond, lhs, rhs, out) => {
+                block.0.push(Instruction::Icmp(
+                    cond,
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::LogicalNot(operand, out) => {
+                block
+                    .0
+                    .push(Instruction::LogicalNot(operand.mapped(var_map), out));
+            }
+            Instruction::LogicalAnd(lhs, rhs, out) => {
+                block.0.push(Instruction::LogicalAnd(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::LogicalOr(lhs, rhs, out) => {
+                block.0.push(Instruction::LogicalOr(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::BitwiseNot(operand, out) => {
+                block
+                    .0
+                    .push(Instruction::BitwiseNot(operand.mapped(var_map), out));
+            }
+            Instruction::BitwiseAnd(lhs, rhs, out) => {
+                block.0.push(Instruction::BitwiseAnd(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::BitwiseOr(lhs, rhs, out) => {
+                block.0.push(Instruction::BitwiseOr(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+            Instruction::BitwiseXor(lhs, rhs, out) => {
+                block.0.push(Instruction::BitwiseXor(
+                    lhs.mapped(var_map),
+                    rhs.mapped(var_map),
+                    out,
+                ));
+            }
+
+            // Phi nodes are handled separately in the SSA transformation, but need to be passed through.
+            Instruction::Phi(..) | Instruction::Jump(..) | Instruction::Return => {
+                block.0.push(instr);
+            }
+        }
+    }
+}
+
+impl Operand {
+    fn mapped(&self, var_map: &impl VariableMapper) -> Operand {
+        match self {
+            Operand::Literal(_) => *self,
+            Operand::Variable(var) => var_map.to_operand(*var),
+        }
+    }
+
+    fn get_type(&self) -> Ty {
+        match self {
+            Operand::Literal(lit) => match lit {
+                Literal::Qubit(_) => Ty::Qubit,
+                Literal::Result(_) => Ty::Result,
+                Literal::Bool(_) => Ty::Boolean,
+                Literal::Integer(_) => Ty::Integer,
+                Literal::Double(_) => Ty::Double,
+                Literal::Pointer => Ty::Pointer,
+            },
+            Operand::Variable(var) => var.ty,
+        }
+    }
+}
+
+trait VariableMapper {
+    fn insert(&mut self, var: Variable, operand: Operand);
+    fn to_operand(&self, var: Variable) -> Operand;
+    fn to_variable(&self, var: Variable) -> Variable;
+}
+
+impl VariableMapper for FxHashMap<VariableId, Operand> {
+    fn insert(&mut self, var: Variable, operand: Operand) {
+        self.insert(var.variable_id, operand);
+    }
+
+    fn to_operand(&self, var: Variable) -> Operand {
+        self.get(&var.variable_id)
+            .copied()
+            .unwrap_or(Operand::Variable(var))
+    }
+
+    fn to_variable(&self, var: Variable) -> Variable {
+        self.get(&var.variable_id)
+            .copied()
+            .map_or(var, |operand| match operand {
+                Operand::Literal(_) => panic!("literal not supported in this context"),
+                Operand::Variable(var) => var,
+            })
+    }
+}

--- a/compiler/qsc_rir/src/passes/ssa_transform.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform.rs
@@ -100,8 +100,8 @@ pub fn transform_to_ssa(program: &mut Program, preds: &IndexMap<BlockId, Vec<Blo
                 }
             }
 
-            // Now that the block has finished processing, apply any updates to the variable map,
-            // and use the updated map to propagate variables through the block.
+            // Now that the block has finished processing, apply any updates to the block and
+            // merge those updates into the stored variable map to propagate to successors.
             map_variable_use_in_block(block, &mut var_map_updates);
             for (var_id, operand) in var_map_updates {
                 let var_map = block_var_map

--- a/compiler/qsc_rir/src/passes/ssa_transform.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform.rs
@@ -102,12 +102,12 @@ pub fn transform_to_ssa(program: &mut Program, preds: &IndexMap<BlockId, Vec<Blo
 
             // Now that the block has finished processing, apply any updates to the variable map,
             // and use the updated map to propagate variables through the block.
+            map_variable_use_in_block(block, &mut var_map_updates);
             for (var_id, operand) in var_map_updates {
                 let var_map = block_var_map
                     .get_mut(block_id)
                     .expect("block should have variable map");
                 var_map.entry(var_id).or_insert(operand);
-                map_variable_use_in_block(block, var_map);
             }
         }
     }

--- a/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
@@ -2033,7 +2033,8 @@ fn ssa_transform_inerts_phi_nodes_for_early_return_graph_pattern() {
                 remap_qubits_on_reuse: false
                 defer_measurements: false
             num_qubits: 0
-            num_results: 0"#]].assert_eq(&program.to_string());
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
 
     // After
     transform_program(&mut program);

--- a/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
@@ -1195,7 +1195,8 @@ fn ssa_transform_inserts_phi_for_node_with_many_predecessors() {
                 remap_qubits_on_reuse: false
                 defer_measurements: false
             num_qubits: 0
-            num_results: 0"#]].assert_eq(&program.to_string());
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
 
     // After
     transform_program(&mut program);
@@ -1326,9 +1327,9 @@ fn ssa_transform_inserts_phi_for_multiple_stored_values() {
             Instruction::Jump(BlockId(3)),
         ]),
     );
-    program
-        .blocks
-        .insert(BlockId(2), Block(vec![
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![
             Instruction::LogicalNot(
                 Operand::Variable(Variable {
                     variable_id: VariableId(2),
@@ -1349,7 +1350,9 @@ fn ssa_transform_inserts_phi_for_multiple_stored_values() {
                     ty: Ty::Boolean,
                 },
             ),
-            Instruction::Jump(BlockId(3))]));
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
     program.blocks.insert(
         BlockId(3),
         Block(vec![

--- a/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
@@ -1,0 +1,1461 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(clippy::too_many_lines, clippy::needless_raw_string_hashes)]
+
+use expect_test::expect;
+
+use crate::{
+    builder::{bell_program, new_program},
+    passes::{build_dominator_graph, check_ssa_form, check_unreachable_code, remap_block_ids},
+    rir::{
+        Block, BlockId, Callable, CallableId, CallableType, Instruction, Operand, Program, Ty,
+        Variable, VariableId,
+    },
+    utils::build_predecessors_map,
+};
+
+use super::transform_to_ssa;
+
+fn transform_program(program: &mut Program) {
+    check_unreachable_code(program);
+    remap_block_ids(program);
+    let preds = build_predecessors_map(program);
+    transform_to_ssa(program, &preds);
+    let doms = build_dominator_graph(program, &preds);
+    check_ssa_form(program, &preds, &doms);
+}
+
+#[test]
+fn ssa_transform_leaves_program_without_store_instruction_unchanged() {
+    let mut program = bell_program();
+    let program_string_orignal = program.to_string();
+
+    transform_program(&mut program);
+
+    assert_eq!(program_string_orignal, program.to_string());
+}
+
+#[test]
+fn ssa_transform_leaves_branching_program_without_store_instruction_unchanged() {
+    let mut program = bell_program();
+    let program_string_orignal = program.to_string();
+
+    transform_program(&mut program);
+
+    assert_eq!(program_string_orignal, program.to_string());
+}
+
+#[test]
+fn ssa_transform_removes_store_in_single_block_program() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Variable(2, Boolean) = LogicalNot Variable(1, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(2, Boolean) = LogicalNot Variable(0, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn ssa_transform_removes_multiple_stores_in_single_block_program() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Variable(2, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(2, Boolean)
+                    Variable(3, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(3, Boolean)
+                    Variable(4, Boolean) = LogicalNot Variable(1, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(2, Boolean) = LogicalNot Variable(0, Boolean)
+                    Variable(3, Boolean) = LogicalNot Variable(2, Boolean)
+                    Variable(4, Boolean) = LogicalNot Variable(3, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn ssa_transform_store_dominating_usage_propagates_to_successor_blocks() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(1),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(3),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Branch Variable(1, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(1, Boolean)
+                    Jump(3)
+                Block 2: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(1, Boolean)
+                    Jump(3)
+                Block 3: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(1, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(0, Boolean)
+                    Jump(3)
+                Block 2: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(0, Boolean)
+                    Jump(3)
+                Block 3: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(0, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn ssa_transform_store_dominating_usage_propagates_to_successor_blocks_without_intermediate_usage()
+{
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+    program
+        .blocks
+        .insert(BlockId(1), Block(vec![Instruction::Jump(BlockId(3))]));
+    program
+        .blocks
+        .insert(BlockId(2), Block(vec![Instruction::Jump(BlockId(3))]));
+    program.blocks.insert(
+        BlockId(3),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Branch Variable(1, Boolean), 1, 2
+                Block 1: Block:
+                    Jump(3)
+                Block 2: Block:
+                    Jump(3)
+                Block 3: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(1, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Jump(3)
+                Block 2: Block:
+                    Jump(3)
+                Block 3: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(0, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn ssa_transform_inserts_phi_for_store_not_dominating_usage() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(1),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(3),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Branch Variable(1, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(2, Boolean)
+                    Jump(3)
+                Block 2: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(3, Boolean)
+                    Jump(3)
+                Block 3: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(1, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(0, Boolean)
+                    Jump(3)
+                Block 2: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(0, Boolean)
+                    Jump(3)
+                Block 3: Block:
+                    Variable(5, Boolean) = Phi ( [Variable(2, Boolean), 1], [Variable(3, Boolean), 2], )
+                    Variable(4, Boolean) = LogicalNot Variable(5, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
+}
+
+#[test]
+fn ssa_transform_inserts_phi_for_store_not_dominating_usage_in_one_branch() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(1),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+    program
+        .blocks
+        .insert(BlockId(2), Block(vec![Instruction::Jump(BlockId(3))]));
+    program.blocks.insert(
+        BlockId(3),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Branch Variable(1, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(2, Boolean)
+                    Jump(3)
+                Block 2: Block:
+                    Jump(3)
+                Block 3: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(1, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(0, Boolean)
+                    Jump(3)
+                Block 2: Block:
+                    Jump(3)
+                Block 3: Block:
+                    Variable(5, Boolean) = Phi ( [Variable(2, Boolean), 1], [Variable(0, Boolean), 2], )
+                    Variable(4, Boolean) = LogicalNot Variable(5, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
+}
+
+#[test]
+fn ssa_transform_inserts_phi_for_node_with_many_predecessors() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(1),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(3),
+                BlockId(4),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(5),
+                BlockId(6),
+            ),
+        ]),
+    );
+    program
+        .blocks
+        .insert(BlockId(3), Block(vec![Instruction::Jump(BlockId(7))]));
+    program
+        .blocks
+        .insert(BlockId(4), Block(vec![Instruction::Jump(BlockId(7))]));
+    program
+        .blocks
+        .insert(BlockId(5), Block(vec![Instruction::Jump(BlockId(7))]));
+    program.blocks.insert(
+        BlockId(6),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(7)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(7),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(5),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Branch Variable(1, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(2, Boolean)
+                    Branch Variable(1, Boolean), 3, 4
+                Block 2: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(3, Boolean)
+                    Branch Variable(1, Boolean), 5, 6
+                Block 3: Block:
+                    Jump(7)
+                Block 4: Block:
+                    Jump(7)
+                Block 5: Block:
+                    Jump(7)
+                Block 6: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(4, Boolean)
+                    Jump(7)
+                Block 7: Block:
+                    Variable(5, Boolean) = LogicalNot Variable(1, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(0, Boolean)
+                    Branch Variable(2, Boolean), 3, 4
+                Block 2: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(0, Boolean)
+                    Branch Variable(3, Boolean), 5, 6
+                Block 3: Block:
+                    Jump(7)
+                Block 4: Block:
+                    Jump(7)
+                Block 5: Block:
+                    Jump(7)
+                Block 6: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(3, Boolean)
+                    Jump(7)
+                Block 7: Block:
+                    Variable(6, Boolean) = Phi ( [Variable(2, Boolean), 3], [Variable(2, Boolean), 4], [Variable(3, Boolean), 5], [Variable(4, Boolean), 6], )
+                    Variable(5, Boolean) = LogicalNot Variable(6, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
+}
+
+#[test]
+fn ssa_transform_inserts_phi_for_multiple_stored_values() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(1),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3)),
+        ]),
+    );
+    program
+        .blocks
+        .insert(BlockId(2), Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(3))]));
+    program.blocks.insert(
+        BlockId(3),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(5),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(6),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Variable(2, Boolean) = Store Variable(0, Boolean)
+                    Branch Variable(1, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(3, Boolean)
+                    Jump(3)
+                Block 2: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(2, Boolean)
+                    Variable(2, Boolean) = Store Variable(4, Boolean)
+                    Jump(3)
+                Block 3: Block:
+                    Variable(5, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(6, Boolean) = LogicalNot Variable(2, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(0, Boolean)
+                    Jump(3)
+                Block 2: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(0, Boolean)
+                    Jump(3)
+                Block 3: Block:
+                    Variable(8, Boolean) = Phi ( [Variable(0, Boolean), 1], [Variable(4, Boolean), 2], )
+                    Variable(7, Boolean) = Phi ( [Variable(3, Boolean), 1], [Variable(0, Boolean), 2], )
+                    Variable(5, Boolean) = LogicalNot Variable(7, Boolean)
+                    Variable(6, Boolean) = LogicalNot Variable(8, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
+}

--- a/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
@@ -1462,3 +1462,336 @@ fn ssa_transform_inserts_phi_for_multiple_stored_values() {
             num_qubits: 0
             num_results: 0"#]].assert_eq(&program.to_string());
 }
+
+#[test]
+fn ssa_transform_inserts_phi_nodes_in_successive_blocks_for_chained_branches() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(1),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(3),
+                BlockId(4),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(5)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(3),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(4),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(6)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(4),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(5),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(5),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(6)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(5),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(6),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(6),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(7)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(6),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(7),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(7),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(7)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(7),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(8),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Branch Variable(1, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(2, Boolean)
+                    Branch Variable(1, Boolean), 3, 4
+                Block 2: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(3, Boolean)
+                    Jump(5)
+                Block 3: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(4, Boolean)
+                    Jump(6)
+                Block 4: Block:
+                    Variable(5, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(5, Boolean)
+                    Jump(6)
+                Block 5: Block:
+                    Variable(6, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(6, Boolean)
+                    Jump(7)
+                Block 6: Block:
+                    Variable(7, Boolean) = LogicalNot Variable(1, Boolean)
+                    Variable(1, Boolean) = Store Variable(7, Boolean)
+                    Jump(7)
+                Block 7: Block:
+                    Variable(8, Boolean) = LogicalNot Variable(1, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  <VOID>
+                    body:  0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type:  <VOID>
+                    output_type:  Boolean
+                    body:  <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = LogicalNot Variable(0, Boolean)
+                    Branch Variable(2, Boolean), 3, 4
+                Block 2: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(0, Boolean)
+                    Jump(5)
+                Block 3: Block:
+                    Variable(4, Boolean) = LogicalNot Variable(2, Boolean)
+                    Jump(6)
+                Block 4: Block:
+                    Variable(5, Boolean) = LogicalNot Variable(2, Boolean)
+                    Jump(6)
+                Block 5: Block:
+                    Variable(6, Boolean) = LogicalNot Variable(3, Boolean)
+                    Jump(7)
+                Block 6: Block:
+                    Variable(9, Boolean) = Phi ( [Variable(4, Boolean), 3], [Variable(5, Boolean), 4], )
+                    Variable(7, Boolean) = LogicalNot Variable(9, Boolean)
+                    Jump(7)
+                Block 7: Block:
+                    Variable(10, Boolean) = Phi ( [Variable(6, Boolean), 5], [Variable(7, Boolean), 6], )
+                    Variable(8, Boolean) = LogicalNot Variable(10, Boolean)
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
+}

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -416,8 +416,15 @@ impl Display for Instruction {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct VariableId(pub u32);
+
+impl VariableId {
+    #[must_use]
+    pub fn successor(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
 
 impl From<VariableId> for usize {
     fn from(id: VariableId) -> usize {
@@ -431,7 +438,7 @@ impl From<usize> for VariableId {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Variable {
     pub variable_id: VariableId,
     pub ty: Ty,
@@ -469,7 +476,7 @@ impl Display for Ty {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum Operand {
     Literal(Literal),
     Variable(Variable),
@@ -484,7 +491,7 @@ impl Display for Operand {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum Literal {
     Qubit(u32),
     Result(u32),

--- a/compiler/qsc_rir/src/rir.rs
+++ b/compiler/qsc_rir/src/rir.rs
@@ -491,6 +491,23 @@ impl Display for Operand {
     }
 }
 
+impl Operand {
+    #[must_use]
+    pub fn get_type(&self) -> Ty {
+        match self {
+            Operand::Literal(lit) => match lit {
+                Literal::Qubit(_) => Ty::Qubit,
+                Literal::Result(_) => Ty::Result,
+                Literal::Bool(_) => Ty::Boolean,
+                Literal::Integer(_) => Ty::Integer,
+                Literal::Double(_) => Ty::Double,
+                Literal::Pointer => Ty::Pointer,
+            },
+            Operand::Variable(var) => var.ty,
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq)]
 pub enum Literal {
     Qubit(u32),

--- a/compiler/qsc_rir/src/utils.rs
+++ b/compiler/qsc_rir/src/utils.rs
@@ -29,7 +29,7 @@ pub fn get_block_successors(block: &Block) -> Vec<BlockId> {
 /// The returned block IDs are sorted in ascending order.
 #[must_use]
 pub fn get_all_block_successors(block: BlockId, program: &Program) -> Vec<BlockId> {
-    let mut blocks_to_visit = vec![block];
+    let mut blocks_to_visit = get_block_successors(program.get_block(block));
     let mut blocks_visited = FxHashSet::default();
     while let Some(block_id) = blocks_to_visit.pop() {
         if blocks_visited.contains(&block_id) {

--- a/compiler/qsc_rir/src/utils.rs
+++ b/compiler/qsc_rir/src/utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::rir::{Block, BlockId, Instruction, Program};
+use crate::rir::{Block, BlockId, Instruction, Program, VariableId};
 use qsc_data_structures::index_map::IndexMap;
 use rustc_hash::FxHashSet;
 
@@ -67,4 +67,48 @@ pub fn build_predecessors_map(program: &Program) -> IndexMap<BlockId, Vec<BlockI
     }
 
     preds
+}
+
+#[must_use]
+pub fn get_variable_assignments(program: &Program) -> IndexMap<VariableId, (BlockId, usize)> {
+    let mut assignments = IndexMap::default();
+    for (block_id, block) in program.blocks.iter() {
+        for (idx, instr) in block.0.iter().enumerate() {
+            match instr {
+                Instruction::Call(_, _, Some(var))
+                | Instruction::Add(_, _, var)
+                | Instruction::Sub(_, _, var)
+                | Instruction::Mul(_, _, var)
+                | Instruction::Sdiv(_, _, var)
+                | Instruction::Srem(_, _, var)
+                | Instruction::Shl(_, _, var)
+                | Instruction::Ashr(_, _, var)
+                | Instruction::Icmp(_, _, _, var)
+                | Instruction::LogicalNot(_, var)
+                | Instruction::LogicalAnd(_, _, var)
+                | Instruction::LogicalOr(_, _, var)
+                | Instruction::BitwiseNot(_, var)
+                | Instruction::BitwiseAnd(_, _, var)
+                | Instruction::BitwiseOr(_, _, var)
+                | Instruction::BitwiseXor(_, _, var)
+                | Instruction::Phi(_, var) => {
+                    assert!(
+                        !assignments.contains_key(var.variable_id),
+                        "Duplicate assignment to {:?} in {block_id:?}, instruction {idx}",
+                        var.variable_id
+                    );
+                    assignments.insert(var.variable_id, (block_id, idx));
+                }
+                Instruction::Call(_, _, None)
+                | Instruction::Jump(..)
+                | Instruction::Branch(..)
+                | Instruction::Return => {}
+
+                Instruction::Store(..) => {
+                    panic!("Unexpected Store at {block_id:?}, instruction {idx}")
+                }
+            }
+        }
+    }
+    assignments
 }


### PR DESCRIPTION
This introduces the transformation pass that removes `Store` instructions in favor of `Phi` instructions and propagates variable values through the program to achieve single static assignment form.

The change also includes wrapper functions `check_and_transform` and `defer_quantum_measurements` at the top level of the passes module to handle invoking the passes in the expected order.