### PR TITLE
Partial evaluation support for array slicing

### DIFF
--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -25,7 +25,9 @@ pub mod output;
 pub mod state;
 pub mod val;
 
-use crate::val::Value;
+use crate::val::{
+    index_array, make_range, slice_array, update_index_range, update_index_single, Value,
+};
 use backend::Backend;
 use debug::{CallStack, Frame};
 pub use error::PackageSpan;
@@ -1105,18 +1107,8 @@ impl State {
         update: Value,
         span: PackageSpan,
     ) -> Result<(), Error> {
-        if index < 0 {
-            return Err(Error::InvalidNegativeInt(index, span));
-        }
-        let i = index.as_index(span)?;
-        let mut values = values.to_vec();
-        match values.get_mut(i) {
-            Some(value) => {
-                *value = update;
-            }
-            None => return Err(Error::IndexOutOfRange(index, span)),
-        }
-        self.set_val_register(Value::Array(values.into()));
+        let updated_array = update_index_single(values, index, update, span)?;
+        self.set_val_register(updated_array);
         Ok(())
     }
 
@@ -1129,19 +1121,8 @@ impl State {
         update: Value,
         span: PackageSpan,
     ) -> Result<(), Error> {
-        let range = make_range(values, start, step, end, span)?;
-        let mut values = values.to_vec();
-        let update = update.unwrap_array();
-        for (idx, update) in range.into_iter().zip(update.iter()) {
-            let i = idx.as_index(span)?;
-            match values.get_mut(i) {
-                Some(value) => {
-                    *value = update.clone();
-                }
-                None => return Err(Error::IndexOutOfRange(idx, span)),
-            }
-        }
-        self.set_val_register(Value::Array(values.into()));
+        let updated_array = update_index_range(values, start, step, end, update, span)?;
+        self.set_val_register(updated_array);
         Ok(())
     }
 
@@ -1480,53 +1461,6 @@ fn lit_to_val(lit: &Lit) -> Value {
         Lit::Pauli(v) => Value::Pauli(*v),
         Lit::Result(fir::Result::Zero) => Value::RESULT_ZERO,
         Lit::Result(fir::Result::One) => Value::RESULT_ONE,
-    }
-}
-
-fn index_array(arr: &[Value], index: i64, span: PackageSpan) -> Result<Value, Error> {
-    let i = index.as_index(span)?;
-    match arr.get(i) {
-        Some(v) => Ok(v.clone()),
-        None => Err(Error::IndexOutOfRange(index, span)),
-    }
-}
-
-fn slice_array(
-    arr: &[Value],
-    start: Option<i64>,
-    step: i64,
-    end: Option<i64>,
-    span: PackageSpan,
-) -> Result<Value, Error> {
-    let range = make_range(arr, start, step, end, span)?;
-    let mut slice = vec![];
-    for i in range {
-        slice.push(index_array(arr, i, span)?);
-    }
-
-    Ok(Value::Array(slice.into()))
-}
-
-fn make_range(
-    arr: &[Value],
-    start: Option<i64>,
-    step: i64,
-    end: Option<i64>,
-    span: PackageSpan,
-) -> Result<Range, Error> {
-    if step == 0 {
-        Err(Error::RangeStepZero(span))
-    } else {
-        let len: i64 = match arr.len().try_into() {
-            Ok(len) => Ok(len),
-            Err(_) => Err(Error::ArrayTooLarge(span)),
-        }?;
-        let (start, end) = if step > 0 {
-            (start.unwrap_or(0), end.unwrap_or(len - 1))
-        } else {
-            (start.unwrap_or(len - 1), end.unwrap_or(0))
-        };
-        Ok(Range::new(start, step, end))
     }
 }
 

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -28,7 +28,7 @@ pub mod val;
 use crate::val::Value;
 use backend::Backend;
 use debug::{CallStack, Frame};
-use error::PackageSpan;
+pub use error::PackageSpan;
 use miette::Diagnostic;
 use num_bigint::BigInt;
 use output::Receiver;
@@ -256,7 +256,7 @@ pub enum StepResult {
     Return(Value),
 }
 
-trait AsIndex {
+pub trait AsIndex {
     type Output;
 
     fn as_index(&self, index_source: PackageSpan) -> Self::Output;
@@ -288,7 +288,7 @@ pub struct VariableInfo {
     pub span: Span,
 }
 
-struct Range {
+pub struct Range {
     step: i64,
     end: i64,
     curr: i64,

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -256,7 +256,7 @@ pub enum StepResult {
     Return(Value),
 }
 
-pub trait AsIndex {
+trait AsIndex {
     type Output;
 
     fn as_index(&self, index_source: PackageSpan) -> Self::Output;

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -383,7 +383,11 @@ impl Value {
     }
 }
 
-fn index_array(arr: &[Value], index: i64, span: PackageSpan) -> std::result::Result<Value, Error> {
+pub fn index_array(
+    arr: &[Value],
+    index: i64,
+    span: PackageSpan,
+) -> std::result::Result<Value, Error> {
     let i = index.as_index(span)?;
     match arr.get(i) {
         Some(v) => Ok(v.clone()),

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -333,7 +333,7 @@ impl<'a> PartialEvaluator<'a> {
             ));
         };
 
-        // Get the value at the specified index or range.
+        // Set the value at the specified index or range.
         let hir_package_id = map_fir_package_to_hir(self.get_current_package_id());
         let index_package_span = PackageSpan {
             package: hir_package_id,

--- a/compiler/qsc_partial_eval/tests/arrays.rs
+++ b/compiler/qsc_partial_eval/tests/arrays.rs
@@ -12,7 +12,10 @@ pub mod test_utils;
 use expect_test::expect;
 use indoc::indoc;
 use qsc_rir::rir::{BlockId, CallableId};
-use test_utils::{assert_block_instructions, assert_callable, get_rir_program};
+use test_utils::{
+    assert_block_instructions, assert_callable, assert_error, get_partial_evaluation_error,
+    get_rir_program,
+};
 
 #[test]
 fn array_with_dynamic_content() {
@@ -216,7 +219,7 @@ fn array_repeat_with_dynamic_content() {
 }
 
 #[test]
-fn result_at_index_in_array() {
+fn result_array_value_at_index() {
     let program = get_rir_program(indoc! {r#"
         namespace Test {
             @EntryPoint()
@@ -268,7 +271,186 @@ fn result_at_index_in_array() {
 }
 
 #[test]
-fn array_slicing() {
+fn result_array_value_at_negative_index_raises_error() {
+    let error = get_partial_evaluation_error(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result {
+                use (q0, q1) = (Qubit(), Qubit());
+                let results = [MResetZ(q0), MResetZ(q1)];
+                results[-1]
+            }
+        }
+    "#});
+    assert_error(
+        &error,
+        &expect![[
+            r#"EvaluationFailed("value cannot be used as an index: -1", Span { lo: 177, hi: 179 })"#
+        ]],
+    );
+}
+
+#[test]
+fn result_array_value_at_index_out_of_bounds_raises_error() {
+    let error = get_partial_evaluation_error(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result {
+                use (q0, q1) = (Qubit(), Qubit());
+                let results = [MResetZ(q0), MResetZ(q1)];
+                results[2]
+            }
+        }
+    "#});
+    assert_error(
+        &error,
+        &expect![[r#"EvaluationFailed("index out of range: 2", Span { lo: 177, hi: 178 })"#]],
+    );
+}
+
+#[test]
+fn result_array_slice_with_explicit_range() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3, q4) = (Qubit(), Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2), MResetZ(q3), MResetZ(q4)];
+                a[0..2..4]
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(1), args( Qubit(3), Result(3), )
+                Call id(1), args( Qubit(4), Result(4), )
+                Call id(2), args( Integer(3), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(2), Pointer, )
+                Call id(3), args( Result(4), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_array_slice_with_open_start_range() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2) = (Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a[...1]
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(2), args( Integer(2), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(1), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_array_slice_with_open_ended_range() {
     let program = get_rir_program(indoc! {r#"
         namespace Test {
             @EntryPoint()
@@ -279,5 +461,570 @@ fn array_slicing() {
             }
         }
     "#});
-    println!("{program}");
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(2), args( Integer(2), Pointer, )
+                Call id(3), args( Result(1), Pointer, )
+                Call id(3), args( Result(2), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_array_slice_with_open_two_step_range() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3, q4) = (Qubit(), Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2), MResetZ(q3), MResetZ(q4)];
+                a[...2...]
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(1), args( Qubit(3), Result(3), )
+                Call id(1), args( Qubit(4), Result(4), )
+                Call id(2), args( Integer(3), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(2), Pointer, )
+                Call id(3), args( Result(4), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_array_slice_with_out_of_bounds_range_raises_error() {
+    let error = get_partial_evaluation_error(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3) = (Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a[1..3]
+            }
+        }
+    "#});
+    assert_error(
+        &error,
+        &expect![[r#"EvaluationFailed("index out of range: 3", Span { lo: 206, hi: 210 })"#]],
+    );
+}
+
+#[test]
+fn result_array_copy_and_update_with_single_index() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3) = (Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a w/ 1 <- MResetZ(q3)
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(1), args( Qubit(3), Result(3), )
+                Call id(2), args( Integer(3), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(3), Pointer, )
+                Call id(3), args( Result(2), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_array_copy_and_update_with_single_negative_index_raises_error() {
+    let error = get_partial_evaluation_error(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3) = (Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a w/ -1 <- MResetZ(q3)
+            }
+        }
+    "#});
+    assert_error(
+        &error,
+        &expect![[
+            r#"EvaluationFailed("negative integers cannot be used here: -1", Span { lo: 209, hi: 211 })"#
+        ]],
+    );
+}
+
+#[test]
+fn result_array_copy_and_update_with_single_out_of_bounds_index_raises_error() {
+    let error = get_partial_evaluation_error(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3) = (Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a w/ 3 <- MResetZ(q3)
+            }
+        }
+    "#});
+    assert_error(
+        &error,
+        &expect![[r#"EvaluationFailed("index out of range: 3", Span { lo: 209, hi: 210 })"#]],
+    );
+}
+
+#[test]
+fn result_array_copy_and_update_with_explicit_range() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3, q4) = (Qubit(), Qubit(), Qubit(), Qubit(), Qubit());
+                use (aux0, aux1, aux2) = (Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2), MResetZ(q3), MResetZ(q4)];
+                a w/ 0..2..4 <- [MResetZ(aux0), MResetZ(aux1), MResetZ(aux2)]
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(1), args( Qubit(3), Result(3), )
+                Call id(1), args( Qubit(4), Result(4), )
+                Call id(1), args( Qubit(5), Result(5), )
+                Call id(1), args( Qubit(6), Result(6), )
+                Call id(1), args( Qubit(7), Result(7), )
+                Call id(2), args( Integer(5), Pointer, )
+                Call id(3), args( Result(5), Pointer, )
+                Call id(3), args( Result(1), Pointer, )
+                Call id(3), args( Result(6), Pointer, )
+                Call id(3), args( Result(3), Pointer, )
+                Call id(3), args( Result(7), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_array_copy_and_update_with_open_start_range() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3, q4) = (Qubit(), Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a w/ ...2 <- [MResetZ(q3), MResetZ(q4)]
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(1), args( Qubit(3), Result(3), )
+                Call id(1), args( Qubit(4), Result(4), )
+                Call id(2), args( Integer(3), Pointer, )
+                Call id(3), args( Result(3), Pointer, )
+                Call id(3), args( Result(4), Pointer, )
+                Call id(3), args( Result(2), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_array_copy_and_update_with_open_ended_range() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3, q4) = (Qubit(), Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a w/ 1... <- [MResetZ(q3), MResetZ(q4)]
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(1), args( Qubit(3), Result(3), )
+                Call id(1), args( Qubit(4), Result(4), )
+                Call id(2), args( Integer(3), Pointer, )
+                Call id(3), args( Result(0), Pointer, )
+                Call id(3), args( Result(3), Pointer, )
+                Call id(3), args( Result(4), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_array_copy_and_update_with_open_two_step_range() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3, q4) = (Qubit(), Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a w/ ...2... <- [MResetZ(q3), MResetZ(q4)]
+            }
+        }
+    "#});
+    let measurement_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        measurement_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__mresetz__body
+                call_type: Measurement
+                input_type:
+                    [0]: Qubit
+                    [1]: Result
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let array_output_recording_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        array_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let result_output_recording_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        result_output_recording_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(1), args( Qubit(2), Result(2), )
+                Call id(1), args( Qubit(3), Result(3), )
+                Call id(1), args( Qubit(4), Result(4), )
+                Call id(2), args( Integer(3), Pointer, )
+                Call id(3), args( Result(3), Pointer, )
+                Call id(3), args( Result(1), Pointer, )
+                Call id(3), args( Result(4), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn result_array_copy_and_update_with_out_of_bounds_range_raises_error() {
+    let error = get_partial_evaluation_error(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2, q3) = (Qubit(), Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a w/ 1..3 <- [MResetZ(q0), MResetZ(q1), MResetZ(q2)]
+            }
+        }
+    "#});
+    assert_error(
+        &error,
+        &expect![[r#"EvaluationFailed("index out of range: 3", Span { lo: 209, hi: 213 })"#]],
+    );
 }

--- a/compiler/qsc_partial_eval/tests/arrays.rs
+++ b/compiler/qsc_partial_eval/tests/arrays.rs
@@ -266,3 +266,18 @@ fn result_at_index_in_array() {
                 Return"#]],
     );
 }
+
+#[test]
+fn array_slicing() {
+    let program = get_rir_program(indoc! {r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Result[] {
+                use (q0, q1, q2) = (Qubit(), Qubit(), Qubit());
+                let a = [MResetZ(q0), MResetZ(q1), MResetZ(q2)];
+                a[1...]
+            }
+        }
+    "#});
+    println!("{program}");
+}

--- a/compiler/qsc_partial_eval/tests/returns.rs
+++ b/compiler/qsc_partial_eval/tests/returns.rs
@@ -1090,9 +1090,7 @@ fn explicit_return_embedded_in_hybrid_update_index_expr_yields_error() {
     "#});
     assert_error(
         &error,
-        &expect![[
-            r#"Unexpected("embedded return in assign index expression", Span { lo: 142, hi: 154 })"#
-        ]],
+        &expect![[r#"Unexpected("embedded return in update expression", Span { lo: 142, hi: 154 })"#]],
     );
 }
 

--- a/compiler/qsc_partial_eval/tests/returns.rs
+++ b/compiler/qsc_partial_eval/tests/returns.rs
@@ -910,10 +910,11 @@ fn explicit_return_embedded_in_assign_index_expr_yields_error() {
         }
     }
     "#});
-    // The type of error will change once this kind of hybrid expression is supported.
     assert_error(
         &error,
-        &expect![[r#"Unimplemented("Update Index Expr", Span { lo: 170, hi: 193 })"#]],
+        &expect![[
+            r#"Unexpected("embedded return in update expression", Span { lo: 181, hi: 193 })"#
+        ]],
     );
 }
 


### PR DESCRIPTION
This change adds support to partial evaluation for array slicing in index expressions, copy expressions and copy & update expressions.