### PR TITLE
Fix docs error on first load

### DIFF
--- a/playground/src/docs.tsx
+++ b/playground/src/docs.tsx
@@ -54,8 +54,8 @@ export function DocumentationDisplay(props: {
   const docsDiv = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!docsDiv.current) return;
-    docsDiv.current.innerHTML = props.documentation!.get(
+    if (!docsDiv.current || !props.documentation) return;
+    docsDiv.current.innerHTML = props.documentation.get(
       props.currentNamespace,
     )!;
     MathJax.typeset();


### PR DESCRIPTION
The type assertion was incorrect, and props.documentation is not defined on first load, causing an error which caused later rendering to have issues.

Use a runtime check rather than a type assertion.