### PR TITLE
Treat dynamic `Pauli` as requiring `HigherLevelConstructs`

### DIFF
--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -70,11 +70,18 @@ fn use_of_dynamic_int_yields_no_errors() {
 }
 
 #[test]
-fn use_of_dynamic_pauli_yields_no_errors() {
+fn use_of_dynamic_pauli_yields_error() {
     check_profile(
         USE_DYNAMIC_PAULI,
         &expect![[r#"
-            []
+            [
+                UseOfDynamicPauli(
+                    Span {
+                        lo: 104,
+                        hi: 134,
+                    },
+                ),
+            ]
         "#]],
     );
 }

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -809,7 +809,7 @@ impl RuntimeFeatureFlags {
             capabilities |= TargetCapabilityFlags::IntegerComputations;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicPauli) {
-            capabilities |= TargetCapabilityFlags::IntegerComputations;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::UseOfDynamicRange) {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;


### PR DESCRIPTION
This updates the logic for dynamic `Pauli` variables so that they produce an RCA check error even when integer computations are supported. This is consistent with the fact that they are not supported at codegen, as expected.