### PR TITLE
Playground Tabs

### DIFF
--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -39,8 +39,8 @@ import {
 
 export type ActiveTab =
   | "results-tab"
-  | "hir-tab"
   | "ast-tab"
+  | "hir-tab"
   | "qir-tab"
   | "logs-tab";
 

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -37,12 +37,7 @@ import {
   monacoPositionToLsPosition,
 } from "./utils.js";
 
-export type ActiveTab =
-  | "results-tab"
-  | "ast-tab"
-  | "hir-tab"
-  | "qir-tab"
-  | "logs-tab";
+export type ActiveTab = "results-tab" | "ast-tab" | "hir-tab" | "qir-tab";
 
 const basePath = (window as any).qscBasePath || "";
 const monacoPath = basePath + "libs/monaco/vs";

--- a/playground/src/tabs.tsx
+++ b/playground/src/tabs.tsx
@@ -10,7 +10,6 @@ const tabArray: Array<[ActiveTab, string]> = [
   ["ast-tab", "AST"],
   ["hir-tab", "HIR"],
   ["qir-tab", "QIR"],
-  ["logs-tab", "LOGS"],
 ];
 
 function AstTab(props: { ast: string; activeTab: ActiveTab }) {

--- a/playground/src/tabs.tsx
+++ b/playground/src/tabs.tsx
@@ -7,8 +7,8 @@ import { ActiveTab } from "./main.js";
 
 const tabArray: Array<[ActiveTab, string]> = [
   ["results-tab", "RESULTS"],
-  ["hir-tab", "HIR"],
   ["ast-tab", "AST"],
+  ["hir-tab", "HIR"],
   ["qir-tab", "QIR"],
   ["logs-tab", "LOGS"],
 ];
@@ -63,8 +63,8 @@ export function OutputTabs(props: {
         </div>
       ) : null}
       <ResultsTab {...props} />
-      <HirTab {...props} />
       <AstTab {...props} />
+      <HirTab {...props} />
       <QirTab {...props} />
     </div>
   );


### PR DESCRIPTION
Small thing, but wanted to change the order of the playground tabs so that "AST" is before "HIR" when reading left-to-right.

Also drops the unused "Logs" tab.