### PR TITLE
Add `CodeGenIntrinsic` attribute for simulator overrides

### DIFF
--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -996,6 +996,21 @@ impl State {
                 );
                 Ok(())
             }
+            CallableImpl::CodeGenIntrinsic(spec_decl) => {
+                self.push_frame(spec_decl.exec_graph.clone(), callee_id, functor);
+                self.push_scope(env);
+
+                self.bind_args_for_spec(
+                    env,
+                    globals,
+                    callee.input,
+                    spec_decl.input,
+                    arg,
+                    functor.controlled,
+                    fixed_args,
+                );
+                Ok(())
+            }
         }
     }
 

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -455,6 +455,8 @@ pub trait PackageStoreLookup {
     fn get_pat(&self, id: StorePatId) -> &Pat;
     /// Gets a statement.
     fn get_stmt(&self, id: StoreStmtId) -> &Stmt;
+    /// Gets an item.
+    fn get_item(&self, id: StoreItemId) -> &Item;
 }
 
 /// A FIR package store.
@@ -480,6 +482,10 @@ impl PackageStoreLookup for PackageStore {
 
     fn get_stmt(&self, id: StoreStmtId) -> &Stmt {
         self.get(id.package).get_stmt(id.stmt)
+    }
+
+    fn get_item(&self, id: StoreItemId) -> &Item {
+        self.get(id.package).get_item(id.item)
     }
 }
 
@@ -797,6 +803,8 @@ pub enum CallableImpl {
     Intrinsic,
     /// A specialized callable implementation.
     Spec(SpecImpl),
+    /// An intrinsic with a simulation override.
+    CodeGenIntrinsic(SpecDecl),
 }
 
 impl Display for CallableImpl {
@@ -810,6 +818,11 @@ impl Display for CallableImpl {
                 write!(indent, "Spec:")?;
                 indent = set_indentation(indent, 1);
                 write!(indent, "\n{spec_impl}")?;
+            }
+            CallableImpl::CodeGenIntrinsic(spec_decl) => {
+                write!(indent, "CodeGenIntrinsic:")?;
+                indent = set_indentation(indent, 1);
+                write!(indent, "\n{spec_decl}")?;
             }
         }
 

--- a/compiler/qsc_fir/src/mut_visit.rs
+++ b/compiler/qsc_fir/src/mut_visit.rs
@@ -79,6 +79,9 @@ pub fn walk_callable_impl<'a>(vis: &mut impl MutVisitor<'a>, callable_impl: &'a 
         CallableImpl::Spec(spec_impl) => {
             vis.visit_spec_impl(spec_impl);
         }
+        CallableImpl::CodeGenIntrinsic(spec_decl) => {
+            vis.visit_spec_decl(spec_decl);
+        }
     }
 }
 

--- a/compiler/qsc_fir/src/visit.rs
+++ b/compiler/qsc_fir/src/visit.rs
@@ -79,6 +79,9 @@ pub fn walk_callable_impl<'a>(vis: &mut impl Visitor<'a>, callable_impl: &'a Cal
         CallableImpl::Spec(spec_impl) => {
             vis.visit_spec_impl(spec_impl);
         }
+        CallableImpl::CodeGenIntrinsic(spec_decl) => {
+            vis.visit_spec_decl(spec_decl);
+        }
     };
 }
 

--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -237,6 +237,15 @@ impl With<'_> {
                 }
                 None
             }
+            Ok(hir::Attr::CodeGenIntrinsic) => match &*attr.arg.kind {
+                ast::ExprKind::Tuple(args) if args.is_empty() => Some(hir::Attr::CodeGenIntrinsic),
+                _ => {
+                    self.lowerer
+                        .errors
+                        .push(Error::InvalidAttrArgs("()".to_string(), attr.arg.span));
+                    None
+                }
+            },
             Err(()) => {
                 self.lowerer.errors.push(Error::UnknownAttr(
                     attr.name.name.to_string(),

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -1161,6 +1161,9 @@ pub enum Attr {
     EntryPoint,
     /// Indicates that an item does not have an implementation available for use.
     Unimplemented,
+    /// Indicates that an item should be treated as an intrinsic callable for QIR code generation
+    /// and any implementation should be ignored.
+    CodeGenIntrinsic,
 }
 
 impl FromStr for Attr {
@@ -1171,6 +1174,7 @@ impl FromStr for Attr {
             "Config" => Ok(Self::Config),
             "EntryPoint" => Ok(Self::EntryPoint),
             "Unimplemented" => Ok(Self::Unimplemented),
+            "CodeGenIntrinsic" => Ok(Self::CodeGenIntrinsic),
             _ => Err(()),
         }
     }

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -736,7 +736,7 @@ impl<'a> PartialEvaluator<'a> {
         // We generate instructions differently depending on whether we are calling an intrinsic or a specialization
         // with an implementation.
         let value = match &callable_decl.implementation {
-            CallableImpl::Intrinsic => {
+            CallableImpl::Intrinsic | CallableImpl::CodeGenIntrinsic(_) => {
                 let callee_expr = self.get_expr(callee_expr_id);
                 self.eval_expr_call_to_intrinsic(
                     store_item_id,

--- a/compiler/qsc_partial_eval/tests/intrinsics.rs
+++ b/compiler/qsc_partial_eval/tests/intrinsics.rs
@@ -1031,3 +1031,35 @@ fn call_to_length_in_inner_function_succeeds() {
                 Return"#]],
     );
 }
+
+#[test]
+fn call_to_operation_with_codegen_intrinsic_override_should_skip_impl() {
+    let program = get_rir_program(indoc! {"
+        namespace Test {
+            operation Op1() : Unit {
+                body intrinsic;
+            }
+            @CodeGenIntrinsic()
+            operation Op2() : Unit {
+                Op1();
+            }
+            operation Op3() : Unit {
+                Op1();
+            }
+            @EntryPoint()
+            operation Main() : Unit {
+                Op1();
+                Op2();
+                Op3();
+            }
+        }
+    "});
+
+    assert_block_instructions(&program, BlockId(0), &expect![[r#"
+        Block:
+            Call id(1), args( )
+            Call id(2), args( )
+            Call id(1), args( )
+            Call id(3), args( Integer(0), Pointer, )
+            Return"#]]);
+}

--- a/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/compiler/qsc_passes/src/capabilitiesck.rs
@@ -275,7 +275,9 @@ impl<'a> Visitor<'a> for Checker<'a> {
 
     fn visit_callable_impl(&mut self, callable_impl: &'a CallableImpl) {
         match callable_impl {
-            CallableImpl::Intrinsic => self.check_spec_decl(FunctorSetValue::Empty, None),
+            CallableImpl::Intrinsic | CallableImpl::CodeGenIntrinsic(_) => {
+                self.check_spec_decl(FunctorSetValue::Empty, None);
+            }
             CallableImpl::Spec(spec_impl) => {
                 self.check_spec_decl(FunctorSetValue::Empty, Some(&spec_impl.body));
                 spec_impl.adj.iter().for_each(|spec_decl| {

--- a/compiler/qsc_passes/src/spec_gen.rs
+++ b/compiler/qsc_passes/src/spec_gen.rs
@@ -16,10 +16,10 @@ use qsc_hir::{
     assigner::Assigner,
     global::Table,
     hir::{
-        Block, CallableDecl, CallableKind, Functor, Ident, NodeId, Package, Pat, PatKind, Res,
-        SpecBody, SpecDecl, SpecGen,
+        Attr, Block, CallableDecl, CallableKind, Functor, Ident, Item, NodeId, Package, Pat,
+        PatKind, Res, SpecBody, SpecDecl, SpecGen,
     },
-    mut_visit::MutVisitor,
+    mut_visit::{walk_item, MutVisitor},
     ty::{Prim, Ty},
 };
 use std::option::Option;
@@ -62,6 +62,11 @@ pub enum Error {
     #[error("specialization generation missing required body implementation")]
     #[diagnostic(code("Qsc.SpecGen.MissingBody"))]
     MissingBody(#[label] Span),
+
+    #[error("specialization generation is not supported for callables with the attribute `CodeGenIntrinsic`")]
+    #[diagnostic(code("Qsc.SpecGen.CodeGenIntrinsic"))]
+    #[diagnostic(help("try removing the specializations for this callable and providing them via a separate wrapper operation"))]
+    CodeGenIntrinsic(#[label] Span),
 }
 
 /// Generates specializations for the given compile unit, updating it in-place.
@@ -144,6 +149,7 @@ fn generate_spec_impls(core: &Table, package: &mut Package, assigner: &mut Assig
         core,
         assigner,
         errors: Vec::new(),
+        is_codegen_intrinsic: false,
     };
     pass.visit_package(package);
     pass.errors
@@ -153,6 +159,7 @@ struct SpecImplPass<'a> {
     core: &'a Table,
     assigner: &'a mut Assigner,
     errors: Vec<Error>,
+    is_codegen_intrinsic: bool,
 }
 
 impl<'a> SpecImplPass<'a> {
@@ -208,6 +215,12 @@ impl<'a> SpecImplPass<'a> {
 }
 
 impl<'a> MutVisitor for SpecImplPass<'a> {
+    fn visit_item(&mut self, item: &mut Item) {
+        self.is_codegen_intrinsic = item.attrs.contains(&Attr::CodeGenIntrinsic);
+        walk_item(self, item);
+        self.is_codegen_intrinsic = false;
+    }
+
     fn visit_callable_decl(&mut self, decl: &mut CallableDecl) {
         let body = &decl.body;
 
@@ -227,15 +240,18 @@ impl<'a> MutVisitor for SpecImplPass<'a> {
         let adj = &mut decl.adj;
         let ctl = &mut decl.ctl;
         let ctl_adj = &mut decl.ctl_adj;
+        let has_specializations = adj.is_some() || ctl.is_some() || ctl_adj.is_some();
 
         let SpecBody::Impl(_, body_block) = &body.body else {
-            if body.body == SpecBody::Gen(SpecGen::Intrinsic)
-                && [adj, ctl, ctl_adj].into_iter().any(|x| Option::is_some(x))
-            {
+            if body.body == SpecBody::Gen(SpecGen::Intrinsic) && has_specializations {
                 self.errors.push(Error::MissingBody(body.span));
             }
             return;
         };
+        if self.is_codegen_intrinsic && has_specializations {
+            self.errors.push(Error::CodeGenIntrinsic(decl.span));
+            return;
+        }
 
         if let Some(ctl) = ctl.as_mut() {
             match ctl.body {

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -2124,3 +2124,100 @@ fn op_array_unsupported_functors_with_lambdas() {
         "#]],
     );
 }
+
+#[test]
+fn codegen_intrinsic_succeeds_with_no_specializations() {
+    check(
+        indoc! {r#"
+            namespace A {
+                @CodeGenIntrinsic()
+                operation Foo(q : Qubit) : Unit {
+                    Bar(q);
+                }
+                operation Bar(q : Qubit) : Unit { }
+            }
+        "#},
+        &expect![[r#"
+            Package:
+                Item 0 [0-139] (Public):
+                    Namespace (Ident 16 [10-11] "A"): Item 1, Item 2
+                Item 1 [18-97] (Public):
+                    Parent: 0
+                    CodeGenIntrinsic
+                    Callable 0 [42-97] (operation):
+                        name: Ident 1 [52-55] "Foo"
+                        input: Pat 2 [56-65] [Type Qubit]: Bind: Ident 3 [56-57] "q"
+                        output: Unit
+                        functors: empty set
+                        body: SpecDecl 4 [42-97]: Impl:
+                            Block 5 [74-97] [Type Unit]:
+                                Stmt 6 [84-91]: Semi: Expr 7 [84-90] [Type Unit]: Call:
+                                    Expr 8 [84-87] [Type (Qubit => Unit)]: Var: Item 2
+                                    Expr 9 [88-89] [Type Qubit]: Var: Local 3
+                        adj: <none>
+                        ctl: <none>
+                        ctl-adj: <none>
+                Item 2 [102-137] (Public):
+                    Parent: 0
+                    Callable 10 [102-137] (operation):
+                        name: Ident 11 [112-115] "Bar"
+                        input: Pat 12 [116-125] [Type Qubit]: Bind: Ident 13 [116-117] "q"
+                        output: Unit
+                        functors: empty set
+                        body: SpecDecl 14 [102-137]: Impl:
+                            Block 15 [134-137]: <empty>
+                        adj: <none>
+                        ctl: <none>
+                        ctl-adj: <none>"#]],
+    );
+}
+
+#[test]
+fn codegen_intrinsic_fails_with_adj_specialization() {
+    check(
+        indoc! {r#"
+            namespace A {
+                @CodeGenIntrinsic()
+                operation Foo(q : Qubit) : Unit is Adj {
+                    Bar(q);
+                }
+                operation Bar(q : Qubit) : Unit { }
+            }
+        "#},
+        &expect![[r#"
+            [
+                CodeGenIntrinsic(
+                    Span {
+                        lo: 42,
+                        hi: 104,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn codegen_intrinsic_fails_with_ctl_specialization() {
+    check(
+        indoc! {r#"
+            namespace A {
+                @CodeGenIntrinsic()
+                operation Foo(q : Qubit) : Unit is Ctl {
+                    Bar(q);
+                }
+                operation Bar(q : Qubit) : Unit { }
+            }
+        "#},
+        &expect![[r#"
+            [
+                CodeGenIntrinsic(
+                    Span {
+                        lo: 42,
+                        hi: 104,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}

--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -18,7 +18,7 @@ use qsc_fir::{
         StoreExprId, StoreItemId, StorePatId, StringComponent,
     },
     ty::{Arrow, FunctorSetValue, Prim, Ty},
-    visit::Visitor,
+    visit::{walk_stmt, Visitor},
 };
 
 pub struct Analyzer<'a> {
@@ -1093,7 +1093,9 @@ impl<'a> Analyzer<'a> {
 
         // Continue with the analysis differently depending on whether the callable is an intrinsic or not.
         match &callable_decl.implementation {
-            CallableImpl::Intrinsic => self.analyze_intrinsic_callable(),
+            CallableImpl::Intrinsic | CallableImpl::CodeGenIntrinsic(_) => {
+                self.analyze_intrinsic_callable();
+            }
             CallableImpl::Spec(spec_impl) => {
                 // Only analyze the specialization that corresponds to the provided ID. Otherwise, we can get into an
                 // infinite analysis loop.
@@ -1492,6 +1494,52 @@ impl<'a> Analyzer<'a> {
             _ => panic!("expected a local variable or a tuple"),
         }
     }
+
+    /// Sets the application generator set for all statements in a block (including nested statements)
+    /// to the default without analyzing them. This is done to prevent the statements from being
+    /// treated as top-level statements by later analysis assumptions.
+    fn set_all_stmts_in_block_to_default(&mut self, block_id: BlockId) {
+        struct StmtCollector<'a> {
+            package: &'a Package,
+            stmts: Vec<StmtId>,
+        }
+        impl<'a> StmtCollector<'a> {
+            fn new(package: &'a Package) -> Self {
+                Self {
+                    package,
+                    stmts: Vec::new(),
+                }
+            }
+        }
+        impl<'a> Visitor<'a> for StmtCollector<'a> {
+            fn get_block(&self, id: BlockId) -> &'a Block {
+                self.package.get_block(id)
+            }
+            fn get_expr(&self, id: ExprId) -> &'a Expr {
+                self.package.get_expr(id)
+            }
+            fn get_pat(&self, id: PatId) -> &'a Pat {
+                self.package.get_pat(id)
+            }
+            fn get_stmt(&self, id: StmtId) -> &'a Stmt {
+                self.package.get_stmt(id)
+            }
+            fn visit_stmt(&mut self, stmt_id: StmtId) {
+                self.stmts.push(stmt_id);
+                walk_stmt(self, stmt_id);
+            }
+        }
+
+        let current_package = self.package_store.get(self.get_current_package_id());
+        let mut stmt_collector = StmtCollector::new(current_package);
+        stmt_collector.visit_block(block_id);
+        for stmt_id in stmt_collector.stmts {
+            self.package_store_compute_properties.insert_stmt(
+                (self.get_current_package_id(), stmt_id).into(),
+                ApplicationGeneratorSet::default(),
+            );
+        }
+    }
 }
 
 impl<'a> Visitor<'a> for Analyzer<'a> {
@@ -1572,7 +1620,15 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
 
     fn visit_callable_impl(&mut self, callable_impl: &'a CallableImpl) {
         match callable_impl {
-            CallableImpl::Intrinsic => self.analyze_intrinsic_callable(),
+            CallableImpl::Intrinsic => {
+                self.analyze_intrinsic_callable();
+            }
+            CallableImpl::CodeGenIntrinsic(spec_decl) => {
+                // Treat this as an intrinsic callable.
+                self.analyze_intrinsic_callable();
+                // Additionally, mark all the statements so that they appear visited.
+                self.set_all_stmts_in_block_to_default(spec_decl.block);
+            }
             CallableImpl::Spec(spec_impl) => {
                 self.visit_spec_impl(spec_impl);
             }

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -301,6 +301,15 @@ pub struct ApplicationGeneratorSet {
     pub(crate) dynamic_param_applications: Vec<ParamApplication>,
 }
 
+impl Default for ApplicationGeneratorSet {
+    fn default() -> Self {
+        Self {
+            inherent: ComputeKind::Classical,
+            dynamic_param_applications: Vec::new(),
+        }
+    }
+}
+
 impl Display for ApplicationGeneratorSet {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let mut indent = set_indentation(indented(f), 0);

--- a/compiler/qsc_rca/tests/calls.rs
+++ b/compiler/qsc_rca/tests/calls.rs
@@ -256,3 +256,60 @@ fn check_rca_for_call_to_operation_with_one_classical_return_and_one_dynamic_ret
         ],
     );
 }
+
+#[test]
+fn check_rca_for_call_to_operation_with_codegen_intrinsic_override_treated_as_intrinsic() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        @CodeGenIntrinsic()
+        operation Foo() : Unit {
+            mutable a = 0;
+            use q = Qubit();
+            if M(q) == Zero {
+                set a = 1;
+            }
+            Message($"a = {a}");
+        }
+        Foo()"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(0x0)
+                    value_kind: Element(Static)
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_call_to_operation_with_codegen_intrinsic_override_treated_as_intrinsic_that_takes_qubit_arg(
+) {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        @CodeGenIntrinsic()
+        operation Foo(q : Qubit) : Unit {
+            mutable a = 0;
+            if M(q) == Zero {
+                set a = 1;
+            }
+            Message($"a = {a}");
+        }
+        use q = Qubit();
+        Foo(q)"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(0x0)
+                    value_kind: Element(Static)
+                dynamic_param_applications: <empty>"#]],
+    );
+}


### PR DESCRIPTION
Fixes #1483