### PR TITLE
Fixing LaTeX in the doc comment for Measure and Exp

### DIFF
--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -258,6 +258,17 @@ namespace Microsoft.Quantum.Intrinsic {
     /// Performs a joint measurement of one or more qubits in the
     /// specified Pauli bases.
     ///
+    /// # Description
+    /// The probability of getting `Zero` is
+    /// $\langle \psi | \frac{I + P_0 \otimes \ldots \otimes P_{N-1}}{2} | \psi \rangle$
+    /// where $P_i$ is the $i$-th element of `bases`, and where
+    /// $N$ is the `Length(bases)`.
+    /// That is, measurement returns a `Result` $d$ such that the eigenvalue of the
+    /// observed measurement effect is $(-1)^d$.
+    ///
+    /// If the basis array and qubit array are different lengths, then the
+    /// operation will fail.
+    ///
     /// # Input
     /// ## bases
     /// Array of single-qubit Pauli values indicating the tensor product
@@ -268,17 +279,6 @@ namespace Microsoft.Quantum.Intrinsic {
     /// # Output
     /// `Zero` if the +1 eigenvalue is observed, and `One` if
     /// the -1 eigenvalue is observed.
-    ///
-    /// # Remarks
-    /// The probability of getting `Zero` is
-    /// $\langle \psi | \frac{I + P_0 \otimes \ldots \otimes P_{N-1}}{2} | \psi \rangle$
-    /// where $P_i$ is the $i$-th element of `bases`, and where
-    /// $N = \texttt{Length}(\texttt{bases})$.
-    /// That is, measurement returns a `Result` $d$ such that the eigenvalue of the
-    /// observed measurement effect is $(-1)^d$.
-    ///
-    /// If the basis array and qubit array are different lengths, then the
-    /// operation will fail.
     @Config(Adaptive)
     operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
         if Length(bases) != Length(qubits) {

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -270,20 +270,9 @@ namespace Microsoft.Quantum.Intrinsic {
     /// the -1 eigenvalue is observed.
     ///
     /// # Remarks
-    /// The output result is given by the distribution:
-    /// $$
-    /// \begin{align}
-    ///     \Pr(\texttt{Zero} | \ket{\psi}) =
-    ///         \frac12 \braket{
-    ///             \psi \mid|
-    ///             \left(
-    ///                 \boldone + P_0 \otimes P_1 \otimes \cdots \otimes P_{N-1}
-    ///             \right) \mid|
-    ///             \psi
-    ///         },
-    /// \end{align}
-    /// $$
-    /// where $P_i$ is the $i$th element of `bases`, and where
+    /// The probability of getting `Zero` is
+    /// $\langle \psi | \frac{I + P_0 \otimes \ldots \otimes P_{N-1}}{2} | \psi \rangle$
+    /// where $P_i$ is the $i$-th element of `bases`, and where
     /// $N = \texttt{Length}(\texttt{bases})$.
     /// That is, measurement returns a `Result` $d$ such that the eigenvalue of the
     /// observed measurement effect is $(-1)^d$.

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -91,7 +91,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///     e^{i \theta [P_0 \otimes P_1 \cdots P_{N-1}]},
     /// \end{align}
     /// $$
-    /// where $P_i$ is the $i$th element of `paulis`, and where
+    /// where $P_i$ is the $i$-th element of `paulis`, and where
     /// $N = $`Length(paulis)`.
     operation Exp(paulis : Pauli[], theta : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
         body ... {

--- a/library/std/intrinsic.qs
+++ b/library/std/intrinsic.qs
@@ -260,7 +260,7 @@ namespace Microsoft.Quantum.Intrinsic {
     ///
     /// # Description
     /// The probability of getting `Zero` is
-    /// $\langle \psi | \frac{I + P_0 \otimes \ldots \otimes P_{N-1}}{2} | \psi \rangle$
+    /// $\bra{\psi} \frac{I + P_0 \otimes \ldots \otimes P_{N-1}}{2} \ket{\psi}$
     /// where $P_i$ is the $i$-th element of `bases`, and where
     /// $N$ is the `Length(bases)`.
     /// That is, measurement returns a `Result` $d$ such that the eigenvalue of the


### PR DESCRIPTION
I updated doc comment for Measure and Exp function.
* Moved text from Remarks to Description as it is specific to the function.
* Simplified formula for probability of getting `Zero` as the outcome of measurement.
* Fixed LaTeX.