### PR TITLE
Set qubit and result counts in partial eval output

### DIFF
--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -757,7 +757,7 @@ mod given_interpreter {
 
                 declare void @__quantum__qis__rz__body(double, %Qubit*)
 
-                attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
+                attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
                 attributes #1 = { "irreversible" }
 
                 ; module flags

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -228,9 +228,22 @@ impl<'a> PartialEvaluator<'a> {
             return Err(error);
         }
 
-        // Insert the return expression and return the generated program.
+        // Insert the return expression.
         let current_block = self.get_current_block_mut();
         current_block.0.push(Instruction::Return);
+
+        // Set the number of qubits and results used by the program.
+        self.program.num_qubits = self
+            .resource_manager
+            .qubit_count()
+            .try_into()
+            .expect("qubits count should fit into a u32");
+        self.program.num_results = self
+            .resource_manager
+            .results_count()
+            .try_into()
+            .expect("results count should fit into a u32");
+
         Ok(self.program)
     }
 

--- a/compiler/qsc_partial_eval/src/management.rs
+++ b/compiler/qsc_partial_eval/src/management.rs
@@ -17,6 +17,14 @@ pub struct ResourceManager {
 }
 
 impl ResourceManager {
+    pub fn qubit_count(&self) -> usize {
+        self.qubits_in_use.len()
+    }
+
+    pub fn results_count(&self) -> usize {
+        self.next_result
+    }
+
     pub fn allocate_qubit(&mut self) -> Qubit {
         if let Some(qubit_id) = self.qubits_in_use.iter().position(|in_use| !in_use) {
             self.qubits_in_use[qubit_id] = true;

--- a/compiler/qsc_partial_eval/tests/qubits.rs
+++ b/compiler/qsc_partial_eval/tests/qubits.rs
@@ -50,6 +50,8 @@ fn qubit_ids_are_correct_for_allocate_use_release_one_qubit() {
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 1);
+    assert_eq!(program.num_results, 0);
 }
 
 #[test]
@@ -97,6 +99,8 @@ fn qubit_ids_are_correct_for_allocate_use_release_multiple_qubits() {
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 3);
+    assert_eq!(program.num_results, 0);
 }
 
 #[test]
@@ -144,6 +148,8 @@ fn qubit_ids_are_correct_for_allocate_use_release_one_qubit_multiple_times() {
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 1);
+    assert_eq!(program.num_results, 0);
 }
 
 #[test]
@@ -207,4 +213,6 @@ fn qubit_ids_are_correct_for_allocate_use_release_multiple_qubits_interleaved() 
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 4);
+    assert_eq!(program.num_results, 0);
 }

--- a/compiler/qsc_partial_eval/tests/results.rs
+++ b/compiler/qsc_partial_eval/tests/results.rs
@@ -72,6 +72,8 @@ fn result_ids_are_correct_for_measuring_and_resetting_one_qubit() {
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 1);
+    assert_eq!(program.num_results, 1);
 }
 
 #[test]
@@ -104,6 +106,8 @@ fn result_ids_are_correct_for_measuring_one_qubit() {
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 1);
+    assert_eq!(program.num_results, 1);
 }
 
 #[test]
@@ -154,6 +158,8 @@ fn result_ids_are_correct_for_measuring_one_qubit_multiple_times() {
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 1);
+    assert_eq!(program.num_results, 3);
 }
 
 #[test]
@@ -204,6 +210,8 @@ fn result_ids_are_correct_for_measuring_multiple_qubits() {
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 3);
+    assert_eq!(program.num_results, 3);
 }
 
 #[test]
@@ -279,6 +287,8 @@ fn comparing_measurement_results_for_equality_adds_read_result_and_comparison_in
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 2);
+    assert_eq!(program.num_results, 2);
 }
 
 #[test]
@@ -354,6 +364,8 @@ fn comparing_measurement_results_for_inequality_adds_read_result_and_comparison_
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 2);
+    assert_eq!(program.num_results, 2);
 }
 
 #[test]
@@ -410,6 +422,8 @@ fn comparing_measurement_result_against_result_literal_for_equality_adds_read_re
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 1);
+    assert_eq!(program.num_results, 1);
 }
 
 #[test]
@@ -466,4 +480,6 @@ fn comparing_measurement_result_against_result_literal_for_inequality_adds_read_
             Instruction::Return,
         ],
     );
+    assert_eq!(program.num_qubits, 1);
+    assert_eq!(program.num_results, 1);
 }

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -350,7 +350,7 @@ def test_adaptive_qir_can_be_generated() -> None:
 
         declare void @__quantum__qis__rz__body(double, %Qubit*)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="0" }
         attributes #1 = { "irreversible" }
 
         ; module flags


### PR DESCRIPTION
This change updates the program generated by partial eval to set the qubit and result counts to non-zero values. This allows later passes to read and possibly update these values so they are correct for QIR codegen.