### PR TITLE
Partial evaluation support for unary operator expressions

### DIFF
--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -26,7 +26,7 @@ use qsc_fir::{
         self, BinOp, Block, BlockId, CallableDecl, CallableImpl, ExecGraphNode, Expr, ExprId,
         ExprKind, Global, Ident, LocalVarId, Mutability, PackageId, PackageStore,
         PackageStoreLookup, Pat, PatId, PatKind, Res, SpecDecl, SpecImpl, Stmt, StmtId, StmtKind,
-        StoreBlockId, StoreExprId, StoreItemId, StorePatId, StoreStmtId,
+        StoreBlockId, StoreExprId, StoreItemId, StorePatId, StoreStmtId, UnOp,
     },
     ty::{Prim, Ty},
 };
@@ -474,7 +474,9 @@ impl<'a> PartialEvaluator<'a> {
                 panic!("instruction generation for string expressions is invalid")
             }
             ExprKind::Tuple(exprs) => self.eval_expr_tuple(exprs),
-            ExprKind::UnOp(_, _) => Err(Error::Unimplemented("Unary Expr".to_string(), expr.span)),
+            ExprKind::UnOp(un_op, value_expr_id) => {
+                self.eval_expr_unary(*un_op, *value_expr_id, expr.span)
+            }
             ExprKind::UpdateField(_, _, _) => Err(Error::Unimplemented(
                 "Updated Field Expr".to_string(),
                 expr.span,
@@ -1102,6 +1104,69 @@ impl<'a> PartialEvaluator<'a> {
             values.push(control_flow.into_value());
         }
         Ok(EvalControlFlow::Continue(Value::Tuple(values.into())))
+    }
+
+    fn eval_expr_unary(
+        &mut self,
+        un_op: UnOp,
+        value_expr_id: ExprId,
+        unary_expr_span: Span, // For diagnostic purposes only.
+    ) -> Result<EvalControlFlow, Error> {
+        let value_expr = self.get_expr(value_expr_id);
+        let value_control_flow = self.try_eval_expr(value_expr_id)?;
+        let EvalControlFlow::Continue(value) = value_control_flow else {
+            return Err(Error::Unexpected(
+                "embedded return in unary operation expression".to_string(),
+                value_expr.span,
+            ));
+        };
+
+        // Create a variable to store the result.
+        let variable_id = self.resource_manager.next_var();
+        let Some(eval_variable_type) = try_get_eval_var_type(&value) else {
+            return Err(Error::Unexpected(
+                format!("invalid type for unary operation value: {value}"),
+                value_expr.span,
+            ));
+        };
+        let rir_variable_type = map_eval_var_type_to_rir_type(eval_variable_type);
+        let rir_variable = rir::Variable {
+            variable_id,
+            ty: rir_variable_type,
+        };
+
+        // Generate the instruction depending on the unary operator.
+        let value_operand = map_eval_value_to_rir_operand(&value);
+        let instruction = match un_op {
+            UnOp::Pos => Instruction::Store(value_operand, rir_variable),
+            UnOp::Neg => {
+                let constant = match rir_variable_type {
+                    rir::Ty::Integer => Operand::Literal(Literal::Integer(-1)),
+                    rir::Ty::Double => Operand::Literal(Literal::Double(-1.0)),
+                    _ => panic!("invalid type for negation operator {rir_variable_type}"),
+                };
+                Instruction::Mul(constant, value_operand, rir_variable)
+            }
+            UnOp::NotB => {
+                assert!(matches!(rir_variable_type, rir::Ty::Integer));
+                Instruction::BitwiseNot(value_operand, rir_variable)
+            }
+            UnOp::NotL => {
+                assert!(matches!(rir_variable_type, rir::Ty::Boolean));
+                Instruction::LogicalNot(value_operand, rir_variable)
+            }
+            UnOp::Functor(_) | UnOp::Unwrap => {
+                return Err(Error::Unexpected(
+                    format!("invalid unary operator: {un_op}"),
+                    unary_expr_span,
+                ));
+            }
+        };
+
+        // Insert the instruction and return the corresponding evaluator variable.
+        self.get_current_rir_block_mut().0.push(instruction);
+        let eval_variable = map_rir_var_to_eval_var(rir_variable);
+        Ok(EvalControlFlow::Continue(Value::Var(eval_variable)))
     }
 
     fn eval_expr_var(&mut self, res: &Res) -> Value {

--- a/compiler/qsc_partial_eval/tests/operators.rs
+++ b/compiler/qsc_partial_eval/tests/operators.rs
@@ -1,0 +1,302 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(clippy::needless_raw_string_hashes)]
+
+pub mod test_utils;
+
+use expect_test::expect;
+use indoc::indoc;
+use qsc_rir::rir::{BlockId, CallableId};
+use test_utils::{assert_block_instructions, assert_blocks, assert_callable, get_rir_program};
+
+#[test]
+fn leading_positive_unary_operator_does_not_generate_rir_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                let i = MResetZ(q) == Zero ? 0 | 1;
+                +i
+            }
+        }
+    "#});
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let readout_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__integer_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                Branch Variable(1, Boolean), 2, 3
+            Block 1:Block:
+                Call id(3), args( Variable(2, Integer), Pointer, )
+                Return
+            Block 2:Block:
+                Variable(2, Integer) = Store Integer(0)
+                Jump(1)
+            Block 3:Block:
+                Variable(2, Integer) = Store Integer(1)
+                Jump(1)"#]],
+    );
+}
+
+#[test]
+fn leading_negative_unary_operator_generates_rir_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                let i = MResetZ(q) == Zero ? 0 | 1;
+                -i
+            }
+        }
+    "#});
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let readout_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__integer_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                Branch Variable(1, Boolean), 2, 3
+            Block 1:Block:
+                Variable(3, Integer) = Mul Integer(-1), Variable(2, Integer)
+                Call id(3), args( Variable(3, Integer), Pointer, )
+                Return
+            Block 2:Block:
+                Variable(2, Integer) = Store Integer(0)
+                Jump(1)
+            Block 3:Block:
+                Variable(2, Integer) = Store Integer(1)
+                Jump(1)"#]],
+    );
+}
+
+#[test]
+fn bitwise_not_unary_operator_generates_rir_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                let i = MResetZ(q) == Zero ? 0 | 1;
+                ~~~i
+            }
+        }
+    "#});
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let readout_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__integer_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                Branch Variable(1, Boolean), 2, 3
+            Block 1:Block:
+                Variable(3, Integer) = BitwiseNot Variable(2, Integer)
+                Call id(3), args( Variable(3, Integer), Pointer, )
+                Return
+            Block 2:Block:
+                Variable(2, Integer) = Store Integer(0)
+                Jump(1)
+            Block 3:Block:
+                Variable(2, Integer) = Store Integer(1)
+                Jump(1)"#]],
+    );
+}
+
+#[test]
+fn logical_not_unary_operator_generates_logical_not_rir_instruction() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Bool {
+                use q = Qubit();
+                let b = MResetZ(q) == Zero;
+                not b
+            }
+        }
+    "#});
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let readout_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        readout_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__read_result__body
+            call_type: Readout
+            input_type:
+                [0]: Result
+            output_type: Boolean
+            body: <NONE>"#]],
+    );
+    let output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__bool_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Boolean
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                Variable(2, Boolean) = LogicalNot Variable(1, Boolean)
+                Call id(3), args( Variable(2, Boolean), Pointer, )
+                Return"#]],
+    );
+}

--- a/compiler/qsc_partial_eval/tests/returns.rs
+++ b/compiler/qsc_partial_eval/tests/returns.rs
@@ -1048,10 +1048,11 @@ fn explicit_return_embedded_in_unary_expr_yields_error() {
         }
     }
     "#});
-    // The type of error will change once this kind of hybrid expression is supported.
     assert_error(
         &error,
-        &expect![[r#"Unimplemented("Unary Expr", Span { lo: 147, hi: 163 })"#]],
+        &expect![[
+            r#"Unexpected("embedded return in unary operation expression", Span { lo: 151, hi: 163 })"#
+        ]],
     );
 }
 


### PR DESCRIPTION
This change implements support in partial evaluation for unary operator expressions (leading positive, leading negative, bitwise not and logical not).