### PR TITLE
Partial evaluation support for assignment expressions and multiple array related expressions

### DIFF
--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -330,7 +330,7 @@ impl Default for Env {
 
 impl Env {
     #[must_use]
-    fn get(&self, id: LocalVarId) -> Option<&Variable> {
+    pub fn get(&self, id: LocalVarId) -> Option<&Variable> {
         self.0.iter().rev().find_map(|scope| scope.bindings.get(id))
     }
 
@@ -541,7 +541,6 @@ impl State {
         step: StepAction,
     ) -> Result<StepResult, (Error, Vec<Frame>)> {
         let current_frame = self.call_stack.len();
-
         while !self.exec_graph_stack.is_empty() {
             let exec_graph = self
                 .exec_graph_stack
@@ -686,7 +685,6 @@ impl State {
     ) -> Result<(), Error> {
         let expr = globals.get_expr((self.package, expr).into());
         self.current_span = expr.span;
-
         match &expr.kind {
             ExprKind::Array(arr) => self.eval_arr(arr.len()),
             ExprKind::ArrayLit(arr) => self.eval_arr_lit(arr, globals),

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -406,6 +406,13 @@ impl Env {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+
+    pub fn update_variable_in_top_frame(&mut self, local_var_id: LocalVarId, value: Value) {
+        let variable = self
+            .get_mut(local_var_id)
+            .expect("local variable is not present");
+        variable.value = value;
+    }
 }
 
 #[derive(Default)]

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -89,7 +89,10 @@ impl From<usize> for Result {
 pub struct Qubit(pub usize);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Var(pub usize);
+pub struct Var {
+    pub id: usize,
+    pub ty: VarTy,
+}
 
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -147,7 +150,24 @@ impl Display for Value {
                 }
                 write!(f, ")")
             }
-            Value::Var(var) => write!(f, "Var{}", (var.0)),
+            Value::Var(var) => write!(f, "Var({}, {})", var.id, var.ty),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum VarTy {
+    Boolean,
+    Integer,
+    Double,
+}
+
+impl Display for VarTy {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Boolean => write!(f, "Boolean"),
+            Self::Integer => write!(f, "Integer"),
+            Self::Double => write!(f, "Double"),
         }
     }
 }

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -18,15 +18,15 @@ use qsc_data_structures::{functors::FunctorApp, target::TargetCapabilityFlags};
 use qsc_eval::{
     self, exec_graph_section,
     output::GenericReceiver,
-    val::{self, Value, Var},
+    val::{self, Value, Var, VarTy},
     State, StepAction, StepResult, Variable,
 };
 use qsc_fir::{
     fir::{
         self, BinOp, Block, BlockId, CallableDecl, CallableImpl, ExecGraphNode, Expr, ExprId,
-        ExprKind, Global, Ident, PackageId, PackageStore, PackageStoreLookup, Pat, PatId, PatKind,
-        Res, SpecDecl, SpecImpl, Stmt, StmtId, StmtKind, StoreBlockId, StoreExprId, StoreItemId,
-        StorePatId, StoreStmtId,
+        ExprKind, Global, Ident, LocalVarId, Mutability, PackageId, PackageStore,
+        PackageStoreLookup, Pat, PatId, PatKind, Res, SpecDecl, SpecImpl, Stmt, StmtId, StmtKind,
+        StoreBlockId, StoreExprId, StoreItemId, StorePatId, StoreStmtId,
     },
     ty::{Prim, Ty},
 };
@@ -137,17 +137,17 @@ impl<'a> PartialEvaluator<'a> {
         }
     }
 
-    fn bind_value_to_pat(&mut self, pat_id: PatId, value: Value) {
+    fn bind_value_to_pat(&mut self, mutability: Mutability, pat_id: PatId, value: Value) {
         let pat = self.get_pat(pat_id);
         match &pat.kind {
             PatKind::Bind(ident) => {
-                self.bind_value_to_ident(ident, value);
+                self.bind_value_to_ident(mutability, ident, value);
             }
             PatKind::Tuple(pats) => {
-                let tup = value.unwrap_tuple();
-                assert!(pats.len() == tup.len());
-                for (pat_id, value) in pats.iter().zip(tup.iter()) {
-                    self.bind_value_to_pat(*pat_id, value.clone());
+                let tuple = value.unwrap_tuple();
+                assert!(pats.len() == tuple.len());
+                for (pat_id, value) in pats.iter().zip(tuple.iter()) {
+                    self.bind_value_to_pat(mutability, *pat_id, value.clone());
                 }
             }
             PatKind::Discard => {
@@ -156,10 +156,62 @@ impl<'a> PartialEvaluator<'a> {
         }
     }
 
-    fn bind_value_to_ident(&mut self, ident: &Ident, value: Value) {
+    fn bind_value_to_ident(&mut self, mutability: Mutability, ident: &Ident, value: Value) {
+        // We do slightly different things depending on the mutability of the identifier.
+        match mutability {
+            Mutability::Immutable => self.bind_value_to_immutable_ident(ident, value),
+            Mutability::Mutable => self.bind_value_to_mutable_ident(ident, value),
+        };
+    }
+
+    fn bind_value_to_immutable_ident(&mut self, ident: &Ident, value: Value) {
+        // If the value is not a variable, bind it to the classical map.
+        if !matches!(value, Value::Var(_)) {
+            self.bind_value_in_classical_map(ident, &value);
+        }
+
+        // Always bind the value to the hybrid map.
+        self.bind_value_in_hybrid_map(ident, value);
+    }
+
+    fn bind_value_to_mutable_ident(&mut self, ident: &Ident, value: Value) {
+        // If the value is not a variable, bind it to the classical map.
+        if !matches!(value, Value::Var(_)) {
+            self.bind_value_in_classical_map(ident, &value);
+        }
+
+        // Always bind the value to the hybrid map but do it differently depending of the value type.
+        let maybe_var_type = try_get_eval_var_type(&value);
+        if let Some(var_type) = maybe_var_type {
+            // Get a variable to store into.
+            let value_operand = map_eval_value_to_rir_operand(&value);
+            let eval_var = self.get_or_create_variable(ident.id, var_type);
+            let rir_var = map_eval_var_to_rir_var(eval_var);
+            // Insert a store instruction.
+            let store_ins = Instruction::Store(value_operand, rir_var);
+            self.get_current_rir_block_mut().0.push(store_ins);
+        } else {
+            self.bind_value_in_hybrid_map(ident, value);
+        }
+    }
+
+    fn bind_value_in_classical_map(&mut self, ident: &Ident, value: &Value) {
+        // Create a variable and bind it to the classical environment.
+        let var = Variable {
+            name: ident.name.clone(),
+            value: value.clone(),
+            span: ident.span,
+        };
+        let scope = self.eval_context.get_current_scope_mut();
+        scope.env.bind_variable_in_top_frame(ident.id, var);
+    }
+
+    fn bind_value_in_hybrid_map(&mut self, ident: &Ident, value: Value) {
+        // Insert the value into the hybrid vars map.
         self.eval_context
             .get_current_scope_mut()
-            .insert_local_var_value(ident.id, value);
+            .hybrid_vars
+            .insert(ident.id, value);
     }
 
     fn create_intrinsic_callable(
@@ -230,7 +282,130 @@ impl<'a> PartialEvaluator<'a> {
         Ok(self.program)
     }
 
+    fn eval_bin_op(
+        &mut self,
+        bin_op: BinOp,
+        lhs_expr_id: ExprId,
+        rhs_expr_id: ExprId,
+        bin_op_expr_span: Span, // For diagnostic purposes only.
+    ) -> Result<EvalControlFlow, Error> {
+        // Try to evaluate the LHS expression, short-circuiting execution if it is a return.
+        let lhs_control_flow = self.try_eval_expr(lhs_expr_id)?;
+        let EvalControlFlow::Continue(lhs_value) = lhs_control_flow else {
+            let lhs_expr = self.get_expr(lhs_expr_id);
+            return Err(Error::Unexpected(
+                "embedded return in LHS expression".to_string(),
+                lhs_expr.span,
+            ));
+        };
+
+        // Evaluate the binary operation differently depending on the LHS value variant.
+        match lhs_value {
+            Value::Array(lhs_array) => self.eval_bin_op_with_lhs_array_operand(
+                bin_op,
+                &lhs_array,
+                rhs_expr_id,
+                bin_op_expr_span,
+            ),
+            Value::Result(_lhs_result) => {
+                let lhs_expr = self.get_expr(lhs_expr_id);
+                Err(Error::Unimplemented(
+                    "result binary operation".to_string(),
+                    lhs_expr.span,
+                ))
+            }
+            Value::Bool(_lhs_bool) => {
+                let lhs_expr = self.get_expr(lhs_expr_id);
+                Err(Error::Unimplemented(
+                    "bool binary operation".to_string(),
+                    lhs_expr.span,
+                ))
+            }
+            Value::Int(_lhs_int) => {
+                let lhs_expr = self.get_expr(lhs_expr_id);
+                Err(Error::Unimplemented(
+                    "int binary operation".to_string(),
+                    lhs_expr.span,
+                ))
+            }
+            Value::Double(_lhs_double) => {
+                let lhs_expr = self.get_expr(lhs_expr_id);
+                Err(Error::Unimplemented(
+                    "double binary operation".to_string(),
+                    lhs_expr.span,
+                ))
+            }
+            Value::Var(_lhs_eval_var) => {
+                let lhs_expr = self.get_expr(lhs_expr_id);
+                Err(Error::Unimplemented(
+                    "binary operation with dynamic LHS".to_string(),
+                    lhs_expr.span,
+                ))
+            }
+            _ => {
+                let lhs_expr = self.get_expr(lhs_expr_id);
+                Err(Error::Unexpected(
+                    format!("unsupported LHS value: {lhs_value}"),
+                    lhs_expr.span,
+                ))
+            }
+        }
+    }
+
+    fn eval_bin_op_with_lhs_array_operand(
+        &mut self,
+        bin_op: BinOp,
+        lhs_array: &Rc<Vec<Value>>,
+        rhs_expr_id: ExprId,
+        bin_op_expr_span: Span, // For diagnostic purposes only.
+    ) -> Result<EvalControlFlow, Error> {
+        // Check that the binary operation is currently supported.
+        if matches!(bin_op, BinOp::Eq | BinOp::Neq) {
+            return Err(Error::Unimplemented(
+                "array comparison".to_string(),
+                bin_op_expr_span,
+            ));
+        }
+
+        // The only possible binary operation with array operands at this point is addition.
+        assert!(
+            matches!(bin_op, BinOp::Add),
+            "expected array addition operation, got {bin_op:?}"
+        );
+
+        // Try to evaluate the RHS array expression to get its value.
+        let rhs_control_flow = self.try_eval_expr(rhs_expr_id)?;
+        let EvalControlFlow::Continue(rhs_value) = rhs_control_flow else {
+            let rhs_expr = self.get_expr(rhs_expr_id);
+            return Err(Error::Unexpected(
+                "embedded return in RHS expression".to_string(),
+                rhs_expr.span,
+            ));
+        };
+        let Value::Array(rhs_array) = rhs_value else {
+            panic!("expected array value from RHS expression");
+        };
+
+        // Concatenate the arrays.
+        let concatenated_array: Vec<Value> =
+            lhs_array.iter().chain(rhs_array.iter()).cloned().collect();
+        let array_value = Value::Array(concatenated_array.into());
+        Ok(EvalControlFlow::Continue(array_value))
+    }
+
     fn eval_classical_expr(&mut self, expr_id: ExprId) -> Result<EvalControlFlow, Error> {
+        // This is a workaround since evaluating sections of the execution graph that correspond to local variable
+        // expressions does not yield the expected results.
+        let expr = self.get_expr(expr_id);
+        if let ExprKind::Var(Res::Local(local_var_id), _) = &expr.kind {
+            let value = self
+                .eval_context
+                .get_current_scope()
+                .get_classical_local_value(*local_var_id);
+            return Ok(EvalControlFlow::Continue(value.clone()));
+        }
+
+        // For any other expression, evaluate the section of the execution graph corresponding to the expression.
         let current_package_id = self.get_current_package_id();
         let store_expr_id = StoreExprId::from((current_package_id, expr_id));
         let expr = self.package_store.get_expr(store_expr_id);
@@ -238,7 +413,7 @@ impl<'a> PartialEvaluator<'a> {
         let scope = self.eval_context.get_current_scope_mut();
         let exec_graph = exec_graph_section(&scope_exec_graph, expr.exec_graph_range.clone());
         let mut state = State::new(current_package_id, exec_graph, None);
-        let eval_result = state.eval(
+        let classical_result = state.eval(
             self.package_store,
             &mut scope.env,
             &mut self.backend,
@@ -246,7 +421,7 @@ impl<'a> PartialEvaluator<'a> {
             &[],
             StepAction::Continue,
         );
-        match eval_result {
+        let eval_result = match classical_result {
             Ok(step_result) => {
                 let StepResult::Return(value) = step_result else {
                     panic!("evaluating a classical expression should always return a value");
@@ -262,41 +437,22 @@ impl<'a> PartialEvaluator<'a> {
                 Ok(eval_control_flow)
             }
             Err((error, _)) => Err(Error::EvaluationFailed(error.to_string(), expr.span)),
-        }
-    }
+        };
 
-    fn eval_classical_stmt(&mut self, stmt_id: StmtId) -> Result<EvalControlFlow, Error> {
-        let current_package_id = self.get_current_package_id();
-        let stmt = self.get_stmt(stmt_id);
-        let scope_exec_graph = self.get_current_scope_exec_graph().clone();
-        let scope = self.eval_context.get_current_scope_mut();
-        let exec_graph = exec_graph_section(&scope_exec_graph, stmt.exec_graph_range.clone());
-        let mut state = State::new(current_package_id, exec_graph, None);
-        let eval_result = state.eval(
-            self.package_store,
-            &mut scope.env,
-            &mut self.backend,
-            &mut GenericReceiver::new(&mut std::io::sink()),
-            &[],
-            StepAction::Continue,
-        );
-        match eval_result {
-            Ok(step_result) => {
-                let StepResult::Return(value) = step_result else {
-                    panic!("evaluating a classical expression should always return a value");
-                };
-
-                // Figure out the control flow kind.
-                let scope = self.eval_context.get_current_scope();
-                let eval_control_flow = if scope.has_classical_evaluator_returned() {
-                    EvalControlFlow::Return(value)
-                } else {
-                    EvalControlFlow::Continue(value)
-                };
-                Ok(eval_control_flow)
+        // If this was an assign expression, update the bindings in the hybrid side to keep them in sync and to insert
+        // store instructions if needed.
+        if let Ok(EvalControlFlow::Continue(_)) = eval_result {
+            let expr = self.get_expr(expr_id);
+            if let ExprKind::Assign(lhs_expr_id, _)
+            | ExprKind::AssignField(lhs_expr_id, _, _)
+            | ExprKind::AssignIndex(lhs_expr_id, _, _)
+            | ExprKind::AssignOp(_, lhs_expr_id, _) = &expr.kind
+            {
+                self.update_hybrid_bindings_from_classical_bindings(*lhs_expr_id)?;
             }
-            Err((error, _)) => Err(Error::EvaluationFailed(error.to_string(), stmt.span)),
         }
+
+        eval_result
     }
 
     fn eval_hybrid_expr(&mut self, expr_id: ExprId) -> Result<EvalControlFlow, Error> {
@@ -306,25 +462,23 @@ impl<'a> PartialEvaluator<'a> {
         match &expr.kind {
             ExprKind::Array(exprs) => self.eval_expr_array(exprs),
             ExprKind::ArrayLit(_) => panic!("array of literal values should always be classical"),
-            ExprKind::ArrayRepeat(_, _) => {
-                Err(Error::Unimplemented("Array Repeat".to_string(), expr.span))
+            ExprKind::ArrayRepeat(value_expr_id, size_expr_id) => {
+                self.eval_expr_array_repeat(*value_expr_id, *size_expr_id)
             }
-            ExprKind::Assign(_, _) => Err(Error::Unimplemented(
-                "Assignment Expr".to_string(),
-                expr.span,
-            )),
+            ExprKind::Assign(lhs_expr_id, rhs_expr_id) => {
+                self.eval_expr_assign(*lhs_expr_id, *rhs_expr_id)
+            }
             ExprKind::AssignField(_, _, _) => Err(Error::Unimplemented(
                 "Field Assignment Expr".to_string(),
                 expr.span,
             )),
-            ExprKind::AssignIndex(_, _, _) => Err(Error::Unimplemented(
-                "Assignment Index Expr".to_string(),
-                expr.span,
-            )),
-            ExprKind::AssignOp(_, _, _) => Err(Error::Unimplemented(
-                "Assignment Op Expr".to_string(),
-                expr.span,
-            )),
+            ExprKind::AssignIndex(array_expr_id, index_expr_id, replace_expr_id) => {
+                self.eval_expr_assign_index(*array_expr_id, *index_expr_id, *replace_expr_id)
+            }
+            ExprKind::AssignOp(bin_op, lhs_expr_id, rhs_expr_id) => {
+                let expr = self.get_expr(expr_id);
+                self.eval_expr_assign_op(*bin_op, *lhs_expr_id, *rhs_expr_id, expr.span)
+            }
             ExprKind::BinOp(bin_op, lhs_expr_id, rhs_expr_id) => {
                 self.eval_expr_bin_op(expr_id, *bin_op, *lhs_expr_id, *rhs_expr_id)
             }
@@ -344,7 +498,9 @@ impl<'a> PartialEvaluator<'a> {
                 *body_expr_id,
                 *otherwise_expr_id,
             ),
-            ExprKind::Index(_, _) => Err(Error::Unimplemented("Index Expr".to_string(), expr.span)),
+            ExprKind::Index(array_expr_id, index_expr_id) => {
+                self.eval_expr_index(*array_expr_id, *index_expr_id)
+            }
             ExprKind::Lit(_) => panic!("instruction generation for literal expressions is invalid"),
             ExprKind::Range(_, _, _) => {
                 panic!("instruction generation for range expressions is invalid")
@@ -370,32 +526,111 @@ impl<'a> PartialEvaluator<'a> {
         }
     }
 
-    fn eval_hybrid_stmt(&mut self, stmt_id: StmtId) -> Result<EvalControlFlow, Error> {
-        let stmt = self.get_stmt(stmt_id);
-        match stmt.kind {
-            StmtKind::Expr(expr_id) => self.try_eval_expr(expr_id),
-            StmtKind::Semi(expr_id) => {
-                let control_flow = self.try_eval_expr(expr_id)?;
-                match control_flow {
-                    EvalControlFlow::Continue(_) => Ok(EvalControlFlow::Continue(Value::unit())),
-                    EvalControlFlow::Return(_) => Ok(control_flow),
-                }
-            }
-            StmtKind::Local(_, pat_id, expr_id) => {
-                let control_flow = self.try_eval_expr(expr_id)?;
-                match control_flow {
-                    EvalControlFlow::Continue(value) => {
-                        self.bind_value_to_pat(pat_id, value);
-                        Ok(EvalControlFlow::Continue(Value::unit()))
-                    }
-                    EvalControlFlow::Return(_) => Ok(control_flow),
-                }
-            }
-            StmtKind::Item(_) => {
-                // Do nothing and return a continue unit value.
-                Ok(EvalControlFlow::Continue(Value::unit()))
-            }
-        }
+    fn eval_expr_array_repeat(
+        &mut self,
+        value_expr_id: ExprId,
+        size_expr_id: ExprId,
+    ) -> Result<EvalControlFlow, Error> {
+        // Try to evaluate both the value and size expressions to get their value, short-circuiting execution if any of the
+        // expressions is a return.
+        let value_control_flow = self.try_eval_expr(value_expr_id)?;
+        let EvalControlFlow::Continue(value) = value_control_flow else {
+            let value_expr = self.get_expr(value_expr_id);
+            return Err(Error::Unexpected(
+                "embedded return in array".to_string(),
+                value_expr.span,
+            ));
+        };
+        let size_control_flow = self.try_eval_expr(size_expr_id)?;
+        let EvalControlFlow::Continue(size) = size_control_flow else {
+            let size_expr = self.get_expr(size_expr_id);
+            return Err(Error::Unexpected(
+                "embedded return in array".to_string(),
+                size_expr.span,
+            ));
+        };
+
+        // We assume the size of the array is a classical value because otherwise it would have been rejected before
+        // getting to the partial evaluation stage.
+        let size = size.unwrap_int();
+        let values = vec![value; TryFrom::try_from(size).expect("could not convert size value")];
+        Ok(EvalControlFlow::Continue(Value::Array(values.into())))
+    }
+
+    fn eval_expr_assign(
+        &mut self,
+        lhs_expr_id: ExprId,
+        rhs_expr_id: ExprId,
+    ) -> Result<EvalControlFlow, Error> {
+        let rhs_control_flow = self.try_eval_expr(rhs_expr_id)?;
+        let EvalControlFlow::Continue(rhs_value) = rhs_control_flow else {
+            let rhs_expr = self.get_expr(rhs_expr_id);
+            return Err(Error::Unexpected(
+                "embedded return in assign expression".to_string(),
+                rhs_expr.span,
+            ));
+        };
+
+        self.update_hybrid_bindings(lhs_expr_id, rhs_value)?;
+        Ok(EvalControlFlow::Continue(Value::unit()))
+    }
+
+    fn eval_expr_assign_index(
+        &mut self,
+        array_expr_id: ExprId,
+        index_expr_id: ExprId,
+        replace_expr_id: ExprId,
+    ) -> Result<EvalControlFlow, Error> {
+        // Get the value of the array expression to use it as the basis to perform a replacement on.
+        let array_control_flow = self.try_eval_expr(array_expr_id)?;
+        let EvalControlFlow::Continue(array_value) = array_control_flow else {
+            panic!("the array in sub-expression in an assign index expression is not expected to contain an embedded return");
+        };
+
+        // Try to evaluate the index and replace expressions to get their value, short-circuiting execution if any of
+        // the expressions is a return.
+        let index_control_flow = self.try_eval_expr(index_expr_id)?;
+        let EvalControlFlow::Continue(index_value) = index_control_flow else {
+            let index_expr = self.get_expr(index_expr_id);
+            return Err(Error::Unexpected(
+                "embedded return in assign index expression".to_string(),
+                index_expr.span,
+            ));
+        };
+        let replace_control_flow = self.try_eval_expr(replace_expr_id)?;
+        let EvalControlFlow::Continue(replace_value) = replace_control_flow else {
+            let replace_expr = self.get_expr(replace_expr_id);
+            return Err(Error::Unexpected(
+                "embedded return in assign index expression".to_string(),
+                replace_expr.span,
+            ));
+        };
+
+        // Replace the value at the corresponding index and update the array binding.
+        let index: usize = index_value
+            .unwrap_int()
+            .try_into()
+            .expect("could not convert array index into usize");
+        let mut array = (*array_value.unwrap_array()).clone();
+        let _ = std::mem::replace(&mut array[index], replace_value);
+        self.update_hybrid_bindings(array_expr_id, Value::Array(array.into()))?;
+        Ok(EvalControlFlow::Continue(Value::unit()))
+    }
+
+    fn eval_expr_assign_op(
+        &mut self,
+        bin_op: BinOp,
+        lhs_expr_id: ExprId,
+        rhs_expr_id: ExprId,
+        bin_op_expr_span: Span, // For diagnostic purposes only.
+    ) -> Result<EvalControlFlow, Error> {
+        let bin_op_control_flow =
+            self.eval_bin_op(bin_op, lhs_expr_id, rhs_expr_id, bin_op_expr_span)?;
+        let EvalControlFlow::Continue(bin_op_value) = bin_op_control_flow else {
+            panic!("evaluating a binary operation is expected to return an error or a continue, never a return");
+        };
+        self.update_hybrid_bindings(lhs_expr_id, bin_op_value)?;
+        Ok(EvalControlFlow::Continue(Value::unit()))
     }
 
     #[allow(clippy::similar_names)]
@@ -464,7 +699,7 @@ impl<'a> PartialEvaluator<'a> {
         current_block.0.push(instruction);
 
         // Return the variable as a value.
-        let value = Value::Var(Var(variable_id.into()));
+        let value = Value::Var(map_rir_var_to_eval_var(variable));
         Ok(EvalControlFlow::Continue(value))
     }
 
@@ -695,10 +930,7 @@ impl<'a> PartialEvaluator<'a> {
 
         // Finally, we insert the branch instruction.
         let condition_value_var = condition_value.unwrap_var();
-        let condition_rir_var = rir::Variable {
-            variable_id: condition_value_var.0.into(),
-            ty: rir::Ty::Boolean,
-        };
+        let condition_rir_var = map_eval_var_to_rir_var(condition_value_var);
         let branch_ins =
             Instruction::Branch(condition_rir_var, if_true_block_id, if_false_block_id);
         self.get_program_block_mut(current_block_node.id)
@@ -707,7 +939,7 @@ impl<'a> PartialEvaluator<'a> {
 
         // Return the value of the if expression.
         let if_expr_value = if let Some(if_expr_var) = maybe_if_expr_var {
-            Value::Var(Var(if_expr_var.variable_id.into()))
+            Value::Var(map_rir_var_to_eval_var(if_expr_var))
         } else {
             Value::unit()
         };
@@ -766,6 +998,44 @@ impl<'a> PartialEvaluator<'a> {
         }
     }
 
+    fn eval_expr_index(
+        &mut self,
+        array_expr_id: ExprId,
+        index_expr_id: ExprId,
+    ) -> Result<EvalControlFlow, Error> {
+        // Get the value of the array expression to use it as the basis to perform a replacement on.
+        let array_control_flow = self.try_eval_expr(array_expr_id)?;
+        let EvalControlFlow::Continue(array_value) = array_control_flow else {
+            let array_expr = self.get_expr(array_expr_id);
+            return Err(Error::Unexpected(
+                "embedded return in index expression".to_string(),
+                array_expr.span,
+            ));
+        };
+
+        // Try to evaluate the index and replace expressions to get their value, short-circuiting execution if any of
+        // the expressions is a return.
+        let index_control_flow = self.try_eval_expr(index_expr_id)?;
+        let EvalControlFlow::Continue(index_value) = index_control_flow else {
+            let index_expr = self.get_expr(index_expr_id);
+            return Err(Error::Unexpected(
+                "embedded return in index expression".to_string(),
+                index_expr.span,
+            ));
+        };
+
+        // Get the value at the specified index.
+        let array = array_value.unwrap_array();
+        let index: usize = index_value
+            .unwrap_int()
+            .try_into()
+            .expect("could not convert index to usize");
+        let value_at_index = array
+            .get(index)
+            .unwrap_or_else(|| panic!("could not get value at index {index}"));
+        Ok(EvalControlFlow::Continue(value_at_index.clone()))
+    }
+
     fn eval_expr_return(&mut self, expr_id: ExprId) -> Result<EvalControlFlow, Error> {
         let control_flow = self.try_eval_expr(expr_id)?;
         Ok(EvalControlFlow::Return(control_flow.into_value()))
@@ -816,7 +1086,7 @@ impl<'a> PartialEvaluator<'a> {
             Res::Local(local_var_id) => self
                 .eval_context
                 .get_current_scope()
-                .get_local_var_value(*local_var_id)
+                .get_hybrid_local_value(*local_var_id)
                 .clone(),
         }
     }
@@ -963,12 +1233,20 @@ impl<'a> PartialEvaluator<'a> {
         expr_generator_set.generate_application_compute_kind(&callable_scope.args_value_kind)
     }
 
-    fn get_stmt_compute_kind(&self, stmt_id: StmtId) -> ComputeKind {
-        let current_package_id = self.get_current_package_id();
-        let store_stmt_id = StoreStmtId::from((current_package_id, stmt_id));
-        let stmt_generator_set = self.compute_properties.get_stmt(store_stmt_id);
-        let callable_scope = self.eval_context.get_current_scope();
-        stmt_generator_set.generate_application_compute_kind(&callable_scope.args_value_kind)
+    fn get_or_create_variable(&mut self, local_var_id: LocalVarId, var_ty: VarTy) -> Var {
+        let current_scope = self.eval_context.get_current_scope_mut();
+        let entry = current_scope.hybrid_vars.entry(local_var_id);
+        let local_var_value = entry.or_insert(Value::Var({
+            let var_id = self.resource_manager.next_var();
+            Var {
+                id: var_id.into(),
+                ty: var_ty,
+            }
+        }));
+        let Value::Var(var) = local_var_value else {
+            panic!("value must be a variable");
+        };
+        *var
     }
 
     fn get_or_insert_callable(&mut self, callable: Callable) -> CallableId {
@@ -995,11 +1273,6 @@ impl<'a> PartialEvaluator<'a> {
 
     fn is_classical_expr(&self, expr_id: ExprId) -> bool {
         let compute_kind = self.get_expr_compute_kind(expr_id);
-        matches!(compute_kind, ComputeKind::Classical)
-    }
-
-    fn is_classical_stmt(&self, stmt_id: StmtId) -> bool {
-        let compute_kind = self.get_stmt_compute_kind(stmt_id);
         matches!(compute_kind, ComputeKind::Classical)
     }
 
@@ -1107,12 +1380,117 @@ impl<'a> PartialEvaluator<'a> {
     }
 
     fn try_eval_stmt(&mut self, stmt_id: StmtId) -> Result<EvalControlFlow, Error> {
-        // If the statement is classical, we can just evaluate it.
-        if self.is_classical_stmt(stmt_id) {
-            self.eval_classical_stmt(stmt_id)
-        } else {
-            self.eval_hybrid_stmt(stmt_id)
+        let stmt = self.get_stmt(stmt_id);
+        match stmt.kind {
+            StmtKind::Expr(expr_id) => self.try_eval_expr(expr_id),
+            StmtKind::Semi(expr_id) => {
+                let control_flow = self.try_eval_expr(expr_id)?;
+                match control_flow {
+                    EvalControlFlow::Continue(_) => Ok(EvalControlFlow::Continue(Value::unit())),
+                    EvalControlFlow::Return(_) => Ok(control_flow),
+                }
+            }
+            StmtKind::Local(mutability, pat_id, expr_id) => {
+                let control_flow = self.try_eval_expr(expr_id)?;
+                match control_flow {
+                    EvalControlFlow::Continue(value) => {
+                        self.bind_value_to_pat(mutability, pat_id, value);
+                        Ok(EvalControlFlow::Continue(Value::unit()))
+                    }
+                    EvalControlFlow::Return(_) => Ok(control_flow),
+                }
+            }
+            StmtKind::Item(_) => {
+                // Do nothing and return a continue unit value.
+                Ok(EvalControlFlow::Continue(Value::unit()))
+            }
         }
+    }
+
+    fn update_hybrid_bindings(
+        &mut self,
+        lhs_expr_id: ExprId,
+        rhs_value: Value,
+    ) -> Result<(), Error> {
+        let lhs_expr = self.get_expr(lhs_expr_id);
+        match (&lhs_expr.kind, rhs_value) {
+            (ExprKind::Hole, _) => {}
+            (ExprKind::Var(Res::Local(local_var_id), _), value) => {
+                self.update_hybrid_local(lhs_expr, *local_var_id, value)?;
+            }
+            (ExprKind::Tuple(exprs), Value::Tuple(values)) => {
+                for (expr_id, value) in exprs.iter().zip(values.iter()) {
+                    self.update_hybrid_bindings(*expr_id, value.clone())?;
+                }
+            }
+            _ => unreachable!("unassignable pattern should be disallowed by compiler"),
+        };
+        Ok(())
+    }
+
+    fn update_hybrid_local(
+        &mut self,
+        local_expr: &Expr,
+        local_var_id: LocalVarId,
+        value: Value,
+    ) -> Result<(), Error> {
+        let bound_value = self
+            .eval_context
+            .get_current_scope()
+            .get_hybrid_local_value(local_var_id);
+        if let Value::Var(var) = bound_value {
+            // Insert a store instruction when the value of a variable is updated.
+            let rhs_operand = map_eval_value_to_rir_operand(&value);
+            let rir_var = map_eval_var_to_rir_var(*var);
+            let store_ins = Instruction::Store(rhs_operand, rir_var);
+            self.get_current_rir_block_mut().0.push(store_ins);
+        } else {
+            // Verify that we are not updating a value that does not have a backing variable from a dynamic branch
+            // because it is unsupported.
+            if self
+                .eval_context
+                .get_current_scope()
+                .is_currently_evaluating_branch()
+            {
+                let msg = format!(
+                    "re-assignment within a dynamic branch is unsupported for type {}",
+                    local_expr.ty
+                );
+                let error = Error::Unexpected(msg, local_expr.span);
+                return Err(error);
+            }
+            self.eval_context
+                .get_current_scope_mut()
+                .update_hybrid_local_value(local_var_id, value);
+        }
+        Ok(())
+    }
+
+    fn update_hybrid_bindings_from_classical_bindings(
+        &mut self,
+        lhs_expr_id: ExprId,
+    ) -> Result<(), Error> {
+        let lhs_expr = &self.get_expr(lhs_expr_id);
+        match &lhs_expr.kind {
+            ExprKind::Hole => {
+                // Nothing to bind to.
+            }
+            ExprKind::Var(Res::Local(local_var_id), _) => {
+                let classical_value = self
+                    .eval_context
+                    .get_current_scope()
+                    .get_classical_local_value(*local_var_id)
+                    .clone();
+                self.update_hybrid_local(lhs_expr, *local_var_id, classical_value)?;
+            }
+            ExprKind::Tuple(exprs) => {
+                for expr_id in exprs {
+                    self.update_hybrid_bindings_from_classical_bindings(*expr_id)?;
+                }
+            }
+            _ => unreachable!("unassignable pattern should be disallowed by compiler"),
+        };
+        Ok(())
     }
 
     fn generate_output_recording_instructions(
@@ -1170,18 +1548,15 @@ impl<'a> PartialEvaluator<'a> {
     }
 
     fn record_variable(&mut self, ty: &Ty, instrs: &mut Vec<Instruction>, var: Var) {
-        let (record_callable_id, record_ty) = match ty {
-            Ty::Prim(Prim::Bool) => (self.get_bool_record_callable(), rir::Ty::Boolean),
-            Ty::Prim(Prim::Int) => (self.get_int_record_callable(), rir::Ty::Integer),
+        let record_callable_id = match ty {
+            Ty::Prim(Prim::Bool) => self.get_bool_record_callable(),
+            Ty::Prim(Prim::Int) => self.get_int_record_callable(),
             _ => panic!("unsupported variable type in output recording"),
         };
         instrs.push(Instruction::Call(
             record_callable_id,
             vec![
-                Operand::Variable(rir::Variable {
-                    variable_id: var.0.into(),
-                    ty: record_ty,
-                }),
+                Operand::Variable(map_eval_var_to_rir_var(var)),
                 Operand::Literal(Literal::Pointer),
             ],
             None,
@@ -1368,7 +1743,23 @@ fn map_eval_value_to_rir_operand(value: &Value) -> Operand {
             )),
             val::Result::Val(bool) => Operand::Literal(Literal::Bool(*bool)),
         },
+        Value::Var(var) => Operand::Variable(map_eval_var_to_rir_var(*var)),
         _ => panic!("{value} cannot be mapped to a RIR operand"),
+    }
+}
+
+fn map_eval_var_to_rir_var(var: Var) -> rir::Variable {
+    rir::Variable {
+        variable_id: var.id.into(),
+        ty: map_eval_var_type_to_rir_type(var.ty),
+    }
+}
+
+fn map_eval_var_type_to_rir_type(var_ty: VarTy) -> rir::Ty {
+    match var_ty {
+        VarTy::Boolean => rir::Ty::Boolean,
+        VarTy::Integer => rir::Ty::Integer,
+        VarTy::Double => rir::Ty::Double,
     }
 }
 
@@ -1390,5 +1781,31 @@ fn map_fir_type_to_rir_type(ty: &Ty) -> rir::Ty {
         Prim::Int => rir::Ty::Integer,
         Prim::Qubit => rir::Ty::Qubit,
         Prim::Result => rir::Ty::Result,
+    }
+}
+
+fn map_rir_var_to_eval_var(var: rir::Variable) -> Var {
+    Var {
+        id: var.variable_id.into(),
+        ty: map_rir_type_to_eval_var_type(var.ty),
+    }
+}
+
+fn map_rir_type_to_eval_var_type(ty: rir::Ty) -> VarTy {
+    match ty {
+        rir::Ty::Boolean => VarTy::Boolean,
+        rir::Ty::Integer => VarTy::Integer,
+        rir::Ty::Double => VarTy::Double,
+        _ => panic!("cannot convert RIR type {ty} to evaluator varible type"),
+    }
+}
+
+fn try_get_eval_var_type(value: &Value) -> Option<VarTy> {
+    match value {
+        Value::Bool(_) => Some(VarTy::Boolean),
+        Value::Int(_) => Some(VarTy::Integer),
+        Value::Double(_) => Some(VarTy::Double),
+        Value::Var(var) => Some(var.ty),
+        _ => None,
     }
 }

--- a/compiler/qsc_partial_eval/tests/arrays.rs
+++ b/compiler/qsc_partial_eval/tests/arrays.rs
@@ -1,0 +1,492 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(
+    clippy::needless_raw_string_hashes,
+    clippy::similar_names,
+    clippy::too_many_lines
+)]
+
+pub mod test_utils;
+
+use expect_test::expect;
+use indoc::indoc;
+use qsc_rir::rir::{BlockId, CallableId};
+use test_utils::{assert_block_instructions, assert_callable, get_rir_program};
+
+#[test]
+fn array_with_dynamic_content() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1) = (Qubit(), Qubit());
+                [MResetZ(q0), MResetZ(q1)]
+            }
+        }
+    "#});
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(1), args( Qubit(1), Result(1), )
+            Call id(2), args( Integer(2), Pointer, )
+            Call id(3), args( Result(0), Pointer, )
+            Call id(3), args( Result(1), Pointer, )
+            Return"#]],
+    );
+}
+
+#[test]
+fn array_with_hybrid_content() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Bool[] {
+                use q = Qubit();
+                let r = MResetZ(q);
+                [true, r == One]
+            }
+        }
+    "#});
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let boolean_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        boolean_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(true)
+                Call id(3), args( Integer(2), Pointer, )
+                Call id(4), args( Bool(true), Pointer, )
+                Call id(4), args( Variable(1, Boolean), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn array_repeat_with_dynamic_content() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use q = Qubit();
+                [MResetZ(q), size = 2]
+            }
+        }
+    "#});
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+        Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(2), args( Integer(2), Pointer, )
+            Call id(3), args( Result(0), Pointer, )
+            Call id(3), args( Result(0), Pointer, )
+            Return"#]],
+    );
+}
+
+#[test]
+fn array_of_results_replace_element_at_index_with_dynamic_content() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1) = (Qubit(), Qubit());
+                mutable arr = [MResetZ(q0), Zero];
+                set arr w/= 1 <- MResetZ(q1);
+                arr
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(2), args( Integer(2), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(1), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn array_of_bools_replace_element_at_index_with_dynamic_content() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Bool[] {
+                use (q0, q1) = (Qubit(), Qubit());
+                mutable arr = [MResetZ(q0) == Zero, true];
+                set arr w/= 1 <- MResetZ(q1) == One;
+                arr
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let readout_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let bool_output_recording_callable_id = CallableId(4);
+    assert_callable(
+        &program,
+        bool_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__bool_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Boolean
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                Call id(1), args( Qubit(1), Result(1), )
+                Variable(2, Boolean) = Call id(2), args( Result(1), )
+                Variable(3, Boolean) = Icmp Eq, Variable(2, Boolean), Bool(true)
+                Call id(3), args( Integer(2), Pointer, )
+                Call id(4), args( Variable(1, Boolean), Pointer, )
+                Call id(4), args( Variable(3, Boolean), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn array_of_results_in_place_concatenation() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1) = (Qubit(), Qubit());
+                mutable results = [MResetZ(q0)];
+                set results += [MResetZ(q1)];
+                results
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(2), args( Integer(2), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(1), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_at_index_in_array() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result {
+                use (q0, q1) = (Qubit(), Qubit());
+                let results = [MResetZ(q0), MResetZ(q1)];
+                results[1]
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(2), args( Result(1), Pointer, )
+                Return"#]],
+    );
+}

--- a/compiler/qsc_partial_eval/tests/assigns.rs
+++ b/compiler/qsc_partial_eval/tests/assigns.rs
@@ -1,0 +1,493 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(
+    clippy::needless_raw_string_hashes,
+    clippy::similar_names,
+    clippy::too_many_lines
+)]
+
+pub mod test_utils;
+
+use expect_test::expect;
+use indoc::indoc;
+use qsc_rir::rir::{BlockId, CallableId};
+use test_utils::{
+    assert_block_instructions, assert_blocks, assert_callable, assert_error,
+    get_partial_evaluation_error, get_rir_program,
+};
+
+#[test]
+fn assigning_result_literal_updates_value() {
+    // This test verifies that the result value is updated using the fact that a program that returns a result literal
+    // value will raise an error in partial evaluation.
+    let error = get_partial_evaluation_error(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result {
+                use q = Qubit();
+                mutable r = MResetZ(q);
+                set r = One;
+                r
+            }
+        }
+    "#});
+    assert_error(
+        &error,
+        &expect!["OutputResultLiteral(Span { lo: 50, hi: 54 })"],
+    );
+}
+
+#[test]
+fn assigning_result_register_updates_value() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result {
+                use q = Qubit();
+                mutable r = Zero;
+                set r = MResetZ(q);
+                r
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(2), args( Result(0), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn assigning_classical_bool_updates_value_and_adds_store_instructions() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Bool {
+                use q = Qubit(); // Needed to make `Main` hybrid.
+                mutable b = true;
+                set b = false;
+                b
+            }
+        }
+    "#});
+    let output_recording_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__bool_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Boolean
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Variable(0, Boolean) = Store Bool(true)
+                Variable(0, Boolean) = Store Bool(false)
+                Call id(1), args( Bool(false), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn assigning_dynamic_bool_updates_value_and_adds_store_instructions() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Bool {
+                use q = Qubit();
+                mutable b = false;
+                set b = MResetZ(q) == One;
+                b
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let readout_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__bool_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Boolean
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Variable(0, Boolean) = Store Bool(false)
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(1, Boolean) = Call id(2), args( Result(0), )
+                Variable(2, Boolean) = Icmp Eq, Variable(1, Boolean), Bool(true)
+                Variable(0, Boolean) = Store Variable(2, Boolean)
+                Call id(3), args( Variable(0, Boolean), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn assigning_classical_int_updates_value_and_adds_store_instructions() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit(); // Needed to make `Main` hybrid.
+                mutable i = 0;
+                set i = 1;
+                i
+            }
+        }
+    "#});
+    let output_recording_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__integer_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Variable(0, Integer) = Store Integer(0)
+                Variable(0, Integer) = Store Integer(1)
+                Call id(1), args( Integer(1), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn assigning_dynamic_int_updates_value_and_adds_store_instructions() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                mutable i = 0;
+                set i = MResetZ(q) == One ? 1 | 2;
+                i
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let readout_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__integer_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Variable(0, Integer) = Store Integer(0)
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(1, Boolean) = Call id(2), args( Result(0), )
+                Variable(2, Boolean) = Icmp Eq, Variable(1, Boolean), Bool(true)
+                Branch Variable(2, Boolean), 2, 3
+            Block 1:Block:
+                Variable(0, Integer) = Store Variable(3, Integer)
+                Call id(3), args( Variable(0, Integer), Pointer, )
+                Return
+            Block 2:Block:
+                Variable(3, Integer) = Store Integer(1)
+                Jump(1)
+            Block 3:Block:
+                Variable(3, Integer) = Store Integer(2)
+                Jump(1)"#]],
+    );
+}
+
+#[test]
+fn assigning_classical_bool_within_dynamic_if_expression_adds_store_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Bool {
+                use q = Qubit();
+                mutable b = false;
+                if MResetZ(q) == One {
+                    set b = true;
+                }
+                b
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let readout_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__bool_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Boolean
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Variable(0, Boolean) = Store Bool(false)
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(1, Boolean) = Call id(2), args( Result(0), )
+                Variable(2, Boolean) = Icmp Eq, Variable(1, Boolean), Bool(true)
+                Branch Variable(2, Boolean), 2, 1
+            Block 1:Block:
+                Call id(3), args( Variable(0, Boolean), Pointer, )
+                Return
+            Block 2:Block:
+                Variable(0, Boolean) = Store Bool(true)
+                Jump(1)"#]],
+    );
+}
+
+#[test]
+fn assigning_classical_int_within_dynamic_if_else_expression_adds_store_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                mutable i = 0;
+                if MResetZ(q) == Zero {
+                    set i = 1;
+                } else {
+                    set i = 2;
+                }
+                i
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let readout_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__integer_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Variable(0, Integer) = Store Integer(0)
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(1, Boolean) = Call id(2), args( Result(0), )
+                Variable(2, Boolean) = Icmp Eq, Variable(1, Boolean), Bool(false)
+                Branch Variable(2, Boolean), 2, 3
+            Block 1:Block:
+                Call id(3), args( Variable(0, Integer), Pointer, )
+                Return
+            Block 2:Block:
+                Variable(0, Integer) = Store Integer(1)
+                Jump(1)
+            Block 3:Block:
+                Variable(0, Integer) = Store Integer(2)
+                Jump(1)"#]],
+    );
+}
+
+#[test]
+fn assigning_result_literal_within_dynamic_if_expression_produces_error() {
+    let error = get_partial_evaluation_error(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result {
+                use q = Qubit();
+                mutable r = Zero;
+                if MResetZ(q) == One {
+                    set r = One;
+                }
+                r
+            }
+        }
+    "#});
+    assert_error(
+        &error,
+        &expect![[
+            r#"Unexpected("re-assignment within a dynamic branch is unsupported for type Result", Span { lo: 166, hi: 167 })"#
+        ]],
+    );
+}

--- a/compiler/qsc_partial_eval/tests/bindings.rs
+++ b/compiler/qsc_partial_eval/tests/bindings.rs
@@ -1,0 +1,399 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(
+    clippy::needless_raw_string_hashes,
+    clippy::similar_names,
+    clippy::too_many_lines
+)]
+
+pub mod test_utils;
+
+use expect_test::expect;
+use indoc::indoc;
+use qsc_rir::rir::{BlockId, CallableId};
+use test_utils::{assert_block_instructions, assert_blocks, assert_callable, get_rir_program};
+
+#[test]
+fn immutable_result_binding_does_not_generate_store_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result {
+                use q = Qubit();
+                let r = MResetZ(q);
+                r
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(2), args( Result(0), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn mutable_result_binding_does_not_generate_store_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result {
+                use q = Qubit();
+                mutable r = MResetZ(q);
+                r
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(2), args( Result(0), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn immutable_bool_binding_does_not_generate_store_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Bool {
+                use q = Qubit();
+                let b = MResetZ(q) == One;
+                b
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let read_result_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__bool_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Boolean
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(true)
+                Call id(3), args( Variable(1, Boolean), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn mutable_bool_binding_generates_store_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Bool {
+                use q = Qubit();
+                mutable b = MResetZ(q) == One;
+                b
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let read_result_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__bool_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Boolean
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(true)
+                Variable(2, Boolean) = Store Variable(1, Boolean)
+                Call id(3), args( Variable(2, Boolean), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn immutable_int_binding_does_not_generate_store_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                let i = MResetZ(q) == One ? 0 | 1;
+                i
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let read_result_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__integer_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(true)
+                Branch Variable(1, Boolean), 2, 3
+            Block 1:Block:
+                Call id(3), args( Variable(2, Integer), Pointer, )
+                Return
+            Block 2:Block:
+                Variable(2, Integer) = Store Integer(0)
+                Jump(1)
+            Block 3:Block:
+                Variable(2, Integer) = Store Integer(1)
+                Jump(1)"#]],
+    );
+}
+
+#[test]
+fn mutable_int_binding_does_not_generate_store_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                mutable i = MResetZ(q) == One ? 0 | 1;
+                i
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let read_result_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__integer_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(true)
+                Branch Variable(1, Boolean), 2, 3
+            Block 1:Block:
+                Variable(3, Integer) = Store Variable(2, Integer)
+                Call id(3), args( Variable(3, Integer), Pointer, )
+                Return
+            Block 2:Block:
+                Variable(2, Integer) = Store Integer(0)
+                Jump(1)
+            Block 3:Block:
+                Variable(2, Integer) = Store Integer(1)
+                Jump(1)"#]],
+    );
+}

--- a/compiler/qsc_partial_eval/tests/bindings.rs
+++ b/compiler/qsc_partial_eval/tests/bindings.rs
@@ -324,7 +324,7 @@ fn immutable_int_binding_does_not_generate_store_instruction() {
 }
 
 #[test]
-fn mutable_int_binding_does_not_generate_store_instruction() {
+fn mutable_int_binding_does_generate_store_instruction() {
     let program = get_rir_program(indoc! {r#"
         namespace Test {
             @EntryPoint()

--- a/compiler/qsc_partial_eval/tests/classical_args.rs
+++ b/compiler/qsc_partial_eval/tests/classical_args.rs
@@ -121,7 +121,9 @@ fn calls_to_intrinsic_operation_using_variables() {
         &expect![[r#"
             Block:
                 Call id(1), args( Double(2), )
+                Variable(0, Double) = Store Double(4)
                 Call id(1), args( Double(4), )
+                Variable(0, Double) = Store Double(8)
                 Call id(1), args( Double(8), )
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],

--- a/compiler/qsc_partial_eval/tests/loops.rs
+++ b/compiler/qsc_partial_eval/tests/loops.rs
@@ -45,9 +45,13 @@ fn unitary_call_within_a_for_loop() {
         BlockId(0),
         &expect![[r#"
             Block:
+                Variable(0, Integer) = Store Integer(1)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(2)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(3)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(4)
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],
     );
@@ -90,9 +94,13 @@ fn unitary_call_within_a_while_loop() {
         BlockId(0),
         &expect![[r#"
             Block:
+                Variable(0, Integer) = Store Integer(0)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(1)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(2)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(3)
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],
     );
@@ -135,9 +143,17 @@ fn unitary_call_within_a_repeat_until_loop() {
         BlockId(0),
         &expect![[r#"
             Block:
+                Variable(0, Integer) = Store Integer(0)
+                Variable(1, Boolean) = Store Bool(true)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(1)
+                Variable(1, Boolean) = Store Bool(true)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(2)
+                Variable(1, Boolean) = Store Bool(true)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(3)
+                Variable(1, Boolean) = Store Bool(false)
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],
     );
@@ -179,9 +195,13 @@ fn rotation_call_within_a_for_loop() {
         BlockId(0),
         &expect![[r#"
             Block:
+                Variable(0, Integer) = Store Integer(0)
                 Call id(1), args( Double(0), Qubit(0), )
+                Variable(0, Integer) = Store Integer(1)
                 Call id(1), args( Double(1), Qubit(0), )
+                Variable(0, Integer) = Store Integer(2)
                 Call id(1), args( Double(2), Qubit(0), )
+                Variable(0, Integer) = Store Integer(3)
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],
     );
@@ -226,9 +246,13 @@ fn rotation_call_within_a_while_loop() {
         BlockId(0),
         &expect![[r#"
             Block:
+                Variable(0, Integer) = Store Integer(0)
                 Call id(1), args( Double(0), Qubit(0), )
+                Variable(0, Integer) = Store Integer(1)
                 Call id(1), args( Double(1), Qubit(0), )
+                Variable(0, Integer) = Store Integer(2)
                 Call id(1), args( Double(2), Qubit(0), )
+                Variable(0, Integer) = Store Integer(3)
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],
     );
@@ -273,9 +297,17 @@ fn rotation_call_within_a_repeat_until_loop() {
         BlockId(0),
         &expect![[r#"
             Block:
+                Variable(0, Integer) = Store Integer(0)
+                Variable(1, Boolean) = Store Bool(true)
                 Call id(1), args( Double(0), Qubit(0), )
+                Variable(0, Integer) = Store Integer(1)
+                Variable(1, Boolean) = Store Bool(true)
                 Call id(1), args( Double(1), Qubit(0), )
+                Variable(0, Integer) = Store Integer(2)
+                Variable(1, Boolean) = Store Bool(true)
                 Call id(1), args( Double(2), Qubit(0), )
+                Variable(0, Integer) = Store Integer(3)
+                Variable(1, Boolean) = Store Bool(false)
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],
     );

--- a/compiler/qsc_partial_eval/tests/misc.rs
+++ b/compiler/qsc_partial_eval/tests/misc.rs
@@ -47,9 +47,16 @@ fn unitary_call_within_an_if_with_classical_condition_within_a_for_loop() {
         BlockId(0),
         &expect![[r#"
             Block:
+                Variable(0, Integer) = Store Integer(0)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(1)
+                Variable(0, Integer) = Store Integer(2)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(3)
+                Variable(0, Integer) = Store Integer(4)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(5)
+                Variable(0, Integer) = Store Integer(6)
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],
     );
@@ -94,9 +101,16 @@ fn unitary_call_within_an_if_with_classical_condition_within_a_while_loop() {
         BlockId(0),
         &expect![[r#"
             Block:
+                Variable(0, Integer) = Store Integer(0)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(1)
+                Variable(0, Integer) = Store Integer(2)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(3)
+                Variable(0, Integer) = Store Integer(4)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(5)
+                Variable(0, Integer) = Store Integer(6)
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],
     );
@@ -141,9 +155,23 @@ fn unitary_call_within_an_if_with_classical_condition_within_a_repeat_until_loop
         BlockId(0),
         &expect![[r#"
             Block:
+                Variable(0, Integer) = Store Integer(0)
+                Variable(1, Boolean) = Store Bool(true)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(1)
+                Variable(1, Boolean) = Store Bool(true)
+                Variable(0, Integer) = Store Integer(2)
+                Variable(1, Boolean) = Store Bool(true)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(3)
+                Variable(1, Boolean) = Store Bool(true)
+                Variable(0, Integer) = Store Integer(4)
+                Variable(1, Boolean) = Store Bool(true)
                 Call id(1), args( Qubit(0), )
+                Variable(0, Integer) = Store Integer(5)
+                Variable(1, Boolean) = Store Bool(true)
+                Variable(0, Integer) = Store Integer(6)
+                Variable(1, Boolean) = Store Bool(false)
                 Call id(2), args( Integer(0), Pointer, )
                 Return"#]],
     );

--- a/compiler/qsc_partial_eval/tests/qubits.rs
+++ b/compiler/qsc_partial_eval/tests/qubits.rs
@@ -248,3 +248,69 @@ fn qubit_ids_are_correct_for_allocate_use_release_multiple_qubits_interleaved() 
     assert_eq!(program.num_qubits, 4);
     assert_eq!(program.num_results, 0);
 }
+
+#[test]
+fn qubit_array_allocation_and_access() {
+    let program = get_rir_program(indoc! {
+        r#"
+        namespace Test {
+            operation Op(q : Qubit) : Unit { body intrinsic; }
+            @EntryPoint()
+            operation Main() : Unit {
+                use qs = Qubit[3];
+                Op(qs[0]);
+                Op(qs[1]);
+                Op(qs[2]);
+            }
+        }
+        "#,
+    });
+    let op_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        op_callable_id,
+        &expect![[r#"
+            Callable:
+                name: Op
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let tuple_record_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        tuple_record_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__rt__tuple_record_output
+            call_type: OutputRecording
+            input_type:
+                [0]: Integer
+                [1]: Pointer
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Variable(0, Integer) = Store Integer(0)
+                Variable(0, Integer) = Store Integer(1)
+                Variable(0, Integer) = Store Integer(2)
+                Variable(0, Integer) = Store Integer(3)
+                Call id(1), args( Qubit(0), )
+                Call id(1), args( Qubit(1), )
+                Call id(1), args( Qubit(2), )
+                Variable(1, Integer) = Store Integer(0)
+                Variable(1, Integer) = Store Integer(1)
+                Variable(1, Integer) = Store Integer(2)
+                Variable(1, Integer) = Store Integer(3)
+                Call id(2), args( Integer(0), Pointer, )
+                Return"#]],
+    );
+    assert_eq!(program.num_qubits, 3);
+    assert_eq!(program.num_results, 0);
+}

--- a/compiler/qsc_partial_eval/tests/returns.rs
+++ b/compiler/qsc_partial_eval/tests/returns.rs
@@ -631,7 +631,7 @@ fn default_qubit_management_releases_qubits_when_they_are_out_of_scope_with_impl
     let program = get_rir_program(indoc! {
         r#"
         namespace Test {
-            operation AllocateAndApply() : Unit { 
+            operation AllocateAndApply() : Unit {
                 use q = Qubit();
                 OpB(q);
             }
@@ -694,7 +694,7 @@ fn default_qubit_management_releases_qubits_when_they_are_out_of_scope_with_expl
     let program = get_rir_program(indoc! {
         r#"
         namespace Test {
-            operation AllocateAndApply() : Unit { 
+            operation AllocateAndApply() : Unit {
                 use q = Qubit();
                 OpB(q);
                 return ();
@@ -759,7 +759,7 @@ fn default_qubit_management_releases_qubits_when_they_are_out_of_scope_with_expl
     let program = get_rir_program(indoc! {
         r#"
         namespace Test {
-            operation AllocateAndApply() : Unit { 
+            operation AllocateAndApply() : Unit {
                 use q = Qubit();
                 OpB(q);
                 return ();
@@ -1083,7 +1083,7 @@ fn explicit_return_embedded_in_hybrid_update_index_expr_yields_error() {
         @EntryPoint()
         operation Main() : Bool {
             use q = Qubit();
-            mutable a = [MResetZ(q)];
+            mutable a = [true];
             set a w/= 0 <- return false;
             true
         }
@@ -1092,7 +1092,26 @@ fn explicit_return_embedded_in_hybrid_update_index_expr_yields_error() {
     assert_error(
         &error,
         &expect![[
-            r#"Unexpected("embedded return in assign index expression", Span { lo: 148, hi: 160 })"#
+            r#"Unexpected("embedded return in assign index expression", Span { lo: 142, hi: 154 })"#
         ]],
+    );
+}
+
+#[test]
+fn explicit_return_embedded_in_hybrid_array_assignop_expr_yields_error() {
+    let error = get_partial_evaluation_error(indoc! {r#"
+    namespace Test {
+        @EntryPoint()
+        operation Main() : Bool {
+            use q = Qubit();
+            mutable a = [true];
+            set a += return false;
+            true
+        }
+    }
+    "#});
+    assert_error(
+        &error,
+        &expect![[r#"Unexpected("embedded return in RHS expression", Span { lo: 136, hi: 148 })"#]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/returns.rs
+++ b/compiler/qsc_partial_eval/tests/returns.rs
@@ -849,10 +849,9 @@ fn explicit_return_embedded_in_array_repeat_expr_yields_error() {
         }
     }
     "#});
-    // The type of error will change once this kind of hybrid expression is supported.
     assert_error(
         &error,
-        &expect![[r#"Unimplemented("Array Repeat", Span { lo: 147, hi: 174 })"#]],
+        &expect![[r#"Unexpected("embedded return in array", Span { lo: 161, hi: 173 })"#]],
     );
 }
 
@@ -869,10 +868,11 @@ fn explicit_return_embedded_in_assign_expr_yields_error() {
         }
     }
     "#});
-    // The type of error will change once this kind of hybrid expression is supported.
     assert_error(
         &error,
-        &expect![[r#"Unimplemented("Assignment Expr", Span { lo: 165, hi: 185 })"#]],
+        &expect![[
+            r#"Unexpected("embedded return in assign expression", Span { lo: 173, hi: 185 })"#
+        ]],
     );
 }
 
@@ -933,7 +933,7 @@ fn explicit_return_embedded_in_assign_op_expr_yields_error() {
     // The type of error will change once this kind of hybrid expression is supported.
     assert_error(
         &error,
-        &expect![[r#"Unimplemented("Assignment Op Expr", Span { lo: 162, hi: 183 })"#]],
+        &expect![[r#"Unimplemented("int binary operation", Span { lo: 166, hi: 167 })"#]],
     );
 }
 
@@ -1010,10 +1010,11 @@ fn explicit_return_embedded_in_index_expr_yields_error() {
         }
     }
     "#});
-    // The type of error will change once this kind of hybrid expression is supported.
     assert_error(
         &error,
-        &expect![[r#"Unimplemented("Index Expr", Span { lo: 168, hi: 195 })"#]],
+        &expect![[
+            r#"Unexpected("embedded return in index expression", Span { lo: 170, hi: 194 })"#
+        ]],
     );
 }
 
@@ -1076,21 +1077,22 @@ fn explicit_return_embedded_in_update_field_expr_yields_error() {
 }
 
 #[test]
-fn explicit_return_embedded_in_update_index_expr_yields_error() {
+fn explicit_return_embedded_in_hybrid_update_index_expr_yields_error() {
     let error = get_partial_evaluation_error(indoc! {r#"
     namespace Test {
         @EntryPoint()
         operation Main() : Bool {
-            use q = Qubit(); // Needed to make `Main` non-classical.
-            mutable a = [1];
+            use q = Qubit();
+            mutable a = [MResetZ(q)];
             set a w/= 0 <- return false;
             true
         }
     }
     "#});
-    // The type of error will change once this kind of hybrid expression is supported.
     assert_error(
         &error,
-        &expect![[r#"Unimplemented("Assignment Index Expr", Span { lo: 164, hi: 191 })"#]],
+        &expect![[
+            r#"Unexpected("embedded return in assign index expression", Span { lo: 148, hi: 160 })"#
+        ]],
     );
 }

--- a/compiler/qsc_partial_eval/tests/returns.rs
+++ b/compiler/qsc_partial_eval/tests/returns.rs
@@ -851,7 +851,7 @@ fn explicit_return_embedded_in_array_repeat_expr_yields_error() {
     "#});
     assert_error(
         &error,
-        &expect![[r#"Unexpected("embedded return in array", Span { lo: 161, hi: 173 })"#]],
+        &expect![[r#"Unexpected("embedded return in array size", Span { lo: 161, hi: 173 })"#]],
     );
 }
 


### PR DESCRIPTION
This change adds support in partial evaluation for the following expressions:
- Assignment.
- Array repeat.
- Array in-place concatenation.
- Array in-place update of value at index.
- Array access to value at index.