### PR TITLE
Fix incomplete string escape in circuit.ts

### DIFF
--- a/vscode/src/circuit.ts
+++ b/vscode/src/circuit.ts
@@ -315,7 +315,7 @@ function errorsToHtml(
 
     const location = documentHtml(document, diag.range);
     const message = escapeHtml(`(${diag.code}) ${diag.message}`).replace(
-      "\n",
+      /\n/g,
       "<br/><br/>",
     );
 


### PR DESCRIPTION
This issue was found by CodeQL (thanks to @idavis for setting this up and raising the alert). `replace` with a string argument only replaces the first occurrence of `\n`.