### PR TITLE
Add `--debug` flag to qsi for testing

### DIFF
--- a/compiler/qsc/README.md
+++ b/compiler/qsc/README.md
@@ -49,6 +49,12 @@ Options:
           Disable automatic inclusion of the standard library
       --exec
           Exit after loading the files or running the given file(s)/entry on the command line
+  -q, --qsharp-json <QSHARP_JSON>
+          Path to a Q# manifest for a project
+  -f, --features <FEATURES>
+          Language features to compile with
+      --debug
+          Compile the given files and interactive snippets in debug mode
   -h, --help
           Print help
   -V, --version

--- a/compiler/qsc/src/bin/qsi.rs
+++ b/compiler/qsc/src/bin/qsi.rs
@@ -52,6 +52,10 @@ struct Cli {
     /// Language features to compile with
     #[arg(short, long)]
     features: Vec<String>,
+
+    /// Compile the given files and interactive snippets in debug mode.
+    #[arg(long)]
+    debug: bool,
 }
 
 struct TerminalReceiver;
@@ -102,7 +106,11 @@ fn main() -> miette::Result<ExitCode> {
         }
     }
     if cli.exec {
-        let mut interpreter = match Interpreter::new(
+        let mut interpreter = match (if cli.debug {
+            Interpreter::new_with_debug
+        } else {
+            Interpreter::new
+        })(
             !cli.nostdlib,
             SourceMap::new(sources, cli.entry.map(std::convert::Into::into)),
             PackageType::Exe,

--- a/compiler/qsc/src/bin/qsi.rs
+++ b/compiler/qsc/src/bin/qsi.rs
@@ -130,7 +130,11 @@ fn main() -> miette::Result<ExitCode> {
         ));
     }
 
-    let mut interpreter = match Interpreter::new(
+    let mut interpreter = match (if cli.debug {
+        Interpreter::new_with_debug
+    } else {
+        Interpreter::new
+    })(
         !cli.nostdlib,
         SourceMap::new(sources, None),
         PackageType::Lib,


### PR DESCRIPTION
This adds a `--debug` flag to qsi that will make it load the interpreter with debug settings. That will make certain testing easier.