### PR TITLE
improve `IndexMap`'s Debug print

### DIFF
--- a/compiler/qsc_data_structures/src/index_map.rs
+++ b/compiler/qsc_data_structures/src/index_map.rs
@@ -147,7 +147,15 @@ impl<K, V: Clone> Clone for IndexMap<K, V> {
 impl<K, V: Debug> Debug for IndexMap<K, V> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("IndexMap")
-            .field("values", &self.values)
+            .field(
+                "values",
+                &self
+                    .values
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(k, v)| v.as_ref().map(|val| format!("{k:?}: {val:?}")))
+                    .collect::<Vec<_>>(),
+            )
             .finish()
     }
 }


### PR DESCRIPTION
I was debugging an `IndexMap`, and I found the debug print to be difficult to use. It didn't print out the keys for the map, and was overly whitespace-heavy. I made this modification for my own debugging, and thought it might be a good update to push upstream.

Before:

```
 IndexMap {
    values: [
        (
            1,
            Item(
                ItemId {
                    package: None,
                    item: LocalItemId(
                        0,
                    ),
                },
                Available,
                Imported,
            ),
        ),
        (
            5,
            Item(
                ItemId {
                    package: None,
                    item: LocalItemId(
                        1,
                    ),
                },
                Available,
                Debug(
                    10,
                ),
            ),
        ),
        (
            8,
            PrimTy(
                Int,
            ),
        ),
        (
            15,
            Item(
                ItemId {
                    package: None,
                    item: LocalItemId(
                        1,
                    ),
                },
                Available,
                Debug(
                    10,
                ),
            ),
        ),
... etc
```



After:

```
IndexMap {
    values: [
        "1: Item(ItemId { package: None, item: LocalItemId(0) }, Available, Imported)",
        "5: Item(ItemId { package: None, item: LocalItemId(1) }, Available, Debug(10))",
        "8: PrimTy(Int)",
        "15: Item(ItemId { package: None, item: LocalItemId(1) }, Available, Debug(10))",
        "16: Item(ItemId { package: None, item: LocalItemId(1) }, Available, Debug(10))",
    ],
}
```


No `expect-test` stuff relies on this print, so it is a pretty isolated change.