### PR TITLE
Replace PrepRandomState with deterministic PrepDemoState

### DIFF
--- a/katas/content/KatasLibrary.qs
+++ b/katas/content/KatasLibrary.qs
@@ -68,6 +68,7 @@ namespace Microsoft.Quantum.Katas {
     /// Given two operations, checks whether they act identically on the given initial state composed of `inputSize` qubits.
     /// The initial state is prepared by applying the `initialState` operation to the state |0〉 ⊗ |0〉 ⊗ ... ⊗ |0〉.
     /// This operation introduces a control qubit to convert a global phase into a relative phase to be able to detect it.
+    /// `initialState` operation should be deterministic.
     operation CheckOperationsEquivalenceOnInitialStateStrict(
         initialState : Qubit[] => Unit is Adj,
         op : (Qubit[] => Unit is Adj + Ctl),
@@ -106,7 +107,8 @@ namespace Microsoft.Quantum.Katas {
 
 
     /// # Summary
-    /// Shows the comparison of the quantum state between a specific operation and a reference operation.
+    /// Shows the comparison of the quantum states produced by a specific operation and a reference operation
+    /// when applied to the state prepared using deterministic operation `initialState`.
     operation ShowQuantumStateComparison(
         registerSize : Int,
         initialState : Qubit[] => Unit,
@@ -176,9 +178,11 @@ namespace Microsoft.Quantum.Katas {
 
     /// # Summary
     /// Prepare a random uneven superposition state on the given qubit array.
-    operation PrepRandomState(qs : Qubit[]) : Unit {
-        for q in qs {
-            Ry(DrawRandomDouble(0.01, 0.99) * 2.0, q);
+    operation PrepDemoState(qs : Qubit[]) : Unit {
+        Fact(Length(qs) <= 4, "States with 5 qubits or more are not supported.");
+        let probs = [0.36, 0.25, 1. / 3., 1. / 5.][... Length(qs) - 1];
+        for (q, prob) in Zipped(qs, probs) {
+            Ry(ArcCos(Sqrt(prob)) * 2.0, q);
         }
     }
 

--- a/katas/content/deutsch_jozsa/msb_oracle/Verification.qs
+++ b/katas/content/deutsch_jozsa/msb_oracle/Verification.qs
@@ -16,7 +16,7 @@ namespace Kata.Verification {
                 Message($"Hint: examine the effect your solution has on the {N}-qubit and compare it with the effect it " +
                     "is expected to have. Note that the simulator might drop the global phase -1, so if you're getting " +
                     "verdict \"Incorrect\" but the actual state matches the expected one, check that you're handling the global phase correctly.");
-                ShowQuantumStateComparison(N, PrepRandomState, solution, reference);
+                ShowQuantumStateComparison(N, PrepDemoState, solution, reference);
                 return false;
             }
         }

--- a/katas/content/deutsch_jozsa/parity_oracle/Verification.qs
+++ b/katas/content/deutsch_jozsa/parity_oracle/Verification.qs
@@ -15,10 +15,10 @@ namespace Kata.Verification {
         for N in 1 .. 4 {
             if not CheckOperationsEquivalenceStrict(solution, reference, N) {
                 Message("Incorrect.");
-                Message($"Hint: examine the effect your solution has on the {N}-qubit and compare it with the effect it " +
+                Message($"Hint: examine the effect your solution has on the {N}-qubit state and compare it with the effect it " +
                     "is expected to have. Note that the simulator might drop the global phase -1, so if you're getting " +
                     "verdict \"Incorrect\" but the actual state matches the expected one, check that you're handling the global phase correctly.");
-                ShowQuantumStateComparison(N, PrepRandomState, solution, reference);
+                ShowQuantumStateComparison(N, PrepDemoState, solution, reference);
                 return false;
             }
         }

--- a/katas/content/multi_qubit_gates/anti_controlled_gate/Verification.qs
+++ b/katas/content/multi_qubit_gates/anti_controlled_gate/Verification.qs
@@ -18,7 +18,7 @@ namespace Kata.Verification {
             Message("Incorrect.");
             Message("Hint: examine the state prepared by your solution and compare it with the state it " +
                 "is expected to prepare.");
-            ShowQuantumStateComparison(2, PrepRandomState, solution, reference);
+            ShowQuantumStateComparison(2, PrepDemoState, solution, reference);
         }
 
         isCorrect

--- a/katas/content/multi_qubit_gates/compound_gate/Verification.qs
+++ b/katas/content/multi_qubit_gates/compound_gate/Verification.qs
@@ -20,7 +20,7 @@ namespace Kata.Verification {
             Message("Incorrect.");
             Message("Hint: examine how your solution transforms the given state and compare it with the expected " +
                 "transformation");
-            ShowQuantumStateComparison(3, PrepRandomState, solution, reference);
+            ShowQuantumStateComparison(3, PrepDemoState, solution, reference);
         }
 
         isCorrect

--- a/katas/content/multi_qubit_gates/fredkin_gate/Verification.qs
+++ b/katas/content/multi_qubit_gates/fredkin_gate/Verification.qs
@@ -17,7 +17,7 @@ namespace Kata.Verification {
             Message("Incorrect.");
             Message("Hint: examine the state prepared by your solution and compare it with the state it " +
                 "is expected to prepare.");
-            ShowQuantumStateComparison(3, PrepRandomState, solution, reference);
+            ShowQuantumStateComparison(3, PrepDemoState, solution, reference);
         }
 
         isCorrect

--- a/katas/content/multi_qubit_gates/index.md
+++ b/katas/content/multi_qubit_gates/index.md
@@ -10,7 +10,7 @@ This kata continues the introduction to quantum gates, focusing on applying quan
 **This kata covers the following topics:**
 
 - Applying quantum gates to a part of the system
-- $CNOT$, $CCNOT$, and $SWAP$ gates
+- $CNOT$, $CZ$, $CCNOT$, and $SWAP$ gates
 - Controlled gates
 
 **What you should know to start working on this kata:**
@@ -251,9 +251,9 @@ $$
 will have the following ket-bra representation:
 $$A =$$
 $$=a_{00} |00\rangle\langle00| + a_{01} |00\rangle\langle01| + a_{02} |00\rangle\langle10| + a_{03} |00\rangle\langle11| +$$
-$$=a_{10} |01\rangle\langle00| + a_{11} |01\rangle\langle01| + a_{12} |01\rangle\langle10| + a_{13} |01\rangle\langle11| +$$
-$$=a_{20} |10\rangle\langle00| + a_{21} |10\rangle\langle01| + a_{22} |10\rangle\langle10| + a_{23} |10\rangle\langle11| +$$
-$$=a_{30} |11\rangle\langle00| + a_{31} |11\rangle\langle01| + a_{32} |11\rangle\langle10| + a_{33} |11\rangle\langle11|$$
+$$+a_{10} |01\rangle\langle00| + a_{11} |01\rangle\langle01| + a_{12} |01\rangle\langle10| + a_{13} |01\rangle\langle11| +$$
+$$+a_{20} |10\rangle\langle00| + a_{21} |10\rangle\langle01| + a_{22} |10\rangle\langle10| + a_{23} |10\rangle\langle11| +$$
+$$+a_{30} |11\rangle\langle00| + a_{31} |11\rangle\langle01| + a_{32} |11\rangle\langle10| + a_{33} |11\rangle\langle11|$$
 
 A similar expression can be extended for matrices that describe $N$-qubit gates, where $N > 2$:
 

--- a/katas/content/multi_qubit_gates/preparing_bell_state/index.md
+++ b/katas/content/multi_qubit_gates/preparing_bell_state/index.md
@@ -1,3 +1,3 @@
-**Input:** Two qubits in state $|00\\rangle$, stored in an array of length 2.
+**Input:** Two qubits in state $|00\rangle$, stored in an array of length 2.
 
-**Goal:** Transform the system into the Bell state $\\Phi^+ = \\frac{1}{\\sqrt{2}}\\big(|00\\rangle + |11\\rangle\\big)$.
+**Goal:** Transform the system into the Bell state $\ket{\Phi^+} = \frac{1}{\sqrt{2}}\big(|00\rangle + |11\rangle\big)$.

--- a/katas/content/multi_qubit_gates/toffoli_gate/Verification.qs
+++ b/katas/content/multi_qubit_gates/toffoli_gate/Verification.qs
@@ -17,7 +17,7 @@ namespace Kata.Verification {
             Message("Incorrect.");
             Message("Hint: examine the state prepared by your solution and compare it with the state it " +
                 "is expected to prepare.");
-            ShowQuantumStateComparison(3, PrepRandomState, solution, reference);
+            ShowQuantumStateComparison(3, PrepDemoState, solution, reference);
         }
 
         isCorrect

--- a/katas/content/oracles/bit_pattern_challenge/Verification.qs
+++ b/katas/content/oracles/bit_pattern_challenge/Verification.qs
@@ -29,7 +29,7 @@ namespace Kata.Verification {
                     Message("Incorrect.");
                     Message("Hint: examine how your solution transforms the given state and compare it with the expected " +
                         $"transformation for the {N}-bit oracle for pattern = {pattern}");
-                    ShowQuantumStateComparison(N, PrepRandomState, sol, ref);
+                    ShowQuantumStateComparison(N, PrepDemoState, sol, ref);
                     return false;
                 }
             }

--- a/katas/content/oracles/bit_pattern_oracle/Verification.qs
+++ b/katas/content/oracles/bit_pattern_oracle/Verification.qs
@@ -21,7 +21,7 @@ namespace Kata.Verification {
                     Message("Incorrect.");
                     Message("Hint: examine how your solution transforms the given state and compare it with the expected " +
                         $"transformation for the {N}-bit oracle for the pattern {pattern}");
-                    ShowQuantumStateComparison(N + 1, qs => PrepRandomState(qs[...N - 1]), sol, ref);
+                    ShowQuantumStateComparison(N + 1, qs => PrepDemoState(qs[...N - 1]), sol, ref);
                     return false;
                 }
             }

--- a/katas/content/oracles/kth_bit_oracle/Verification.qs
+++ b/katas/content/oracles/kth_bit_oracle/Verification.qs
@@ -17,7 +17,7 @@ namespace Kata.Verification {
                     Message("Incorrect.");
                     Message("Hint: examine how your solution transforms the given state and compare it with the expected " +
                         $"transformation for the {N}-bit oracle for k = {k}");
-                    ShowQuantumStateComparison(N, PrepRandomState, sol, ref);
+                    ShowQuantumStateComparison(N, PrepDemoState, sol, ref);
                     return false;
                 }
             }

--- a/katas/content/oracles/marking_oracle_as_phase/Verification.qs
+++ b/katas/content/oracles/marking_oracle_as_phase/Verification.qs
@@ -31,7 +31,7 @@ namespace Kata.Verification {
                     Message("Incorrect.");
                     Message("Hint: examine how your solution transforms the given state and compare it with the expected " +
                         $"transformation for the {N}-bit oracle that marks the bit string {pattern}");
-                    ShowQuantumStateComparison(N, PrepRandomState, sol, ref);
+                    ShowQuantumStateComparison(N, PrepDemoState, sol, ref);
                     return false;
                 }
             }

--- a/katas/content/oracles/marking_oracle_seven/Verification.qs
+++ b/katas/content/oracles/marking_oracle_seven/Verification.qs
@@ -19,7 +19,7 @@ namespace Kata.Verification {
             Message("Incorrect.");
             Message("Hint: examine how your solution transforms the given state and compare it with the expected " +
                 "transformation");
-            ShowQuantumStateComparison(4, qs => PrepRandomState(qs[...2]), sol, ref);
+            ShowQuantumStateComparison(4, qs => PrepDemoState(qs[...2]), sol, ref);
         }
         isCorrect
     }

--- a/katas/content/oracles/or_but_kth_oracle/Verification.qs
+++ b/katas/content/oracles/or_but_kth_oracle/Verification.qs
@@ -28,7 +28,7 @@ namespace Kata.Verification {
                     Message("Incorrect.");
                     Message("Hint: examine how your solution transforms the given state and compare it with the expected " +
                         $"transformation for the {N}-bit oracle for k = {k}");
-                    ShowQuantumStateComparison(N, PrepRandomState, sol, ref);
+                    ShowQuantumStateComparison(N, PrepDemoState, sol, ref);
                     return false;
                 }
             }

--- a/katas/content/oracles/or_oracle/Verification.qs
+++ b/katas/content/oracles/or_oracle/Verification.qs
@@ -18,7 +18,7 @@ namespace Kata.Verification {
                 Message("Incorrect.");
                 Message("Hint: examine how your solution transforms the given state and compare it with the expected " +
                     $"transformation for the {N}-bit oracle");
-                ShowQuantumStateComparison(N + 1, qs => PrepRandomState(qs[...N - 1]), sol, ref);
+                ShowQuantumStateComparison(N + 1, qs => PrepDemoState(qs[...N - 1]), sol, ref);
                 return false;
             }
         }

--- a/katas/content/oracles/phase_oracle_seven/Verification.qs
+++ b/katas/content/oracles/phase_oracle_seven/Verification.qs
@@ -20,7 +20,7 @@ namespace Kata.Verification {
             Message("Incorrect.");
             Message("Hint: examine how your solution transforms the given state and compare it with the expected " +
                 "transformation");
-            ShowQuantumStateComparison(3, PrepRandomState, Kata.IsSeven_PhaseOracle, IsSeven_PhaseOracle_Reference);
+            ShowQuantumStateComparison(3, PrepDemoState, Kata.IsSeven_PhaseOracle, IsSeven_PhaseOracle_Reference);
         }
         isCorrect
     }

--- a/katas/content/single_qubit_measurements/index.md
+++ b/katas/content/single_qubit_measurements/index.md
@@ -187,7 +187,7 @@ Similarly, for either qubit, if $b_i$ is the measurement outcome, the post-measu
 
 ## Measurements as Projection Operations
 
-Just as qubits are represented by vectors and quantum gates are represented by matrices, quantum measurements are represented by orthogonal projection operators. An orthogonal projection operator is a matrix $P$ which satisfies the following property:
+Just as qubits are represented by vectors and quantum gates are represented by matrices, quantum measurements are represented by _orthogonal projection operators_. An orthogonal projection operator (sometimes referred to as _projector_) is a matrix $P$ which satisfies the following property:
 $$
 P^2 = P^\dagger = P.
 $$
@@ -202,7 +202,7 @@ $$
 A measurement in an orthogonal basis $\\{ \ket{b_0}, \ket{b_1}\\}$ is described by a pair of projectors $P_0 = \ket{b_0}\bra{b_0}$ and $P_1 = \ket{b_1}\bra{b_1}$. Since $\ket{b_0}$ and $\ket{b_1}$ are orthogonal, their projectors are also orthogonal, i.e., $P_0 P_1 = P_1 P_0 = 0$. The rules for measurements in this basis can then be summarized as follows:
 
 - Measuring a qubit in a state $\ket \psi$ is done by picking one of these projection operators at random.
-- Projection $P_0$ is chosen with probability $|P_0 \ket{\psi}|^2$, and the projector $P_1$ is chosen with probability $|P_1\ket{\psi}|^2.$
+- Projector $P_0$ is chosen with probability $|P_0 \ket{\psi}|^2$, and the projector $P_1$ is chosen with probability $|P_1\ket{\psi}|^2.$
 - If projector $P_0$ is chosen, the post-measurement state of the qubit is given by
     $$
     \frac1{|P_0 \ket{\psi}|}P_0 \ket\psi,


### PR DESCRIPTION
This fixes the issue in ShowQuantumStateComparison: if initialState is non-deterministic, "actual state after applying operation" will always be wildly different from "expected state" because initial states will be different.