### PR TITLE
Move Span methods in qsc_utils to Span impl

### DIFF
--- a/compiler/qsc_data_structures/src/span.rs
+++ b/compiler/qsc_data_structures/src/span.rs
@@ -17,19 +17,21 @@ pub struct Span {
 }
 
 impl Span {
-    /// Returns true if the position is within the range.
+    /// Returns true if the position is within the span. Meaning it is in the
+    /// right open interval `[self.lo, self.hi)`.
     #[must_use]
     pub fn contains(&self, offset: u32) -> bool {
         (self.lo..self.hi).contains(&offset)
     }
 
+    /// Returns true if the position is in the closed interval `[self.lo, self.hi]`.
     #[must_use]
     pub fn touches(&self, offset: u32) -> bool {
         (self.lo..=self.hi).contains(&offset)
     }
 
-    /// Intersect `range` with this range and returns a new range or `None`
-    /// if the ranges have no overlap.
+    /// Intersect `other` with `self` and returns a new `Span` or `None`
+    /// if the spans have no overlap.
     #[must_use]
     pub fn intersection(&self, other: &Self) -> Option<Self> {
         let lo = self.lo.max(other.lo);

--- a/compiler/qsc_data_structures/src/span.rs
+++ b/compiler/qsc_data_structures/src/span.rs
@@ -23,6 +23,11 @@ impl Span {
         (self.lo..self.hi).contains(&offset)
     }
 
+    #[must_use]
+    pub fn touches(&self, offset: u32) -> bool {
+        (self.lo..=self.hi).contains(&offset)
+    }
+
     /// Intersect `range` with this range and returns a new range or `None`
     /// if the ranges have no overlap.
     #[must_use]

--- a/language_service/src/code_lens.rs
+++ b/language_service/src/code_lens.rs
@@ -7,7 +7,7 @@ mod tests;
 use crate::{
     compilation::{Compilation, CompilationKind},
     protocol::{CodeLens, CodeLensCommand, OperationInfo},
-    qsc_utils::{into_range, span_contains},
+    qsc_utils::into_range,
 };
 use qsc::{
     circuit::qubit_param_info,
@@ -30,7 +30,7 @@ pub(crate) fn get_code_lenses(
 
     // Get callables in the current source file.
     let callables = user_unit.package.items.values().filter_map(|item| {
-        if span_contains(source_span, item.span.lo) {
+        if source_span.contains(item.span.lo) {
             // We don't support any commands for internal operations.
             if matches!(item.visibility, Visibility::Internal) {
                 return None;

--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use crate::compilation::{Compilation, CompilationKind};
 use crate::protocol::{CompletionItem, CompletionItemKind, CompletionList, TextEdit};
-use crate::qsc_utils::{into_range, span_contains};
+use crate::qsc_utils::into_range;
 
 use qsc::ast::visit::{self, Visitor};
 use qsc::display::{CodeDisplay, Lookup};
@@ -637,7 +637,7 @@ enum Context {
 
 impl Visitor<'_> for ContextFinder {
     fn visit_namespace(&mut self, namespace: &'_ qsc::ast::Namespace) {
-        if span_contains(namespace.span, self.offset) {
+        if namespace.span.contains(self.offset) {
             self.current_namespace_name = Some(namespace.name.clone().into());
             self.context = Context::Namespace;
             self.opens = vec![];
@@ -656,13 +656,13 @@ impl Visitor<'_> for ContextFinder {
                 .push((name.into(), alias.as_ref().map(|alias| alias.name.clone())));
         }
 
-        if span_contains(item.span, self.offset) {
+        if item.span.contains(self.offset) {
             visit::walk_item(self, item);
         }
     }
 
     fn visit_callable_decl(&mut self, decl: &'_ qsc::ast::CallableDecl) {
-        if span_contains(decl.span, self.offset) {
+        if decl.span.contains(self.offset) {
             // This span covers the body too, but the
             // context will get overwritten by visit_block
             // if the offset is inside the actual body
@@ -672,7 +672,7 @@ impl Visitor<'_> for ContextFinder {
     }
 
     fn visit_block(&mut self, block: &'_ qsc::ast::Block) {
-        if span_contains(block.span, self.offset) {
+        if block.span.contains(self.offset) {
             self.context = Context::Block;
         }
     }

--- a/language_service/src/name_locator.rs
+++ b/language_service/src/name_locator.rs
@@ -5,7 +5,7 @@ use std::mem::replace;
 use std::rc::Rc;
 
 use crate::compilation::Compilation;
-use crate::qsc_utils::{find_ident, span_contains, span_touches};
+use crate::qsc_utils::find_ident;
 use qsc::ast::visit::{walk_expr, walk_namespace, walk_pat, walk_ty, walk_ty_def, Visitor};
 use qsc::display::Lookup;
 use qsc::{ast, hir, resolve};
@@ -127,7 +127,7 @@ impl<'inner, 'package, T> Locator<'inner, 'package, T> {
 
 impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inner, 'package, T> {
     fn visit_namespace(&mut self, namespace: &'package ast::Namespace) {
-        if span_contains(namespace.span, self.offset) {
+        if namespace.span.contains(self.offset) {
             self.context.current_namespace = namespace.name.name();
             walk_namespace(self, namespace);
         }
@@ -135,19 +135,19 @@ impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inne
 
     // Handles callable, UDT, and type param definitions
     fn visit_item(&mut self, item: &'package ast::Item) {
-        if span_contains(item.span, self.offset) {
+        if item.span.contains(self.offset) {
             let context = replace(&mut self.context.current_item_doc, item.doc.clone());
             match &*item.kind {
                 ast::ItemKind::Callable(decl) => {
-                    if span_touches(decl.name.span, self.offset) {
+                    if decl.name.span.touches(self.offset) {
                         self.inner.at_callable_def(&self.context, &decl.name, decl);
-                    } else if span_contains(decl.span, self.offset) {
+                    } else if decl.span.contains(self.offset) {
                         let context = self.context.current_callable;
                         self.context.current_callable = Some(decl);
 
                         // walk callable decl
                         decl.generics.iter().for_each(|p| {
-                            if span_touches(p.span, self.offset) {
+                            if p.span.touches(self.offset) {
                                 if let Some(resolve::Res::Param(param_id)) =
                                     self.compilation.get_res(p.id)
                                 {
@@ -182,7 +182,7 @@ impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inne
                         let context = self.context.current_udt_id;
                         self.context.current_udt_id = Some(item_id);
 
-                        if span_touches(ident.span, self.offset) {
+                        if ident.span.touches(self.offset) {
                             self.inner.at_new_type_def(ident, def);
                         } else {
                             self.visit_ty_def(def);
@@ -212,10 +212,10 @@ impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inne
 
     // Handles UDT field definitions
     fn visit_ty_def(&mut self, def: &'package ast::TyDef) {
-        if span_contains(def.span, self.offset) {
+        if def.span.contains(self.offset) {
             if let ast::TyDefKind::Field(ident, ty) = &*def.kind {
                 if let Some(ident) = ident {
-                    if span_touches(ident.span, self.offset) {
+                    if ident.span.touches(self.offset) {
                         self.inner.at_field_def(&self.context, ident, ty);
                     } else {
                         self.visit_ty(ty);
@@ -231,7 +231,7 @@ impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inne
 
     // Handles type param references
     fn visit_ty(&mut self, ty: &'package ast::Ty) {
-        if span_touches(ty.span, self.offset) {
+        if ty.span.touches(self.offset) {
             if let ast::TyKind::Param(param) = &*ty.kind {
                 if let Some(resolve::Res::Param(param_id)) = self.compilation.get_res(param.id) {
                     if let Some(curr) = self.context.current_callable {
@@ -249,10 +249,10 @@ impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inne
 
     // Handles local variable definitions
     fn visit_pat(&mut self, pat: &'package ast::Pat) {
-        if span_touches(pat.span, self.offset) {
+        if pat.span.touches(self.offset) {
             match &*pat.kind {
                 ast::PatKind::Bind(ident, anno) => {
-                    if span_touches(ident.span, self.offset) {
+                    if ident.span.touches(self.offset) {
                         self.inner.at_local_def(&self.context, ident, pat);
                     } else if let Some(ty) = anno {
                         self.visit_ty(ty);
@@ -265,11 +265,9 @@ impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inne
 
     // Handles UDT field references
     fn visit_expr(&mut self, expr: &'package ast::Expr) {
-        if span_touches(expr.span, self.offset) {
+        if expr.span.touches(self.offset) {
             match &*expr.kind {
-                ast::ExprKind::Field(udt, field_ref)
-                    if span_touches(field_ref.span, self.offset) =>
-                {
+                ast::ExprKind::Field(udt, field_ref) if field_ref.span.touches(self.offset) => {
                     if let Some(hir::ty::Ty::Udt(_, res)) = &self.compilation.get_ty(udt.id) {
                         let (item, resolved_item_id) = self
                             .compilation
@@ -304,7 +302,7 @@ impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inne
 
     // Handles local variable, UDT, and callable references
     fn visit_path(&mut self, path: &'package ast::Path) {
-        if span_touches(path.span, self.offset) {
+        if path.span.touches(self.offset) {
             let res = self.compilation.get_res(path.id);
             if let Some(res) = res {
                 match &res {

--- a/language_service/src/qsc_utils.rs
+++ b/language_service/src/qsc_utils.rs
@@ -6,14 +6,6 @@ use qsc::line_column::{Encoding, Range};
 use qsc::location::Location;
 use qsc::{ast, hir::PackageId, SourceMap, Span};
 
-pub(crate) fn span_contains(span: Span, offset: u32) -> bool {
-    offset >= span.lo && offset < span.hi
-}
-
-pub(crate) fn span_touches(span: Span, offset: u32) -> bool {
-    offset >= span.lo && offset <= span.hi
-}
-
 pub(crate) fn into_range(encoding: Encoding, span: Span, source_map: &SourceMap) -> Range {
     let lo_source = source_map
         .find_by_offset(span.lo)

--- a/language_service/src/signature_help.rs
+++ b/language_service/src/signature_help.rs
@@ -7,7 +7,6 @@ mod tests;
 use crate::{
     compilation::Compilation,
     protocol::{ParameterInformation, SignatureHelp, SignatureInformation},
-    qsc_utils::{span_contains, span_touches},
     Encoding,
 };
 use qsc::{
@@ -76,15 +75,15 @@ struct SignatureHelpFinder<'a> {
 
 impl<'a> Visitor<'a> for SignatureHelpFinder<'a> {
     fn visit_item(&mut self, item: &'a ast::Item) {
-        if span_contains(item.span, self.offset) {
+        if item.span.contains(self.offset) {
             walk_item(self, item);
         }
     }
 
     fn visit_expr(&mut self, expr: &'a ast::Expr) {
-        if span_touches(expr.span, self.offset) {
+        if expr.span.touches(self.offset) {
             match &*expr.kind {
-                ast::ExprKind::Call(callee, args) if span_touches(args.span, self.offset) => {
+                ast::ExprKind::Call(callee, args) if args.span.touches(self.offset) => {
                     walk_expr(self, args);
                     if self.signature_help.is_none() {
                         let callee = unwrap_parens(callee);


### PR DESCRIPTION
This PR just moves things around. It moves the `span_contains` and `span_touches` methods in `qsc_utils` to `impl Span { ... }`.