### PR TITLE
Truncate decimal to 4 places in alternate state visualization

### DIFF
--- a/compiler/qsc_eval/src/state.rs
+++ b/compiler/qsc_eval/src/state.rs
@@ -483,7 +483,8 @@ fn write_latex_for_real_number(latex: &mut String, number: &RealNumber, render_o
 /// 1 is only rendered if ``render_one`` is true.
 fn write_latex_for_decimal_number(latex: &mut String, number: &DecimalNumber, render_one: bool) {
     if render_one || is_significant(number.value - 1.0) {
-        write!(latex, "{}", (number.value * 10000.0).round() / 10000.0).expect("Expected to write decimal value.");
+        write!(latex, "{}", (number.value * 10000.0).round() / 10000.0)
+            .expect("Expected to write decimal value.");
     }
 }
 

--- a/compiler/qsc_eval/src/state.rs
+++ b/compiler/qsc_eval/src/state.rs
@@ -484,7 +484,7 @@ fn write_latex_for_real_number(latex: &mut String, number: &RealNumber, render_o
 fn write_latex_for_decimal_number(latex: &mut String, number: &DecimalNumber, render_one: bool) {
     if render_one || is_significant(number.value - 1.0) {
         /// Using round() instead of neater string formatting({:.4})
-        /// because we do not want trailing zeros(We need 0.5 and not 0.5000)
+        /// because we do not want trailing zeros (we need 0.5 and not 0.5000)
         write!(latex, "{}", (number.value * 10000.0).round() / 10000.0)
             .expect("Expected to write decimal value.");
     }

--- a/compiler/qsc_eval/src/state.rs
+++ b/compiler/qsc_eval/src/state.rs
@@ -483,8 +483,8 @@ fn write_latex_for_real_number(latex: &mut String, number: &RealNumber, render_o
 /// 1 is only rendered if ``render_one`` is true.
 fn write_latex_for_decimal_number(latex: &mut String, number: &DecimalNumber, render_one: bool) {
     if render_one || is_significant(number.value - 1.0) {
-        /// Using round() instead of neater string formatting({:.4})
-        /// because we do not want trailing zeros (we need 0.5 and not 0.5000)
+        // Using round() instead of neater string formatting({:.4})
+        // because we do not want trailing zeros (we need 0.5 and not 0.5000)
         write!(latex, "{}", (number.value * 10000.0).round() / 10000.0)
             .expect("Expected to write decimal value.");
     }

--- a/compiler/qsc_eval/src/state.rs
+++ b/compiler/qsc_eval/src/state.rs
@@ -483,7 +483,7 @@ fn write_latex_for_real_number(latex: &mut String, number: &RealNumber, render_o
 /// 1 is only rendered if ``render_one`` is true.
 fn write_latex_for_decimal_number(latex: &mut String, number: &DecimalNumber, render_one: bool) {
     if render_one || is_significant(number.value - 1.0) {
-        write!(latex, "{:.4}", number.value).expect("Expected to write decimal value.");
+        write!(latex, "{}", (number.value * 10000.0).round() / 10000.0).expect("Expected to write decimal value.");
     }
 }
 

--- a/compiler/qsc_eval/src/state.rs
+++ b/compiler/qsc_eval/src/state.rs
@@ -483,7 +483,7 @@ fn write_latex_for_real_number(latex: &mut String, number: &RealNumber, render_o
 /// 1 is only rendered if ``render_one`` is true.
 fn write_latex_for_decimal_number(latex: &mut String, number: &DecimalNumber, render_one: bool) {
     if render_one || is_significant(number.value - 1.0) {
-        write!(latex, "{}", number.value).expect("Expected to write decimal value.");
+        write!(latex, "{:.4}", number.value).expect("Expected to write decimal value.");
     }
 }
 

--- a/compiler/qsc_eval/src/state.rs
+++ b/compiler/qsc_eval/src/state.rs
@@ -483,6 +483,8 @@ fn write_latex_for_real_number(latex: &mut String, number: &RealNumber, render_o
 /// 1 is only rendered if ``render_one`` is true.
 fn write_latex_for_decimal_number(latex: &mut String, number: &DecimalNumber, render_one: bool) {
     if render_one || is_significant(number.value - 1.0) {
+        /// Using round() instead of neater string formatting({:.4})
+        /// because we do not want trailing zeros(We need 0.5 and not 0.5000)
         write!(latex, "{}", (number.value * 10000.0).round() / 10000.0)
             .expect("Expected to write decimal value.");
     }

--- a/compiler/qsc_eval/src/state/tests.rs
+++ b/compiler/qsc_eval/src/state/tests.rs
@@ -647,9 +647,9 @@ fn check_get_latex_for_real() {
     );
     assert_latex_for_real(
         &expect!([r#"
-            "0.0025"
+            "0.0003"
         "#]),
-        1.0 / 400.0,
+        1.0 / 4000.0,
         false,
     );
 }

--- a/compiler/qsc_eval/src/state/tests.rs
+++ b/compiler/qsc_eval/src/state/tests.rs
@@ -566,14 +566,14 @@ fn assert_latex_for_decimal(expected: &Expect, number: f64, render_one: bool) {
 fn check_get_latex_for_decimal() {
     assert_latex_for_decimal(
         &expect!([r#"
-            "0.2500"
+            "0.25"
         "#]),
         0.25,
         false,
     );
     assert_latex_for_decimal(
         &expect!([r#"
-            "0.2500"
+            "0.25"
         "#]),
         -0.25,
         false,
@@ -594,7 +594,7 @@ fn check_get_latex_for_decimal() {
     );
     assert_latex_for_decimal(
         &expect!([r#"
-            "1.0000"
+            "1"
         "#]),
         1.0,
         true,

--- a/compiler/qsc_eval/src/state/tests.rs
+++ b/compiler/qsc_eval/src/state/tests.rs
@@ -566,14 +566,14 @@ fn assert_latex_for_decimal(expected: &Expect, number: f64, render_one: bool) {
 fn check_get_latex_for_decimal() {
     assert_latex_for_decimal(
         &expect!([r#"
-            "0.25"
+            "0.2500"
         "#]),
         0.25,
         false,
     );
     assert_latex_for_decimal(
         &expect!([r#"
-            "0.25"
+            "0.2500"
         "#]),
         -0.25,
         false,
@@ -594,7 +594,7 @@ fn check_get_latex_for_decimal() {
     );
     assert_latex_for_decimal(
         &expect!([r#"
-            "1"
+            "1.0000"
         "#]),
         1.0,
         true,
@@ -647,9 +647,9 @@ fn check_get_latex_for_real() {
     );
     assert_latex_for_real(
         &expect!([r#"
-            "0.00025"
+            "0.0025"
         "#]),
-        1.0 / 4000.0,
+        1.0 / 400.0,
         false,
     );
 }


### PR DESCRIPTION
## Code Path
`get_latex` -> `write_latex_for_term` -> `write_latex_for_real_number` -> `write_latex_for_decimal_number`

## Codespace Playground Link
https://miniature-telegram-j4vjv94qqv53pv6r-5555.app.github.dev/

## Changes Done
Truncating decimal output for state visualization for katas
![image](https://github.com/microsoft/qsharp/assets/40084144/312b48ee-8999-4925-b00e-16409f27ae4a)



## Scope: State Visualization in Katas
This flow doesn't impact any other outputs, like one from Python which shows 4 decimal digits accuracy.
![image](https://github.com/microsoft/qsharp/assets/40084144/cc586f67-0485-4e12-ace5-5ce0ef007531)


