### PR TITLE
Fix for logic based on `CallToUnresolvedCallee` flag

### DIFF
--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -981,13 +981,7 @@ impl<'a> PartialEvaluator<'a> {
         // Now that we are in evaluation, we have a distinct callable resolved and can perform runtime capability check
         // ahead of performing the actual call and return the appropriate capabilities error if this call is not supported
         // by the target.
-        let call_expr_compute_kind = self.get_expr_compute_kind(call_expr_id);
-        let call_was_unresolved = match call_expr_compute_kind {
-            ComputeKind::Quantum(props) => props
-                .runtime_features
-                .contains(RuntimeFeatureFlags::CallToUnresolvedCallee),
-            ComputeKind::Classical => false,
-        };
+        let call_was_unresolved = self.is_unresolved_callee_expr(callee_expr_id);
         if call_was_unresolved {
             let call_compute_kind = self.get_call_compute_kind(&call_scope);
             if let ComputeKind::Quantum(QuantumProperties {
@@ -1646,6 +1640,13 @@ impl<'a> PartialEvaluator<'a> {
         let expr_generator_set = self.compute_properties.get_expr(store_expr_id);
         let callable_scope = self.eval_context.get_current_scope();
         expr_generator_set.generate_application_compute_kind(&callable_scope.args_value_kind)
+    }
+
+    fn is_unresolved_callee_expr(&self, expr_id: ExprId) -> bool {
+        let current_package_id = self.get_current_package_id();
+        let store_expr_id = StoreExprId::from((current_package_id, expr_id));
+        self.compute_properties
+            .is_unresolved_callee_expr(store_expr_id)
     }
 
     fn get_call_compute_kind(&self, callable_scope: &Scope) -> ComputeKind {

--- a/compiler/qsc_rca/src/applications.rs
+++ b/compiler/qsc_rca/src/applications.rs
@@ -384,6 +384,16 @@ impl GeneratorSetsBuilder {
                 .exprs
                 .insert(expr_id, application_generator_set);
         }
+
+        // Save the unresolved callee expressions.
+        for unresolved_callee_expr_id in inherent_application_compute_properties
+            .unresolved_callee_exprs
+            .drain(..)
+        {
+            package_compute_properties
+                .unresolved_callee_exprs
+                .push(unresolved_callee_expr_id);
+        }
     }
 }
 
@@ -406,6 +416,7 @@ pub struct ApplicationInstance {
     stmts: FxHashMap<StmtId, ComputeKind>,
     /// The compute kind of the expressions related to the application instance.
     exprs: FxHashMap<ExprId, ComputeKind>,
+    pub unresolved_callee_exprs: Vec<ExprId>,
 }
 
 impl ApplicationInstance {
@@ -505,6 +516,7 @@ impl ApplicationInstance {
             blocks: FxHashMap::default(),
             stmts: FxHashMap::default(),
             exprs: FxHashMap::default(),
+            unresolved_callee_exprs: Vec::new(),
         }
     }
 
@@ -562,6 +574,7 @@ impl ApplicationInstance {
             blocks: self.blocks,
             stmts: self.stmts,
             exprs: self.exprs,
+            unresolved_callee_exprs: self.unresolved_callee_exprs,
             value_kind,
         }
     }
@@ -619,6 +632,7 @@ struct ApplicationInstanceComputeProperties {
     stmts: FxHashMap<StmtId, ComputeKind>,
     exprs: FxHashMap<ExprId, ComputeKind>,
     value_kind: Option<ValueKind>,
+    unresolved_callee_exprs: Vec<ExprId>,
 }
 
 impl ApplicationInstanceComputeProperties {

--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -511,6 +511,9 @@ impl<'a> Analyzer<'a> {
                 runtime_features: RuntimeFeatureFlags::CallToUnresolvedCallee,
                 value_kind,
             });
+            self.get_current_application_instance_mut()
+                .unresolved_callee_exprs
+                .push(callee_expr_id);
             return CallComputeKind::Regular(compute_kind);
         };
 

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -30,6 +30,7 @@ use qsc_fir::{
     },
     ty::Ty,
 };
+use rustc_hash::FxHashSet;
 
 use std::{
     cmp::Ord,
@@ -140,6 +141,13 @@ impl PackageStoreComputeProperties {
     pub fn iter(&self) -> Iter<PackageId, PackageComputeProperties> {
         self.0.iter()
     }
+
+    #[must_use]
+    pub fn is_unresolved_callee_expr(&self, id: StoreExprId) -> bool {
+        self.get(id.package)
+            .unresolved_callee_exprs
+            .contains(&id.expr)
+    }
 }
 
 /// The compute properties of a package.
@@ -153,6 +161,8 @@ pub struct PackageComputeProperties {
     pub stmts: IndexMap<StmtId, ApplicationGeneratorSet>,
     /// The application generator sets of the package expressions.
     pub exprs: IndexMap<ExprId, ApplicationGeneratorSet>,
+    /// The expressions that were unresolved callees at analysis time.
+    pub unresolved_callee_exprs: FxHashSet<ExprId>,
 }
 
 impl Default for PackageComputeProperties {
@@ -162,6 +172,7 @@ impl Default for PackageComputeProperties {
             blocks: IndexMap::new(),
             stmts: IndexMap::new(),
             exprs: IndexMap::new(),
+            unresolved_callee_exprs: FxHashSet::default(),
         }
     }
 }

--- a/compiler/qsc_rca/src/scaffolding.rs
+++ b/compiler/qsc_rca/src/scaffolding.rs
@@ -35,6 +35,10 @@ impl From<PackageStoreComputeProperties> for InternalPackageStoreComputeProperti
                 blocks: package_compute_properties.blocks,
                 stmts: package_compute_properties.stmts,
                 exprs: package_compute_properties.exprs,
+                unresolved_callee_exprs: package_compute_properties
+                    .unresolved_callee_exprs
+                    .into_iter()
+                    .collect(),
             };
             scaffolding.insert(package_id, package_compute_properties);
         }
@@ -59,6 +63,10 @@ impl From<InternalPackageStoreComputeProperties> for PackageStoreComputeProperti
                 blocks: package_scaffolding.blocks,
                 stmts: package_scaffolding.stmts,
                 exprs: package_scaffolding.exprs,
+                unresolved_callee_exprs: package_scaffolding
+                    .unresolved_callee_exprs
+                    .into_iter()
+                    .collect(),
             };
             package_store_compute_properties.insert(package_id, package_compute_properties);
         }
@@ -194,6 +202,8 @@ pub struct InternalPackageComputeProperties {
     pub stmts: IndexMap<StmtId, ApplicationGeneratorSet>,
     /// The application generator sets of the package expressions.
     pub exprs: IndexMap<ExprId, ApplicationGeneratorSet>,
+    /// The expressions that were unresolved callees at analysis time.
+    pub unresolved_callee_exprs: Vec<ExprId>,
 }
 
 /// Scaffolding used to build the compute properties of an item.


### PR DESCRIPTION
The check for the dynamism of the return from unresolved callees incorrectly ended up applying to calls where the flag had propagated from another call site, including the entry point callable itself. This change introduces new infra to track the call expression that introduced the flag as opposed to all calls the flag had propagated to, which keeps the desired protection but avoids rejecting other call expressions.