### PR TITLE
Fix links to documentation in single qubit kata

### DIFF
--- a/katas/content/single_qubit_gates/prepare_rotated_state/index.md
+++ b/katas/content/single_qubit_gates/prepare_rotated_state/index.md
@@ -5,6 +5,6 @@
 
 **Goal:** Use a rotation gate to transform the qubit into state $\alpha|0\rangle -i\beta|1\rangle$.
 
-> You will probably need functions from the `Microsoft.Quantum.Math` namespace, specifically <a href="https://learn.microsoft.com/en-us/qsharp/api/qsharp-lang/microsoft.quantum.math/arctan2" target="_blank">ArcTan2</a>.
+> You will probably need functions from the `Microsoft.Quantum.Math` namespace, specifically <a href="https://learn.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math/arctan2" target="_blank">ArcTan2</a>.
 >
 > You can assign variables in Q# by using the `let` keyword: `let num = 3;` or `let result = Function(input);`

--- a/katas/content/single_qubit_gates/prepare_rotated_state/index.md
+++ b/katas/content/single_qubit_gates/prepare_rotated_state/index.md
@@ -5,6 +5,6 @@
 
 **Goal:** Use a rotation gate to transform the qubit into state $\alpha|0\rangle -i\beta|1\rangle$.
 
-> You will probably need functions from the <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math" target="_blank">Math</a> namespace, specifically <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
+> You will probably need functions from the <a href="https://docs.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math" target="_blank">Math</a> namespace, specifically <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
 >
 > You can assign variables in Q# by using the `let` keyword: `let num = 3;` or `let result = Function(input);`

--- a/katas/content/single_qubit_gates/prepare_rotated_state/index.md
+++ b/katas/content/single_qubit_gates/prepare_rotated_state/index.md
@@ -5,6 +5,6 @@
 
 **Goal:** Use a rotation gate to transform the qubit into state $\alpha|0\rangle -i\beta|1\rangle$.
 
-> You will probably need functions from the `Microsoft.Quantum.Math` namespace, specifically <a href="https://docs.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
+> You will probably need functions from the `Microsoft.Quantum.Math` namespace, specifically <a href="https://learn.microsoft.com/en-us/qsharp/api/qsharp-lang/microsoft.quantum.math/arctan2" target="_blank">ArcTan2</a>.
 >
 > You can assign variables in Q# by using the `let` keyword: `let num = 3;` or `let result = Function(input);`

--- a/katas/content/single_qubit_gates/prepare_rotated_state/index.md
+++ b/katas/content/single_qubit_gates/prepare_rotated_state/index.md
@@ -5,6 +5,6 @@
 
 **Goal:** Use a rotation gate to transform the qubit into state $\alpha|0\rangle -i\beta|1\rangle$.
 
-> You will probably need functions from the <a href="https://docs.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math" target="_blank">Math</a> namespace, specifically <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
+> You will probably need functions from the `Microsoft.Quantum.Math` namespace, specifically <a href="https://docs.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
 >
 > You can assign variables in Q# by using the `let` keyword: `let num = 3;` or `let result = Function(input);`

--- a/katas/content/single_qubit_gates/prepare_rotated_state/solution.md
+++ b/katas/content/single_qubit_gates/prepare_rotated_state/solution.md
@@ -3,7 +3,7 @@ This is similar to the state we need. We just need to find an angle $\theta$ suc
 Hence the required gate is $R_x(2\arctan\frac{\beta}{\alpha})$, which in matrix form is $\begin{bmatrix} \alpha & -i\beta \\\ -i\beta & \alpha \end{bmatrix}$.
 This gate turns $|0\rangle = \begin{bmatrix} 1 \\\ 0\end{bmatrix}$ into $\begin{bmatrix} \alpha & -i\beta \\\ -i\beta & \alpha \end{bmatrix} \begin{bmatrix} 1 \\\ 0\end{bmatrix} = \begin{bmatrix} \alpha \\\ -i\beta \end{bmatrix} = \alpha|0\rangle -i\beta|1\rangle$.
 
-> Trigonometric functions are available in Q# via the <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math" target="_blank">Math</a> namespace. In this case we will need <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
+> Trigonometric functions are available in Q# via the <a href="https://docs.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math" target="_blank">Math</a> namespace. In this case we will need <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
 
 @[solution]({
     "id": "single_qubit_gates__prepare_rotated_state_solution",

--- a/katas/content/single_qubit_gates/prepare_rotated_state/solution.md
+++ b/katas/content/single_qubit_gates/prepare_rotated_state/solution.md
@@ -3,7 +3,7 @@ This is similar to the state we need. We just need to find an angle $\theta$ suc
 Hence the required gate is $R_x(2\arctan\frac{\beta}{\alpha})$, which in matrix form is $\begin{bmatrix} \alpha & -i\beta \\\ -i\beta & \alpha \end{bmatrix}$.
 This gate turns $|0\rangle = \begin{bmatrix} 1 \\\ 0\end{bmatrix}$ into $\begin{bmatrix} \alpha & -i\beta \\\ -i\beta & \alpha \end{bmatrix} \begin{bmatrix} 1 \\\ 0\end{bmatrix} = \begin{bmatrix} \alpha \\\ -i\beta \end{bmatrix} = \alpha|0\rangle -i\beta|1\rangle$.
 
-> Trigonometric functions are available in Q# via the <a href="https://docs.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math" target="_blank">Math</a> namespace. In this case we will need <a href="https://docs.microsoft.com/qsharp/api/qsharp/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
+> Trigonometric functions are available in Q# via the `Microsoft.Quantum.Math` namespace. In this case we will need <a href="https://docs.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
 
 @[solution]({
     "id": "single_qubit_gates__prepare_rotated_state_solution",

--- a/katas/content/single_qubit_gates/prepare_rotated_state/solution.md
+++ b/katas/content/single_qubit_gates/prepare_rotated_state/solution.md
@@ -3,7 +3,7 @@ This is similar to the state we need. We just need to find an angle $\theta$ suc
 Hence the required gate is $R_x(2\arctan\frac{\beta}{\alpha})$, which in matrix form is $\begin{bmatrix} \alpha & -i\beta \\\ -i\beta & \alpha \end{bmatrix}$.
 This gate turns $|0\rangle = \begin{bmatrix} 1 \\\ 0\end{bmatrix}$ into $\begin{bmatrix} \alpha & -i\beta \\\ -i\beta & \alpha \end{bmatrix} \begin{bmatrix} 1 \\\ 0\end{bmatrix} = \begin{bmatrix} \alpha \\\ -i\beta \end{bmatrix} = \alpha|0\rangle -i\beta|1\rangle$.
 
-> Trigonometric functions are available in Q# via the `Microsoft.Quantum.Math` namespace. In this case we will need <a href="https://learn.microsoft.com/en-us/qsharp/api/qsharp-lang/microsoft.quantum.math/arctan2" target="_blank">ArcTan2</a>.
+> Trigonometric functions are available in Q# via the `Microsoft.Quantum.Math` namespace. In this case we will need <a href="https://learn.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math/arctan2" target="_blank">ArcTan2</a>.
 
 @[solution]({
     "id": "single_qubit_gates__prepare_rotated_state_solution",

--- a/katas/content/single_qubit_gates/prepare_rotated_state/solution.md
+++ b/katas/content/single_qubit_gates/prepare_rotated_state/solution.md
@@ -3,7 +3,7 @@ This is similar to the state we need. We just need to find an angle $\theta$ suc
 Hence the required gate is $R_x(2\arctan\frac{\beta}{\alpha})$, which in matrix form is $\begin{bmatrix} \alpha & -i\beta \\\ -i\beta & \alpha \end{bmatrix}$.
 This gate turns $|0\rangle = \begin{bmatrix} 1 \\\ 0\end{bmatrix}$ into $\begin{bmatrix} \alpha & -i\beta \\\ -i\beta & \alpha \end{bmatrix} \begin{bmatrix} 1 \\\ 0\end{bmatrix} = \begin{bmatrix} \alpha \\\ -i\beta \end{bmatrix} = \alpha|0\rangle -i\beta|1\rangle$.
 
-> Trigonometric functions are available in Q# via the `Microsoft.Quantum.Math` namespace. In this case we will need <a href="https://docs.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.math.arctan2" target="_blank">ArcTan2</a>.
+> Trigonometric functions are available in Q# via the `Microsoft.Quantum.Math` namespace. In this case we will need <a href="https://learn.microsoft.com/en-us/qsharp/api/qsharp-lang/microsoft.quantum.math/arctan2" target="_blank">ArcTan2</a>.
 
 @[solution]({
     "id": "single_qubit_gates__prepare_rotated_state_solution",


### PR DESCRIPTION
Noticed a couple of links were out of date.