### PR TITLE
GHZ and CAT samples work in Adaptive and Base Profiles

### DIFF
--- a/samples/algorithms/CatState.qs
+++ b/samples/algorithms/CatState.qs
@@ -7,9 +7,7 @@
 ///
 /// This Q# program implements a cat state of 5 qubits.
 namespace Sample {
-    open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Diagnostics;
-    open Microsoft.Quantum.Measurement;
 
     @EntryPoint()
     operation Main() : Result[] {
@@ -35,6 +33,6 @@ namespace Sample {
         // Set the first qubit in the register into a (|0〉 + |1〉) / √2 superposition.
         // Then apply a CNOT to the remaining qubits using the first qubit as control.
         H(register[0]);
-        ApplyToEach(CNOT(register[0], _), Rest(register));
+        ApplyToEach(CNOT(register[0], _), register[1...]);
     }
 }

--- a/samples/algorithms/CatState.qs
+++ b/samples/algorithms/CatState.qs
@@ -7,6 +7,7 @@
 ///
 /// This Q# program implements a cat state of 5 qubits.
 namespace Sample {
+    open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Measurement;
 
@@ -21,20 +22,19 @@ namespace Sample {
         DumpMachine();
 
         // Measure and reset qubits before releasing them.
-        let results = MeasureEachZ(register);
-        ResetAll(register);
-        return results;
+        MResetEachZ(register)
     }
 
-    // Prepares a cat state 1/sqrt(2)(|0...0〉 + |1...1〉) using a qubit register
-    // in the zero state.
+    /// # Summary
+    /// Prepares state (|0...0〉 + |1...1〉) / √2 (a generalized GHZ state
+    /// or a cat state) across the `register` of qubits.
+    /// All qubits are assumed to be in |0〉 state on input.
     operation PrepareCatState(register : Qubit[]) : Unit {
         Fact(Length(register) > 0, "Qubit register must not be empty.");
-        Fact(CheckAllZero(register), "Qubits are not in the |0〉 state.");
 
-        // Set the first qubit in the register into a 1/sqrt(2)(|0〉 + |1〉) superposition.
+        // Set the first qubit in the register into a (|0〉 + |1〉) / √2 superposition.
         // Then apply a CNOT to the remaining qubits using the first qubit as control.
         H(register[0]);
-        ApplyToEach(CNOT(register[0], _), register[1...]);
+        ApplyToEach(CNOT(register[0], _), Rest(register));
     }
 }

--- a/samples/algorithms/GHZ.qs
+++ b/samples/algorithms/GHZ.qs
@@ -18,6 +18,7 @@
 namespace Sample {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Measurement;
+    open Microsoft.Quantum.Arrays;
 
     @EntryPoint()
     operation Main() : Result[] {
@@ -30,23 +31,17 @@ namespace Sample {
         DumpMachine();
 
         // Measure and reset qubits before releasing them.
-        let results = MeasureEachZ(qs);
-        ResetAll(qs);
-        return results;
+        MResetEachZ(qs)
     }
 
     /// # Summary
-    /// This operation prepares a generalized GHZ state across a register of qubits.
-    ///
-    /// # Input
-    /// ## qs
-    /// The given register of qubits to be transformed into the GHZ state. It is assumed
-    /// that these qubits are in their default |0〉 state.
+    /// This operation prepares a generalized GHZ state (or cat state)
+    /// across a register of qubits `qs`. All qubits are assumed to be
+    /// in |0〉 state on input. 
     operation PrepareGHZState(qs : Qubit[]) : Unit {
         Fact(Length(qs) > 0, "`qs` length must be greater than zero");
-        Fact(CheckAllZero(qs), "All qubits must be in the |0〉 state");
 
         H(qs[0]);
-        ApplyToEach(CNOT(qs[0], _), qs[1...]);
+        ApplyToEach(CNOT(qs[0], _), Rest(qs));
     }
 }

--- a/samples/algorithms/GHZ.qs
+++ b/samples/algorithms/GHZ.qs
@@ -17,8 +17,6 @@
 /// returns the result of measuring those qubits.
 namespace Sample {
     open Microsoft.Quantum.Diagnostics;
-    open Microsoft.Quantum.Measurement;
-    open Microsoft.Quantum.Arrays;
 
     @EntryPoint()
     operation Main() : Result[] {
@@ -39,7 +37,7 @@ namespace Sample {
     /// of three qubits `qs`.
     /// All qubits are assumed to be in |0〉 state on input.
     operation PrepareGHZState(qs : Qubit[]) : Unit {
-        Fact(Length(qs) == 3, "`qs` length be 3.");
+        Fact(Length(qs) == 3, "`qs` length shuold be 3.");
 
         H(qs[0]);
         CNOT(qs[0], qs[1]);

--- a/samples/algorithms/GHZ.qs
+++ b/samples/algorithms/GHZ.qs
@@ -35,13 +35,14 @@ namespace Sample {
     }
 
     /// # Summary
-    /// This operation prepares a generalized GHZ state (or cat state)
-    /// across a register of qubits `qs`. All qubits are assumed to be
-    /// in |0〉 state on input. 
+    /// Prepares state (|000〉 + |111〉) / √2 (GHZ state) across a register
+    /// of three qubits `qs`.
+    /// All qubits are assumed to be in |0〉 state on input.
     operation PrepareGHZState(qs : Qubit[]) : Unit {
-        Fact(Length(qs) > 0, "`qs` length must be greater than zero");
+        Fact(Length(qs) == 3, "`qs` length be 3.");
 
         H(qs[0]);
-        ApplyToEach(CNOT(qs[0], _), Rest(qs));
+        CNOT(qs[0], qs[1]);
+        CNOT(qs[0], qs[2]);
     }
 }


### PR DESCRIPTION
This updates GHZ state and CAT state sample to work in base profile and adaptive profile.
- Removed check for zero state
- updated comments
- Used library functions MResetEachZ() and Rest()
- Made preparation function specific to GHZ in GHZ sample