### PR TITLE
Support target name in Python, remove Adaptive warnings

### DIFF
--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -31,8 +31,6 @@ class Config:
     ):
         if target_profile == TargetProfile.Adaptive_RI:
             self._config = {"targetProfile": "adaptive_ri"}
-            warn("The Adaptive_RI target profile is a preview feature.")
-            warn("Functionality may be incomplete or incorrect.")
         elif target_profile == TargetProfile.Base:
             self._config = {"targetProfile": "base"}
         elif target_profile == TargetProfile.Unrestricted:
@@ -60,6 +58,7 @@ class Config:
 def init(
     *,
     target_profile: TargetProfile = TargetProfile.Unrestricted,
+    target_name: Optional[str] = None,
     project_root: Optional[str] = None,
     language_features: Optional[List[str]] = None,
 ) -> Config:
@@ -70,12 +69,26 @@ def init(
         interpreter to generate programs that are compatible
         with a specific target. See :py:class: `qsharp.TargetProfile`.
 
+    :param target_name: An optional name of the target machine to use for inferring the compatible
+        target_profile setting.
+
     :param project_root: An optional path to a root directory with a Q# project to include.
         It must contain a qsharp.json project manifest.
     """
     from ._fs import read_file, list_directory, exists, join
 
     global _interpreter
+
+    if isinstance(target_name, str):
+        target = target_name.split(".")[0].lower()
+        if target == "ionq" or target == "rigetti":
+            target_profile = TargetProfile.Base
+        elif target == "quantinuum":
+            target_profile = TargetProfile.Adaptive_RI
+        else:
+            raise QSharpError(
+                f'target_name "{target_name}" not recognized. Please set target_profile directly.'
+            )
 
     manifest_contents = None
     manifest_descriptor = None

--- a/pip/tests-qir/test_qir.py
+++ b/pip/tests-qir/test_qir.py
@@ -111,7 +111,5 @@ def test_compile_qir_all_gates() -> None:
     check_call(25, "__quantum__rt__result_record_output", 2)
     check_call(26, "__quantum__rt__result_record_output", 2)
 
-    # TODO: these checks fail at the moment. They should become asserts with the release
-    # of PyQIR 0.10.0.
-    # assert required_num_qubits(module.functions[0]) == 2
-    # assert required_num_results(module.functions[0]) == 2
+    assert required_num_qubits(module.functions[0]) == 5
+    assert required_num_results(module.functions[0]) == 2

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -265,6 +265,19 @@ def test_compile_qir_str() -> None:
     assert "define void @ENTRYPOINT__main()" in qir
 
 
+def test_init_from_provider_name() -> None:
+    config = qsharp.init(target_name="ionq.simulator")
+    assert config._config["targetProfile"] == "base"
+    config = qsharp.init(target_name="rigetti.sim.qvm")
+    assert config._config["targetProfile"] == "base"
+    config = qsharp.init(target_name="quantinuum.sim")
+    assert config._config["targetProfile"] == "adaptive_ri"
+    config = qsharp.init(target_name="Quantinuum")
+    assert config._config["targetProfile"] == "adaptive_ri"
+    config = qsharp.init(target_name="IonQ")
+    assert config._config["targetProfile"] == "base"
+
+
 def test_run_with_result(capsys) -> None:
     qsharp.init()
     qsharp.eval('operation Foo() : Result { Message("Hello, world!"); Zero }')


### PR DESCRIPTION
This change adds an optional `target_name` property to `qsharp.init()` where the user can specify the target and have the profile inferred. Right now it just uses some hard-coded logic to decide between "ionq", "rigetti", or "quantinuum" and anything else is treated as unrecognized with a prompt for the user to specify `target_profile` directly.