### PR TITLE
Update language service when manifest is saved. (Closes #1284)

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -184,6 +184,36 @@ async function activateLanguageService(extensionUri: vscode.Uri) {
     ...registerQSharpNotebookCellUpdateHandlers(languageService),
   );
 
+  // Watch manifest changes and update each document in the same project as the manifest.
+  subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument((manifest) => {
+      if (
+        manifest.languageId === "json" &&
+        manifest.uri.scheme === "file" &&
+        manifest.fileName.endsWith("qsharp.json")
+      ) {
+        const project_folder = manifest.fileName.slice(
+          0,
+          manifest.fileName.length - "qsharp.json".length,
+        );
+        vscode.workspace.textDocuments.forEach((document) => {
+          if (
+            !document.isClosed &&
+            isQsharpDocument(document) &&
+            // Check that the document is on the same project as the manifest.
+            document.fileName.startsWith(project_folder)
+          ) {
+            languageService.updateDocument(
+              document.uri.toString(),
+              document.version,
+              document.getText(),
+            );
+          }
+        });
+      }
+    }),
+  );
+
   // format document
   const isFormattingEnabled = getEnableFormating();
   const formatterHandle = {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -161,6 +161,8 @@ function registerDocumentUpdateHandlers(languageService: ILanguageService) {
     }),
   );
 
+  // Trigger an update on all .qs child documents when their manifest is deleted,
+  // so that they can get reparented to single-file-projects.
   subscriptions.push(
     vscode.workspace.onDidDeleteFiles((event) => {
       event.files.forEach((uri) => {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -157,27 +157,37 @@ function registerDocumentUpdateHandlers(languageService: ILanguageService) {
   // Watch manifest changes and update each document in the same project as the manifest.
   subscriptions.push(
     vscode.workspace.onDidSaveTextDocument((manifest) => {
-      if (
-        manifest.languageId === "json" &&
-        manifest.uri.scheme === "file" &&
-        manifest.fileName.endsWith("qsharp.json")
-      ) {
-        const project_folder = manifest.fileName.slice(
-          0,
-          manifest.fileName.length - "qsharp.json".length,
-        );
-        vscode.workspace.textDocuments.forEach((document) => {
-          if (
-            !document.isClosed &&
-            // Check that the document is on the same project as the manifest.
-            document.fileName.startsWith(project_folder)
-          ) {
-            updateIfQsharpDocument(document);
-          }
-        });
-      }
+      updateProjectDocuments(manifest.uri);
     }),
   );
+
+  subscriptions.push(
+    vscode.workspace.onDidDeleteFiles((event) => {
+      event.files.forEach((uri) => {
+        updateProjectDocuments(uri);
+      });
+    }),
+  );
+
+  // Checks if the URI belongs to a qsharp manifest, and updates all
+  // open documents in the same project as the manifest.
+  function updateProjectDocuments(manifest: vscode.Uri) {
+    if (manifest.scheme === "file" && manifest.fsPath.endsWith("qsharp.json")) {
+      const project_folder = manifest.fsPath.slice(
+        0,
+        manifest.fsPath.length - "qsharp.json".length,
+      );
+      vscode.workspace.textDocuments.forEach((document) => {
+        if (
+          !document.isClosed &&
+          // Check that the document is on the same project as the manifest.
+          document.fileName.startsWith(project_folder)
+        ) {
+          updateIfQsharpDocument(document);
+        }
+      });
+    }
+  }
 
   function updateIfQsharpDocument(document: vscode.TextDocument) {
     if (isQsharpDocument(document) && !isQsharpNotebookCell(document)) {


### PR DESCRIPTION
This PR enables sending document-updates to a given project documents when its manifest is edited and saved.


https://github.com/microsoft/qsharp/assets/156957451/9d528103-97f3-4a53-858b-0b05b4b2b707

