### PR TITLE
[Node Watch] Fix node watch error windows

### DIFF
--- a/watch.mjs
+++ b/watch.mjs
@@ -55,7 +55,7 @@ function buildRust() {
   const result = spawnSync(
     "wasm-pack",
     ["build", "--dev", "--no-pack", "--target", "web", "--out-dir", buildDir],
-    { cwd: wasmDir },
+    { cwd: wasmDir, shell: true },
   );
   console.log("wasm-pack done! ", result.stderr.toString());
 
@@ -105,7 +105,7 @@ onRustChange();
  */
 function runWatcher(dir, name, watchTask = "tsc:watch") {
   console.log(`Spawning tsc:watch for ${name} in ${dir}`);
-  const npmWatcher = spawn(npmCmd, ["run", watchTask], { cwd: dir });
+  const npmWatcher = spawn(npmCmd, ["run", watchTask], { cwd: dir, shell: true });
   npmWatcher.stdout.on("data", (data) =>
     console.log(`tsc:watch ${name}: ${data}`),
   );

--- a/watch.mjs
+++ b/watch.mjs
@@ -105,7 +105,10 @@ onRustChange();
  */
 function runWatcher(dir, name, watchTask = "tsc:watch") {
   console.log(`Spawning tsc:watch for ${name} in ${dir}`);
-  const npmWatcher = spawn(npmCmd, ["run", watchTask], { cwd: dir, shell: true });
+  const npmWatcher = spawn(npmCmd, ["run", watchTask], {
+    cwd: dir,
+    shell: true,
+  });
   npmWatcher.stdout.on("data", (data) =>
     console.log(`tsc:watch ${name}: ${data}`),
   );


### PR DESCRIPTION
### Issue
```
Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:421:11)
    at spawn (node:child_process:761:9)
    at runWatcher (file:///C:/Users/manvi/Documents/qsharp/watch.mjs:108:22)
    at file:///C:/Users/manvi/Documents/qsharp/watch.mjs:121:1
    at ModuleJob.run (node:internal/modules/esm/module_job:222:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:323:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12) {
  errno: -4071,
  code: 'EINVAL',
  syscall: 'spawn'
}
```
### Fix
As per https://github.com/nodejs/node/issues/52554#issuecomment-2060026269, we should set `{shell: true}` because
spawning .cmd files is blocked.

`const npmCmd = isWin ? "npm.cmd" : "npm";`

### Verification
- Watch is working on Windows after my change.
- Tested on codespaces(Linux environment), and observed no side effect.

### Possible Side Effects
Need to investigate if `shell:True` can cause issues on Linux.