### PR TITLE
Fix RIR panic on value updated during loop

### DIFF
--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -36,7 +36,7 @@ use num_bigint::BigInt;
 use output::Receiver;
 use qsc_data_structures::{functors::FunctorApp, index_map::IndexMap, span::Span};
 use qsc_fir::fir::{
-    self, BinOp, CallableImpl, ExecGraphNode, Expr, ExprId, ExprKind, Field, Functor, Global, Lit,
+    self, BinOp, CallableImpl, ExecGraphNode, Expr, ExprId, ExprKind, Field, Global, Lit,
     LocalItemId, LocalVarId, PackageId, PackageStoreLookup, PatId, PatKind, PrimField, Res, StmtId,
     StoreItemId, StringComponent, UnOp,
 };
@@ -52,6 +52,7 @@ use std::{
     rc::Rc,
 };
 use thiserror::Error;
+use val::update_functor_app;
 
 #[derive(Clone, Debug, Diagnostic, Error)]
 pub enum Error {
@@ -1813,19 +1814,6 @@ fn eval_binop_xorb(lhs_val: Value, rhs_val: Value) -> Value {
             Value::Int(val ^ rhs)
         }
         _ => panic!("value type does not support xorb"),
-    }
-}
-
-fn update_functor_app(functor: Functor, app: FunctorApp) -> FunctorApp {
-    match functor {
-        Functor::Adj => FunctorApp {
-            adjoint: !app.adjoint,
-            controlled: app.controlled,
-        },
-        Functor::Ctl => FunctorApp {
-            adjoint: app.adjoint,
-            controlled: app.controlled + 1,
-        },
     }
 }
 

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -3,7 +3,7 @@
 
 use num_bigint::BigInt;
 use qsc_data_structures::{display::join, functors::FunctorApp};
-use qsc_fir::fir::{Pauli, StoreItemId};
+use qsc_fir::fir::{Functor, Pauli, StoreItemId};
 use std::{
     fmt::{self, Display, Formatter},
     rc::Rc,
@@ -475,4 +475,18 @@ pub fn update_index_range(
         }
     }
     Ok(Value::Array(values.into()))
+}
+
+#[must_use]
+pub fn update_functor_app(functor: Functor, app: FunctorApp) -> FunctorApp {
+    match functor {
+        Functor::Adj => FunctorApp {
+            adjoint: !app.adjoint,
+            controlled: app.controlled,
+        },
+        Functor::Ctl => FunctorApp {
+            adjoint: app.adjoint,
+            controlled: app.controlled + 1,
+        },
+    }
 }

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -2744,8 +2744,7 @@ fn eval_un_op_with_literals(un_op: UnOp, value: Value) -> Value {
             Value::Global(id, app) => Value::Global(id, update_functor_app(functor, app)),
             _ => panic!("value should be callable"),
         },
-        UnOp::Unwrap => value,
-        UnOp::Pos => panic!("the leading positive operator should have been a no-op"),
+        UnOp::Pos | UnOp::Unwrap => value,
     }
 }
 

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -21,7 +21,8 @@ use qsc_eval::{
     output::GenericReceiver,
     resolve_closure,
     val::{
-        self, index_array, slice_array, update_index_range, update_index_single, Value, Var, VarTy,
+        self, index_array, slice_array, update_functor_app, update_index_range,
+        update_index_single, Value, Var, VarTy,
     },
     Error as EvalError, PackageSpan, State, StepAction, StepResult, Variable,
 };
@@ -1612,6 +1613,12 @@ impl<'a> PartialEvaluator<'a> {
             return Ok(control_flow);
         }
 
+        // If the variable is a literal, we can evaluate the unary operation directly.
+        if !matches!(value, Value::Var(_)) {
+            let result = eval_un_op_with_literals(un_op, value);
+            return Ok(EvalControlFlow::Continue(result));
+        }
+
         // For all the other supported unary operations we have to generate an instruction, so create a variable to
         // store the result.
         let variable_id = self.resource_manager.next_var();
@@ -2700,6 +2707,45 @@ impl<'a> PartialEvaluator<'a> {
             .insert("__quantum__rt__int_record_output".into(), callable_id);
         self.program.callables.insert(callable_id, callable);
         callable_id
+    }
+}
+
+fn eval_un_op_with_literals(un_op: UnOp, value: Value) -> Value {
+    match un_op {
+        UnOp::Neg => match value {
+            Value::Int(i) => Value::Int(-i),
+            Value::Double(d) => Value::Double(-d),
+            Value::BigInt(b) => Value::BigInt(-b),
+            _ => panic!("invalid type for negation operator {}", value.type_name()),
+        },
+        UnOp::NotB => match value {
+            Value::Int(i) => Value::Int(!i),
+            Value::BigInt(b) => Value::BigInt(!b),
+            _ => panic!(
+                "invalid type for bitwise negation operator {}",
+                value.type_name()
+            ),
+        },
+        UnOp::NotL => match value {
+            Value::Bool(b) => Value::Bool(!b),
+            _ => panic!(
+                "invalid type for logical negation operator {}",
+                value.type_name()
+            ),
+        },
+        UnOp::Functor(functor) => match value {
+            Value::Closure(inner) => Value::Closure(
+                val::Closure {
+                    functor: update_functor_app(functor, inner.functor),
+                    ..*inner
+                }
+                .into(),
+            ),
+            Value::Global(id, app) => Value::Global(id, update_functor_app(functor, app)),
+            _ => panic!("value should be callable"),
+        },
+        UnOp::Unwrap => value,
+        UnOp::Pos => panic!("the leading positive operator should have been a no-op"),
     }
 }
 


### PR DESCRIPTION
This fixes an issue with mutable variables that are static on a first run through a loop and dynamic afterward when they are used in a unary operation. The unary operation needs to be fully evaluated rather than generated into RIR, much the way static binary operations are.