### PR TITLE
Avoid dynamic string in `IntAsBoolArray`

### DIFF
--- a/library/std/arrays.qs
+++ b/library/std/arrays.qs
@@ -1054,7 +1054,7 @@ namespace Microsoft.Quantum.Arrays {
     /// let naturals = SequenceI(1, _); // function to create sequence from 1 to `to`
     /// ```
     function SequenceI(from : Int, to : Int) : Int[] {
-        Fact(to >= from, $"`to` must be larger than `from`.");
+        Fact(to >= from, "`to` must be larger than `from`.");
         mutable array = [];
         for index in from..to {
             set array += [index];

--- a/library/std/convert.qs
+++ b/library/std/convert.qs
@@ -107,7 +107,7 @@ namespace Microsoft.Quantum.Convert {
             set result += [(runningValue &&& 1) != 0];
             set runningValue >>>= 1;
         }
-        Fact(runningValue == 0, $"`number`={number} is too large to fit into {bits} bits.");
+        Fact(runningValue == 0, "`number` is too large to fit into array of length `bits`.");
 
         result
     }


### PR DESCRIPTION
For targets with adaptive profile plus integer support, the `IntAsBoolArray` function should work with a constant number of bits. However, the presence of a call to `Fact` with an interpolated string causes it to require dynamic string support. Simplifying the assert message avoids this requirement.