### PR TITLE
Make the span of the entry-point expression just the span of name of the entry-point operation

### DIFF
--- a/compiler/qsc_passes/src/entry_point.rs
+++ b/compiler/qsc_passes/src/entry_point.rs
@@ -98,7 +98,7 @@ fn create_entry_from_callables(
                         };
                         let call = Expr {
                             id: assigner.next_node(),
-                            span: ep.span,
+                            span: ep.name.span,
                             ty: block.ty.clone(),
                             kind: ExprKind::Call(Box::new(callee), Box::new(arg)),
                         };

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -44,7 +44,7 @@ fn test_entry_point_attr_to_expr() {
             }"},
         "",
         &expect![[r#"
-            Expr 12 [40-73] [Type Int]: Call:
+            Expr 12 [50-54] [Type Int]: Call:
                 Expr 11 [40-73] [Type Int]: Var: Item 1
                 Expr 10 [40-73] [Type Unit]: Unit"#]],
     );


### PR DESCRIPTION
Use the span of the entry-point operation name instead of the span of the whole entry-point operation as the span of the entry-point expression.

The purpose of this is to keep the red squiggles focused when an error in the entry-point expression is reported.