### PR TITLE
Remove stray $ in kata

### DIFF
--- a/katas/content/complex_arithmetic/index.md
+++ b/katas/content/complex_arithmetic/index.md
@@ -258,7 +258,7 @@ Sometimes $\theta$ will be referred to as the number's **argument** or **phase**
 
 > In Q#, complex numbers in polar form are represented as user-defined type `ComplexPolar` from the `Microsoft.Quantum.Math` namespace. 
 > 
-> You can convert a complex number $x = $r \cdot e^{i\theta}$ into a tuple of two `Double` numbers using unwrap operator and tuple deconstruction: `let (r, theta) = x!;`, 
+> You can convert a complex number $x = r \cdot e^{i\theta}$ into a tuple of two `Double` numbers using unwrap operator and tuple deconstruction: `let (r, theta) = x!;`, 
 > or access its real and imaginary parts using their names: `let (r, theta) = (x::Magnitude, x::Argument);`.
 > 
 > You can construct a complex number from its real and imaginary parts as follows: `let x = ComplexPolar(r, theta);`.


### PR DESCRIPTION
Currently Polar Coordinates kata has a note which renders below (note the second paragraph LaTeX). This fixes it.

<img width="716" alt="image" src="https://github.com/microsoft/qsharp/assets/993909/26ec2e3d-80ed-4c78-be05-98cc0abbfc0b">
