### PR TITLE
Drop FIR increment if FIR passes fail

### DIFF
--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -618,7 +618,7 @@ impl Interpreter {
 
         let compute_properties = cap_results.map_err(|caps_errors| {
             // if there are errors, convert them to interpreter errors
-            // and revert the update the lowerer/FIR store.
+            // and revert the update to the lowerer/FIR store.
             let fir_package = self.fir_store.get_mut(self.package);
             self.lowerer.revert_last_increment(fir_package);
 

--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -618,7 +618,10 @@ impl Interpreter {
 
         let compute_properties = cap_results.map_err(|caps_errors| {
             // if there are errors, convert them to interpreter errors
-            // and don't update the lowerer or FIR store.
+            // and revert the update the lowerer/FIR store.
+            let fir_package = self.fir_store.get_mut(self.package);
+            self.lowerer.revert_last_increment(fir_package);
+
             let source_package = self
                 .compiler
                 .package_store()

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -548,22 +548,7 @@ mod given_interpreter {
         }
 
         #[test]
-        fn once_rca_validation_fails_following_calls_also_fail_by_design() {
-            fn verify_same_error<E>(result: &Result<Value, Vec<E>>, output: &str)
-            where
-                E: Diagnostic,
-            {
-                is_only_error(
-                    result,
-                    output,
-                    &expect![[r#"
-                    cannot use a dynamic integer value
-                       [line_0] [set x = 2]
-                    cannot use a dynamic integer value
-                       [line_0] [x]
-                "#]],
-                );
-            }
+        fn once_rca_validation_fails_following_calls_do_not_fail() {
             let mut interpreter = get_interpreter_with_capbilities(TargetCapabilityFlags::Adaptive);
             let (result, output) = line(
                 &mut interpreter,
@@ -571,7 +556,16 @@ mod given_interpreter {
                     operation Foo() : Int { use q = Qubit(); mutable x = 1; if MResetZ(q) == One { set x = 2; } x }
                 "#},
             );
-            verify_same_error(&result, &output);
+            is_only_error(
+                &result,
+                &output,
+                &expect![[r#"
+                cannot use a dynamic integer value
+                   [line_0] [set x = 2]
+                cannot use a dynamic integer value
+                   [line_0] [x]
+            "#]],
+            );
             // do something innocuous
             let (result, output) = line(
                 &mut interpreter,
@@ -579,7 +573,7 @@ mod given_interpreter {
                     let y = 7;
                 "#},
             );
-            verify_same_error(&result, &output);
+            is_only_value(&result, &output, &Value::unit());
         }
 
         #[test]

--- a/compiler/qsc_lowerer/src/lib.rs
+++ b/compiler/qsc_lowerer/src/lib.rs
@@ -22,6 +22,15 @@ pub fn map_fir_package_to_hir(package: fir::PackageId) -> hir::PackageId {
     hir::PackageId::from(Into::<usize>::into(package))
 }
 
+#[derive(Debug, Default)]
+struct FirIncrement {
+    blocks: Vec<BlockId>,
+    exprs: Vec<ExprId>,
+    pats: Vec<PatId>,
+    stmts: Vec<StmtId>,
+    items: Vec<LocalItemId>,
+}
+
 pub struct Lowerer {
     nodes: IndexMap<hir::NodeId, fir::NodeId>,
     locals: IndexMap<hir::NodeId, fir::LocalVarId>,
@@ -33,6 +42,7 @@ pub struct Lowerer {
     exec_graph: Vec<ExecGraphNode>,
     enable_debug: bool,
     ret_node: ExecGraphNode,
+    fir_increment: FirIncrement,
 }
 
 impl Default for Lowerer {
@@ -55,6 +65,7 @@ impl Lowerer {
             exec_graph: Vec::new(),
             enable_debug: false,
             ret_node: ExecGraphNode::Ret,
+            fir_increment: FirIncrement::default(),
         }
     }
 
@@ -118,6 +129,9 @@ impl Lowerer {
         fir_package: &mut fir::Package,
         hir_package: &hir::Package,
     ) {
+        // Clear the previous increment since we are about to take a new one.
+        self.fir_increment = FirIncrement::default();
+
         let items: IndexMap<LocalItemId, fir::Item> = hir_package
             .items
             .values()
@@ -135,6 +149,7 @@ impl Lowerer {
 
         for (k, v) in items {
             fir_package.items.insert(k, v);
+            self.fir_increment.items.push(k);
         }
 
         fir_package.entry = entry;
@@ -142,21 +157,43 @@ impl Lowerer {
         qsc_fir::validate::validate(fir_package);
     }
 
+    pub fn revert_last_increment(&mut self, package: &mut fir::Package) {
+        for id in self.fir_increment.blocks.drain(..) {
+            self.blocks.remove(id);
+        }
+        for id in self.fir_increment.exprs.drain(..) {
+            self.exprs.remove(id);
+        }
+        for id in self.fir_increment.pats.drain(..) {
+            self.pats.remove(id);
+        }
+        for id in self.fir_increment.stmts.drain(..) {
+            self.stmts.remove(id);
+        }
+        for id in self.fir_increment.items.drain(..) {
+            package.items.remove(id);
+        }
+    }
+
     fn update_package(&mut self, package: &mut fir::Package) {
         for (id, value) in self.blocks.drain() {
             package.blocks.insert(id, value);
+            self.fir_increment.blocks.push(id);
         }
 
         for (id, value) in self.exprs.drain() {
             package.exprs.insert(id, value);
+            self.fir_increment.exprs.push(id);
         }
 
         for (id, value) in self.pats.drain() {
             package.pats.insert(id, value);
+            self.fir_increment.pats.push(id);
         }
 
         for (id, value) in self.stmts.drain() {
             package.stmts.insert(id, value);
+            self.fir_increment.stmts.push(id);
         }
     }
 

--- a/compiler/qsc_lowerer/src/lib.rs
+++ b/compiler/qsc_lowerer/src/lib.rs
@@ -159,16 +159,16 @@ impl Lowerer {
 
     pub fn revert_last_increment(&mut self, package: &mut fir::Package) {
         for id in self.fir_increment.blocks.drain(..) {
-            self.blocks.remove(id);
+            package.blocks.remove(id);
         }
         for id in self.fir_increment.exprs.drain(..) {
-            self.exprs.remove(id);
+            package.exprs.remove(id);
         }
         for id in self.fir_increment.pats.drain(..) {
-            self.pats.remove(id);
+            package.pats.remove(id);
         }
         for id in self.fir_increment.stmts.drain(..) {
-            self.stmts.remove(id);
+            package.stmts.remove(id);
         }
         for id in self.fir_increment.items.drain(..) {
             package.items.remove(id);

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -281,6 +281,10 @@ def test_callables_failing_profile_validation_are_not_registered() -> None:
             "operation Foo() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x }"
         )
     assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
+    # In this case, the callable Foo failed compilation late enough that the symbol is bound. This makes later
+    # use of `Foo` valid from a name resolution standpoint, but the callable cannot be invoked because it was found
+    # to be invalid for the current profile. To stay consistent with the behavior of other compilations that
+    # leave unbound symbols, the call will compile but fail to run.
     with pytest.raises(Exception) as excinfo:
         e.interpret("Foo()")
     assert "Qsc.Eval.UnboundName" in str(excinfo)

--- a/pip/tests/test_interpreter.py
+++ b/pip/tests/test_interpreter.py
@@ -274,8 +274,7 @@ def test_entry_expr_circuit() -> None:
     )
 
 
-# this is by design
-def test_callables_failing_profile_validation_are_still_registered() -> None:
+def test_callables_failing_profile_validation_are_not_registered() -> None:
     e = Interpreter(TargetProfile.Adaptive_RI)
     with pytest.raises(Exception) as excinfo:
         e.interpret(
@@ -284,11 +283,10 @@ def test_callables_failing_profile_validation_are_still_registered() -> None:
     assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
     with pytest.raises(Exception) as excinfo:
         e.interpret("Foo()")
-    assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
+    assert "Qsc.Eval.UnboundName" in str(excinfo)
 
 
-# this is by design
-def test_once_rca_validation_fails_following_calls_also_fail() -> None:
+def test_once_callable_fails_profile_validation_it_fails_compile_to_QIR() -> None:
     e = Interpreter(TargetProfile.Adaptive_RI)
     with pytest.raises(Exception) as excinfo:
         e.interpret(
@@ -296,8 +294,20 @@ def test_once_rca_validation_fails_following_calls_also_fail() -> None:
         )
     assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
     with pytest.raises(Exception) as excinfo:
-        e.interpret("let x = 5;")
+        e.qir("{Foo();}")
+    assert "Qsc.PartialEval.EvaluationFailed" in str(excinfo)
+    assert "name is not bound" in str(excinfo)
+
+
+def test_once_rca_validation_fails_following_calls_do_not_fail() -> None:
+    e = Interpreter(TargetProfile.Adaptive_RI)
+    with pytest.raises(Exception) as excinfo:
+        e.interpret(
+            "operation Foo() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x }"
+        )
     assert "Qsc.CapabilitiesCk.UseOfDynamicDouble" in str(excinfo)
+    value = e.interpret("let x = 5; x")
+    assert value == 5
 
 
 def test_adaptive_errors_are_raised_when_interpreting() -> None:

--- a/samples/notebooks/azure_submission.ipynb
+++ b/samples/notebooks/azure_submission.ipynb
@@ -231,7 +231,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.6"
+      "version": "3.11.7"
     },
     "orig_nbformat": 4
   },

--- a/samples/notebooks/azure_submission.ipynb
+++ b/samples/notebooks/azure_submission.ipynb
@@ -33,7 +33,7 @@
       "outputs": [
         {
           "data": {
-            "application/javascript": "// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT License.\n\n// This file provides CodeMirror syntax highlighting for Q# magic cells\n// in classic Jupyter Notebooks. It does nothing in other (Jupyter Notebook 7,\n// VS Code, Azure Notebooks, etc.) environments.\n\n// Detect the prerequisites and do nothing if they don't exist.\nif (window.require && window.CodeMirror && window.Jupyter) {\n  // The simple mode plugin for CodeMirror is not loaded by default, so require it.\n  window.require([\"codemirror/addon/mode/simple\"], function defineMode() {\n    let rules = [\n      {\n        token: \"comment\",\n        regex: /(\\/\\/).*/,\n        beginWord: false,\n      },\n      {\n        token: \"string\",\n        regex: String.raw`^\\\"(?:[^\\\"\\\\]|\\\\[\\s\\S])*(?:\\\"|$)`,\n        beginWord: false,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(namespace|open|as|operation|function|body|adjoint|newtype|controlled|internal)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(let|set|use|borrow|mutable)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"operatorKeyword\",\n        regex: String.raw`(not|and|or)\\b|(w/)`,\n        beginWord: true,\n      },\n      {\n        token: \"operatorKeyword\",\n        regex: String.raw`(=)|(!)|(<)|(>)|(\\\\+)|(-)|(\\\\*)|(\\\\/)|(\\\\^)|(%)|(\\\\|)|(\\\\&\\\\&\\\\&)|(\\\\~\\\\~\\\\~)|(\\\\.\\\\.\\\\.)|(\\\\.\\\\.)|(\\\\?)`,\n        beginWord: false,\n      },\n      {\n        token: \"meta\",\n        regex: String.raw`(Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"atom\",\n        regex: String.raw`(true|false|Pauli(I|X|Y|Z)|One|Zero)\\b`,\n        beginWord: true,\n      },\n    ];\n    let simpleRules = [];\n    for (let rule of rules) {\n      simpleRules.push({\n        token: rule.token,\n        regex: new RegExp(rule.regex, \"g\"),\n        sol: rule.beginWord,\n      });\n      if (rule.beginWord) {\n        // Need an additional rule due to the fact that CodeMirror simple mode doesn't work with ^ token\n        simpleRules.push({\n          token: rule.token,\n          regex: new RegExp(String.raw`\\W` + rule.regex, \"g\"),\n          sol: false,\n        });\n      }\n    }\n\n    // Register the mode defined above with CodeMirror\n    window.CodeMirror.defineSimpleMode(\"qsharp\", { start: simpleRules });\n    window.CodeMirror.defineMIME(\"text/x-qsharp\", \"qsharp\");\n\n    // Tell Jupyter to associate %%qsharp magic cells with the qsharp mode\n    window.Jupyter.CodeCell.options_default.highlight_modes[\"qsharp\"] = {\n      reg: [/^%%qsharp/],\n    };\n\n    // Force re-highlighting of all cells the first time this code runs\n    for (const cell of window.Jupyter.notebook.get_cells()) {\n      cell.auto_highlight();\n    }\n  });\n}\n",
+            "application/javascript": "// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT License.\n\n// This file provides CodeMirror syntax highlighting for Q# magic cells\n// in classic Jupyter Notebooks. It does nothing in other (Jupyter Notebook 7,\n// VS Code, Azure Notebooks, etc.) environments.\n\n// Detect the prerequisites and do nothing if they don't exist.\nif (window.require && window.CodeMirror && window.Jupyter) {\n  // The simple mode plugin for CodeMirror is not loaded by default, so require it.\n  window.require([\"codemirror/addon/mode/simple\"], function defineMode() {\n    let rules = [\n      {\n        token: \"comment\",\n        regex: /(\\/\\/).*/,\n        beginWord: false,\n      },\n      {\n        token: \"string\",\n        regex: String.raw`^\\\"(?:[^\\\"\\\\]|\\\\[\\s\\S])*(?:\\\"|$)`,\n        beginWord: false,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(namespace|open|as|operation|function|body|adjoint|newtype|controlled|internal)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(if|elif|else|repeat|until|fixup|for|in|return|fail|within|apply)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(Adjoint|Controlled|Adj|Ctl|is|self|auto|distribute|invert|intrinsic)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"keyword\",\n        regex: String.raw`(let|set|use|borrow|mutable)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"operatorKeyword\",\n        regex: String.raw`(not|and|or)\\b|(w/)`,\n        beginWord: true,\n      },\n      {\n        token: \"operatorKeyword\",\n        regex: String.raw`(=)|(!)|(<)|(>)|(\\+)|(-)|(\\*)|(/)|(\\^)|(%)|(\\|)|(&&&)|(~~~)|(\\.\\.\\.)|(\\.\\.)|(\\?)`,\n        beginWord: false,\n      },\n      {\n        token: \"meta\",\n        regex: String.raw`(Int|BigInt|Double|Bool|Qubit|Pauli|Result|Range|String|Unit)\\b`,\n        beginWord: true,\n      },\n      {\n        token: \"atom\",\n        regex: String.raw`(true|false|Pauli(I|X|Y|Z)|One|Zero)\\b`,\n        beginWord: true,\n      },\n    ];\n    let simpleRules = [];\n    for (let rule of rules) {\n      simpleRules.push({\n        token: rule.token,\n        regex: new RegExp(rule.regex, \"g\"),\n        sol: rule.beginWord,\n      });\n      if (rule.beginWord) {\n        // Need an additional rule due to the fact that CodeMirror simple mode doesn't work with ^ token\n        simpleRules.push({\n          token: rule.token,\n          regex: new RegExp(String.raw`\\W` + rule.regex, \"g\"),\n          sol: false,\n        });\n      }\n    }\n\n    // Register the mode defined above with CodeMirror\n    window.CodeMirror.defineSimpleMode(\"qsharp\", { start: simpleRules });\n    window.CodeMirror.defineMIME(\"text/x-qsharp\", \"qsharp\");\n\n    // Tell Jupyter to associate %%qsharp magic cells with the qsharp mode\n    window.Jupyter.CodeCell.options_default.highlight_modes[\"qsharp\"] = {\n      reg: [/^%%qsharp/],\n    };\n\n    // Force re-highlighting of all cells the first time this code runs\n    for (const cell of window.Jupyter.notebook.get_cells()) {\n      cell.auto_highlight();\n    }\n  });\n}\n",
             "text/plain": []
           },
           "metadata": {},
@@ -41,9 +41,9 @@
         },
         {
           "data": {
-            "application/x.qsharp-config": "{\"targetProfile\":\"base\"}",
+            "application/x.qsharp-config": "{\"targetProfile\":\"base\",\"languageFeatures\":null,\"manifest\":null}",
             "text/plain": [
-              "Q# initialized with configuration: {'targetProfile': 'base'}"
+              "Q# initialized with configuration: {'targetProfile': 'base', 'languageFeatures': None, 'manifest': None}"
             ]
           },
           "execution_count": 1,
@@ -74,34 +74,22 @@
       },
       "outputs": [
         {
-          "data": {
-            "text/plain": [
-              "\u001b[31mQsc.BaseProfCk.ResultComparison\u001b[0m\n",
-              "\n",
-              "  \u001b[31m×\u001b[0m cannot compare measurement results\n",
-              "   ╭─[\u001b[36;1;4mline_0\u001b[0m:4:1]\n",
-              " \u001b[2m4\u001b[0m │     let result = M(q);\n",
-              " \u001b[2m5\u001b[0m │     if (result == Zero) {\n",
-              "   · \u001b[35;1m        ──────────────\u001b[0m\n",
-              " \u001b[2m6\u001b[0m │         Message(\"The result is Zero\");\n",
-              "   ╰────\n",
-              "\u001b[36m  help: \u001b[0mcomparing measurement results is not supported when performing base\n",
-              "        profile QIR generation\n",
-              "\u001b[31mQsc.BaseProfCk.ResultLiteral\u001b[0m\n",
-              "\n",
-              "  \u001b[31m×\u001b[0m result literals are not supported\n",
-              "   ╭─[\u001b[36;1;4mline_0\u001b[0m:4:1]\n",
-              " \u001b[2m4\u001b[0m │     let result = M(q);\n",
-              " \u001b[2m5\u001b[0m │     if (result == Zero) {\n",
-              "   · \u001b[35;1m                  ────\u001b[0m\n",
-              " \u001b[2m6\u001b[0m │         Message(\"The result is Zero\");\n",
-              "   ╰────\n",
-              "\u001b[36m  help: \u001b[0mresult literals `One` and `Zero` are not supported when performing\n",
-              "        base profile QIR generation\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
+          "ename": "QSharpCellError",
+          "evalue": "\u001b[31mQsc.CapabilitiesCk.UseOfDynamicBool\u001b[0m\n\n  \u001b[31m×\u001b[0m cannot use a dynamic bool value\n   ╭─[\u001b[36;1;4mline_0\u001b[0m:4:1]\n \u001b[2m4\u001b[0m │     let result = M(q);\n \u001b[2m5\u001b[0m │     if (result == Zero) {\n   · \u001b[35;1m        ──────────────\u001b[0m\n \u001b[2m6\u001b[0m │         Message(\"The result is Zero\");\n   ╰────\n\u001b[36m  help: \u001b[0musing a bool value that depends on a measurement result is not\n        supported by the current target\n",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[31mQsc.CapabilitiesCk.UseOfDynamicBool\u001b[0m",
+            "",
+            "  \u001b[31m×\u001b[0m cannot use a dynamic bool value",
+            "   ╭─[\u001b[36;1;4mline_0\u001b[0m:4:1]",
+            " \u001b[2m4\u001b[0m │     let result = M(q);",
+            " \u001b[2m5\u001b[0m │     if (result == Zero) {",
+            "   · \u001b[35;1m        ──────────────\u001b[0m",
+            " \u001b[2m6\u001b[0m │         Message(\"The result is Zero\");",
+            "   ╰────",
+            "\u001b[36m  help: \u001b[0musing a bool value that depends on a measurement result is not",
+            "        supported by the current target"
+          ]
         }
       ],
       "source": [
@@ -243,7 +231,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.7"
+      "version": "3.11.6"
     },
     "orig_nbformat": 4
   },


### PR DESCRIPTION
This fixes an issue with incremental compilation where an increment with a failure could still have that FIR present in the package during later compilation, making errors "sticky" instead of associated with just the increment. This achieves it by tracking what the most recently lowered additions to the package were and removing them if there were pass failures like those from RCA check.