### PR TITLE
Fix normalization math in `DumpRegister`

### DIFF
--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -493,6 +493,46 @@ fn dump_register_target_in_minus_with_other_in_one() {
 }
 
 #[test]
+fn dump_register_all_qubits_normalized_is_same_as_dump_machine() {
+    check_intrinsic_output(
+        "",
+        indoc! {
+        "{
+            open Microsoft.Quantum.Diagnostics;
+            use qs = Qubit[2];
+
+            let alpha = -4.20025;
+            let beta = 2.04776;
+            let gamma = -5.47097;
+
+            within{
+                Ry(alpha, qs[0]);
+                Ry(beta, qs[1]);
+                CNOT(qs[0], qs[1]);
+                Ry(gamma, qs[1]);
+            }
+            apply{
+                DumpRegister(qs);
+                DumpMachine();
+            }
+        }"
+        },
+        &expect![[r#"
+            STATE:
+            |00⟩: 0.0709+0.0000𝑖
+            |01⟩: 0.5000+0.0000𝑖
+            |10⟩: 0.5000+0.0000𝑖
+            |11⟩: 0.7036+0.0000𝑖
+            STATE:
+            |00⟩: 0.0709+0.0000𝑖
+            |01⟩: 0.5000+0.0000𝑖
+            |10⟩: 0.5000+0.0000𝑖
+            |11⟩: 0.7036+0.0000𝑖
+        "#]],
+    );
+}
+
+#[test]
 fn message() {
     check_intrinsic_output(
         "",

--- a/compiler/qsc_eval/src/intrinsic/utils.rs
+++ b/compiler/qsc_eval/src/intrinsic/utils.rs
@@ -128,7 +128,7 @@ fn collect_split_state(
         }
         if let Entry::Vacant(entry) = other_state.entry(other_label) {
             let amplitude = curr_val / dump_val;
-            let norm = amplitude.norm();
+            let norm = amplitude.norm().powi(2);
             if !norm.is_nearly_zero() {
                 entry.insert(amplitude);
             }

--- a/compiler/qsc_eval/src/intrinsic/utils.rs
+++ b/compiler/qsc_eval/src/intrinsic/utils.rs
@@ -120,7 +120,7 @@ fn collect_split_state(
             // When capturing the amplitude for the dump state, we must divide out the amplitude for the other
             // state, and vice-versa below.
             let amplitude = curr_val / other_val;
-            let norm = amplitude.norm();
+            let norm = amplitude.norm().powi(2);
             if !norm.is_nearly_zero() {
                 entry.insert(amplitude);
                 dump_norm += norm;


### PR DESCRIPTION
This fixes a bug in the way the wave function was produced for calls to `DumpRegister`, specifically because the calculation needs to use the sum of the squares of the normalization of each amplitude rather than just the sum of the normalization value itself. This ensures the amplitudes output by `DumpRegister` correctly sum to 1.

Output before fix:
![image](https://github.com/microsoft/qsharp/assets/10567287/8d598a7a-84af-4750-b3d6-4cd2767b222f)

Output after fix:
![image](https://github.com/microsoft/qsharp/assets/10567287/db4bebb8-5b49-44fb-b211-90131fdf9e41)
