### PR TITLE
Fix RIR transform for large unrolled loops, chained stores across branches

### DIFF
--- a/compiler/qsc_partial_eval/tests/misc.rs
+++ b/compiler/qsc_partial_eval/tests/misc.rs
@@ -339,3 +339,37 @@ fn integer_assign_with_hybrid_value_within_an_if_with_dynamic_condition() {
             Jump(3)"#]],
     );
 }
+
+#[test]
+fn large_loop_with_inner_if_completes_eval_and_transform() {
+    let program = get_rir_program(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Int {
+                use q = Qubit();
+                mutable i = 0;
+                for idx in 0..99 {
+                    if MResetZ(q) == One {
+                        set i += 1;
+                    }
+                }
+                return i;
+            }
+        }
+        "#,
+    });
+
+    // Program is expected to be too large to reasonably print out here, so instead verify the last block
+    // and the total number of blocks.
+    assert_eq!(program.blocks.iter().count(), 201);
+    assert_block_instructions(
+        &program,
+        BlockId(199),
+        &expect![[r#"
+            Block:
+                Variable(1, Integer) = Store Integer(100)
+                Call id(3), args( Variable(0, Integer), Pointer, )
+                Return"#]],
+    );
+}

--- a/compiler/qsc_rir/src/passes/remap_block_ids.rs
+++ b/compiler/qsc_rir/src/passes/remap_block_ids.rs
@@ -43,6 +43,17 @@ pub fn remap_block_ids(program: &mut Program) {
         }
         block_id_map.push(block_id);
 
+        let successors = get_block_successors(program.get_block(block_id));
+        if blocks_to_visit.len() >= successors.len()
+            && blocks_to_visit
+                .iter()
+                .skip(blocks_to_visit.len() - successors.len())
+                .eq(successors.iter())
+        {
+            // All successors are already in the queue in same order, so avoid adding them and reprocessing
+            // the same blocks back-to-back.
+            continue;
+        }
         blocks_to_visit.extend(get_block_successors(program.get_block(block_id)));
     }
 

--- a/compiler/qsc_rir/src/passes/remap_block_ids.rs
+++ b/compiler/qsc_rir/src/passes/remap_block_ids.rs
@@ -50,11 +50,11 @@ pub fn remap_block_ids(program: &mut Program) {
                 .skip(blocks_to_visit.len() - successors.len())
                 .eq(successors.iter())
         {
-            // All successors are already in the queue in same order, so avoid adding them and reprocessing
+            // All successors are already at the end of the queue in same order, so avoid adding them and reprocessing
             // the same blocks back-to-back.
             continue;
         }
-        blocks_to_visit.extend(get_block_successors(program.get_block(block_id)));
+        blocks_to_visit.extend(successors);
     }
 
     let block_id_map = block_id_map

--- a/compiler/qsc_rir/src/passes/ssa_transform.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform.rs
@@ -76,15 +76,14 @@ pub fn transform_to_ssa(program: &mut Program, preds: &IndexMap<BlockId, Vec<Blo
                     // Start with the first predecessor's value and block id, then add the values from the other predecessors.
                     let mut phi_args = vec![(*operand, *first_pred)];
                     for pred in rest_preds {
-                        phi_args.push((
-                            block_var_map
-                                .get(*pred)
-                                .expect("block should have variable map")
-                                .get(var_id)
-                                .copied()
-                                .expect("variable should be defined in all predecessors"),
-                            *pred,
-                        ));
+                        let pred_var_map = block_var_map
+                            .get(*pred)
+                            .expect("block should have variable map");
+                        let mut pred_operand = *pred_var_map
+                            .get(var_id)
+                            .expect("variable should be in predecessor's variable map");
+                        pred_operand = pred_operand.mapped(pred_var_map);
+                        phi_args.push((pred_operand, *pred));
                     }
                     phi_nodes.insert(*var_id, phi_args);
                 } else {

--- a/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
@@ -10,8 +10,8 @@ use crate::{
     builder::{bell_program, new_program, teleport_program},
     passes::check_and_transform,
     rir::{
-        Block, BlockId, Callable, CallableId, CallableType, Instruction, Operand, Program, Ty,
-        Variable, VariableId,
+        Block, BlockId, Callable, CallableId, CallableType, Instruction, Literal, Operand, Program,
+        Ty, Variable, VariableId,
     },
 };
 fn transform_program(program: &mut Program) {
@@ -2333,6 +2333,159 @@ fn ssa_transform_maps_store_instrs_that_use_values_from_other_store_instrs() {
                 Block 0: Block:
                     Variable(0, Boolean) = Call id(1), args( )
                     Variable(3, Boolean) = LogicalNot Variable(0, Boolean)
+                    Return
+            config: Config:
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
+}
+
+#[test]
+fn ssa_transform_maps_store_with_variable_from_store_in_conditional_to_phi_node() {
+    let mut program = new_program();
+    program.callables.insert(
+        CallableId(1),
+        Callable {
+            name: "dynamic_bool".to_string(),
+            input_type: Vec::new(),
+            output_type: Some(Ty::Boolean),
+            body: None,
+            call_type: CallableType::Regular,
+        },
+    );
+
+    program.blocks.insert(
+        BlockId(0),
+        Block(vec![
+            Instruction::Call(
+                CallableId(1),
+                Vec::new(),
+                Some(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+            ),
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(0),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Store(
+                Operand::Literal(Literal::Bool(true)),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Branch(
+                Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                },
+                BlockId(1),
+                BlockId(2),
+            ),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(1),
+        Block(vec![
+            Instruction::Store(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(1),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Jump(BlockId(2)),
+        ]),
+    );
+    program.blocks.insert(
+        BlockId(2),
+        Block(vec![
+            Instruction::LogicalNot(
+                Operand::Variable(Variable {
+                    variable_id: VariableId(2),
+                    ty: Ty::Boolean,
+                }),
+                Variable {
+                    variable_id: VariableId(3),
+                    ty: Ty::Boolean,
+                },
+            ),
+            Instruction::Return,
+        ]),
+    );
+
+    // Before
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Variable(1, Boolean) = Store Variable(0, Boolean)
+                    Variable(2, Boolean) = Store Bool(true)
+                    Branch Variable(1, Boolean), 1, 2
+                Block 1: Block:
+                    Variable(2, Boolean) = Store Variable(1, Boolean)
+                    Jump(2)
+                Block 2: Block:
+                    Variable(3, Boolean) = LogicalNot Variable(2, Boolean)
+                    Return
+            config: Config:
+                capabilities: Base
+            num_qubits: 0
+            num_results: 0"#]].assert_eq(&program.to_string());
+
+    // After
+    transform_program(&mut program);
+    expect![[r#"
+        Program:
+            entry: 0
+            callables:
+                Callable 0: Callable:
+                    name: main
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: <VOID>
+                    body: 0
+                Callable 1: Callable:
+                    name: dynamic_bool
+                    call_type: Regular
+                    input_type: <VOID>
+                    output_type: Boolean
+                    body: <NONE>
+            blocks:
+                Block 0: Block:
+                    Variable(0, Boolean) = Call id(1), args( )
+                    Branch Variable(0, Boolean), 1, 2
+                Block 1: Block:
+                    Jump(2)
+                Block 2: Block:
+                    Variable(4, Boolean) = Phi ( [Bool(true), 0], [Variable(0, Boolean), 1], )
+                    Variable(3, Boolean) = LogicalNot Variable(4, Boolean)
                     Return
             config: Config:
                 capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)

--- a/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
+++ b/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
@@ -2457,7 +2457,8 @@ fn ssa_transform_maps_store_with_variable_from_store_in_conditional_to_phi_node(
             config: Config:
                 capabilities: Base
             num_qubits: 0
-            num_results: 0"#]].assert_eq(&program.to_string());
+            num_results: 0"#]]
+    .assert_eq(&program.to_string());
 
     // After
     transform_program(&mut program);


### PR DESCRIPTION
This fixes two RIR transformation bugs:

 - Avoid revisiting same nodes back to back in node remapping pass, which can cause exponential increase in memory usage for programs with large loops containing nested branching.
 - Use variable map for operands in phi node arguments to avoid orphaned variable when that variable comes from a store of another stored variable across branches.