### PR TITLE
When `@EntryPoint` missing assume `Main` is entry

### DIFF
--- a/compiler/qsc_passes/src/entry_point.rs
+++ b/compiler/qsc_passes/src/entry_point.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 #[derive(Clone, Debug, Diagnostic, Error)]
 pub enum Error {
     #[error("duplicate entry point callable `{0}`")]
-    #[diagnostic(help("only one callable should be annotated with the entry point attribute"))]
+    #[diagnostic(help("only one callable named `Main` or one callable with the `@EntryPoint()` attribute must be present if no entry expression is provided"))]
     #[diagnostic(code("Qsc.EntryPoint.Duplicate"))]
     Duplicate(String, #[label] Span),
 
@@ -34,7 +34,7 @@ pub enum Error {
     BodyMissing(#[label("cannot have specialization implementation")] Span),
 
     #[error("entry point not found")]
-    #[diagnostic(help("a single callable with the `@EntryPoint()` attribute must be present if no entry expression is provided"))]
+    #[diagnostic(help("a single callable with the `@EntryPoint()` attribute must be present if no entry expression is provided and no callable named `Main` is present"))]
     #[diagnostic(code("Qsc.EntryPoint.NotFound"))]
     NotFound,
 }
@@ -124,13 +124,19 @@ fn create_entry_from_callables(
 fn get_callables(package: &Package) -> Vec<(&CallableDecl, LocalItemId)> {
     let mut finder = EntryPointFinder {
         callables: Vec::new(),
+        main: Vec::new(),
     };
     finder.visit_package(package);
-    finder.callables
+    if finder.callables.is_empty() {
+        finder.main
+    } else {
+        finder.callables
+    }
 }
 
 struct EntryPointFinder<'a> {
     callables: Vec<(&'a CallableDecl, LocalItemId)>,
+    main: Vec<(&'a CallableDecl, LocalItemId)>,
 }
 
 impl<'a> Visitor<'a> for EntryPointFinder<'a> {
@@ -138,6 +144,9 @@ impl<'a> Visitor<'a> for EntryPointFinder<'a> {
         if let ItemKind::Callable(callable) = &item.kind {
             if item.attrs.iter().any(|a| a == &Attr::EntryPoint) {
                 self.callables.push((callable, item.id));
+            }
+            if callable.name.name.as_ref().to_lowercase() == "main" {
+                self.main.push((callable, item.id));
             }
         }
     }

--- a/compiler/qsc_passes/src/entry_point.rs
+++ b/compiler/qsc_passes/src/entry_point.rs
@@ -145,7 +145,7 @@ impl<'a> Visitor<'a> for EntryPointFinder<'a> {
             if item.attrs.iter().any(|a| a == &Attr::EntryPoint) {
                 self.callables.push((callable, item.id));
             }
-            if callable.name.name.as_ref().to_lowercase() == "main" {
+            if callable.name.name.as_ref() == "Main" {
                 self.main.push((callable, item.id));
             }
         }

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -66,17 +66,20 @@ fn test_entry_point_attr_missing_implies_main() {
 }
 
 #[test]
-fn test_entry_point_attr_missing_implies_main_alernate_casing() {
+fn test_entry_point_attr_missing_implies_main_alernate_casing_not_allowed() {
     check(
         indoc! {"
             namespace Test {
-                operation maIn() : Int { 41 + 1 }
+                operation main() : Int { 41 + 1 }
             }"},
         "",
         &expect![[r#"
-            Expr 12 [0-0] [Type Int]: Call:
-                Expr 11 [32-36] [Type Int]: Var: Item 1
-                Expr 10 [36-38] [Type Unit]: Unit"#]],
+            [
+                EntryPoint(
+                    NotFound,
+                ),
+            ]
+        "#]],
     );
 }
 

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -51,11 +51,41 @@ fn test_entry_point_attr_to_expr() {
 }
 
 #[test]
-fn test_entry_point_attr_missing() {
+fn test_entry_point_attr_missing_implies_main() {
     check(
         indoc! {"
             namespace Test {
                 operation Main() : Int { 41 + 1 }
+            }"},
+        "",
+        &expect![[r#"
+            Expr 12 [0-0] [Type Int]: Call:
+                Expr 11 [32-36] [Type Int]: Var: Item 1
+                Expr 10 [36-38] [Type Unit]: Unit"#]],
+    );
+}
+
+#[test]
+fn test_entry_point_attr_missing_implies_main_alernate_casing() {
+    check(
+        indoc! {"
+            namespace Test {
+                operation maIn() : Int { 41 + 1 }
+            }"},
+        "",
+        &expect![[r#"
+            Expr 12 [0-0] [Type Int]: Call:
+                Expr 11 [32-36] [Type Int]: Var: Item 1
+                Expr 10 [36-38] [Type Unit]: Unit"#]],
+    );
+}
+
+#[test]
+fn test_entry_point_attr_missing_without_main_error() {
+    check(
+        indoc! {"
+            namespace Test {
+                operation Main2() : Int { 41 + 1 }
             }"},
         "",
         &expect![[r#"
@@ -97,6 +127,42 @@ fn test_entry_point_attr_multiple() {
                         Span {
                             lo: 107,
                             hi: 112,
+                        },
+                    ),
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn test_entry_point_main_multiple() {
+    check(
+        indoc! {"
+            namespace Test {
+                operation Main() : Int { 41 + 1 }
+            }
+            namespace Test2 {
+                operation Main() : Int { 40 + 1 }
+            }"},
+        "",
+        &expect![[r#"
+            [
+                EntryPoint(
+                    Duplicate(
+                        "Main",
+                        Span {
+                            lo: 32,
+                            hi: 36,
+                        },
+                    ),
+                ),
+                EntryPoint(
+                    Duplicate(
+                        "Main",
+                        Span {
+                            lo: 90,
+                            hi: 94,
                         },
                     ),
                 ),

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -437,7 +437,7 @@ async fn package_type_update_causes_error() {
         .update_document(
             "single/foo.qs",
             1,
-            "namespace Foo { operation Main() : Unit {} }",
+            "namespace Foo { operation Test() : Unit {} }",
         )
         .await;
 

--- a/npm/qsharp/test/basics.js
+++ b/npm/qsharp/test/basics.js
@@ -606,7 +606,7 @@ test("language service configuration update", async () => {
     "test.qs",
     1,
     `namespace Sample {
-    operation main() : Unit {
+    operation Test() : Unit {
     }
 }`,
   );
@@ -628,7 +628,7 @@ test("language service configuration update", async () => {
         messages: [
           "entry point not found\n" +
             "\n" +
-            "help: a single callable with the `@EntryPoint()` attribute must be present if no entry expression is provided",
+            "help: a single callable with the `@EntryPoint()` attribute must be present if no entry expression is provided and no callable named `Main` is present",
         ],
       },
       {
@@ -729,7 +729,7 @@ test("debug service loading source without entry point attr fails - web worker",
         [
           "test.qs",
           `namespace Sample {
-    operation main() : Result[] {
+    operation test() : Result[] {
         use q1 = Qubit();
         Y(q1);
         let m1 = M(q1);
@@ -756,7 +756,7 @@ test("debug service loading source with syntax error fails - web worker", async 
         [
           "test.qs",
           `namespace Sample {
-    operation main() : Result[]
+    operation test() : Result[]
     }
 }`,
         ],

--- a/wasm/src/tests.rs
+++ b/wasm/src/tests.rs
@@ -193,7 +193,7 @@ fn test_entrypoint() {
 #[test]
 fn test_missing_entrypoint() {
     let code = "namespace Sample {
-        operation main() : Result[] {
+        operation test() : Result[] {
             use q1 = Qubit();
             let m1 = M(q1);
             return [m1];
@@ -203,7 +203,7 @@ fn test_missing_entrypoint() {
     let result = run_internal(
         SourceMap::new([("test.qs".into(), code.into())], Some(expr.into())),
         |msg| {
-            expect![[r#"{"result":{"code":"Qsc.EntryPoint.NotFound","message":"entry point not found\n\nhelp: a single callable with the `@EntryPoint()` attribute must be present if no entry expression is provided","range":{"end":{"character":1,"line":0},"start":{"character":0,"line":0}},"severity":"error"},"success":false,"type":"Result"}"#]].assert_eq(msg);
+            expect![[r#"{"result":{"code":"Qsc.EntryPoint.NotFound","message":"entry point not found\n\nhelp: a single callable with the `@EntryPoint()` attribute must be present if no entry expression is provided and no callable named `Main` is present","range":{"end":{"character":1,"line":0},"start":{"character":0,"line":0}},"severity":"error"},"success":false,"type":"Result"}"#]].assert_eq(msg);
         },
         1,
     );


### PR DESCRIPTION
This change updates the entry point logic to assume that in the absence of an explicit `@EntryPoint` attributed callable, a unique `Main` is the entry point.
<img width="1101" alt="image" src="https://github.com/microsoft/qsharp/assets/10567287/9b27513b-57e4-47b8-b4a5-fd1bdf266dcd">
