### PR TITLE
Add notification with cancel to VS Code for QIR code gen

### DIFF
--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -10,7 +10,7 @@ import { getTarget, setTarget } from "./config";
 import { loadProject } from "./projectSystem";
 import { invokeAndReportCommandDiagnostics } from "./diagnostics";
 
-const generateQirTimeoutMs = 30000;
+const generateQirTimeoutMs = 120000;
 
 let compilerWorkerScriptPath: string;
 


### PR DESCRIPTION
This change adds an infinite progress notification when we generate QIR for both stand-alone and submit to Azure scenarios. The notification includes a cancel button which will terminate the worker and use updated error messages specific to cancellation or timeout. Now that QIR code generation can be gracefully cancelled, the timeout is updated to be 2 minutes rather than the previous 30 seconds.

This looks like:
![image](https://github.com/microsoft/qsharp/assets/10567287/a27ef346-c2be-4893-83e5-010f1e398074)
