### PR TITLE
Run profile analysis in language service for notebooks

### DIFF
--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -77,25 +77,13 @@ impl Compilation {
             .get(package_id)
             .expect("expected to find user package");
 
-        // baseprofchk will handle the case where the target profile is Base
-        if errors.is_empty()
-            && target_profile != Profile::Unrestricted
-            && target_profile != Profile::Base
-        {
-            let cap_results = PassContext::run_fir_passes_on_hir(
-                &package_store,
-                package_id,
-                target_profile.into(),
-            );
-            if let Err(caps_errors) = cap_results {
-                for err in caps_errors {
-                    errors.push(WithSource::from_map(
-                        &unit.sources,
-                        compile::ErrorKind::Pass(err),
-                    ));
-                }
-            }
-        }
+        run_fir_passes(
+            &mut errors,
+            target_profile,
+            &package_store,
+            package_id,
+            unit,
+        );
 
         let lints = qsc::linter::run_lints(unit, Some(lints_config));
         for lint in lints {
@@ -146,6 +134,17 @@ impl Compilation {
         }
 
         let (package_store, package_id) = compiler.into_package_store();
+        let unit = package_store
+            .get(package_id)
+            .expect("expected to find user package");
+
+        run_fir_passes(
+            &mut errors,
+            target_profile,
+            &package_store,
+            package_id,
+            unit,
+        );
 
         Self {
             package_store,
@@ -241,6 +240,31 @@ impl Compilation {
         self.package_store = new.package_store;
         self.user_package_id = new.user_package_id;
         self.errors = new.errors;
+    }
+}
+
+fn run_fir_passes(
+    errors: &mut Vec<WithSource<compile::ErrorKind>>,
+    target_profile: Profile,
+    package_store: &PackageStore,
+    package_id: PackageId,
+    unit: &CompileUnit,
+) {
+    // baseprofchk will handle the case where the target profile is Base
+    if errors.is_empty()
+        && target_profile != Profile::Unrestricted
+        && target_profile != Profile::Base
+    {
+        let cap_results =
+            PassContext::run_fir_passes_on_hir(package_store, package_id, target_profile.into());
+        if let Err(caps_errors) = cap_results {
+            for err in caps_errors {
+                errors.push(WithSource::from_map(
+                    &unit.sources,
+                    compile::ErrorKind::Pass(err),
+                ));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Enables RCA checks when compiling notebooks with the language service surfacing errors to the user.

![image](https://github.com/microsoft/qsharp/assets/63540/4799a74c-8715-400a-8220-2fe2f4556b73)
