### PR TITLE
Support closures in RCA

### DIFF
--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -1119,7 +1119,7 @@ impl<'a> PartialEvaluator<'a> {
         if callable_decl.output != Ty::UNIT {
             return Err(Error::Unexpected(
                 format!(
-                    "dynamic call to non-Unit intrinsic `{}`",
+                    "non-classical call to non-Unit intrinsic `{}`",
                     callable_decl.name.name
                 ),
                 callee_expr_span,

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -76,7 +76,7 @@ pub enum Error {
     ))]
     UnexpectedDynamicValue(#[label] Span),
 
-    #[error("partial evaluation failed with error {0}")]
+    #[error("partial evaluation failed with error: {0}")]
     #[diagnostic(code("Qsc.PartialEval.EvaluationFailed"))]
     EvaluationFailed(String, #[label] Span),
 
@@ -90,7 +90,7 @@ pub enum Error {
     #[error("an unexpected error occurred related to: {0}")]
     #[diagnostic(code("Qsc.PartialEval.Unexpected"))]
     #[diagnostic(help(
-        "this is probably a bug. please consider reporting this as an issue to the development team"
+        "this is probably a bug, please consider reporting this as an issue to the development team"
     ))]
     Unexpected(String, #[label] Span),
 
@@ -1099,7 +1099,12 @@ impl<'a> PartialEvaluator<'a> {
                     callee_expr_span,
                 ))
             }
-            _ => Ok(self.eval_expr_call_to_intrinsic_qis(store_item_id, callable_decl, args_value)),
+            _ => self.eval_expr_call_to_intrinsic_qis(
+                store_item_id,
+                callable_decl,
+                args_value,
+                callee_expr_span,
+            ),
         }
     }
 
@@ -1108,9 +1113,15 @@ impl<'a> PartialEvaluator<'a> {
         store_item_id: StoreItemId,
         callable_decl: &CallableDecl,
         args_value: Value,
-    ) -> Value {
+        callee_expr_span: Span,
+    ) -> Result<Value, Error> {
         // Intrinsic callables that make it to this point are expected to be unitary.
-        assert_eq!(callable_decl.output, Ty::UNIT);
+        if callable_decl.output != Ty::UNIT {
+            return Err(Error::Unexpected(
+                format!("dynamic call to intrinsic `{}`", callable_decl.name.name),
+                callee_expr_span,
+            ));
+        }
 
         // Check if the callable is already in the program, and if not add it.
         let callable = self.create_intrinsic_callable(store_item_id, callable_decl);
@@ -1135,7 +1146,7 @@ impl<'a> PartialEvaluator<'a> {
         let instruction = Instruction::Call(callable_id, args_operands, None);
         let current_block = self.get_current_rir_block_mut();
         current_block.0.push(instruction);
-        Value::unit()
+        Ok(Value::unit())
     }
 
     fn eval_expr_call_to_spec(

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -1118,7 +1118,10 @@ impl<'a> PartialEvaluator<'a> {
         // Intrinsic callables that make it to this point are expected to be unitary.
         if callable_decl.output != Ty::UNIT {
             return Err(Error::Unexpected(
-                format!("dynamic call to intrinsic `{}`", callable_decl.name.name),
+                format!(
+                    "dynamic call to non-Unit intrinsic `{}`",
+                    callable_decl.name.name
+                ),
                 callee_expr_span,
             ));
         }

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -534,18 +534,11 @@ fn loop_with_dynamic_condition_yields_errors() {
 }
 
 #[test]
-fn use_closure_yields_errors() {
+fn use_closure_allowed() {
     check_profile(
         USE_CLOSURE_FUNCTION,
         &expect![[r#"
-            [
-                UseOfClosure(
-                    Span {
-                        lo: 149,
-                        hi: 168,
-                    },
-                ),
-            ]
+            []
         "#]],
     );
 }

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -432,18 +432,11 @@ fn loop_with_dynamic_condition_yields_errors() {
 }
 
 #[test]
-fn use_closure_yields_errors() {
+fn use_closure_allowed() {
     check_profile(
         USE_CLOSURE_FUNCTION,
         &expect![[r#"
-            [
-                UseOfClosure(
-                    Span {
-                        lo: 149,
-                        hi: 168,
-                    },
-                ),
-            ]
+            []
         "#]],
     );
 }

--- a/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -672,18 +672,11 @@ fn loop_with_dynamic_condition_yields_errors() {
 }
 
 #[test]
-fn use_closure_yields_errors() {
+fn use_closure_allowed() {
     check_profile(
         USE_CLOSURE_FUNCTION,
         &expect![[r#"
-            [
-                UseOfClosure(
-                    Span {
-                        lo: 149,
-                        hi: 168,
-                    },
-                ),
-            ]
+            []
         "#]],
     );
 }

--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -16,9 +16,9 @@ use qsc_fir::{
     extensions::InputParam,
     fir::{
         Block, BlockId, CallableDecl, CallableImpl, CallableKind, Expr, ExprId, ExprKind, Global,
-        Ident, Item, ItemKind, Mutability, Package, PackageId, PackageLookup, PackageStore,
-        PackageStoreLookup, Pat, PatId, PatKind, Res, SpecDecl, SpecImpl, Stmt, StmtId, StmtKind,
-        StoreExprId, StoreItemId, StorePatId, StringComponent,
+        Ident, Item, ItemKind, LocalVarId, Mutability, Package, PackageId, PackageLookup,
+        PackageStore, PackageStoreLookup, Pat, PatId, PatKind, Res, SpecDecl, SpecImpl, Stmt,
+        StmtId, StmtKind, StoreExprId, StoreItemId, StorePatId, StringComponent,
     },
     ty::{Arrow, FunctorSetValue, Prim, Ty},
     visit::Visitor,
@@ -376,6 +376,7 @@ impl<'a> Analyzer<'a> {
         callable_decl: &'a CallableDecl,
         args_expr_id: ExprId,
         expr_type: &Ty,
+        fixed_args: Option<Vec<LocalVarId>>,
     ) -> CallComputeKind {
         // The `Length` intrinsic function has a specialized override.
         if is_length_intrinsic(callable_decl) {
@@ -405,11 +406,27 @@ impl<'a> Analyzer<'a> {
             callee_input_pattern_id,
             args_input_id,
             self.package_store,
+            fixed_args.as_ref().map_or(0, Vec::len),
         );
         let application_instance = self.get_current_application_instance();
 
         // Derive the compute kind based on the value kind of the arguments.
-        let arg_value_kinds = self.derive_arg_value_kinds(&arg_exprs);
+        let arg_value_kinds = if let Some(fixed_args) = fixed_args {
+            fixed_args
+                .into_iter()
+                .map(|local_var_id| {
+                    self.get_current_application_instance()
+                        .locals_map
+                        .find_local_compute_kind(local_var_id)
+                        .expect("local should have been processed before this")
+                        .compute_kind
+                        .value_kind_or_default(ValueKind::Element(RuntimeKind::Static))
+                })
+                .chain(self.derive_arg_value_kinds(&arg_exprs))
+                .collect()
+        } else {
+            self.derive_arg_value_kinds(&arg_exprs)
+        };
         let mut compute_kind =
             application_generator_set.generate_application_compute_kind(&arg_value_kinds);
 
@@ -482,7 +499,7 @@ impl<'a> Analyzer<'a> {
         );
 
         // If the callee could not be resolved, return a compute kind with certain runtime features.
-        let Some(callee) = maybe_callee else {
+        let (Some(callee), fixed_args) = maybe_callee else {
             // The value kind of a call expression with an unresolved callee is not known, so to avoid
             // spurious errors in later analysis where the value is used we assume static.
             // During partial-evaluation, the callable is known the actual return kind will be checked.
@@ -505,6 +522,7 @@ impl<'a> Analyzer<'a> {
                 callable_decl,
                 args_expr_id,
                 expr_type,
+                fixed_args,
             ),
             Global::Udt => {
                 CallComputeKind::Regular(self.analyze_expr_call_with_udt_callee(args_expr_id))
@@ -530,11 +548,6 @@ impl<'a> Analyzer<'a> {
         }
 
         compute_kind
-    }
-
-    fn analyze_expr_closure(expr_type: &Ty) -> ComputeKind {
-        let value_kind = ValueKind::new_dynamic_from_type(expr_type);
-        ComputeKind::new_with_runtime_features(RuntimeFeatureFlags::UseOfClosure, value_kind)
     }
 
     fn analyze_expr_fail(&mut self, msg_expr_id: ExprId) -> ComputeKind {
@@ -1627,7 +1640,7 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
             ExprKind::Call(callee_expr_id, args_expr_id) => {
                 self.analyze_expr_call(*callee_expr_id, *args_expr_id, &expr.ty)
             }
-            ExprKind::Closure(_, _) => Self::analyze_expr_closure(&expr.ty),
+            ExprKind::Closure(..) => ComputeKind::Classical,
             ExprKind::Fail(msg_expr_id) => self.analyze_expr_fail(*msg_expr_id),
             ExprKind::Field(record_expr_id, _) => {
                 self.analyze_expr_field(*record_expr_id, &expr.ty)
@@ -2279,29 +2292,32 @@ fn map_input_pattern_to_input_expressions(
     pat_id: StorePatId,
     expr_id: StoreExprId,
     package_store: &impl PackageStoreLookup,
+    skip_ahead: usize,
 ) -> Vec<ExprId> {
     let pat = package_store.get_pat(pat_id);
     match &pat.kind {
         PatKind::Bind(_) | PatKind::Discard => vec![expr_id.expr],
         PatKind::Tuple(pats) => {
+            let pats = &pats[skip_ahead..];
             let expr = package_store.get_expr(expr_id);
-            match &expr.kind {
-                ExprKind::Tuple(exprs) => {
-                    assert!(pats.len() == exprs.len());
-                    let mut input_param_exprs = Vec::<ExprId>::with_capacity(pats.len());
-                    for (local_pat_id, local_expr_id) in pats.iter().zip(exprs.iter()) {
-                        let global_pat_id = StorePatId::from((pat_id.package, *local_pat_id));
-                        let global_expr_id = StoreExprId::from((expr_id.package, *local_expr_id));
-                        let mut sub_input_param_exprs = map_input_pattern_to_input_expressions(
-                            global_pat_id,
-                            global_expr_id,
-                            package_store,
-                        );
-                        input_param_exprs.append(&mut sub_input_param_exprs);
-                    }
-                    input_param_exprs
+            if let ExprKind::Tuple(exprs) = &expr.kind {
+                assert!(pats.len() == exprs.len());
+                let mut input_param_exprs = Vec::<ExprId>::with_capacity(pats.len());
+                for (local_pat_id, local_expr_id) in pats.iter().zip(exprs.iter()) {
+                    let global_pat_id = StorePatId::from((pat_id.package, *local_pat_id));
+                    let global_expr_id = StoreExprId::from((expr_id.package, *local_expr_id));
+                    let mut sub_input_param_exprs = map_input_pattern_to_input_expressions(
+                        global_pat_id,
+                        global_expr_id,
+                        package_store,
+                        0,
+                    );
+                    input_param_exprs.append(&mut sub_input_param_exprs);
                 }
-                _ => panic!("expected tuple expression"),
+                input_param_exprs
+            } else {
+                assert!(pats.len() == 1);
+                vec![expr_id.expr]
             }
         }
     }

--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -412,6 +412,9 @@ impl<'a> Analyzer<'a> {
 
         // Derive the compute kind based on the value kind of the arguments.
         let arg_value_kinds = if let Some(fixed_args) = fixed_args {
+            // In items that come from lifted lambdas, fixed arguments that capture local variables, if any, come before
+            // other arguments, so we use the `fixed_args` as the base of the chain of values and concatenate the rest of
+            // the arguments when building the full list of arguments for a callable application.
             fixed_args
                 .into_iter()
                 .map(|local_var_id| {

--- a/compiler/qsc_rca/src/cycle_detection.rs
+++ b/compiler/qsc_rca/src/cycle_detection.rs
@@ -109,7 +109,8 @@ impl<'a> CycleDetector<'a> {
             .specializations_locals
             .get_mut(local_spec_id)
             .expect("node map should exist");
-        let maybe_callee = try_resolve_callee(callee, self.package_id, self.package, locals_map);
+        let (maybe_callee, _) =
+            try_resolve_callee(callee, self.package_id, self.package, locals_map);
         if let Some(callee) = maybe_callee {
             // We are not interested in visiting callables outside this package.
             if callee.item.package != self.package_id {

--- a/compiler/qsc_rca/src/errors.rs
+++ b/compiler/qsc_rca/src/errors.rs
@@ -135,11 +135,6 @@ pub enum Error {
     #[diagnostic(code("Qsc.CapabilitiesCk.LoopWithDynamicCondition"))]
     LoopWithDynamicCondition(#[label] Span),
 
-    #[error("cannot use a closure")]
-    #[diagnostic(help("closures are not supported by the current target"))]
-    #[diagnostic(code("Qsc.CapabilitiesCk.UseOfClosure"))]
-    UseOfClosure(#[label] Span),
-
     #[error("cannot use a bool value as an output")]
     #[diagnostic(help("using a bool value as an output is not supported by the current target"))]
     #[diagnostic(code("Qsc.CapabilitiesCk.UseOfBoolOutput"))]
@@ -231,9 +226,6 @@ pub fn generate_errors_from_runtime_features(
     }
     if runtime_features.contains(RuntimeFeatureFlags::LoopWithDynamicCondition) {
         errors.push(Error::LoopWithDynamicCondition(span));
-    }
-    if runtime_features.contains(RuntimeFeatureFlags::UseOfClosure) {
-        errors.push(Error::UseOfClosure(span));
     }
     if runtime_features.contains(RuntimeFeatureFlags::UseOfBoolOutput) {
         errors.push(Error::UseOfBoolOutput(span));

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -756,16 +756,14 @@ bitflags! {
         const ReturnWithinDynamicScope = 1 << 19;
         /// A loop with a dynamic condition.
         const LoopWithDynamicCondition = 1 << 20;
-        /// Use of a closure.
-        const UseOfClosure = 1 << 21;
         /// Use of an advanced type as output of a computation.
-        const UseOfAdvancedOutput = 1 << 22;
+        const UseOfAdvancedOutput = 1 << 21;
         // Use of a `Bool` as output of a computation.
-        const UseOfBoolOutput = 1 << 23;
+        const UseOfBoolOutput = 1 << 22;
         // Use of a `Double` as output of a computation.
-        const UseOfDoubleOutput = 1 << 24;
+        const UseOfDoubleOutput = 1 << 23;
         // Use of an `Int` as output of a computation.
-        const UseOfIntOutput = 1 << 25;
+        const UseOfIntOutput = 1 << 24;
     }
 }
 
@@ -849,9 +847,6 @@ impl RuntimeFeatureFlags {
         }
         if self.contains(RuntimeFeatureFlags::LoopWithDynamicCondition) {
             capabilities |= TargetCapabilityFlags::BackwardsBranching;
-        }
-        if self.contains(RuntimeFeatureFlags::UseOfClosure) {
-            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfBoolOutput) {
             capabilities |= TargetCapabilityFlags::Adaptive;

--- a/compiler/qsc_rca/tests/callables.rs
+++ b/compiler/qsc_rca/tests/callables.rs
@@ -22,18 +22,12 @@ fn check_rca_for_closure_function_with_classical_captured_value() {
     );
     let package_store_compute_properties = compilation_context.get_compute_properties();
 
-    // Note that a closure is always considered dynamic because we are currently not performing detailed analysis on
-    // them.
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
-                    runtime_features: RuntimeFeatureFlags(UseOfClosure)
-                    value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -50,18 +44,12 @@ fn check_rca_for_closure_function_with_dynamic_captured_value() {
     );
     let package_store_compute_properties = compilation_context.get_compute_properties();
 
-    // Note that only the "use of closure" runtime feature appears because we are currently not performing detailed
-    // analysis on closures.
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
-                    runtime_features: RuntimeFeatureFlags(UseOfClosure)
-                    value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -77,18 +65,12 @@ fn check_rca_for_closure_operation_with_classical_captured_value() {
     );
     let package_store_compute_properties = compilation_context.get_compute_properties();
 
-    // Note that a closure is always considered dynamic because we are currently not performing detailed analysis on
-    // them.
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
-                    runtime_features: RuntimeFeatureFlags(UseOfClosure)
-                    value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -105,18 +87,12 @@ fn check_rca_for_closure_operation_with_dynamic_captured_value() {
     );
     let package_store_compute_properties = compilation_context.get_compute_properties();
 
-    // Note that only the "use of closure" runtime feature appears because we are currently not performing detailed
-    // analysis on closures.
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
-                    runtime_features: RuntimeFeatureFlags(UseOfClosure)
-                    value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
     );
 }
 

--- a/compiler/qsc_rca/tests/calls.rs
+++ b/compiler/qsc_rca/tests/calls.rs
@@ -25,12 +25,10 @@ fn check_rca_for_call_to_cyclic_function_with_classical_argument() {
     let package_store_compute_properties = compilation_context.get_compute_properties();
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Classical
-                dynamic_param_applications: <empty>"#
-        ],
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -52,14 +50,12 @@ fn check_rca_for_call_to_cyclic_function_with_dynamic_argument() {
     let package_store_compute_properties = compilation_context.get_compute_properties();
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Quantum: QuantumProperties:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | CallToCyclicFunctionWithDynamicArg)
                     value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -80,14 +76,12 @@ fn check_rca_for_call_to_cyclic_operation_with_classical_argument() {
     let package_store_compute_properties = compilation_context.get_compute_properties();
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Quantum: QuantumProperties:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | CallToCyclicOperation)
                     value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -109,14 +103,12 @@ fn check_rca_for_call_to_cyclic_operation_with_dynamic_argument() {
     let package_store_compute_properties = compilation_context.get_compute_properties();
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Quantum: QuantumProperties:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | CallToCyclicOperation)
                     value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -131,18 +123,12 @@ fn check_rca_for_call_to_static_closure_function() {
     );
     let package_store_compute_properties = compilation_context.get_compute_properties();
 
-    // Note that the output of the closure function is dynamic due to closures currently considered always dynamic
-    // because we are not performing detailed analysis on them.
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | CallToDynamicCallee | UseOfClosure)
-                    value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -159,18 +145,14 @@ fn check_rca_for_call_to_dynamic_closure_function() {
     );
     let package_store_compute_properties = compilation_context.get_compute_properties();
 
-    // Note that the "use of dynamic integer" runtime feature is missing because we are currently not performing
-    // detailed analysis on closures.
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Quantum: QuantumProperties:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | CallToDynamicCallee | UseOfClosure)
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | LoopWithDynamicCondition)
                     value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -187,17 +169,14 @@ fn check_rca_for_call_to_static_closure_operation() {
     );
     let package_store_compute_properties = compilation_context.get_compute_properties();
 
-    // Note that closures currently considered always dynamic because we are not performing detailed analysis on them.
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
-        ApplicationsGeneratorSet:
-            inherent: Quantum: QuantumProperties:
-                runtime_features: RuntimeFeatureFlags(CallToDynamicCallee | UseOfClosure)
-                value_kind: Element(Static)
-            dynamic_param_applications: <empty>"#
-        ],
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(0x0)
+                    value_kind: Element(Static)
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -214,18 +193,14 @@ fn check_rca_for_call_to_dynamic_closure_operation() {
     );
     let package_store_compute_properties = compilation_context.get_compute_properties();
 
-    // Note that the "use of dynamic bool" and the "use of dynamic double" runtime features are missing because we are
-    // currently not performing detailed analysis on closures.
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
-        ApplicationsGeneratorSet:
-            inherent: Quantum: QuantumProperties:
-                runtime_features: RuntimeFeatureFlags(CallToDynamicCallee | UseOfClosure)
-                value_kind: Element(Static)
-            dynamic_param_applications: <empty>"#
-        ],
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                    value_kind: Element(Static)
+                dynamic_param_applications: <empty>"#]],
     );
 }
 
@@ -246,13 +221,11 @@ fn check_rca_for_call_to_operation_with_one_classical_return_and_one_dynamic_ret
     let package_store_compute_properties = compilation_context.get_compute_properties();
     check_last_statement_compute_properties(
         package_store_compute_properties,
-        &expect![
-            r#"
+        &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Quantum: QuantumProperties:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | ReturnWithinDynamicScope)
                     value_kind: Element(Dynamic)
-                dynamic_param_applications: <empty>"#
-        ],
+                dynamic_param_applications: <empty>"#]],
     );
 }


### PR DESCRIPTION
This change adds full support for analysis of closures for runtime capabilities and calls when the callee expression is known to resolve to a bound closure. This allows analysis to include captured variables as well.