### PR TITLE
Respect configured target profile for histogram in VS Code

### DIFF
--- a/npm/qsharp/src/compiler/compiler.ts
+++ b/npm/qsharp/src/compiler/compiler.ts
@@ -240,6 +240,7 @@ export class Compiler implements ICompiler {
     eventHandler: IQscEventTarget,
   ): Promise<void> {
     let sources;
+    let profile: TargetProfile = "unrestricted";
     let languageFeatures: string[] = [];
 
     if (Array.isArray(sourcesOrConfig)) {
@@ -249,6 +250,7 @@ export class Compiler implements ICompiler {
       // this is the new API
       sources = sourcesOrConfig.sources;
       languageFeatures = sourcesOrConfig.languageFeatures || [];
+      profile = sourcesOrConfig.profile || "unrestricted";
     }
     // All results are communicated as events, but if there is a compiler error (e.g. an invalid
     // entry expression or similar), it may throw on run. The caller should expect this promise
@@ -259,6 +261,7 @@ export class Compiler implements ICompiler {
       (msg: string) => onCompilerEvent(msg, eventHandler!),
       shots!,
       languageFeatures,
+      profile,
     );
   }
 

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -25,6 +25,7 @@ import { showDocumentationCommand } from "./documentation";
 import { loadProject } from "./projectSystem";
 import { EventType, sendTelemetryEvent } from "./telemetry";
 import { getRandomGuid } from "./utils";
+import { getTarget } from "./config";
 
 const QSharpWebViewType = "qsharp-webview";
 const compilerRunTimeoutMs = 1000 * 60 * 5; // 5 minutes
@@ -359,6 +360,7 @@ export function registerWebViewCommands(context: ExtensionContext) {
         const config = {
           sources,
           languageFeatures,
+          profile: getTarget(),
         };
         await worker.run(config, "", parseInt(numberOfShots), evtTarget);
         sendTelemetryEvent(

--- a/wasm/src/tests.rs
+++ b/wasm/src/tests.rs
@@ -13,7 +13,13 @@ fn run_internal<F>(sources: SourceMap, event_cb: F, shots: u32) -> Result<(), Bo
 where
     F: FnMut(&str),
 {
-    run_internal_with_features(sources, event_cb, shots, LanguageFeatures::default())
+    run_internal_with_features(
+        sources,
+        event_cb,
+        shots,
+        LanguageFeatures::default(),
+        TargetCapabilityFlags::all(),
+    )
 }
 
 #[test]


### PR DESCRIPTION
This updates the call to `run` to that is used by the histogram feature to take the current target profile, such that histograms in the VS Code extension correctly compile the code with the configured target.