### PR TITLE
Improve error reporting spans in RCA check

### DIFF
--- a/compiler/qsc_partial_eval/tests/output_recording.rs
+++ b/compiler/qsc_partial_eval/tests/output_recording.rs
@@ -5,7 +5,7 @@
 
 use expect_test::expect;
 use indoc::indoc;
-use test_utils::get_rir_program;
+use test_utils::{assert_error, get_partial_evaluation_error, get_rir_program};
 
 pub mod test_utils;
 
@@ -519,11 +519,8 @@ fn output_recording_for_mix_of_literal_and_variable() {
 }
 
 #[test]
-#[should_panic(
-    expected = "partial evaluation failed: OutputResultLiteral(Span { lo: 50, hi: 54 })"
-)]
 fn output_recording_fails_with_result_literal_one() {
-    let _ = get_rir_program(indoc! {
+    let error = get_partial_evaluation_error(indoc! {
         r#"
         namespace Test {
             @EntryPoint()
@@ -533,14 +530,16 @@ fn output_recording_fails_with_result_literal_one() {
         }
         "#,
     });
+
+    assert_error(
+        &error,
+        &expect!["OutputResultLiteral(Span { lo: 50, hi: 54 })"],
+    );
 }
 
 #[test]
-#[should_panic(
-    expected = "partial evaluation failed: OutputResultLiteral(Span { lo: 50, hi: 54 })"
-)]
 fn output_recording_fails_with_result_literal_zero() {
-    let _ = get_rir_program(indoc! {
+    let error = get_partial_evaluation_error(indoc! {
         r#"
         namespace Test {
             @EntryPoint()
@@ -550,14 +549,16 @@ fn output_recording_fails_with_result_literal_zero() {
         }
         "#,
     });
+
+    assert_error(
+        &error,
+        &expect!["OutputResultLiteral(Span { lo: 50, hi: 54 })"],
+    );
 }
 
 #[test]
-#[should_panic(
-    expected = "partial evaluation failed: OutputResultLiteral(Span { lo: 50, hi: 54 })"
-)]
 fn output_recording_fails_with_result_literal_in_array() {
-    let _ = get_rir_program(indoc! {
+    let error = get_partial_evaluation_error(indoc! {
         r#"
         namespace Test {
             @EntryPoint()
@@ -568,14 +569,16 @@ fn output_recording_fails_with_result_literal_in_array() {
         }
         "#,
     });
+
+    assert_error(
+        &error,
+        &expect!["OutputResultLiteral(Span { lo: 50, hi: 54 })"],
+    );
 }
 
 #[test]
-#[should_panic(
-    expected = "partial evaluation failed: OutputResultLiteral(Span { lo: 50, hi: 54 })"
-)]
 fn output_recording_fails_with_result_literal_in_tuple() {
-    let _ = get_rir_program(indoc! {
+    let error = get_partial_evaluation_error(indoc! {
         r#"
         namespace Test {
             @EntryPoint()
@@ -586,4 +589,9 @@ fn output_recording_fails_with_result_literal_in_tuple() {
         }
         "#,
     });
+
+    assert_error(
+        &error,
+        &expect!["OutputResultLiteral(Span { lo: 50, hi: 54 })"],
+    );
 }

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -661,12 +661,6 @@ fn use_of_static_int_in_tuple_return_from_entry_point_errors() {
         USE_ENTRY_POINT_STATIC_INT_IN_TUPLE,
         &expect![[r#"
             [
-                UseOfDynamicInt(
-                    Span {
-                        lo: 63,
-                        hi: 66,
-                    },
-                ),
                 UseOfIntOutput(
                     Span {
                         lo: 63,
@@ -684,12 +678,6 @@ fn use_of_static_sized_array_in_tuple_error() {
         USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE,
         &expect![[r#"
             [
-                UseOfDynamicInt(
-                    Span {
-                        lo: 63,
-                        hi: 66,
-                    },
-                ),
                 UseOfIntOutput(
                     Span {
                         lo: 63,

--- a/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -806,12 +806,6 @@ fn use_of_static_int_in_tuple_return_from_entry_point_errors() {
         USE_ENTRY_POINT_STATIC_INT_IN_TUPLE,
         &expect![[r#"
             [
-                UseOfDynamicInt(
-                    Span {
-                        lo: 63,
-                        hi: 66,
-                    },
-                ),
                 UseOfIntOutput(
                     Span {
                         lo: 63,
@@ -829,12 +823,6 @@ fn use_of_static_sized_array_in_tuple_error() {
         USE_ENTRY_POINT_INT_ARRAY_IN_TUPLE,
         &expect![[r#"
             [
-                UseOfDynamicInt(
-                    Span {
-                        lo: 63,
-                        hi: 66,
-                    },
-                ),
                 UseOfIntOutput(
                     Span {
                         lo: 63,

--- a/compiler/qsc_passes/src/entry_point.rs
+++ b/compiler/qsc_passes/src/entry_point.rs
@@ -81,7 +81,7 @@ fn create_entry_from_callables(
                     qsc_hir::hir::SpecBody::Impl(_, block) => {
                         let arg = Expr {
                             id: assigner.next_node(),
-                            span: ep.span,
+                            span: ep.input.span,
                             ty: Ty::UNIT,
                             kind: ExprKind::Tuple(Vec::new()),
                         };
@@ -92,13 +92,13 @@ fn create_entry_from_callables(
                         };
                         let callee = Expr {
                             id: assigner.next_node(),
-                            span: ep.span,
+                            span: ep.name.span,
                             ty: block.ty.clone(),
                             kind: ExprKind::Var(Res::Item(item_id), Vec::new()),
                         };
                         let call = Expr {
                             id: assigner.next_node(),
-                            span: ep.name.span,
+                            span: Span::default(),
                             ty: block.ty.clone(),
                             kind: ExprKind::Call(Box::new(callee), Box::new(arg)),
                         };

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -44,9 +44,9 @@ fn test_entry_point_attr_to_expr() {
             }"},
         "",
         &expect![[r#"
-            Expr 12 [50-54] [Type Int]: Call:
-                Expr 11 [40-73] [Type Int]: Var: Item 1
-                Expr 10 [40-73] [Type Unit]: Unit"#]],
+            Expr 12 [0-0] [Type Int]: Call:
+                Expr 11 [50-54] [Type Int]: Var: Item 1
+                Expr 10 [54-56] [Type Unit]: Unit"#]],
     );
 }
 

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -844,9 +844,6 @@ impl RuntimeFeatureFlags {
         if self.contains(RuntimeFeatureFlags::CallToDynamicCallee) {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
-        if self.contains(RuntimeFeatureFlags::CallToUnresolvedCallee) {
-            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
-        }
         if self.contains(RuntimeFeatureFlags::MeasurementWithinDynamicScope) {
             capabilities |= TargetCapabilityFlags::Adaptive;
         }
@@ -872,5 +869,13 @@ impl RuntimeFeatureFlags {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         capabilities
+    }
+
+    #[must_use]
+    pub fn output_recording_flags() -> RuntimeFeatureFlags {
+        RuntimeFeatureFlags::UseOfIntOutput
+            | RuntimeFeatureFlags::UseOfDoubleOutput
+            | RuntimeFeatureFlags::UseOfBoolOutput
+            | RuntimeFeatureFlags::UseOfAdvancedOutput
     }
 }


### PR DESCRIPTION
This fixes minor issues in error spans used when reporting RCA check errors to avoid duplicate errors being reported for generated entry expressions that come from `@EntryPoint` attributed callables in standalone Q# files.

Fixes #1537.