### PR TITLE
Distinguishing Unitaries kata: add first task

### DIFF
--- a/katas/content/distinguishing_states/zero_one/solution.md
+++ b/katas/content/distinguishing_states/zero_one/solution.md
@@ -3,6 +3,6 @@ The input qubit is guaranteed to be either in basis state $|0\rangle$ or $|1\ran
 In Q# the operation `M` can be used to measure a single qubit in the computational basis. The measurement result is a value of type `Result` - the operation `M` will return `One` if the input qubit was in the $|1\rangle$ state and `Zero` if the input qubit was in the $|0\rangle$ state. Since we need to encode the first case as `true` and the second one as `false`, we can return the result of equality comparison between measurement result and `One`.
 
 @[solution]({
-    "id": "single_qubit_measurements__zero_one_solution",
+    "id": "distinguishing_states__zero_one_solution",
     "codePath": "Solution.qs"
 })

--- a/katas/content/distinguishing_unitaries/Common.qs
+++ b/katas/content/distinguishing_unitaries/Common.qs
@@ -1,0 +1,61 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Random;
+
+    // "Framework" operation for testing tasks for distinguishing unitaries
+    // "unitaries" is the list of unitaries that can be passed to the task
+    // "testImpl" - the solution to be tested
+    // "unitaryNames" - the labels of unitaries in the list
+    // "maxCalls" - max # of calls to the unitary that are allowed (-1 means unlimited) - currently unused, TODO use after #1154
+    operation DistinguishUnitaries_Framework<'UInput> (
+        unitaries : ('UInput => Unit is Adj + Ctl)[], 
+        testImpl : ('UInput => Unit is Adj + Ctl) => Int,
+        unitaryNames : String[],
+        maxCalls : Int
+    ) : Bool {
+
+        let nUnitaries = Length(unitaries);
+        let nTotal = 100;
+        mutable wrongClassifications = [0, size = nUnitaries * nUnitaries]; // [i * nU + j] number of times unitary i was classified as j
+        mutable unknownClassifications = [0, size = nUnitaries];            // number of times unitary i was classified as something unknown
+        
+        for i in 1 .. nTotal {
+            // get a random integer to define the unitary used
+            let actualIndex = DrawRandomInt(0, nUnitaries - 1);
+            
+            // get the solution's answer and verify that it's a match
+            let returnedIndex = testImpl(unitaries[actualIndex]);
+
+            if returnedIndex != actualIndex {
+                if returnedIndex < 0 or returnedIndex >= nUnitaries {
+                    set unknownClassifications w/= actualIndex <- unknownClassifications[actualIndex] + 1;
+                } else {
+                    let index = actualIndex * nUnitaries + returnedIndex;
+                    set wrongClassifications w/= index <- wrongClassifications[index] + 1;
+                }
+            }
+        }
+        
+        mutable totalMisclassifications = 0;
+        for i in 0 .. nUnitaries - 1 {
+            for j in 0 .. nUnitaries - 1 {
+                let misclassifiedIasJ = wrongClassifications[(i * nUnitaries) + j];
+                if misclassifiedIasJ != 0 {
+                    set totalMisclassifications += misclassifiedIasJ;
+                    Message($"Misclassified {unitaryNames[i]} as {unitaryNames[j]} in {misclassifiedIasJ} test runs.");
+                }
+            }
+            if unknownClassifications[i] != 0 {
+                set totalMisclassifications += unknownClassifications[i];
+                Message($"Failed to classify {unitaryNames[i]} in {unknownClassifications[i]} test runs.");
+            }
+        }
+        // This check will tell the total number of failed classifications
+        if totalMisclassifications != 0 {
+            Message($"{totalMisclassifications} test runs out of {nTotal} returned incorrect state.");
+            Message("Incorrect.");
+            return false;
+        }
+        Message("Correct!");
+        true
+    }
+}

--- a/katas/content/distinguishing_unitaries/i_x/Placeholder.qs
+++ b/katas/content/distinguishing_unitaries/i_x/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation DistinguishIX (unitary : (Qubit => Unit is Adj + Ctl)) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/distinguishing_unitaries/i_x/Solution.qs
+++ b/katas/content/distinguishing_unitaries/i_x/Solution.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation DistinguishIX (unitary : (Qubit => Unit is Adj + Ctl)) : Int {
+        use q = Qubit();
+        unitary(q);
+        return MResetZ(q) == Zero ? 0 | 1;
+    }
+}

--- a/katas/content/distinguishing_unitaries/i_x/Verification.qs
+++ b/katas/content/distinguishing_unitaries/i_x/Verification.qs
@@ -1,0 +1,8 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        DistinguishUnitaries_Framework([I, X], Kata.DistinguishIX, ["I", "X"], 1)
+    }
+}

--- a/katas/content/distinguishing_unitaries/i_x/index.md
+++ b/katas/content/distinguishing_unitaries/i_x/index.md
@@ -1,0 +1,7 @@
+**Input:** An operation that implements a single-qubit unitary transformation:
+either the identity $I$ or the Pauli $X$ gate. 
+
+**Output:**  0 if the given operation is the $I$ gate, 1 if the given operation is the $X$ gate.
+
+The operation will have Adjoint and Controlled variants defined.
+You can apply the given operation and its adjoint/controlled variants exactly **once**.

--- a/katas/content/distinguishing_unitaries/i_x/solution.md
+++ b/katas/content/distinguishing_unitaries/i_x/solution.md
@@ -1,0 +1,27 @@
+The only way to extract information out of a quantum system is measurement. 
+Measurements give us information about the states of a system, so to get information about the gate, we need to find a way to convert it into information about a state.
+If we want to distinguish two gates, we need to figure out to prepare a state and perform a measurement on it that will give us a result that we can interpret.
+To do this, we'll need to find a qubit state that, by applying to it $I$ gate or $X$ gate, will be transformed into states that can be distinguished using measurement, i.e., orthogonal states. 
+Let's find such state.
+
+> As a reminder, here are the matrices that correspond to the given gates:
+> $$I = \begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}, X = \begin{bmatrix} 0 & 1 \\ 1 & 0 \end{bmatrix}$$
+
+Consider the effects of these gates on the basis state $\ket{0}$.
+
+$$I\ket{0} = \ket{0}$$
+$$X\ket{0} = \ket{1}$$
+
+We see that the $I$ gate leaves the $\ket{0}$ state unchanged, and the $X$ gate transforms it into the $\ket{1}$ state. 
+So the easiest thing to do is to prepare a $\ket{0}$ state, apply the given unitary to it, and measure the resulting state in the computational basis:
+* If the measurement result is `Zero`, the measured state was $\ket{0}$, and we know the unitary applied to it was the $I$ gate.
+* If the measurement result is `One`, the measured state was $\ket{1}$, and we know the unitary applied to it was the $X$ gate.
+
+> In Q#, the freshly allocated qubits start in the $\ket{0}$ state, so you don't need to do anything to prepare the necessary state before applying the unitary to it.
+> You also have to return the qubits you allocated to the $\ket{0}$ state before releasing them. 
+> You can do that by measuring the qubit using the `M` operation and applying the $X$ gate if it was measured in the $\ket{1}$ state, or you can use [`MResetZ`](https://learn.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.measurement/mresetz) operation that wraps this measurement and qubit reset into one operation.
+
+@[solution]({
+    "id": "distinguishing_unitaries__i_x_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_unitaries/index.md
+++ b/katas/content/distinguishing_unitaries/index.md
@@ -1,0 +1,46 @@
+# Distinguishing Unitaries
+
+@[section]({
+    "id": "distinguishing_unitaries__overview",
+    "title": "Overview"
+})
+
+This kata offers you a series of tasks in which you are given one unitary from the given list and have to figure out which one it is by designing and performing experiments on it.
+
+**This kata covers the following topics:**
+
+- quantum measurements,
+- designing experiments to analyze behavior of unitary transformations.
+
+**What you should know to start working on this kata:**
+
+- Dirac notation for single-qubit and multi-qubit quantum systems
+- Basic single-qubit and multi-qubit gates
+- Quantum measurements and their effect on quantum systems
+
+@[section]({
+    "id": "distinguishing_unitaries__single_qubit",
+    "title": "Distinguishing Single-Qubit Gates"
+})
+
+@[exercise]({
+    "id": "distinguishing_unitaries__i_x",
+    "title": "Identity or X?",
+    "path": "./i_x/",
+    "qsDependencies": [
+        "../KatasLibrary.qs",
+        "./Common.qs"
+    ]
+})
+
+@[section]({
+    "id": "distinguishing_unitaries__multi_qubit",
+    "title": "Distinguishing Multi-Qubit Gates"
+})
+
+@[section]({
+    "id": "distinguishing_unitaries__conclusion",
+    "title": "Conclusion"
+})
+
+Congratulations! In this kata you learned to use measurements and basic quantum computing gates to identify unknown unitaries.

--- a/katas/content/index.json
+++ b/katas/content/index.json
@@ -9,7 +9,6 @@
   "preparing_states",
   "single_qubit_measurements",
   "multi_qubit_measurements",
-  "distinguishing_unitaries",
   "random_numbers",
   "superdense_coding",
   "oracles",

--- a/katas/content/index.json
+++ b/katas/content/index.json
@@ -9,6 +9,7 @@
   "preparing_states",
   "single_qubit_measurements",
   "multi_qubit_measurements",
+  "distinguishing_unitaries",
   "random_numbers",
   "superdense_coding",
   "oracles",


### PR DESCRIPTION
Testing harness doesn't enforce limitation on the number of unitary calls, but I still pass that parameter to simplify implementing this limitation later