### PR TITLE
Update profile configuration

### DIFF
--- a/compiler/qsc/benches/eval.rs
+++ b/compiler/qsc/benches/eval.rs
@@ -8,7 +8,7 @@ use indoc::indoc;
 use qsc::{interpret::Interpreter, PackageType};
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_eval::output::GenericReceiver;
-use qsc_frontend::compile::{RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{SourceMap, TargetCapabilityFlags};
 
 const TELEPORT: &str = include_str!("../../../samples/algorithms/Teleportation.qs");
 const DEUTSCHJOZSA: &str = include_str!("../../../samples/algorithms/DeutschJozsa.qs");
@@ -22,7 +22,7 @@ pub fn teleport(c: &mut Criterion) {
             true,
             sources,
             PackageType::Exe,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("code should compile");
@@ -41,7 +41,7 @@ pub fn deutsch_jozsa(c: &mut Criterion) {
             true,
             sources,
             PackageType::Exe,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("code should compile");
@@ -60,7 +60,7 @@ pub fn large_file(c: &mut Criterion) {
             true,
             sources,
             PackageType::Exe,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("code should compile");
@@ -91,7 +91,7 @@ pub fn array_append(c: &mut Criterion) {
             true,
             sources,
             PackageType::Exe,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("code should compile");
@@ -122,7 +122,7 @@ pub fn array_update(c: &mut Criterion) {
             true,
             sources,
             PackageType::Exe,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("code should compile");
@@ -141,7 +141,7 @@ pub fn array_literal(c: &mut Criterion) {
             true,
             sources,
             PackageType::Exe,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("code should compile");
@@ -177,7 +177,7 @@ pub fn large_nested_iteration(c: &mut Criterion) {
             true,
             sources,
             PackageType::Exe,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("code should compile");

--- a/compiler/qsc/benches/large.rs
+++ b/compiler/qsc/benches/large.rs
@@ -6,7 +6,7 @@ allocator::assign_global!();
 use criterion::{criterion_group, criterion_main, Criterion};
 use qsc::compile::{self, compile};
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_passes::PackageType;
 
 const INPUT: &str = include_str!("./large.qs");
@@ -14,7 +14,7 @@ const INPUT: &str = include_str!("./large.qs");
 pub fn large_file(c: &mut Criterion) {
     c.bench_function("Large input file compilation", |b| {
         let mut store = PackageStore::new(compile::core());
-        let std = store.insert(compile::std(&store, RuntimeCapabilityFlags::all()));
+        let std = store.insert(compile::std(&store, TargetCapabilityFlags::all()));
         b.iter(|| {
             let sources = SourceMap::new([("large.qs".into(), INPUT.into())], None);
             let (_, reports) = compile(
@@ -22,7 +22,7 @@ pub fn large_file(c: &mut Criterion) {
                 &[std],
                 sources,
                 PackageType::Exe,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 LanguageFeatures::default(),
             );
             assert!(reports.is_empty());
@@ -38,7 +38,7 @@ pub fn large_file_interpreter(c: &mut Criterion) {
                 true,
                 sources,
                 PackageType::Exe,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 LanguageFeatures::default(),
             )
             .expect("code should compile");

--- a/compiler/qsc/benches/library.rs
+++ b/compiler/qsc/benches/library.rs
@@ -5,13 +5,13 @@ allocator::assign_global!();
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use qsc::compile;
-use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags};
+use qsc_frontend::compile::{PackageStore, TargetCapabilityFlags};
 
 pub fn library(c: &mut Criterion) {
     c.bench_function("Core + Standard library compilation", |b| {
         b.iter(|| {
             let store = PackageStore::new(compile::core());
-            compile::std(&store, RuntimeCapabilityFlags::all())
+            compile::std(&store, TargetCapabilityFlags::all())
         });
     });
 }

--- a/compiler/qsc/benches/rca.rs
+++ b/compiler/qsc/benches/rca.rs
@@ -5,7 +5,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use qsc::incremental::Compiler;
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_fir::fir::PackageStore;
-use qsc_frontend::compile::{PackageStore as HirPackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{PackageStore as HirPackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_lowerer::{map_hir_package_to_fir, Lowerer};
 use qsc_passes::PackageType;
 use qsc_rca::{Analyzer, PackageStoreComputeProperties};
@@ -130,7 +130,7 @@ impl Default for CompilationContext {
             true,
             SourceMap::default(),
             PackageType::Lib,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("should be able to create a new compiler");

--- a/compiler/qsc/src/bin/memtest.rs
+++ b/compiler/qsc/src/bin/memtest.rs
@@ -4,7 +4,7 @@
 //! Records the memory usage of the compiler.
 
 use qsc::{compile, CompileUnit};
-use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags};
+use qsc_frontend::compile::{PackageStore, TargetCapabilityFlags};
 use std::{
     alloc::{GlobalAlloc, Layout, System},
     sync::atomic::{AtomicU64, Ordering},
@@ -48,7 +48,7 @@ static ALLOCATOR: AllocationCounter<System> = AllocationCounter::new(System);
 #[must_use]
 pub fn compile_stdlib() -> CompileUnit {
     let store = PackageStore::new(compile::core());
-    compile::std(&store, RuntimeCapabilityFlags::all())
+    compile::std(&store, TargetCapabilityFlags::all())
 }
 
 fn main() {

--- a/compiler/qsc/src/bin/qsc.rs
+++ b/compiler/qsc/src/bin/qsc.rs
@@ -10,7 +10,7 @@ use qsc::compile::compile;
 use qsc_codegen::qir_base;
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_frontend::{
-    compile::{PackageStore, RuntimeCapabilityFlags, SourceContents, SourceMap, SourceName},
+    compile::{PackageStore, SourceContents, SourceMap, SourceName, TargetCapabilityFlags},
     error::WithSource,
 };
 use qsc_hir::hir::{Package, PackageId};
@@ -74,9 +74,9 @@ fn main() -> miette::Result<ExitCode> {
     let mut dependencies = Vec::new();
 
     let (package_type, capabilities) = if cli.emit.contains(&Emit::Qir) {
-        (PackageType::Exe, RuntimeCapabilityFlags::empty())
+        (PackageType::Exe, TargetCapabilityFlags::empty())
     } else {
-        (PackageType::Lib, RuntimeCapabilityFlags::all())
+        (PackageType::Lib, TargetCapabilityFlags::all())
     };
 
     if !cli.nostdlib {

--- a/compiler/qsc/src/bin/qsi.rs
+++ b/compiler/qsc/src/bin/qsi.rs
@@ -14,7 +14,7 @@ use qsc_eval::{
     state::format_state_id,
     val::Value,
 };
-use qsc_frontend::compile::{RuntimeCapabilityFlags, SourceContents, SourceMap, SourceName};
+use qsc_frontend::compile::{SourceContents, SourceMap, SourceName, TargetCapabilityFlags};
 use qsc_passes::PackageType;
 use qsc_project::{FileSystem, Manifest, StdFs};
 use std::{
@@ -106,7 +106,7 @@ fn main() -> miette::Result<ExitCode> {
             !cli.nostdlib,
             SourceMap::new(sources, cli.entry.map(std::convert::Into::into)),
             PackageType::Exe,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             features,
         ) {
             Ok(interpreter) => interpreter,
@@ -126,7 +126,7 @@ fn main() -> miette::Result<ExitCode> {
         !cli.nostdlib,
         SourceMap::new(sources, None),
         PackageType::Lib,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         features,
     ) {
         Ok(interpreter) => interpreter,

--- a/compiler/qsc/src/codegen.rs
+++ b/compiler/qsc/src/codegen.rs
@@ -3,7 +3,7 @@
 
 use qsc_codegen::qir::fir_to_qir;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_partial_eval::ProgramEntry;
 use qsc_passes::{PackageType, PassContext};
 
@@ -12,7 +12,7 @@ use crate::compile;
 pub fn get_qir(
     sources: SourceMap,
     language_features: LanguageFeatures,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
 ) -> Result<String, String> {
     let core = compile::core();
     let mut package_store = PackageStore::new(core);

--- a/compiler/qsc/src/compile.rs
+++ b/compiler/qsc/src/compile.rs
@@ -4,7 +4,7 @@
 use miette::{Diagnostic, Report};
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_frontend::{
-    compile::{CompileUnit, PackageStore, RuntimeCapabilityFlags, SourceMap},
+    compile::{CompileUnit, PackageStore, SourceMap, TargetCapabilityFlags},
     error::WithSource,
 };
 use qsc_hir::hir::PackageId;
@@ -39,7 +39,7 @@ pub fn compile(
     dependencies: &[PackageId],
     sources: SourceMap,
     package_type: PackageType,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
     language_features: LanguageFeatures,
 ) -> (CompileUnit, Vec<Error>) {
     let mut unit = qsc_frontend::compile::compile(
@@ -90,7 +90,7 @@ pub fn core() -> CompileUnit {
 ///
 /// Panics if the standard library does not compile without errors.
 #[must_use]
-pub fn std(store: &PackageStore, capabilities: RuntimeCapabilityFlags) -> CompileUnit {
+pub fn std(store: &PackageStore, capabilities: TargetCapabilityFlags) -> CompileUnit {
     let mut unit = qsc_frontend::compile::std(store, capabilities);
     let pass_errors = run_default_passes(store.core(), &mut unit, PackageType::Lib, capabilities);
     if pass_errors.is_empty() {

--- a/compiler/qsc/src/incremental.rs
+++ b/compiler/qsc/src/incremental.rs
@@ -5,7 +5,7 @@ use crate::compile::{self, compile, core, std};
 use miette::Diagnostic;
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_frontend::{
-    compile::{OpenPackageStore, PackageStore, RuntimeCapabilityFlags, SourceMap},
+    compile::{OpenPackageStore, PackageStore, SourceMap, TargetCapabilityFlags},
     error::WithSource,
     incremental::Increment,
 };
@@ -37,7 +37,7 @@ impl Compiler {
         include_std: bool,
         sources: SourceMap,
         package_type: PackageType,
-        capabilities: RuntimeCapabilityFlags,
+        capabilities: TargetCapabilityFlags,
         language_features: LanguageFeatures,
     ) -> Result<Self, Errors> {
         let core = core();

--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -58,7 +58,7 @@ use qsc_fir::{
     visit::{self, Visitor},
 };
 use qsc_frontend::{
-    compile::{CompileUnit, PackageStore, RuntimeCapabilityFlags, Source, SourceMap},
+    compile::{CompileUnit, PackageStore, Source, SourceMap, TargetCapabilityFlags},
     error::WithSource,
 };
 use qsc_passes::{PackageType, PassContext};
@@ -108,8 +108,8 @@ pub enum Error {
 pub struct Interpreter {
     /// The incremental Q# compiler.
     compiler: Compiler,
-    /// The runtime capabilities used for compilation.
-    capabilities: RuntimeCapabilityFlags,
+    /// The target capabilities used for compilation.
+    capabilities: TargetCapabilityFlags,
     /// The number of lines that have so far been compiled.
     /// This field is used to generate a unique label
     /// for each line evaluated with `eval_fragments`.
@@ -147,7 +147,7 @@ impl Interpreter {
         std: bool,
         sources: SourceMap,
         package_type: PackageType,
-        capabilities: RuntimeCapabilityFlags,
+        capabilities: TargetCapabilityFlags,
         language_features: LanguageFeatures,
     ) -> std::result::Result<Self, Vec<Error>> {
         Self::new_internal(
@@ -167,7 +167,7 @@ impl Interpreter {
         std: bool,
         sources: SourceMap,
         package_type: PackageType,
-        capabilities: RuntimeCapabilityFlags,
+        capabilities: TargetCapabilityFlags,
         language_features: LanguageFeatures,
     ) -> std::result::Result<Self, Vec<Error>> {
         Self::new_internal(
@@ -185,7 +185,7 @@ impl Interpreter {
         std: bool,
         sources: SourceMap,
         package_type: PackageType,
-        capabilities: RuntimeCapabilityFlags,
+        capabilities: TargetCapabilityFlags,
         language_features: LanguageFeatures,
     ) -> std::result::Result<Self, Vec<Error>> {
         let compiler = Compiler::new(std, sources, package_type, capabilities, language_features)
@@ -350,10 +350,10 @@ impl Interpreter {
     /// Performs QIR codegen using the given entry expression on a new instance of the environment
     /// and simulator but using the current compilation.
     pub fn qirgen(&mut self, expr: &str) -> std::result::Result<String, Vec<Error>> {
-        if self.capabilities == RuntimeCapabilityFlags::all() {
+        if self.capabilities == TargetCapabilityFlags::all() {
             return Err(vec![Error::UnsupportedRuntimeCapabilities]);
         }
-        if self.capabilities == RuntimeCapabilityFlags::empty() {
+        if self.capabilities == TargetCapabilityFlags::empty() {
             let mut sim = BaseProfSim::new();
             let mut stdout = std::io::sink();
             let mut out = GenericReceiver::new(&mut stdout);
@@ -504,7 +504,7 @@ impl Interpreter {
         unit_addition: &qsc_frontend::incremental::Increment,
     ) -> core::result::Result<(Vec<ExecGraphNode>, Option<PackageStoreComputeProperties>), Vec<Error>>
     {
-        if self.capabilities != RuntimeCapabilityFlags::all() {
+        if self.capabilities != TargetCapabilityFlags::all() {
             return self.run_fir_passes(unit_addition);
         }
         let fir_package = self.fir_store.get_mut(self.package);
@@ -607,7 +607,7 @@ pub struct Debugger {
 impl Debugger {
     pub fn new(
         sources: SourceMap,
-        capabilities: RuntimeCapabilityFlags,
+        capabilities: TargetCapabilityFlags,
         position_encoding: Encoding,
         language_features: LanguageFeatures,
     ) -> std::result::Result<Self, Vec<Error>> {

--- a/compiler/qsc/src/interpret/debug/tests.rs
+++ b/compiler/qsc/src/interpret/debug/tests.rs
@@ -7,7 +7,7 @@ use indoc::indoc;
 use miette::Result;
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_eval::{output::CursorReceiver, val::Value};
-use qsc_frontend::compile::{RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{SourceMap, TargetCapabilityFlags};
 use qsc_passes::PackageType;
 use std::io::Cursor;
 
@@ -70,7 +70,7 @@ fn stack_traces_can_cross_eval_session_and_file_boundaries() {
         true,
         source_map,
         PackageType::Lib,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     )
     .expect("Failed to compile base environment.");
@@ -145,7 +145,7 @@ fn stack_traces_can_cross_file_and_entry_boundaries() {
         true,
         source_map,
         PackageType::Exe,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     )
     .expect("Failed to compile base environment.");

--- a/compiler/qsc/src/interpret/debugger_tests.rs
+++ b/compiler/qsc/src/interpret/debugger_tests.rs
@@ -8,7 +8,7 @@ use crate::line_column::Encoding;
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_eval::{output::CursorReceiver, StepAction, StepResult};
 use qsc_fir::fir::StmtId;
-use qsc_frontend::compile::{RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{SourceMap, TargetCapabilityFlags};
 use std::io::Cursor;
 
 fn get_breakpoint_ids(debugger: &Debugger, path: &str) -> Vec<StmtId> {
@@ -131,7 +131,7 @@ mod given_debugger {
             let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
             let mut debugger = Debugger::new(
                 sources,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 Encoding::Utf8,
                 LanguageFeatures::default(),
             )?;
@@ -154,7 +154,7 @@ mod given_debugger {
             let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
             let mut debugger = Debugger::new(
                 sources,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 Encoding::Utf8,
                 LanguageFeatures::default(),
             )?;
@@ -173,7 +173,7 @@ mod given_debugger {
             let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
             let mut debugger = Debugger::new(
                 sources,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 Encoding::Utf8,
                 LanguageFeatures::default(),
             )?;
@@ -199,7 +199,7 @@ mod given_debugger {
             let sources = SourceMap::new([("test".into(), STEPPING_SOURCE.into())], None);
             let mut debugger = Debugger::new(
                 sources,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 Encoding::Utf8,
                 LanguageFeatures::default(),
             )?;

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -524,7 +524,7 @@ mod given_interpreter {
                 );
             }
             let mut interpreter =
-                get_interpreter_with_capbilities(RuntimeCapabilityFlags::ForwardBranching);
+                get_interpreter_with_capbilities(RuntimeCapabilityFlags::Adaptive);
             let (result, output) = line(
                 &mut interpreter,
                 indoc! {r#"
@@ -556,7 +556,7 @@ mod given_interpreter {
                 );
             }
             let mut interpreter =
-                get_interpreter_with_capbilities(RuntimeCapabilityFlags::ForwardBranching);
+                get_interpreter_with_capbilities(RuntimeCapabilityFlags::Adaptive);
             let (result, output) = line(
                 &mut interpreter,
                 indoc! {r#"
@@ -718,7 +718,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::ForwardBranching,
+                RuntimeCapabilityFlags::Adaptive,
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -778,7 +778,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::ForwardBranching,
+                RuntimeCapabilityFlags::Adaptive,
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -9,7 +9,7 @@ mod given_interpreter {
     use miette::Diagnostic;
     use qsc_data_structures::language_features::LanguageFeatures;
     use qsc_eval::{output::CursorReceiver, val::Value};
-    use qsc_frontend::compile::{RuntimeCapabilityFlags, SourceMap};
+    use qsc_frontend::compile::{SourceMap, TargetCapabilityFlags};
     use qsc_passes::PackageType;
     use std::{fmt::Write, io::Cursor, iter, str::from_utf8};
 
@@ -42,7 +42,7 @@ mod given_interpreter {
     mod without_sources {
         use expect_test::expect;
         use indoc::indoc;
-        use qsc_frontend::compile::RuntimeCapabilityFlags;
+        use qsc_frontend::compile::TargetCapabilityFlags;
 
         use super::*;
 
@@ -58,7 +58,7 @@ mod given_interpreter {
                     false,
                     SourceMap::default(),
                     PackageType::Lib,
-                    RuntimeCapabilityFlags::all(),
+                    TargetCapabilityFlags::all(),
                     LanguageFeatures::default(),
                 )
                 .expect("interpreter should be created");
@@ -523,8 +523,7 @@ mod given_interpreter {
                 "#]],
                 );
             }
-            let mut interpreter =
-                get_interpreter_with_capbilities(RuntimeCapabilityFlags::Adaptive);
+            let mut interpreter = get_interpreter_with_capbilities(TargetCapabilityFlags::Adaptive);
             let (result, output) = line(
                 &mut interpreter,
                 indoc! {r#"
@@ -555,8 +554,7 @@ mod given_interpreter {
                 "#]],
                 );
             }
-            let mut interpreter =
-                get_interpreter_with_capbilities(RuntimeCapabilityFlags::Adaptive);
+            let mut interpreter = get_interpreter_with_capbilities(TargetCapabilityFlags::Adaptive);
             let (result, output) = line(
                 &mut interpreter,
                 indoc! {r#"
@@ -620,7 +618,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::empty(),
+                TargetCapabilityFlags::empty(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -651,7 +649,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::empty(),
+                TargetCapabilityFlags::empty(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -718,7 +716,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::Adaptive,
+                TargetCapabilityFlags::Adaptive,
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -778,7 +776,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::Adaptive,
+                TargetCapabilityFlags::Adaptive,
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -809,7 +807,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::empty(),
+                TargetCapabilityFlags::empty(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -876,7 +874,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::empty(),
+                TargetCapabilityFlags::empty(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -958,7 +956,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::empty(),
+                TargetCapabilityFlags::empty(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -985,7 +983,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::empty(),
+                TargetCapabilityFlags::empty(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -1072,7 +1070,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::empty(),
+                TargetCapabilityFlags::empty(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -1136,7 +1134,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::empty(),
+                TargetCapabilityFlags::empty(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -1241,7 +1239,7 @@ mod given_interpreter {
                 true,
                 SourceMap::default(),
                 PackageType::Lib,
-                RuntimeCapabilityFlags::empty(),
+                TargetCapabilityFlags::empty(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -1255,13 +1253,13 @@ mod given_interpreter {
             true,
             SourceMap::default(),
             PackageType::Lib,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("interpreter should be created")
     }
 
-    fn get_interpreter_with_capbilities(capabilities: RuntimeCapabilityFlags) -> Interpreter {
+    fn get_interpreter_with_capbilities(capabilities: TargetCapabilityFlags) -> Interpreter {
         Interpreter::new(
             true,
             SourceMap::default(),
@@ -1356,7 +1354,7 @@ mod given_interpreter {
         use crate::line_column::Encoding;
         use expect_test::expect;
         use indoc::indoc;
-        use qsc_frontend::compile::{RuntimeCapabilityFlags, SourceMap};
+        use qsc_frontend::compile::{SourceMap, TargetCapabilityFlags};
         use qsc_passes::PackageType;
 
         #[test]
@@ -1374,7 +1372,7 @@ mod given_interpreter {
                 true,
                 sources,
                 PackageType::Exe,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -1397,7 +1395,7 @@ mod given_interpreter {
                 true,
                 sources,
                 PackageType::Lib,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -1424,7 +1422,7 @@ mod given_interpreter {
                 true,
                 sources,
                 PackageType::Lib,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -1466,7 +1464,7 @@ mod given_interpreter {
             let sources = SourceMap::new(sources, None);
             let debugger = Debugger::new(
                 sources,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 Encoding::Utf8,
                 LanguageFeatures::default(),
             )
@@ -1497,7 +1495,7 @@ mod given_interpreter {
                 true,
                 sources,
                 PackageType::Lib,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");
@@ -1528,7 +1526,7 @@ mod given_interpreter {
                 true,
                 sources,
                 PackageType::Lib,
-                RuntimeCapabilityFlags::all(),
+                TargetCapabilityFlags::all(),
                 LanguageFeatures::default(),
             )
             .expect("interpreter should be created");

--- a/compiler/qsc/src/lib.rs
+++ b/compiler/qsc/src/lib.rs
@@ -12,7 +12,7 @@ pub mod target;
 pub use qsc_formatter::formatter;
 
 pub use qsc_frontend::compile::{
-    CompileUnit, PackageStore, RuntimeCapabilityFlags, SourceContents, SourceMap, SourceName,
+    CompileUnit, PackageStore, SourceContents, SourceMap, SourceName, TargetCapabilityFlags,
 };
 
 pub mod resolve {

--- a/compiler/qsc/src/location.rs
+++ b/compiler/qsc/src/location.rs
@@ -63,7 +63,7 @@ mod tests {
     use qsc_data_structures::{
         language_features::LanguageFeatures, line_column::Encoding, span::Span,
     };
-    use qsc_frontend::compile::{PackageStore, RuntimeCapabilityFlags, SourceMap};
+    use qsc_frontend::compile::{PackageStore, SourceMap, TargetCapabilityFlags};
     use qsc_hir::hir::PackageId;
     use qsc_passes::PackageType;
 
@@ -236,7 +236,7 @@ mod tests {
         let mut store = PackageStore::new(compile::core());
         let mut dependencies = Vec::new();
 
-        let (package_type, capabilities) = (PackageType::Lib, RuntimeCapabilityFlags::all());
+        let (package_type, capabilities) = (PackageType::Lib, TargetCapabilityFlags::all());
 
         let std = compile::std(&store, capabilities);
         let std_package_id = store.insert(std);

--- a/compiler/qsc/src/target.rs
+++ b/compiler/qsc/src/target.rs
@@ -28,7 +28,7 @@ impl From<Profile> for RuntimeCapabilityFlags {
         match value {
             Profile::Unrestricted => Self::all(),
             Profile::Base => Self::empty(),
-            Profile::Quantinuum => Self::ForwardBranching | Self::IntegerComputations,
+            Profile::Quantinuum => Self::Adaptive | Self::IntegerComputations | Self::QubitReset,
         }
     }
 }

--- a/compiler/qsc/src/target.rs
+++ b/compiler/qsc/src/target.rs
@@ -9,7 +9,7 @@ use qsc_frontend::compile::RuntimeCapabilityFlags;
 pub enum Profile {
     Unrestricted,
     Base,
-    Adaptive,
+    Quantinuum,
 }
 
 impl Profile {
@@ -18,7 +18,7 @@ impl Profile {
         match self {
             Self::Unrestricted => "Unrestricted",
             Self::Base => "Base",
-            Self::Adaptive => "Adaptive",
+            Self::Quantinuum => "Quantinuum",
         }
     }
 }
@@ -28,7 +28,7 @@ impl From<Profile> for RuntimeCapabilityFlags {
         match value {
             Profile::Unrestricted => Self::all(),
             Profile::Base => Self::empty(),
-            Profile::Adaptive => Self::ForwardBranching,
+            Profile::Quantinuum => Self::ForwardBranching | Self::IntegerComputations,
         }
     }
 }
@@ -38,7 +38,7 @@ impl FromStr for Profile {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "Adaptive" | "adaptive" => Ok(Self::Adaptive),
+            "Quantinuum" | "quantinuum" => Ok(Self::Quantinuum),
             "Base" | "base" => Ok(Self::Base),
             "Unrestricted" | "unrestricted" => Ok(Self::Unrestricted),
             _ => Err(()),

--- a/compiler/qsc/src/target.rs
+++ b/compiler/qsc/src/target.rs
@@ -3,7 +3,7 @@
 
 use std::str::FromStr;
 
-use qsc_frontend::compile::RuntimeCapabilityFlags;
+use qsc_frontend::compile::TargetCapabilityFlags;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Profile {
@@ -23,7 +23,7 @@ impl Profile {
     }
 }
 
-impl From<Profile> for RuntimeCapabilityFlags {
+impl From<Profile> for TargetCapabilityFlags {
     fn from(value: Profile) -> Self {
         match value {
             Profile::Unrestricted => Self::all(),

--- a/compiler/qsc_circuit/src/operations/tests.rs
+++ b/compiler/qsc_circuit/src/operations/tests.rs
@@ -4,13 +4,13 @@
 use super::*;
 use expect_test::expect;
 use qsc_data_structures::{functors::FunctorApp, language_features::LanguageFeatures};
-use qsc_frontend::compile::{compile, core, std, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{compile, core, std, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_hir::hir::{Item, ItemKind};
 
 fn compile_one_operation(code: &str) -> (Item, String) {
     let core_pkg = core();
     let mut store = PackageStore::new(core_pkg);
-    let std = std(&store, RuntimeCapabilityFlags::empty());
+    let std = std(&store, TargetCapabilityFlags::empty());
     let std = store.insert(std);
 
     let sources = SourceMap::new([("test".into(), code.into())], None);
@@ -18,7 +18,7 @@ fn compile_one_operation(code: &str) -> (Item, String) {
         &store,
         &[std],
         sources,
-        RuntimeCapabilityFlags::empty(),
+        TargetCapabilityFlags::empty(),
         LanguageFeatures::default(),
     );
     let mut callables = unit.package.items.values().filter_map(|i| {

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -7,7 +7,7 @@ mod instruction_tests;
 #[cfg(test)]
 mod tests;
 
-use qsc_frontend::compile::RuntimeCapabilityFlags;
+use qsc_frontend::compile::TargetCapabilityFlags;
 use qsc_lowerer::map_hir_package_to_fir;
 use qsc_partial_eval::{partially_evaluate, ProgramEntry};
 use qsc_rca::PackageStoreComputeProperties;
@@ -29,7 +29,7 @@ fn lower_store(package_store: &qsc_frontend::compile::PackageStore) -> qsc_fir::
 /// converts the given sources to QIR using the given language features.
 pub fn hir_to_qir(
     package_store: &qsc_frontend::compile::PackageStore,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
     compute_properties: Option<PackageStoreComputeProperties>,
     entry: &ProgramEntry,
 ) -> Result<String, qsc_partial_eval::Error> {
@@ -39,7 +39,7 @@ pub fn hir_to_qir(
 
 pub fn fir_to_qir(
     fir_store: &qsc_fir::fir::PackageStore,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
     compute_properties: Option<PackageStoreComputeProperties>,
     entry: &ProgramEntry,
 ) -> Result<String, qsc_partial_eval::Error> {

--- a/compiler/qsc_codegen/src/qir_base/tests.rs
+++ b/compiler/qsc_codegen/src/qir_base/tests.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_passes::{run_core_passes, run_default_passes, PackageType};
 
 use crate::qir_base::generate_qir;
@@ -18,12 +18,12 @@ fn check(program: &str, expr: Option<&str>, expect: &Expect) {
     let mut core = compile::core();
     assert!(run_core_passes(&mut core).is_empty());
     let mut store = PackageStore::new(core);
-    let mut std = compile::std(&store, RuntimeCapabilityFlags::empty());
+    let mut std = compile::std(&store, TargetCapabilityFlags::empty());
     assert!(run_default_passes(
         store.core(),
         &mut std,
         PackageType::Lib,
-        RuntimeCapabilityFlags::empty()
+        TargetCapabilityFlags::empty()
     )
     .is_empty());
     let std = store.insert(std);
@@ -35,7 +35,7 @@ fn check(program: &str, expr: Option<&str>, expect: &Expect) {
         &store,
         &[std],
         sources,
-        RuntimeCapabilityFlags::empty(),
+        TargetCapabilityFlags::empty(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
@@ -43,7 +43,7 @@ fn check(program: &str, expr: Option<&str>, expect: &Expect) {
         store.core(),
         &mut unit,
         PackageType::Exe,
-        RuntimeCapabilityFlags::empty()
+        TargetCapabilityFlags::empty()
     )
     .is_empty());
     let package = store.insert(unit);

--- a/compiler/qsc_codegen/src/qsharp/spec_decls.rs
+++ b/compiler/qsc_codegen/src/qsharp/spec_decls.rs
@@ -36,14 +36,14 @@ fn attributes() {
         indoc! {r#"
             namespace Sample {
                 @EntryPoint()
-                @Config(Base)
+                @Config(Unrestricted)
                 operation Entry() : Unit {}
             }"#},
         None,
         &expect![[r#"
             namespace Sample {
                 @EntryPoint()
-                @Config(Base)
+                @Config(Unrestricted)
                 operation Entry() : Unit {}
             }"#]],
     );

--- a/compiler/qsc_codegen/src/qsharp/test_utils.rs
+++ b/compiler/qsc_codegen/src/qsharp/test_utils.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use expect_test::Expect;
 use qsc_ast::{ast::Package, mut_visit::MutVisitor};
 use qsc_data_structures::{language_features::LanguageFeatures, span::Span};
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_hir::hir::PackageId;
 use qsc_passes::{run_core_passes, run_default_passes, PackageType};
 
@@ -31,12 +31,12 @@ pub(crate) fn get_compilation(sources: Option<SourceMap>) -> (PackageId, Package
     let mut core = compile::core();
     assert!(run_core_passes(&mut core).is_empty());
     let mut store = PackageStore::new(core);
-    let mut std = compile::std(&store, RuntimeCapabilityFlags::empty());
+    let mut std = compile::std(&store, TargetCapabilityFlags::empty());
     assert!(run_default_passes(
         store.core(),
         &mut std,
         PackageType::Lib,
-        RuntimeCapabilityFlags::empty()
+        TargetCapabilityFlags::empty()
     )
     .is_empty());
     let std = store.insert(std);
@@ -45,7 +45,7 @@ pub(crate) fn get_compilation(sources: Option<SourceMap>) -> (PackageId, Package
         &store,
         &[std],
         sources.unwrap_or_default(),
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::empty(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
@@ -53,7 +53,7 @@ pub(crate) fn get_compilation(sources: Option<SourceMap>) -> (PackageId, Package
         store.core(),
         &mut unit,
         PackageType::Lib,
-        RuntimeCapabilityFlags::all()
+        TargetCapabilityFlags::all()
     )
     .is_empty());
     let package_id = store.insert(unit);

--- a/compiler/qsc_doc_gen/src/generate_docs.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs.rs
@@ -7,7 +7,7 @@ mod tests;
 use crate::display::{increase_header_level, parse_doc_for_summary};
 use crate::display::{CodeDisplay, Lookup};
 use qsc_ast::ast;
-use qsc_frontend::compile::{self, PackageStore, RuntimeCapabilityFlags};
+use qsc_frontend::compile::{self, PackageStore, TargetCapabilityFlags};
 use qsc_frontend::resolve;
 use qsc_hir::hir::{CallableKind, Item, ItemKind, Package, PackageId, Visibility};
 use qsc_hir::{hir, ty};
@@ -29,7 +29,7 @@ impl Compilation {
     /// Creates a new `Compilation` by compiling sources.
     pub(crate) fn new() -> Self {
         let mut package_store = PackageStore::new(compile::core());
-        package_store.insert(compile::std(&package_store, RuntimeCapabilityFlags::all()));
+        package_store.insert(compile::std(&package_store, TargetCapabilityFlags::all()));
 
         Self { package_store }
     }

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -18,7 +18,7 @@ use indoc::indoc;
 use num_bigint::BigInt;
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_fir::fir;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_lowerer::map_hir_package_to_fir;
 use qsc_passes::{run_core_passes, run_default_passes, PackageType};
 
@@ -151,13 +151,13 @@ fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Va
     let core_fir = qsc_lowerer::Lowerer::new().lower_package(&core.package);
     let mut store = PackageStore::new(core);
 
-    let mut std = compile::std(&store, RuntimeCapabilityFlags::all());
+    let mut std = compile::std(&store, TargetCapabilityFlags::all());
     assert!(std.errors.is_empty());
     assert!(run_default_passes(
         store.core(),
         &mut std,
         PackageType::Lib,
-        RuntimeCapabilityFlags::all()
+        TargetCapabilityFlags::all()
     )
     .is_empty());
     let std_fir = qsc_lowerer::Lowerer::new().lower_package(&std.package);
@@ -168,7 +168,7 @@ fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Va
         &store,
         &[std_id],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty());
@@ -176,7 +176,7 @@ fn check_intrinsic(file: &str, expr: &str, out: &mut impl Receiver) -> Result<Va
         store.core(),
         &mut unit,
         PackageType::Lib,
-        RuntimeCapabilityFlags::all()
+        TargetCapabilityFlags::all()
     )
     .is_empty());
     let unit_fir = qsc_lowerer::Lowerer::new().lower_package(&unit.package);

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -18,7 +18,7 @@ use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_fir::fir::{self, ExecGraphNode, StmtId};
 use qsc_fir::fir::{PackageId, PackageStoreLookup};
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_lowerer::map_hir_package_to_fir;
 use qsc_passes::{run_core_passes, run_default_passes, PackageType};
 
@@ -50,13 +50,13 @@ fn check_expr(file: &str, expr: &str, expect: &Expect) {
     let core_fir = fir_lowerer.lower_package(&core.package);
     let mut store = PackageStore::new(core);
 
-    let mut std = compile::std(&store, RuntimeCapabilityFlags::all());
+    let mut std = compile::std(&store, TargetCapabilityFlags::all());
     assert!(std.errors.is_empty());
     assert!(run_default_passes(
         store.core(),
         &mut std,
         PackageType::Lib,
-        RuntimeCapabilityFlags::all()
+        TargetCapabilityFlags::all()
     )
     .is_empty());
     let std_fir = fir_lowerer.lower_package(&std.package);
@@ -67,7 +67,7 @@ fn check_expr(file: &str, expr: &str, expect: &Expect) {
         &store,
         &[std_id],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
@@ -75,7 +75,7 @@ fn check_expr(file: &str, expr: &str, expect: &Expect) {
         store.core(),
         &mut unit,
         PackageType::Lib,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
     );
     assert!(pass_errors.is_empty(), "{pass_errors:?}");
     let unit_fir = fir_lowerer.lower_package(&unit.package);
@@ -116,13 +116,13 @@ fn check_partial_eval_stmt(
     let core_fir = qsc_lowerer::Lowerer::new().lower_package(&core.package);
     let mut store = PackageStore::new(core);
 
-    let mut std = compile::std(&store, RuntimeCapabilityFlags::all());
+    let mut std = compile::std(&store, TargetCapabilityFlags::all());
     assert!(std.errors.is_empty());
     assert!(run_default_passes(
         store.core(),
         &mut std,
         PackageType::Lib,
-        RuntimeCapabilityFlags::all()
+        TargetCapabilityFlags::all()
     )
     .is_empty());
     let std_fir = qsc_lowerer::Lowerer::new().lower_package(&std.package);
@@ -133,7 +133,7 @@ fn check_partial_eval_stmt(
         &store,
         &[std_id],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);
@@ -141,7 +141,7 @@ fn check_partial_eval_stmt(
         store.core(),
         &mut unit,
         PackageType::Lib,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
     );
     assert!(pass_errors.is_empty(), "{pass_errors:?}");
     let unit_fir = qsc_lowerer::Lowerer::new().lower_package(&unit.package);

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -39,7 +39,7 @@ use thiserror::Error;
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct RuntimeCapabilityFlags: u32 {
+    pub struct TargetCapabilityFlags: u32 {
         const Adaptive = 0b0000_0001;
         const IntegerComputations = 0b0000_0010;
         const FloatingPointComputations = 0b0000_0100;
@@ -49,19 +49,19 @@ bitflags! {
     }
 }
 
-impl FromStr for RuntimeCapabilityFlags {
+impl FromStr for TargetCapabilityFlags {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "Base" => Ok(RuntimeCapabilityFlags::empty()),
-            "Adaptive" => Ok(RuntimeCapabilityFlags::Adaptive),
-            "IntegerComputations" => Ok(RuntimeCapabilityFlags::IntegerComputations),
-            "FloatingPointComputations" => Ok(RuntimeCapabilityFlags::FloatingPointComputations),
-            "BackwardsBranching" => Ok(RuntimeCapabilityFlags::BackwardsBranching),
-            "HigherLevelConstructs" => Ok(RuntimeCapabilityFlags::HigherLevelConstructs),
-            "QubitReset" => Ok(RuntimeCapabilityFlags::QubitReset),
-            "Unrestricted" => Ok(RuntimeCapabilityFlags::all()),
+            "Base" => Ok(TargetCapabilityFlags::empty()),
+            "Adaptive" => Ok(TargetCapabilityFlags::Adaptive),
+            "IntegerComputations" => Ok(TargetCapabilityFlags::IntegerComputations),
+            "FloatingPointComputations" => Ok(TargetCapabilityFlags::FloatingPointComputations),
+            "BackwardsBranching" => Ok(TargetCapabilityFlags::BackwardsBranching),
+            "HigherLevelConstructs" => Ok(TargetCapabilityFlags::HigherLevelConstructs),
+            "QubitReset" => Ok(TargetCapabilityFlags::QubitReset),
+            "Unrestricted" => Ok(TargetCapabilityFlags::all()),
             _ => Err(()),
         }
     }
@@ -318,7 +318,7 @@ pub fn compile(
     store: &PackageStore,
     dependencies: &[PackageId],
     sources: SourceMap,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
     language_features: LanguageFeatures,
 ) -> CompileUnit {
     let (mut ast_package, parse_errors) = parse_all(&sources, language_features);
@@ -393,7 +393,7 @@ pub fn core() -> CompileUnit {
         &store,
         &[],
         sources,
-        RuntimeCapabilityFlags::empty(),
+        TargetCapabilityFlags::empty(),
         LanguageFeatures::default(),
     );
     assert_no_errors(&unit.sources, &mut unit.errors);
@@ -406,7 +406,7 @@ pub fn core() -> CompileUnit {
 ///
 /// Panics if the standard library does not compile without errors.
 #[must_use]
-pub fn std(store: &PackageStore, capabilities: RuntimeCapabilityFlags) -> CompileUnit {
+pub fn std(store: &PackageStore, capabilities: TargetCapabilityFlags) -> CompileUnit {
     let std: Vec<(SourceName, SourceContents)> = library::STD_LIB
         .iter()
         .map(|(name, contents)| ((*name).into(), (*contents).into()))

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -40,11 +40,12 @@ use thiserror::Error;
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct RuntimeCapabilityFlags: u32 {
-        const ForwardBranching = 0b0000_0001;
+        const Adaptive = 0b0000_0001;
         const IntegerComputations = 0b0000_0010;
         const FloatingPointComputations = 0b0000_0100;
         const BackwardsBranching = 0b0000_1000;
         const HigherLevelConstructs = 0b0001_0000;
+        const QubitReset = 0b0010_0000;
     }
 }
 
@@ -54,11 +55,12 @@ impl FromStr for RuntimeCapabilityFlags {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "Base" | "None" => Ok(RuntimeCapabilityFlags::empty()),
-            "ForwardBranching" => Ok(RuntimeCapabilityFlags::ForwardBranching),
+            "Adaptive" => Ok(RuntimeCapabilityFlags::Adaptive),
             "IntegerComputations" => Ok(RuntimeCapabilityFlags::IntegerComputations),
             "FloatingPointComputations" => Ok(RuntimeCapabilityFlags::FloatingPointComputations),
             "BackwardsBranching" => Ok(RuntimeCapabilityFlags::BackwardsBranching),
             "HigherLevelConstructs" => Ok(RuntimeCapabilityFlags::HigherLevelConstructs),
+            "QubitReset" => Ok(RuntimeCapabilityFlags::QubitReset),
             "Unrestricted" => Ok(RuntimeCapabilityFlags::all()),
             _ => Err(()),
         }

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -54,7 +54,7 @@ impl FromStr for RuntimeCapabilityFlags {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "Base" | "None" => Ok(RuntimeCapabilityFlags::empty()),
+            "Base" => Ok(RuntimeCapabilityFlags::empty()),
             "Adaptive" => Ok(RuntimeCapabilityFlags::Adaptive),
             "IntegerComputations" => Ok(RuntimeCapabilityFlags::IntegerComputations),
             "FloatingPointComputations" => Ok(RuntimeCapabilityFlags::FloatingPointComputations),

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -48,48 +48,19 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum ConfigAttr {
-    Adaptive,
-    Base,
-    Unrestricted,
-}
-
-impl ConfigAttr {
-    #[must_use]
-    pub fn to_str(&self) -> &'static str {
-        match self {
-            Self::Adaptive => "Adaptive",
-            Self::Base => "Base",
-            Self::Unrestricted => "Unrestricted",
-        }
-    }
-
-    #[must_use]
-    pub fn is_target_str(s: &str) -> bool {
-        Self::from_str(s).is_ok()
-    }
-}
-
-impl FromStr for ConfigAttr {
+impl FromStr for RuntimeCapabilityFlags {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "Adaptive" => Ok(ConfigAttr::Adaptive),
-            "Base" => Ok(ConfigAttr::Base),
-            "Unrestricted" => Ok(ConfigAttr::Unrestricted),
+            "Base" | "None" => Ok(RuntimeCapabilityFlags::empty()),
+            "ForwardBranching" => Ok(RuntimeCapabilityFlags::ForwardBranching),
+            "IntegerComputations" => Ok(RuntimeCapabilityFlags::IntegerComputations),
+            "FloatingPointComputations" => Ok(RuntimeCapabilityFlags::FloatingPointComputations),
+            "BackwardsBranching" => Ok(RuntimeCapabilityFlags::BackwardsBranching),
+            "HigherLevelConstructs" => Ok(RuntimeCapabilityFlags::HigherLevelConstructs),
+            "Unrestricted" => Ok(RuntimeCapabilityFlags::all()),
             _ => Err(()),
-        }
-    }
-}
-
-impl From<ConfigAttr> for RuntimeCapabilityFlags {
-    fn from(value: ConfigAttr) -> Self {
-        match value {
-            ConfigAttr::Unrestricted => Self::all(),
-            ConfigAttr::Base => Self::empty(),
-            ConfigAttr::Adaptive => Self::ForwardBranching,
         }
     }
 }

--- a/compiler/qsc_frontend/src/compile/preprocess.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess.rs
@@ -11,6 +11,9 @@ use std::rc::Rc;
 
 use super::RuntimeCapabilityFlags;
 
+#[cfg(test)]
+mod tests;
+
 #[derive(PartialEq, Hash, Clone, Debug)]
 pub struct TrackedName {
     pub name: Rc<str>,
@@ -154,139 +157,4 @@ fn matches_config(attrs: &[Box<Attr>], capabilities: RuntimeCapabilityFlags) -> 
         return capabilities == RuntimeCapabilityFlags::empty();
     }
     capabilities.contains(found_capabilities)
-}
-
-#[cfg(test)]
-mod test {
-    use qsc_ast::ast::{Attr, Expr, ExprKind, Ident, NodeId, Path};
-    use qsc_data_structures::span::Span;
-
-    use crate::compile::{preprocess::matches_config, RuntimeCapabilityFlags};
-
-    fn named_attr(name: &str) -> Attr {
-        Attr {
-            name: Box::new(Ident {
-                name: name.into(),
-                span: Span::default(),
-                id: NodeId::default(),
-            }),
-            arg: Box::new(Expr {
-                id: NodeId::default(),
-                span: Span::default(),
-                kind: Box::new(ExprKind::Tuple(Box::new([]))),
-            }),
-            span: Span::default(),
-            id: NodeId::default(),
-        }
-    }
-
-    fn name_value_attr(name: &str, value: &str) -> Attr {
-        Attr {
-            name: Box::new(Ident {
-                name: name.into(),
-                span: Span::default(),
-                id: NodeId::default(),
-            }),
-            arg: Box::new(Expr {
-                id: NodeId::default(),
-                span: Span::default(),
-                kind: Box::new(ExprKind::Paren(Box::new(Expr {
-                    id: NodeId::default(),
-                    span: Span::default(),
-                    kind: Box::new(ExprKind::Path(Box::new(Path {
-                        id: NodeId::default(),
-                        span: Span::default(),
-                        namespace: None,
-                        name: Box::new(Ident {
-                            name: value.into(),
-                            span: Span::default(),
-                            id: NodeId::default(),
-                        }),
-                    }))),
-                }))),
-            }),
-            span: Span::default(),
-            id: NodeId::default(),
-        }
-    }
-
-    #[test]
-    fn no_attrs_matches() {
-        assert!(matches_config(&[], RuntimeCapabilityFlags::empty()));
-    }
-
-    #[test]
-    fn unknown_attrs_matches() {
-        assert!(matches_config(
-            &[Box::new(named_attr("unknown"))],
-            RuntimeCapabilityFlags::empty()
-        ));
-    }
-
-    #[test]
-    fn none_attrs_matches_empty() {
-        assert!(matches_config(
-            &[Box::new(name_value_attr("Config", "None"))],
-            RuntimeCapabilityFlags::empty()
-        ));
-    }
-
-    #[test]
-    fn none_attrs_does_not_match_all() {
-        assert!(!matches_config(
-            &[Box::new(name_value_attr("Config", "None"))],
-            RuntimeCapabilityFlags::all()
-        ));
-    }
-
-    #[test]
-    fn none_attrs_does_not_match_forwardbranching() {
-        assert!(!matches_config(
-            &[Box::new(name_value_attr("Config", "None"))],
-            RuntimeCapabilityFlags::ForwardBranching
-        ));
-    }
-
-    #[test]
-    fn forwardbranching_attrs_does_not_match_empty() {
-        assert!(!matches_config(
-            &[Box::new(name_value_attr("Config", "ForwardBranching"))],
-            RuntimeCapabilityFlags::empty()
-        ));
-    }
-
-    #[test]
-    fn integercomputations_attrs_does_not_match_empty() {
-        assert!(!matches_config(
-            &[Box::new(name_value_attr("Config", "IntegerComputations"))],
-            RuntimeCapabilityFlags::empty()
-        ));
-    }
-
-    #[test]
-    fn floatingpointcomputations_attrs_does_not_match_empty() {
-        assert!(!matches_config(
-            &[Box::new(name_value_attr(
-                "Config",
-                "FloatingPointComputations"
-            ))],
-            RuntimeCapabilityFlags::empty()
-        ));
-    }
-
-    #[test]
-    fn unrestricted_attrs_does_not_match_empty() {
-        assert!(!matches_config(
-            &[Box::new(name_value_attr("Config", "Unrestricted"))],
-            RuntimeCapabilityFlags::empty()
-        ));
-    }
-
-    #[test]
-    fn unrestricted_attrs_matches_all() {
-        assert!(matches_config(
-            &[Box::new(name_value_attr("Config", "Unrestricted"))],
-            RuntimeCapabilityFlags::all()
-        ));
-    }
 }

--- a/compiler/qsc_frontend/src/compile/preprocess.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess.rs
@@ -9,7 +9,7 @@ use qsc_ast::{
 use qsc_hir::hir;
 use std::rc::Rc;
 
-use super::{ConfigAttr, RuntimeCapabilityFlags};
+use super::RuntimeCapabilityFlags;
 
 #[derive(PartialEq, Hash, Clone, Debug)]
 pub struct TrackedName {
@@ -119,33 +119,174 @@ impl MutVisitor for Conditional {
 }
 
 fn matches_config(attrs: &[Box<Attr>], capabilities: RuntimeCapabilityFlags) -> bool {
+    let attrs: Vec<_> = attrs
+        .iter()
+        .filter(|attr| hir::Attr::from_str(attr.name.name.as_ref()) == Ok(hir::Attr::Config))
+        .collect();
+
     if attrs.is_empty() {
         return true;
     }
-    attrs.iter().any(|attr| {
-        if hir::Attr::from_str(attr.name.name.as_ref()) == Ok(hir::Attr::Config) {
-            if let ExprKind::Paren(inner) = attr.arg.kind.as_ref() {
-                match inner.kind.as_ref() {
-                    // If there is no config attribute, then we assume that the item matches
-                    // the target. We can't do membership tests on the capabilities because
-                    // Base is not a subset of any capabilities, it is a lack of capabilities.
-                    ExprKind::Path(path) => match ConfigAttr::from_str(path.name.name.as_ref()) {
-                        Ok(ConfigAttr::Unrestricted) => capabilities.is_all(),
-                        Ok(ConfigAttr::Base) => capabilities.is_empty(),
-                        Ok(ConfigAttr::Adaptive) => {
-                            capabilities == RuntimeCapabilityFlags::ForwardBranching
-                        }
-                        _ => true,
-                    },
-                    _ => true, // Unknown config attribute, so we assume it matches
+    let mut found_capabilities = RuntimeCapabilityFlags::empty();
+
+    for attr in attrs {
+        if let ExprKind::Paren(inner) = attr.arg.kind.as_ref() {
+            match inner.kind.as_ref() {
+                ExprKind::Path(path) => {
+                    if let Ok(capability) =
+                        RuntimeCapabilityFlags::from_str(path.name.name.as_ref())
+                    {
+                        found_capabilities |= capability;
+                    } else {
+                        return true; // Unknown capability, so we assume it matches
+                    }
                 }
-            } else {
-                // Something other than a parenthesized expression, so we assume it matches
-                true
+                _ => return true, // Unknown config attribute, so we assume it matches
             }
         } else {
-            // Unknown attribute, so we assume it matches
-            true
+            // Something other than a parenthesized expression, so we assume it matches
+            return true;
         }
-    })
+    }
+    if found_capabilities == RuntimeCapabilityFlags::empty() {
+        // There was at least one config attribute, but it was None
+        // Therefore, we only match if there are no capabilities
+        return capabilities == RuntimeCapabilityFlags::empty();
+    }
+    capabilities.contains(found_capabilities)
+}
+
+#[cfg(test)]
+mod test {
+    use qsc_ast::ast::{Attr, Expr, ExprKind, Ident, NodeId, Path};
+    use qsc_data_structures::span::Span;
+
+    use crate::compile::{preprocess::matches_config, RuntimeCapabilityFlags};
+
+    fn named_attr(name: &str) -> Attr {
+        Attr {
+            name: Box::new(Ident {
+                name: name.into(),
+                span: Span::default(),
+                id: NodeId::default(),
+            }),
+            arg: Box::new(Expr {
+                id: NodeId::default(),
+                span: Span::default(),
+                kind: Box::new(ExprKind::Tuple(Box::new([]))),
+            }),
+            span: Span::default(),
+            id: NodeId::default(),
+        }
+    }
+
+    fn name_value_attr(name: &str, value: &str) -> Attr {
+        Attr {
+            name: Box::new(Ident {
+                name: name.into(),
+                span: Span::default(),
+                id: NodeId::default(),
+            }),
+            arg: Box::new(Expr {
+                id: NodeId::default(),
+                span: Span::default(),
+                kind: Box::new(ExprKind::Paren(Box::new(Expr {
+                    id: NodeId::default(),
+                    span: Span::default(),
+                    kind: Box::new(ExprKind::Path(Box::new(Path {
+                        id: NodeId::default(),
+                        span: Span::default(),
+                        namespace: None,
+                        name: Box::new(Ident {
+                            name: value.into(),
+                            span: Span::default(),
+                            id: NodeId::default(),
+                        }),
+                    }))),
+                }))),
+            }),
+            span: Span::default(),
+            id: NodeId::default(),
+        }
+    }
+
+    #[test]
+    fn no_attrs_matches() {
+        assert!(matches_config(&[], RuntimeCapabilityFlags::empty()));
+    }
+
+    #[test]
+    fn unknown_attrs_matches() {
+        assert!(matches_config(
+            &[Box::new(named_attr("unknown"))],
+            RuntimeCapabilityFlags::empty()
+        ));
+    }
+
+    #[test]
+    fn none_attrs_matches_empty() {
+        assert!(matches_config(
+            &[Box::new(name_value_attr("Config", "None"))],
+            RuntimeCapabilityFlags::empty()
+        ));
+    }
+
+    #[test]
+    fn none_attrs_does_not_match_all() {
+        assert!(!matches_config(
+            &[Box::new(name_value_attr("Config", "None"))],
+            RuntimeCapabilityFlags::all()
+        ));
+    }
+
+    #[test]
+    fn none_attrs_does_not_match_forwardbranching() {
+        assert!(!matches_config(
+            &[Box::new(name_value_attr("Config", "None"))],
+            RuntimeCapabilityFlags::ForwardBranching
+        ));
+    }
+
+    #[test]
+    fn forwardbranching_attrs_does_not_match_empty() {
+        assert!(!matches_config(
+            &[Box::new(name_value_attr("Config", "ForwardBranching"))],
+            RuntimeCapabilityFlags::empty()
+        ));
+    }
+
+    #[test]
+    fn integercomputations_attrs_does_not_match_empty() {
+        assert!(!matches_config(
+            &[Box::new(name_value_attr("Config", "IntegerComputations"))],
+            RuntimeCapabilityFlags::empty()
+        ));
+    }
+
+    #[test]
+    fn floatingpointcomputations_attrs_does_not_match_empty() {
+        assert!(!matches_config(
+            &[Box::new(name_value_attr(
+                "Config",
+                "FloatingPointComputations"
+            ))],
+            RuntimeCapabilityFlags::empty()
+        ));
+    }
+
+    #[test]
+    fn unrestricted_attrs_does_not_match_empty() {
+        assert!(!matches_config(
+            &[Box::new(name_value_attr("Config", "Unrestricted"))],
+            RuntimeCapabilityFlags::empty()
+        ));
+    }
+
+    #[test]
+    fn unrestricted_attrs_matches_all() {
+        assert!(matches_config(
+            &[Box::new(name_value_attr("Config", "Unrestricted"))],
+            RuntimeCapabilityFlags::all()
+        ));
+    }
 }

--- a/compiler/qsc_frontend/src/compile/preprocess.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess.rs
@@ -9,7 +9,7 @@ use qsc_ast::{
 use qsc_hir::hir;
 use std::rc::Rc;
 
-use super::RuntimeCapabilityFlags;
+use super::TargetCapabilityFlags;
 
 #[cfg(test)]
 mod tests;
@@ -21,13 +21,13 @@ pub struct TrackedName {
 }
 
 pub(crate) struct Conditional {
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
     dropped_names: Vec<TrackedName>,
     included_names: Vec<TrackedName>,
 }
 
 impl Conditional {
-    pub(crate) fn new(capabilities: RuntimeCapabilityFlags) -> Self {
+    pub(crate) fn new(capabilities: TargetCapabilityFlags) -> Self {
         Self {
             capabilities,
             dropped_names: Vec::new(),
@@ -121,7 +121,7 @@ impl MutVisitor for Conditional {
     }
 }
 
-fn matches_config(attrs: &[Box<Attr>], capabilities: RuntimeCapabilityFlags) -> bool {
+fn matches_config(attrs: &[Box<Attr>], capabilities: TargetCapabilityFlags) -> bool {
     let attrs: Vec<_> = attrs
         .iter()
         .filter(|attr| hir::Attr::from_str(attr.name.name.as_ref()) == Ok(hir::Attr::Config))
@@ -130,14 +130,13 @@ fn matches_config(attrs: &[Box<Attr>], capabilities: RuntimeCapabilityFlags) -> 
     if attrs.is_empty() {
         return true;
     }
-    let mut found_capabilities = RuntimeCapabilityFlags::empty();
+    let mut found_capabilities = TargetCapabilityFlags::empty();
 
     for attr in attrs {
         if let ExprKind::Paren(inner) = attr.arg.kind.as_ref() {
             match inner.kind.as_ref() {
                 ExprKind::Path(path) => {
-                    if let Ok(capability) =
-                        RuntimeCapabilityFlags::from_str(path.name.name.as_ref())
+                    if let Ok(capability) = TargetCapabilityFlags::from_str(path.name.name.as_ref())
                     {
                         found_capabilities |= capability;
                     } else {
@@ -151,10 +150,10 @@ fn matches_config(attrs: &[Box<Attr>], capabilities: RuntimeCapabilityFlags) -> 
             return true;
         }
     }
-    if found_capabilities == RuntimeCapabilityFlags::empty() {
+    if found_capabilities == TargetCapabilityFlags::empty() {
         // There was at least one config attribute, but it was None
         // Therefore, we only match if there are no capabilities
-        return capabilities == RuntimeCapabilityFlags::empty();
+        return capabilities == TargetCapabilityFlags::empty();
     }
     capabilities.contains(found_capabilities)
 }

--- a/compiler/qsc_frontend/src/compile/preprocess/tests.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess/tests.rs
@@ -4,7 +4,7 @@
 use qsc_ast::ast::{Attr, Expr, ExprKind, Ident, NodeId, Path};
 use qsc_data_structures::span::Span;
 
-use crate::compile::{preprocess::matches_config, RuntimeCapabilityFlags};
+use crate::compile::{preprocess::matches_config, TargetCapabilityFlags};
 
 fn named_attr(name: &str) -> Attr {
     Attr {
@@ -55,14 +55,14 @@ fn name_value_attr(name: &str, value: &str) -> Attr {
 
 #[test]
 fn no_attrs_matches() {
-    assert!(matches_config(&[], RuntimeCapabilityFlags::empty()));
+    assert!(matches_config(&[], TargetCapabilityFlags::empty()));
 }
 
 #[test]
 fn unknown_attrs_matches() {
     assert!(matches_config(
         &[Box::new(named_attr("unknown"))],
-        RuntimeCapabilityFlags::empty()
+        TargetCapabilityFlags::empty()
     ));
 }
 
@@ -70,7 +70,7 @@ fn unknown_attrs_matches() {
 fn none_attrs_matches_empty() {
     assert!(matches_config(
         &[Box::new(name_value_attr("Config", "Base"))],
-        RuntimeCapabilityFlags::empty()
+        TargetCapabilityFlags::empty()
     ));
 }
 
@@ -78,7 +78,7 @@ fn none_attrs_matches_empty() {
 fn none_attrs_does_not_match_all() {
     assert!(!matches_config(
         &[Box::new(name_value_attr("Config", "Base"))],
-        RuntimeCapabilityFlags::all()
+        TargetCapabilityFlags::all()
     ));
 }
 
@@ -86,7 +86,7 @@ fn none_attrs_does_not_match_all() {
 fn none_attrs_does_not_match_adaptive() {
     assert!(!matches_config(
         &[Box::new(name_value_attr("Config", "Base"))],
-        RuntimeCapabilityFlags::Adaptive
+        TargetCapabilityFlags::Adaptive
     ));
 }
 
@@ -94,7 +94,7 @@ fn none_attrs_does_not_match_adaptive() {
 fn adaptive_attrs_does_not_match_empty() {
     assert!(!matches_config(
         &[Box::new(name_value_attr("Config", "Adaptive"))],
-        RuntimeCapabilityFlags::empty()
+        TargetCapabilityFlags::empty()
     ));
 }
 
@@ -102,7 +102,7 @@ fn adaptive_attrs_does_not_match_empty() {
 fn integercomputations_attrs_does_not_match_empty() {
     assert!(!matches_config(
         &[Box::new(name_value_attr("Config", "IntegerComputations"))],
-        RuntimeCapabilityFlags::empty()
+        TargetCapabilityFlags::empty()
     ));
 }
 
@@ -113,7 +113,7 @@ fn floatingpointcomputations_attrs_does_not_match_empty() {
             "Config",
             "FloatingPointComputations"
         ))],
-        RuntimeCapabilityFlags::empty()
+        TargetCapabilityFlags::empty()
     ));
 }
 
@@ -121,7 +121,7 @@ fn floatingpointcomputations_attrs_does_not_match_empty() {
 fn unrestricted_attrs_does_not_match_empty() {
     assert!(!matches_config(
         &[Box::new(name_value_attr("Config", "Unrestricted"))],
-        RuntimeCapabilityFlags::empty()
+        TargetCapabilityFlags::empty()
     ));
 }
 
@@ -129,6 +129,6 @@ fn unrestricted_attrs_does_not_match_empty() {
 fn unrestricted_attrs_matches_all() {
     assert!(matches_config(
         &[Box::new(name_value_attr("Config", "Unrestricted"))],
-        RuntimeCapabilityFlags::all()
+        TargetCapabilityFlags::all()
     ));
 }

--- a/compiler/qsc_frontend/src/compile/preprocess/tests.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess/tests.rs
@@ -69,7 +69,7 @@ fn unknown_attrs_matches() {
 #[test]
 fn none_attrs_matches_empty() {
     assert!(matches_config(
-        &[Box::new(name_value_attr("Config", "None"))],
+        &[Box::new(name_value_attr("Config", "Base"))],
         RuntimeCapabilityFlags::empty()
     ));
 }
@@ -77,7 +77,7 @@ fn none_attrs_matches_empty() {
 #[test]
 fn none_attrs_does_not_match_all() {
     assert!(!matches_config(
-        &[Box::new(name_value_attr("Config", "None"))],
+        &[Box::new(name_value_attr("Config", "Base"))],
         RuntimeCapabilityFlags::all()
     ));
 }
@@ -85,7 +85,7 @@ fn none_attrs_does_not_match_all() {
 #[test]
 fn none_attrs_does_not_match_adaptive() {
     assert!(!matches_config(
-        &[Box::new(name_value_attr("Config", "None"))],
+        &[Box::new(name_value_attr("Config", "Base"))],
         RuntimeCapabilityFlags::Adaptive
     ));
 }

--- a/compiler/qsc_frontend/src/compile/preprocess/tests.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess/tests.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use qsc_ast::ast::{Attr, Expr, ExprKind, Ident, NodeId, Path};
+use qsc_data_structures::span::Span;
+
+use crate::compile::{preprocess::matches_config, RuntimeCapabilityFlags};
+
+fn named_attr(name: &str) -> Attr {
+    Attr {
+        name: Box::new(Ident {
+            name: name.into(),
+            span: Span::default(),
+            id: NodeId::default(),
+        }),
+        arg: Box::new(Expr {
+            id: NodeId::default(),
+            span: Span::default(),
+            kind: Box::new(ExprKind::Tuple(Box::new([]))),
+        }),
+        span: Span::default(),
+        id: NodeId::default(),
+    }
+}
+
+fn name_value_attr(name: &str, value: &str) -> Attr {
+    Attr {
+        name: Box::new(Ident {
+            name: name.into(),
+            span: Span::default(),
+            id: NodeId::default(),
+        }),
+        arg: Box::new(Expr {
+            id: NodeId::default(),
+            span: Span::default(),
+            kind: Box::new(ExprKind::Paren(Box::new(Expr {
+                id: NodeId::default(),
+                span: Span::default(),
+                kind: Box::new(ExprKind::Path(Box::new(Path {
+                    id: NodeId::default(),
+                    span: Span::default(),
+                    namespace: None,
+                    name: Box::new(Ident {
+                        name: value.into(),
+                        span: Span::default(),
+                        id: NodeId::default(),
+                    }),
+                }))),
+            }))),
+        }),
+        span: Span::default(),
+        id: NodeId::default(),
+    }
+}
+
+#[test]
+fn no_attrs_matches() {
+    assert!(matches_config(&[], RuntimeCapabilityFlags::empty()));
+}
+
+#[test]
+fn unknown_attrs_matches() {
+    assert!(matches_config(
+        &[Box::new(named_attr("unknown"))],
+        RuntimeCapabilityFlags::empty()
+    ));
+}
+
+#[test]
+fn none_attrs_matches_empty() {
+    assert!(matches_config(
+        &[Box::new(name_value_attr("Config", "None"))],
+        RuntimeCapabilityFlags::empty()
+    ));
+}
+
+#[test]
+fn none_attrs_does_not_match_all() {
+    assert!(!matches_config(
+        &[Box::new(name_value_attr("Config", "None"))],
+        RuntimeCapabilityFlags::all()
+    ));
+}
+
+#[test]
+fn none_attrs_does_not_match_adaptive() {
+    assert!(!matches_config(
+        &[Box::new(name_value_attr("Config", "None"))],
+        RuntimeCapabilityFlags::Adaptive
+    ));
+}
+
+#[test]
+fn adaptive_attrs_does_not_match_empty() {
+    assert!(!matches_config(
+        &[Box::new(name_value_attr("Config", "Adaptive"))],
+        RuntimeCapabilityFlags::empty()
+    ));
+}
+
+#[test]
+fn integercomputations_attrs_does_not_match_empty() {
+    assert!(!matches_config(
+        &[Box::new(name_value_attr("Config", "IntegerComputations"))],
+        RuntimeCapabilityFlags::empty()
+    ));
+}
+
+#[test]
+fn floatingpointcomputations_attrs_does_not_match_empty() {
+    assert!(!matches_config(
+        &[Box::new(name_value_attr(
+            "Config",
+            "FloatingPointComputations"
+        ))],
+        RuntimeCapabilityFlags::empty()
+    ));
+}
+
+#[test]
+fn unrestricted_attrs_does_not_match_empty() {
+    assert!(!matches_config(
+        &[Box::new(name_value_attr("Config", "Unrestricted"))],
+        RuntimeCapabilityFlags::empty()
+    ));
+}
+
+#[test]
+fn unrestricted_attrs_matches_all() {
+    assert!(matches_config(
+        &[Box::new(name_value_attr("Config", "Unrestricted"))],
+        RuntimeCapabilityFlags::all()
+    ));
+}

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::needless_raw_string_hashes)]
 
-use crate::compile::RuntimeCapabilityFlags;
+use crate::compile::TargetCapabilityFlags;
 
 use super::{compile, CompileUnit, Error, PackageStore, SourceMap};
 use expect_test::expect;
@@ -58,7 +58,7 @@ fn default_compile(sources: SourceMap) -> CompileUnit {
         &PackageStore::new(super::core()),
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     )
 }
@@ -440,7 +440,7 @@ fn package_dependency() {
         &store,
         &[],
         sources1,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit1.errors.is_empty(), "{:#?}", unit1.errors);
@@ -464,7 +464,7 @@ fn package_dependency() {
         &store,
         &[package1],
         sources2,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit2.errors.is_empty(), "{:#?}", unit2.errors);
@@ -513,7 +513,7 @@ fn package_dependency_internal_error() {
         &store,
         &[],
         sources1,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit1.errors.is_empty(), "{:#?}", unit1.errors);
@@ -537,7 +537,7 @@ fn package_dependency_internal_error() {
         &store,
         &[package1],
         sources2,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
 
@@ -593,7 +593,7 @@ fn package_dependency_udt() {
         &store,
         &[],
         sources1,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit1.errors.is_empty(), "{:#?}", unit1.errors);
@@ -617,7 +617,7 @@ fn package_dependency_udt() {
         &store,
         &[package1],
         sources2,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit2.errors.is_empty(), "{:#?}", unit2.errors);
@@ -668,7 +668,7 @@ fn package_dependency_nested_udt() {
         &store,
         &[],
         sources1,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit1.errors.is_empty(), "{:#?}", unit1.errors);
@@ -697,7 +697,7 @@ fn package_dependency_nested_udt() {
         &store,
         &[package1],
         sources2,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit2.errors.is_empty(), "{:#?}", unit2.errors);
@@ -754,7 +754,7 @@ fn package_dependency_nested_udt() {
 #[test]
 fn std_dependency() {
     let mut store = PackageStore::new(super::core());
-    let std = store.insert(super::std(&store, RuntimeCapabilityFlags::all()));
+    let std = store.insert(super::std(&store, TargetCapabilityFlags::all()));
     let sources = SourceMap::new(
         [(
             "test".into(),
@@ -777,7 +777,7 @@ fn std_dependency() {
         &store,
         &[std],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
@@ -786,7 +786,7 @@ fn std_dependency() {
 #[test]
 fn std_dependency_base_profile() {
     let mut store = PackageStore::new(super::core());
-    let std = store.insert(super::std(&store, RuntimeCapabilityFlags::empty()));
+    let std = store.insert(super::std(&store, TargetCapabilityFlags::empty()));
     let sources = SourceMap::new(
         [(
             "test".into(),
@@ -809,7 +809,7 @@ fn std_dependency_base_profile() {
         &store,
         &[std],
         sources,
-        RuntimeCapabilityFlags::empty(),
+        TargetCapabilityFlags::empty(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);
@@ -818,7 +818,7 @@ fn std_dependency_base_profile() {
 #[test]
 fn introduce_prelude_ambiguity() {
     let mut store = PackageStore::new(super::core());
-    let std = store.insert(super::std(&store, RuntimeCapabilityFlags::all()));
+    let std = store.insert(super::std(&store, TargetCapabilityFlags::all()));
     let sources = SourceMap::new(
         [(
             "test".into(),
@@ -837,7 +837,7 @@ fn introduce_prelude_ambiguity() {
         &store,
         &[std],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     let errors: Vec<Error> = unit.errors;
@@ -926,7 +926,7 @@ fn unimplemented_call_from_dependency_produces_error() {
         &store,
         &[],
         lib_sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(lib.errors.is_empty(), "{:#?}", lib.errors);
@@ -951,7 +951,7 @@ fn unimplemented_call_from_dependency_produces_error() {
         &store,
         &[lib],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     expect![[r#"
@@ -1063,7 +1063,7 @@ fn unimplemented_attribute_avoids_ambiguous_error_with_duplicate_names_in_scope(
         &store,
         &[],
         lib_sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(lib.errors.is_empty(), "{:#?}", lib.errors);
@@ -1092,7 +1092,7 @@ fn unimplemented_attribute_avoids_ambiguous_error_with_duplicate_names_in_scope(
         &store,
         &[lib],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     expect![[r#"
@@ -1121,7 +1121,7 @@ fn duplicate_intrinsic_from_dependency() {
         &store,
         &[],
         lib_sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(lib.errors.is_empty(), "{:#?}", lib.errors);
@@ -1144,7 +1144,7 @@ fn duplicate_intrinsic_from_dependency() {
         &store,
         &[lib],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     expect![[r#"
@@ -1168,7 +1168,7 @@ fn duplicate_intrinsic_from_dependency() {
 #[test]
 fn reject_use_qubit_block_syntax_if_preview_feature_is_on() {
     let mut store = PackageStore::new(super::core());
-    let std = store.insert(super::std(&store, RuntimeCapabilityFlags::empty()));
+    let std = store.insert(super::std(&store, TargetCapabilityFlags::empty()));
     let sources = SourceMap::new(
         [(
             "test".into(),
@@ -1182,7 +1182,7 @@ fn reject_use_qubit_block_syntax_if_preview_feature_is_on() {
                             // we have the v2 preview syntax feature enabled
                             X(q);
                         };
-                        
+
                     }
                 }
             "}
@@ -1195,7 +1195,7 @@ fn reject_use_qubit_block_syntax_if_preview_feature_is_on() {
         &store,
         &[std],
         sources,
-        RuntimeCapabilityFlags::empty(),
+        TargetCapabilityFlags::empty(),
         LanguageFeatures::V2PreviewSyntax,
     );
     expect![[r#"
@@ -1224,7 +1224,7 @@ fn reject_use_qubit_block_syntax_if_preview_feature_is_on() {
 #[test]
 fn accept_use_qubit_block_syntax_if_preview_feature_is_off() {
     let mut store = PackageStore::new(super::core());
-    let std = store.insert(super::std(&store, RuntimeCapabilityFlags::empty()));
+    let std = store.insert(super::std(&store, TargetCapabilityFlags::empty()));
     let sources = SourceMap::new(
         [(
             "test".into(),
@@ -1250,7 +1250,7 @@ fn accept_use_qubit_block_syntax_if_preview_feature_is_off() {
         &store,
         &[std],
         sources,
-        RuntimeCapabilityFlags::empty(),
+        TargetCapabilityFlags::empty(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:#?}", unit.errors);

--- a/compiler/qsc_frontend/src/incremental.rs
+++ b/compiler/qsc_frontend/src/incremental.rs
@@ -6,8 +6,8 @@ mod tests;
 
 use crate::{
     compile::{
-        self, preprocess, AstPackage, CompileUnit, Offsetter, PackageStore, RuntimeCapabilityFlags,
-        SourceMap,
+        self, preprocess, AstPackage, CompileUnit, Offsetter, PackageStore, SourceMap,
+        TargetCapabilityFlags,
     },
     error::WithSource,
     lower::Lowerer,
@@ -38,7 +38,7 @@ pub struct Compiler {
     resolver: Resolver,
     checker: Checker,
     lowerer: Lowerer,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
     language_features: LanguageFeatures,
 }
 
@@ -58,7 +58,7 @@ impl Compiler {
     pub fn new(
         store: &PackageStore,
         dependencies: impl IntoIterator<Item = PackageId>,
-        capabilities: RuntimeCapabilityFlags,
+        capabilities: TargetCapabilityFlags,
         language_features: LanguageFeatures,
     ) -> Self {
         let mut resolve_globals = resolve::GlobalTable::new();

--- a/compiler/qsc_frontend/src/incremental/tests.rs
+++ b/compiler/qsc_frontend/src/incremental/tests.rs
@@ -243,7 +243,7 @@ fn conditional_compilation_not_available() {
             &mut CompileUnit::default(),
             "test_1",
             indoc! {"
-                @Config(None)
+                @Config(Base)
                 function Dropped() : Unit {}
 
                 function Usage() : Unit {

--- a/compiler/qsc_frontend/src/incremental/tests.rs
+++ b/compiler/qsc_frontend/src/incremental/tests.rs
@@ -3,7 +3,7 @@
 
 use super::{Compiler, Increment};
 use crate::{
-    compile::{self, CompileUnit, PackageStore, RuntimeCapabilityFlags},
+    compile::{self, CompileUnit, PackageStore, TargetCapabilityFlags},
     incremental::Error,
 };
 use expect_test::{expect, Expect};
@@ -19,7 +19,7 @@ fn one_callable() {
     let mut compiler = Compiler::new(
         &store,
         vec![],
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     let unit = compiler
@@ -127,7 +127,7 @@ fn one_statement() {
     let mut compiler = Compiler::new(
         &store,
         vec![],
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     let unit = compiler
@@ -190,7 +190,7 @@ fn parse_error() {
     let mut compiler = Compiler::new(
         &store,
         vec![],
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     let errors = compiler
@@ -235,7 +235,7 @@ fn conditional_compilation_not_available() {
     let mut compiler = Compiler::new(
         &store,
         vec![],
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     let errors = compiler
@@ -260,12 +260,12 @@ fn conditional_compilation_not_available() {
 #[test]
 fn errors_across_multiple_lines() {
     let mut store = PackageStore::new(compile::core());
-    let std = compile::std(&store, RuntimeCapabilityFlags::all());
+    let std = compile::std(&store, TargetCapabilityFlags::all());
     let std_id = store.insert(std);
     let mut compiler = Compiler::new(
         &store,
         [std_id],
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     let mut unit = CompileUnit::default();
@@ -334,7 +334,7 @@ fn continue_after_parse_error() {
     let mut compiler = Compiler::new(
         &store,
         vec![],
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     let mut errors = Vec::new();
@@ -410,7 +410,7 @@ fn continue_after_lower_error() {
     let mut compiler = Compiler::new(
         &store,
         vec![],
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     let mut unit = CompileUnit::default();

--- a/compiler/qsc_frontend/src/incremental/tests.rs
+++ b/compiler/qsc_frontend/src/incremental/tests.rs
@@ -243,7 +243,7 @@ fn conditional_compilation_not_available() {
             &mut CompileUnit::default(),
             "test_1",
             indoc! {"
-                @Config(Base)
+                @Config(None)
                 function Dropped() : Unit {}
 
                 function Usage() : Unit {

--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use crate::{
     closure::{self, Lambda, PartialApp},
-    compile::RuntimeCapabilityFlags,
+    compile::TargetCapabilityFlags,
     resolve::{self, Names},
     typeck::{self, convert},
 };
@@ -229,7 +229,7 @@ impl With<'_> {
             Ok(hir::Attr::Config) => {
                 if !matches!(attr.arg.kind.as_ref(), ast::ExprKind::Paren(inner)
                     if matches!(inner.kind.as_ref(), ast::ExprKind::Path(path)
-                        if RuntimeCapabilityFlags::from_str(path.name.name.as_ref()).is_ok()))
+                        if TargetCapabilityFlags::from_str(path.name.name.as_ref()).is_ok()))
                 {
                     self.lowerer.errors.push(Error::InvalidAttrArgs(
                         "runtime capability".to_string(),

--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use crate::{
     closure::{self, Lambda, PartialApp},
-    compile::ConfigAttr,
+    compile::RuntimeCapabilityFlags,
     resolve::{self, Names},
     typeck::{self, convert},
 };
@@ -229,12 +229,11 @@ impl With<'_> {
             Ok(hir::Attr::Config) => {
                 if !matches!(attr.arg.kind.as_ref(), ast::ExprKind::Paren(inner)
                     if matches!(inner.kind.as_ref(), ast::ExprKind::Path(path)
-                        if ConfigAttr::from_str(path.name.name.as_ref()).is_ok()))
+                        if RuntimeCapabilityFlags::from_str(path.name.name.as_ref()).is_ok()))
                 {
-                    self.lowerer.errors.push(Error::InvalidAttrArgs(
-                        "Unrestricted or Base",
-                        attr.arg.span,
-                    ));
+                    self.lowerer
+                        .errors
+                        .push(Error::InvalidAttrArgs("runtime capability", attr.arg.span));
                 }
                 None
             }

--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -30,7 +30,7 @@ pub(super) enum Error {
     UnknownAttr(String, #[label] Span),
     #[error("invalid attribute arguments: expected {0}")]
     #[diagnostic(code("Qsc.LowerAst.InvalidAttrArgs"))]
-    InvalidAttrArgs(&'static str, #[label] Span),
+    InvalidAttrArgs(String, #[label] Span),
     #[error("missing callable body")]
     #[diagnostic(code("Qsc.LowerAst.MissingBody"))]
     MissingBody(#[label] Span),
@@ -213,7 +213,7 @@ impl With<'_> {
                 _ => {
                     self.lowerer
                         .errors
-                        .push(Error::InvalidAttrArgs("()", attr.arg.span));
+                        .push(Error::InvalidAttrArgs("()".to_string(), attr.arg.span));
                     None
                 }
             },
@@ -222,7 +222,7 @@ impl With<'_> {
                 _ => {
                     self.lowerer
                         .errors
-                        .push(Error::InvalidAttrArgs("()", attr.arg.span));
+                        .push(Error::InvalidAttrArgs("()".to_string(), attr.arg.span));
                     None
                 }
             },
@@ -231,9 +231,10 @@ impl With<'_> {
                     if matches!(inner.kind.as_ref(), ast::ExprKind::Path(path)
                         if RuntimeCapabilityFlags::from_str(path.name.name.as_ref()).is_ok()))
                 {
-                    self.lowerer
-                        .errors
-                        .push(Error::InvalidAttrArgs("runtime capability", attr.arg.span));
+                    self.lowerer.errors.push(Error::InvalidAttrArgs(
+                        "runtime capability".to_string(),
+                        attr.arg.span,
+                    ));
                 }
                 None
             }

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::needless_raw_string_hashes)]
 
-use crate::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use crate::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
@@ -14,7 +14,7 @@ fn check_hir(input: &str, expect: &Expect) {
         &PackageStore::new(compile::core()),
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     expect.assert_eq(&unit.package.to_string());
@@ -26,7 +26,7 @@ fn check_errors(input: &str, expect: &Expect) {
         &PackageStore::new(compile::core()),
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
 

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -94,24 +94,7 @@ fn test_target_profile_base_attr_allowed() {
     check_errors(
         indoc! {"
             namespace input {
-                @Config(Base)
-                operation Foo() : Unit {
-                    body ... {}
-                }
-            }
-        "},
-        &expect![[r#"
-            []
-        "#]],
-    );
-}
-
-#[test]
-fn test_target_profile_full_attr_allowed() {
-    check_errors(
-        indoc! {"
-            namespace input {
-                @Config(Unrestricted)
+                @Config(None)
                 operation Foo() : Unit {
                     body ... {}
                 }
@@ -137,7 +120,7 @@ fn test_target_profile_attr_wrong_args() {
         &expect![[r#"
             [
                 InvalidAttrArgs(
-                    "Unrestricted or Base",
+                    "runtime capability",
                     Span {
                         lo: 29,
                         hi: 34,

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -94,7 +94,7 @@ fn test_target_profile_base_attr_allowed() {
     check_errors(
         indoc! {"
             namespace input {
-                @Config(None)
+                @Config(Base)
                 operation Foo() : Unit {
                     body ... {}
                 }

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -6,7 +6,7 @@
 use super::{Error, Locals, Names, Res};
 use crate::{
     compile,
-    compile::RuntimeCapabilityFlags,
+    compile::TargetCapabilityFlags,
     resolve::{LocalKind, Resolver},
 };
 use expect_test::{expect, Expect};
@@ -104,7 +104,7 @@ fn compile(
 
     AstAssigner::new().visit_package(&mut package);
 
-    let mut cond_compile = compile::preprocess::Conditional::new(RuntimeCapabilityFlags::all());
+    let mut cond_compile = compile::preprocess::Conditional::new(TargetCapabilityFlags::all());
     cond_compile.visit_package(&mut package);
     let dropped_names = cond_compile.into_names();
 

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -1980,13 +1980,13 @@ fn multiple_definition_dropped_is_not_found() {
     check(
         indoc! {"
             namespace A {
-                @Config(ForwardBranching)
+                @Config(Adaptive)
                 operation B() : Unit {}
                 @Config(None)
                 operation B() : Unit {}
                 @Config(None)
                 operation C() : Unit {}
-                @Config(ForwardBranching)
+                @Config(Adaptive)
                 operation C() : Unit {}
             }
             namespace D {
@@ -2003,13 +2003,13 @@ fn multiple_definition_dropped_is_not_found() {
         "},
         &expect![[r#"
             namespace item0 {
-                @Config(ForwardBranching)
+                @Config(Adaptive)
                 operation item1() : Unit {}
                 @Config(None)
                 operation B() : Unit {}
                 @Config(None)
                 operation C() : Unit {}
-                @Config(ForwardBranching)
+                @Config(Adaptive)
                 operation item2() : Unit {}
             }
             namespace item3 {
@@ -2024,8 +2024,8 @@ fn multiple_definition_dropped_is_not_found() {
                 }
             }
 
-            // NotFound("B", Span { lo: 273, hi: 274 })
-            // NotFound("C", Span { lo: 286, hi: 287 })
+            // NotFound("B", Span { lo: 257, hi: 258 })
+            // NotFound("C", Span { lo: 270, hi: 271 })
         "#]],
     );
 }

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -1952,7 +1952,7 @@ fn dropped_callable() {
     check(
         indoc! {"
             namespace A {
-                @Config(Base)
+                @Config(None)
                 function Dropped() : Unit {}
 
                 function B() : Unit {
@@ -1962,7 +1962,7 @@ fn dropped_callable() {
         "},
         &expect![[r#"
             namespace item0 {
-                @Config(Base)
+                @Config(None)
                 function Dropped() : Unit {}
 
                 function item1() : Unit {
@@ -1980,13 +1980,13 @@ fn multiple_definition_dropped_is_not_found() {
     check(
         indoc! {"
             namespace A {
-                @Config(Unrestricted)
+                @Config(ForwardBranching)
                 operation B() : Unit {}
-                @Config(Base)
+                @Config(None)
                 operation B() : Unit {}
-                @Config(Base)
+                @Config(None)
                 operation C() : Unit {}
-                @Config(Unrestricted)
+                @Config(ForwardBranching)
                 operation C() : Unit {}
             }
             namespace D {
@@ -2003,13 +2003,13 @@ fn multiple_definition_dropped_is_not_found() {
         "},
         &expect![[r#"
             namespace item0 {
-                @Config(Unrestricted)
+                @Config(ForwardBranching)
                 operation item1() : Unit {}
-                @Config(Base)
+                @Config(None)
                 operation B() : Unit {}
-                @Config(Base)
+                @Config(None)
                 operation C() : Unit {}
-                @Config(Unrestricted)
+                @Config(ForwardBranching)
                 operation item2() : Unit {}
             }
             namespace item3 {
@@ -2024,8 +2024,8 @@ fn multiple_definition_dropped_is_not_found() {
                 }
             }
 
-            // NotFound("B", Span { lo: 265, hi: 266 })
-            // NotFound("C", Span { lo: 278, hi: 279 })
+            // NotFound("B", Span { lo: 273, hi: 274 })
+            // NotFound("C", Span { lo: 286, hi: 287 })
         "#]],
     );
 }

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -1952,7 +1952,7 @@ fn dropped_callable() {
     check(
         indoc! {"
             namespace A {
-                @Config(None)
+                @Config(Base)
                 function Dropped() : Unit {}
 
                 function B() : Unit {
@@ -1962,7 +1962,7 @@ fn dropped_callable() {
         "},
         &expect![[r#"
             namespace item0 {
-                @Config(None)
+                @Config(Base)
                 function Dropped() : Unit {}
 
                 function item1() : Unit {
@@ -1982,9 +1982,9 @@ fn multiple_definition_dropped_is_not_found() {
             namespace A {
                 @Config(Adaptive)
                 operation B() : Unit {}
-                @Config(None)
+                @Config(Base)
                 operation B() : Unit {}
-                @Config(None)
+                @Config(Base)
                 operation C() : Unit {}
                 @Config(Adaptive)
                 operation C() : Unit {}
@@ -2005,9 +2005,9 @@ fn multiple_definition_dropped_is_not_found() {
             namespace item0 {
                 @Config(Adaptive)
                 operation item1() : Unit {}
-                @Config(None)
+                @Config(Base)
                 operation B() : Unit {}
-                @Config(None)
+                @Config(Base)
                 operation C() : Unit {}
                 @Config(Adaptive)
                 operation item2() : Unit {}

--- a/compiler/qsc_linter/src/tests.rs
+++ b/compiler/qsc_linter/src/tests.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use expect_test::{expect, Expect};
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, CompileUnit, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, CompileUnit, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_passes::PackageType;
 
 #[test]
@@ -162,14 +162,14 @@ fn hir_placeholder() {
 fn check(source: &str, expected: &Expect) {
     let source = wrap_in_namespace(source);
     let mut store = PackageStore::new(compile::core());
-    let std = store.insert(compile::std(&store, RuntimeCapabilityFlags::all()));
+    let std = store.insert(compile::std(&store, TargetCapabilityFlags::all()));
     let sources = SourceMap::new([("source.qs".into(), source.clone().into())], None);
     let (package, _) = qsc::compile::compile(
         &store,
         &[std],
         sources,
         PackageType::Exe,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
 

--- a/compiler/qsc_partial_eval/tests/test_utils.rs
+++ b/compiler/qsc_partial_eval/tests/test_utils.rs
@@ -4,7 +4,7 @@
 use qsc::{incremental::Compiler, PackageType};
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_fir::fir::PackageStore;
-use qsc_frontend::compile::{PackageStore as HirPackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{PackageStore as HirPackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_lowerer::{map_hir_package_to_fir, Lowerer};
 use qsc_partial_eval::{partially_evaluate, ProgramEntry};
 use qsc_rca::{Analyzer, PackageStoreComputeProperties};
@@ -93,7 +93,7 @@ impl CompilationContext {
             true,
             source_map,
             PackageType::Exe,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("should be able to create a new compiler");

--- a/compiler/qsc_passes/src/baseprofck/tests.rs
+++ b/compiler/qsc_passes/src/baseprofck/tests.rs
@@ -6,19 +6,19 @@
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 
 use crate::baseprofck::check_base_profile_compliance;
 
 fn check(expr: &str, expect: &Expect) {
     let mut store = PackageStore::new(compile::core());
-    let std = store.insert(compile::std(&store, RuntimeCapabilityFlags::all()));
+    let std = store.insert(compile::std(&store, TargetCapabilityFlags::all()));
     let sources = SourceMap::new([("test".into(), "".into())], Some(expr.into()));
     let unit = compile(
         &store,
         &[std],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);

--- a/compiler/qsc_passes/src/borrowck/tests.rs
+++ b/compiler/qsc_passes/src/borrowck/tests.rs
@@ -6,7 +6,7 @@
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_hir::visit::Visitor;
 
 use crate::borrowck::Checker;
@@ -18,7 +18,7 @@ fn check(expr: &str, expect: &Expect) {
         &store,
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);

--- a/compiler/qsc_passes/src/callable_limits/tests.rs
+++ b/compiler/qsc_passes/src/callable_limits/tests.rs
@@ -6,7 +6,7 @@
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_hir::visit::Visitor;
 
 use crate::callable_limits::CallableLimits;
@@ -18,7 +18,7 @@ fn check(file: &str, expect: &Expect) {
         &store,
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);

--- a/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/compiler/qsc_passes/src/capabilitiesck.rs
@@ -25,7 +25,7 @@ use qsc_fir::{
     ty::FunctorSetValue,
     visit::Visitor,
 };
-use qsc_frontend::compile::RuntimeCapabilityFlags;
+use qsc_frontend::compile::TargetCapabilityFlags;
 use qsc_lowerer::map_hir_package_to_fir;
 use qsc_rca::{
     Analyzer, ComputeKind, ItemComputeProperties, PackageComputeProperties,
@@ -188,7 +188,7 @@ pub fn lower_store(
 pub fn run_rca_pass(
     fir_store: &qsc_fir::fir::PackageStore,
     package_id: qsc_fir::fir::PackageId,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
 ) -> Result<PackageStoreComputeProperties, Vec<crate::Error>> {
     let analyzer = Analyzer::init(fir_store);
     let compute_properties = analyzer.analyze_all();
@@ -213,7 +213,7 @@ pub fn run_rca_pass(
 pub fn check_supported_capabilities(
     package: &Package,
     compute_properties: &PackageComputeProperties,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
 ) -> Vec<Error> {
     let checker = Checker {
         package,
@@ -229,7 +229,7 @@ pub fn check_supported_capabilities(
 struct Checker<'a> {
     package: &'a Package,
     compute_properties: &'a PackageComputeProperties,
-    target_capabilities: RuntimeCapabilityFlags,
+    target_capabilities: TargetCapabilityFlags,
     current_callable: Option<LocalItemId>,
     missing_features_map: FxHashMap<Span, RuntimeFeatureFlags>,
 }
@@ -583,9 +583,9 @@ fn generate_errors_from_runtime_features(
 
 fn get_missing_runtime_features(
     runtime_features: RuntimeFeatureFlags,
-    target_capabilities: RuntimeCapabilityFlags,
+    target_capabilities: TargetCapabilityFlags,
 ) -> RuntimeFeatureFlags {
-    let missing_capabilities = !target_capabilities & runtime_features.runtime_capabilities();
+    let missing_capabilities = !target_capabilities & runtime_features.target_capabilities();
     runtime_features.contributing_features(missing_capabilities)
 }
 

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -18,7 +18,7 @@ use expect_test::{expect, Expect};
 use qsc_frontend::compile::RuntimeCapabilityFlags;
 
 fn check_profile(source: &str, expect: &Expect) {
-    check(source, expect, RuntimeCapabilityFlags::ForwardBranching);
+    check(source, expect, RuntimeCapabilityFlags::Adaptive);
 }
 
 #[test]

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -15,10 +15,10 @@ use super::tests_common::{
     USE_DYNAMIC_QUBIT, USE_DYNAMIC_RANGE, USE_DYNAMIC_STRING, USE_DYNAMIC_UDT,
 };
 use expect_test::{expect, Expect};
-use qsc_frontend::compile::RuntimeCapabilityFlags;
+use qsc_frontend::compile::TargetCapabilityFlags;
 
 fn check_profile(source: &str, expect: &Expect) {
-    check(source, expect, RuntimeCapabilityFlags::Adaptive);
+    check(source, expect, TargetCapabilityFlags::Adaptive);
 }
 
 #[test]

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -23,7 +23,7 @@ fn check_profile(source: &str, expect: &Expect) {
     check(
         source,
         expect,
-        RuntimeCapabilityFlags::ForwardBranching | RuntimeCapabilityFlags::IntegerComputations,
+        RuntimeCapabilityFlags::Adaptive | RuntimeCapabilityFlags::IntegerComputations,
     );
 }
 

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -17,13 +17,13 @@ use super::tests_common::{
     USE_DYNAMIC_QUBIT, USE_DYNAMIC_STRING, USE_DYNAMIC_UDT,
 };
 use expect_test::{expect, Expect};
-use qsc_frontend::compile::RuntimeCapabilityFlags;
+use qsc_frontend::compile::TargetCapabilityFlags;
 
 fn check_profile(source: &str, expect: &Expect) {
     check(
         source,
         expect,
-        RuntimeCapabilityFlags::Adaptive | RuntimeCapabilityFlags::IntegerComputations,
+        TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::IntegerComputations,
     );
 }
 

--- a/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -15,10 +15,10 @@ use super::tests_common::{
     USE_DYNAMIC_QUBIT, USE_DYNAMIC_RANGE, USE_DYNAMIC_STRING, USE_DYNAMIC_UDT,
 };
 use expect_test::{expect, Expect};
-use qsc_frontend::compile::RuntimeCapabilityFlags;
+use qsc_frontend::compile::TargetCapabilityFlags;
 
 fn check_profile(source: &str, expect: &Expect) {
-    check(source, expect, RuntimeCapabilityFlags::empty());
+    check(source, expect, TargetCapabilityFlags::empty());
 }
 
 #[test]

--- a/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -9,11 +9,11 @@ use crate::capabilitiesck::check_supported_capabilities;
 use qsc::{incremental::Compiler, PackageType};
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_fir::fir::{Package, PackageId, PackageStore};
-use qsc_frontend::compile::{PackageStore as HirPackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{PackageStore as HirPackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_lowerer::{map_hir_package_to_fir, Lowerer};
 use qsc_rca::{Analyzer, PackageComputeProperties, PackageStoreComputeProperties};
 
-pub fn check(source: &str, expect: &Expect, capabilities: RuntimeCapabilityFlags) {
+pub fn check(source: &str, expect: &Expect, capabilities: TargetCapabilityFlags) {
     let compilation_context = CompilationContext::new(source);
     let (package, compute_properties) = compilation_context.get_package_compute_properties_tuple();
     let errors = check_supported_capabilities(package, compute_properties, capabilities);
@@ -46,7 +46,7 @@ impl CompilationContext {
             true,
             SourceMap::default(),
             PackageType::Lib,
-            RuntimeCapabilityFlags::all(),
+            TargetCapabilityFlags::all(),
             LanguageFeatures::default(),
         )
         .expect("should be able to create a new compiler");

--- a/compiler/qsc_passes/src/conjugate_invert/tests.rs
+++ b/compiler/qsc_passes/src/conjugate_invert/tests.rs
@@ -7,7 +7,7 @@
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_hir::{validate::Validator, visit::Visitor};
 
 use crate::conjugate_invert::invert_conjugate_exprs;
@@ -19,7 +19,7 @@ fn check(file: &str, expect: &Expect) {
         &store,
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -7,7 +7,7 @@ use crate::entry_point::generate_entry_expr;
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 
 fn check(file: &str, expr: &str, expect: &Expect) {
     let sources = SourceMap::new([("test".into(), file.into())], Some(expr.into()));
@@ -15,7 +15,7 @@ fn check(file: &str, expr: &str, expect: &Expect) {
         &PackageStore::new(compile::core()),
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -21,7 +21,7 @@ use entry_point::generate_entry_expr;
 use loop_unification::LoopUni;
 use miette::Diagnostic;
 use qsc_fir::fir;
-use qsc_frontend::compile::{CompileUnit, RuntimeCapabilityFlags};
+use qsc_frontend::compile::{CompileUnit, TargetCapabilityFlags};
 use qsc_hir::{
     assigner::Assigner,
     global::{self, Table},
@@ -65,13 +65,13 @@ pub fn lower_hir_to_fir(
 }
 
 pub struct PassContext {
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
     borrow_check: borrowck::Checker,
 }
 
 impl PassContext {
     #[must_use]
-    pub fn new(capabilities: RuntimeCapabilityFlags) -> Self {
+    pub fn new(capabilities: TargetCapabilityFlags) -> Self {
         Self {
             capabilities,
             borrow_check: borrowck::Checker::default(),
@@ -113,7 +113,7 @@ impl PassContext {
         ReplaceQubitAllocation::new(core, assigner).visit_package(package);
         Validator::default().visit_package(package);
 
-        let base_prof_errors = if self.capabilities == RuntimeCapabilityFlags::empty() {
+        let base_prof_errors = if self.capabilities == TargetCapabilityFlags::empty() {
             baseprofck::check_base_profile_compliance(package)
         } else {
             Vec::new()
@@ -133,7 +133,7 @@ impl PassContext {
     pub fn run_fir_passes_on_fir(
         fir_store: &qsc_fir::fir::PackageStore,
         package_id: qsc_fir::fir::PackageId,
-        capabilities: RuntimeCapabilityFlags,
+        capabilities: TargetCapabilityFlags,
     ) -> Result<PackageStoreComputeProperties, Vec<Error>> {
         run_rca_pass(fir_store, package_id, capabilities)
     }
@@ -144,7 +144,7 @@ pub fn run_default_passes(
     core: &Table,
     unit: &mut CompileUnit,
     package_type: PackageType,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
 ) -> Vec<Error> {
     PassContext::new(capabilities).run_default_passes(
         &mut unit.package,
@@ -182,7 +182,7 @@ pub fn run_core_passes(core: &mut CompileUnit) -> Vec<Error> {
 pub fn run_fir_passes(
     package: &fir::Package,
     compute_properties: &PackageComputeProperties,
-    capabilities: RuntimeCapabilityFlags,
+    capabilities: TargetCapabilityFlags,
 ) -> Vec<Error> {
     let capabilities_errors =
         check_supported_capabilities(package, compute_properties, capabilities);

--- a/compiler/qsc_passes/src/logic_sep/tests.rs
+++ b/compiler/qsc_passes/src/logic_sep/tests.rs
@@ -6,7 +6,7 @@
 
 use expect_test::{expect, Expect};
 use qsc_data_structures::{language_features::LanguageFeatures, span::Span};
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_hir::{
     hir::{ExprKind, NodeId, Stmt},
     visit::{walk_stmt, Visitor},
@@ -28,12 +28,12 @@ impl<'a> Visitor<'a> for StmtSpans {
 
 fn check(block_str: &str, expect: &Expect) {
     let mut store = PackageStore::new(compile::core());
-    let std = store.insert(compile::std(&store, RuntimeCapabilityFlags::all()));
+    let std = store.insert(compile::std(&store, TargetCapabilityFlags::all()));
     let unit = compile(
         &store,
         &[std],
         SourceMap::new([], Some(block_str.into())),
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);

--- a/compiler/qsc_passes/src/loop_unification/tests.rs
+++ b/compiler/qsc_passes/src/loop_unification/tests.rs
@@ -6,7 +6,7 @@
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_hir::{mut_visit::MutVisitor, validate::Validator, visit::Visitor};
 
 use crate::loop_unification::LoopUni;
@@ -18,7 +18,7 @@ fn check(file: &str, expect: &Expect) {
         &store,
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);

--- a/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
+++ b/compiler/qsc_passes/src/replace_qubit_allocation/tests.rs
@@ -5,7 +5,7 @@ use crate::replace_qubit_allocation::ReplaceQubitAllocation;
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_hir::{mut_visit::MutVisitor, validate::Validator, visit::Visitor};
 
 fn check(file: &str, expect: &Expect) {
@@ -15,7 +15,7 @@ fn check(file: &str, expect: &Expect) {
         &store,
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -7,7 +7,7 @@
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::language_features::LanguageFeatures;
-use qsc_frontend::compile::{self, compile, PackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_hir::{validate::Validator, visit::Visitor};
 
 use crate::spec_gen::generate_specs;
@@ -19,7 +19,7 @@ fn check(file: &str, expect: &Expect) {
         &store,
         &[],
         sources,
-        RuntimeCapabilityFlags::all(),
+        TargetCapabilityFlags::all(),
         LanguageFeatures::default(),
     );
     assert!(unit.errors.is_empty(), "{:?}", unit.errors);

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -26,7 +26,7 @@ use qsc_fir::{
     },
     ty::Ty,
 };
-use qsc_frontend::compile::RuntimeCapabilityFlags;
+use qsc_frontend::compile::TargetCapabilityFlags;
 use std::{
     cmp::Ord,
     fmt::{self, Debug, Display, Formatter, Write},
@@ -752,15 +752,12 @@ bitflags! {
 }
 
 impl RuntimeFeatureFlags {
-    /// Determines the runtime features that contribute to the provided runtime capabilities.
+    /// Determines the runtime features that contribute to the provided target capabilities.
     #[must_use]
-    pub fn contributing_features(&self, runtime_capabilities: RuntimeCapabilityFlags) -> Self {
+    pub fn contributing_features(&self, capabilities: TargetCapabilityFlags) -> Self {
         let mut contributing_features = Self::empty();
         for feature in self.iter() {
-            if feature
-                .runtime_capabilities()
-                .intersects(runtime_capabilities)
-            {
+            if feature.target_capabilities().intersects(capabilities) {
                 contributing_features |= feature;
             }
         }
@@ -768,76 +765,76 @@ impl RuntimeFeatureFlags {
         contributing_features
     }
 
-    /// Maps program contructs to runtime capabilities.
+    /// Maps program constructs to target capabilities.
     #[must_use]
-    pub fn runtime_capabilities(&self) -> RuntimeCapabilityFlags {
-        let mut runtume_capabilities = RuntimeCapabilityFlags::empty();
+    pub fn target_capabilities(&self) -> TargetCapabilityFlags {
+        let mut capabilities = TargetCapabilityFlags::empty();
         if self.contains(RuntimeFeatureFlags::UseOfDynamicBool) {
-            runtume_capabilities |= RuntimeCapabilityFlags::Adaptive;
+            capabilities |= TargetCapabilityFlags::Adaptive;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicInt) {
-            runtume_capabilities |= RuntimeCapabilityFlags::IntegerComputations;
+            capabilities |= TargetCapabilityFlags::IntegerComputations;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicPauli) {
-            runtume_capabilities |= RuntimeCapabilityFlags::IntegerComputations;
+            capabilities |= TargetCapabilityFlags::IntegerComputations;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicRange) {
-            runtume_capabilities |= RuntimeCapabilityFlags::IntegerComputations;
+            capabilities |= TargetCapabilityFlags::IntegerComputations;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicDouble) {
-            runtume_capabilities |= RuntimeCapabilityFlags::FloatingPointComputations;
+            capabilities |= TargetCapabilityFlags::FloatingPointComputations;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicQubit) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicBigInt) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicString) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicallySizedArray) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicUdt) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicArrowFunction) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicArrowOperation) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::CallToCyclicFunctionWithDynamicArg) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::CyclicOperationSpec) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::CallToCyclicOperation) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::CallToDynamicCallee) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::CallToUnresolvedCallee) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::MeasurementWithinDynamicScope) {
-            runtume_capabilities |= RuntimeCapabilityFlags::Adaptive;
+            capabilities |= TargetCapabilityFlags::Adaptive;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicIndex) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::ReturnWithinDynamicScope) {
-            runtume_capabilities |= RuntimeCapabilityFlags::Adaptive;
+            capabilities |= TargetCapabilityFlags::Adaptive;
         }
         if self.contains(RuntimeFeatureFlags::LoopWithDynamicCondition) {
-            runtume_capabilities |= RuntimeCapabilityFlags::BackwardsBranching;
+            capabilities |= TargetCapabilityFlags::BackwardsBranching;
         }
         if self.contains(RuntimeFeatureFlags::UseOfClosure) {
-            runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
-        runtume_capabilities
+        capabilities
     }
 }

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -773,7 +773,7 @@ impl RuntimeFeatureFlags {
     pub fn runtime_capabilities(&self) -> RuntimeCapabilityFlags {
         let mut runtume_capabilities = RuntimeCapabilityFlags::empty();
         if self.contains(RuntimeFeatureFlags::UseOfDynamicBool) {
-            runtume_capabilities |= RuntimeCapabilityFlags::ForwardBranching;
+            runtume_capabilities |= RuntimeCapabilityFlags::Adaptive;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicInt) {
             runtume_capabilities |= RuntimeCapabilityFlags::IntegerComputations;
@@ -824,13 +824,13 @@ impl RuntimeFeatureFlags {
             runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::MeasurementWithinDynamicScope) {
-            runtume_capabilities |= RuntimeCapabilityFlags::ForwardBranching;
+            runtume_capabilities |= RuntimeCapabilityFlags::Adaptive;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicIndex) {
             runtume_capabilities |= RuntimeCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::ReturnWithinDynamicScope) {
-            runtume_capabilities |= RuntimeCapabilityFlags::ForwardBranching;
+            runtume_capabilities |= RuntimeCapabilityFlags::Adaptive;
         }
         if self.contains(RuntimeFeatureFlags::LoopWithDynamicCondition) {
             runtume_capabilities |= RuntimeCapabilityFlags::BackwardsBranching;

--- a/compiler/qsc_rca/tests/callables.rs
+++ b/compiler/qsc_rca/tests/callables.rs
@@ -6,7 +6,7 @@
 pub mod test_utils;
 
 use expect_test::expect;
-use qsc::RuntimeCapabilityFlags;
+use qsc::TargetCapabilityFlags;
 use test_utils::{
     check_callable_compute_properties, check_last_statement_compute_properties, CompilationContext,
 };
@@ -200,7 +200,7 @@ fn check_rca_for_unrestricted_h() {
 
 #[test]
 fn check_rca_for_base_h() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -304,7 +304,7 @@ fn check_rca_for_unrestricted_r1() {
 
 #[test]
 fn check_rca_for_base_r1() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -420,7 +420,7 @@ fn check_rca_for_unrestricted_rx() {
 
 #[test]
 fn check_rca_for_base_rx() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -548,7 +548,7 @@ fn check_rca_for_unrestricted_rxx() {
 
 #[test]
 fn check_rca_for_base_rxx() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -676,7 +676,7 @@ fn check_rca_for_unrestricted_ry() {
 
 #[test]
 fn check_rca_for_base_ry() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -804,7 +804,7 @@ fn check_rca_for_unrestricted_ryy() {
 
 #[test]
 fn check_rca_for_base_ryy() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -932,7 +932,7 @@ fn check_rca_for_unrestricted_rz() {
 
 #[test]
 fn check_rca_for_base_rz() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -1060,7 +1060,7 @@ fn check_rca_for_unrestricted_rzz() {
 
 #[test]
 fn check_rca_for_base_rzz() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -1176,7 +1176,7 @@ fn check_rca_for_unrestricted_s() {
 
 #[test]
 fn check_rca_for_base_s() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -1268,7 +1268,7 @@ fn check_rca_for_unrestricted_t() {
 
 #[test]
 fn check_rca_for_base_t() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -1360,7 +1360,7 @@ fn check_rca_for_unrestricted_x() {
 
 #[test]
 fn check_rca_for_base_x() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -1452,7 +1452,7 @@ fn check_rca_for_unrestricted_y() {
 
 #[test]
 fn check_rca_for_base_y() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
@@ -1544,7 +1544,7 @@ fn check_rca_for_unrestricted_z() {
 
 #[test]
 fn check_rca_for_base_z() {
-    let compilation_context = CompilationContext::new(RuntimeCapabilityFlags::empty());
+    let compilation_context = CompilationContext::new(TargetCapabilityFlags::empty());
     check_callable_compute_properties(
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),

--- a/compiler/qsc_rca/tests/test_utils.rs
+++ b/compiler/qsc_rca/tests/test_utils.rs
@@ -5,7 +5,7 @@ use expect_test::Expect;
 use qsc::incremental::Compiler;
 use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_fir::fir::{ItemKind, LocalItemId, Package, PackageStore, StoreItemId};
-use qsc_frontend::compile::{PackageStore as HirPackageStore, RuntimeCapabilityFlags, SourceMap};
+use qsc_frontend::compile::{PackageStore as HirPackageStore, SourceMap, TargetCapabilityFlags};
 use qsc_lowerer::{map_hir_package_to_fir, Lowerer};
 use qsc_passes::PackageType;
 use qsc_rca::{Analyzer, ComputePropertiesLookup, PackageStoreComputeProperties};
@@ -19,7 +19,7 @@ pub struct CompilationContext {
 
 impl CompilationContext {
     #[must_use]
-    pub fn new(runtime_capabilities: RuntimeCapabilityFlags) -> Self {
+    pub fn new(runtime_capabilities: TargetCapabilityFlags) -> Self {
         let compiler = Compiler::new(
             true,
             SourceMap::default(),
@@ -68,7 +68,7 @@ impl CompilationContext {
 
 impl Default for CompilationContext {
     fn default() -> Self {
-        Self::new(RuntimeCapabilityFlags::all())
+        Self::new(TargetCapabilityFlags::all())
     }
 }
 

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -311,12 +311,12 @@ async fn rca_errors_are_reported_when_compilation_succeeds() {
     let mut updater = new_updater(&errors);
 
     updater.update_configuration(WorkspaceConfigurationUpdate {
-        target_profile: Some(Profile::Adaptive),
+        target_profile: Some(Profile::Quantinuum),
         package_type: Some(PackageType::Lib),
     });
 
     updater
-        .update_document("single/foo.qs", 1, "namespace Test { operation RcaCheck() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x } }")
+        .update_document("single/foo.qs", 1, "namespace Test { operation RcaCheck() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x } }")
         .await;
 
     // we expect two errors, one for `set x = 2` and one for `x`
@@ -332,20 +332,20 @@ async fn rca_errors_are_reported_when_compilation_succeeds() {
                     [
                         Pass(
                             CapabilitiesCk(
-                                UseOfDynamicInt(
+                                UseOfDynamicDouble(
                                     Span {
-                                        lo: 101,
-                                        hi: 110,
+                                        lo: 106,
+                                        hi: 117,
                                     },
                                 ),
                             ),
                         ),
                         Pass(
                             CapabilitiesCk(
-                                UseOfDynamicInt(
+                                UseOfDynamicDouble(
                                     Span {
-                                        lo: 114,
-                                        hi: 115,
+                                        lo: 121,
+                                        hi: 122,
                                     },
                                 ),
                             ),

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -168,8 +168,8 @@ namespace Microsoft.Quantum.Convert {
     /// // The following returns 1
     /// let int1 = ResultArrayAsInt([One,Zero])
     /// ```
-    @Config(IntegerComputations)
     @Config(ForwardBranching)
+    @Config(IntegerComputations)
     function ResultArrayAsInt(results : Result[]) : Int {
         let nBits = Length(results);
         Fact(nBits < 64, $"`Length(bits)` must be less than 64, but was {nBits}.");

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool` representing the `input`.
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     function ResultAsBool(input : Result) : Bool {
         input == One
     }
@@ -42,7 +42,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result` representing the `input`.
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     function BoolAsResult(input : Bool) : Result {
         if input { One } else { Zero }
     }
@@ -168,8 +168,7 @@ namespace Microsoft.Quantum.Convert {
     /// // The following returns 1
     /// let int1 = ResultArrayAsInt([One,Zero])
     /// ```
-    @Config(ForwardBranching)
-    @Config(IntegerComputations)
+    @Config(Adaptive)
     function ResultArrayAsInt(results : Result[]) : Int {
         let nBits = Length(results);
         Fact(nBits < 64, $"`Length(bits)` must be less than 64, but was {nBits}.");
@@ -194,7 +193,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool[]` representing the `input`.
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     function ResultArrayAsBoolArray(input : Result[]) : Bool[] {
         mutable output = [];
         for r in input {
@@ -214,7 +213,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result[]` representing the `input`.
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     function BoolArrayAsResultArray(input : Bool[]) : Result[] {
         mutable output = [];
         for b in input {

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -27,8 +27,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool` representing the `input`.
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     function ResultAsBool(input : Result) : Bool {
         input == One
     }
@@ -43,8 +42,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result` representing the `input`.
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     function BoolAsResult(input : Bool) : Result {
         if input { One } else { Zero }
     }
@@ -170,8 +168,8 @@ namespace Microsoft.Quantum.Convert {
     /// // The following returns 1
     /// let int1 = ResultArrayAsInt([One,Zero])
     /// ```
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(IntegerComputations)
+    @Config(ForwardBranching)
     function ResultArrayAsInt(results : Result[]) : Int {
         let nBits = Length(results);
         Fact(nBits < 64, $"`Length(bits)` must be less than 64, but was {nBits}.");
@@ -196,8 +194,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Bool[]` representing the `input`.
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     function ResultArrayAsBoolArray(input : Result[]) : Bool[] {
         mutable output = [];
         for r in input {
@@ -217,8 +214,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Output
     /// A `Result[]` representing the `input`.
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     function BoolArrayAsResultArray(input : Bool[]) : Result[] {
         mutable output = [];
         for b in input {

--- a/library/std/diagnostics.qs
+++ b/library/std/diagnostics.qs
@@ -69,14 +69,12 @@ namespace Microsoft.Quantum.Diagnostics {
         body intrinsic;
     }
 
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     operation CheckZero(qubit : Qubit) : Bool {
         body intrinsic;
     }
 
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     operation CheckAllZero(qubits : Qubit[]) : Bool {
         for q in qubits {
             if not CheckZero(q) {
@@ -122,8 +120,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// Operation defining the expected behavior for the operation under test.
     /// # Output
     /// True if operations are equal, false otherwise.
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     operation CheckOperationsAreEqual(
         nQubits : Int,
         actual : (Qubit[] => Unit),

--- a/library/std/diagnostics.qs
+++ b/library/std/diagnostics.qs
@@ -69,12 +69,12 @@ namespace Microsoft.Quantum.Diagnostics {
         body intrinsic;
     }
 
-    @Config(ForwardBranching)
+    @Config(Unrestricted)
     operation CheckZero(qubit : Qubit) : Bool {
         body intrinsic;
     }
 
-    @Config(ForwardBranching)
+    @Config(Unrestricted)
     operation CheckAllZero(qubits : Qubit[]) : Bool {
         for q in qubits {
             if not CheckZero(q) {
@@ -120,7 +120,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// Operation defining the expected behavior for the operation under test.
     /// # Output
     /// True if operations are equal, false otherwise.
-    @Config(ForwardBranching)
+    @Config(Unrestricted)
     operation CheckOperationsAreEqual(
         nQubits : Int,
         actual : (Qubit[] => Unit),

--- a/library/std/internal.qs
+++ b/library/std/internal.qs
@@ -131,7 +131,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     internal operation AND(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         body ... {
             __quantum__qis__ccx__body(control1, control2, target);

--- a/library/std/internal.qs
+++ b/library/std/internal.qs
@@ -131,8 +131,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     internal operation AND(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         body ... {
             __quantum__qis__ccx__body(control1, control2, target);
@@ -145,7 +144,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    @Config(Base)
+    @Config(None)
     internal operation AND(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         PhaseCCX(control1, control2, target);
     }

--- a/library/std/internal.qs
+++ b/library/std/internal.qs
@@ -144,7 +144,7 @@ namespace Microsoft.Quantum.Intrinsic {
         }
     }
 
-    @Config(None)
+    @Config(Base)
     internal operation AND(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         PhaseCCX(control1, control2, target);
     }

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -218,7 +218,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// Measure([PauliZ], [qubit]);
     /// ```
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     operation M(qubit : Qubit) : Result {
         __quantum__qis__m__body(qubit)
     }
@@ -290,7 +290,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// If the basis array and qubit array are different lengths, then the
     /// operation will fail.
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
         if Length(bases) != Length(qubits) {
             fail "Arrays 'bases' and 'qubits' must be of the same length.";

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -249,7 +249,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// Measure([PauliZ], [qubit]);
     /// ```
-    @Config(None)
+    @Config(Base)
     operation M(qubit : Qubit) : Result {
         Measure([PauliZ], [qubit])
     }
@@ -350,7 +350,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// If the basis array and qubit array are different lengths, then the
     /// operation will fail.
-    @Config(None)
+    @Config(Base)
     operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
         if Length(bases) != Length(qubits) {
             fail "Arrays 'bases' and 'qubits' must be of the same length.";

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -218,8 +218,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// Measure([PauliZ], [qubit]);
     /// ```
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     operation M(qubit : Qubit) : Result {
         __quantum__qis__m__body(qubit)
     }
@@ -250,7 +249,7 @@ namespace Microsoft.Quantum.Intrinsic {
     /// ```qsharp
     /// Measure([PauliZ], [qubit]);
     /// ```
-    @Config(Base)
+    @Config(None)
     operation M(qubit : Qubit) : Result {
         Measure([PauliZ], [qubit])
     }
@@ -291,8 +290,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// If the basis array and qubit array are different lengths, then the
     /// operation will fail.
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
         if Length(bases) != Length(qubits) {
             fail "Arrays 'bases' and 'qubits' must be of the same length.";
@@ -352,7 +350,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// If the basis array and qubit array are different lengths, then the
     /// operation will fail.
-    @Config(Base)
+    @Config(None)
     operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
         if Length(bases) != Length(qubits) {
             fail "Arrays 'bases' and 'qubits' must be of the same length.";

--- a/library/std/measurement.qs
+++ b/library/std/measurement.qs
@@ -146,6 +146,7 @@ namespace Microsoft.Quantum.Measurement {
     /// # Remarks
     /// This operation resets its input register to the |00...0> state,
     /// suitable for releasing back to a target machine.
+    @Config(IntegerComputations)
     @Config(ForwardBranching)
     operation MeasureInteger(target : Qubit[]) : Int {
         let nBits = Length(target);

--- a/library/std/measurement.qs
+++ b/library/std/measurement.qs
@@ -146,8 +146,8 @@ namespace Microsoft.Quantum.Measurement {
     /// # Remarks
     /// This operation resets its input register to the |00...0> state,
     /// suitable for releasing back to a target machine.
-    @Config(IntegerComputations)
     @Config(ForwardBranching)
+    @Config(IntegerComputations)
     operation MeasureInteger(target : Qubit[]) : Int {
         let nBits = Length(target);
         Fact(nBits < 64, $"`Length(target)` must be less than 64, but was {nBits}.");

--- a/library/std/measurement.qs
+++ b/library/std/measurement.qs
@@ -146,8 +146,7 @@ namespace Microsoft.Quantum.Measurement {
     /// # Remarks
     /// This operation resets its input register to the |00...0> state,
     /// suitable for releasing back to a target machine.
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     operation MeasureInteger(target : Qubit[]) : Int {
         let nBits = Length(target);
         Fact(nBits < 64, $"`Length(target)` must be less than 64, but was {nBits}.");

--- a/library/std/measurement.qs
+++ b/library/std/measurement.qs
@@ -146,8 +146,7 @@ namespace Microsoft.Quantum.Measurement {
     /// # Remarks
     /// This operation resets its input register to the |00...0> state,
     /// suitable for releasing back to a target machine.
-    @Config(ForwardBranching)
-    @Config(IntegerComputations)
+    @Config(Adaptive)
     operation MeasureInteger(target : Qubit[]) : Int {
         let nBits = Length(target);
         Fact(nBits < 64, $"`Length(target)` must be less than 64, but was {nBits}.");

--- a/library/std/random.qs
+++ b/library/std/random.qs
@@ -24,8 +24,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let roll = DrawRandomInt(1, 6);
     /// ```
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(IntegerComputations)
     operation DrawRandomInt(min : Int, max : Int) : Int {
         body intrinsic;
     }
@@ -51,8 +50,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let angle = DrawRandomDouble(0.0, 2.0 * PI());
     /// ```
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(FloatingPointComputations)
     operation DrawRandomDouble(min : Double, max : Double) : Double {
         body intrinsic;
     }

--- a/library/std/random.qs
+++ b/library/std/random.qs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let roll = DrawRandomInt(1, 6);
     /// ```
-    @Config(IntegerComputations)
+    @Config(Unrestricted)
     operation DrawRandomInt(min : Int, max : Int) : Int {
         body intrinsic;
     }
@@ -50,7 +50,7 @@ namespace Microsoft.Quantum.Random {
     /// ```qsharp
     /// let angle = DrawRandomDouble(0.0, 2.0 * PI());
     /// ```
-    @Config(FloatingPointComputations)
+    @Config(Unrestricted)
     operation DrawRandomDouble(min : Double, max : Double) : Double {
         body intrinsic;
     }

--- a/library/std/re.qs
+++ b/library/std/re.qs
@@ -33,8 +33,7 @@ namespace Microsoft.Quantum.ResourceEstimation {
     /// needs to be executed in order to collect and cache estimates.
     /// `false` indicates if cached estimates have been incorporated into the overall costs
     /// and the code fragment should be skipped.
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     function BeginEstimateCaching(name : String, variant : Int) : Bool {
         body intrinsic;
     }

--- a/library/std/re.qs
+++ b/library/std/re.qs
@@ -33,7 +33,6 @@ namespace Microsoft.Quantum.ResourceEstimation {
     /// needs to be executed in order to collect and cache estimates.
     /// `false` indicates if cached estimates have been incorporated into the overall costs
     /// and the code fragment should be skipped.
-    @Config(ForwardBranching)
     function BeginEstimateCaching(name : String, variant : Int) : Bool {
         body intrinsic;
     }

--- a/library/std/unstable_arithmetic_internal.qs
+++ b/library/std/unstable_arithmetic_internal.qs
@@ -285,7 +285,7 @@ namespace Microsoft.Quantum.Unstable.Arithmetic {
     ///   Phys. Rev. A 87, 022328, 2013
     ///   [arXiv:1212.5069](https://arxiv.org/abs/1212.5069)
     ///   doi:10.1103/PhysRevA.87.022328
-    @Config(None)
+    @Config(Base)
     internal operation ApplyAndAssuming0Target(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         H(target);
         T(target);

--- a/library/std/unstable_arithmetic_internal.qs
+++ b/library/std/unstable_arithmetic_internal.qs
@@ -243,8 +243,7 @@ namespace Microsoft.Quantum.Unstable.Arithmetic {
     ///   Phys. Rev. A 87, 022328, 2013
     ///   [arXiv:1212.5069](https://arxiv.org/abs/1212.5069)
     ///   doi:10.1103/PhysRevA.87.022328
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     internal operation ApplyAndAssuming0Target(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         // NOTE: Eventually this operation will be public and intrinsic.
         body (...) {
@@ -289,7 +288,7 @@ namespace Microsoft.Quantum.Unstable.Arithmetic {
     ///   Phys. Rev. A 87, 022328, 2013
     ///   [arXiv:1212.5069](https://arxiv.org/abs/1212.5069)
     ///   doi:10.1103/PhysRevA.87.022328
-    @Config(Base)
+    @Config(None)
     internal operation ApplyAndAssuming0Target(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         H(target);
         T(target);

--- a/library/std/unstable_arithmetic_internal.qs
+++ b/library/std/unstable_arithmetic_internal.qs
@@ -243,13 +243,10 @@ namespace Microsoft.Quantum.Unstable.Arithmetic {
     ///   Phys. Rev. A 87, 022328, 2013
     ///   [arXiv:1212.5069](https://arxiv.org/abs/1212.5069)
     ///   doi:10.1103/PhysRevA.87.022328
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     internal operation ApplyAndAssuming0Target(control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj {
         // NOTE: Eventually this operation will be public and intrinsic.
         body (...) {
-            if not CheckZero(target) {
-                fail "ApplyAndAssuming0Target expects `target` to be in |0> state.";
-            }
             CCNOT(control1, control2, target);
         }
         adjoint (...) {

--- a/library/std/unstable_table_lookup.qs
+++ b/library/std/unstable_table_lookup.qs
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
     ///     "Windowed arithmetic"
     /// [3] [arXiv:2211.01133](https://arxiv.org/abs/2211.01133)
     ///     "Space-time optimized table lookup"
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     operation Select(
         data : Bool[][],
         address : Qubit[],
@@ -97,7 +97,6 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
         }
     }
 
-    @Config(ForwardBranching)
     internal operation SinglyControlledSelect(
         ctl : Qubit,
         data : Bool[][],
@@ -166,7 +165,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
     /// # References
     /// - [arXiv:1905.07682](https://arxiv.org/abs/1905.07682)
     ///   "Windowed arithmetic"
-    @Config(ForwardBranching)
+    @Config(Adaptive)
     internal operation Unlookup(
         lookup : (Bool[][], Qubit[], Qubit[]) => Unit,
         data : Bool[][],

--- a/library/std/unstable_table_lookup.qs
+++ b/library/std/unstable_table_lookup.qs
@@ -43,8 +43,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
     ///     "Windowed arithmetic"
     /// [3] [arXiv:2211.01133](https://arxiv.org/abs/2211.01133)
     ///     "Space-time optimized table lookup"
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     operation Select(
         data : Bool[][],
         address : Qubit[],
@@ -98,8 +97,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
         }
     }
 
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     internal operation SinglyControlledSelect(
         ctl : Qubit,
         data : Bool[][],
@@ -168,8 +166,7 @@ namespace Microsoft.Quantum.Unstable.TableLookup {
     /// # References
     /// - [arXiv:1905.07682](https://arxiv.org/abs/1905.07682)
     ///   "Windowed arithmetic"
-    @Config(Adaptive)
-    @Config(Unrestricted)
+    @Config(ForwardBranching)
     internal operation Unlookup(
         lookup : (Bool[][], Qubit[], Qubit[]) => Unit,
         data : Bool[][],

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -24,8 +24,9 @@ class TargetProfile:
     """
     Target supports Quantinuum profile.
 
-    This option maps to the Adaptive Profile as defined by the QIR
-    specification with integer computations and qubit reset extensions.
+    This profile includes all of the required Adaptive Profile
+    capabilities, as well as the optional integer computation and qubit
+    reset capabilities, as defined by the QIR specification.
     """
 
     Unrestricted: ClassVar[Any]

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -2,22 +2,14 @@
 # Licensed under the MIT License.
 
 from enum import Enum
-from typing import Any, Callable, ClassVar, Tuple, Optional, Dict, List
+from typing import Any, Callable, ClassVar, Optional, Dict, List
 
 class TargetProfile:
     """
     A Q# target profile.
 
-    The target is the hardware or simulator which will be used to run the Q# program.
-    The target profile is a description of a target's capabilities.
-    """
-
-    Adaptive: ClassVar[Any]
-    """
-    Target supports the core set of adaptive.
-
-    This option maps to the Adaptive Profile as defined by the QIR specification
-    without any extensions.
+    A target profile describes the capabilities of the hardware or simulator
+    which will be used to run the Q# program.
     """
 
     Base: ClassVar[Any]
@@ -26,6 +18,14 @@ class TargetProfile:
     program.
 
     This option maps to the Base Profile as defined by the QIR specification.
+    """
+
+    Quantinuum: ClassVar[Any]
+    """
+    Target supports Quantinuum profile.
+
+    This option maps to the Adaptive Profile as defined by the QIR
+    specification with integer computations and reset extensions.
     """
 
     Unrestricted: ClassVar[Any]

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -25,7 +25,7 @@ class TargetProfile:
     Target supports Quantinuum profile.
 
     This option maps to the Adaptive Profile as defined by the QIR
-    specification with integer computations and reset extensions.
+    specification with integer computations and qubit reset extensions.
     """
 
     Unrestricted: ClassVar[Any]

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -24,9 +24,9 @@ class Config:
     """
 
     def __init__(self, target_profile: TargetProfile, language_features: List[str]):
-        if target_profile == TargetProfile.Adaptive:
-            self._config = {"targetProfile": "adaptive"}
-            warn("The adaptive target profile is a preview feature.")
+        if target_profile == TargetProfile.Quantinuum:
+            self._config = {"targetProfile": "quantinuum"}
+            warn("The Quantinuum target profile is a preview feature.")
             warn("Functionality may be incomplete or incorrect.")
         elif target_profile == TargetProfile.Base:
             self._config = {"targetProfile": "base"}

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -51,14 +51,15 @@ fn _native(py: Python, m: &PyModule) -> PyResult<()> {
 /// A target profile describes the capabilities of the hardware or simulator
 /// which will be used to run the Q# program.
 pub(crate) enum TargetProfile {
-    /// Target supports the core set of adaptive.
-    ///
-    /// This option maps to the Adaptive Profile as defined by the QIR specification without any extensions.
-    Adaptive,
     /// Target supports the minimal set of capabilities required to run a quantum program.
     ///
     /// This option maps to the Base Profile as defined by the QIR specification.
     Base,
+    /// Target supports Quantinuum profile.
+    ///
+    /// This option maps to the Adaptive Profile as defined by the QIR
+    /// specification with integer computations and reset extensions.
+    Quantinuum,
     /// Target supports the full set of capabilities required to run any Q# program.
     ///
     /// This option maps to the Full Profile as defined by the QIR specification.
@@ -114,7 +115,7 @@ impl Interpreter {
         list_directory: Option<PyObject>,
     ) -> PyResult<Self> {
         let target = match target {
-            TargetProfile::Adaptive => Profile::Adaptive,
+            TargetProfile::Quantinuum => Profile::Quantinuum,
             TargetProfile::Base => Profile::Base,
             TargetProfile::Unrestricted => Profile::Unrestricted,
         };

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -58,8 +58,9 @@ pub(crate) enum TargetProfile {
     Base,
     /// Target supports Quantinuum profile.
     ///
-    /// This option maps to the Adaptive Profile as defined by the QIR
-    /// specification with integer computations and qubit reset extensions.
+    /// This profile includes all of the required Adaptive Profile
+    /// capabilities, as well as the optional integer computation and qubit
+    /// reset capabilities, as defined by the QIR specification.
     Quantinuum,
     /// Target supports the full set of capabilities required to run any Q# program.
     ///

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -44,6 +44,7 @@ fn _native(py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
+// This ordering must match the _native.pyi file.
 #[derive(Clone, Copy)]
 #[pyclass(unsendable)]
 /// A Q# target profile.
@@ -58,7 +59,7 @@ pub(crate) enum TargetProfile {
     /// Target supports Quantinuum profile.
     ///
     /// This option maps to the Adaptive Profile as defined by the QIR
-    /// specification with integer computations and reset extensions.
+    /// specification with integer computations and qubit reset extensions.
     Quantinuum,
     /// Target supports the full set of capabilities required to run any Q# program.
     ///

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -274,45 +274,45 @@ def test_entry_expr_circuit() -> None:
 
 # this is by design
 def test_callables_failing_profile_validation_are_still_registered() -> None:
-    e = Interpreter(TargetProfile.Adaptive)
+    e = Interpreter(TargetProfile.Quantinuum)
     with pytest.raises(Exception) as excinfo:
         e.interpret(
-            "operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }"
+            "operation Foo() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x }"
         )
-    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+    assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
     with pytest.raises(Exception) as excinfo:
         e.interpret("Foo()")
-    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+    assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
 
 
 # this is by design
 def test_once_rca_validation_fails_following_calls_also_fail() -> None:
-    e = Interpreter(TargetProfile.Adaptive)
+    e = Interpreter(TargetProfile.Quantinuum)
     with pytest.raises(Exception) as excinfo:
         e.interpret(
-            "operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }"
+            "operation Foo() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x }"
         )
-    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+    assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
     with pytest.raises(Exception) as excinfo:
         e.interpret("let x = 5;")
-    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+    assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
 
 
 def test_adaptive_errors_are_raised_when_interpreting() -> None:
-    e = Interpreter(TargetProfile.Adaptive)
+    e = Interpreter(TargetProfile.Quantinuum)
     with pytest.raises(Exception) as excinfo:
         e.interpret(
-            "operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }"
+            "operation Foo() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x }"
         )
-    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+    assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
 
 
 def test_adaptive_errors_are_raised_from_entry_expr() -> None:
-    e = Interpreter(TargetProfile.Adaptive)
+    e = Interpreter(TargetProfile.Quantinuum)
     e.interpret("use q = Qubit();")
     with pytest.raises(Exception) as excinfo:
-        e.run("{mutable x = 1; if MResetZ(q) == One { set x = 2; }}")
-    assert "Qsc.CapabilitiesCk.UseOfDynamicInt" in str(excinfo)
+        e.run("{mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; }}")
+    assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
 
 
 def test_adaptive_qir_can_be_generated() -> None:
@@ -332,7 +332,7 @@ def test_adaptive_qir_can_be_generated() -> None:
             }
         }
         """
-    e = Interpreter(TargetProfile.Adaptive)
+    e = Interpreter(TargetProfile.Quantinuum)
     e.interpret(adaptive_input)
     qir = e.qir("Test.Main()")
     assert qir == dedent(

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -102,12 +102,12 @@
           "enum": [
             "unrestricted",
             "base",
-            "adaptive"
+            "quantinuum"
           ],
           "enumDescriptions": [
             "The set of all capabilities required to run any Q# program.",
             "The minimal set of capabilities required to run a quantum program. This option maps to the Base Profile as defined by the QIR specification.",
-            "The set of capabilities required to run an adaptive quantum program. This option maps to the Adaptive Profile as defined by the QIR specification."
+            "The Quantinuum target profile includes all of the required Adaptive Profile capabilities, as well as the optional integer computation and qubit reset capabilities, as defined by the QIR specification."
           ],
           "description": "Setting the target profile allows the Q# extension to generate programs that are compatible with a specific target. The target is the hardware or simulator which will be used to run the Q# program. The target profile is a description of a target's capabilities."
         },

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -9,8 +9,8 @@ export function getTarget(): TargetProfile {
     .getConfiguration("Q#")
     .get<TargetProfile>("targetProfile", "unrestricted");
   switch (target) {
-    case "adaptive":
     case "base":
+    case "quantinuum":
     case "unrestricted":
       return target;
     default:
@@ -30,10 +30,10 @@ export async function setTarget(target: TargetProfile) {
 
 export function getTargetFriendlyName(targetProfile?: string) {
   switch (targetProfile) {
-    case "adaptive":
-      return "Q#: QIR adaptive";
     case "base":
       return "Q#: QIR base";
+    case "quantinuum":
+      return "Q#: QIR Quantinuum";
     case "unrestricted":
       return "Q#: unrestricted";
     default:

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -315,8 +315,8 @@ async function updateLanguageServiceProfile(languageService: ILanguageService) {
   const targetProfile = getTarget();
 
   switch (targetProfile) {
-    case "adaptive":
     case "base":
+    case "quantinuum":
     case "unrestricted":
       break;
     default:

--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -34,7 +34,7 @@ export async function getQirForActiveWindow(): Promise<string> {
   const targetProfile = getTarget();
   const enablePreviewQirGen = getEnablePreviewQirGen();
   if (targetProfile !== "base") {
-    const allowed = targetProfile === "adaptive" && enablePreviewQirGen;
+    const allowed = targetProfile === "quantinuum" && enablePreviewQirGen;
     if (!allowed) {
       const result = await vscode.window.showWarningMessage(
         "Submitting to Azure is only supported when targeting the QIR base profile.",

--- a/vscode/src/statusbar.ts
+++ b/vscode/src/statusbar.ts
@@ -100,8 +100,8 @@ function registerTargetProfileCommand() {
 }
 
 const targetProfiles = [
-  { configName: "adaptive", uiText: "Q#: QIR adaptive" },
   { configName: "base", uiText: "Q#: QIR base" },
+  { configName: "quantinuum", uiText: "Q#: QIR Quantinuum" },
   { configName: "unrestricted", uiText: "Q#: unrestricted" },
 ];
 
@@ -109,22 +109,22 @@ function getTargetProfiles(): {
   configName: string;
   uiText: string;
 }[] {
-  const allow_adaptive = getEnableAdaptiveProfile();
-  if (allow_adaptive) {
+  const allow_quantinuum = getEnableAdaptiveProfile();
+  if (allow_quantinuum) {
     return targetProfiles;
   } else {
     return targetProfiles.filter(
-      (profile) => profile.configName !== "adaptive",
+      (profile) => profile.configName !== "quantinuum",
     );
   }
 }
 
 function getTargetProfileSetting(uiText: string): TargetProfile {
   switch (uiText) {
-    case "Q#: QIR adaptive":
-      return "adaptive";
     case "Q#: QIR base":
       return "base";
+    case "Q#: QIR Quantinuum":
+      return "quantinuum";
     case "Q#: unrestricted":
       return "unrestricted";
     default:

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -489,7 +489,7 @@ serializable_type! {
         pub languageFeatures: Option<Vec<String>>
     },
     r#"export interface INotebookMetadata {
-        targetProfile?: "adaptive" | "base" | "unrestricted";
+        targetProfile?: "base" | "quantinuum" | "unrestricted";
         languageFeatures?: "v2-preview-syntax"[];
     }"#,
     INotebookMetadata

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -457,5 +457,5 @@ pub fn generate_docs() -> Vec<IDocFile> {
 
 #[wasm_bindgen(typescript_custom_section)]
 const TARGET_PROFILE: &'static str = r#"
-export type TargetProfile = "adaptive" | "base" | "unrestricted";
+export type TargetProfile = "base" | "quantinuum" |"unrestricted";
 "#;


### PR DESCRIPTION
This updates the conditional compilation logic and target profile names. We need to take a good look at the conditional compilation attributes used to ensure that they are correct. This also updates the config attribute logic to deal with capabilities rather than profiles.