### PR TITLE
Partial Evaluation Output Recording support

### DIFF
--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -783,7 +783,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::ForwardBranching,
+                TargetCapabilityFlags::Adaptive,
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -729,7 +729,7 @@ mod given_interpreter {
                     open Microsoft.Quantum.Math;
                     open QIR.Intrinsic;
                     @EntryPoint()
-                    operation Main() : Unit {
+                    operation Main() : Result {
                         use q = Qubit();
                         let pi_over_2 = 4.0 / 2.0;
                         __quantum__qis__rz__body(pi_over_2, q);
@@ -737,6 +737,7 @@ mod given_interpreter {
                         __quantum__qis__rz__body(some_angle, q);
                         set some_angle = ArcCos(-1.0) / PI();
                         __quantum__qis__rz__body(some_angle, q);
+                        __quantum__qis__mresetz__body(q)
                     }
                 }"#
                 },
@@ -752,10 +753,16 @@ mod given_interpreter {
                   call void @__quantum__qis__rz__body(double 2.0, %Qubit* inttoptr (i64 0 to %Qubit*))
                   call void @__quantum__qis__rz__body(double 0.0, %Qubit* inttoptr (i64 0 to %Qubit*))
                   call void @__quantum__qis__rz__body(double 1.0, %Qubit* inttoptr (i64 0 to %Qubit*))
+                  call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+                  call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
 
                 declare void @__quantum__qis__rz__body(double, %Qubit*)
+
+                declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
+
+                declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
                 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
                 attributes #1 = { "irreversible" }

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -834,7 +834,7 @@ mod given_interpreter {
 
                 declare void @__quantum__rt__bool_record_output(i1, i8*)
 
-                attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
+                attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
                 attributes #1 = { "irreversible" }
 
                 ; module flags

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -3,7 +3,6 @@
 
 #![allow(clippy::needless_raw_string_hashes)]
 
-use core::panic;
 use std::rc::Rc;
 
 use crate::{
@@ -173,7 +172,7 @@ fn check_partial_eval_stmt(
             &mut GenericReceiver::new(&mut out),
         ) {
             Ok(_) => {}
-            Err(err) => panic!("Unexpected error: {:?}", err),
+            Err(err) => panic!("Unexpected error: {err:?}"),
         }
     }
 

--- a/compiler/qsc_partial_eval/src/evaluation_context.rs
+++ b/compiler/qsc_partial_eval/src/evaluation_context.rs
@@ -94,8 +94,7 @@ impl Scope {
         }
     }
 
-    // Maybe this can be removed in favor of a single value getter, which would also eliminate the need
-    // for `hybrid_exprs` entirely?
+    // Potential candidate for removal if only the last expression value is needed.
     pub fn _get_expr_value(&self, expr_id: ExprId) -> &Value {
         self.hybrid_exprs
             .get(&expr_id)

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -4,7 +4,6 @@
 mod evaluation_context;
 mod management;
 
-use core::panic;
 use evaluation_context::{BlockNode, EvaluationContext, Scope};
 use management::{QuantumIntrinsicsChecker, ResourceManager};
 use miette::Diagnostic;

--- a/compiler/qsc_partial_eval/tests/branching.rs
+++ b/compiler/qsc_partial_eval/tests/branching.rs
@@ -1,58 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes, clippy::similar_names)]
+#![allow(
+    clippy::needless_raw_string_hashes,
+    clippy::similar_names,
+    clippy::too_many_lines
+)]
 
 pub mod test_utils;
 
+use expect_test::expect;
 use indoc::indoc;
-use qsc_rir::rir::{
-    BlockId, Callable, CallableId, CallableType, Instruction, Literal, Operand, Ty, Variable,
-};
+use qsc_rir::rir::{BlockId, CallableId};
 use test_utils::{
     assert_block_instructions, assert_block_last_instruction, assert_callable,
-    compile_and_partially_evaluate, mresetz_callable, read_result_callable,
+    compile_and_partially_evaluate,
 };
-
-fn single_qubit_intrinsic_op_a() -> Callable {
-    Callable {
-        name: "opA".to_string(),
-        input_type: vec![Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
-
-fn single_qubit_intrinsic_op_b() -> Callable {
-    Callable {
-        name: "opB".to_string(),
-        input_type: vec![Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
-
-fn single_qubit_intrinsic_op_c() -> Callable {
-    Callable {
-        name: "opC".to_string(),
-        input_type: vec![Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
-
-fn single_qubit_intrinsic_op_d() -> Callable {
-    Callable {
-        name: "opD".to_string(),
-        input_type: vec![Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
 
 #[test]
 fn if_expression_with_true_condition() {
@@ -71,18 +34,26 @@ fn if_expression_with_true_condition() {
         "#,
     });
     let op_a_callable_id = CallableId(1);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -102,10 +73,14 @@ fn if_expression_with_false_condition() {
         }
         "#,
     });
-    // This program is expected to just have the entry-point callable, whose block only has a return
-    // intruction.
-    assert_eq!(program.callables.iter().count(), 1);
-    assert_block_instructions(&program, BlockId(0), &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+        Block:
+            Call id(1), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[test]
@@ -128,18 +103,26 @@ fn if_else_expression_with_true_condition() {
         "#,
     });
     let op_a_callable_id = CallableId(1);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -163,18 +146,26 @@ fn if_else_expression_with_false_condition() {
         "#,
     });
     let op_b_callable_id = CallableId(1);
-    assert_callable(&program, op_b_callable_id, &single_qubit_intrinsic_op_b());
+    assert_callable(
+        &program,
+        op_b_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opB
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_b_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -201,18 +192,26 @@ fn if_elif_else_expression_with_true_elif_condition() {
         "#,
     });
     let op_b_callable_id = CallableId(1);
-    assert_callable(&program, op_b_callable_id, &single_qubit_intrinsic_op_b());
+    assert_callable(
+        &program,
+        op_b_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opB
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_b_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -236,11 +235,45 @@ fn if_expression_with_dynamic_condition() {
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -248,29 +281,31 @@ fn if_expression_with_dynamic_condition() {
     let if_block_id = BlockId(2);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, continuation_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 1"],
+    );
 
     // Verify the instructions in the if-block.
     assert_block_instructions(
         &program,
         if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
-    assert_block_instructions(&program, continuation_block_id, &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        continuation_block_id,
+        &expect![[r#"
+        Block:
+            Call id(4), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[test]
@@ -296,13 +331,58 @@ fn if_else_expression_with_dynamic_condition() {
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_b_callable_id = CallableId(4);
-    assert_callable(&program, op_b_callable_id, &single_qubit_intrinsic_op_b());
+    assert_callable(
+        &program,
+        op_b_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opB
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -311,43 +391,41 @@ fn if_else_expression_with_dynamic_condition() {
     let else_block_id = BlockId(3);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, else_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 3"],
+    );
 
     // Verify the instructions in the if-block.
     assert_block_instructions(
         &program,
         if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the else-block.
     assert_block_instructions(
         &program,
         else_block_id,
-        &[
-            Instruction::Call(
-                op_b_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(4), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
-    assert_block_instructions(&program, continuation_block_id, &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        continuation_block_id,
+        &expect![[r#"
+        Block:
+            Call id(5), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[test]
@@ -377,89 +455,133 @@ fn if_elif_else_expression_with_dynamic_condition() {
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_b_callable_id = CallableId(4);
-    assert_callable(&program, op_b_callable_id, &single_qubit_intrinsic_op_b());
+    assert_callable(
+        &program,
+        op_b_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opB
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_c_callable_id = CallableId(5);
-    assert_callable(&program, op_c_callable_id, &single_qubit_intrinsic_op_c());
+    assert_callable(
+        &program,
+        op_c_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opC
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
     let continuation_block_id = BlockId(1);
     let if_block_id = BlockId(2);
     let else_block_id = BlockId(3);
-    let nested_continuation_block_id = BlockId(4);
     let nested_if_block_id = BlockId(5);
     let nested_else_block_id = BlockId(6);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, else_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 3"],
+    );
 
     // Verify the instructions in the if-block.
     assert_block_instructions(
         &program,
         if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(2))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(2), )
+            Jump(1)"#]],
     );
 
     // Verify the branch instruction in the else-block.
-    let nested_condition_var = Variable {
-        variable_id: 3.into(),
-        ty: Ty::Boolean,
-    };
-    let nested_branch_inst = Instruction::Branch(
-        nested_condition_var,
-        nested_if_block_id,
-        nested_else_block_id,
+    assert_block_last_instruction(
+        &program,
+        else_block_id,
+        &expect!["Branch Variable(3, Boolean), 5, 6"],
     );
-    assert_block_last_instruction(&program, else_block_id, &nested_branch_inst);
 
     // Verify the instructions in the nested-if-block.
     assert_block_instructions(
         &program,
         nested_if_block_id,
-        &[
-            Instruction::Call(
-                op_b_callable_id,
-                vec![Operand::Literal(Literal::Qubit(2))],
-                None,
-            ),
-            Instruction::Jump(nested_continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(4), args( Qubit(2), )
+            Jump(4)"#]],
     );
 
     // Verify the instructions in the nested-else-block.
     assert_block_instructions(
         &program,
         nested_else_block_id,
-        &[
-            Instruction::Call(
-                op_c_callable_id,
-                vec![Operand::Literal(Literal::Qubit(2))],
-                None,
-            ),
-            Instruction::Jump(nested_continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(5), args( Qubit(2), )
+            Jump(4)"#]],
     );
 
     // Verify the instructions in the continuation-block.
-    assert_block_instructions(&program, continuation_block_id, &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        continuation_block_id,
+        &expect![[r#"
+        Block:
+            Call id(6), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[test]
@@ -484,11 +606,45 @@ fn if_expression_with_dynamic_condition_and_nested_if_expression_with_true_condi
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -496,29 +652,31 @@ fn if_expression_with_dynamic_condition_and_nested_if_expression_with_true_condi
     let if_block_id = BlockId(2);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, continuation_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 1"],
+    );
 
     // Verify the instructions in the if-block.
     assert_block_instructions(
         &program,
         if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
-    assert_block_instructions(&program, continuation_block_id, &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        continuation_block_id,
+        &expect![[r#"
+        Block:
+            Call id(4), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[test]
@@ -543,9 +701,32 @@ fn if_expression_with_dynamic_condition_and_nested_if_expression_with_false_cond
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -553,22 +734,30 @@ fn if_expression_with_dynamic_condition_and_nested_if_expression_with_false_cond
     let if_block_id = BlockId(2);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, continuation_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 1"],
+    );
 
     // Verify the instructions in the if-block.
     assert_block_instructions(
         &program,
         if_block_id,
-        &[Instruction::Jump(continuation_block_id)],
+        &expect![[r#"
+        Block:
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
-    assert_block_instructions(&program, continuation_block_id, &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        continuation_block_id,
+        &expect![[r#"
+        Block:
+            Call id(3), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[test]
@@ -596,13 +785,58 @@ fn if_else_expression_with_dynamic_condition_and_nested_if_expression_with_true_
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_b_callable_id = CallableId(4);
-    assert_callable(&program, op_b_callable_id, &single_qubit_intrinsic_op_b());
+    assert_callable(
+        &program,
+        op_b_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opB
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -611,43 +845,41 @@ fn if_else_expression_with_dynamic_condition_and_nested_if_expression_with_true_
     let else_block_id = BlockId(3);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, else_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 3"],
+    );
 
     // Verify the instructions in the if-block.
     assert_block_instructions(
         &program,
         if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the else-block.
     assert_block_instructions(
         &program,
         else_block_id,
-        &[
-            Instruction::Call(
-                op_b_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(4), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
-    assert_block_instructions(&program, continuation_block_id, &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        continuation_block_id,
+        &expect![[r#"
+        Block:
+            Call id(5), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[test]
@@ -675,11 +907,45 @@ fn if_else_expression_with_dynamic_condition_and_nested_if_expression_with_false
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -688,36 +954,40 @@ fn if_else_expression_with_dynamic_condition_and_nested_if_expression_with_false
     let else_block_id = BlockId(3);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, else_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 3"],
+    );
 
     // Verify the instructions in the if-block.
     assert_block_instructions(
         &program,
         if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the else-block.
     assert_block_instructions(
         &program,
         else_block_id,
-        &[Instruction::Jump(continuation_block_id)],
+        &expect![[r#"
+        Block:
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
-    assert_block_instructions(&program, continuation_block_id, &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        continuation_block_id,
+        &expect![[r#"
+        Block:
+            Call id(4), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[test]
@@ -743,11 +1013,45 @@ fn if_expression_with_dynamic_condition_and_nested_if_expression_with_dynamic_co
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -757,48 +1061,47 @@ fn if_expression_with_dynamic_condition_and_nested_if_expression_with_dynamic_co
     let nested_if_block_id = BlockId(4);
 
     // Verify the branch instruction in the initial block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, continuation_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 1"],
+    );
 
     // Verify the branch instruction in the if-block.
-    let nested_condition_var = Variable {
-        variable_id: 3.into(),
-        ty: Ty::Boolean,
-    };
-    let nested_branch_inst = Instruction::Branch(
-        nested_condition_var,
-        nested_if_block_id,
-        nested_continuation_block_id,
+    assert_block_last_instruction(
+        &program,
+        if_block_id,
+        &expect!["Branch Variable(3, Boolean), 4, 3"],
     );
-    assert_block_last_instruction(&program, if_block_id, &nested_branch_inst);
 
     // Verify the instructions in the nested-if-block.
     assert_block_instructions(
         &program,
         nested_if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(2))],
-                None,
-            ),
-            Instruction::Jump(nested_continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(2), )
+            Jump(3)"#]],
     );
 
     // Verify the instructions in the nested-continuation-block.
     assert_block_instructions(
         &program,
         nested_continuation_block_id,
-        &[Instruction::Jump(continuation_block_id)],
+        &expect![[r#"
+        Block:
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
-    assert_block_instructions(&program, continuation_block_id, &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        continuation_block_id,
+        &expect![[r#"
+        Block:
+            Call id(4), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[allow(clippy::too_many_lines)]
@@ -836,17 +1139,84 @@ fn doubly_nested_if_else_expressions_with_dynamic_conditions() {
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_b_callable_id = CallableId(4);
-    assert_callable(&program, op_b_callable_id, &single_qubit_intrinsic_op_b());
+    assert_callable(
+        &program,
+        op_b_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opB
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_c_callable_id = CallableId(5);
-    assert_callable(&program, op_c_callable_id, &single_qubit_intrinsic_op_c());
+    assert_callable(
+        &program,
+        op_c_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opC
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_d_callable_id = CallableId(6);
-    assert_callable(&program, op_d_callable_id, &single_qubit_intrinsic_op_d());
+    assert_callable(
+        &program,
+        op_d_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opD
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -861,109 +1231,93 @@ fn doubly_nested_if_else_expressions_with_dynamic_conditions() {
     let second_nested_else_block_id = BlockId(9);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, else_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 6"],
+    );
 
     // Verify the branch instruction in the if-block.
-    let first_nested_condition_var = Variable {
-        variable_id: 3.into(),
-        ty: Ty::Boolean,
-    };
-    let first_nested_branch_inst = Instruction::Branch(
-        first_nested_condition_var,
-        first_nested_if_block_id,
-        first_nested_else_block_id,
+    assert_block_last_instruction(
+        &program,
+        if_block_id,
+        &expect!["Branch Variable(3, Boolean), 4, 5"],
     );
-    assert_block_last_instruction(&program, if_block_id, &first_nested_branch_inst);
 
     // Verify the instructions in the first nested if-block.
     assert_block_instructions(
         &program,
         first_nested_if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(2))],
-                None,
-            ),
-            Instruction::Jump(first_nested_continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(2), )
+            Jump(3)"#]],
     );
 
     // Verify the instructions in the first nested else-block.
     assert_block_instructions(
         &program,
         first_nested_else_block_id,
-        &[
-            Instruction::Call(
-                op_b_callable_id,
-                vec![Operand::Literal(Literal::Qubit(2))],
-                None,
-            ),
-            Instruction::Jump(first_nested_continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(4), args( Qubit(2), )
+            Jump(3)"#]],
     );
 
     // Verify the instructions in the first nested continuation-block.
     assert_block_instructions(
         &program,
         first_nested_continuation_block_id,
-        &[Instruction::Jump(continuation_block_id)],
+        &expect![[r#"
+        Block:
+            Jump(1)"#]],
     );
 
     // Verify the branch instruction in the else-block.
-    let second_nested_condition_var = Variable {
-        variable_id: 5.into(),
-        ty: Ty::Boolean,
-    };
-    let second_nested_branch_inst = Instruction::Branch(
-        second_nested_condition_var,
-        second_nested_if_block_id,
-        second_nested_else_block_id,
+    assert_block_last_instruction(
+        &program,
+        else_block_id,
+        &expect!["Branch Variable(5, Boolean), 8, 9"],
     );
-    assert_block_last_instruction(&program, else_block_id, &second_nested_branch_inst);
 
     // Verify the instructions in the second nested if-block.
     assert_block_instructions(
         &program,
         second_nested_if_block_id,
-        &[
-            Instruction::Call(
-                op_c_callable_id,
-                vec![Operand::Literal(Literal::Qubit(2))],
-                None,
-            ),
-            Instruction::Jump(second_nested_continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(5), args( Qubit(2), )
+            Jump(7)"#]],
     );
 
     // Verify the instructions in the second nested else-block.
     assert_block_instructions(
         &program,
         second_nested_else_block_id,
-        &[
-            Instruction::Call(
-                op_d_callable_id,
-                vec![Operand::Literal(Literal::Qubit(2))],
-                None,
-            ),
-            Instruction::Jump(second_nested_continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(6), args( Qubit(2), )
+            Jump(7)"#]],
     );
 
     // Verify the instructions in the second nested continuation-block.
     assert_block_instructions(
         &program,
         second_nested_continuation_block_id,
-        &[Instruction::Jump(continuation_block_id)],
+        &expect![[r#"
+        Block:
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
-    assert_block_instructions(&program, continuation_block_id, &[Instruction::Return]);
+    assert_block_instructions(
+        &program,
+        continuation_block_id,
+        &expect![[r#"
+        Block:
+            Call id(7), args( Integer(0), Pointer, )
+            Return"#]],
+    );
 }
 
 #[test]
@@ -988,13 +1342,58 @@ fn if_expression_with_dynamic_condition_and_subsequent_call_to_operation() {
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_b_callable_id = CallableId(4);
-    assert_callable(&program, op_b_callable_id, &single_qubit_intrinsic_op_b());
+    assert_callable(
+        &program,
+        op_b_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opB
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -1002,39 +1401,31 @@ fn if_expression_with_dynamic_condition_and_subsequent_call_to_operation() {
     let if_block_id = BlockId(2);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, continuation_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 1"],
+    );
 
     // Verify the instructions in the if-block.
     assert_block_instructions(
         &program,
         if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
     assert_block_instructions(
         &program,
         continuation_block_id,
-        &[
-            Instruction::Call(
-                op_b_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(4), args( Qubit(0), )
+            Call id(5), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -1063,15 +1454,71 @@ fn if_else_expression_with_dynamic_condition_and_subsequent_call_to_operation() 
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &mresetz_callable());
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &read_result_callable());
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let op_a_callable_id = CallableId(3);
-    assert_callable(&program, op_a_callable_id, &single_qubit_intrinsic_op_a());
+    assert_callable(
+        &program,
+        op_a_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opA
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_b_callable_id = CallableId(4);
-    assert_callable(&program, op_b_callable_id, &single_qubit_intrinsic_op_b());
+    assert_callable(
+        &program,
+        op_b_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opB
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let op_c_callable_id = CallableId(5);
-    assert_callable(&program, op_c_callable_id, &single_qubit_intrinsic_op_c());
+    assert_callable(
+        &program,
+        op_c_callable_id,
+        &expect![[r#"
+        Callable:
+            name: opC
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
 
     // Set the IDs of the blocks we want to verify.
     let initial_block_id = BlockId(0);
@@ -1080,52 +1527,40 @@ fn if_else_expression_with_dynamic_condition_and_subsequent_call_to_operation() 
     let else_block_id = BlockId(3);
 
     // Verify the branch instruction in the initial-block.
-    let condition_var = Variable {
-        variable_id: 1.into(),
-        ty: Ty::Boolean,
-    };
-    let branch_inst = Instruction::Branch(condition_var, if_block_id, else_block_id);
-    assert_block_last_instruction(&program, initial_block_id, &branch_inst);
+    assert_block_last_instruction(
+        &program,
+        initial_block_id,
+        &expect!["Branch Variable(1, Boolean), 2, 3"],
+    );
 
     // Verify the instructions in the if-block.
     assert_block_instructions(
         &program,
         if_block_id,
-        &[
-            Instruction::Call(
-                op_a_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(3), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the else-block.
     assert_block_instructions(
         &program,
         else_block_id,
-        &[
-            Instruction::Call(
-                op_b_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Jump(continuation_block_id),
-        ],
+        &expect![[r#"
+        Block:
+            Call id(4), args( Qubit(0), )
+            Jump(1)"#]],
     );
 
     // Verify the instructions in the continuation-block.
     assert_block_instructions(
         &program,
         continuation_block_id,
-        &[
-            Instruction::Call(
-                op_c_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(5), args( Qubit(0), )
+            Call id(6), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/classical_args.rs
+++ b/compiler/qsc_partial_eval/tests/classical_args.rs
@@ -38,10 +38,10 @@ fn call_to_intrinsic_operation_using_double_literal() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Double(1), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Double(1), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -76,12 +76,12 @@ fn calls_to_intrinsic_operation_using_inline_expressions() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Double(0), )
-            Call id(1), args( Double(1), )
-            Call id(1), args( Double(1), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Double(0), )
+                Call id(1), args( Double(1), )
+                Call id(1), args( Double(1), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -119,11 +119,11 @@ fn calls_to_intrinsic_operation_using_variables() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Double(2), )
-            Call id(1), args( Double(4), )
-            Call id(1), args( Double(8), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Double(2), )
+                Call id(1), args( Double(4), )
+                Call id(1), args( Double(8), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/classical_args.rs
+++ b/compiler/qsc_partial_eval/tests/classical_args.rs
@@ -5,21 +5,10 @@
 
 pub mod test_utils;
 
+use expect_test::expect;
 use indoc::indoc;
-use qsc_rir::rir::{
-    BlockId, Callable, CallableId, CallableType, Instruction, Literal, Operand, Ty,
-};
+use qsc_rir::rir::{BlockId, CallableId};
 use test_utils::{assert_block_instructions, assert_callable, compile_and_partially_evaluate};
-
-fn double_to_unit_intrinsic_op() -> Callable {
-    Callable {
-        name: "op".to_string(),
-        input_type: vec![Ty::Double],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
 
 #[test]
 fn call_to_intrinsic_operation_using_double_literal() {
@@ -33,18 +22,26 @@ fn call_to_intrinsic_operation_using_double_literal() {
         }
     "#});
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &double_to_unit_intrinsic_op());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: op
+            call_type: Regular
+            input_type:
+                [0]: Double
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Double(1.0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Double(1), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -63,28 +60,28 @@ fn calls_to_intrinsic_operation_using_inline_expressions() {
         }
     "#});
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &double_to_unit_intrinsic_op());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: op
+            call_type: Regular
+            input_type:
+                [0]: Double
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Double(0.0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Double(1.0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Double(1.0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Double(0), )
+            Call id(1), args( Double(1), )
+            Call id(1), args( Double(1), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -106,27 +103,27 @@ fn calls_to_intrinsic_operation_using_variables() {
         }
     "#});
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &double_to_unit_intrinsic_op());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: op
+            call_type: Regular
+            input_type:
+                [0]: Double
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Double(2.0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Double(4.0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Double(8.0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Double(2), )
+            Call id(1), args( Double(4), )
+            Call id(1), args( Double(8), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/dynamic_vars.rs
+++ b/compiler/qsc_partial_eval/tests/dynamic_vars.rs
@@ -57,7 +57,9 @@ fn dynamic_int_from_if_expression_with_single_measurement_comparison_and_classic
             body: <NONE>"#]],
     );
 
-    assert_blocks(&program, &expect![[r#"
+    assert_blocks(
+        &program,
+        &expect![[r#"
         Blocks:
         Block 0:Block:
             Call id(1), args( Qubit(0), Result(0), )
@@ -72,7 +74,8 @@ fn dynamic_int_from_if_expression_with_single_measurement_comparison_and_classic
             Jump(1)
         Block 3:Block:
             Variable(2, Integer) = Store Integer(1)
-            Jump(1)"#]]);
+            Jump(1)"#]],
+    );
 }
 
 #[test]

--- a/compiler/qsc_partial_eval/tests/intrinsics.rs
+++ b/compiler/qsc_partial_eval/tests/intrinsics.rs
@@ -5,14 +5,15 @@
 
 pub mod test_utils;
 
+use expect_test::{expect, Expect};
 use indoc::{formatdoc, indoc};
-use qsc_rir::rir::{
-    BlockId, Callable, CallableId, CallableType, Instruction, Literal, Operand, Ty,
-};
+use qsc_rir::rir::{BlockId, CallableId};
 use test_utils::{assert_block_instructions, assert_callable, compile_and_partially_evaluate};
 
 fn check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction(
     intrinsic_name: &str,
+    expected_callable: &Expect,
+    expected_block: &Expect,
 ) {
     let program = compile_and_partially_evaluate(
         formatdoc! {
@@ -30,27 +31,14 @@ fn check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction
         .as_str(),
     );
     let op_callable_id = CallableId(1);
-    assert_callable(
-        &program,
-        op_callable_id,
-        &single_qubit_intrinsic_op(intrinsic_name),
-    );
-    assert_block_instructions(
-        &program,
-        BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
-    );
+    assert_callable(&program, op_callable_id, expected_callable);
+    assert_block_instructions(&program, BlockId(0), expected_block);
 }
 
 fn check_call_to_single_qubit_rotation_instrinsic_adds_callable_and_generates_instruction(
     intrinsic_name: &str,
+    expected_callable: &Expect,
+    expected_block: &Expect,
 ) {
     let program = compile_and_partially_evaluate(
         formatdoc! {
@@ -68,30 +56,14 @@ fn check_call_to_single_qubit_rotation_instrinsic_adds_callable_and_generates_in
         .as_str(),
     );
     let op_callable_id = CallableId(1);
-    assert_callable(
-        &program,
-        op_callable_id,
-        &single_qubit_rotation_intrinsic_op(intrinsic_name),
-    );
-    assert_block_instructions(
-        &program,
-        BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(0.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
-    );
+    assert_callable(&program, op_callable_id, expected_callable);
+    assert_block_instructions(&program, BlockId(0), expected_block);
 }
 
 fn check_call_to_two_qubits_rotation_instrinsic_adds_callable_and_generates_instruction(
     intrinsic_name: &str,
+    expected_callable: &Expect,
+    expected_block: &Expect,
 ) {
     let program = compile_and_partially_evaluate(
         formatdoc! {
@@ -109,31 +81,14 @@ fn check_call_to_two_qubits_rotation_instrinsic_adds_callable_and_generates_inst
         .as_str(),
     );
     let op_callable_id = CallableId(1);
-    assert_callable(
-        &program,
-        op_callable_id,
-        &two_qubits_rotation_intrinsic_op(intrinsic_name),
-    );
-    assert_block_instructions(
-        &program,
-        BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(0.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Qubit(1)),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
-    );
+    assert_callable(&program, op_callable_id, expected_callable);
+    assert_block_instructions(&program, BlockId(0), expected_block);
 }
 
 fn check_call_to_two_qubits_instrinsic_adds_callable_and_generates_instruction(
     intrinsic_name: &str,
+    expected_callable: &Expect,
+    expected_block: &Expect,
 ) {
     let program = compile_and_partially_evaluate(
         formatdoc! {
@@ -151,30 +106,14 @@ fn check_call_to_two_qubits_instrinsic_adds_callable_and_generates_instruction(
         .as_str(),
     );
     let op_callable_id = CallableId(1);
-    assert_callable(
-        &program,
-        op_callable_id,
-        &two_qubits_intrinsic_op(intrinsic_name),
-    );
-    assert_block_instructions(
-        &program,
-        BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Qubit(1)),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
-    );
+    assert_callable(&program, op_callable_id, expected_callable);
+    assert_block_instructions(&program, BlockId(0), expected_block);
 }
 
 fn check_call_to_three_qubits_instrinsic_adds_callable_and_generates_instruction(
     intrinsic_name: &str,
+    expected_callable: &Expect,
+    expected_block: &Expect,
 ) {
     let program = compile_and_partially_evaluate(
         formatdoc! {
@@ -192,103 +131,27 @@ fn check_call_to_three_qubits_instrinsic_adds_callable_and_generates_instruction
         .as_str(),
     );
     let op_callable_id = CallableId(1);
-    assert_callable(
-        &program,
-        op_callable_id,
-        &three_qubits_intrinsic_op(intrinsic_name),
-    );
-    assert_block_instructions(
-        &program,
-        BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Qubit(1)),
-                    Operand::Literal(Literal::Qubit(2)),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
-    );
-}
-
-fn measurement_intrinsic_op(name: &str) -> Callable {
-    Callable {
-        name: name.to_string(),
-        input_type: vec![Ty::Qubit, Ty::Result],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Measurement,
-    }
-}
-
-fn reset_intrinsic_op() -> Callable {
-    Callable {
-        name: "__quantum__qis__reset__body".to_string(),
-        input_type: vec![Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Reset,
-    }
-}
-
-fn single_qubit_intrinsic_op(name: &str) -> Callable {
-    Callable {
-        name: name.to_string(),
-        input_type: vec![Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
-
-fn single_qubit_rotation_intrinsic_op(name: &str) -> Callable {
-    Callable {
-        name: name.to_string(),
-        input_type: vec![Ty::Double, Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
-
-fn two_qubits_intrinsic_op(name: &str) -> Callable {
-    Callable {
-        name: name.to_string(),
-        input_type: vec![Ty::Qubit, Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
-
-fn two_qubits_rotation_intrinsic_op(name: &str) -> Callable {
-    Callable {
-        name: name.to_string(),
-        input_type: vec![Ty::Double, Ty::Qubit, Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
-
-fn three_qubits_intrinsic_op(name: &str) -> Callable {
-    Callable {
-        name: name.to_string(),
-        input_type: vec![Ty::Qubit, Ty::Qubit, Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
+    assert_callable(&program, op_callable_id, expected_callable);
+    assert_block_instructions(&program, BlockId(0), expected_block);
 }
 
 #[test]
 fn call_to_intrinsic_h_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__h__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__h__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -296,6 +159,19 @@ fn call_to_intrinsic_h_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_s_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__s__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__s__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -303,6 +179,19 @@ fn call_to_intrinsic_s_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_adjoint_s_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__s__adj",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__s__adj
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -310,6 +199,19 @@ fn call_to_intrinsic_adjoint_s_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_t_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__t__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__t__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -317,6 +219,19 @@ fn call_to_intrinsic_t_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_adjoint_t_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__t__adj",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__t__adj
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -324,6 +239,19 @@ fn call_to_intrinsic_adjoint_t_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_x_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__x__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__x__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -331,6 +259,19 @@ fn call_to_intrinsic_x_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_y_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__y__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__y__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -338,6 +279,19 @@ fn call_to_intrinsic_y_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_z_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__z__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__z__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -345,6 +299,20 @@ fn call_to_intrinsic_z_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_swap_adds_callable_and_generates_instruction() {
     check_call_to_two_qubits_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__swap__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__swap__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                    [1]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Qubit(1), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -352,6 +320,20 @@ fn call_to_intrinsic_swap_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_cx_adds_callable_and_generates_instruction() {
     check_call_to_two_qubits_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__cx__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__cx__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                    [1]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Qubit(1), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -359,6 +341,20 @@ fn call_to_intrinsic_cx_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_cy_adds_callable_and_generates_instruction() {
     check_call_to_two_qubits_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__cy__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__cy__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                    [1]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Qubit(1), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -366,6 +362,20 @@ fn call_to_intrinsic_cy_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_cz_adds_callable_and_generates_instruction() {
     check_call_to_two_qubits_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__cz__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__cz__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                    [1]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Qubit(1), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -373,6 +383,21 @@ fn call_to_intrinsic_cz_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_ccx_adds_callable_and_generates_instruction() {
     check_call_to_three_qubits_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__ccx__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__ccx__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                    [1]: Qubit
+                    [2]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Qubit(1), Qubit(2), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -380,6 +405,20 @@ fn call_to_intrinsic_ccx_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_rx_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_rotation_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__rx__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__rx__body
+                call_type: Regular
+                input_type:
+                    [0]: Double
+                    [1]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Double(0), Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -387,6 +426,21 @@ fn call_to_intrinsic_rx_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_rxx_adds_callable_and_generates_instruction() {
     check_call_to_two_qubits_rotation_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__rxx__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__rxx__body
+                call_type: Regular
+                input_type:
+                    [0]: Double
+                    [1]: Qubit
+                    [2]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Double(0), Qubit(0), Qubit(1), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -394,6 +448,20 @@ fn call_to_intrinsic_rxx_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_ry_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_rotation_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__ry__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__ry__body
+                call_type: Regular
+                input_type:
+                    [0]: Double
+                    [1]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Double(0), Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -401,6 +469,21 @@ fn call_to_intrinsic_ry_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_ryy_adds_callable_and_generates_instruction() {
     check_call_to_two_qubits_rotation_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__ryy__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__ryy__body
+                call_type: Regular
+                input_type:
+                    [0]: Double
+                    [1]: Qubit
+                    [2]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Double(0), Qubit(0), Qubit(1), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -408,6 +491,20 @@ fn call_to_intrinsic_ryy_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_rz_adds_callable_and_generates_instruction() {
     check_call_to_single_qubit_rotation_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__rz__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__rz__body
+                call_type: Regular
+                input_type:
+                    [0]: Double
+                    [1]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Double(0), Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -415,6 +512,21 @@ fn call_to_intrinsic_rz_adds_callable_and_generates_instruction() {
 fn call_to_intrinsic_rzz_adds_callable_and_generates_instruction() {
     check_call_to_two_qubits_rotation_instrinsic_adds_callable_and_generates_instruction(
         "__quantum__qis__rzz__body",
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__rzz__body
+                call_type: Regular
+                input_type:
+                    [0]: Double
+                    [1]: Qubit
+                    [2]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+        &expect![[r#"
+            Block:
+                Call id(1), args( Double(0), Qubit(0), Qubit(1), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -432,18 +544,26 @@ fn check_partial_eval_for_call_to_reset() {
         "#,
     });
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &reset_intrinsic_op());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__reset__body
+            call_type: Reset
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -464,22 +584,24 @@ fn call_to_intrinsic_m_adds_callable_and_generates_instruction() {
     assert_callable(
         &program,
         op_callable_id,
-        &measurement_intrinsic_op("__quantum__qis__mz__body"),
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
     );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -500,21 +622,23 @@ fn call_to_intrinsic_mresetz_adds_callable_and_generates_instruction() {
     assert_callable(
         &program,
         op_callable_id,
-        &measurement_intrinsic_op("__quantum__qis__mresetz__body"),
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
     );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/intrinsics.rs
+++ b/compiler/qsc_partial_eval/tests/intrinsics.rs
@@ -560,10 +560,10 @@ fn check_partial_eval_for_call_to_reset() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -598,10 +598,10 @@ fn call_to_intrinsic_m_adds_callable_and_generates_instruction() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -636,9 +636,9 @@ fn call_to_intrinsic_mresetz_adds_callable_and_generates_instruction() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/loops.rs
+++ b/compiler/qsc_partial_eval/tests/loops.rs
@@ -5,31 +5,10 @@
 
 pub mod test_utils;
 
+use expect_test::expect;
 use indoc::indoc;
-use qsc_rir::rir::{
-    BlockId, Callable, CallableId, CallableType, Instruction, Literal, Operand, Ty,
-};
+use qsc_rir::rir::{BlockId, CallableId};
 use test_utils::{assert_block_instructions, assert_callable, compile_and_partially_evaluate};
-
-fn single_qubit_intrinsic() -> Callable {
-    Callable {
-        name: "op".to_string(),
-        input_type: vec![Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
-
-fn single_qubit_rotation_intrinsic() -> Callable {
-    Callable {
-        name: "rotation".to_string(),
-        input_type: vec![Ty::Double, Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
 
 #[test]
 fn unitary_call_within_a_for_loop() {
@@ -49,28 +28,28 @@ fn unitary_call_within_a_for_loop() {
     });
 
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &single_qubit_intrinsic());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: op
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -94,28 +73,28 @@ fn unitary_call_within_a_while_loop() {
     });
 
     let rotation_callable_id = CallableId(1);
-    assert_callable(&program, rotation_callable_id, &single_qubit_intrinsic());
+    assert_callable(
+        &program,
+        rotation_callable_id,
+        &expect![[r#"
+        Callable:
+            name: op
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                rotation_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                rotation_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                rotation_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -139,28 +118,28 @@ fn unitary_call_within_a_repeat_until_loop() {
     });
 
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &single_qubit_intrinsic());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: op
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -185,38 +164,26 @@ fn rotation_call_within_a_for_loop() {
     assert_callable(
         &program,
         rotation_callable_id,
-        &single_qubit_rotation_intrinsic(),
+        &expect![[r#"
+        Callable:
+            name: rotation
+            call_type: Regular
+            input_type:
+                [0]: Double
+                [1]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
     );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                rotation_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(0.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                rotation_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(1.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                rotation_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(2.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Double(0), Qubit(0), )
+            Call id(1), args( Double(1), Qubit(0), )
+            Call id(1), args( Double(2), Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -241,37 +208,29 @@ fn rotation_call_within_a_while_loop() {
     });
 
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &single_qubit_rotation_intrinsic());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: rotation
+            call_type: Regular
+            input_type:
+                [0]: Double
+                [1]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(0.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(1.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(2.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Double(0), Qubit(0), )
+            Call id(1), args( Double(1), Qubit(0), )
+            Call id(1), args( Double(2), Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -299,37 +258,25 @@ fn rotation_call_within_a_repeat_until_loop() {
     assert_callable(
         &program,
         rotation_callable_id,
-        &single_qubit_rotation_intrinsic(),
+        &expect![[r#"
+        Callable:
+            name: rotation
+            call_type: Regular
+            input_type:
+                [0]: Double
+                [1]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
     );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                rotation_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(0.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                rotation_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(1.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                rotation_callable_id,
-                vec![
-                    Operand::Literal(Literal::Double(2.0)),
-                    Operand::Literal(Literal::Qubit(0)),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Double(0), Qubit(0), )
+            Call id(1), args( Double(1), Qubit(0), )
+            Call id(1), args( Double(2), Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/loops.rs
+++ b/compiler/qsc_partial_eval/tests/loops.rs
@@ -44,12 +44,12 @@ fn unitary_call_within_a_for_loop() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -89,12 +89,12 @@ fn unitary_call_within_a_while_loop() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -134,12 +134,12 @@ fn unitary_call_within_a_repeat_until_loop() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -178,12 +178,12 @@ fn rotation_call_within_a_for_loop() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Double(0), Qubit(0), )
-            Call id(1), args( Double(1), Qubit(0), )
-            Call id(1), args( Double(2), Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Double(0), Qubit(0), )
+                Call id(1), args( Double(1), Qubit(0), )
+                Call id(1), args( Double(2), Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -225,12 +225,12 @@ fn rotation_call_within_a_while_loop() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Double(0), Qubit(0), )
-            Call id(1), args( Double(1), Qubit(0), )
-            Call id(1), args( Double(2), Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Double(0), Qubit(0), )
+                Call id(1), args( Double(1), Qubit(0), )
+                Call id(1), args( Double(2), Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -272,11 +272,11 @@ fn rotation_call_within_a_repeat_until_loop() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Double(0), Qubit(0), )
-            Call id(1), args( Double(1), Qubit(0), )
-            Call id(1), args( Double(2), Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Double(0), Qubit(0), )
+                Call id(1), args( Double(1), Qubit(0), )
+                Call id(1), args( Double(2), Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/misc.rs
+++ b/compiler/qsc_partial_eval/tests/misc.rs
@@ -46,12 +46,12 @@ fn unitary_call_within_an_if_with_classical_condition_within_a_for_loop() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -93,12 +93,12 @@ fn unitary_call_within_an_if_with_classical_condition_within_a_while_loop() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }
 
@@ -140,11 +140,11 @@ fn unitary_call_within_an_if_with_classical_condition_within_a_repeat_until_loop
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/misc.rs
+++ b/compiler/qsc_partial_eval/tests/misc.rs
@@ -5,21 +5,10 @@
 
 pub mod test_utils;
 
+use expect_test::expect;
 use indoc::indoc;
-use qsc_rir::rir::{
-    BlockId, Callable, CallableId, CallableType, Instruction, Literal, Operand, Ty,
-};
+use qsc_rir::rir::{BlockId, CallableId};
 use test_utils::{assert_block_instructions, assert_callable, compile_and_partially_evaluate};
-
-fn single_qubit_intrinsic_op() -> Callable {
-    Callable {
-        name: "op".to_string(),
-        input_type: vec![Ty::Qubit],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Regular,
-    }
-}
 
 #[test]
 fn unitary_call_within_an_if_with_classical_condition_within_a_for_loop() {
@@ -41,28 +30,28 @@ fn unitary_call_within_an_if_with_classical_condition_within_a_for_loop() {
     });
 
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &single_qubit_intrinsic_op());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: op
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -88,28 +77,28 @@ fn unitary_call_within_an_if_with_classical_condition_within_a_while_loop() {
     });
 
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &single_qubit_intrinsic_op());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: op
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -135,27 +124,27 @@ fn unitary_call_within_an_if_with_classical_condition_within_a_repeat_until_loop
     });
 
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &single_qubit_intrinsic_op());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: op
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(1), args( Qubit(0), )
+            Call id(2), args( Integer(0), Pointer, )
+            Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/output_recording.rs
+++ b/compiler/qsc_partial_eval/tests/output_recording.rs
@@ -366,3 +366,161 @@ fn output_recording_for_array_of_tuples() {
             num_results: 1"#]]
     .assert_eq(&program.to_string());
 }
+
+#[test]
+fn output_recording_for_literal_bool() {
+    let program = compile_and_partially_evaluate(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Bool {
+                true
+            }
+        }
+        "#,
+    });
+
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__rt__bool_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Boolean
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Bool(true), Pointer, )
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn output_recording_for_literal_int() {
+    let program = compile_and_partially_evaluate(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                42
+            }
+        }
+        "#,
+    });
+
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__rt__integer_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Integer(42), Pointer, )
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn output_recording_for_mix_of_literal_and_variable() {
+    let program = compile_and_partially_evaluate(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : (Result, Bool) {
+                use q = Qubit();
+                let r = QIR.Intrinsic.__quantum__qis__mresetz__body(q);
+                (r, true)
+            }
+        }
+        "#,
+    });
+
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__qis__mresetz__body
+                    call_type: Measurement
+                    input_type:
+                        [0]: Qubit
+                        [1]: Result
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 2: Callable:
+                    name: __quantum__rt__tuple_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 3: Callable:
+                    name: __quantum__rt__result_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Result
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 4: Callable:
+                    name: __quantum__rt__bool_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Boolean
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Qubit(0), Result(0), )
+                    Call id(2), args( Integer(2), Pointer, )
+                    Call id(3), args( Result(0), Pointer, )
+                    Call id(4), args( Bool(true), Pointer, )
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 1
+            num_results: 1"#]]
+    .assert_eq(&program.to_string());
+}

--- a/compiler/qsc_partial_eval/tests/output_recording.rs
+++ b/compiler/qsc_partial_eval/tests/output_recording.rs
@@ -85,8 +85,8 @@ fn output_recording_for_tuple_of_different_types() {
             config: Config:
                 remap_qubits_on_reuse: false
                 defer_measurements: false
-            num_qubits: 0
-            num_results: 0"#]]
+            num_qubits: 1
+            num_results: 1"#]]
     .assert_eq(&program.to_string());
 }
 
@@ -172,8 +172,8 @@ fn output_recording_for_nested_tuples() {
             config: Config:
                 remap_qubits_on_reuse: false
                 defer_measurements: false
-            num_qubits: 0
-            num_results: 0"#]]
+            num_qubits: 1
+            num_results: 1"#]]
     .assert_eq(&program.to_string());
 }
 
@@ -267,8 +267,8 @@ fn output_recording_for_tuple_of_arrays() {
             config: Config:
                 remap_qubits_on_reuse: false
                 defer_measurements: false
-            num_qubits: 0
-            num_results: 0"#]]
+            num_qubits: 1
+            num_results: 1"#]]
     .assert_eq(&program.to_string());
 }
 
@@ -362,7 +362,7 @@ fn output_recording_for_array_of_tuples() {
             config: Config:
                 remap_qubits_on_reuse: false
                 defer_measurements: false
-            num_qubits: 0
-            num_results: 0"#]]
+            num_qubits: 1
+            num_results: 1"#]]
     .assert_eq(&program.to_string());
 }

--- a/compiler/qsc_partial_eval/tests/output_recording.rs
+++ b/compiler/qsc_partial_eval/tests/output_recording.rs
@@ -1,0 +1,368 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(clippy::needless_raw_string_hashes)]
+
+use expect_test::expect;
+use indoc::indoc;
+use test_utils::compile_and_partially_evaluate;
+
+pub mod test_utils;
+
+#[test]
+fn output_recording_for_tuple_of_different_types() {
+    let program = compile_and_partially_evaluate(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : (Result, Bool) {
+                use q = Qubit();
+                let r = QIR.Intrinsic.__quantum__qis__mresetz__body(q);
+                (r, r == Zero)
+            }
+        }
+        "#,
+    });
+
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__qis__mresetz__body
+                    call_type: Measurement
+                    input_type:
+                        [0]: Qubit
+                        [1]: Result
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 2: Callable:
+                    name: __quantum__qis__read_result__body
+                    call_type: Readout
+                    input_type:
+                        [0]: Result
+                    output_type: Boolean
+                    body: <NONE>
+                Callable 3: Callable:
+                    name: __quantum__rt__tuple_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 4: Callable:
+                    name: __quantum__rt__result_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Result
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 5: Callable:
+                    name: __quantum__rt__bool_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Boolean
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Qubit(0), Result(0), )
+                    Variable(0, Boolean) = Call id(2), args( Result(0), )
+                    Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                    Call id(3), args( Integer(2), Pointer, )
+                    Call id(4), args( Result(0), Pointer, )
+                    Call id(5), args( Variable(1, Boolean), Pointer, )
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn output_recording_for_nested_tuples() {
+    let program = compile_and_partially_evaluate(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : (Result, (Bool, Result), (Bool,)) {
+                use q = Qubit();
+                let r = QIR.Intrinsic.__quantum__qis__mresetz__body(q);
+                (r, (r == Zero, r), (r == One,))
+            }
+        }
+        "#,
+    });
+
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__qis__mresetz__body
+                    call_type: Measurement
+                    input_type:
+                        [0]: Qubit
+                        [1]: Result
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 2: Callable:
+                    name: __quantum__qis__read_result__body
+                    call_type: Readout
+                    input_type:
+                        [0]: Result
+                    output_type: Boolean
+                    body: <NONE>
+                Callable 3: Callable:
+                    name: __quantum__rt__tuple_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 4: Callable:
+                    name: __quantum__rt__result_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Result
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 5: Callable:
+                    name: __quantum__rt__bool_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Boolean
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Qubit(0), Result(0), )
+                    Variable(0, Boolean) = Call id(2), args( Result(0), )
+                    Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                    Variable(2, Boolean) = Call id(2), args( Result(0), )
+                    Variable(3, Boolean) = Icmp Eq, Variable(2, Boolean), Bool(true)
+                    Call id(3), args( Integer(3), Pointer, )
+                    Call id(4), args( Result(0), Pointer, )
+                    Call id(3), args( Integer(2), Pointer, )
+                    Call id(5), args( Variable(1, Boolean), Pointer, )
+                    Call id(4), args( Result(0), Pointer, )
+                    Call id(3), args( Integer(1), Pointer, )
+                    Call id(5), args( Variable(3, Boolean), Pointer, )
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn output_recording_for_tuple_of_arrays() {
+    // This program would not actually pass RCA checks as it shows up as using a dynamically sized array.
+    // However, the output recording should still be correct if/when we support this kind of return in the future.
+    let program = compile_and_partially_evaluate(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : (Result, Bool[]) {
+                use q = Qubit();
+                let r = QIR.Intrinsic.__quantum__qis__mresetz__body(q);
+                (r, [r == Zero, r == One])
+            }
+        }
+        "#,
+    });
+
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__qis__mresetz__body
+                    call_type: Measurement
+                    input_type:
+                        [0]: Qubit
+                        [1]: Result
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 2: Callable:
+                    name: __quantum__qis__read_result__body
+                    call_type: Readout
+                    input_type:
+                        [0]: Result
+                    output_type: Boolean
+                    body: <NONE>
+                Callable 3: Callable:
+                    name: __quantum__rt__tuple_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 4: Callable:
+                    name: __quantum__rt__result_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Result
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 5: Callable:
+                    name: __quantum__rt__array_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 6: Callable:
+                    name: __quantum__rt__bool_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Boolean
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Qubit(0), Result(0), )
+                    Variable(0, Boolean) = Call id(2), args( Result(0), )
+                    Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                    Variable(2, Boolean) = Call id(2), args( Result(0), )
+                    Variable(3, Boolean) = Icmp Eq, Variable(2, Boolean), Bool(true)
+                    Call id(3), args( Integer(2), Pointer, )
+                    Call id(4), args( Result(0), Pointer, )
+                    Call id(5), args( Integer(2), Pointer, )
+                    Call id(6), args( Variable(1, Boolean), Pointer, )
+                    Call id(6), args( Variable(3, Boolean), Pointer, )
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}
+
+#[test]
+fn output_recording_for_array_of_tuples() {
+    let program = compile_and_partially_evaluate(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : (Result, Bool)[] {
+                use q = Qubit();
+                let r = QIR.Intrinsic.__quantum__qis__mresetz__body(q);
+                [(r, r == Zero), (r, r == One)]
+            }
+        }
+        "#,
+    });
+
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: __quantum__qis__mresetz__body
+                    call_type: Measurement
+                    input_type:
+                        [0]: Qubit
+                        [1]: Result
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 2: Callable:
+                    name: __quantum__qis__read_result__body
+                    call_type: Readout
+                    input_type:
+                        [0]: Result
+                    output_type: Boolean
+                    body: <NONE>
+                Callable 3: Callable:
+                    name: __quantum__rt__array_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 4: Callable:
+                    name: __quantum__rt__tuple_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 5: Callable:
+                    name: __quantum__rt__result_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Result
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 6: Callable:
+                    name: __quantum__rt__bool_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Boolean
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Qubit(0), Result(0), )
+                    Variable(0, Boolean) = Call id(2), args( Result(0), )
+                    Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                    Variable(2, Boolean) = Call id(2), args( Result(0), )
+                    Variable(3, Boolean) = Icmp Eq, Variable(2, Boolean), Bool(true)
+                    Call id(3), args( Integer(2), Pointer, )
+                    Call id(4), args( Integer(2), Pointer, )
+                    Call id(5), args( Result(0), Pointer, )
+                    Call id(6), args( Variable(1, Boolean), Pointer, )
+                    Call id(4), args( Integer(2), Pointer, )
+                    Call id(5), args( Result(0), Pointer, )
+                    Call id(6), args( Variable(3, Boolean), Pointer, )
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
+}

--- a/compiler/qsc_partial_eval/tests/qubits.rs
+++ b/compiler/qsc_partial_eval/tests/qubits.rs
@@ -104,12 +104,12 @@ fn qubit_ids_are_correct_for_allocate_use_release_multiple_qubits() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(1), )
-            Call id(1), args( Qubit(2), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(1), )
+                Call id(1), args( Qubit(2), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 3);
     assert_eq!(program.num_results, 0);
@@ -167,12 +167,12 @@ fn qubit_ids_are_correct_for_allocate_use_release_one_qubit_multiple_times() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(0), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(0), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 1);
     assert_eq!(program.num_results, 0);
@@ -236,14 +236,14 @@ fn qubit_ids_are_correct_for_allocate_use_release_multiple_qubits_interleaved() 
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), )
-            Call id(1), args( Qubit(1), )
-            Call id(1), args( Qubit(2), )
-            Call id(1), args( Qubit(2), )
-            Call id(1), args( Qubit(3), )
-            Call id(2), args( Integer(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(1), )
+                Call id(1), args( Qubit(2), )
+                Call id(1), args( Qubit(2), )
+                Call id(1), args( Qubit(3), )
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 4);
     assert_eq!(program.num_results, 0);

--- a/compiler/qsc_partial_eval/tests/qubits.rs
+++ b/compiler/qsc_partial_eval/tests/qubits.rs
@@ -5,9 +5,11 @@
 
 pub mod test_utils;
 
+use expect_test::expect;
 use indoc::indoc;
-use qsc_rir::rir::{
-    BlockId, Callable, CallableId, CallableType, Instruction, Literal, Operand, Ty,
+use qsc_rir::{
+    builder,
+    rir::{BlockId, Callable, CallableId, CallableType, Instruction, Literal, Operand, Ty},
 };
 use test_utils::{assert_block_instructions, assert_callable, compile_and_partially_evaluate};
 
@@ -36,20 +38,42 @@ fn qubit_ids_are_correct_for_allocate_use_release_one_qubit() {
         }
         "#,
     });
-    let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &single_qubit_intrinsic_op());
-    assert_block_instructions(
-        &program,
-        BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![Operand::Literal(Literal::Qubit(0))],
-                None,
-            ),
-            Instruction::Return,
-        ],
-    );
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: op
+                    call_type: Regular
+                    input_type:
+                        [0]: Qubit
+                    output_type: <VOID>
+                    body: <NONE>
+                Callable 2: Callable:
+                    name: __quantum__rt__tuple_record_output
+                    call_type: OutputRecording
+                    input_type:
+                        [0]: Integer
+                        [1]: Pointer
+                    output_type: <VOID>
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Call id(1), args( Qubit(0), )
+                    Call id(2), args( Integer(0), Pointer, )
+                    Return
+            config: Config:
+                remap_qubits_on_reuse: false
+                defer_measurements: false
+            num_qubits: 0
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
 }
 
 #[test]
@@ -75,6 +99,8 @@ fn qubit_ids_are_correct_for_allocate_use_release_multiple_qubits() {
     });
     let op_callable_id = CallableId(1);
     assert_callable(&program, op_callable_id, &single_qubit_intrinsic_op());
+    let tuple_callable_id = CallableId(2);
+    assert_callable(&program, tuple_callable_id, &builder::tuple_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -92,6 +118,14 @@ fn qubit_ids_are_correct_for_allocate_use_release_multiple_qubits() {
             Instruction::Call(
                 op_callable_id,
                 vec![Operand::Literal(Literal::Qubit(2))],
+                None,
+            ),
+            Instruction::Call(
+                tuple_callable_id,
+                vec![
+                    Operand::Literal(Literal::Integer(0)),
+                    Operand::Literal(Literal::Pointer),
+                ],
                 None,
             ),
             Instruction::Return,
@@ -122,6 +156,8 @@ fn qubit_ids_are_correct_for_allocate_use_release_one_qubit_multiple_times() {
     });
     let op_callable_id = CallableId(1);
     assert_callable(&program, op_callable_id, &single_qubit_intrinsic_op());
+    let tuple_callable_id = CallableId(2);
+    assert_callable(&program, tuple_callable_id, &builder::tuple_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -139,6 +175,14 @@ fn qubit_ids_are_correct_for_allocate_use_release_one_qubit_multiple_times() {
             Instruction::Call(
                 op_callable_id,
                 vec![Operand::Literal(Literal::Qubit(0))],
+                None,
+            ),
+            Instruction::Call(
+                tuple_callable_id,
+                vec![
+                    Operand::Literal(Literal::Integer(0)),
+                    Operand::Literal(Literal::Pointer),
+                ],
                 None,
             ),
             Instruction::Return,
@@ -175,6 +219,8 @@ fn qubit_ids_are_correct_for_allocate_use_release_multiple_qubits_interleaved() 
     });
     let op_callable_id = CallableId(1);
     assert_callable(&program, op_callable_id, &single_qubit_intrinsic_op());
+    let tuple_callable_id = CallableId(2);
+    assert_callable(&program, tuple_callable_id, &builder::tuple_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -202,6 +248,14 @@ fn qubit_ids_are_correct_for_allocate_use_release_multiple_qubits_interleaved() 
             Instruction::Call(
                 op_callable_id,
                 vec![Operand::Literal(Literal::Qubit(3))],
+                None,
+            ),
+            Instruction::Call(
+                tuple_callable_id,
+                vec![
+                    Operand::Literal(Literal::Integer(0)),
+                    Operand::Literal(Literal::Pointer),
+                ],
                 None,
             ),
             Instruction::Return,

--- a/compiler/qsc_partial_eval/tests/results.rs
+++ b/compiler/qsc_partial_eval/tests/results.rs
@@ -6,41 +6,13 @@
 pub mod test_utils;
 
 use indoc::indoc;
-use qsc_rir::rir::{
-    BlockId, Callable, CallableId, CallableType, ConditionCode, Instruction, Literal, Operand, Ty,
-    Variable, VariableId,
+use qsc_rir::{
+    builder,
+    rir::{
+        BlockId, CallableId, ConditionCode, Instruction, Literal, Operand, Ty, Variable, VariableId,
+    },
 };
 use test_utils::{assert_block_instructions, assert_callable, compile_and_partially_evaluate};
-
-fn m_intrinsic_op() -> Callable {
-    Callable {
-        name: "__quantum__qis__mz__body".to_string(),
-        input_type: vec![Ty::Qubit, Ty::Result],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Measurement,
-    }
-}
-
-fn mresetz_intrinsic_op() -> Callable {
-    Callable {
-        name: "__quantum__qis__mresetz__body".to_string(),
-        input_type: vec![Ty::Qubit, Ty::Result],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Measurement,
-    }
-}
-
-fn read_reasult_intrinsic_op() -> Callable {
-    Callable {
-        name: "__quantum__rt__read_result__body".to_string(),
-        input_type: vec![Ty::Result],
-        output_type: Some(Ty::Boolean),
-        body: None,
-        call_type: CallableType::Readout,
-    }
-}
 
 #[test]
 fn result_ids_are_correct_for_measuring_and_resetting_one_qubit() {
@@ -48,15 +20,17 @@ fn result_ids_are_correct_for_measuring_and_resetting_one_qubit() {
         r#"
         namespace Test {
             @EntryPoint()
-            operation Main() : Unit {
+            operation Main() : Result {
                 use q = Qubit();
-                QIR.Intrinsic.__quantum__qis__mresetz__body(q);
+                QIR.Intrinsic.__quantum__qis__mresetz__body(q)
             }
         }
         "#,
     });
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &mresetz_intrinsic_op());
+    let result_record_id = CallableId(2);
+    assert_callable(&program, op_callable_id, &builder::mresetz_decl());
+    assert_callable(&program, result_record_id, &builder::result_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -66,6 +40,14 @@ fn result_ids_are_correct_for_measuring_and_resetting_one_qubit() {
                 vec![
                     Operand::Literal(Literal::Qubit(0)),
                     Operand::Literal(Literal::Result(0)),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(0)),
+                    Operand::Literal(Literal::Pointer),
                 ],
                 None,
             ),
@@ -80,15 +62,17 @@ fn result_ids_are_correct_for_measuring_one_qubit() {
         r#"
         namespace Test {
             @EntryPoint()
-            operation Main() : Unit {
+            operation Main() : Result {
                 use q = Qubit();
-                QIR.Intrinsic.__quantum__qis__m__body(q);
+                QIR.Intrinsic.__quantum__qis__m__body(q)
             }
         }
         "#,
     });
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &m_intrinsic_op());
+    let result_record_id = CallableId(2);
+    assert_callable(&program, op_callable_id, &builder::mz_decl());
+    assert_callable(&program, result_record_id, &builder::result_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -98,6 +82,14 @@ fn result_ids_are_correct_for_measuring_one_qubit() {
                 vec![
                     Operand::Literal(Literal::Qubit(0)),
                     Operand::Literal(Literal::Result(0)),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(0)),
+                    Operand::Literal(Literal::Pointer),
                 ],
                 None,
             ),
@@ -112,17 +104,21 @@ fn result_ids_are_correct_for_measuring_one_qubit_multiple_times() {
         r#"
         namespace Test {
             @EntryPoint()
-            operation Main() : Unit {
+            operation Main() : (Result, Result, Result) {
                 use q = Qubit();
-                QIR.Intrinsic.__quantum__qis__m__body(q);
-                QIR.Intrinsic.__quantum__qis__m__body(q);
-                QIR.Intrinsic.__quantum__qis__m__body(q);
+                (QIR.Intrinsic.__quantum__qis__m__body(q),
+                QIR.Intrinsic.__quantum__qis__m__body(q),
+                QIR.Intrinsic.__quantum__qis__m__body(q))
             }
         }
         "#,
     });
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &m_intrinsic_op());
+    let tuple_record_id = CallableId(2);
+    let result_record_id = CallableId(3);
+    assert_callable(&program, op_callable_id, &builder::mz_decl());
+    assert_callable(&program, tuple_record_id, &builder::tuple_record_decl());
+    assert_callable(&program, result_record_id, &builder::result_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -151,6 +147,124 @@ fn result_ids_are_correct_for_measuring_one_qubit_multiple_times() {
                 ],
                 None,
             ),
+            Instruction::Call(
+                tuple_record_id,
+                vec![
+                    Operand::Literal(Literal::Integer(3)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(0)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(1)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(2)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Return,
+        ],
+    );
+}
+
+#[test]
+fn result_ids_are_correct_for_measuring_one_qubit_multiple_times_into_array() {
+    let program = compile_and_partially_evaluate(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use q = Qubit();
+                [QIR.Intrinsic.__quantum__qis__m__body(q),
+                QIR.Intrinsic.__quantum__qis__m__body(q),
+                QIR.Intrinsic.__quantum__qis__m__body(q)]
+            }
+        }
+        "#,
+    });
+    let op_callable_id = CallableId(1);
+    let array_record_id = CallableId(2);
+    let result_record_id = CallableId(3);
+    assert_callable(&program, op_callable_id, &builder::mz_decl());
+    assert_callable(&program, array_record_id, &builder::array_record_decl());
+    assert_callable(&program, result_record_id, &builder::result_record_decl());
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &[
+            Instruction::Call(
+                op_callable_id,
+                vec![
+                    Operand::Literal(Literal::Qubit(0)),
+                    Operand::Literal(Literal::Result(0)),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                op_callable_id,
+                vec![
+                    Operand::Literal(Literal::Qubit(0)),
+                    Operand::Literal(Literal::Result(1)),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                op_callable_id,
+                vec![
+                    Operand::Literal(Literal::Qubit(0)),
+                    Operand::Literal(Literal::Result(2)),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                array_record_id,
+                vec![
+                    Operand::Literal(Literal::Integer(3)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(0)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(1)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(2)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
             Instruction::Return,
         ],
     );
@@ -162,17 +276,21 @@ fn result_ids_are_correct_for_measuring_multiple_qubits() {
         r#"
         namespace Test {
             @EntryPoint()
-            operation Main() : Unit {
+            operation Main() : (Result, Result, Result) {
                 use (q0, q1, q2) = (Qubit(), Qubit(), Qubit());
-                QIR.Intrinsic.__quantum__qis__m__body(q0);
-                QIR.Intrinsic.__quantum__qis__m__body(q1);
-                QIR.Intrinsic.__quantum__qis__m__body(q2);
+                (QIR.Intrinsic.__quantum__qis__m__body(q0),
+                QIR.Intrinsic.__quantum__qis__m__body(q1),
+                QIR.Intrinsic.__quantum__qis__m__body(q2))
             }
         }
         "#,
     });
     let op_callable_id = CallableId(1);
-    assert_callable(&program, op_callable_id, &m_intrinsic_op());
+    let tuple_record_id = CallableId(2);
+    let result_record_id = CallableId(3);
+    assert_callable(&program, op_callable_id, &builder::mz_decl());
+    assert_callable(&program, tuple_record_id, &builder::tuple_record_decl());
+    assert_callable(&program, result_record_id, &builder::result_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -201,6 +319,38 @@ fn result_ids_are_correct_for_measuring_multiple_qubits() {
                 ],
                 None,
             ),
+            Instruction::Call(
+                tuple_record_id,
+                vec![
+                    Operand::Literal(Literal::Integer(3)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(0)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(1)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
+            Instruction::Call(
+                result_record_id,
+                vec![
+                    Operand::Literal(Literal::Result(2)),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
             Instruction::Return,
         ],
     );
@@ -212,19 +362,21 @@ fn comparing_measurement_results_for_equality_adds_read_result_and_comparison_in
         r#"
         namespace Test {
             @EntryPoint()
-            operation Main() : Unit {
+            operation Main() : Bool {
                 use (q0, q1) = (Qubit(), Qubit());
                 let r0 = QIR.Intrinsic.__quantum__qis__m__body(q0);
                 let r1 = QIR.Intrinsic.__quantum__qis__m__body(q1);
-                let b = r0 == r1;
+                r0 == r1
             }
         }
         "#,
     });
     let measurement_callable_id = CallableId(1);
-    assert_callable(&program, measurement_callable_id, &m_intrinsic_op());
+    assert_callable(&program, measurement_callable_id, &builder::mz_decl());
     let readout_callable_id = CallableId(2);
-    assert_callable(&program, readout_callable_id, &read_reasult_intrinsic_op());
+    assert_callable(&program, readout_callable_id, &builder::read_result_decl());
+    let bool_record_id = CallableId(3);
+    assert_callable(&program, bool_record_id, &builder::bool_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -276,6 +428,17 @@ fn comparing_measurement_results_for_equality_adds_read_result_and_comparison_in
                     ty: Ty::Boolean,
                 },
             ),
+            Instruction::Call(
+                bool_record_id,
+                vec![
+                    Operand::Variable(Variable {
+                        variable_id: VariableId(2),
+                        ty: Ty::Boolean,
+                    }),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
             Instruction::Return,
         ],
     );
@@ -287,19 +450,21 @@ fn comparing_measurement_results_for_inequality_adds_read_result_and_comparison_
         r#"
         namespace Test {
             @EntryPoint()
-            operation Main() : Unit {
+            operation Main() : Bool {
                 use (q0, q1) = (Qubit(), Qubit());
                 let r0 = QIR.Intrinsic.__quantum__qis__m__body(q0);
                 let r1 = QIR.Intrinsic.__quantum__qis__m__body(q1);
-                let b = r0 != r1;
+                r0 != r1
             }
         }
         "#,
     });
     let measurement_callable_id = CallableId(1);
-    assert_callable(&program, measurement_callable_id, &m_intrinsic_op());
+    assert_callable(&program, measurement_callable_id, &builder::mz_decl());
     let readout_callable_id = CallableId(2);
-    assert_callable(&program, readout_callable_id, &read_reasult_intrinsic_op());
+    assert_callable(&program, readout_callable_id, &builder::read_result_decl());
+    let bool_record_id = CallableId(3);
+    assert_callable(&program, bool_record_id, &builder::bool_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -351,6 +516,17 @@ fn comparing_measurement_results_for_inequality_adds_read_result_and_comparison_
                     ty: Ty::Boolean,
                 },
             ),
+            Instruction::Call(
+                bool_record_id,
+                vec![
+                    Operand::Variable(Variable {
+                        variable_id: VariableId(2),
+                        ty: Ty::Boolean,
+                    }),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
             Instruction::Return,
         ],
     );
@@ -363,18 +539,20 @@ fn comparing_measurement_result_against_result_literal_for_equality_adds_read_re
         r#"
         namespace Test {
             @EntryPoint()
-            operation Main() : Unit {
+            operation Main() : Bool {
                 use q = Qubit();
                 let r = QIR.Intrinsic.__quantum__qis__m__body(q);
-                let b = r == One;
+                r == One
             }
         }
         "#,
     });
     let measurement_callable_id = CallableId(1);
-    assert_callable(&program, measurement_callable_id, &m_intrinsic_op());
+    assert_callable(&program, measurement_callable_id, &builder::mz_decl());
     let readout_callable_id = CallableId(2);
-    assert_callable(&program, readout_callable_id, &read_reasult_intrinsic_op());
+    assert_callable(&program, readout_callable_id, &builder::read_result_decl());
+    let bool_record_id = CallableId(3);
+    assert_callable(&program, bool_record_id, &builder::bool_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -407,6 +585,17 @@ fn comparing_measurement_result_against_result_literal_for_equality_adds_read_re
                     ty: Ty::Boolean,
                 },
             ),
+            Instruction::Call(
+                bool_record_id,
+                vec![
+                    Operand::Variable(Variable {
+                        variable_id: VariableId(1),
+                        ty: Ty::Boolean,
+                    }),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
+            ),
             Instruction::Return,
         ],
     );
@@ -419,18 +608,20 @@ fn comparing_measurement_result_against_result_literal_for_inequality_adds_read_
         r#"
         namespace Test {
             @EntryPoint()
-            operation Main() : Unit {
+            operation Main() : Bool {
                 use q = Qubit();
                 let r = QIR.Intrinsic.__quantum__qis__m__body(q);
-                let b = r != Zero;
+                r != Zero
             }
         }
         "#,
     });
     let measurement_callable_id = CallableId(1);
-    assert_callable(&program, measurement_callable_id, &m_intrinsic_op());
+    assert_callable(&program, measurement_callable_id, &builder::mz_decl());
     let readout_callable_id = CallableId(2);
-    assert_callable(&program, readout_callable_id, &read_reasult_intrinsic_op());
+    assert_callable(&program, readout_callable_id, &builder::read_result_decl());
+    let bool_record_id = CallableId(3);
+    assert_callable(&program, bool_record_id, &builder::bool_record_decl());
     assert_block_instructions(
         &program,
         BlockId(0),
@@ -462,6 +653,17 @@ fn comparing_measurement_result_against_result_literal_for_inequality_adds_read_
                     variable_id: VariableId(1),
                     ty: Ty::Boolean,
                 },
+            ),
+            Instruction::Call(
+                bool_record_id,
+                vec![
+                    Operand::Variable(Variable {
+                        variable_id: VariableId(1),
+                        ty: Ty::Boolean,
+                    }),
+                    Operand::Literal(Literal::Pointer),
+                ],
+                None,
             ),
             Instruction::Return,
         ],

--- a/compiler/qsc_partial_eval/tests/results.rs
+++ b/compiler/qsc_partial_eval/tests/results.rs
@@ -55,10 +55,10 @@ fn result_ids_are_correct_for_measuring_and_resetting_one_qubit() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Call id(2), args( Result(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(2), args( Result(0), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 1);
     assert_eq!(program.num_results, 1);
@@ -109,10 +109,10 @@ fn result_ids_are_correct_for_measuring_one_qubit() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Call id(2), args( Result(0), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(2), args( Result(0), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 1);
     assert_eq!(program.num_results, 1);
@@ -179,15 +179,15 @@ fn result_ids_are_correct_for_measuring_one_qubit_multiple_times() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Call id(1), args( Qubit(0), Result(1), )
-            Call id(1), args( Qubit(0), Result(2), )
-            Call id(2), args( Integer(3), Pointer, )
-            Call id(3), args( Result(0), Pointer, )
-            Call id(3), args( Result(1), Pointer, )
-            Call id(3), args( Result(2), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(0), Result(1), )
+                Call id(1), args( Qubit(0), Result(2), )
+                Call id(2), args( Integer(3), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(1), Pointer, )
+                Call id(3), args( Result(2), Pointer, )
+                Return"#]],
     );
 }
 
@@ -252,15 +252,15 @@ fn result_ids_are_correct_for_measuring_one_qubit_multiple_times_into_array() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Call id(1), args( Qubit(0), Result(1), )
-            Call id(1), args( Qubit(0), Result(2), )
-            Call id(2), args( Integer(3), Pointer, )
-            Call id(3), args( Result(0), Pointer, )
-            Call id(3), args( Result(1), Pointer, )
-            Call id(3), args( Result(2), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(0), Result(1), )
+                Call id(1), args( Qubit(0), Result(2), )
+                Call id(2), args( Integer(3), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(1), Pointer, )
+                Call id(3), args( Result(2), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 1);
     assert_eq!(program.num_results, 3);
@@ -327,15 +327,15 @@ fn result_ids_are_correct_for_measuring_multiple_qubits() {
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Call id(1), args( Qubit(1), Result(1), )
-            Call id(1), args( Qubit(2), Result(2), )
-            Call id(2), args( Integer(3), Pointer, )
-            Call id(3), args( Result(0), Pointer, )
-            Call id(3), args( Result(1), Pointer, )
-            Call id(3), args( Result(2), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(2), args( Integer(3), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(1), Pointer, )
+                Call id(3), args( Result(2), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 3);
     assert_eq!(program.num_results, 3);
@@ -401,14 +401,14 @@ fn comparing_measurement_results_for_equality_adds_read_result_and_comparison_in
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Call id(1), args( Qubit(1), Result(1), )
-            Variable(0, Boolean) = Call id(2), args( Result(0), )
-            Variable(1, Boolean) = Call id(2), args( Result(1), )
-            Variable(2, Boolean) = Icmp Eq, Variable(0, Boolean), Variable(1, Boolean)
-            Call id(3), args( Variable(2, Boolean), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Call id(2), args( Result(1), )
+                Variable(2, Boolean) = Icmp Eq, Variable(0, Boolean), Variable(1, Boolean)
+                Call id(3), args( Variable(2, Boolean), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 2);
     assert_eq!(program.num_results, 2);
@@ -474,14 +474,14 @@ fn comparing_measurement_results_for_inequality_adds_read_result_and_comparison_
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Call id(1), args( Qubit(1), Result(1), )
-            Variable(0, Boolean) = Call id(2), args( Result(0), )
-            Variable(1, Boolean) = Call id(2), args( Result(1), )
-            Variable(2, Boolean) = Icmp Ne, Variable(0, Boolean), Variable(1, Boolean)
-            Call id(3), args( Variable(2, Boolean), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Call id(2), args( Result(1), )
+                Variable(2, Boolean) = Icmp Ne, Variable(0, Boolean), Variable(1, Boolean)
+                Call id(3), args( Variable(2, Boolean), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 2);
     assert_eq!(program.num_results, 2);
@@ -547,12 +547,12 @@ fn comparing_measurement_result_against_result_literal_for_equality_adds_read_re
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Variable(0, Boolean) = Call id(2), args( Result(0), )
-            Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(true)
-            Call id(3), args( Variable(1, Boolean), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(true)
+                Call id(3), args( Variable(1, Boolean), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 1);
     assert_eq!(program.num_results, 1);
@@ -618,12 +618,12 @@ fn comparing_measurement_result_against_result_literal_for_inequality_adds_read_
         &program,
         BlockId(0),
         &expect![[r#"
-        Block:
-            Call id(1), args( Qubit(0), Result(0), )
-            Variable(0, Boolean) = Call id(2), args( Result(0), )
-            Variable(1, Boolean) = Icmp Ne, Variable(0, Boolean), Bool(false)
-            Call id(3), args( Variable(1, Boolean), Pointer, )
-            Return"#]],
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Ne, Variable(0, Boolean), Bool(false)
+                Call id(3), args( Variable(1, Boolean), Pointer, )
+                Return"#]],
     );
     assert_eq!(program.num_qubits, 1);
     assert_eq!(program.num_results, 1);

--- a/compiler/qsc_partial_eval/tests/results.rs
+++ b/compiler/qsc_partial_eval/tests/results.rs
@@ -5,13 +5,9 @@
 
 pub mod test_utils;
 
+use expect_test::expect;
 use indoc::indoc;
-use qsc_rir::{
-    builder,
-    rir::{
-        BlockId, CallableId, ConditionCode, Instruction, Literal, Operand, Ty, Variable, VariableId,
-    },
-};
+use qsc_rir::rir::{BlockId, CallableId};
 use test_utils::{assert_block_instructions, assert_callable, compile_and_partially_evaluate};
 
 #[test]
@@ -29,30 +25,40 @@ fn result_ids_are_correct_for_measuring_and_resetting_one_qubit() {
     });
     let op_callable_id = CallableId(1);
     let result_record_id = CallableId(2);
-    assert_callable(&program, op_callable_id, &builder::mresetz_decl());
-    assert_callable(&program, result_record_id, &builder::result_record_decl());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    assert_callable(
+        &program,
+        result_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__result_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Result
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(0)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(2), args( Result(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -71,30 +77,40 @@ fn result_ids_are_correct_for_measuring_one_qubit() {
     });
     let op_callable_id = CallableId(1);
     let result_record_id = CallableId(2);
-    assert_callable(&program, op_callable_id, &builder::mz_decl());
-    assert_callable(&program, result_record_id, &builder::result_record_decl());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    assert_callable(
+        &program,
+        result_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__result_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Result
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(0)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(2), args( Result(0), Pointer, )
+            Return"#]],
     );
 }
 
@@ -116,71 +132,58 @@ fn result_ids_are_correct_for_measuring_one_qubit_multiple_times() {
     let op_callable_id = CallableId(1);
     let tuple_record_id = CallableId(2);
     let result_record_id = CallableId(3);
-    assert_callable(&program, op_callable_id, &builder::mz_decl());
-    assert_callable(&program, tuple_record_id, &builder::tuple_record_decl());
-    assert_callable(&program, result_record_id, &builder::result_record_decl());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    assert_callable(
+        &program,
+        tuple_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__tuple_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Integer
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    assert_callable(
+        &program,
+        result_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__result_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Result
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(1)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(2)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                tuple_record_id,
-                vec![
-                    Operand::Literal(Literal::Integer(3)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(0)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(1)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(2)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(1), args( Qubit(0), Result(1), )
+            Call id(1), args( Qubit(0), Result(2), )
+            Call id(2), args( Integer(3), Pointer, )
+            Call id(3), args( Result(0), Pointer, )
+            Call id(3), args( Result(1), Pointer, )
+            Call id(3), args( Result(2), Pointer, )
+            Return"#]],
     );
 }
 
@@ -202,71 +205,58 @@ fn result_ids_are_correct_for_measuring_one_qubit_multiple_times_into_array() {
     let op_callable_id = CallableId(1);
     let array_record_id = CallableId(2);
     let result_record_id = CallableId(3);
-    assert_callable(&program, op_callable_id, &builder::mz_decl());
-    assert_callable(&program, array_record_id, &builder::array_record_decl());
-    assert_callable(&program, result_record_id, &builder::result_record_decl());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    assert_callable(
+        &program,
+        array_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__array_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Integer
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    assert_callable(
+        &program,
+        result_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__result_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Result
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(1)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(2)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                array_record_id,
-                vec![
-                    Operand::Literal(Literal::Integer(3)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(0)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(1)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(2)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(1), args( Qubit(0), Result(1), )
+            Call id(1), args( Qubit(0), Result(2), )
+            Call id(2), args( Integer(3), Pointer, )
+            Call id(3), args( Result(0), Pointer, )
+            Call id(3), args( Result(1), Pointer, )
+            Call id(3), args( Result(2), Pointer, )
+            Return"#]],
     );
 }
 
@@ -288,71 +278,58 @@ fn result_ids_are_correct_for_measuring_multiple_qubits() {
     let op_callable_id = CallableId(1);
     let tuple_record_id = CallableId(2);
     let result_record_id = CallableId(3);
-    assert_callable(&program, op_callable_id, &builder::mz_decl());
-    assert_callable(&program, tuple_record_id, &builder::tuple_record_decl());
-    assert_callable(&program, result_record_id, &builder::result_record_decl());
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    assert_callable(
+        &program,
+        tuple_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__tuple_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Integer
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    assert_callable(
+        &program,
+        result_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__result_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Result
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(1)),
-                    Operand::Literal(Literal::Result(1)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                op_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(2)),
-                    Operand::Literal(Literal::Result(2)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                tuple_record_id,
-                vec![
-                    Operand::Literal(Literal::Integer(3)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(0)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(1)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                result_record_id,
-                vec![
-                    Operand::Literal(Literal::Result(2)),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(1), args( Qubit(1), Result(1), )
+            Call id(1), args( Qubit(2), Result(2), )
+            Call id(2), args( Integer(3), Pointer, )
+            Call id(3), args( Result(0), Pointer, )
+            Call id(3), args( Result(1), Pointer, )
+            Call id(3), args( Result(2), Pointer, )
+            Return"#]],
     );
 }
 
@@ -372,75 +349,58 @@ fn comparing_measurement_results_for_equality_adds_read_result_and_comparison_in
         "#,
     });
     let measurement_callable_id = CallableId(1);
-    assert_callable(&program, measurement_callable_id, &builder::mz_decl());
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let readout_callable_id = CallableId(2);
-    assert_callable(&program, readout_callable_id, &builder::read_result_decl());
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let bool_record_id = CallableId(3);
-    assert_callable(&program, bool_record_id, &builder::bool_record_decl());
+    assert_callable(
+        &program,
+        bool_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__bool_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Boolean
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &vec![
-            Instruction::Call(
-                measurement_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                measurement_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(1)),
-                    Operand::Literal(Literal::Result(1)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                readout_callable_id,
-                vec![Operand::Literal(Literal::Result(0))],
-                Some(Variable {
-                    variable_id: VariableId(0),
-                    ty: Ty::Boolean,
-                }),
-            ),
-            Instruction::Call(
-                readout_callable_id,
-                vec![Operand::Literal(Literal::Result(1))],
-                Some(Variable {
-                    variable_id: VariableId(1),
-                    ty: Ty::Boolean,
-                }),
-            ),
-            Instruction::Icmp(
-                ConditionCode::Eq,
-                Operand::Variable(Variable {
-                    variable_id: VariableId(0),
-                    ty: Ty::Boolean,
-                }),
-                Operand::Variable(Variable {
-                    variable_id: VariableId(1),
-                    ty: Ty::Boolean,
-                }),
-                Variable {
-                    variable_id: VariableId(2),
-                    ty: Ty::Boolean,
-                },
-            ),
-            Instruction::Call(
-                bool_record_id,
-                vec![
-                    Operand::Variable(Variable {
-                        variable_id: VariableId(2),
-                        ty: Ty::Boolean,
-                    }),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(1), args( Qubit(1), Result(1), )
+            Variable(0, Boolean) = Call id(2), args( Result(0), )
+            Variable(1, Boolean) = Call id(2), args( Result(1), )
+            Variable(2, Boolean) = Icmp Eq, Variable(0, Boolean), Variable(1, Boolean)
+            Call id(3), args( Variable(2, Boolean), Pointer, )
+            Return"#]],
     );
 }
 
@@ -460,75 +420,58 @@ fn comparing_measurement_results_for_inequality_adds_read_result_and_comparison_
         "#,
     });
     let measurement_callable_id = CallableId(1);
-    assert_callable(&program, measurement_callable_id, &builder::mz_decl());
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let readout_callable_id = CallableId(2);
-    assert_callable(&program, readout_callable_id, &builder::read_result_decl());
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let bool_record_id = CallableId(3);
-    assert_callable(&program, bool_record_id, &builder::bool_record_decl());
+    assert_callable(
+        &program,
+        bool_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__bool_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Boolean
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &vec![
-            Instruction::Call(
-                measurement_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                measurement_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(1)),
-                    Operand::Literal(Literal::Result(1)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                readout_callable_id,
-                vec![Operand::Literal(Literal::Result(0))],
-                Some(Variable {
-                    variable_id: VariableId(0),
-                    ty: Ty::Boolean,
-                }),
-            ),
-            Instruction::Call(
-                readout_callable_id,
-                vec![Operand::Literal(Literal::Result(1))],
-                Some(Variable {
-                    variable_id: VariableId(1),
-                    ty: Ty::Boolean,
-                }),
-            ),
-            Instruction::Icmp(
-                ConditionCode::Ne,
-                Operand::Variable(Variable {
-                    variable_id: VariableId(0),
-                    ty: Ty::Boolean,
-                }),
-                Operand::Variable(Variable {
-                    variable_id: VariableId(1),
-                    ty: Ty::Boolean,
-                }),
-                Variable {
-                    variable_id: VariableId(2),
-                    ty: Ty::Boolean,
-                },
-            ),
-            Instruction::Call(
-                bool_record_id,
-                vec![
-                    Operand::Variable(Variable {
-                        variable_id: VariableId(2),
-                        ty: Ty::Boolean,
-                    }),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(1), args( Qubit(1), Result(1), )
+            Variable(0, Boolean) = Call id(2), args( Result(0), )
+            Variable(1, Boolean) = Call id(2), args( Result(1), )
+            Variable(2, Boolean) = Icmp Ne, Variable(0, Boolean), Variable(1, Boolean)
+            Call id(3), args( Variable(2, Boolean), Pointer, )
+            Return"#]],
     );
 }
 
@@ -548,56 +491,56 @@ fn comparing_measurement_result_against_result_literal_for_equality_adds_read_re
         "#,
     });
     let measurement_callable_id = CallableId(1);
-    assert_callable(&program, measurement_callable_id, &builder::mz_decl());
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let readout_callable_id = CallableId(2);
-    assert_callable(&program, readout_callable_id, &builder::read_result_decl());
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let bool_record_id = CallableId(3);
-    assert_callable(&program, bool_record_id, &builder::bool_record_decl());
+    assert_callable(
+        &program,
+        bool_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__bool_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Boolean
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                measurement_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                readout_callable_id,
-                vec![Operand::Literal(Literal::Result(0))],
-                Some(Variable {
-                    variable_id: VariableId(0),
-                    ty: Ty::Boolean,
-                }),
-            ),
-            Instruction::Icmp(
-                ConditionCode::Eq,
-                Operand::Variable(Variable {
-                    variable_id: VariableId(0),
-                    ty: Ty::Boolean,
-                }),
-                Operand::Literal(Literal::Bool(true)),
-                Variable {
-                    variable_id: VariableId(1),
-                    ty: Ty::Boolean,
-                },
-            ),
-            Instruction::Call(
-                bool_record_id,
-                vec![
-                    Operand::Variable(Variable {
-                        variable_id: VariableId(1),
-                        ty: Ty::Boolean,
-                    }),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Variable(0, Boolean) = Call id(2), args( Result(0), )
+            Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(true)
+            Call id(3), args( Variable(1, Boolean), Pointer, )
+            Return"#]],
     );
 }
 
@@ -617,55 +560,55 @@ fn comparing_measurement_result_against_result_literal_for_inequality_adds_read_
         "#,
     });
     let measurement_callable_id = CallableId(1);
-    assert_callable(&program, measurement_callable_id, &builder::mz_decl());
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     let readout_callable_id = CallableId(2);
-    assert_callable(&program, readout_callable_id, &builder::read_result_decl());
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
     let bool_record_id = CallableId(3);
-    assert_callable(&program, bool_record_id, &builder::bool_record_decl());
+    assert_callable(
+        &program,
+        bool_record_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__bool_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Boolean
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
     assert_block_instructions(
         &program,
         BlockId(0),
-        &[
-            Instruction::Call(
-                measurement_callable_id,
-                vec![
-                    Operand::Literal(Literal::Qubit(0)),
-                    Operand::Literal(Literal::Result(0)),
-                ],
-                None,
-            ),
-            Instruction::Call(
-                readout_callable_id,
-                vec![Operand::Literal(Literal::Result(0))],
-                Some(Variable {
-                    variable_id: VariableId(0),
-                    ty: Ty::Boolean,
-                }),
-            ),
-            Instruction::Icmp(
-                ConditionCode::Ne,
-                Operand::Variable(Variable {
-                    variable_id: VariableId(0),
-                    ty: Ty::Boolean,
-                }),
-                Operand::Literal(Literal::Bool(false)),
-                Variable {
-                    variable_id: VariableId(1),
-                    ty: Ty::Boolean,
-                },
-            ),
-            Instruction::Call(
-                bool_record_id,
-                vec![
-                    Operand::Variable(Variable {
-                        variable_id: VariableId(1),
-                        ty: Ty::Boolean,
-                    }),
-                    Operand::Literal(Literal::Pointer),
-                ],
-                None,
-            ),
-            Instruction::Return,
-        ],
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Variable(0, Boolean) = Call id(2), args( Result(0), )
+            Variable(1, Boolean) = Icmp Ne, Variable(0, Boolean), Bool(false)
+            Call id(3), args( Variable(1, Boolean), Pointer, )
+            Return"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/test_utils.rs
+++ b/compiler/qsc_partial_eval/tests/test_utils.rs
@@ -11,15 +11,19 @@ use qsc_partial_eval::{partially_evaluate, ProgramEntry};
 use qsc_rca::{Analyzer, PackageStoreComputeProperties};
 use qsc_rir::rir::{BlockId, CallableId, Program};
 
-pub fn assert_block_last_instruction(program: &Program, block_id: BlockId, expected_inst: &Expect) {
-    let block = program.get_block(block_id);
-    let actual_inst = block.0.last().expect("block does not have instructions");
-    expected_inst.assert_eq(&actual_inst.to_string());
-}
-
 pub fn assert_block_instructions(program: &Program, block_id: BlockId, expected_insts: &Expect) {
     let block = program.get_block(block_id);
     expected_insts.assert_eq(&block.to_string());
+}
+
+pub fn assert_blocks(program: &Program, expected_blocks: &Expect) {
+    let all_blocks = program
+        .blocks
+        .iter()
+        .fold("Blocks:".to_string(), |acc, (id, block)| {
+            acc + &format!("\nBlock {}:", id.0) + &block.to_string()
+        });
+    expected_blocks.assert_eq(&all_blocks);
 }
 
 pub fn assert_callable(program: &Program, callable_id: CallableId, expected_callable: &Expect) {

--- a/compiler/qsc_partial_eval/tests/test_utils.rs
+++ b/compiler/qsc_partial_eval/tests/test_utils.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use expect_test::Expect;
 use qsc::{incremental::Compiler, PackageType};
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_fir::fir::PackageStore;
@@ -8,40 +9,22 @@ use qsc_frontend::compile::{PackageStore as HirPackageStore, RuntimeCapabilityFl
 use qsc_lowerer::{map_hir_package_to_fir, Lowerer};
 use qsc_partial_eval::{partially_evaluate, ProgramEntry};
 use qsc_rca::{Analyzer, PackageStoreComputeProperties};
-use qsc_rir::rir::{BlockId, Callable, CallableId, CallableType, Instruction, Program, Ty};
+use qsc_rir::rir::{BlockId, CallableId, Program};
 
-pub fn assert_block_last_instruction(
-    program: &Program,
-    block_id: BlockId,
-    expected_inst: &Instruction,
-) {
-    let block = program.blocks.get(block_id).expect("block does not exist");
+pub fn assert_block_last_instruction(program: &Program, block_id: BlockId, expected_inst: &Expect) {
+    let block = program.get_block(block_id);
     let actual_inst = block.0.last().expect("block does not have instructions");
-    assert_eq!(expected_inst, actual_inst);
+    expected_inst.assert_eq(&actual_inst.to_string());
 }
 
-pub fn assert_block_instructions(
-    program: &Program,
-    block_id: BlockId,
-    expected_insts: &[Instruction],
-) {
-    let block = program.blocks.get(block_id).expect("block does not exist");
-    assert_eq!(
-        block.0.len(),
-        expected_insts.len(),
-        "expected number of instructions is different than actual number of instructions"
-    );
-    for (expected_inst, actual_inst) in expected_insts.iter().zip(block.0.iter()) {
-        assert_eq!(expected_inst, actual_inst);
-    }
+pub fn assert_block_instructions(program: &Program, block_id: BlockId, expected_insts: &Expect) {
+    let block = program.get_block(block_id);
+    expected_insts.assert_eq(&block.to_string());
 }
 
-pub fn assert_callable(program: &Program, callable_id: CallableId, expected_callable: &Callable) {
-    let actual_callable = program
-        .callables
-        .get(callable_id)
-        .expect("callable does not exist ");
-    assert_eq!(expected_callable, actual_callable);
+pub fn assert_callable(program: &Program, callable_id: CallableId, expected_callable: &Expect) {
+    let actual_callable = program.get_callable(callable_id);
+    expected_callable.assert_eq(&actual_callable.to_string());
 }
 
 #[must_use]
@@ -55,28 +38,6 @@ pub fn compile_and_partially_evaluate(source: &str) -> Program {
     match maybe_program {
         Ok(program) => program,
         Err(error) => panic!("partial evaluation failed: {error:?}"),
-    }
-}
-
-#[must_use]
-pub fn mresetz_callable() -> Callable {
-    Callable {
-        name: "__quantum__qis__mresetz__body".to_string(),
-        input_type: vec![Ty::Qubit, Ty::Result],
-        output_type: None,
-        body: None,
-        call_type: CallableType::Measurement,
-    }
-}
-
-#[must_use]
-pub fn read_result_callable() -> Callable {
-    Callable {
-        name: "__quantum__rt__read_result__body".to_string(),
-        input_type: vec![Ty::Result],
-        output_type: Some(Ty::Boolean),
-        body: None,
-        call_type: CallableType::Readout,
     }
 }
 

--- a/compiler/qsc_passes/src/loop_unification.rs
+++ b/compiler/qsc_passes/src/loop_unification.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use core::panic;
 use std::mem::take;
 
 use qsc_data_structures::span::Span;

--- a/compiler/qsc_rir/src/builder.rs
+++ b/compiler/qsc_rir/src/builder.rs
@@ -117,9 +117,42 @@ pub fn result_record_decl() -> Callable {
 }
 
 #[must_use]
+pub fn int_record_decl() -> Callable {
+    Callable {
+        name: "__quantum__rt__integer_record_output".to_string(),
+        input_type: vec![Ty::Integer, Ty::Pointer],
+        output_type: None,
+        body: None,
+        call_type: CallableType::OutputRecording,
+    }
+}
+
+#[must_use]
+pub fn bool_record_decl() -> Callable {
+    Callable {
+        name: "__quantum__rt__bool_record_output".to_string(),
+        input_type: vec![Ty::Boolean, Ty::Pointer],
+        output_type: None,
+        body: None,
+        call_type: CallableType::OutputRecording,
+    }
+}
+
+#[must_use]
 pub fn array_record_decl() -> Callable {
     Callable {
         name: "__quantum__rt__array_record_output".to_string(),
+        input_type: vec![Ty::Integer, Ty::Pointer],
+        output_type: None,
+        body: None,
+        call_type: CallableType::OutputRecording,
+    }
+}
+
+#[must_use]
+pub fn tuple_record_decl() -> Callable {
+    Callable {
+        name: "__quantum__rt__tuple_record_output".to_string(),
         input_type: vec![Ty::Integer, Ty::Pointer],
         output_type: None,
         body: None,

--- a/compiler/qsc_rir/src/passes/unreachable_code_check.rs
+++ b/compiler/qsc_rir/src/passes/unreachable_code_check.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use core::panic;
 use std::iter::once;
 
 use crate::{

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -321,7 +321,7 @@ def test_adaptive_qir_can_be_generated() -> None:
             open Microsoft.Quantum.Math;
             open QIR.Intrinsic;
             @EntryPoint()
-            operation Main() : Unit {
+            operation Main() : Result {
                 use q = Qubit();
                 let pi_over_two = 4.0 / 2.0;
                 __quantum__qis__rz__body(pi_over_two, q);
@@ -329,6 +329,7 @@ def test_adaptive_qir_can_be_generated() -> None:
                 __quantum__qis__rz__body(some_angle, q);
                 set some_angle = ArcCos(-1.0) / PI();
                 __quantum__qis__rz__body(some_angle, q);
+                __quantum__qis__mresetz__body(q)
             }
         }
         """
@@ -345,10 +346,16 @@ def test_adaptive_qir_can_be_generated() -> None:
           call void @__quantum__qis__rz__body(double 2.0, %Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__rz__body(double 0.0, %Qubit* inttoptr (i64 0 to %Qubit*))
           call void @__quantum__qis__rz__body(double 1.0, %Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
           ret void
         }
 
         declare void @__quantum__qis__rz__body(double, %Qubit*)
+
+        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
         attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
         attributes #1 = { "irreversible" }


### PR DESCRIPTION
This adds logic to insert output recording calls for recognized types into RIR programs generated by partial evaluation.