### PR TITLE
Fix new warnings in Clippy 1.78

### DIFF
--- a/compiler/qsc_circuit/src/circuit.rs
+++ b/compiler/qsc_circuit/src/circuit.rs
@@ -121,7 +121,7 @@ impl Row {
     }
 
     fn add_vertical(&mut self, column: usize) {
-        if self.objects.get(&column).is_none() {
+        if !self.objects.contains_key(&column) {
             match self.wire {
                 Wire::Qubit { .. } => self.add(column, QUBIT_WIRE_CROSS),
                 Wire::Classical { start_column } => {
@@ -136,7 +136,7 @@ impl Row {
     }
 
     fn add_dashed_vertical(&mut self, column: usize) {
-        if self.objects.get(&column).is_none() {
+        if !self.objects.contains_key(&column) {
             match self.wire {
                 Wire::Qubit { .. } => self.add(column, QUBIT_WIRE_DASHED_CROSS),
                 Wire::Classical { start_column } => {

--- a/compiler/qsc_doc_gen/src/display.rs
+++ b/compiler/qsc_doc_gen/src/display.rs
@@ -397,20 +397,6 @@ impl Display for UdtDef<'_> {
     }
 }
 
-struct FunctorSet<'a> {
-    functor_set: &'a ty::FunctorSet,
-}
-
-impl<'a> Display for FunctorSet<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        if *self.functor_set == ty::FunctorSet::Value(ty::FunctorSetValue::Empty) {
-            Ok(())
-        } else {
-            write!(f, " is {}", self.functor_set)
-        }
-    }
-}
-
 struct FunctorSetValue {
     functors: ty::FunctorSetValue,
 }

--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -127,7 +127,7 @@ pub struct Scope {
     ///
     /// Bug: Because we keep track of only one `valid_at` offset per name,
     /// when a variable is later shadowed in the same scope,
-    /// it is missed in the list. https://github.com/microsoft/qsharp/issues/897
+    /// it is missed in the list. <a href=https://github.com/microsoft/qsharp/issues/897 />
     vars: FxHashMap<Rc<str>, (u32, NodeId)>,
     /// Type parameters.
     ty_vars: FxHashMap<Rc<str>, ParamId>,

--- a/compiler/qsc_rca/src/common.rs
+++ b/compiler/qsc_rca/src/common.rs
@@ -38,10 +38,6 @@ pub enum LocalKind {
 
 pub trait LocalsLookup {
     fn find(&self, local_var_id: LocalVarId) -> Option<&Local>;
-
-    fn get(&self, local_var_id: LocalVarId) -> &Local {
-        self.find(local_var_id).expect("local should exist")
-    }
 }
 
 impl LocalsLookup for FxHashMap<LocalVarId, Local> {

--- a/resource_estimator/src/system/error.rs
+++ b/resource_estimator/src/system/error.rs
@@ -109,7 +109,7 @@ pub enum Error {
     /// Handles various types of invalid input
     ///
     /// ✅ This does not contain user data and can be logged
-    /// (mostly user error, but check InvalidInput for more details)
+    /// (mostly user error, but check `InvalidInput` for more details)
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidInput(InvalidInput),

--- a/resource_estimator/src/system/modeling/tfactory.rs
+++ b/resource_estimator/src/system/modeling/tfactory.rs
@@ -81,7 +81,6 @@ impl<'a> TFactoryQubit<'a> {
 }
 
 impl Display for TFactoryDistillationUnitType {
-
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TFactoryDistillationUnitType::Logical => f.write_str("Logical"),

--- a/resource_estimator/src/system/modeling/tfactory.rs
+++ b/resource_estimator/src/system/modeling/tfactory.rs
@@ -5,7 +5,7 @@
 mod tests;
 
 use core::fmt;
-use std::{collections::BTreeMap, vec};
+use std::{collections::BTreeMap, fmt::Display, vec};
 
 use serde::{ser::SerializeMap, Serialize};
 
@@ -80,12 +80,13 @@ impl<'a> TFactoryQubit<'a> {
     }
 }
 
-impl ToString for TFactoryDistillationUnitType {
-    fn to_string(&self) -> String {
+impl Display for TFactoryDistillationUnitType {
+
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            TFactoryDistillationUnitType::Logical => String::from("Logical"),
-            TFactoryDistillationUnitType::Physical => String::from("Physical"),
-            TFactoryDistillationUnitType::Combined => String::from("Combined"),
+            TFactoryDistillationUnitType::Logical => f.write_str("Logical"),
+            TFactoryDistillationUnitType::Physical => f.write_str("Physical"),
+            TFactoryDistillationUnitType::Combined => f.write_str("Combined"),
         }
     }
 }

--- a/resource_estimator/src/system/optimization/tfactory_exhaustive.rs
+++ b/resource_estimator/src/system/optimization/tfactory_exhaustive.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use std::borrow::Cow;
+use std::fmt::Display;
 use std::rc::Rc;
 
 use crate::system::modeling::{
@@ -28,14 +29,14 @@ where
 {
     /// Target output T-error rate
     output_t_error_rate: f64,
-    /// Number of combinations for which a TFactory was tried to build
+    /// Number of combinations for which a `TFactory` was tried to build
     num_combinations: usize,
-    /// Number of valid TFactory instances that were successfully build
+    /// Number of valid `TFactory` instances that were successfully build
     num_valid: usize,
-    /// Number of sufficient TFactory instances that do not succeed the user
+    /// Number of sufficient `TFactory` instances that do not succeed the user
     /// specified output T-error rate
     num_candidates: usize,
-    /// Pareto frontier of currently best TFactories.
+    /// Pareto frontier of currently best `TFactories`.
     /// We optimize them by two duration and normalized qubits.
     frontier_factories: Population<P>,
 }
@@ -176,12 +177,12 @@ impl From<TFactory> for Point2D<TFactory> {
     }
 }
 
-impl ToString for Point2D<TFactory> {
-    fn to_string(&self) -> String {
-        format!(
+impl Display for Point2D<TFactory> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
             "Pareto frontier point.   normalized qubits: {},    duration: {}",
             self.value1, self.value2,
-        )
+        ))
     }
 }
 
@@ -199,12 +200,12 @@ impl From<TFactory> for Point4D<TFactory> {
     }
 }
 
-impl ToString for Point4D<TFactory> {
-    fn to_string(&self) -> String {
-        format!(
+impl Display for Point4D<TFactory> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
             "Pareto frontier point.   normalized qubits: {},    duration: {},    output T-error rate: {},    code distance: {}",
             self.value1, self.value2, self.value3, self.value4,
-        )
+        ))
     }
 }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(non_snake_case, clippy::empty_docs)]
+#![allow(unknown_lints, clippy::empty_docs)]
+#![allow(non_snake_case)]
 
 use diagnostic::{interpret_errors_into_vs_diagnostics, VSDiagnostic};
 use katas::check_solution;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(non_snake_case)]
+#![allow(non_snake_case, clippy::empty_docs)]
 
 use diagnostic::{interpret_errors_into_vs_diagnostics, VSDiagnostic};
 use katas::check_solution;


### PR DESCRIPTION
This fixes the warnings that are new or newly detected as of Clippy 1.78. We will follow up with a prereqs, CI, and release pipeline update once the toolchain is available in all build environments.