### PR TITLE
Tweak the QIR settings

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -96,7 +96,7 @@
     "configuration": {
       "title": "Q#",
       "properties": {
-        "Q#.targetProfile": {
+        "Q#.qir.targetProfile": {
           "type": "string",
           "default": "unrestricted",
           "enum": [
@@ -109,7 +109,7 @@
             "The minimal set of capabilities required to run a quantum program. This option maps to the Base Profile as defined by the QIR specification.",
             "The Adaptive_RI target profile includes all of the required Adaptive Profile capabilities, as well as the optional integer computation and qubit reset capabilities, as defined by the QIR specification."
           ],
-          "description": "Setting the target profile allows the Q# extension to generate programs that are compatible with a specific target. The target is the hardware or simulator which will be used to run the Q# program. The target profile is a description of a target's capabilities."
+          "markdownDescription": "Setting the target profile allows the Q# extension to generate programs that are compatible with a specific target. The target is the hardware or simulator which will be used to run the Q# program. [Learn more](https://aka.ms/qdk.qir)"
         },
         "Q#.enableFormatting": {
           "type": "boolean",
@@ -121,15 +121,15 @@
           "default": true,
           "description": "Enables the Circuit code lens to synthesize circuit diagrams for Q# programs and operations."
         },
-        "Q#.enablePreviewQirGen": {
+        "Q#.qir.experimentalCodeGeneration": {
           "type": "boolean",
           "default": false,
-          "description": "Enables the preview QIR code generation functionality."
+          "markdownDescription": "Enable the experimental QIR code generation functionality. (Required to generate code targeting the Adaptive Profile). [Learn more](https://aka.ms/qdk.qir)"
         },
-        "Q#.enableAdaptiveProfile": {
+        "Q#.qir.enableAdaptiveProfile": {
           "type": "boolean",
           "default": false,
-          "description": "Enables Adaptive as a target profile."
+          "markdownDescription": "Enable Adaptive Profile as a target. [Learn more](https://aka.ms/qdk.qir)"
         }
       }
     },

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -7,7 +7,7 @@ import * as vscode from "vscode";
 export function getTarget(): TargetProfile {
   const target = vscode.workspace
     .getConfiguration("Q#")
-    .get<TargetProfile>("targetProfile", "unrestricted");
+    .get<TargetProfile>("qir.targetProfile", "unrestricted");
   switch (target) {
     case "base":
     case "adaptive_ri":
@@ -22,7 +22,7 @@ export function getTarget(): TargetProfile {
 export async function setTarget(target: TargetProfile) {
   const config = vscode.workspace.getConfiguration("Q#");
   await config.update(
-    "targetProfile",
+    "qir.targetProfile",
     target,
     vscode.ConfigurationTarget.Global,
   );
@@ -58,14 +58,14 @@ export function getShowCircuitCodeLens(): boolean {
 
 export function getEnablePreviewQirGen(): boolean {
   return vscode.workspace.getConfiguration("Q#").get<boolean>(
-    "enablePreviewQirGen",
+    "qir.experimentalCodeGeneration",
     false, // The default value should be set in `package.json` as well.
   );
 }
 
 export function getEnableAdaptiveProfile(): boolean {
   return vscode.workspace.getConfiguration("Q#").get<boolean>(
-    "enableAdaptiveProfile",
+    "qir.enableAdaptiveProfile",
     false, // The default value should be set in `package.json` as well.
   );
 }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -379,7 +379,7 @@ function registerConfigurationChangeHandlers(
   formatterHandle: any,
 ) {
   return vscode.workspace.onDidChangeConfiguration((event) => {
-    if (event.affectsConfiguration("Q#.targetProfile")) {
+    if (event.affectsConfiguration("Q#.qir.targetProfile")) {
       updateLanguageServiceProfile(languageService);
     } else if (event.affectsConfiguration("Q#.enableFormatting")) {
       updateLanguageServiceEnableFormatting(languageService, formatterHandle);

--- a/vscode/src/statusbar.ts
+++ b/vscode/src/statusbar.ts
@@ -46,7 +46,7 @@ export function activateTargetProfileStatusBarItem(): vscode.Disposable[] {
       if (
         vscode.window.activeTextEditor &&
         isQsharpDocument(vscode.window.activeTextEditor.document) &&
-        event.affectsConfiguration("Q#.targetProfile")
+        event.affectsConfiguration("Q#.qir.targetProfile")
       ) {
         refreshStatusBarItemValue();
       }


### PR DESCRIPTION
This groups QIR settings together, updates the setting name and description to be a little more helpful, and uses markdown to be able to provide a link to our wiki for QIR.

The new settings appear as below.

<img width="661" alt="image" src="https://github.com/microsoft/qsharp/assets/993909/35227bab-5ce3-45fb-953e-03e961b28fcb">
