### PR TITLE
Surface partial evaluation errors in VS Code

### DIFF
--- a/npm/qsharp/src/browser.ts
+++ b/npm/qsharp/src/browser.ts
@@ -158,17 +158,19 @@ export function getLanguageServiceWorker(
   return createProxy(worker, wasmModule, languageServiceProtocol);
 }
 
-export { StepResultId, type IStructStepResult } from "../lib/web/qsc_wasm.js";
+export { StepResultId } from "../lib/web/qsc_wasm.js";
 export type {
   IBreakpointSpan,
   ICodeLens,
+  IDocFile,
   ILocation,
   IOperationInfo,
   IPosition,
+  IQSharpError,
   IRange,
   IStackFrame,
+  IStructStepResult,
   VSDiagnostic,
-  IDocFile,
 } from "../lib/web/qsc_wasm.js";
 export { type Dump, type ShotResult } from "./compiler/common.js";
 export { type CompilerState, type ProgramConfig } from "./compiler/compiler.js";

--- a/vscode/src/debugger/activate.ts
+++ b/vscode/src/debugger/activate.ts
@@ -10,6 +10,7 @@ import { getRandomGuid } from "../utils";
 
 import * as vscode from "vscode";
 import { loadProject } from "../projectSystem";
+import { clearCommandDiagnostics } from "../diagnostics";
 
 let debugServiceWorkerFactory: () => IDebugServiceWorker;
 
@@ -74,6 +75,8 @@ function registerCommands(context: vscode.ExtensionContext) {
     config: { name: string; [key: string]: any },
     options?: vscode.DebugSessionOptions,
   ) {
+    clearCommandDiagnostics();
+
     if (vscode.debug.activeDebugSession?.type === "qsharp") {
       // Multiple debug sessions disallowed, to reduce confusion
       return;

--- a/vscode/src/diagnostics.ts
+++ b/vscode/src/diagnostics.ts
@@ -238,6 +238,7 @@ function reportIfQSharpErrors(e: unknown) {
       }
     } catch (_) {
       // Couldn't parse the error as JSON.
+      log.warn(`could not parse error string ${e}`);
     }
   }
 

--- a/vscode/src/diagnostics.ts
+++ b/vscode/src/diagnostics.ts
@@ -275,8 +275,12 @@ function reportIfQSharpErrors(e: unknown) {
  * @returns A VS code URI that's okay to use in a Diagnostic object
  */
 function getSourceUri(maybeUri: string): vscode.Uri {
+  // An error without a span (e.g. "no entrypoint found") gets reported as a "project-level" error.
+  // See: https://github.com/microsoft/qsharp/blob/f8d344b32a1f1f918f3c91edf58c975db10f4370/wasm/src/diagnostic.rs#L191
+  // Ideally this would be a proper URI pointing to the project root or root document.
+  // For now, make up a fake file path for display purposes.
   if (maybeUri === "<project>") {
-    return vscode.Uri.parse(maybeUri, false); // strict=false ignores lack of scheme
+    return vscode.Uri.file("Q# project");
   }
 
   try {

--- a/vscode/src/diagnostics.ts
+++ b/vscode/src/diagnostics.ts
@@ -3,6 +3,7 @@
 
 import {
   ILanguageService,
+  IQSharpError,
   VSDiagnostic,
   log,
   qsharpLibraryUriScheme,
@@ -16,6 +17,7 @@ export function startCheckingQSharp(
   return [
     ...startLanguageServiceDiagnostics(languageService),
     ...startQsharpJsonDiagnostics(),
+    ...startCommandDiagnostics(),
   ];
 }
 
@@ -42,37 +44,7 @@ function startLanguageServiceDiagnostics(
 
     diagCollection.set(
       uri,
-      diagnostics.diagnostics.map((d) => {
-        let severity;
-        switch (d.severity) {
-          case "error":
-            severity = vscode.DiagnosticSeverity.Error;
-            break;
-          case "warning":
-            severity = vscode.DiagnosticSeverity.Warning;
-            break;
-          case "info":
-            severity = vscode.DiagnosticSeverity.Information;
-            break;
-        }
-        const vscodeDiagnostic = new vscode.Diagnostic(
-          toVscodeRange(d.range),
-          d.message,
-          severity,
-        );
-        if (d.code) {
-          vscodeDiagnostic.code = d.code;
-        }
-        if (d.related) {
-          vscodeDiagnostic.relatedInformation = d.related.map((r) => {
-            return new vscode.DiagnosticRelatedInformation(
-              toVscodeLocation(r.location),
-              r.message,
-            );
-          });
-        }
-        return vscodeDiagnostic;
-      }),
+      diagnostics.diagnostics.map((d) => toVsCodeDiagnostic(d)),
     );
   }
 
@@ -87,6 +59,44 @@ function startLanguageServiceDiagnostics(
     diagCollection,
   ];
 }
+
+export function toVsCodeDiagnostic(d: VSDiagnostic): vscode.Diagnostic {
+  let severity;
+  switch (d.severity) {
+    case "error":
+      severity = vscode.DiagnosticSeverity.Error;
+      break;
+    case "warning":
+      severity = vscode.DiagnosticSeverity.Warning;
+      break;
+    case "info":
+      severity = vscode.DiagnosticSeverity.Information;
+      break;
+  }
+  const vscodeDiagnostic = new vscode.Diagnostic(
+    toVscodeRange(d.range),
+    d.message,
+    severity,
+  );
+  if (d.code) {
+    vscodeDiagnostic.code = d.code;
+  }
+  if (d.related) {
+    vscodeDiagnostic.relatedInformation = d.related.map((r) => {
+      return new vscode.DiagnosticRelatedInformation(
+        toVscodeLocation(r.location),
+        r.message,
+      );
+    });
+  }
+  return vscodeDiagnostic;
+}
+
+//
+// qsharp.json diagnostics.
+//
+// These are reported whenever problems are detected in a qsharp.json file.
+//
 
 let qsharpJsonDiagnostics: vscode.DiagnosticCollection | undefined;
 let deleteQsharpJsonListener: vscode.Disposable | undefined;
@@ -129,4 +139,152 @@ export function updateQSharpJsonDiagnostics(
     : [];
 
   qsharpJsonDiagnostics?.set(qsharpJson, errors);
+}
+
+//
+// Command diagnostics.
+//
+// These are Q# diagnostics that are caused by the invocation of a command, e.g. "generate QIR".
+//
+// These behave differently than diagnostics coming from the language service. They are not live.
+// They pertain to the last-run command. They don't get cleared or refreshed when the
+// user edits the document. They will be cleared when a new command is run.
+// They can also be dismissed by the user with a code action.
+//
+
+let commandDiagnostics: vscode.DiagnosticCollection | undefined;
+
+function startCommandDiagnostics(): vscode.Disposable[] {
+  commandDiagnostics =
+    vscode.languages.createDiagnosticCollection(qsharpLanguageId);
+
+  const dismissCommand = vscode.commands.registerCommand(
+    "qsharp-vscode.dismissCommandDiagnostics",
+    clearCommandDiagnostics,
+  );
+
+  const dismissActionProvider = vscode.languages.registerCodeActionsProvider(
+    qsharpLanguageId,
+    {
+      provideCodeActions(doc, range, context): vscode.CodeAction[] | undefined {
+        const commandErrors = context.diagnostics.filter((d) =>
+          d.message.startsWith("Q# command error: "),
+        );
+
+        if (commandErrors.length > 0) {
+          const action = new vscode.CodeAction(
+            "Dismiss errors for the last run Q# command",
+          );
+          action.diagnostics = commandErrors;
+          action.command = {
+            command: "qsharp-vscode.dismissCommandDiagnostics",
+            title: "Dismiss errors for the last run Q# command",
+          };
+          action.isPreferred = true;
+          return [action];
+        }
+      },
+    },
+  );
+
+  return [commandDiagnostics, dismissCommand, dismissActionProvider];
+}
+
+export function clearCommandDiagnostics() {
+  if (!commandDiagnostics) {
+    log.warn(`no diagnostic collection for commands, not clearing`);
+  }
+
+  commandDiagnostics?.clear();
+}
+
+/**
+ * Wrapper that invokes a function. This function would be something that calls into
+ * the Q# compiler. If the function throws an exception that contains Q# diagnostics,
+ * reports the diagnostics to VS Code before rethrowing the original exception.
+ */
+export async function invokeAndReportCommandDiagnostics<T>(
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  try {
+    // Clear the diagnostics from the last command run.
+    clearCommandDiagnostics();
+    return await fn();
+  } catch (e: unknown) {
+    reportIfQSharpErrors(e);
+    throw e;
+  }
+}
+
+/**
+ * Given an exception, checks if it's a JSON string representation of IQSharpError[],
+ * and if so, reports the diagnostics to VS Code.
+ *
+ * @param e an exception originating from the qsharp-lang package
+ */
+function reportIfQSharpErrors(e: unknown) {
+  if (!commandDiagnostics) {
+    log.warn(`diagnostic collection for commands was not initialized`);
+    return;
+  }
+
+  let qsharpErrors: IQSharpError[] | undefined;
+  if (typeof e === "string") {
+    try {
+      const errors = JSON.parse(e);
+      // Check for the shape of IQSharpError[]
+      if (Array.isArray(errors) && errors.length > 0 && errors[0].document) {
+        qsharpErrors = errors;
+      }
+    } catch (_) {
+      // Couldn't parse the error as JSON.
+    }
+  }
+
+  if (qsharpErrors) {
+    const byUri = new Map<vscode.Uri, vscode.Diagnostic[]>();
+
+    for (const error of qsharpErrors) {
+      const uri = getSourceUri(error.document);
+
+      const diagnostics = byUri.get(uri) || [];
+      error.diagnostic.message = `Q# command error: ${error.diagnostic.message}`;
+      diagnostics.push(toVsCodeDiagnostic(error.diagnostic));
+      byUri.set(uri, diagnostics);
+    }
+
+    for (const [uri, diags] of byUri) {
+      commandDiagnostics.set(uri, diags);
+    }
+
+    // Focus on Problems view
+    vscode.commands.executeCommand("workbench.action.problems.focus");
+
+    vscode.window.showErrorMessage(
+      "The Q# command returned errors. Please see the Problems view.",
+      { modal: true },
+    );
+  }
+}
+
+/**
+ * This is temporary until we're able to report proper stdlib and project URIs from
+ * the wasm layer. See https://github.com/microsoft/qsharp/blob/f8d344b32a1f1f918f3c91edf58c975db10f4370/wasm/src/diagnostic.rs
+ *
+ * @param maybeUri A source name returned from a Q# diagnostic
+ * @returns A VS code URI that's okay to use in a Diagnostic object
+ */
+function getSourceUri(maybeUri: string): vscode.Uri {
+  if (maybeUri === "<project>") {
+    return vscode.Uri.parse(maybeUri, false); // strict=false ignores lack of scheme
+  }
+
+  try {
+    return vscode.Uri.parse(maybeUri, true);
+  } catch (e) {
+    // Not a URI, assume it's a filename from the stdlib
+    // This URI should ideally be properly propagated from
+    // https://github.com/microsoft/qsharp/blob/f8d344b32a1f1f918f3c91edf58c975db10f4370/wasm/src/diagnostic.rs#L105
+    return vscode.Uri.from({ scheme: qsharpLibraryUriScheme, path: maybeUri });
+  }
 }

--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -8,6 +8,7 @@ import { EventType, sendTelemetryEvent } from "./telemetry";
 import { getRandomGuid } from "./utils";
 import { getTarget, setTarget } from "./config";
 import { loadProject } from "./projectSystem";
+import { invokeAndReportCommandDiagnostics } from "./diagnostics";
 
 const generateQirTimeoutMs = 30000;
 
@@ -60,16 +61,7 @@ export async function getQirForActiveWindow(): Promise<string> {
   } catch (e: any) {
     throw new QirGenerationError(e.message);
   }
-  for (const source of sources) {
-    const diagnostics = await vscode.languages.getDiagnostics(
-      vscode.Uri.parse(source[0]),
-    );
-    if (diagnostics?.length > 0) {
-      throw new QirGenerationError(
-        "The current program contains errors that must be fixed before submitting to Azure",
-      );
-    }
-  }
+
   // Create a temporary worker just to get the QIR, as it may loop/panic during codegen.
   // Let it run for max 10 seconds, then terminate it if not complete.
   const worker = getCompilerWorker(compilerWorkerScriptPath);
@@ -86,7 +78,10 @@ export async function getQirForActiveWindow(): Promise<string> {
       languageFeatures,
       profile: getTarget(),
     } as ProgramConfig;
-    result = await worker.getQir(config);
+
+    result = await invokeAndReportCommandDiagnostics(() =>
+      worker.getQir(config),
+    );
 
     sendTelemetryEvent(
       EventType.GenerateQirEnd,

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -9,21 +9,22 @@ import {
   log,
 } from "qsharp-lang";
 import {
-  commands,
   ExtensionContext,
   Uri,
   ViewColumn,
   Webview,
   WebviewPanel,
   WebviewPanelSerializer,
+  commands,
   window,
 } from "vscode";
+import { showCircuitCommand } from "./circuit";
 import { isQsharpDocument } from "./common";
+import { clearCommandDiagnostics } from "./diagnostics";
+import { showDocumentationCommand } from "./documentation";
 import { loadProject } from "./projectSystem";
 import { EventType, sendTelemetryEvent } from "./telemetry";
 import { getRandomGuid } from "./utils";
-import { showCircuitCommand } from "./circuit";
-import { showDocumentationCommand } from "./documentation";
 
 const QSharpWebViewType = "qsharp-webview";
 const compilerRunTimeoutMs = 1000 * 60 * 5; // 5 minutes
@@ -43,6 +44,7 @@ export function registerWebViewCommands(context: ExtensionContext) {
 
   context.subscriptions.push(
     commands.registerCommand("qsharp-vscode.showRe", async () => {
+      clearCommandDiagnostics();
       const associationId = getRandomGuid();
       sendTelemetryEvent(
         EventType.TriggerResourceEstimation,
@@ -290,6 +292,8 @@ export function registerWebViewCommands(context: ExtensionContext) {
 
   context.subscriptions.push(
     commands.registerCommand("qsharp-vscode.showHistogram", async () => {
+      clearCommandDiagnostics();
+
       const associationId = getRandomGuid();
       sendTelemetryEvent(EventType.TriggerHistogram, { associationId }, {});
       function resultToLabel(result: string | VSDiagnostic): string {

--- a/wasm/src/tests.rs
+++ b/wasm/src/tests.rs
@@ -482,7 +482,7 @@ fn code_with_errors_returns_errors() {
 
     expect![[r#"
         Err(
-            "[{\"message\": \"syntax error\",\"code\": \"Qsc.Parse.Token\",\"severity\": \"error\",\"causes\": [\"expected `;`, found keyword `let`\"],\"filename\": \"test.qs\",\"labels\": [{\"span\": {\"offset\": 129,\"length\": 3}}],\"related\": []}]",
+            "[{\"document\":\"test.qs\",\"diagnostic\":{\"range\":{\"start\":{\"line\":4,\"character\":16},\"end\":{\"line\":4,\"character\":19}},\"message\":\"syntax error: expected `;`, found keyword `let`\",\"severity\":\"error\",\"code\":\"Qsc.Parse.Token\"},\"stack\":null}]",
         )
     "#]]
     .assert_debug_eq(&_get_qir(sources, language_features, capabilities));


### PR DESCRIPTION
- Defines a struct `IQSharpError` at the WASM boundary to contain full error information from Q# interpreter error calls. Currently this is only used in QIR generation and circuit visualization, but it can and should eventually be wired up for all `ICompiler` methods that can return errors.

- We create a new diagnostic collection (a set of errors to be shown in the Problems view in VS Code) that shows errors from the last run command. These errors persist in the editor, but can be dismissed by the user or when another command is run.

![partial-eval-errors](https://github.com/microsoft/qsharp/assets/16928427/1a54866c-8e45-475d-8cdb-e5b10cee5b45)
