### PR TITLE
Ensure variable types are supported by target in partial eval

### DIFF
--- a/compiler/qsc_data_structures/src/target.rs
+++ b/compiler/qsc_data_structures/src/target.rs
@@ -38,3 +38,29 @@ impl Default for TargetCapabilityFlags {
         TargetCapabilityFlags::empty()
     }
 }
+
+impl TargetCapabilityFlags {
+    #[must_use]
+    pub fn to_user_string(&self) -> String {
+        let mut output = Vec::new();
+        if self.contains(TargetCapabilityFlags::Adaptive) {
+            output.push("Adaptive");
+        }
+        if self.contains(TargetCapabilityFlags::IntegerComputations) {
+            output.push("Integer Computations");
+        }
+        if self.contains(TargetCapabilityFlags::FloatingPointComputations) {
+            output.push("Floating Point Computations");
+        }
+        if self.contains(TargetCapabilityFlags::BackwardsBranching) {
+            output.push("Backwards Branching");
+        }
+        if self.contains(TargetCapabilityFlags::HigherLevelConstructs) {
+            output.push("Higher Level Constructs");
+        }
+        if self.contains(TargetCapabilityFlags::QubitReset) {
+            output.push("Qubit Reset");
+        }
+        output.join(", ")
+    }
+}

--- a/compiler/qsc_partial_eval/tests/output_recording.rs
+++ b/compiler/qsc_partial_eval/tests/output_recording.rs
@@ -83,7 +83,7 @@ fn output_recording_for_tuple_of_different_types() {
                     Call id(5), args( Variable(1, Boolean), Pointer, )
                     Return
             config: Config:
-                capabilities: Base
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
             num_qubits: 1
             num_results: 1"#]]
     .assert_eq(&program.to_string());
@@ -169,7 +169,7 @@ fn output_recording_for_nested_tuples() {
                     Call id(5), args( Variable(3, Boolean), Pointer, )
                     Return
             config: Config:
-                capabilities: Base
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
             num_qubits: 1
             num_results: 1"#]]
     .assert_eq(&program.to_string());
@@ -263,7 +263,7 @@ fn output_recording_for_tuple_of_arrays() {
                     Call id(6), args( Variable(3, Boolean), Pointer, )
                     Return
             config: Config:
-                capabilities: Base
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
             num_qubits: 1
             num_results: 1"#]]
     .assert_eq(&program.to_string());
@@ -357,7 +357,7 @@ fn output_recording_for_array_of_tuples() {
                     Call id(6), args( Variable(3, Boolean), Pointer, )
                     Return
             config: Config:
-                capabilities: Base
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
             num_qubits: 1
             num_results: 1"#]]
     .assert_eq(&program.to_string());
@@ -399,7 +399,7 @@ fn output_recording_for_literal_bool() {
                     Call id(1), args( Bool(true), Pointer, )
                     Return
             config: Config:
-                capabilities: Base
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
             num_qubits: 0
             num_results: 0"#]]
     .assert_eq(&program.to_string());
@@ -441,7 +441,7 @@ fn output_recording_for_literal_int() {
                     Call id(1), args( Integer(42), Pointer, )
                     Return
             config: Config:
-                capabilities: Base
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
             num_qubits: 0
             num_results: 0"#]]
     .assert_eq(&program.to_string());
@@ -512,7 +512,7 @@ fn output_recording_for_mix_of_literal_and_variable() {
                     Call id(4), args( Bool(true), Pointer, )
                     Return
             config: Config:
-                capabilities: Base
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
             num_qubits: 1
             num_results: 1"#]]
     .assert_eq(&program.to_string());

--- a/compiler/qsc_partial_eval/tests/test_utils.rs
+++ b/compiler/qsc_partial_eval/tests/test_utils.rs
@@ -37,7 +37,19 @@ pub fn assert_error(error: &Error, expected_error: &Expect) {
 
 #[must_use]
 pub fn get_partial_evaluation_error(source: &str) -> Error {
-    let maybe_program = compile_and_partially_evaluate(source);
+    let maybe_program = compile_and_partially_evaluate(source, TargetCapabilityFlags::all());
+    match maybe_program {
+        Ok(_) => panic!("partial evaluation succeeded"),
+        Err(error) => error,
+    }
+}
+
+#[must_use]
+pub fn get_partial_evaluation_error_with_capabilities(
+    source: &str,
+    capabilities: TargetCapabilityFlags,
+) -> Error {
+    let maybe_program = compile_and_partially_evaluate(source, capabilities);
     match maybe_program {
         Ok(_) => panic!("partial evaluation succeeded"),
         Err(error) => error,
@@ -46,20 +58,35 @@ pub fn get_partial_evaluation_error(source: &str) -> Error {
 
 #[must_use]
 pub fn get_rir_program(source: &str) -> Program {
-    let maybe_program = compile_and_partially_evaluate(source);
+    let maybe_program = compile_and_partially_evaluate(source, TargetCapabilityFlags::all());
     match maybe_program {
         Ok(program) => program,
         Err(error) => panic!("partial evaluation failed: {error:?}"),
     }
 }
 
-fn compile_and_partially_evaluate(source: &str) -> Result<Program, Error> {
-    let compilation_context = CompilationContext::new(source);
+#[must_use]
+pub fn get_rir_program_with_capabilities(
+    source: &str,
+    capabilities: TargetCapabilityFlags,
+) -> Program {
+    let maybe_program = compile_and_partially_evaluate(source, capabilities);
+    match maybe_program {
+        Ok(program) => program,
+        Err(error) => panic!("partial evaluation failed: {error:?}"),
+    }
+}
+
+fn compile_and_partially_evaluate(
+    source: &str,
+    capabilities: TargetCapabilityFlags,
+) -> Result<Program, Error> {
+    let compilation_context = CompilationContext::new(source, capabilities);
     partially_evaluate(
         &compilation_context.fir_store,
         &compilation_context.compute_properties,
         &compilation_context.entry,
-        TargetCapabilityFlags::empty(),
+        capabilities,
     )
 }
 
@@ -70,13 +97,13 @@ struct CompilationContext {
 }
 
 impl CompilationContext {
-    fn new(source: &str) -> Self {
+    fn new(source: &str, capabilities: TargetCapabilityFlags) -> Self {
         let source_map = SourceMap::new([("test".into(), source.into())], Some("".into()));
         let compiler = Compiler::new(
             true,
             source_map,
             PackageType::Exe,
-            TargetCapabilityFlags::all(),
+            capabilities,
             LanguageFeatures::default(),
         )
         .expect("should be able to create a new compiler");


### PR DESCRIPTION
This change adds logic to verify that RIR variables that are created by partial eval are supported by the currently configured target capabilities.