### PR TITLE
[Unitary Hack] Save Python qsharp-widgets RE output to PNG

### DIFF
--- a/npm/qsharp/package.json
+++ b/npm/qsharp/package.json
@@ -36,8 +36,5 @@
     "docs",
     "lib",
     "ux"
-  ],
-  "dependencies": {
-    "html2canvas": "^1.4.1"
-  }
+  ]
 }

--- a/npm/qsharp/package.json
+++ b/npm/qsharp/package.json
@@ -36,5 +36,8 @@
     "docs",
     "lib",
     "ux"
-  ]
+  ],
+  "dependencies": {
+    "html2canvas": "^1.4.1"
+  }
 }

--- a/npm/qsharp/ux/estimatesOverview.tsx
+++ b/npm/qsharp/ux/estimatesOverview.tsx
@@ -5,6 +5,8 @@
 // The results table is also a legend for the scatter chart.
 
 import { useState } from "preact/hooks";
+import { createRef } from "preact";
+import html2canvas from 'html2canvas';
 import { ColorMap } from "./colormap.js";
 import {
   CreateSingleEstimateResult,
@@ -187,6 +189,29 @@ export function EstimatesOverview(props: {
   const [selectedRow, setSelectedRow] = useState<string | null>(null);
   const [selectedPoint, setSelectedPoint] = useState<[number, number]>();
 
+  const printRef = createRef();
+
+  const handleDownloadImage = async () => {
+    const element = printRef.current;
+    const canvas = await html2canvas(element, {
+      backgroundColor: getComputedStyle(element).getPropertyValue("--main-background")
+    });
+
+    const data = canvas.toDataURL('image/png');
+    const link = document.createElement('a');
+
+    if (typeof link.download === 'string') {
+      link.href = data;
+      link.download = 'image.png';
+
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } else {
+      window.open(data);
+    }
+  };
+
   const runNameRenderingError =
     props.runNames != null &&
     props.runNames.length > 0 &&
@@ -306,8 +331,13 @@ export function EstimatesOverview(props: {
         </>
       ) : (
         <>
-          {getResultTable()}
-          {getScatterChart()}
+          <button type="button" onClick={handleDownloadImage}>
+            Save as Image
+          </button>
+          <div ref={printRef}>
+            {getResultTable()}
+            {getScatterChart()}
+          </div>
         </>
       )}
     </div>

--- a/npm/qsharp/ux/estimatesOverview.tsx
+++ b/npm/qsharp/ux/estimatesOverview.tsx
@@ -5,7 +5,6 @@
 // The results table is also a legend for the scatter chart.
 
 import { useState } from "preact/hooks";
-import { createRef } from "preact";
 import { ColorMap } from "./colormap.js";
 import {
   CreateSingleEstimateResult,
@@ -15,7 +14,6 @@ import {
 } from "./data.js";
 import { ResultsTable, Row } from "./resultsTable.js";
 import { Axis, PlotItem, ScatterChart, ScatterSeries } from "./scatterChart.js";
-import { saveToPng } from "./saveImage.js";
 
 const columnNames = [
   "Run name",
@@ -189,27 +187,6 @@ export function EstimatesOverview(props: {
   const [selectedRow, setSelectedRow] = useState<string | null>(null);
   const [selectedPoint, setSelectedPoint] = useState<[number, number]>();
 
-  const printRef = createRef();
-
-  const handleSaveImage = async () => {
-    const element = printRef.current;
-    const backgroundColor =
-      getComputedStyle(element).getPropertyValue("--main-background");
-    const data = await saveToPng(element, backgroundColor);
-
-    const link = document.createElement("a");
-    if (typeof link.download === "string") {
-      link.href = data;
-      link.download = "image.png";
-
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    } else {
-      window.open(data);
-    }
-  };
-
   const runNameRenderingError =
     props.runNames != null &&
     props.runNames.length > 0 &&
@@ -329,31 +306,8 @@ export function EstimatesOverview(props: {
         </>
       ) : (
         <>
-          <button
-            role="button"
-            onClick={handleSaveImage}
-            className={"qs-estimatesOverview-saveIcon"}
-            style="position: absolute; top: 5px; right: 5px;"
-          >
-            <span>
-              <svg
-                width="75%"
-                height="75%"
-                viewBox="0 0 16 16"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  className={"qs-estimatesOverview-saveIconSvgPath"}
-                  d="M12.0147 2.8595L13.1397 3.9845L13.25 4.25V12.875L12.875 13.25H3.125L2.75 12.875V3.125L3.125 2.75H11.75L12.0147 2.8595ZM3.5 3.5V12.5H12.5V4.406L11.5947 3.5H10.25V6.5H5V3.5H3.5ZM8 3.5V5.75H9.5V3.5H8Z"
-                />
-              </svg>
-            </span>
-          </button>
-          <div ref={printRef}>
-            {getResultTable()}
-            {getScatterChart()}
-          </div>
+          {getResultTable()}
+          {getScatterChart()}
         </>
       )}
     </div>

--- a/npm/qsharp/ux/estimatesOverview.tsx
+++ b/npm/qsharp/ux/estimatesOverview.tsx
@@ -6,7 +6,6 @@
 
 import { useState } from "preact/hooks";
 import { createRef } from "preact";
-import html2canvas from 'html2canvas';
 import { ColorMap } from "./colormap.js";
 import {
   CreateSingleEstimateResult,
@@ -192,26 +191,9 @@ export function EstimatesOverview(props: {
   const printRef = createRef();
 
   const handleDownloadImage = async () => {
-    const element = printRef.current;
-    const canvas = await html2canvas(element, {
-      backgroundColor: getComputedStyle(element).getPropertyValue("--main-background")
-    });
-
-    const data = canvas.toDataURL('image/png');
-    const link = document.createElement('a');
-
-    if (typeof link.download === 'string') {
-      link.href = data;
-      link.download = 'image.png';
-
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    } else {
-      window.open(data);
-    }
-  };
-
+    console.log("DATA");
+  }
+  
   const runNameRenderingError =
     props.runNames != null &&
     props.runNames.length > 0 &&

--- a/npm/qsharp/ux/estimatesOverview.tsx
+++ b/npm/qsharp/ux/estimatesOverview.tsx
@@ -15,6 +15,7 @@ import {
 } from "./data.js";
 import { ResultsTable, Row } from "./resultsTable.js";
 import { Axis, PlotItem, ScatterChart, ScatterSeries } from "./scatterChart.js";
+import { saveToPng } from "./saveImage.js";
 
 const columnNames = [
   "Run name",
@@ -190,10 +191,25 @@ export function EstimatesOverview(props: {
 
   const printRef = createRef();
 
-  const handleDownloadImage = async () => {
-    console.log("DATA");
-  }
-  
+  const handleSaveImage = async () => {
+    const element = printRef.current;
+    const backgroundColor =
+      getComputedStyle(element).getPropertyValue("--main-background");
+    const data = await saveToPng(element, backgroundColor);
+
+    const link = document.createElement("a");
+    if (typeof link.download === "string") {
+      link.href = data;
+      link.download = "image.png";
+
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } else {
+      window.open(data);
+    }
+  };
+
   const runNameRenderingError =
     props.runNames != null &&
     props.runNames.length > 0 &&
@@ -313,8 +329,26 @@ export function EstimatesOverview(props: {
         </>
       ) : (
         <>
-          <button type="button" onClick={handleDownloadImage}>
-            Save as Image
+          <button
+            role="button"
+            onClick={handleSaveImage}
+            className={"qs-estimatesOverview-saveIcon"}
+            style="position: absolute; top: 5px; right: 5px;"
+          >
+            <span>
+              <svg
+                width="75%"
+                height="75%"
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  className={"qs-estimatesOverview-saveIconSvgPath"}
+                  d="M12.0147 2.8595L13.1397 3.9845L13.25 4.25V12.875L12.875 13.25H3.125L2.75 12.875V3.125L3.125 2.75H11.75L12.0147 2.8595ZM3.5 3.5V12.5H12.5V4.406L11.5947 3.5H10.25V6.5H5V3.5H3.5ZM8 3.5V5.75H9.5V3.5H8Z"
+                />
+              </svg>
+            </span>
           </button>
           <div ref={printRef}>
             {getResultTable()}

--- a/npm/qsharp/ux/qsharp-ux.css
+++ b/npm/qsharp/ux/qsharp-ux.css
@@ -711,3 +711,15 @@ html {
 .qs-estimatesOverview-error {
   color: red;
 }
+
+.qs-estimatesOverview-saveIcon {
+  cursor: pointer;
+  width: 3em;
+  height: 3em;
+}
+
+.qs-estimatesOverview-saveIconSvgPath {
+  fill: #424242 !important;
+  fill-rule: evenodd !important;
+  clip-rule: evenodd !important;
+}

--- a/npm/qsharp/ux/qsharp-ux.css
+++ b/npm/qsharp/ux/qsharp-ux.css
@@ -716,10 +716,15 @@ html {
   cursor: pointer;
   width: 3em;
   height: 3em;
+  background-color: var(--main-background);
+  position: absolute;
+  bottom: 5px;
+  left: 5px;
+  border: none;
 }
 
 .qs-estimatesOverview-saveIconSvgPath {
-  fill: #424242 !important;
+  fill: var(--main-color) !important;
   fill-rule: evenodd !important;
   clip-rule: evenodd !important;
 }

--- a/npm/qsharp/ux/saveImage.tsx
+++ b/npm/qsharp/ux/saveImage.tsx
@@ -3,7 +3,6 @@
 
 // Writes resource estimator output to PNG file
 
-import { RefObject } from "preact";
 import {
   getImageSize,
   createImage,
@@ -58,16 +57,14 @@ function decorate<T extends HTMLElement>(nativeNode: T, clonedNode: T): T {
   return clonedNode;
 }
 
-export async function cloneNode<T extends HTMLElement>(
-  node: T,
-): Promise<T | null> {
+async function cloneNode<T extends HTMLElement>(node: T): Promise<T | null> {
   return Promise.resolve(node)
     .then((clonedNode) => cloneSingleNode(clonedNode) as Promise<T>)
     .then((clonedNode) => cloneChildren(node, clonedNode))
     .then((clonedNode) => decorate(node, clonedNode));
 }
 
-export async function saveToPng<T extends HTMLElement>(
+async function saveToPng<T extends HTMLElement>(
   node: T,
   backgroundColor: string,
 ): Promise<string> {
@@ -89,11 +86,10 @@ export async function saveToPng<T extends HTMLElement>(
   return canvas.toDataURL();
 }
 
-export async function saveRefToImage(
-  saveRef: RefObject<any>,
+export async function saveToImage<T extends HTMLElement>(
+  element: T,
   filename = "image.png",
 ) {
-  const element = saveRef.current;
   const backgroundColor =
     getComputedStyle(element).getPropertyValue("--main-background");
   const data = await saveToPng(element, backgroundColor);

--- a/npm/qsharp/ux/saveImage.tsx
+++ b/npm/qsharp/ux/saveImage.tsx
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Writes resource estimator output to PNG file
+
+import {
+  getImageSize,
+  createImage,
+  nodeToDataURI,
+  toArray,
+} from "./saveImageUtil.js";
+
+async function cloneSingleNode<T extends HTMLElement>(
+  node: T,
+): Promise<HTMLElement> {
+  return node.cloneNode(false) as T;
+}
+
+async function cloneChildren<T extends HTMLElement>(
+  nativeNode: T,
+  clonedNode: T,
+): Promise<T> {
+  let children: T[] = [];
+  children = toArray<T>((nativeNode.shadowRoot ?? nativeNode).childNodes);
+
+  // Depth-first traversal of DOM objects
+  await children.reduce(
+    (deferred, child) =>
+      deferred
+        .then(() => cloneNode(child))
+        .then((clonedChild: HTMLElement | null) => {
+          if (clonedChild) {
+            clonedNode.appendChild(clonedChild);
+          }
+        }),
+    Promise.resolve(),
+  );
+
+  return clonedNode;
+}
+
+function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
+  const targetStyle = clonedNode.style;
+  if (!targetStyle) {
+    return;
+  }
+
+  const sourceStyle = window.getComputedStyle(nativeNode);
+  toArray<string>(sourceStyle).forEach((name) => {
+    const value = sourceStyle.getPropertyValue(name);
+    targetStyle.setProperty(name, value, sourceStyle.getPropertyPriority(name));
+  });
+}
+
+function decorate<T extends HTMLElement>(nativeNode: T, clonedNode: T): T {
+  cloneCSSStyle(nativeNode, clonedNode);
+  return clonedNode;
+}
+
+export async function cloneNode<T extends HTMLElement>(
+  node: T,
+): Promise<T | null> {
+  return Promise.resolve(node)
+    .then((clonedNode) => cloneSingleNode(clonedNode) as Promise<T>)
+    .then((clonedNode) => cloneChildren(node, clonedNode))
+    .then((clonedNode) => decorate(node, clonedNode));
+}
+
+export async function toSvg<T extends HTMLElement>(
+  node: T,
+  width: number,
+  height: number,
+): Promise<string> {
+  const clonedNode = (await cloneNode(node)) as HTMLElement;
+  const dataURI = await nodeToDataURI(clonedNode, width, height);
+  return dataURI;
+}
+
+export async function saveToPng<T extends HTMLElement>(
+  node: T,
+  backgroundColor: string,
+): Promise<string> {
+  let { width, height } = getImageSize(node);
+  height += 10; // Hack to include cutoff region
+  const svg = await toSvg(node, width, height);
+  const img = await createImage(svg);
+
+  const ratio = window.devicePixelRatio || 1;
+  const canvas = document.createElement("canvas");
+  canvas.width = width * ratio;
+  canvas.height = height * ratio;
+
+  const context = canvas.getContext("2d")!;
+  context.fillStyle = backgroundColor;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  context.drawImage(img, 0, 0, canvas.width, canvas.height);
+  return canvas.toDataURL();
+}

--- a/npm/qsharp/ux/saveImage.tsx
+++ b/npm/qsharp/ux/saveImage.tsx
@@ -3,6 +3,7 @@
 
 // Writes resource estimator output to PNG file
 
+import { RefObject } from "preact";
 import {
   getImageSize,
   createImage,
@@ -80,9 +81,7 @@ export async function saveToPng<T extends HTMLElement>(
   backgroundColor: string,
 ): Promise<string> {
   const { width, height } = getImageSize(node);
-  // const clonedNode = (await cloneNode(node)) as Element;
   const clonedNode = (await cloneNode(node)) as HTMLElement;
-  // const uri = await svgToDataURI(clonedNode);
   const uri = await nodeToDataURI(clonedNode, width, height);
   const img = await createImage(uri);
 
@@ -97,4 +96,25 @@ export async function saveToPng<T extends HTMLElement>(
 
   context.drawImage(img, 0, 0, canvas.width, canvas.height);
   return canvas.toDataURL();
+}
+
+export async function saveRefToImage(
+  saveRef: RefObject<any>,
+  filename = "image.png",
+) {
+  const element = saveRef.current;
+  const backgroundColor =
+    getComputedStyle(element).getPropertyValue("--main-background");
+  const data = await saveToPng(element, backgroundColor);
+  const link = document.createElement("a");
+  if (typeof link.download === "string") {
+    link.href = data;
+    link.download = filename;
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  } else {
+    window.open(data);
+  }
 }

--- a/npm/qsharp/ux/saveImage.tsx
+++ b/npm/qsharp/ux/saveImage.tsx
@@ -68,14 +68,6 @@ export async function cloneNode<T extends HTMLElement>(
     .then((clonedNode) => decorate(node, clonedNode));
 }
 
-export async function saveToSvg<T extends HTMLElement>(
-  node: T,
-): Promise<string> {
-  const clonedNode = (await cloneNode(node)) as Element;
-  const uri = await svgToDataURI(clonedNode);
-  return uri;
-}
-
 export async function saveToPng<T extends HTMLElement>(
   node: T,
   backgroundColor: string,

--- a/npm/qsharp/ux/saveImage.tsx
+++ b/npm/qsharp/ux/saveImage.tsx
@@ -80,8 +80,7 @@ export async function saveToPng<T extends HTMLElement>(
   node: T,
   backgroundColor: string,
 ): Promise<string> {
-  let { width, height } = getImageSize(node);
-  height += 10; // Hack to include cutoff region
+  const { width, height } = getImageSize(node);
   const svg = await toSvg(node, width, height);
   const img = await createImage(svg);
 

--- a/npm/qsharp/ux/saveImage.tsx
+++ b/npm/qsharp/ux/saveImage.tsx
@@ -6,6 +6,7 @@
 import {
   getImageSize,
   createImage,
+  svgToDataURI,
   nodeToDataURI,
   toArray,
 } from "./saveImageUtil.js";
@@ -66,14 +67,12 @@ export async function cloneNode<T extends HTMLElement>(
     .then((clonedNode) => decorate(node, clonedNode));
 }
 
-export async function toSvg<T extends HTMLElement>(
+export async function saveToSvg<T extends HTMLElement>(
   node: T,
-  width: number,
-  height: number,
 ): Promise<string> {
-  const clonedNode = (await cloneNode(node)) as HTMLElement;
-  const dataURI = await nodeToDataURI(clonedNode, width, height);
-  return dataURI;
+  const clonedNode = (await cloneNode(node)) as Element;
+  const uri = await svgToDataURI(clonedNode);
+  return uri;
 }
 
 export async function saveToPng<T extends HTMLElement>(
@@ -81,8 +80,11 @@ export async function saveToPng<T extends HTMLElement>(
   backgroundColor: string,
 ): Promise<string> {
   const { width, height } = getImageSize(node);
-  const svg = await toSvg(node, width, height);
-  const img = await createImage(svg);
+  // const clonedNode = (await cloneNode(node)) as Element;
+  const clonedNode = (await cloneNode(node)) as HTMLElement;
+  // const uri = await svgToDataURI(clonedNode);
+  const uri = await nodeToDataURI(clonedNode, width, height);
+  const img = await createImage(uri);
 
   const ratio = window.devicePixelRatio || 1;
   const canvas = document.createElement("canvas");

--- a/npm/qsharp/ux/saveImage.tsx
+++ b/npm/qsharp/ux/saveImage.tsx
@@ -7,7 +7,6 @@ import { RefObject } from "preact";
 import {
   getImageSize,
   createImage,
-  svgToDataURI,
   nodeToDataURI,
   toArray,
 } from "./saveImageUtil.js";

--- a/npm/qsharp/ux/saveImageUtil.tsx
+++ b/npm/qsharp/ux/saveImageUtil.tsx
@@ -24,7 +24,7 @@ export function getImageSize<T extends HTMLElement>(node: T) {
 
   return {
     width: node.clientWidth + leftBorder + rightBorder,
-    height: node.clientHeight + topBorder + bottomBorder, //+ 12, // Fixes up truncated region
+    height: node.clientHeight + topBorder + bottomBorder + 12, // Fixes up truncated region
   };
 }
 

--- a/npm/qsharp/ux/saveImageUtil.tsx
+++ b/npm/qsharp/ux/saveImageUtil.tsx
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function toArray<T>(arrayLike: any): T[] {
+  const arr: T[] = [];
+  for (let i = 0, l = arrayLike.length; i < l; i++) {
+    arr.push(arrayLike[i]);
+  }
+
+  return arr;
+}
+
+function px(node: HTMLElement, styleProperty: string) {
+  const win = node.ownerDocument.defaultView || window;
+  const val = win.getComputedStyle(node).getPropertyValue(styleProperty);
+  return val ? parseFloat(val.replace("px", "")) : 0;
+}
+
+export function getImageSize(node: HTMLElement) {
+  const leftBorder = px(node, "border-left-width");
+  const rightBorder = px(node, "border-right-width");
+  const topBorder = px(node, "border-top-width");
+  const bottomBorder = px(node, "border-bottom-width");
+
+  return {
+    width: node.clientWidth + leftBorder + rightBorder,
+    height: node.clientHeight + topBorder + bottomBorder,
+  };
+}
+
+export function createImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.decode = () => resolve(img) as any;
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.crossOrigin = "anonymous";
+    img.decoding = "async";
+    img.src = url;
+  });
+}
+
+export async function svgToDataURI(svg: SVGElement): Promise<string> {
+  return Promise.resolve()
+    .then(() => new XMLSerializer().serializeToString(svg))
+    .then(encodeURIComponent)
+    .then((html) => `data:image/svg+xml;charset=utf-8,${html}`);
+}
+
+export async function nodeToDataURI(
+  node: HTMLElement,
+  width: number,
+  height: number,
+): Promise<string> {
+  const xmlns = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(xmlns, "svg");
+  const foreignObject = document.createElementNS(xmlns, "foreignObject");
+
+  svg.setAttribute("width", `${width}`);
+  svg.setAttribute("height", `${height}`);
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+  foreignObject.setAttribute("width", "100%");
+  foreignObject.setAttribute("height", "100%");
+  foreignObject.setAttribute("x", "0");
+  foreignObject.setAttribute("y", "0");
+  foreignObject.setAttribute("externalResourcesRequired", "true");
+
+  svg.appendChild(foreignObject);
+  foreignObject.appendChild(node);
+  return svgToDataURI(svg);
+}

--- a/npm/qsharp/ux/saveImageUtil.tsx
+++ b/npm/qsharp/ux/saveImageUtil.tsx
@@ -10,13 +10,13 @@ export function toArray<T>(arrayLike: any): T[] {
   return arr;
 }
 
-function px(node: HTMLElement, styleProperty: string) {
+function px<T extends HTMLElement>(node: T, styleProperty: string) {
   const win = node.ownerDocument.defaultView || window;
   const val = win.getComputedStyle(node).getPropertyValue(styleProperty);
   return val ? parseFloat(val.replace("px", "")) : 0;
 }
 
-export function getImageSize(node: HTMLElement) {
+export function getImageSize<T extends HTMLElement>(node: T) {
   const leftBorder = px(node, "border-left-width");
   const rightBorder = px(node, "border-right-width");
   const topBorder = px(node, "border-top-width");
@@ -24,7 +24,7 @@ export function getImageSize(node: HTMLElement) {
 
   return {
     width: node.clientWidth + leftBorder + rightBorder,
-    height: node.clientHeight + topBorder + bottomBorder + 10, // Fixes up truncated region
+    height: node.clientHeight + topBorder + bottomBorder, //+ 12, // Fixes up truncated region
   };
 }
 
@@ -40,7 +40,7 @@ export function createImage(url: string): Promise<HTMLImageElement> {
   });
 }
 
-export async function svgToDataURI(svg: SVGElement): Promise<string> {
+export async function svgToDataURI(svg: Element): Promise<string> {
   return Promise.resolve()
     .then(() => new XMLSerializer().serializeToString(svg))
     .then(encodeURIComponent)

--- a/npm/qsharp/ux/saveImageUtil.tsx
+++ b/npm/qsharp/ux/saveImageUtil.tsx
@@ -24,7 +24,7 @@ export function getImageSize(node: HTMLElement) {
 
   return {
     width: node.clientWidth + leftBorder + rightBorder,
-    height: node.clientHeight + topBorder + bottomBorder,
+    height: node.clientHeight + topBorder + bottomBorder + 10, // Fixes up truncated region
   };
 }
 

--- a/npm/qsharp/ux/scatterChart.tsx
+++ b/npm/qsharp/ux/scatterChart.tsx
@@ -108,7 +108,7 @@ export function ScatterChart(props: {
     const centerX = (pointRect.left + pointRect.right) / 2;
     const divRect = topDiv.getBoundingClientRect();
     tooltip.style.left = `${centerX - divRect.left - halfWidth}px`;
-    tooltip.style.top = `${centerY - divRect.top}px`;
+    tooltip.style.top = `${centerY - divRect.top + 12}px`;
     tooltip.style.visibility = "visible";
   }
 

--- a/npm/qsharp/ux/scatterChart.tsx
+++ b/npm/qsharp/ux/scatterChart.tsx
@@ -4,7 +4,7 @@
 import { useRef, useEffect } from "preact/hooks";
 import { createRef } from "preact";
 import * as utils from "../src/utils.js";
-import { saveRefToImage } from "./saveImage.js";
+import { saveToImage } from "./saveImage.js";
 
 export type ScatterSeries = {
   color: string;
@@ -107,7 +107,7 @@ export function ScatterChart(props: {
     const centerX = (pointRect.left + pointRect.right) / 2;
     const divRect = topDiv.getBoundingClientRect();
     tooltip.style.left = `${centerX - divRect.left - halfWidth}px`;
-    tooltip.style.top = `${centerY - divRect.top}px`; // + 12}px`;
+    tooltip.style.top = `${centerY - divRect.top}px`;
     tooltip.style.visibility = "visible";
   }
 
@@ -159,7 +159,7 @@ export function ScatterChart(props: {
   const saveRef = createRef();
 
   const handleSaveImage = async () => {
-    saveRefToImage(saveRef);
+    saveToImage(saveRef!.current);
   };
 
   // Need to render first to get the element layout to position the tooltip

--- a/npm/qsharp/ux/scatterChart.tsx
+++ b/npm/qsharp/ux/scatterChart.tsx
@@ -162,10 +162,8 @@ export function ScatterChart(props: {
     const element = saveRef.current;
     const backgroundColor =
       getComputedStyle(element).getPropertyValue("--main-background");
-    const checkVSCodeEnv = getComputedStyle(element).getPropertyValue(
-      "--vscode-foreground",
-    );
-    const isVSCodeEnv = true ? checkVSCodeEnv : false;
+    const isVSCodeEnv = true;
+    // const isVSCodeEnv = false;
 
     if (isVSCodeEnv) {
       const data = await saveToPng(element, backgroundColor);

--- a/npm/qsharp/ux/scatterChart.tsx
+++ b/npm/qsharp/ux/scatterChart.tsx
@@ -4,7 +4,7 @@
 import { useRef, useEffect } from "preact/hooks";
 import { createRef } from "preact";
 import * as utils from "../src/utils.js";
-import { saveToPng, saveToSvg } from "./saveImage.js";
+import { saveRefToImage } from "./saveImage.js";
 
 export type ScatterSeries = {
   color: string;
@@ -107,7 +107,7 @@ export function ScatterChart(props: {
     const centerX = (pointRect.left + pointRect.right) / 2;
     const divRect = topDiv.getBoundingClientRect();
     tooltip.style.left = `${centerX - divRect.left - halfWidth}px`;
-    tooltip.style.top = `${centerY - divRect.top}px`;// + 12}px`;
+    tooltip.style.top = `${centerY - divRect.top}px`; // + 12}px`;
     tooltip.style.visibility = "visible";
   }
 
@@ -159,39 +159,7 @@ export function ScatterChart(props: {
   const saveRef = createRef();
 
   const handleSaveImage = async () => {
-    const element = saveRef.current;
-    const backgroundColor =
-      getComputedStyle(element).getPropertyValue("--main-background");
-    const isVSCodeEnv = true;
-    // const isVSCodeEnv = false;
-
-    if (isVSCodeEnv) {
-      const data = await saveToPng(element, backgroundColor);
-      const link = document.createElement("a");
-      if (typeof link.download === "string") {
-        link.href = data;
-        link.download = "image.png";
-
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-      } else {
-        window.open(data);
-      }
-    } else {
-      const data = await saveToSvg(element);
-      const link = document.createElement("a");
-      if (typeof link.download === "string") {
-        link.href = data;
-        link.download = "image.svg";
-
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-      } else {
-        window.open(data);
-      }
-    }
+    saveRefToImage(saveRef);
   };
 
   // Need to render first to get the element layout to position the tooltip

--- a/package-lock.json
+++ b/package-lock.json
@@ -2355,6 +2355,15 @@
         "bare-os": "^2.1.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -2745,6 +2754,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/debug": {
@@ -3681,6 +3699,19 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-assert": {
@@ -5617,6 +5648,15 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5804,6 +5844,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -6059,6 +6108,9 @@
       "name": "qsharp-lang",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "html2canvas": "^1.4.1"
+      },
       "engines": {
         "node": ">=16.17.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2355,15 +2355,6 @@
         "bare-os": "^2.1.0"
       }
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -2754,15 +2745,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/debug": {
@@ -3699,19 +3681,6 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/http-assert": {
@@ -5648,15 +5617,6 @@
         "streamx": "^2.15.0"
       }
     },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5844,15 +5804,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
-      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -6108,9 +6059,6 @@
       "name": "qsharp-lang",
       "version": "0.0.0",
       "license": "MIT",
-      "dependencies": {
-        "html2canvas": "^1.4.1"
-      },
       "engines": {
         "node": ">=16.17.0"
       }


### PR DESCRIPTION
Submission for Unitary Hack issue: fixes #1063 

This change adds the ability to save the resource estimates diagram locally as a PNG. For this I added a new dependency called `html2canvas` that takes a DOM and renders it to an image. This currently works only on IPython `qsharp-widgets`, could be extended to the VSCode version. 

Additionally we take into account the color theme within VSCode (which is provided in the stylesheet `qsharp-ux.css`) and this is passed in as the background color for rendering. Tested on (dark/light) Modern VSCode themes.


https://github.com/microsoft/qsharp/assets/3744263/898de6d9-fba4-4fea-b729-a3bb698dc51c



~Current issues:~
- ~This button is placeholder, nicer version: https://github.com/microsoft/vscode-notebook-renderers/pull/118~
- ~Saved imaged is slightly truncated at the bottom~