### PR TITLE
Create QEC kata on bit flip, phase flip and Shor codes

### DIFF
--- a/katas/content/KatasLibrary.qs
+++ b/katas/content/KatasLibrary.qs
@@ -66,7 +66,7 @@ namespace Microsoft.Quantum.Katas {
 
     /// # Summary
     /// Given two operations, checks whether they act identically on the given initial state composed of `inputSize` qubits.
-    /// The initial state is prepared by applying initialState operation to the state |0〉 ⊗ |0〉 ⊗ ... ⊗ |0〉.
+    /// The initial state is prepared by applying the `initialState` operation to the state |0〉 ⊗ |0〉 ⊗ ... ⊗ |0〉.
     /// This operation introduces a control qubit to convert a global phase into a relative phase to be able to detect it.
     operation CheckOperationsEquivalenceOnInitialStateStrict(
         initialState : Qubit[] => Unit is Adj,

--- a/katas/content/KatasLibrary.qs
+++ b/katas/content/KatasLibrary.qs
@@ -63,6 +63,33 @@ namespace Microsoft.Quantum.Katas {
         isCorrect
     }
 
+
+    /// # Summary
+    /// Given two operations, checks whether they act identically on the given initial state composed of `inputSize` qubits.
+    /// The initial state is prepared by applying initialState operation to the state |0〉 ⊗ |0〉 ⊗ ... ⊗ |0〉.
+    /// This operation introduces a control qubit to convert a global phase into a relative phase to be able to detect it.
+    operation CheckOperationsEquivalenceOnInitialStateStrict(
+        initialState : Qubit[] => Unit is Adj,
+        op : (Qubit[] => Unit is Adj + Ctl),
+        reference : (Qubit[] => Unit is Adj + Ctl),
+        inputSize : Int
+    ) : Bool {
+        use (control, target) = (Qubit(), Qubit[inputSize]);
+        within {
+            H(control);
+            initialState(target);
+        }
+        apply {
+            Controlled op([control], target);
+            Adjoint Controlled reference([control], target);
+        }
+
+        let isCorrect = CheckAllZero([control] + target);
+        ResetAll([control] + target);
+        isCorrect
+    }
+
+
     /// # Summary
     /// Given two operations, checks whether they act identically on the zero state |0〉 ⊗ |0〉 ⊗ ... ⊗ |0〉 composed of
     /// `inputSize` qubits.
@@ -74,19 +101,7 @@ namespace Microsoft.Quantum.Katas {
         inputSize : Int)
     : Bool {
         Fact(inputSize > 0, "`inputSize` must be positive");
-        use control = Qubit();
-        use target = Qubit[inputSize];
-        within {
-            H(control);
-        }
-        apply {
-            Controlled op([control], target);
-            Adjoint Controlled reference([control], target);
-        }
-
-        let isCorrect = CheckAllZero([control] + target);
-        ResetAll([control] + target);
-        isCorrect
+        CheckOperationsEquivalenceOnInitialStateStrict(qs => (), op, reference, inputSize)
     }
 
 

--- a/katas/content/index.json
+++ b/katas/content/index.json
@@ -11,5 +11,6 @@
   "random_numbers",
   "oracles",
   "deutsch_algo",
-  "deutsch_jozsa"
+  "deutsch_jozsa",
+  "qec_shor"
 ]

--- a/katas/content/multi_qubit_gates/entangle_qubits/Verification.qs
+++ b/katas/content/multi_qubit_gates/entangle_qubits/Verification.qs
@@ -8,26 +8,7 @@ namespace Kata.Verification {
         CNOT(qs[0], qs[1]);
     }
 
-    operation CheckOperationsEquivalenceOnInitialStateStrict(
-        initialState : Qubit[] => Unit is Adj,
-        op : (Qubit[] => Unit is Adj + Ctl),
-        reference : (Qubit[] => Unit is Adj + Ctl),
-        inputSize : Int
-    ) : Bool {
-        use (control, target) = (Qubit(), Qubit[inputSize]);
-        within {
-            H(control);
-            initialState(target);
-        }
-        apply {
-            Controlled op([control], target);
-            Adjoint Controlled reference([control], target);
-        }
-        let isCorrect = CheckAllZero([control] + target);
-        ResetAll([control] + target);
-        isCorrect
-    }
-    
+    @EntryPoint()
     operation CheckSolution() : Bool {
         let range = 10;
         for i in 0 .. range - 1 {

--- a/katas/content/multi_qubit_gates/relative_phase_minusone/Verification.qs
+++ b/katas/content/multi_qubit_gates/relative_phase_minusone/Verification.qs
@@ -5,30 +5,13 @@ namespace Kata.Verification {
     operation PrepareState(qs : Qubit[]) : Unit is Adj + Ctl {
         ApplyToEachCA(H, qs);
     }
-    operation  RelativePhaseMinusOne (qs : Qubit[]) : Unit is Adj + Ctl {
+
+    operation RelativePhaseMinusOne (qs : Qubit[]) : Unit is Adj + Ctl {
         CZ(qs[0], qs[1]);
     }
 
-    operation CheckOperationsEquivalenceOnInitialStateStrict(
-        initialState : Qubit[] => Unit is Adj,
-        op : (Qubit[] => Unit is Adj + Ctl),
-        reference : (Qubit[] => Unit is Adj + Ctl),
-        inputSize : Int
-    ) : Bool {
-        use (control, target) = (Qubit(), Qubit[inputSize]);
-        within {
-            H(control);
-            initialState(target);
-        }
-        apply {
-            Controlled op([control], target);
-            Adjoint Controlled reference([control], target);
-        }
-        let isCorrect = CheckAllZero([control] + target);
-        ResetAll([control] + target);
-        isCorrect
-    }
-
+    
+    @EntryPoint()
     operation CheckSolution() : Bool {
         let isCorrect = CheckOperationsEquivalenceOnInitialStateStrict(
             PrepareState,

--- a/katas/content/multi_qubit_systems/bell_state_change_1/Verification.qs
+++ b/katas/content/multi_qubit_systems/bell_state_change_1/Verification.qs
@@ -1,6 +1,4 @@
 namespace Kata.Verification {
-    open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Katas;
 
@@ -15,29 +13,6 @@ namespace Kata.Verification {
     }
 
 
-    operation CheckOperationsEquivalenceOnInitialStateStrict(
-        initialState : Qubit[] => Unit is Adj,
-        op : (Qubit[] => Unit is Adj + Ctl),
-        reference : (Qubit[] => Unit is Adj + Ctl),
-        inputSize : Int
-    ) : Bool {
-        use (control, target) = (Qubit(), Qubit[inputSize]);
-        within {
-            H(control);
-            initialState(target);
-        }
-        apply {
-            Controlled op([control], target);
-            Adjoint Controlled reference([control], target);
-        }
-
-
-        let isCorrect = CheckAllZero([control] + target);
-        ResetAll([control] + target);
-        isCorrect
-    }
-
-
     @EntryPoint()
     operation CheckSolution() : Bool {
         let isCorrect = CheckOperationsEquivalenceOnInitialStateStrict(
@@ -46,7 +21,6 @@ namespace Kata.Verification {
             BellStateChange1_Reference, 
             2);
 
-
         if isCorrect {
             Message("Correct!");
         } else {
@@ -54,9 +28,6 @@ namespace Kata.Verification {
             ShowQuantumStateComparison(2, PrepareBellState, Kata.BellStateChange1, BellStateChange1_Reference);
         }
 
-
         return isCorrect;
     }
-
-   
 }

--- a/katas/content/multi_qubit_systems/bell_state_change_2/Verification.qs
+++ b/katas/content/multi_qubit_systems/bell_state_change_2/Verification.qs
@@ -1,6 +1,4 @@
 namespace Kata.Verification {
-    open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Katas;
 
@@ -15,29 +13,6 @@ namespace Kata.Verification {
     }
 
 
-    operation CheckOperationsEquivalenceOnInitialStateStrict(
-        initialState : Qubit[] => Unit is Adj,
-        op : (Qubit[] => Unit is Adj + Ctl),
-        reference : (Qubit[] => Unit is Adj + Ctl),
-        inputSize : Int
-    ) : Bool {
-        use (control, target) = (Qubit(), Qubit[inputSize]);
-        within {
-            H(control);
-            initialState(target);
-        }
-        apply {
-            Controlled op([control], target);
-            Adjoint Controlled reference([control], target);
-        }
-
-
-        let isCorrect = CheckAllZero([control] + target);
-        ResetAll([control] + target);
-        isCorrect
-    }
-
-
     @EntryPoint()
     operation CheckSolution() : Bool {
         let isCorrect = CheckOperationsEquivalenceOnInitialStateStrict(
@@ -46,7 +21,6 @@ namespace Kata.Verification {
             BellStateChange2_Reference, 
             2);
 
-
         if isCorrect {
             Message("Correct!");
         } else {
@@ -54,9 +28,6 @@ namespace Kata.Verification {
             ShowQuantumStateComparison(2, PrepareBellState, Kata.BellStateChange2, BellStateChange2_Reference);
         }
 
-
         return isCorrect;
     }
-
-   
 }

--- a/katas/content/multi_qubit_systems/bell_state_change_3/Verification.qs
+++ b/katas/content/multi_qubit_systems/bell_state_change_3/Verification.qs
@@ -1,6 +1,4 @@
 namespace Kata.Verification {
-    open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Katas;
 
@@ -16,29 +14,6 @@ namespace Kata.Verification {
     }
 
 
-    operation CheckOperationsEquivalenceOnInitialStateStrict(
-        initialState : Qubit[] => Unit is Adj,
-        op : (Qubit[] => Unit is Adj + Ctl),
-        reference : (Qubit[] => Unit is Adj + Ctl),
-        inputSize : Int
-    ) : Bool {
-        use (control, target) = (Qubit(), Qubit[inputSize]);
-        within {
-            H(control);
-            initialState(target);
-        }
-        apply {
-            Controlled op([control], target);
-            Adjoint Controlled reference([control], target);
-        }
-
-
-        let isCorrect = CheckAllZero([control] + target);
-        ResetAll([control] + target);
-        isCorrect
-    }
-
-
     @EntryPoint()
     operation CheckSolution() : Bool {
         let isCorrect = CheckOperationsEquivalenceOnInitialStateStrict(
@@ -47,7 +22,6 @@ namespace Kata.Verification {
             BellStateChange3_Reference, 
             2);
 
-
         if isCorrect {
             Message("Correct!");
         } else {
@@ -55,9 +29,6 @@ namespace Kata.Verification {
             ShowQuantumStateComparison(2, PrepareBellState, Kata.BellStateChange3, BellStateChange3_Reference);
         }
 
-
         return isCorrect;
     }
-
-   
 }

--- a/katas/content/qec_shor/Common.qs
+++ b/katas/content/qec_shor/Common.qs
@@ -1,0 +1,50 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Random;
+
+    operation CheckErrorDetection(
+        n : Int,
+        encode : (Qubit[] => Unit is Adj),
+        error : (Qubit => Unit is Adj),
+        detect : (Qubit[] => Int)
+    ) : Bool {
+        for err_ind in -1 .. n - 1 {
+            for _ in 1 .. 10 {
+                use qs = Qubit[n];
+                let theta = DrawRandomDouble(0.0, 1.0);
+                within {
+                    // Prepare logical state on first qubit
+                    Ry(2.0 * theta * PI(), qs[0]);
+                    // Encode the state in multiple qubits
+                    encode(qs);
+                    // Introduce X error
+                    if err_ind > -1 {
+                        error(qs[err_ind]);
+                    }
+                } apply {
+                    // Call solution to detect index
+                    let detected = detect(qs);
+                    // Check that it is correct
+                    if detected != err_ind {
+                        Message("Incorrect.");
+                        let actual = err_ind == -1 ? "No error happened" | $"Error happened on qubit {err_ind}";
+                        Message($"{actual}, but solution returned {detected}");
+                        ResetAll(qs);
+                        return false;
+                    }
+                }
+                // Check that the state was not modified by the solution
+                if not CheckAllZero(qs) {
+                    Message("Incorrect.");
+                    Message("The state of the qubits changed after the solution was applied");
+                    ResetAll(qs);
+                    return false;
+                }
+            }
+        }
+
+        Message("Correct!");
+        true
+    }
+}

--- a/katas/content/qec_shor/bitflip_detect/Placeholder.qs
+++ b/katas/content/qec_shor/bitflip_detect/Placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation BitflipDetectError (register : Qubit[]) : Int {
+    operation BitflipDetectError (qs : Qubit[]) : Int {
         // Implement your solution here...
 
         return -2;

--- a/katas/content/qec_shor/bitflip_detect/Placeholder.qs
+++ b/katas/content/qec_shor/bitflip_detect/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation BitflipDetectError (register : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -2;
+    }
+}

--- a/katas/content/qec_shor/bitflip_detect/Solution.qs
+++ b/katas/content/qec_shor/bitflip_detect/Solution.qs
@@ -1,0 +1,16 @@
+namespace Kata {
+    operation BitflipDetectError (qs : Qubit[]) : Int {
+        let m1 = Measure([PauliZ, PauliZ], qs[0 .. 1]);
+        let m2 = Measure([PauliZ, PauliZ], qs[1 .. 2]);
+        
+        if m1 == One and m2 == Zero {
+            return 0;
+        } elif m1 == One and m2 == One {
+            return 1;
+        } elif m1 == Zero and m2 == One {
+            return 2;
+        } else {
+            return -1;
+        }
+    }
+}

--- a/katas/content/qec_shor/bitflip_detect/Verification.qs
+++ b/katas/content/qec_shor/bitflip_detect/Verification.qs
@@ -1,0 +1,13 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    operation BitflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        CheckErrorDetection(3, BitflipEncode, X, Kata.BitflipDetectError)
+    }
+}

--- a/katas/content/qec_shor/bitflip_detect/index.md
+++ b/katas/content/qec_shor/bitflip_detect/index.md
@@ -1,0 +1,6 @@
+**Input**: three qubits that are either in the state $\ket{\psi_L} = \alpha \ket{000} + \beta \ket{111}$
+or in one of the states $(X \otimes I \otimes I)\ket{\psi_L}$, $(I \otimes X \otimes I)\ket{\psi_L}$, or $(I \otimes I \otimes X)\ket{\psi_L}$ (that is, either in a valid code word of the bit flip code or a code word with an $X$ error occurring on one of the qubits).
+
+**Goal**: determine whether an $X$ error has occurred, and if so, on which qubit. 
+The return value should be the index of the qubit on which the error occurred, or $-1$ if no error occurred.
+The state of the qubits after your operation is applied should not change.

--- a/katas/content/qec_shor/bitflip_detect/solution.md
+++ b/katas/content/qec_shor/bitflip_detect/solution.md
@@ -1,0 +1,12 @@
+To identify the qubit on which the error happened, we need to do two parity measurements in the $Z$ basis on any two different pairs of qubits and analyze their oucomes: 
+
+- If both parity measurements yield $0$, no error occurred.
+- If both parity measurements yield $1$, the error occurred on the qubit that is shared between the measured pairs of qubits.
+- If one of the parity measurements yields $1$ and the other $0$, the error occurred on the qubit that was part of only the pair of qubits involved in the measurement that yields $1$ but not the other pair.
+
+The code below implements this logic using $ZZ$ parity measurements on pairs of qubits $0, 1$ and $1, 2$.
+
+@[solution]({
+    "id": "qec_shor__bitflip_detect_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/qec_shor/bitflip_detect/solution.md
+++ b/katas/content/qec_shor/bitflip_detect/solution.md
@@ -1,4 +1,4 @@
-To identify the qubit on which the error happened, we need to do two parity measurements in the $Z$ basis on any two different pairs of qubits and analyze their oucomes: 
+To identify the qubit on which the error happened, we need to do two parity measurements in the $Z$ basis on any two different pairs of qubits and analyze their outcomes: 
 
 - If both parity measurements yield $0$, no error occurred.
 - If both parity measurements yield $1$, the error occurred on the qubit that is shared between the measured pairs of qubits.

--- a/katas/content/qec_shor/bitflip_detect/solution.md
+++ b/katas/content/qec_shor/bitflip_detect/solution.md
@@ -1,4 +1,4 @@
-To identify the qubit on which the error happened, we need to do two parity measurements in the $Z$ basis on any two different pairs of qubits and analyze their outcomes: 
+To identify the qubit on which the error happened, we need to do two parity measurements in the $ZZ$ basis on any two different pairs of qubits and analyze their outcomes: 
 
 - If both parity measurements yield $0$, no error occurred.
 - If both parity measurements yield $1$, the error occurred on the qubit that is shared between the measured pairs of qubits.

--- a/katas/content/qec_shor/bitflip_encode/Placeholder.qs
+++ b/katas/content/qec_shor/bitflip_encode/Placeholder.qs
@@ -1,0 +1,6 @@
+namespace Kata {
+    operation BitflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        // Implement your solution here...
+        
+    }
+}

--- a/katas/content/qec_shor/bitflip_encode/Solution.qs
+++ b/katas/content/qec_shor/bitflip_encode/Solution.qs
@@ -1,0 +1,6 @@
+namespace Kata {
+    operation BitflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+    }
+}

--- a/katas/content/qec_shor/bitflip_encode/Verification.qs
+++ b/katas/content/qec_shor/bitflip_encode/Verification.qs
@@ -1,0 +1,35 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Katas;
+    open Microsoft.Quantum.Math;
+
+    operation BitflipEncode_Reference (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+    }
+
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        let range = 10;
+        for i in 0 .. range - 1 {
+            let angle = 2.0 * PI() * IntAsDouble(i) / IntAsDouble(range);
+            let initialState = qs => Ry(2.0 * angle, qs[0]);
+            let isCorrect = CheckOperationsEquivalenceOnInitialStateStrict(
+                initialState,
+                Kata.BitflipEncode, 
+                BitflipEncode_Reference, 
+                3);
+            if not isCorrect {
+                Message("Incorrect");
+                Message($"Test fails for alpha = {Cos(angle)}, beta = {Sin(angle)}.");
+                ShowQuantumStateComparison(3, initialState, Kata.BitflipEncode, BitflipEncode_Reference);
+                return false;
+            }
+        }
+
+        Message("Correct!");
+        true
+    }
+}

--- a/katas/content/qec_shor/bitflip_encode/index.md
+++ b/katas/content/qec_shor/bitflip_encode/index.md
@@ -1,0 +1,3 @@
+**Input**: three qubits in the state $\ket{\psi} \otimes \ket{00}$, where $\ket{\psi} = \alpha \ket{0} + \beta \ket{1}$ is the state of the first qubit, i.e., `qs[0]`.
+
+**Goal**: prepare a state $\alpha \ket{000} + \beta \ket{111}$ on these qubits.

--- a/katas/content/qec_shor/bitflip_encode/solution.md
+++ b/katas/content/qec_shor/bitflip_encode/solution.md
@@ -1,0 +1,6 @@
+We can do this using $CNOT$ gates with the first qubit as control. This will keep the term $\alpha \ket{000}$ unchanged and flip $\beta \ket{100}$ to $\beta \ket{111}$.
+
+@[solution]({
+    "id": "qec_shor__bitflip_encode_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/qec_shor/examples/ShorCodeDemo.qs
+++ b/katas/content/qec_shor/examples/ShorCodeDemo.qs
@@ -1,0 +1,108 @@
+namespace Kata {
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Math;
+
+    @EntryPoint()
+    operation RunExample() : Unit {
+        // Allocate qubits and prepare initial logical state.
+        use qs = Qubit[9];
+        Ry(ArcCos(0.6), qs[0]);
+
+        // Encode the logical state using Shor code.
+        ShorEncode(qs);
+
+        // Introduce an arbitrary error on one qubit.
+        Rz(0.1, qs[5]);
+
+        // Detect and correct error.
+        let (ind, err) = ShorDetectError(qs);
+
+        if ind > -1 {
+            if err == PauliX {
+                X(qs[ind]);
+            } elif err == PauliY {
+                Y(qs[ind]);
+            } else {
+                ForEach(q => Z(q), qs[ind * 3 .. ind * 3 + 2]);
+            }
+        }
+
+        // Check that the state was error-corrected accurately by uncomputing
+        // the encoding and state preparation to see that the result is the |0⟩ state.
+        Adjoint ShorEncode(qs);
+        Ry(-ArcCos(0.6), qs[0]);
+        if not CheckAllZero(qs) {
+            Message("State recovered incorrectly!");
+            ResetAll(qs);
+        } else {
+            Message("State recovered correctly!");
+        }
+    }
+
+    operation ShorEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        BitflipEncode(qs[0 .. 3 .. 8]);
+        ApplyToEachCA(H, qs[0 .. 3 .. 8]);
+        for i in 0 .. 2 {
+            BitflipEncode(qs[3 * i .. 3 * i + 2]);
+        }
+    }
+
+    operation BitflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+    }
+
+    operation ShorDetectError (qs : Qubit[]) : (Int, Pauli) {
+        // Detect X error first
+        mutable x_ind = -1;
+        for i in 0 .. 2 {
+            let err_ind = BitflipDetectError(qs[3 * i .. 3 * i + 2]);
+            if err_ind > -1 {
+                set x_ind = 3 * i + err_ind;
+            }
+        }
+
+        // Detect Z error 
+        mutable z_ind = -1;
+        let m1 = Measure([PauliX, size = 6], qs[0 .. 5]);
+        let m2 = Measure([PauliX, size = 6], qs[3 .. 8]);
+
+        if m1 == Zero and m2 == Zero {
+            set z_ind = -1;
+        } elif m1 == One and m2 == Zero {
+            set z_ind = 0;
+        } elif m1 == One and m2 == One {
+            set z_ind = 1;
+        } elif m1 == Zero and m2 == One {
+            set z_ind = 2;
+        }
+
+        // Combine both errors into return value
+        if x_ind == -1 and z_ind == -1 {
+            return (-1, PauliI);
+        }
+        if x_ind > -1 and z_ind > -1 {
+            return (x_ind, PauliY);
+        }
+        if x_ind > -1 {
+            return (x_ind, PauliX);
+        }
+        return (z_ind, PauliZ);
+    }
+
+    operation BitflipDetectError (qs : Qubit[]) : Int {
+        let m1 = Measure([PauliZ, PauliZ], qs[0 .. 1]);
+        let m2 = Measure([PauliZ, PauliZ], qs[1 .. 2]);
+        
+        if m1 == One and m2 == Zero {
+            return 0;
+        } elif m1 == One and m2 == One {
+            return 1;
+        } elif m1 == Zero and m2 == One {
+            return 2;
+        } else {
+            return -1;
+        }
+    }
+}

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -140,6 +140,16 @@ However, if a $Z$ error happens on any one of these qubits, we won't be able to 
     ]
 })
 
+@[exercise]({
+    "id": "qec_shor__bitflip_detect",
+    "title": "Bit Flip Code: Detect X Error",
+    "path": "./bitflip_detect/",
+    "qsDependencies": [
+        "../KatasLibrary.qs",
+        "./Common.qs"
+    ]
+})
+
 
 @[section]({
     "id": "qec_shor__phase_flip_code",
@@ -200,6 +210,16 @@ However, if an $X$ error happens on any one of these qubits, we won't be able to
     "path": "./phaseflip_encode/",
     "qsDependencies": [
         "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "qec_shor__phaseflip_detect",
+    "title": "Phase Flip Code: Detect Z Error",
+    "path": "./phaseflip_detect/",
+    "qsDependencies": [
+        "../KatasLibrary.qs",
+        "./Common.qs"
     ]
 })
 

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -9,11 +9,11 @@ This kata introduces you to the basic concepts of quantum error correction using
 
 **This kata covers the following topics:**
 
-- simple models of noise in quantum systems,
-- parity measurements in Z and X bases,
-- bit flip code - the simplest code that protects qubits from the effects of bit flip noise,
-- phase flip code - the simplest code that protects qubits from the effects of phase flip noise,
-- Shor code - the simplest code that can protect from an arbitrary error on a single qubit.
+- Simple models of noise in quantum systems
+- Parity measurements in Z and X bases
+- Bit flip code - the simplest code that protects qubits from the effects of bit flip noise
+- Phase flip code - the simplest code that protects qubits from the effects of phase flip noise
+- Shor code - the simplest code that can protect from an arbitrary error on a single qubit
 
 **What you should know to start working on this kata:**
 
@@ -25,7 +25,7 @@ This kata introduces you to the basic concepts of quantum error correction using
     "title": "Noise in Classical and Quantum Systems"
 })
 
-Any quantum systems we can use to carry out quantum computation are inherently noisy. 
+Any quantum system we can use to carry out quantum computation is inherently noisy. 
 Quantum noise can be caused by different physical processes, depending on the type of a particle or device used as a qubit.
 From the computation point of view, the presence of noise in the quantum system means that its state can suffer from random errors, and thus end up different from the state we're relying on to do our computations. 
 This makes computations unreliable very fast, since the effects of noise accumulate quickly to make computation results effectively random.
@@ -33,7 +33,7 @@ This makes computations unreliable very fast, since the effects of noise accumul
 Before we dive into dealing with noise in quantum systems, let's take a quick look at how we do that for classical systems.
 
 The model used for analyzing classical noise is called *binary symmetric channel*, in which classical bits sent through the channel are transmitted correctly with probability $1-p$ and flipped with probability $p$.
-In this scenario, the information sent through the channel can be protected against the effects of the noise using *repetition code*:
+In this scenario, the information sent through the channel can be protected against the effects of the noise using the *repetition code*:
 
 - On the sender side, we replace each bit we want to send with three copies of itself:
 $$0 \rightarrow 000, 1 \rightarrow 111$$
@@ -42,19 +42,19 @@ $$000, 100, 010, 001 \rightarrow 0$$
 $$111, 011, 101, 110 \rightarrow 1$$
 
 What is the probability of this scheme failure, that is, the value of the message bit changing after it was sent through the channel? 
-Majority vote allows for one error on any bit to happen without affecting the decoding outcome, so it would take two or three errors happening on individual bits for decoding to produce an incorrect result. The probability of this happening is $3p^2(1-p) + p^3 = 3p^2 - 2p^3$. If we compare this with the probability of an individual bit transmission failing $p$, we can see that using repetition code yields higher success probability, as long as $p < \frac12$. We can improve success probability further by increasing the number of repetitions we use to encode each bit: $5$ repetitions allow us to detect and correct $2$ errors, $7$ repetitions - $3$ errors, and so on.
+Majority vote allows for one error on any bit to happen without affecting the decoding outcome, so it would take two or three errors happening on individual bits for decoding to produce an incorrect result. The probability of this happening is $3p^2(1-p) + p^3 = 3p^2 - 2p^3$. If we compare this with the probability of an individual bit transmission failing $p$, we can see that using the repetition code yields higher success probability, as long as $p < \frac12$. We can improve success probability further by increasing the number of repetitions we use to encode each bit: $5$ repetitions allow us to detect and correct $2$ errors, $7$ repetitions - $3$ errors, and so on.
 
 > This noise model is useful not only for describing noisy communication channels, but also for memory - any classical system that introduces errors in information when it is left on its own, as opposed to systems that introduce errors during information manipulation. Indeed, we assume that no errors are introduced as we copy the bits during encoding or read and compare their values during decoding.
 
 The main idea of quantum error correction is the same as that for classical error correction: encode information with enough redundancy that we can recover the message even from the noisy transmission results.
 Dealing with the noise in quantum systems is more challenging than in classical systems, though, due to the limitations imposed by their nature:
 
-- **No cloning**: We cannot replicate repetition code for quantum systems in a straightforward manner, by duplicating the quantum state several times, since the no-cloning theorem prohibits that.
+- **No cloning**: We cannot replicate the repetition code for quantum systems in a straightforward manner, by duplicating the quantum state several times, since the no-cloning theorem prohibits that.
 - **Observing the system damages information**: Even if we could produce several copies of a quantum state we want to transmit, we would not be able to compare them afterwards without damaging their state.
-- **Errors are continuous**: We need to recover from arbitrary errors that are much more complicated than bit flip we have in classical systems.
+- **Errors are continuous**: We need to recover from arbitrary errors that are much more complicated than the bit flip error we have in classical systems.
 
 The simplest model used to analyze quantum noise is *quantum depolarizing channel*. 
-In this model, we assume that we send qubits through a channel that transmits the qubit unchanged with probability $1-p$, and applies one of the Pauli gates $X$, $Y$, and $Z$ with probability $\frac{p}{3}$ each. (The effects of the noise on each qubit transmitted are independent.)
+In this model, we assume that we send qubits through a channel that transmits the qubit unchanged with probability $1-p$, and applies one of the Pauli gates $X$, $Y$, and $Z$ with probability $\frac{p}{3}$ each. The effects of the noise on each qubit transmitted are independent.
 
 At first glance, this model seems to be limited, and not representative of the full spectrum of errors that can occur in a quantum system. Fortunately, it turns out that any errors on encoded states can be corrected by correcting only a discrete subset of errors - exactly the Pauli $X$, $Y$, and $Z$ errors! This is called *discretization of quantum errors*, and we'll see how it works later in this kata.
 
@@ -148,9 +148,9 @@ $$\ket{0} \rightarrow \ket{000}, \ket{1} \rightarrow \ket{111}$$
 
 $$\alpha \ket{0} + \beta \ket{1} \rightarrow \alpha \ket{000} + \beta \ket{111}$$
 
-This encoding is called **bit flip code**, and the states $\ket{000}$, $\ket{111}$, and their linear combinations are called **code words** in this code. Bit flip code allows us to detect and correct some errors that can occur on qubits in the depolarizing channel, though not all of them.
+This encoding is called **bit flip code**, and the states $\ket{000}$, $\ket{111}$, and their linear combinations are called **code words** in this code. The bit flip code allows us to detect and correct some errors that can occur on qubits in the depolarizing channel, though not all of them.
 
-Let's see what happens if an $X$ error happens on one of the qubits, and how we can detect it using two parity measurements (measurements in $ZZ$ basis).
+Let's see what happens if an $X$ error happens on one of the qubits, and how we can detect it using two parity measurements (measurements in the $ZZ$ basis).
 
 <table>
 <tr>
@@ -302,7 +302,7 @@ How can we detect and correct errors using this encoding?
 
 $X$ errors happening on any qubit manifest very similarly to the way they do in the bit flip code. 
 Let's consider the first triplet of qubits and an error that happens on any of the first three qubits.
-Same as in the bit flip code, measuring the parity of pairs of qubits always returns $0$ if there is no error (since all bits in each basis state of the code words are the same), so getting parity measurement return $1$ on one or two pairs indicates an error, and the measurements which return $1$ allow us to track down the qubit on which it happened.
+Same as in the bit flip code, measuring the parity of pairs of qubits always returns $0$ if there is no error (since all bits in each basis state of the code words are the same), so a parity measurement returning $1$ on one or two pairs indicates an error, and the measurements which returned $1$ allow us to track down the qubit on which it happened.
 
 To correct an $X$ error, we simply apply an $X$ gate to the affected qubit.
 
@@ -368,4 +368,4 @@ Here are a few key concepts to keep in mind:
 
 - Quantum error correction is more challenging compared to classical error correction, since quantum information cannot be copied, the act of observing the system damages information stored in it, and there is a much broader variety of errors in quantum systems compared to only bit flip errors in the classical systems.
 - Discretization of quantum errors is the phenomenon that allows us to correct arbitrary errors on quantum systems by correcting only a limited discrete subset of errors. For single-qubit errors, this subset is Pauli $X$, $Y$, and $Z$ errors.
-- Bit flip quantum error correction code allows us to detect and correct only $X$ errors, phase flip - only $Z$ errors, and Shor code allows us to detect and correct one arbitrary single-qubit error.
+- The bit flip quantum error correction code allows us to detect and correct only $X$ errors, the phase flip code only $Z$ errors, and the Shor code allows us to detect and correct one arbitrary single-qubit error.

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -131,8 +131,15 @@ You can see that these two parity measurements give us different pairs of result
 
 However, if a $Z$ error happens on any one of these qubits, we won't be able to detect it: it will convert the state $\alpha \ket{000} + \beta \ket{111}$ to the state $\alpha \ket{000} - \beta \ket{111}$ which is a valid code word in this code - it's an encoding of the quantum state $\alpha \ket{0} - \beta \ket{1}$. We'll need to come up with a different way to detect $Z$ errors.
 
-- exercise: bit flip code: encode (use op from 1385 for testing once merged)
-- exercise: bit flip code: detect X error
+@[exercise]({
+    "id": "qec_shor__bitflip_encode",
+    "title": "Bit Flip Code: Encode Codewords",
+    "path": "./bitflip_encode/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
 
 @[section]({
     "id": "qec_shor__phase_flip_code",
@@ -187,8 +194,14 @@ You can see that these two parity measurements give us different pairs of result
 
 However, if an $X$ error happens on any one of these qubits, we won't be able to detect it: it will convert the state $\alpha \ket{+++} + \beta \ket{---}$ to the state $\alpha \ket{+++} - \beta \ket{---}$ which is a valid code word in this code - it's an encoding of the quantum state $\alpha \ket{0} - \beta \ket{1}$. We'll need to come up with a different way to detect both $X$ and $Z$ errors in the same encoding.
 
-- exercise: phase flip code: encode (use op from 1385 for testing once merged)
-- exercise: phase flip code: detect Z error
+@[exercise]({
+    "id": "qec_shor__phaseflip_encode",
+    "title": "Phase Flip Code: Encode Codewords",
+    "path": "./phaseflip_encode/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
 
 
 @[section]({
@@ -196,9 +209,17 @@ However, if an $X$ error happens on any one of these qubits, we won't be able to
     "title": "Shor Code"
 })
 
-- exercise: Shor code: encode
 - exercise: Shor code: detect all errors
 - demo: does Shor code indeed correct all errors?
+
+@[exercise]({
+    "id": "qec_shor__shor_encode",
+    "title": "Shor Code: Encode Codewords",
+    "path": "./shor_encode/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
 
 
 @[section]({

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -127,11 +127,11 @@ Let's see what happens if an $X$ error happens on one of the qubits, and how we 
 </tr>
 </table>
 
-You can see that these two parity measurements give us different pairs of results depending on whether the error happened and on which qubit. This means that we can use them to detect the error, and then correct it by applying an $X$ gate to the qubit that was affected by it.
+You can see that these two parity measurements give us different pairs of results depending on whether the $X$ error happened and on which qubit. This means that we can use them to detect the error, and then correct it by applying an $X$ gate to the qubit that was affected by it.
 
 However, if a $Z$ error happens on any one of these qubits, we won't be able to detect it: it will convert the state $\alpha \ket{000} + \beta \ket{111}$ to the state $\alpha \ket{000} - \beta \ket{111}$ which is a valid code word in this code - it's an encoding of the quantum state $\alpha \ket{0} - \beta \ket{1}$. We'll need to come up with a different way to detect $Z$ errors.
 
-- exercise: bit flip code: encode
+- exercise: bit flip code: encode (use op from 1385 for testing once merged)
 - exercise: bit flip code: detect X error
 
 @[section]({
@@ -139,7 +139,55 @@ However, if a $Z$ error happens on any one of these qubits, we won't be able to 
     "title": "Phase Flip Code"
 })
 
-- exercise: phase flip code: encode
+What kind of code could detect and correct a $Z$ error? We detected an $X$ error using the fact that in the $\\{\ket{0}, \ket{1}\\}$ basis the error changed the basis state. Similarly, we can detect a $Z$ error using the $\\{\ket{+}, \ket{-}\\}$ basis, in which the $Z$ gate converts $\ket{+}$ to $\ket{-}$ and vice versa, acting as a basis change operation.
+
+Based on this idea, we can construct the **phase flip code** that uses the following encoding:
+
+$$\ket{0} \rightarrow \ket{+++}, \ket{1} \rightarrow \ket{---}$$
+
+$$\alpha \ket{0} + \beta \ket{1} \rightarrow \alpha \ket{+++} + \beta \ket{---}$$
+
+Let's see what happens if a $Z$ error happens on one of the qubits, and how we can detect it using two parity measurements. 
+This time we'll do the parity measurements in the $X$ basis to distinguish the cases of $\ket{++}$ and $\ket{--}$ (parity $0$) from $\ket{+-}$ and $\ket{-+}$ (parity $1$).
+
+<table>
+<tr>
+<th>Error</th>
+<th>State after the error</th>
+<th>$XX$ parity of qubits 0 and 1</th>
+<th>$XX$ parity of qubits 1 and 2</th>
+</tr>
+<tr>
+<td>No error</td>
+<td>$\alpha \ket{+++} + \beta \ket{---}$</td>
+<td>$0$</td>
+<td>$0$</td>
+</tr>
+<tr>
+<td>$Z_0$ (error on qubit $0$)</td>
+<td>$\alpha \ket{-++} + \beta \ket{+--}$</td>
+<td>$1$</td>
+<td>$0$</td>
+</tr>
+<tr>
+<td>$Z_1$ (error on qubit $1$)</td>
+<td>$\alpha \ket{+-+} + \beta \ket{-+-}$</td>
+<td>$1$</td>
+<td>$1$</td>
+</tr>
+<tr>
+<td>$Z_2$ (error on qubit $2$)</td>
+<td>$\alpha \ket{++-} + \beta \ket{--+}$</td>
+<td>$0$</td>
+<td>$1$</td>
+</tr>
+</table>
+
+You can see that these two parity measurements give us different pairs of results depending on whether the $Z$ error happened and on which qubit. This means that we can use them to detect the error, and then correct it by applying a $Z$ gate to the qubit that was affected by it.
+
+However, if an $X$ error happens on any one of these qubits, we won't be able to detect it: it will convert the state $\alpha \ket{+++} + \beta \ket{---}$ to the state $\alpha \ket{+++} - \beta \ket{---}$ which is a valid code word in this code - it's an encoding of the quantum state $\alpha \ket{0} - \beta \ket{1}$. We'll need to come up with a different way to detect both $X$ and $Z$ errors in the same encoding.
+
+- exercise: phase flip code: encode (use op from 1385 for testing once merged)
 - exercise: phase flip code: detect Z error
 
 

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -1,0 +1,78 @@
+# QEC: Bit Flip, Phase Flip, and Shor Codes
+
+@[section]({
+    "id": "qec_shor__overview",
+    "title": "Overview"
+})
+
+This kata introduces you to the basic concepts of quantum error correction using several simple error correction codes.
+
+**This kata covers the following topics:**
+
+- simple models of noise in quantum systems,
+- parity measurements in Z and X bases,
+- bit flip code - the simplest code that protects qubits from the effects of bit flip noise,
+- phase flip code - the simplest code that protects qubits from the effects of phase flip noise,
+- Shor code - the simplest code that can protect from an arbitrary error on a single qubit.
+
+**What you should know to start working on this kata:**
+
+- Basic single-qubit and multi-qubit gates
+- Single-qubit and multi-qubit quantum measurements and their effect on quantum systems
+
+@[section]({
+    "id": "qec_shor__noise",
+    "title": "Noise in Classical and Quantum Systems"
+})
+
+
+
+> For now, we are assuming that the gates and measurements we use for encoding and decoding procedures of a quantum error correction code are perfect and don't introduce any errors themselves. This is a useful assumption to get started with error correction, but in real life all gates and measurements are noisy, so we'll need to modify our approach. 
+> *Fault-tolerant quantum computation* handles the more general scenario of performing computations on encoded states in a way that tolerates errors introduced by noisy gates and measurements.
+
+
+@[section]({
+    "id": "qec_shor__parity_measurements",
+    "title": "Parity Measurements in Different Bases"
+})
+
+- exercise: parity measurement in Z basis
+- exercise: parity measurement in X basis
+
+
+@[section]({
+    "id": "qec_shor__bit_flip_code",
+    "title": "Bit Flip Code"
+})
+
+- exercise: bit flip code: encode
+- exercise: bit flip code: detect X error
+
+@[section]({
+    "id": "qec_shor__phase_flip_code",
+    "title": "Phase Flip Code"
+})
+
+- exercise: phase flip code: encode
+- exercise: phase flip code: detect Z error
+
+
+@[section]({
+    "id": "qec_shor__shor_code",
+    "title": "Shor Code"
+})
+
+- exercise: Shor code: encode
+- exercise: Shor code: detect all errors
+- demo: does Shor code indeed correct all errors?
+
+
+@[section]({
+    "id": "qec_shor__conclusion",
+    "title": "Conclusion"
+})
+
+Congratulations! In this kata you learned the basics of quantum error correction and several simple error-correction codes.
+Here are a few key concepts to keep in mind:
+
+- TODO

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -25,16 +25,49 @@ This kata introduces you to the basic concepts of quantum error correction using
     "title": "Noise in Classical and Quantum Systems"
 })
 
+Any quantum systems we can use to carry out quantum computation are inherently noisy. 
+Quantum noise can be caused by different physical processes, depending on the type of a particle or device used as a qubit.
+From the computation point of view, the presence of noise in the quantum system means that its state can suffer from random errors, and thus end up different from the state we're relying on to do our computations. 
+This makes computations unreliable very fast, since the effects of noise accumulate quickly to make computation results effectively random.
 
+Before we dive into dealing with noise in quantum systems, let's take a quick look at how we do that for classical systems.
 
-> For now, we are assuming that the gates and measurements we use for encoding and decoding procedures of a quantum error correction code are perfect and don't introduce any errors themselves. This is a useful assumption to get started with error correction, but in real life all gates and measurements are noisy, so we'll need to modify our approach. 
+The model used for analyzing classical noise is called *binary symmetric channel*, in which classical bits sent through the channel are transmitted correctly with probability $1-p$ and flipped with probability $p$.
+In this scenario, the information sent through the channel can be protected against the effects of the noise using *repetition code*:
+
+- On the sender side, we replace each bit we want to send with three copies of itself:
+$$0 \rightarrow 000, 1 \rightarrow 111$$
+- On the receiver side, we decode the original bit by majority vote: 
+$$000, 100, 010, 001 \rightarrow 0$$
+$$111, 011, 101, 110 \rightarrow 1$$
+
+What is the probability of this scheme failure, that is, the value of the message bit changing after it was sent through the channel? 
+Majority vote allows for one error on any bit to happen without affecting the decoding outcome, so it would take two or three errors happening on individual bits for decoding to produce an incorrect result. The probability of this happening is $3p^2(1-p) + p^3 = 3p^2 - 2p^3$. If we compare this with the probability of an individual bit transmission failing $p$, we can see that using repetition code yields higher success probability, as long as $p < \frac12$. We can improve success probability further by increasing the number of repetitions we use to encode each bit: $5$ repetitions allow us to detect and correct $2$ errors, $7$ repetitions - $3$ errors, and so on.
+
+> This noise model is useful not only for describing noisy communication channels, but also for memory - any classical system that introduces errors in information when it is left on its own, as opposed to systems that introduce errors during information manipulation. Indeed, we assume that no errors are inroduced as we copy the bits during encoding or read and compare their values during decoding.
+
+The main idea of quantum error correction is the same as that for classical error correction: encode information with enough redundancy that we can recover the message even from the noisy transmission results.
+Dealing with the noise in quantum systems is more challenging than in classical systems, though, due to the limitations imposed by their nature:
+
+- **No cloning**: We cannot replicate repetition code for quantum systems in a straightforward manner, by duplicating the quantum state several times, since the no-cloning theorem prohibits that.
+- **Observing the system damages information**: Even if we could produce several copies of a quantum state we want to transmit, we would not be able to compare them afterwards without damaging their state.
+- **Errors are continuous**: We need to recover from arbitrary errors that are much more complicated than bit flip we have in classical systems.
+
+The simplest model used to analyze quantum noise is *quantum depolarizing channel*. 
+In this model, we assume that we send qubits through a channel that transmits the qubit unchanged with probability $1-p$, and applies one of the Pauli gates $X$, $Y$, and $Z$ with probability $\frac{p}{3}$ each. (The effects of the noise on each qubit transmitted are independent.)
+
+At first glance, this model seems to be limited, and not representative of the full spectrum of errors that can occur in a quantum system. Fortunately, it turns out that any errors on encoded states can be corrected by correcting only a discrete subset of errors - exactly the Pauli $X$, $Y$, and $Z$ errors! This is called *discretization of quantum errors*, and we'll see how it works later in this kata.
+
+> For now, we are assuming that all errors are introduced by the channel, and the gates and measurements we use for encoding and decoding procedures of a quantum error correction code are perfect and don't introduce any errors themselves. This is a useful assumption to get started with error correction, but in real life all gates and measurements are noisy, so eventually we'll need to modify our approach. 
 > *Fault-tolerant quantum computation* handles the more general scenario of performing computations on encoded states in a way that tolerates errors introduced by noisy gates and measurements.
-
 
 @[section]({
     "id": "qec_shor__parity_measurements",
-    "title": "Parity Measurements in Different Bases"
+    "title": "Parity Measurements"
 })
+
+Quantum error correction is based on the use of a special kind of measurements - parity measurements.
+
 
 - exercise: parity measurement in Z basis
 - exercise: parity measurement in X basis

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -62,15 +62,73 @@ At first glance, this model seems to be limited, and not representative of the f
 > *Fault-tolerant quantum computation* handles the more general scenario of performing computations on encoded states in a way that tolerates errors introduced by noisy gates and measurements.
 
 @[section]({
-    "id": "qec_shor__parity_measurements",
-    "title": "Parity Measurements"
+    "id": "qec_shor__joint_measurements",
+    "title": "Joint Measurements"
 })
 
-Quantum error correction is based on the use of a special kind of measurements - parity measurements.
+Quantum error correction is based on the use of a special kind of measurements - joint measurements in Pauli bases.
+We introduced the single-qubit measurements in different Pauli bases in the Measurements in Single-Qubit Systems kata,
+and then the general case of joint measurements in the Measurements in Multi-Qubit Systems kata.
+Let's take a closer look at the kinds of joint measurements we'll be using in this kata.
 
+A multi-qubit Pauli measurement on $n$ qubits corresponds to an operator $M_1 \otimes \dotsc \otimes M_n$, with each $M_j$ being from the set of gates $\\{X,Y,Z,I\\}$, and at least one of the $M_j$ is not the identity matrix. (If $M_j = I$, you can think of it as qubit $j$ not being involved in the measurement.) The measurement can produce one of the two outcomes: `Zero` corresponding to eigenvalue $+1$ of this operator, or `One` corresponding to the eigenvalue $-1$. The corresponding projection operators are the projections onto the corresponding eigenspaces. The operator $M_1 \otimes \dotsc \otimes M_n$ is referred to as the _measurement basis_.
 
-- exercise: parity measurement in Z basis
-- exercise: parity measurement in X basis
+For example, the first two joint measurements we'll encounter later in this kata are two-qubit measurements in $ZZ$ and $XX$ bases. They can be described as follows:
+
+<table>
+    <tr>
+        <th>Pauli Operator</th>
+        <th>Eigenvalue</th>
+        <th>Eigenvectors</th>
+        <th>Measurement Projector</th>
+        <th>Measurement Result in Q#</th>
+    </tr>
+    <tr>
+        <td rowspan="2">$ZZ$</td>
+        <td>$+1$</td>
+        <td>$\ket{00}$, $\ket{11}$</td>
+        <td>$\ket{00}\bra{00} + \ket{11}\bra{11}$</td>
+        <td>Zero</td>
+    </tr><tr>
+        <td>$-1$</td>
+        <td>$\ket{01}$, $\ket{10}$</td>
+        <td>$\ket{01}\bra{01} + \ket{10}\bra{10}$</td>
+        <td>One</td>
+    </tr>
+    <tr>
+        <td rowspan="2">$XX$</td>
+        <td>$+1$</td>
+        <td>$\ket{++}$, $\ket{--}$</td>
+        <td>$\ket{++}\bra{++} + \ket{--}\bra{--}$</td>
+        <td>Zero</td>
+    </tr><tr>
+        <td>$-1$</td>
+        <td>$\ket{+-}$, $\ket{-+}$</td>
+        <td>$\ket{+-}\bra{+-} + \ket{-+}\bra{-+}$</td>
+        <td>One</td>
+    </tr>
+</table>
+
+In Q#, joint measurements in Pauli bases are implemented using the `Measure` operation.
+It takes two parameters: the array of `Pauli` constants (`PauliI`, `PauliX`, `PauliY`, or `PauliZ`) that define the basis for measurement, and the array of qubits to be measured.
+
+@[exercise]({
+    "id": "qec_shor__zz_measurement",
+    "title": "Measurement in ZZ basis",
+    "path": "./zz_measurement/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "qec_shor__xx_measurement",
+    "title": "Measurement in XX basis",
+    "path": "./xx_measurement/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
 
 
 @[section]({
@@ -92,7 +150,7 @@ $$\alpha \ket{0} + \beta \ket{1} \rightarrow \alpha \ket{000} + \beta \ket{111}$
 
 This encoding is called **bit flip code**, and the states $\ket{000}$, $\ket{111}$, and their linear combinations are called **code words** in this code. Bit flip code allows us to detect and correct some errors that can occur on qubits in the depolarizing channel, though not all of them.
 
-Let's see what happens if an $X$ error happens on one of the qubits, and how we can detect it using two parity measurements.
+Let's see what happens if an $X$ error happens on one of the qubits, and how we can detect it using two parity measurements (measurements in $ZZ$ basis).
 
 <table>
 <tr>

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -229,13 +229,23 @@ However, if an $X$ error happens on any one of these qubits, we won't be able to
     "title": "Shor Code"
 })
 
-- exercise: Shor code: detect all errors
+TODO
+
 - demo: does Shor code indeed correct all errors?
 
 @[exercise]({
     "id": "qec_shor__shor_encode",
     "title": "Shor Code: Encode Codewords",
     "path": "./shor_encode/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "qec_shor__shor_detect",
+    "title": "Shor Code: Detect X, Y, and Z Errors",
+    "path": "./shor_detect/",
     "qsDependencies": [
         "../KatasLibrary.qs"
     ]

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -78,6 +78,59 @@ Quantum error correction is based on the use of a special kind of measurements -
     "title": "Bit Flip Code"
 })
 
+Can we reuse the ideas of a classical repetition code for a quantum error correction code? 
+
+The naive approach to it would be to try and encode a quantum state $\ket{\psi}$ as several copies of itself: 
+$\ket{\psi} \rightarrow \ket{\psi} \otimes \ket{\psi} \otimes \ket{\psi}$.
+Unfortunately, the no-cloning theorem and the inability to reconstruct a state accurately after measuring it prevent us from doing that.
+
+We can, however, take a slightly different approach: encode the *basis states* $\ket{0}$ and $\ket{1}$ in repetition code using a unitary transformation, and deduce the effects of this transformation on superposition states based on its linearity:
+
+$$\ket{0} \rightarrow \ket{000}, \ket{1} \rightarrow \ket{111}$$
+
+$$\alpha \ket{0} + \beta \ket{1} \rightarrow \alpha \ket{000} + \beta \ket{111}$$
+
+This encoding is called **bit flip code**, and the states $\ket{000}$, $\ket{111}$, and their linear combinations are called **code words** in this code. Bit flip code allows us to detect and correct some errors that can occur on qubits in the depolarizing channel, though not all of them.
+
+Let's see what happens if an $X$ error happens on one of the qubits, and how we can detect it using two parity measurements.
+
+<table>
+<tr>
+<th>Error</th>
+<th>State after the error</th>
+<th>Parity of qubits 0 and 1</th>
+<th>Parity of qubits 1 and 2</th>
+</tr>
+<tr>
+<td>No error</td>
+<td>$\alpha \ket{000} + \beta \ket{111}$</td>
+<td>$0$</td>
+<td>$0$</td>
+</tr>
+<tr>
+<td>$X_0$ (error on qubit $0$)</td>
+<td>$\alpha \ket{100} + \beta \ket{011}$</td>
+<td>$1$</td>
+<td>$0$</td>
+</tr>
+<tr>
+<td>$X_1$ (error on qubit $1$)</td>
+<td>$\alpha \ket{010} + \beta \ket{101}$</td>
+<td>$1$</td>
+<td>$1$</td>
+</tr>
+<tr>
+<td>$X_2$ (error on qubit $2$)</td>
+<td>$\alpha \ket{001} + \beta \ket{110}$</td>
+<td>$0$</td>
+<td>$1$</td>
+</tr>
+</table>
+
+You can see that these two parity measurements give us different pairs of results depending on whether the error happened and on which qubit. This means that we can use them to detect the error, and then correct it by applying an $X$ gate to the qubit that was affected by it.
+
+However, if a $Z$ error happens on any one of these qubits, we won't be able to detect it: it will convert the state $\alpha \ket{000} + \beta \ket{111}$ to the state $\alpha \ket{000} - \beta \ket{111}$ which is a valid code word in this code - it's an encoding of the quantum state $\alpha \ket{0} - \beta \ket{1}$. We'll need to come up with a different way to detect $Z$ errors.
+
 - exercise: bit flip code: encode
 - exercise: bit flip code: detect X error
 

--- a/katas/content/qec_shor/phaseflip_detect/Placeholder.qs
+++ b/katas/content/qec_shor/phaseflip_detect/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation PhaseflipDetectError (register : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -2;
+    }
+}

--- a/katas/content/qec_shor/phaseflip_detect/Placeholder.qs
+++ b/katas/content/qec_shor/phaseflip_detect/Placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation PhaseflipDetectError (register : Qubit[]) : Int {
+    operation PhaseflipDetectError (qs : Qubit[]) : Int {
         // Implement your solution here...
 
         return -2;

--- a/katas/content/qec_shor/phaseflip_detect/Solution.qs
+++ b/katas/content/qec_shor/phaseflip_detect/Solution.qs
@@ -1,0 +1,16 @@
+namespace Kata {
+    operation PhaseflipDetectError (qs : Qubit[]) : Int {
+        let m1 = Measure([PauliX, PauliX], qs[0 .. 1]);
+        let m2 = Measure([PauliX, PauliX], qs[1 .. 2]);
+        
+        if m1 == One and m2 == Zero {
+            return 0;
+        } elif m1 == One and m2 == One {
+            return 1;
+        } elif m1 == Zero and m2 == One {
+            return 2;
+        } else {
+            return -1;
+        }
+    }
+}

--- a/katas/content/qec_shor/phaseflip_detect/Verification.qs
+++ b/katas/content/qec_shor/phaseflip_detect/Verification.qs
@@ -1,0 +1,14 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    operation PhaseflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+        ApplyToEachCA(H, qs);
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        CheckErrorDetection(3, PhaseflipEncode, Z, Kata.PhaseflipDetectError)
+    }
+}

--- a/katas/content/qec_shor/phaseflip_detect/index.md
+++ b/katas/content/qec_shor/phaseflip_detect/index.md
@@ -1,0 +1,6 @@
+**Input**: three qubits that are either in the state $\ket{\psi_L} = \alpha \ket{+++} + \beta \ket{---}$
+or in one of the states $(Z \otimes I \otimes I)\ket{\psi_L}$, $(I \otimes Z \otimes I)\ket{\psi_L}$, or $(I \otimes I \otimes Z)\ket{\psi_L}$ (that is, either in a valid code word of the bit flip code or a code word with a $Z$ error occurring on one of the qubits).
+
+**Goal**: determine whether a $Z$ error has occurred, and if so, on which qubit. 
+The return value should be the index of the qubit on which the error occurred, or $-1$ if no error occurred.
+The state of the qubits after your operation is applied should not change.

--- a/katas/content/qec_shor/phaseflip_detect/index.md
+++ b/katas/content/qec_shor/phaseflip_detect/index.md
@@ -1,5 +1,5 @@
 **Input**: three qubits that are either in the state $\ket{\psi_L} = \alpha \ket{+++} + \beta \ket{---}$
-or in one of the states $(Z \otimes I \otimes I)\ket{\psi_L}$, $(I \otimes Z \otimes I)\ket{\psi_L}$, or $(I \otimes I \otimes Z)\ket{\psi_L}$ (that is, either in a valid code word of the bit flip code or a code word with a $Z$ error occurring on one of the qubits).
+or in one of the states $(Z \otimes I \otimes I)\ket{\psi_L}$, $(I \otimes Z \otimes I)\ket{\psi_L}$, or $(I \otimes I \otimes Z)\ket{\psi_L}$ (that is, either in a valid code word of the phase flip code or a code word with a $Z$ error occurring on one of the qubits).
 
 **Goal**: determine whether a $Z$ error has occurred, and if so, on which qubit. 
 The return value should be the index of the qubit on which the error occurred, or $-1$ if no error occurred.

--- a/katas/content/qec_shor/phaseflip_detect/solution.md
+++ b/katas/content/qec_shor/phaseflip_detect/solution.md
@@ -1,4 +1,4 @@
-To identify the qubit on which the error happened, we can use the same logic as we did for the error detection for the bit flip code. We need to do two parity measurements, this time in the $X$ basis, on any two different pairs of qubits and analyze their outcomes.
+To identify the qubit on which the error happened, we can use the same logic as we did for the error detection for the bit flip code. We need to do two parity measurements, this time in the $XX$ basis, on any two different pairs of qubits and analyze their outcomes.
 The code below implements this logic using $XX$ parity measurements on pairs of qubits $0, 1$ and $1, 2$.
 
 @[solution]({

--- a/katas/content/qec_shor/phaseflip_detect/solution.md
+++ b/katas/content/qec_shor/phaseflip_detect/solution.md
@@ -1,0 +1,7 @@
+To identify the qubit on which the error happened, we can use the same logic as we did for the error detection for the bit flip code. We need to do two parity measurements, this time in the $X$ basis, on any two different pairs of qubits and analyze their oucomes.
+The code below implements this logic using $XX$ parity measurements on pairs of qubits $0, 1$ and $1, 2$.
+
+@[solution]({
+    "id": "qec_shor__phaseflip_detect_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/qec_shor/phaseflip_detect/solution.md
+++ b/katas/content/qec_shor/phaseflip_detect/solution.md
@@ -1,4 +1,4 @@
-To identify the qubit on which the error happened, we can use the same logic as we did for the error detection for the bit flip code. We need to do two parity measurements, this time in the $X$ basis, on any two different pairs of qubits and analyze their oucomes.
+To identify the qubit on which the error happened, we can use the same logic as we did for the error detection for the bit flip code. We need to do two parity measurements, this time in the $X$ basis, on any two different pairs of qubits and analyze their outcomes.
 The code below implements this logic using $XX$ parity measurements on pairs of qubits $0, 1$ and $1, 2$.
 
 @[solution]({

--- a/katas/content/qec_shor/phaseflip_encode/Placeholder.qs
+++ b/katas/content/qec_shor/phaseflip_encode/Placeholder.qs
@@ -1,0 +1,6 @@
+namespace Kata {
+    operation PhaseflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        // Implement your solution here...
+        
+    }
+}

--- a/katas/content/qec_shor/phaseflip_encode/Solution.qs
+++ b/katas/content/qec_shor/phaseflip_encode/Solution.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation PhaseflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+        ApplyToEachCA(H, qs);
+    }
+}

--- a/katas/content/qec_shor/phaseflip_encode/Verification.qs
+++ b/katas/content/qec_shor/phaseflip_encode/Verification.qs
@@ -1,0 +1,36 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Katas;
+    open Microsoft.Quantum.Math;
+
+    operation PhaseflipEncode_Reference (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+        ApplyToEachCA(H, qs);
+    }
+
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        let range = 10;
+        for i in 0 .. range - 1 {
+            let angle = 2.0 * PI() * IntAsDouble(i) / IntAsDouble(range);
+            let initialState = qs => Ry(2.0 * angle, qs[0]);
+            let isCorrect = CheckOperationsEquivalenceOnInitialStateStrict(
+                initialState,
+                Kata.PhaseflipEncode, 
+                PhaseflipEncode_Reference, 
+                3);
+            if not isCorrect {
+                Message("Incorrect");
+                Message($"Test fails for alpha = {Cos(angle)}, beta = {Sin(angle)}.");
+                ShowQuantumStateComparison(3, initialState, Kata.PhaseflipEncode, PhaseflipEncode_Reference);
+                return false;
+            }
+        }
+
+        Message("Correct!");
+        true
+    }
+}

--- a/katas/content/qec_shor/phaseflip_encode/index.md
+++ b/katas/content/qec_shor/phaseflip_encode/index.md
@@ -1,0 +1,3 @@
+**Input**: three qubits in the state $\ket{\psi} \otimes \ket{00}$, where $\ket{\psi} = \alpha \ket{0} + \beta \ket{1}$ is the state of the first qubit, i.e., `qs[0]`.
+
+**Goal**: prepare a state $\alpha \ket{+++} + \beta \ket{---}$ on these qubits.

--- a/katas/content/qec_shor/phaseflip_encode/solution.md
+++ b/katas/content/qec_shor/phaseflip_encode/solution.md
@@ -1,0 +1,9 @@
+We can implement this encoding in two steps:
+
+1. Use bit flip encoding to convert $\alpha \ket{000} + \beta \ket{100}$ into $\alpha \ket{000} + \beta \ket{111}$.
+2. Apply a Hadamard gate to each qubit to convert each of the $\ket{0}$ states into $\ket{+}$ and each of the $\ket{1}$ states into $\ket{-}$.
+
+@[solution]({
+    "id": "qec_shor__phaseflip_encode_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/qec_shor/shor_detect/Placeholder.qs
+++ b/katas/content/qec_shor/shor_detect/Placeholder.qs
@@ -1,0 +1,23 @@
+namespace Kata {
+    operation ShorDetectError (qs : Qubit[]) : (Int, Pauli) {
+        // Implement your solution here...
+
+        return (-2, PauliI);
+    }
+
+    // You might find this helper operation from an earlier task useful.
+    operation BitflipDetectError (qs : Qubit[]) : Int {
+        let m1 = Measure([PauliZ, PauliZ], qs[0 .. 1]);
+        let m2 = Measure([PauliZ, PauliZ], qs[1 .. 2]);
+        
+        if m1 == One and m2 == Zero {
+            return 0;
+        } elif m1 == One and m2 == One {
+            return 1;
+        } elif m1 == Zero and m2 == One {
+            return 2;
+        } else {
+            return -1;
+        }
+    }
+}

--- a/katas/content/qec_shor/shor_detect/Solution.qs
+++ b/katas/content/qec_shor/shor_detect/Solution.qs
@@ -1,0 +1,55 @@
+namespace Kata {
+    operation ShorDetectError (qs : Qubit[]) : (Int, Pauli) {
+        // Detect X error first
+        mutable x_ind = -1;
+        for i in 0 .. 2 {
+            let err_ind = BitflipDetectError(qs[3 * i .. 3 * i + 2]);
+            if err_ind > -1 {
+                set x_ind = 3 * i + err_ind;
+            }
+        }
+
+        // Detect Z error 
+        mutable z_ind = -1;
+        let m1 = Measure([PauliX, size = 6], qs[0 .. 5]);
+        let m2 = Measure([PauliX, size = 6], qs[3 .. 8]);
+
+        if m1 == Zero and m2 == Zero {
+            set z_ind = -1;
+        } elif m1 == One and m2 == Zero {
+            set z_ind = 0;
+        } elif m1 == One and m2 == One {
+            set z_ind = 1;
+        } elif m1 == Zero and m2 == One {
+            set z_ind = 2;
+        }
+
+        // Combine both errors into return value
+        if x_ind == -1 and z_ind == -1 {
+            return (-1, PauliI);
+        }
+        if x_ind > -1 and z_ind > -1 {
+            return (x_ind, PauliY);
+        }
+        if x_ind > -1 {
+            return (x_ind, PauliX);
+        }
+        return (z_ind, PauliZ);
+    }
+
+    // You might find this helper operation from an earlier task useful.
+    operation BitflipDetectError (qs : Qubit[]) : Int {
+        let m1 = Measure([PauliZ, PauliZ], qs[0 .. 1]);
+        let m2 = Measure([PauliZ, PauliZ], qs[1 .. 2]);
+        
+        if m1 == One and m2 == Zero {
+            return 0;
+        } elif m1 == One and m2 == One {
+            return 1;
+        } elif m1 == Zero and m2 == One {
+            return 2;
+        } else {
+            return -1;
+        }
+    }
+}

--- a/katas/content/qec_shor/shor_detect/Verification.qs
+++ b/katas/content/qec_shor/shor_detect/Verification.qs
@@ -1,0 +1,95 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Katas;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Random;
+
+    operation ShorEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        BitflipEncode(qs[0 .. 3 .. 8]);
+        ApplyToEachCA(H, qs[0 .. 3 .. 8]);
+        for i in 0 .. 2 {
+            BitflipEncode(qs[3 * i .. 3 * i + 2]);
+        }
+    }
+
+    operation BitflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+    }
+
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        for err_ind in -1 .. 8 {
+            for err in [PauliX, PauliZ, PauliY] {
+                for _ in 1 .. 10 {
+                    mutable correct = true;
+                    mutable msg = "";
+                    use qs = Qubit[9];
+                    let theta = DrawRandomDouble(0.0, 1.0);
+                    within {
+                        // Prepare logical state on first qubit
+                        Ry(2.0 * theta * PI(), qs[0]);
+                        // Encode the state in multiple qubits
+                        ShorEncode(qs);
+                        // Introduce the error
+                        if err_ind > -1 {
+                            if err == PauliX {
+                                X(qs[err_ind]);
+                            } elif err == PauliZ {
+                                Z(qs[err_ind]);
+                            } else {
+                                Y(qs[err_ind]);
+                            }
+                        }
+                    } apply {
+                        // Call solution to detect error
+                        let (detected_ind, detected_err) = Kata.ShorDetectError(qs);
+                        // Check that it is correct
+                        if err_ind == -1 {
+                            // No error
+                            if detected_ind != -1 {
+                                set correct = false;
+                                set msg = $"There was no error, but the solution detected error at qubit {detected_ind}";
+                            }
+                        } else {
+                            // There was an error
+                            if detected_err != err {
+                                set correct = false;
+                                set msg = $"There was a {err} error, but the solution detected {detected_err} error";
+                            } else {
+                                if err == PauliX or err == PauliY {
+                                    if detected_ind != err_ind {
+                                        set correct = false;
+                                        set msg = $"There was a {err} error at qubit {err_ind}, but the solution detected it at qubit {detected_ind}";
+                                    }
+                                } else {
+                                    // For PauliZ errors, cannot say for certain in which qubit of the triplet it happened, so identify triplet
+                                    if detected_ind != err_ind / 3 {
+                                        set correct = false;
+                                        set msg = $"There was a {err} error at qubit {err_ind}, but the solution detected it at qubit triplet {detected_ind}";
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    // Check that the state was not modified by the solution
+                    if not CheckAllZero(qs) {
+                        set correct = false;
+                        set msg = "The state of the qubits changed after the solution was applied";
+                    }
+
+                    if not correct {
+                        Message("Incorrect.");
+                        Message(msg);
+                        ResetAll(qs);
+                        return false;
+                    }
+                }
+            }
+        }
+
+        Message("Correct!");
+        true
+    }
+}

--- a/katas/content/qec_shor/shor_detect/index.md
+++ b/katas/content/qec_shor/shor_detect/index.md
@@ -1,0 +1,37 @@
+**Input**: nine qubits that are either in the state $\ket{\psi_L} = \alpha \ket{0_L} + \beta \ket{0_L}$ (a valid code word of the Shor code) or the state that is a code word with $X$, $Y$, or $Z$ error occurring on one of the qubits.
+
+**Goal**: determine whether an error has occurred, and if so, what type and on which qubit. 
+The return value is a tuple of two elements, describing the detected error as follows:
+
+- The first element of the return is an `Int` - the index of the qubit on which the error occurred, or $-1$ if no error occurred.
+- The second element of the return is a `Pauli` indicating the type of the error (`PauliX`, `PauliY`, or `PauliZ`).
+If no error occurred, the second element of the return can be any value, it is not validated.
+- In case of a single $Z$ error, the qubit on which it occurred cannot be identified uniquely. 
+In this case, the return value should be the index of the triplet of qubits in which the error occurred ($0$ for qubits $0 \ldots 2$, $1$ for qubits $3 \ldots 5$, and $2$ for qubits $6 \ldots 8$).
+
+Example return values:
+
+<table>
+<tr>
+<th>Error</th>
+<th>Return value</th>
+</tr>
+<tr>
+<td>No error</td>
+<td>(-1, PauliI)</td>
+</tr>
+<tr>
+<td>$X$ error on qubit $0$</td>
+<td>(0, PauliX)</td>
+</tr>
+<tr>
+<td>$Y$ error on qubit $4$</td>
+<td>(4, PauliY)</td>
+</tr>
+<tr>
+<td>$Z$ error on qubit $8$ (last triplet)</td>
+<td>(2, PauliZ)</td>
+</tr>
+</table>
+
+The state of the qubits after your operation is applied should not change.

--- a/katas/content/qec_shor/shor_detect/solution.md
+++ b/katas/content/qec_shor/shor_detect/solution.md
@@ -1,0 +1,24 @@
+For this code, we'll detect $X$ and $Z$ errors separately, similarly to how we did it for bit flip code and phase flip code, and then combine the results into the final answer. A $Y$ error will be signaled by both $X$ and $Z$ errors occurring, since the problem states that at most one error happened.
+
+1. To detect $X$ errors, we recall that in Shor code, each triplet of qubits $0 \ldots 2, 3 \ldots 5, 6 \ldots 8$ is an encoding of a $\ket{+}$ state in the bit flip code. This means that we can detect an $X$ error by applying the bit flip error detection logic to each triplet of qubits separately. 
+
+2. To detect $Z$ errors, we recall that 6-qubit joint measurements in $X$ basis can detect the parity of the relative phase of the first three qubits and the last three qubits in the measurement, that is, distinguish
+
+    $$\frac12 \left( (\ket{000} + \ket{111}) \otimes (\ket{000} + \ket{111}) + (\ket{000} - \ket{111}) \otimes (\ket{000} - \ket{111}) \right)$$
+
+    from 
+
+    $$\frac12 \left( (\ket{000} + \ket{111}) \otimes (\ket{000} - \ket{111}) + (\ket{000} - \ket{111}) \otimes (\ket{000} + \ket{111}) \right)$$
+
+    This means that we can detect a $Z$ error by doing two 6-qubit joint measurements on qubit triplets $0 \ldots 2$ & $3 \ldots 5$ and on $3 \ldots 5$ & $6 \ldots 8$ and interpret their results in the same way as we did for bit flip and phase flip codes.
+
+3. To combine the results, we check which of the results occurred: 
+
+- if neither $X$ nor $Z$ error was detected, we return "no error";
+- if both were detected, we return the $Y$ error and use the index of the qubit where the $X$ error was detected (remember that we can tract the $Z$ error only to the triplet in which it occurred, not to the exact qubit);
+- if only one error was detected, we return that error.
+
+@[solution]({
+    "id": "qec_shor__shor_detect_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/qec_shor/shor_encode/Placeholder.qs
+++ b/katas/content/qec_shor/shor_encode/Placeholder.qs
@@ -1,0 +1,12 @@
+namespace Kata {
+    operation ShorEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        // Implement your solution here...
+        
+    }
+
+    // You might find this helper operation from an earlier task useful.
+    operation BitflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+    }
+}

--- a/katas/content/qec_shor/shor_encode/Solution.qs
+++ b/katas/content/qec_shor/shor_encode/Solution.qs
@@ -1,0 +1,14 @@
+namespace Kata {
+    operation ShorEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        BitflipEncode(qs[0 .. 3 .. 8]);
+        ApplyToEachCA(H, qs[0 .. 3 .. 8]);
+        for i in 0 .. 2 {
+            BitflipEncode(qs[3 * i .. 3 * i + 2]);
+        }
+    }
+
+    operation BitflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+    }
+}

--- a/katas/content/qec_shor/shor_encode/Verification.qs
+++ b/katas/content/qec_shor/shor_encode/Verification.qs
@@ -1,0 +1,43 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Katas;
+    open Microsoft.Quantum.Math;
+
+    operation ShorEncode_Reference (qs : Qubit[]) : Unit is Adj + Ctl {
+        BitflipEncode(qs[0 .. 3 .. 8]);
+        ApplyToEachCA(H, qs[0 .. 3 .. 8]);
+        for i in 0 .. 2 {
+            BitflipEncode(qs[3 * i .. 3 * i + 2]);
+        }
+    }
+
+    operation BitflipEncode (qs : Qubit[]) : Unit is Adj + Ctl {
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
+    }
+
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        let range = 10;
+        for i in 0 .. range - 1 {
+            let angle = 2.0 * PI() * IntAsDouble(i) / IntAsDouble(range);
+            let initialState = qs => Ry(2.0 * angle, qs[0]);
+            let isCorrect = CheckOperationsEquivalenceOnInitialStateStrict(
+                initialState,
+                Kata.ShorEncode, 
+                ShorEncode_Reference, 
+                9);
+            if not isCorrect {
+                Message("Incorrect");
+                Message($"Test fails for alpha = {Cos(angle)}, beta = {Sin(angle)}.");
+                ShowQuantumStateComparison(9, initialState, Kata.ShorEncode, ShorEncode_Reference);
+                return false;
+            }
+        }
+
+        Message("Correct!");
+        true
+    }
+}

--- a/katas/content/qec_shor/shor_encode/index.md
+++ b/katas/content/qec_shor/shor_encode/index.md
@@ -1,4 +1,4 @@
-**Input**: nine qubits in the state $\ket{\psi} \otimes \ket{0...0}$, where $\ket{\psi} = \alpha \ket{0} + \beta \ket{1}$ is the state of the first qubit, i.e., `qs[0]`.
+**Input**: nine qubits in the state $\ket{\psi} \otimes \ket{0 \ldots 0}$, where $\ket{\psi} = \alpha \ket{0} + \beta \ket{1}$ is the state of the first qubit, i.e., `qs[0]`.
 
 **Goal**: prepare a state $\alpha \ket{0_L} + \beta \ket{1_L}$ on these qubits, where
 $$\ket{0_L} = \frac1{2\sqrt2} (\ket{000} + \ket{111}) \otimes (\ket{000} + \ket{111}) \otimes (\ket{000} + \ket{111})$$

--- a/katas/content/qec_shor/shor_encode/index.md
+++ b/katas/content/qec_shor/shor_encode/index.md
@@ -1,0 +1,6 @@
+**Input**: nine qubits in the state $\ket{\psi} \otimes \ket{0...0}$, where $\ket{\psi} = \alpha \ket{0} + \beta \ket{1}$ is the state of the first qubit, i.e., `qs[0]`.
+
+**Goal**: prepare a state $\alpha \ket{0_L} + \beta \ket{1_L}$ on these qubits, where
+$$\ket{0_L} = \frac1{2\sqrt2} (\ket{000} + \ket{111}) \otimes (\ket{000} + \ket{111}) \otimes (\ket{000} + \ket{111})$$
+and 
+$$\ket{1_L} = \frac1{2\sqrt2} (\ket{000} - \ket{111}) \otimes (\ket{000} - \ket{111}) \otimes (\ket{000} - \ket{111})$$

--- a/katas/content/qec_shor/shor_encode/solution.md
+++ b/katas/content/qec_shor/shor_encode/solution.md
@@ -1,0 +1,13 @@
+We can implement this encoding in two steps.
+
+First, we use phase flip encoding on qubits with indices $0, 3, 6$ to convert $\alpha \ket{000} + \beta \ket{100}$ into $\alpha \ket{+++} + \beta \ket{---}$.
+After this, the state of the system will be 
+
+$$\alpha \ket{+00} \otimes \ket{+00} \otimes \ket{+00} + \beta \ket{-00} \otimes \ket{-00} \otimes \ket{-00}$$
+
+Then, we use bit flip encoding on each triplet of qubits $0 \ldots 2, 3 \ldots 5, 6 \ldots 8$ to convert each $\ket{+00}$ into $\frac1{\sqrt2} (\ket{000} + \ket{111})$ and each $\ket{-00}$ into $\frac1{\sqrt2} (\ket{000} - \ket{111})$. After this, the nine-qubit system will be exactly in the state we're looking for.
+
+@[solution]({
+    "id": "qec_shor__shor_encode_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/qec_shor/xx_measurement/Placeholder.qs
+++ b/katas/content/qec_shor/xx_measurement/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation XXMeasurement(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/qec_shor/xx_measurement/Solution.qs
+++ b/katas/content/qec_shor/xx_measurement/Solution.qs
@@ -1,0 +1,5 @@
+namespace Kata {
+    operation XXMeasurement(qs : Qubit[]) : Int {
+        return Measure([PauliX, PauliX], qs) == Zero ? 0 | 1;
+    }
+}

--- a/katas/content/qec_shor/xx_measurement/Verification.qs
+++ b/katas/content/qec_shor/xx_measurement/Verification.qs
@@ -1,0 +1,34 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    operation StatePrep_XXMeasurement(qs : Qubit[], state : Int, alpha : Double) : Unit is Adj {
+        // prep cos(alpha) * |0..0⟩ + sin(alpha) * |1..1⟩
+        Ry(2.0 * alpha, qs[0]);
+        CNOT(qs[0], qs[1]);
+
+        if state == 1 {
+            X(qs[0]);
+        }
+
+        ApplyToEachA(H, qs);
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        let isCorrect = DistinguishStates_MultiQubit(
+            2,
+            2,
+            StatePrep_XXMeasurement,
+            Kata.XXMeasurement,
+            true,
+            ["α|++⟩ + β|--⟩", "α|+-⟩ + β|-+⟩"]);
+
+        if (isCorrect) {
+            Message("Correct!");
+        } else {
+            Message("Incorrect.");
+        }
+
+        isCorrect
+    }
+}

--- a/katas/content/qec_shor/xx_measurement/index.md
+++ b/katas/content/qec_shor/xx_measurement/index.md
@@ -1,0 +1,4 @@
+**Input**: Two qubits stored in an array which are guaranteed to be either in a superposition of the states $|++\rangle$ and $|--\rangle$ or in a superposition of states $|+-\rangle$ and $|-+\rangle$.
+
+**Output**: 0 if qubits were in the first superposition, 1 if they were in the second superposition.  
+The state of the qubits at the end of the operation should be the same as the starting state.

--- a/katas/content/qec_shor/xx_measurement/solution.md
+++ b/katas/content/qec_shor/xx_measurement/solution.md
@@ -1,0 +1,9 @@
+This time, we need to do the $X \otimes X$ measurement on both qubits.
+
+The state $\alpha |++\rangle + \beta |--\rangle$ is an eigenstate of the $X \otimes X$ operator with the eigenvalue $+1$, and the state $\alpha |+-\rangle + \beta |-+\rangle$ is an eigenstate with the eigenvalue $-1$.
+Hence, we can use this joint measurement to recognize which of the superposition states we were given while preserving the initial superposition state.
+
+@[solution]({
+    "id": "qec_shor__xx_measurement_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/qec_shor/zz_measurement/Placeholder.qs
+++ b/katas/content/qec_shor/zz_measurement/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation ZZMeasurement(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/qec_shor/zz_measurement/Solution.qs
+++ b/katas/content/qec_shor/zz_measurement/Solution.qs
@@ -1,0 +1,5 @@
+namespace Kata {
+    operation ZZMeasurement(qs : Qubit[]) : Int {
+        return Measure([PauliZ, PauliZ], qs) == Zero ? 0 | 1;
+    }
+}

--- a/katas/content/qec_shor/zz_measurement/Verification.qs
+++ b/katas/content/qec_shor/zz_measurement/Verification.qs
@@ -1,0 +1,32 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    operation StatePrep_ZZMeasurement(qs : Qubit[], state : Int, alpha : Double) : Unit is Adj {
+        // prep cos(alpha) * |0..0⟩ + sin(alpha) * |1..1⟩
+        Ry(2.0 * alpha, qs[0]);
+        CNOT(qs[0], qs[1]);
+
+        if state == 1 {
+            X(qs[0]);
+        }
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        let isCorrect = DistinguishStates_MultiQubit(
+            2,
+            2,
+            StatePrep_ZZMeasurement,
+            Kata.ZZMeasurement,
+            true,
+            ["α|00⟩ + β|11⟩", "α|01⟩ + β|10⟩"]);
+
+        if (isCorrect) {
+            Message("Correct!");
+        } else {
+            Message("Incorrect.");
+        }
+
+        isCorrect
+    }
+}

--- a/katas/content/qec_shor/zz_measurement/index.md
+++ b/katas/content/qec_shor/zz_measurement/index.md
@@ -1,0 +1,4 @@
+**Input**: Two qubits stored in an array which are guaranteed to be either in a superposition of the states $|00\rangle$ and $|11\rangle$ or in a superposition of states $|01\rangle$ and $|10\rangle$.
+
+**Output**: 0 if qubits were in the first superposition, 1 if they were in the second superposition.  
+The state of the qubits at the end of the operation should be the same as the starting state.

--- a/katas/content/qec_shor/zz_measurement/solution.md
+++ b/katas/content/qec_shor/zz_measurement/solution.md
@@ -1,0 +1,11 @@
+We need to measure the *parity* of the state without collapsing it all the way to the basis states. This means that we need to do the $Z \otimes Z$ measurement on both qubits.
+
+A joint measurement using $Z \otimes Z$ operator can be thought of as projecting the measured state to one of the two eigenspaces of $Z \otimes Z$ with $+1$ and $-1$ as the corresponding eigenvalues. The measurement returns `Zero` if the measured state is projected to the space with an eigenvalue of $+1$, and a result of `One` if projected to the space with an eigenvalue of $-1$.
+
+We can see that the state $\alpha |00\rangle + \beta |11\rangle$ is an eigenstate of the $Z \otimes Z$ operator with the eigenvalue $+1$, and the state $\alpha |01\rangle + \beta |10\rangle$ is an eigenstate with the eigenvalue $-1$.
+Hence, we can use this joint measurement to recognize which of the superposition states we were given while preserving the initial superposition state.
+
+@[solution]({
+    "id": "qec_shor__zz_measurement_solution",
+    "codePath": "Solution.qs"
+})


### PR DESCRIPTION
Includes refactoring to bring CheckOperationsEquivalenceOnInitialStateStrict operation from multi_qubit_gates to shared katas library, since it's used for this kata.