### PR TITLE
Handle impossible factories in RE API

### DIFF
--- a/resource_estimator/src/estimates/error.rs
+++ b/resource_estimator/src/estimates/error.rs
@@ -37,6 +37,12 @@ pub enum Error {
     #[error("No solution found for the provided maximum number of physical qubits.")]
     #[diagnostic(code("Qsc.Estimates.MaxPhysicalQubitsTooSmall"))]
     MaxPhysicalQubitsTooSmall,
+    /// Resource estimation configuration can never produce T states
+    ///
+    /// ✅ This error cannot be triggered by the system.
+    #[error("Resource estimation configuration can never produce T states, required magic state output error rate was {0:.3e}")]
+    #[diagnostic(code("Qsc.Estimates.CannotComputeMagicStates"))]
+    CannotComputeMagicStates(f64),
     /// Constraint-based search only supports one magic state type.
     ///
     /// ✅ This error cannot be triggered by the system, since only one magic

--- a/resource_estimator/src/estimates/factory/dispatch.rs
+++ b/resource_estimator/src/estimates/factory/dispatch.rs
@@ -76,7 +76,7 @@ impl<E: ErrorCorrection, Builder1: FactoryBuilder<E>, Builder2: FactoryBuilder<E
         magic_state_type: usize,
         output_error_rate: f64,
         max_code_parameter: &E::Parameter,
-    ) -> Vec<Cow<Self::Factory>> {
+    ) -> Option<Vec<Cow<Self::Factory>>> {
         match magic_state_type {
             0 => self
                 .builder1
@@ -87,9 +87,12 @@ impl<E: ErrorCorrection, Builder1: FactoryBuilder<E>, Builder2: FactoryBuilder<E
                     output_error_rate,
                     max_code_parameter,
                 )
-                .into_iter()
-                .map(|f| Cow::Owned(FactoryDispatch2::Factory1(f.into_owned())))
-                .collect(),
+                .map(|factories| {
+                    factories
+                        .into_iter()
+                        .map(|f| Cow::Owned(FactoryDispatch2::Factory1(f.into_owned())))
+                        .collect()
+                }),
             1 => self
                 .builder2
                 .find_factories(
@@ -99,9 +102,12 @@ impl<E: ErrorCorrection, Builder1: FactoryBuilder<E>, Builder2: FactoryBuilder<E
                     output_error_rate,
                     max_code_parameter,
                 )
-                .into_iter()
-                .map(|f| Cow::Owned(FactoryDispatch2::Factory2(f.into_owned())))
-                .collect(),
+                .map(|factories| {
+                    factories
+                        .into_iter()
+                        .map(|f| Cow::Owned(FactoryDispatch2::Factory2(f.into_owned())))
+                        .collect()
+                }),
             _ => unreachable!("factory builder only has two magic state types"),
         }
     }

--- a/resource_estimator/src/estimates/factory/empty.rs
+++ b/resource_estimator/src/estimates/factory/empty.rs
@@ -32,7 +32,7 @@ impl<E: ErrorCorrection<Parameter = impl Clone>> FactoryBuilder<E> for NoFactori
         _magic_state_type: usize,
         _output_error_rate: f64,
         _max_code_parameter: &<E as ErrorCorrection>::Parameter,
-    ) -> Vec<std::borrow::Cow<Self::Factory>> {
+    ) -> Option<Vec<std::borrow::Cow<Self::Factory>>> {
         unreachable!()
     }
 

--- a/resource_estimator/src/system.rs
+++ b/resource_estimator/src/system.rs
@@ -22,8 +22,10 @@ mod serialization;
 use crate::estimates::{Overhead, PhysicalResourceEstimation};
 use std::rc::Rc;
 
-pub use self::modeling::{GateBasedPhysicalQubit, MajoranaQubit, PhysicalQubit, Protocol};
-use self::optimization::TFactoryBuilder;
+pub use self::modeling::{
+    GateBasedPhysicalQubit, MajoranaQubit, PhysicalQubit, Protocol, TFactory,
+};
+pub use self::optimization::TFactoryBuilder;
 pub use self::{data::LogicalResourceCounts, error::Error};
 use data::{EstimateType, JobParams};
 pub use data::{LayoutReportData, PartitioningOverhead};

--- a/resource_estimator/src/system/optimization.rs
+++ b/resource_estimator/src/system/optimization.rs
@@ -5,4 +5,4 @@ mod code_distance_iterators;
 mod distillation_units_map;
 mod tfactory_exhaustive;
 
-pub(crate) use tfactory_exhaustive::TFactoryBuilder;
+pub use tfactory_exhaustive::TFactoryBuilder;

--- a/resource_estimator/src/system/optimization/tfactory_exhaustive.rs
+++ b/resource_estimator/src/system/optimization/tfactory_exhaustive.rs
@@ -370,14 +370,14 @@ impl FactoryBuilder<Protocol> for TFactoryBuilder {
         _magic_state_type: usize,
         output_t_error_rate: f64,
         max_code_distance: &u64,
-    ) -> Vec<Cow<Self::Factory>> {
-        find_nondominated_tfactories(
+    ) -> Option<Vec<Cow<Self::Factory>>> {
+        Some(find_nondominated_tfactories(
             ftp,
             qubit,
             &self.distillation_unit_templates,
             output_t_error_rate,
             *max_code_distance,
-        )
+        ))
     }
 }
 

--- a/resource_estimator/src/system/tests.rs
+++ b/resource_estimator/src/system/tests.rs
@@ -271,13 +271,15 @@ pub fn test_hubbard_e2e() -> Result<()> {
     let same_ftp = Protocol::default();
     let output_t_error_rate = part.required_output_error_rate();
     let builder = TFactoryBuilder::default();
-    let tfactories = builder.find_factories(
-        &same_ftp,
-        &qubit,
-        0,
-        output_t_error_rate,
-        &same_ftp.max_code_distance(),
-    );
+    let tfactories = builder
+        .find_factories(
+            &same_ftp,
+            &qubit,
+            0,
+            output_t_error_rate,
+            &same_ftp.max_code_distance(),
+        )
+        .expect("can compute factories");
 
     assert_eq!(tfactories.len(), 2);
     if let Some(factory1) = find_factory(&tfactories, 88000, 27900) {
@@ -362,13 +364,15 @@ pub fn test_hubbard_e2e_measurement_based() -> Result<()> {
     let output_t_error_rate = part.required_output_error_rate();
     let same_ftp = Protocol::floquet_code();
     let builder = TFactoryBuilder::default();
-    let tfactories = builder.find_factories(
-        &same_ftp,
-        &qubit,
-        0,
-        output_t_error_rate,
-        &same_ftp.max_code_distance(),
-    );
+    let tfactories = builder
+        .find_factories(
+            &same_ftp,
+            &qubit,
+            0,
+            output_t_error_rate,
+            &same_ftp.max_code_distance(),
+        )
+        .expect("can compute factories");
 
     assert_eq!(tfactories.len(), 2);
     if let Some(factory1) = find_factory(&tfactories, 12300, 1612) {


### PR DESCRIPTION
Currently, the factory builder API returns a vector of factories for space-time evaluation. However, returning no factory may mean that the algorithm was too fast, and the optimizer will continue to search for some. But there are some cases in which no factory can be found given the input parameters, no matter of the duration of the algorithm.

This PR changes the API to allow to indicate if no magic factories can be computed by returning `Option<Vec<...>>` instead of `Vec<...>`.