### PR TITLE
Fix duplicated lints

### DIFF
--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -289,10 +289,9 @@ fn run_linter_passes(
 ) {
     if errors.is_empty() {
         let lints = qsc::linter::run_lints(unit, Some(config));
-        let lints: Vec<_> = lints
+        let lints = lints
             .into_iter()
-            .map(|lint| WithSource::from_map(&unit.sources, qsc::compile::ErrorKind::Lint(lint)))
-            .collect();
+            .map(|lint| WithSource::from_map(&unit.sources, qsc::compile::ErrorKind::Lint(lint)));
         errors.extend(lints);
     }
 }

--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -85,7 +85,7 @@ impl Compilation {
             unit,
         );
 
-        run_linter_passes(Some(lints_config), &mut errors, unit);
+        run_linter_passes(lints_config, &mut errors, unit);
 
         Self {
             package_store,
@@ -141,7 +141,7 @@ impl Compilation {
             unit,
         );
 
-        run_linter_passes(Some(lints_config), &mut errors, unit);
+        run_linter_passes(lints_config, &mut errors, unit);
 
         Self {
             package_store,
@@ -283,12 +283,12 @@ fn run_fir_passes(
 /// reasons we don't want to waste time running lints every few keystrokes,
 /// if the user is in the middle of typing a statement, for example.
 fn run_linter_passes(
-    config: Option<&[LintConfig]>,
+    config: &[LintConfig],
     errors: &mut Vec<WithSource<compile::ErrorKind>>,
     unit: &CompileUnit,
 ) {
     if errors.is_empty() {
-        let lints = qsc::linter::run_lints(unit, config);
+        let lints = qsc::linter::run_lints(unit, Some(config));
         let lints: Vec<_> = lints
             .into_iter()
             .map(|lint| WithSource::from_map(&unit.sources, qsc::compile::ErrorKind::Lint(lint)))

--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -72,21 +72,6 @@ impl Compilation {
             language_features,
         );
 
-        // Compute new lints and append them to the errors Vec.
-        // Lints are only computed if the erros vector is empty. For performance
-        // reasons we don't want to waste time running lints every few keystrokes,
-        // if the user is in the middle of typing a statement, for example.
-        if errors.is_empty() {
-            let lints = qsc::linter::run_lints(&unit, Some(lints_config));
-            let lints: Vec<_> = lints
-                .into_iter()
-                .map(|lint| {
-                    WithSource::from_map(&unit.sources, qsc::compile::ErrorKind::Lint(lint))
-                })
-                .collect();
-            errors.extend(lints);
-        }
-
         let package_id = package_store.insert(unit);
         let unit = package_store
             .get(package_id)
@@ -100,13 +85,7 @@ impl Compilation {
             unit,
         );
 
-        let lints = qsc::linter::run_lints(unit, Some(lints_config));
-        for lint in lints {
-            errors.push(WithSource::from_map(
-                &unit.sources,
-                qsc::compile::ErrorKind::Lint(lint),
-            ));
-        }
+        run_linter_passes(Some(lints_config), &mut errors, unit);
 
         Self {
             package_store,
@@ -154,21 +133,6 @@ impl Compilation {
             .get(package_id)
             .expect("expected to find user package");
 
-        // Compute new lints and append them to the errors Vec.
-        // Lints are only computed if the erros vector is empty. For performance
-        // reasons we don't want to waste time running lints every few keystrokes,
-        // if the user is in the middle of typing a statement, for example.
-        if errors.is_empty() {
-            let lints = qsc::linter::run_lints(unit, Some(lints_config));
-            let lints: Vec<_> = lints
-                .into_iter()
-                .map(|lint| {
-                    WithSource::from_map(&unit.sources, qsc::compile::ErrorKind::Lint(lint))
-                })
-                .collect();
-            errors.extend(lints);
-        }
-
         run_fir_passes(
             &mut errors,
             target_profile,
@@ -176,6 +140,8 @@ impl Compilation {
             package_id,
             unit,
         );
+
+        run_linter_passes(Some(lints_config), &mut errors, unit);
 
         Self {
             package_store,
@@ -309,6 +275,25 @@ fn run_fir_passes(
             let err = WithSource::from_map(&unit.sources, compile::ErrorKind::Pass(err));
             errors.push(err);
         }
+    }
+}
+
+/// Compute new lints and append them to the errors Vec.
+/// Lints are only computed if the erros vector is empty. For performance
+/// reasons we don't want to waste time running lints every few keystrokes,
+/// if the user is in the middle of typing a statement, for example.
+fn run_linter_passes(
+    config: Option<&[LintConfig]>,
+    errors: &mut Vec<WithSource<compile::ErrorKind>>,
+    unit: &CompileUnit,
+) {
+    if errors.is_empty() {
+        let lints = qsc::linter::run_lints(unit, config);
+        let lints: Vec<_> = lints
+            .into_iter()
+            .map(|lint| WithSource::from_map(&unit.sources, qsc::compile::ErrorKind::Lint(lint)))
+            .collect();
+        errors.extend(lints);
     }
 }
 

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -1418,7 +1418,8 @@ async fn loading_lints_config_from_manifest() {
 
 #[tokio::test]
 async fn lints_update_after_manifest_change() {
-    let this_file_qs = "namespace Foo { operation Main() : Unit { let x = 5 / 0 + (2 ^ 4); } }";
+    let this_file_qs =
+        "namespace Foo { @EntryPoint() operation Main() : Unit { let x = 5 / 0 + (2 ^ 4); } }";
     let fs = FsNode::Dir(
         [dir(
             "project",
@@ -1458,8 +1459,8 @@ async fn lints_update_after_manifest_change() {
             Lint(
                 Lint {
                     span: Span {
-                        lo: 58,
-                        hi: 65,
+                        lo: 72,
+                        hi: 79,
                     },
                     level: Error,
                     message: "unnecessary parentheses",
@@ -1469,8 +1470,8 @@ async fn lints_update_after_manifest_change() {
             Lint(
                 Lint {
                     span: Span {
-                        lo: 50,
-                        hi: 55,
+                        lo: 64,
+                        hi: 69,
                     },
                     level: Error,
                     message: "attempt to divide by zero",
@@ -1500,8 +1501,8 @@ async fn lints_update_after_manifest_change() {
             Lint(
                 Lint {
                     span: Span {
-                        lo: 58,
-                        hi: 65,
+                        lo: 72,
+                        hi: 79,
                     },
                     level: Warn,
                     message: "unnecessary parentheses",
@@ -1511,8 +1512,8 @@ async fn lints_update_after_manifest_change() {
             Lint(
                 Lint {
                     span: Span {
-                        lo: 50,
-                        hi: 55,
+                        lo: 64,
+                        hi: 69,
                     },
                     level: Warn,
                     message: "attempt to divide by zero",


### PR DESCRIPTION
Lints were being generated twice for `qsharp` files. This PR fixes that issue. It also changes the order of the passes, now the linter-passes happen after the fir-passes.