### PR TITLE
Fix panic when updating array with dynamic value

### DIFF
--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -184,10 +184,11 @@ impl<'a> Analyzer<'a> {
         // runtime feature is used to mark the array itself as dynamically sized.
         if !application_instance.active_dynamic_scopes.is_empty() {
             default_value_kind = ValueKind::Array(RuntimeKind::Dynamic, RuntimeKind::Dynamic);
+            let replacement_ty = &self.get_expr(replacement_value_expr_id).ty;
             replacement_value_compute_kind =
                 replacement_value_compute_kind.aggregate(ComputeKind::new_with_runtime_features(
                     RuntimeFeatureFlags::UseOfDynamicallySizedArray,
-                    default_value_kind,
+                    ValueKind::new_static_from_type(replacement_ty),
                 ));
         }
 

--- a/compiler/qsc_rca/tests/arrays.rs
+++ b/compiler/qsc_rca/tests/arrays.rs
@@ -342,6 +342,56 @@ fn check_rca_for_mutable_array_assign_index_in_dynamic_context() {
 }
 
 #[test]
+fn check_rca_for_mutable_array_assign_index_dynamic_content_in_dynamic_context() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        mutable arr = [Zero];
+        use q = Qubit();
+        let r = M(q);
+        if r == One {
+            set arr w/= 0 <- r;
+        }
+        arr"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray)
+                    value_kind: Array(Content: Dynamic, Size: Dynamic)
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_mutable_array_assign_index_dynamic_nested_array_content_in_dynamic_context() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        mutable arr = [[Zero]];
+        use q = Qubit();
+        let r = M(q);
+        if r == One {
+            set arr w/= 0 <- [r];
+        }
+        arr"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray)
+                    value_kind: Array(Content: Dynamic, Size: Dynamic)
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
 fn check_rca_for_access_using_classical_index() {
     let mut compilation_context = CompilationContext::default();
     compilation_context.update(


### PR DESCRIPTION
This fixes a panic that was introduced in #1571, where if the content being used to update an array was a dynamic, non-array value it would panic when trying to aggreate a default array type into a element type. To make sure the update matches the chosen type, generate the `ValueKind` from the matching expression type. Added unit tests for both array and non-array dynamic update types.