### PR TITLE
Include return type of entry point in RCA check

### DIFF
--- a/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/compiler/qsc_passes/src/capabilitiesck.rs
@@ -171,6 +171,28 @@ pub enum Error {
     #[diagnostic(help("closures are not supported by the current target"))]
     #[diagnostic(code("Qsc.CapabilitiesCk.UseOfClosure"))]
     UseOfClosure(#[label] Span),
+
+    #[error("cannot use a bool value as an output")]
+    #[diagnostic(help("using a bool value as an output is not supported by the current target"))]
+    #[diagnostic(code("Qsc.CapabilitiesCk.UseOfBoolOutput"))]
+    UseOfBoolOutput(#[label] Span),
+
+    #[error("cannot use a double value as an output")]
+    #[diagnostic(help("using a Double as an output is not supported by the current target"))]
+    #[diagnostic(code("Qsc.CapabilitiesCk.UseOfDoubleOutput"))]
+    UseOfDoubleOutput(#[label] Span),
+
+    #[error("cannot use an integer value as an output")]
+    #[diagnostic(help("using an integer as an output is not supported by the current target"))]
+    #[diagnostic(code("Qsc.CapabilitiesCk.UseOfIntOutput"))]
+    UseOfIntOutput(#[label] Span),
+
+    #[error("cannot use value with advanced type as an output")]
+    #[diagnostic(help(
+        "using a value of type callable, range, big integer, Pauli, Qubit or string as an output is not supported by the current target"
+    ))]
+    #[diagnostic(code("Qsc.CapabilitiesCk.UseOfAdvancedOutput"))]
+    UseOfAdvancedOutput(#[label] Span),
 }
 
 /// Lower a package store from `qsc_frontend` HIR store to a `qsc_fir` FIR store.
@@ -577,6 +599,18 @@ fn generate_errors_from_runtime_features(
     }
     if runtime_features.contains(RuntimeFeatureFlags::UseOfClosure) {
         errors.push(Error::UseOfClosure(span));
+    }
+    if runtime_features.contains(RuntimeFeatureFlags::UseOfBoolOutput) {
+        errors.push(Error::UseOfBoolOutput(span));
+    }
+    if runtime_features.contains(RuntimeFeatureFlags::UseOfDoubleOutput) {
+        errors.push(Error::UseOfDoubleOutput(span));
+    }
+    if runtime_features.contains(RuntimeFeatureFlags::UseOfIntOutput) {
+        errors.push(Error::UseOfIntOutput(span));
+    }
+    if runtime_features.contains(RuntimeFeatureFlags::UseOfAdvancedOutput) {
+        errors.push(Error::UseOfAdvancedOutput(span));
     }
     errors
 }

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::needless_raw_string_hashes)]
 
 use super::tests_common::{
-    check, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
+    check, check_for_exe, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
     CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
@@ -13,12 +13,19 @@ use super::tests_common::{
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
     USE_DYNAMIC_INDEX, USE_DYNAMIC_INT, USE_DYNAMIC_OPERATION, USE_DYNAMIC_PAULI,
     USE_DYNAMIC_QUBIT, USE_DYNAMIC_RANGE, USE_DYNAMIC_STRING, USE_DYNAMIC_UDT,
+    USE_ENTRY_POINT_STATIC_BIG_INT, USE_ENTRY_POINT_STATIC_BOOL, USE_ENTRY_POINT_STATIC_DOUBLE,
+    USE_ENTRY_POINT_STATIC_INT, USE_ENTRY_POINT_STATIC_INT_IN_TUPLE, USE_ENTRY_POINT_STATIC_PAULI,
+    USE_ENTRY_POINT_STATIC_RANGE, USE_ENTRY_POINT_STATIC_STRING,
 };
 use expect_test::{expect, Expect};
 use qsc_data_structures::target::TargetCapabilityFlags;
 
 fn check_profile(source: &str, expect: &Expect) {
     check(source, expect, TargetCapabilityFlags::Adaptive);
+}
+
+fn check_profile_for_exe(source: &str, expect: &Expect) {
+    check_for_exe(source, expect, TargetCapabilityFlags::Adaptive);
 }
 
 #[test]
@@ -548,6 +555,141 @@ fn use_closure_yields_errors() {
                     Span {
                         lo: 149,
                         hi: 168,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn use_of_static_int_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_INT,
+        &expect![[r#"
+        [
+            UseOfIntOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_double_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_DOUBLE,
+        &expect![[r#"
+        [
+            UseOfDoubleOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_string_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_STRING,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_bool_return_from_entry_point_supported() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_BOOL,
+        &expect![[r#"
+        []
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_big_int_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_BIG_INT,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_pauli_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_PAULI,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_range_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_RANGE,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_int_in_tuple_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_INT_IN_TUPLE,
+        &expect![[r#"
+            [
+                UseOfDynamicInt(
+                    Span {
+                        lo: 63,
+                        hi: 66,
+                    },
+                ),
+                UseOfIntOutput(
+                    Span {
+                        lo: 63,
+                        hi: 66,
                     },
                 ),
             ]

--- a/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::needless_raw_string_hashes)]
 
 use super::tests_common::{
-    check, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
+    check, check_for_exe, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
     CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
@@ -13,12 +13,19 @@ use super::tests_common::{
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
     USE_DYNAMIC_INDEX, USE_DYNAMIC_INT, USE_DYNAMIC_OPERATION, USE_DYNAMIC_PAULI,
     USE_DYNAMIC_QUBIT, USE_DYNAMIC_RANGE, USE_DYNAMIC_STRING, USE_DYNAMIC_UDT,
+    USE_ENTRY_POINT_STATIC_BIG_INT, USE_ENTRY_POINT_STATIC_BOOL, USE_ENTRY_POINT_STATIC_DOUBLE,
+    USE_ENTRY_POINT_STATIC_INT, USE_ENTRY_POINT_STATIC_INT_IN_TUPLE, USE_ENTRY_POINT_STATIC_PAULI,
+    USE_ENTRY_POINT_STATIC_RANGE, USE_ENTRY_POINT_STATIC_STRING,
 };
 use expect_test::{expect, Expect};
 use qsc_data_structures::target::TargetCapabilityFlags;
 
 fn check_profile(source: &str, expect: &Expect) {
     check(source, expect, TargetCapabilityFlags::empty());
+}
+
+fn check_profile_for_exe(source: &str, expect: &Expect) {
+    check_for_exe(source, expect, TargetCapabilityFlags::empty());
 }
 
 #[test]
@@ -686,6 +693,148 @@ fn use_closure_yields_errors() {
                     Span {
                         lo: 149,
                         hi: 168,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn use_of_static_int_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_INT,
+        &expect![[r#"
+        [
+            UseOfIntOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_double_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_DOUBLE,
+        &expect![[r#"
+        [
+            UseOfDoubleOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_string_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_STRING,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_bool_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_BOOL,
+        &expect![[r#"
+        [
+            UseOfBoolOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_big_int_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_BIG_INT,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_pauli_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_PAULI,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_range_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_RANGE,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_int_in_tuple_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_INT_IN_TUPLE,
+        &expect![[r#"
+            [
+                UseOfDynamicInt(
+                    Span {
+                        lo: 63,
+                        hi: 66,
+                    },
+                ),
+                UseOfIntOutput(
+                    Span {
+                        lo: 63,
+                        hi: 66,
                     },
                 ),
             ]

--- a/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -20,6 +20,13 @@ pub fn check(source: &str, expect: &Expect, capabilities: TargetCapabilityFlags)
     expect.assert_debug_eq(&errors);
 }
 
+pub fn check_for_exe(source: &str, expect: &Expect, capabilities: TargetCapabilityFlags) {
+    let compilation_context = CompilationContext::new_for_exe(source);
+    let (package, compute_properties) = compilation_context.get_package_compute_properties_tuple();
+    let errors = check_supported_capabilities(package, compute_properties, capabilities);
+    expect.assert_debug_eq(&errors);
+}
+
 fn lower_hir_package_store(
     lowerer: &mut Lowerer,
     hir_package_store: &HirPackageStore,
@@ -55,6 +62,27 @@ impl CompilationContext {
             .compile_fragments_fail_fast("test", source)
             .expect("code should compile");
         compiler.update(increment);
+        let mut lowerer = Lowerer::new();
+        let fir_store = lower_hir_package_store(&mut lowerer, compiler.package_store());
+        let analyzer = Analyzer::init(&fir_store);
+        let compute_properties = analyzer.analyze_all();
+        Self {
+            fir_store,
+            compute_properties,
+            package_id,
+        }
+    }
+
+    fn new_for_exe(source: &str) -> Self {
+        let compiler = Compiler::new(
+            true,
+            SourceMap::new([("test".into(), source.into())], Some("".into())),
+            PackageType::Exe,
+            TargetCapabilityFlags::all(),
+            LanguageFeatures::default(),
+        )
+        .expect("should be able to create a new compiler");
+        let package_id = map_hir_package_to_fir(compiler.source_package_id());
         let mut lowerer = Lowerer::new();
         let fir_store = lower_hir_package_store(&mut lowerer, compiler.package_store());
         let analyzer = Analyzer::init(&fir_store);
@@ -325,5 +353,70 @@ pub const USE_CLOSURE_FUNCTION: &str = r#"
         operation Foo() : Unit {
             let theta = PI();
             let lambdaFn = theta -> Sin(theta);
+        }
+    }"#;
+
+pub const USE_ENTRY_POINT_STATIC_INT: &str = r#"
+    namespace Test {
+        @EntryPoint()
+        operation Foo() : Int {
+            42
+        }
+    }"#;
+
+pub const USE_ENTRY_POINT_STATIC_DOUBLE: &str = r#"
+    namespace Test {
+        @EntryPoint()
+        operation Foo() : Double {
+            42.0
+        }
+    }"#;
+
+pub const USE_ENTRY_POINT_STATIC_STRING: &str = r#"
+    namespace Test {
+        @EntryPoint()
+        operation Foo() : String {
+            "Hello, World!"
+        }
+    }"#;
+
+pub const USE_ENTRY_POINT_STATIC_BOOL: &str = r#"
+    namespace Test {
+        @EntryPoint()
+        operation Foo() : Bool {
+            true
+        }
+    }"#;
+
+pub const USE_ENTRY_POINT_STATIC_BIG_INT: &str = r#"
+    namespace Test {
+        @EntryPoint()
+        operation Foo() : BigInt {
+            42L
+        }
+    }"#;
+
+pub const USE_ENTRY_POINT_STATIC_PAULI: &str = r#"
+    namespace Test {
+        @EntryPoint()
+        operation Foo() : Pauli {
+            PauliX
+        }
+    }"#;
+
+pub const USE_ENTRY_POINT_STATIC_RANGE: &str = r#"
+    namespace Test {
+        @EntryPoint()
+        operation Foo() : Range {
+            1..10
+        }
+    }"#;
+
+pub const USE_ENTRY_POINT_STATIC_INT_IN_TUPLE: &str = r#"
+    namespace Test {
+        @EntryPoint()
+        operation Foo() : (Result, Int) {
+            use q = Qubit();
+            (M(q), 42)
         }
     }"#;

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -752,6 +752,14 @@ bitflags! {
         const LoopWithDynamicCondition = 1 << 20;
         /// Use of a closure.
         const UseOfClosure = 1 << 21;
+        /// Use of an advanced type as output of a computation.
+        const UseOfAdvancedOutput = 1 << 22;
+        // Use of a `Bool` as output of a computation.
+        const UseOfBoolOutput = 1 << 23;
+        // Use of a `Double` as output of a computation.
+        const UseOfDoubleOutput = 1 << 24;
+        // Use of an `Int` as output of a computation.
+        const UseOfIntOutput = 1 << 25;
     }
 }
 
@@ -837,6 +845,18 @@ impl RuntimeFeatureFlags {
             capabilities |= TargetCapabilityFlags::BackwardsBranching;
         }
         if self.contains(RuntimeFeatureFlags::UseOfClosure) {
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
+        }
+        if self.contains(RuntimeFeatureFlags::UseOfBoolOutput) {
+            capabilities |= TargetCapabilityFlags::Adaptive;
+        }
+        if self.contains(RuntimeFeatureFlags::UseOfDoubleOutput) {
+            capabilities |= TargetCapabilityFlags::FloatingPointComputations;
+        }
+        if self.contains(RuntimeFeatureFlags::UseOfIntOutput) {
+            capabilities |= TargetCapabilityFlags::IntegerComputations;
+        }
+        if self.contains(RuntimeFeatureFlags::UseOfAdvancedOutput) {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         capabilities


### PR DESCRIPTION
This change adds new runtime feature flags for use of specific types in output from the entry expression/entry point that RCA can annotate a program with. This allows the later check pass to verify that the code will use types in output recording that are supported for the given target. For example, a target that does not support dynamic integers cannot accomodate recoding output with integer values, even if they are static.