### PR TITLE
Read correct field in QEC scheme

### DIFF
--- a/resource_estimator/src/system/modeling/fault_tolerance.rs
+++ b/resource_estimator/src/system/modeling/fault_tolerance.rs
@@ -191,7 +191,7 @@ impl Protocol {
                 .clone();
 
             let physical_qubits_per_logical_qubit_expr = model
-                .logical_cycle_time
+                .physical_qubits_per_logical_qubit
                 .as_ref()
                 .ok_or_else(|| {
                     CannotParseJSON(serde::de::Error::missing_field(


### PR DESCRIPTION
The wrong field is read to calculate the physical number of qubits for a QEC scheme.