### PR TITLE
Fix use of `ForEach` in samples for compatibility

### DIFF
--- a/samples/algorithms/BernsteinVazirani.qs
+++ b/samples/algorithms/BernsteinVazirani.qs
@@ -107,7 +107,7 @@ namespace Sample {
 
         // Measure all qubits and reset them to the |0〉 state so that they can
         // be safely deallocated at the end of the block.
-        let resultArray = ForEach(MResetZ, queryRegister);
+        let resultArray = MResetEachZ(queryRegister);
 
         // Finally, the last qubit, which held the y-register, is reset.
         Reset(target);

--- a/samples/algorithms/BernsteinVaziraniNISQ.qs
+++ b/samples/algorithms/BernsteinVaziraniNISQ.qs
@@ -91,7 +91,7 @@ namespace Sample {
 
         // Measure all qubits and reset them to the |0〉 state so that they can
         // be safely deallocated at the end of the block.
-        let resultArray = ForEach(MResetZ, queryRegister);
+        let resultArray = MResetEachZ(queryRegister);
 
         // Finally, the last qubit, which held the y-register, is reset.
         Reset(target);

--- a/samples/algorithms/HiddenShift.qs
+++ b/samples/algorithms/HiddenShift.qs
@@ -110,7 +110,7 @@ namespace Sample {
 
         // Measure the n qubits and reset them to zero so that they can be
         // safely deallocated at the end of the block.
-        return ForEach(MResetZ, qubits);
+        return MResetEachZ(qubits);
     }
 
     /// # Summary

--- a/samples/algorithms/HiddenShiftNISQ.qs
+++ b/samples/algorithms/HiddenShiftNISQ.qs
@@ -100,7 +100,7 @@ namespace Sample {
 
         // Measure the n qubits and reset them to zero so that they can be
         // safely deallocated at the end of the block.
-        return ForEach(MResetZ, qubits);
+        return MResetEachZ(qubits);
     }
 
     /// # Summary


### PR DESCRIPTION
The Bernstein-Vazirani and Hidden Shift samples both used a pattern that is not well supported by RCA, specifically calling `ForEach(MResetZ, qubits)` to perform measurement on each qubit in an array. Passing a callable that produces a dynamic value makes static analysis very challenging, so instead we can update these to use the equivalent `MResetEachZ` operation. This allows the samples to work well with analysis and produce QIR for both base and adaptive profile.