### PR TITLE
[Node Watch] [Playground] Minor update to docs

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -5,14 +5,14 @@ This is a simple web site built using the Monaco editor and the qsharp npm packa
 ## Building the Playground Locally
 
 1. Build the entire repo by running `./build.py` in the root directory.
-   If you only want to build the functionality necessary to run the playground, you can use `python .\build.py --wasm --npm --play`.
+   If you only want to build the functionality necessary to run the playground, you can use `python ./build.py --wasm --npm --play`.
 2. Then make `./playground` your current directory and run `npm start` to start the web server.
 3. Copy the URL that will be printed to console and open it in a browser to use the playground.
 
 ## Building the Playground Locally in Watch Mode
 
 1. Build the entire repo by running `./build.py` in the root directory.
-   If you only want to build the functionality necessary to run the playground, you can use `python .\build.py --wasm --npm --play`.
+   If you only want to build the functionality necessary to run the playground, you can use `python ./build.py --wasm --npm --play`.
 2. Run `node watch.mjs` at the root of the repo.
 3. Copy the URL that will be printed to the console and open it in a browser to use the playground.
 

--- a/watch.mjs
+++ b/watch.mjs
@@ -9,17 +9,16 @@ Always use ./build.py to ensure that all projects are built correctly before che
 Also run ./build.py to do any initial repo setup (npm install, copying 3rd party libs, etc.)
 
 Once running, any changes to the source code for Rust directories listed, or for
-the npm, vscode, or playground projects, should automatically recompile. Just
+the npm, vscode, docs, katas, samples or playground projects, should automatically recompile. Just
 reload the playground page or reload the VS Code window to see the changes.
 
 Notes:
 
-- This builds the wasm module, npm package, VS Code extension, and runs the playground.
+- This builds the wasm module, npm package, VS Code extension, docs, katas, samples and runs the playground.
 - It does NOT build Python packages or native binaries (currently).
-- It does NOT watch for docs, katas, or samples changes (currently).
 - It does NOT build the Node.js wasm package (or run any of the node unit tests).
 - It builds debug binaries (whereas ./build.py builds for release).
-- Future updates could include watching for katas changes, and supporting '--release'
+- Future updates could include supporting '--release'
 
 */
 


### PR DESCRIPTION
- Update comments in `watch.mjs` script after https://github.com/microsoft/qsharp/pull/1487
- Change relative path to `python ./build.py` for people on linux. This would be convenient for people who use codespaces :-)