### PR TITLE
Added newline after inline html

### DIFF
--- a/playground/src/docs.tsx
+++ b/playground/src/docs.tsx
@@ -35,7 +35,7 @@ export function processDocumentFiles(
       const existingContent = contentByNamespace.get(newNamespace)!;
       contentByNamespace.set(
         newNamespace,
-        existingContent + "\n<br>\n<br>\n" + doc.contents,
+        existingContent + "\n<br>\n<br>\n\n" + doc.contents,
       );
     } else {
       contentByNamespace.set(newNamespace, doc.contents);


### PR DESCRIPTION
Fixes a playground issue with headings in the docs. Needed another line break after the inline HTML.