### PR TITLE
Update RCA handling of array dynamism

### DIFF
--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -13,8 +13,9 @@ use super::tests_common::{
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
     USE_DYNAMIC_INDEX, USE_DYNAMIC_INT, USE_DYNAMIC_OPERATION, USE_DYNAMIC_PAULI,
     USE_DYNAMIC_QUBIT, USE_DYNAMIC_RANGE, USE_DYNAMIC_STRING, USE_DYNAMIC_UDT,
-    USE_ENTRY_POINT_STATIC_BIG_INT, USE_ENTRY_POINT_STATIC_BOOL, USE_ENTRY_POINT_STATIC_DOUBLE,
-    USE_ENTRY_POINT_STATIC_INT, USE_ENTRY_POINT_STATIC_INT_IN_TUPLE, USE_ENTRY_POINT_STATIC_PAULI,
+    USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE, USE_ENTRY_POINT_STATIC_BIG_INT,
+    USE_ENTRY_POINT_STATIC_BOOL, USE_ENTRY_POINT_STATIC_DOUBLE, USE_ENTRY_POINT_STATIC_INT,
+    USE_ENTRY_POINT_STATIC_INT_IN_TUPLE, USE_ENTRY_POINT_STATIC_PAULI,
     USE_ENTRY_POINT_STATIC_RANGE, USE_ENTRY_POINT_STATIC_STRING,
 };
 use expect_test::{expect, Expect};
@@ -678,6 +679,29 @@ fn use_of_static_range_return_from_entry_point_errors() {
 fn use_of_static_int_in_tuple_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_INT_IN_TUPLE,
+        &expect![[r#"
+            [
+                UseOfDynamicInt(
+                    Span {
+                        lo: 63,
+                        hi: 66,
+                    },
+                ),
+                UseOfIntOutput(
+                    Span {
+                        lo: 63,
+                        hi: 66,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn use_of_static_sized_array_in_tuple_error() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE,
         &expect![[r#"
             [
                 UseOfDynamicInt(

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -6,7 +6,7 @@
 use crate::capabilitiesck::tests_common::USE_DYNAMIC_RANGE;
 
 use super::tests_common::{
-    check, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
+    check, check_for_exe, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
     CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION,
@@ -14,13 +14,24 @@ use super::tests_common::{
     RETURN_WITHIN_DYNAMIC_SCOPE, USE_CLOSURE_FUNCTION, USE_DYNAMICALLY_SIZED_ARRAY,
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
     USE_DYNAMIC_INDEX, USE_DYNAMIC_INT, USE_DYNAMIC_OPERATION, USE_DYNAMIC_PAULI,
-    USE_DYNAMIC_QUBIT, USE_DYNAMIC_STRING, USE_DYNAMIC_UDT,
+    USE_DYNAMIC_QUBIT, USE_DYNAMIC_STRING, USE_DYNAMIC_UDT, USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE,
+    USE_ENTRY_POINT_STATIC_BIG_INT, USE_ENTRY_POINT_STATIC_BOOL, USE_ENTRY_POINT_STATIC_DOUBLE,
+    USE_ENTRY_POINT_STATIC_INT, USE_ENTRY_POINT_STATIC_INT_IN_TUPLE, USE_ENTRY_POINT_STATIC_PAULI,
+    USE_ENTRY_POINT_STATIC_RANGE, USE_ENTRY_POINT_STATIC_STRING,
 };
 use expect_test::{expect, Expect};
 use qsc_data_structures::target::TargetCapabilityFlags;
 
 fn check_profile(source: &str, expect: &Expect) {
     check(
+        source,
+        expect,
+        TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::IntegerComputations,
+    );
+}
+
+fn check_profile_for_exe(source: &str, expect: &Expect) {
+    check_for_exe(
         source,
         expect,
         TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::IntegerComputations,
@@ -446,6 +457,131 @@ fn use_closure_yields_errors() {
                     },
                 ),
             ]
+        "#]],
+    );
+}
+
+#[test]
+fn use_of_static_int_return_from_entry_point_allowed() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_INT,
+        &expect![[r#"
+        []
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_double_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_DOUBLE,
+        &expect![[r#"
+        [
+            UseOfDoubleOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_string_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_STRING,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_bool_return_from_entry_point_supported() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_BOOL,
+        &expect![[r#"
+        []
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_big_int_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_BIG_INT,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_pauli_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_PAULI,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_range_return_from_entry_point_errors() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_RANGE,
+        &expect![[r#"
+        [
+            UseOfAdvancedOutput(
+                Span {
+                    lo: 63,
+                    hi: 66,
+                },
+            ),
+        ]
+    "#]],
+    );
+}
+
+#[test]
+fn use_of_static_int_in_tuple_return_from_entry_point_allowed() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_STATIC_INT_IN_TUPLE,
+        &expect![[r#"
+            []
+        "#]],
+    );
+}
+
+#[test]
+fn use_of_static_sized_array_in_tuple_allowed() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE,
+        &expect![[r#"
+            []
         "#]],
     );
 }

--- a/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -13,8 +13,9 @@ use super::tests_common::{
     USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE, USE_DYNAMIC_FUNCTION,
     USE_DYNAMIC_INDEX, USE_DYNAMIC_INT, USE_DYNAMIC_OPERATION, USE_DYNAMIC_PAULI,
     USE_DYNAMIC_QUBIT, USE_DYNAMIC_RANGE, USE_DYNAMIC_STRING, USE_DYNAMIC_UDT,
-    USE_ENTRY_POINT_STATIC_BIG_INT, USE_ENTRY_POINT_STATIC_BOOL, USE_ENTRY_POINT_STATIC_DOUBLE,
-    USE_ENTRY_POINT_STATIC_INT, USE_ENTRY_POINT_STATIC_INT_IN_TUPLE, USE_ENTRY_POINT_STATIC_PAULI,
+    USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE, USE_ENTRY_POINT_STATIC_BIG_INT,
+    USE_ENTRY_POINT_STATIC_BOOL, USE_ENTRY_POINT_STATIC_DOUBLE, USE_ENTRY_POINT_STATIC_INT,
+    USE_ENTRY_POINT_STATIC_INT_IN_TUPLE, USE_ENTRY_POINT_STATIC_PAULI,
     USE_ENTRY_POINT_STATIC_RANGE, USE_ENTRY_POINT_STATIC_STRING,
 };
 use expect_test::{expect, Expect};
@@ -823,6 +824,29 @@ fn use_of_static_range_return_from_entry_point_errors() {
 fn use_of_static_int_in_tuple_return_from_entry_point_errors() {
     check_profile_for_exe(
         USE_ENTRY_POINT_STATIC_INT_IN_TUPLE,
+        &expect![[r#"
+            [
+                UseOfDynamicInt(
+                    Span {
+                        lo: 63,
+                        hi: 66,
+                    },
+                ),
+                UseOfIntOutput(
+                    Span {
+                        lo: 63,
+                        hi: 66,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn use_of_static_sized_array_in_tuple_error() {
+    check_profile_for_exe(
+        USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE,
         &expect![[r#"
             [
                 UseOfDynamicInt(

--- a/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -420,3 +420,12 @@ pub const USE_ENTRY_POINT_STATIC_INT_IN_TUPLE: &str = r#"
             (M(q), 42)
         }
     }"#;
+
+pub const USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE: &str = r#"
+    namespace Test {
+        @EntryPoint()
+        operation Foo() : (Result, Int[]) {
+            use q = Qubit();
+            (M(q), [1, 2, 3])
+        }
+    }"#;

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -599,8 +599,10 @@ impl ValueKind {
             Self::Element(RuntimeKind::Static)
         } else {
             match ty {
-                // For a dynamic array, both contents and size are dynamic.
-                Ty::Array(_) => ValueKind::Array(RuntimeKind::Dynamic, RuntimeKind::Dynamic),
+                // For a dynamic array, the contents dynamic and size is static.
+                // We assume this because the source of the array produces something with dynamic length,
+                // that source should have already added the runtime feature flag for dynamic arrays.
+                Ty::Array(_) => ValueKind::Array(RuntimeKind::Dynamic, RuntimeKind::Static),
                 // For every other dynamic type, we use the element variant with a dynamic runtime value.
                 _ => ValueKind::Element(RuntimeKind::Dynamic),
             }
@@ -659,7 +661,7 @@ impl ValueKind {
                 }
                 ValueKind::Element(self_runtime_kind) => {
                     *content_runtime_kind = self_runtime_kind;
-                    *size_runtime_kind = self_runtime_kind;
+                    *size_runtime_kind = RuntimeKind::Static;
                 }
             },
             ValueKind::Element(runtime_kind) => {

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -661,6 +661,9 @@ impl ValueKind {
                 }
                 ValueKind::Element(self_runtime_kind) => {
                     *content_runtime_kind = self_runtime_kind;
+                    // When we project from an element variant to an array variant, we assume the size of the
+                    // array is statically sized because we rely on the dynamically sized arrays runtime feature
+                    // flag to detect such cases.
                     *size_runtime_kind = RuntimeKind::Static;
                 }
             },

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -599,7 +599,7 @@ impl ValueKind {
             Self::Element(RuntimeKind::Static)
         } else {
             match ty {
-                // For a dynamic array, the contents dynamic and size is static.
+                // For a dynamic array, the content is dynamic and the size is static.
                 // We assume this because the source of the array produces something with dynamic length,
                 // that source should have already added the runtime feature flag for dynamic arrays.
                 Ty::Array(_) => ValueKind::Array(RuntimeKind::Dynamic, RuntimeKind::Static),

--- a/compiler/qsc_rca/tests/cycles.rs
+++ b/compiler/qsc_rca/tests/cycles.rs
@@ -420,17 +420,17 @@ fn check_rca_for_function_cycle_within_call_input() {
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Array(Content: Dynamic, Size: Dynamic)
+                            value_kind: Array(Content: Dynamic, Size: Static)
                         [1]: [Parameter Type Array] ArrayParamApplication:
                             static_content_dynamic_size: Quantum: QuantumProperties:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                                value_kind: Array(Content: Dynamic, Size: Dynamic)
+                                value_kind: Array(Content: Dynamic, Size: Static)
                             dynamic_content_static_size: Quantum: QuantumProperties:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                                value_kind: Array(Content: Dynamic, Size: Dynamic)
+                                value_kind: Array(Content: Dynamic, Size: Static)
                             dynamic_content_dynamic_size: Quantum: QuantumProperties:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                                value_kind: Array(Content: Dynamic, Size: Dynamic)
+                                value_kind: Array(Content: Dynamic, Size: Static)
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#
@@ -787,7 +787,7 @@ fn check_rca_for_operation_body_adj_recursion() {
             body ... {
                 Adjoint Foo(q);
             }
-            adjoint ... { 
+            adjoint ... {
                 Foo(q);
             }
         }"#,
@@ -830,7 +830,7 @@ fn check_rca_for_operation_body_ctl_recursion() {
             body ... {
                 Controlled Foo([], q);
             }
-            controlled (_, ...) { 
+            controlled (_, ...) {
                 Foo(q);
             }
         }"#,
@@ -873,7 +873,7 @@ fn check_rca_for_operation_multi_controlled_functor_recursion() {
             body ... {
                 Controlled Controlled Foo([], ([], q));
             }
-            controlled (_, ...) { 
+            controlled (_, ...) {
                 Foo(q);
             }
         }"#,

--- a/compiler/qsc_rca/tests/intrinsics.rs
+++ b/compiler/qsc_rca/tests/intrinsics.rs
@@ -1205,8 +1205,7 @@ fn check_rca_for_account_for_estimates_internal() {
         &compilation_context.fir_store,
         compilation_context.get_compute_properties(),
         "AccountForEstimatesInternal",
-        &expect![
-            r#"
+        &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
@@ -1218,7 +1217,7 @@ fn check_rca_for_account_for_estimates_internal() {
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | UseOfDynamicallySizedArray)
                                 value_kind: Element(Static)
                             dynamic_content_static_size: Quantum: QuantumProperties:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | UseOfDynamicallySizedArray)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
                                 value_kind: Element(Static)
                             dynamic_content_dynamic_size: Quantum: QuantumProperties:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | UseOfDynamicallySizedArray)
@@ -1231,15 +1230,14 @@ fn check_rca_for_account_for_estimates_internal() {
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | UseOfDynamicallySizedArray)
                                 value_kind: Element(Static)
                             dynamic_content_static_size: Quantum: QuantumProperties:
-                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | UseOfDynamicallySizedArray)
+                                runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                                 value_kind: Element(Static)
                             dynamic_content_dynamic_size: Quantum: QuantumProperties:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | UseOfDynamicallySizedArray)
                                 value_kind: Element(Static)
                 adj: <none>
                 ctl: <none>
-                ctl-adj: <none>"#
-        ],
+                ctl-adj: <none>"#]],
     );
 }
 


### PR DESCRIPTION
This change updates the assumptions in RCA to be less restrictive on assuming the dynamic size of arrays. Before, generating the `ValueKind` for arrays would always assume both dynamic content and dynamic size, which could cause failures in checks when, for example, a tuple of static sized arrays is returned from the entry point. Instead, we rely on the propagation of the runtime feature flags to track whether a dynamically sized array is used. This is a precursor to later simplifying the `QuantumProperties` struct by removing `ValueKind` in favor of just tracking dynamic vs static.