### PR TITLE
Migrate tasks 1.4-1.6 from Measurements to Distinguishing States kata

### DIFF
--- a/katas/content/distinguishing_states/a_b/Placeholder.qs
+++ b/katas/content/distinguishing_states/a_b/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation IsQubitA(alpha : Double, q : Qubit) : Bool {
+        // Implement your solution here...
+
+        return false;
+    }
+}

--- a/katas/content/distinguishing_states/a_b/Solution.qs
+++ b/katas/content/distinguishing_states/a_b/Solution.qs
@@ -1,0 +1,6 @@
+namespace Kata {
+    operation IsQubitA(alpha : Double, q : Qubit) : Bool {
+        Ry(-2.0 * alpha, q);
+        return M(q) == Zero;
+    }
+}

--- a/katas/content/distinguishing_states/a_b/Verification.qs
+++ b/katas/content/distinguishing_states/a_b/Verification.qs
@@ -1,0 +1,39 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Katas;
+
+    // |A⟩ =   cos(alpha) * |0⟩ + sin(alpha) * |1⟩,
+    // |B⟩ = - sin(alpha) * |0⟩ + cos(alpha) * |1⟩.
+    operation StatePrep_IsQubitA(alpha : Double, q : Qubit, state : Int) : Unit is Adj {
+        if state == 0 {
+            // convert |0⟩ to |B⟩
+            X(q);
+            Ry(2.0 * alpha, q);
+        } else {
+            // convert |0⟩ to |A⟩
+            Ry(2.0 * alpha, q);
+        }
+    }
+
+    // We can use the StatePrep_IsQubitA operation for the testing
+    operation CheckSolution() : Bool {
+        for i in 0..10 {
+            let alpha = (PI() * IntAsDouble(i)) / 10.0;
+            let isCorrect = DistinguishTwoStates_SingleQubit(
+                StatePrep_IsQubitA(alpha, _, _),
+                Kata.IsQubitA(alpha, _),
+                [$"|B⟩=(-sin({i}π/10)|0⟩ + cos({i}π/10)|1⟩)", $"|A⟩=(cos({i}π/10)|0⟩ + sin({i}π/10)|1⟩)"],
+                false
+            );
+
+            if not isCorrect {
+                Message($"Test fails for alpha={alpha}");
+                return isCorrect;
+            }
+        }
+
+        Message("Correct!");
+        true
+    }
+}

--- a/katas/content/distinguishing_states/a_b/Verification.qs
+++ b/katas/content/distinguishing_states/a_b/Verification.qs
@@ -18,7 +18,7 @@ namespace Kata.Verification {
 
     // We can use the StatePrep_IsQubitA operation for the testing
     operation CheckSolution() : Bool {
-        for i in 0..10 {
+        for i in 0 .. 10 {
             let alpha = (PI() * IntAsDouble(i)) / 10.0;
             let isCorrect = DistinguishTwoStates_SingleQubit(
                 StatePrep_IsQubitA(alpha, _, _),
@@ -29,7 +29,7 @@ namespace Kata.Verification {
 
             if not isCorrect {
                 Message($"Test fails for alpha={alpha}");
-                return isCorrect;
+                return false;
             }
         }
 

--- a/katas/content/distinguishing_states/a_b/index.md
+++ b/katas/content/distinguishing_states/a_b/index.md
@@ -1,6 +1,8 @@
 **Inputs:**
 
 1. Angle $\alpha$, in radians, represented as a `Double`.
-2. A qubit which is guaranteed to be either in $\ket{A}$ or the $\ket{B}$ state, where $\ket{A} = \cos \alpha \ket{0} + \sin \alpha \ket{1}$ and $\ket{B} = - \sin \alpha \ket{0} + \cos \alpha \ket{1}$.
+2. A qubit which is guaranteed to be either in $\ket{A}$ or the $\ket{B}$ state, where 
+$$\ket{A} = \cos \alpha \ket{0} + \sin \alpha \ket{1}$$ 
+$$\ket{B} = - \sin \alpha \ket{0} + \cos \alpha \ket{1}$$
 
 **Output:** `true` if the qubit was in the $\ket{A}$ state, or `false` if it was in the $\ket{B}$ state. The state of the qubit at the end of the operation does not matter. 

--- a/katas/content/distinguishing_states/a_b/index.md
+++ b/katas/content/distinguishing_states/a_b/index.md
@@ -1,0 +1,6 @@
+**Inputs:**
+
+1. Angle $\alpha$, in radians, represented as a `Double`.
+2. A qubit which is guaranteed to be either in $\ket{A}$ or the $\ket{B}$ state, where $\ket{A} = \cos \alpha \ket{0} + \sin \alpha \ket{1}$ and $\ket{B} = - \sin \alpha \ket{0} + \cos \alpha \ket{1}$.
+
+**Output:** `true` if the qubit was in the $\ket{A}$ state, or `false` if it was in the $\ket{B}$ state. The state of the qubit at the end of the operation does not matter. 

--- a/katas/content/distinguishing_states/a_b/solution.md
+++ b/katas/content/distinguishing_states/a_b/solution.md
@@ -1,0 +1,16 @@
+We take a similar approach to the previous task: figure out a way to prepare the input states from the basis states and apply adjoint of that preparation before measuring the qubit.
+
+To create the input states $\ket{A}$ and $\ket{B}$, a $R_y$ gate with $\theta = 2\alpha$ was applied to the basis states $\ket{0}$ and $\ket{1}$. As a reminder, 
+
+$$R_y(\theta) = \begin{bmatrix} \cos\frac{\theta}{2} & -\sin\frac{\theta}{2} \\\\ \sin\frac{\theta}{2} & \cos\frac{\theta}{2} \end{bmatrix}$$
+
+We can return the input state to the basis state by applying $R_y$ gate with $-2\alpha$ as the rotation angle parameter to the input qubit.
+
+The measurement in Pauli $Z$ basis gives two possibilities: 
+1. The qubit is measured as $\ket{1}$, the input state was $\ket{B}$, we return `false`.
+2. The qubit is measured as $\ket{0}$, the input state was $\ket{A}$, we return `true`.
+
+@[solution]({
+    "id": "distinguishing_states__a_b_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_states/a_b/solution.md
+++ b/katas/content/distinguishing_states/a_b/solution.md
@@ -2,7 +2,7 @@ We take a similar approach to the previous task: figure out a way to prepare the
 
 To create the input states $\ket{A}$ and $\ket{B}$, a $R_y$ gate with $\theta = 2\alpha$ was applied to the basis states $\ket{0}$ and $\ket{1}$. As a reminder, 
 
-$$R_y(\theta) = \begin{bmatrix} \cos\frac{\theta}{2} & -\sin\frac{\theta}{2} \\\\ \sin\frac{\theta}{2} & \cos\frac{\theta}{2} \end{bmatrix}$$
+$$R_y(\theta) = \begin{bmatrix} \cos\frac{\theta}{2} & -\sin\frac{\theta}{2} \\ \sin\frac{\theta}{2} & \cos\frac{\theta}{2} \end{bmatrix}$$
 
 We can return the input state to the basis state by applying $R_y$ gate with $-2\alpha$ as the rotation angle parameter to the input qubit.
 

--- a/katas/content/distinguishing_states/four_basis_states/Placeholder.qs
+++ b/katas/content/distinguishing_states/four_basis_states/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation BasisStateMeasurement(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return 0;
+    }
+}

--- a/katas/content/distinguishing_states/four_basis_states/Solution.qs
+++ b/katas/content/distinguishing_states/four_basis_states/Solution.qs
@@ -1,6 +1,5 @@
 namespace Kata {
     operation BasisStateMeasurement(qs : Qubit[]) : Int {
-        // Measurement on the first qubit gives the higher bit of the answer, on the second - the lower
         let m1 = M(qs[0]) == Zero ? 0 | 1;
         let m2 = M(qs[1]) == Zero ? 0 | 1;
         return m1 * 2 + m2;

--- a/katas/content/distinguishing_states/four_basis_states/Solution.qs
+++ b/katas/content/distinguishing_states/four_basis_states/Solution.qs
@@ -1,0 +1,8 @@
+namespace Kata {
+    operation BasisStateMeasurement(qs : Qubit[]) : Int {
+        // Measurement on the first qubit gives the higher bit of the answer, on the second - the lower
+        let m1 = M(qs[0]) == Zero ? 0 | 1;
+        let m2 = M(qs[1]) == Zero ? 0 | 1;
+        return m1 * 2 + m2;
+    }
+}

--- a/katas/content/distinguishing_states/four_basis_states/Verification.qs
+++ b/katas/content/distinguishing_states/four_basis_states/Verification.qs
@@ -1,0 +1,29 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Katas;
+
+    operation StatePrep_BasisStateMeasurement(qs : Qubit[], state : Int, dummyVar : Double) : Unit is Adj {
+
+        if state / 2 == 1 {
+            // |10⟩ or |11⟩
+            X(qs[0]);
+        }
+
+        if state % 2 == 1 {
+            // |01⟩ or |11⟩
+            X(qs[1]);
+        }
+    }
+
+    operation CheckSolution() : Bool {
+        let isCorrect = DistinguishStates_MultiQubit(2, 4, StatePrep_BasisStateMeasurement, Kata.BasisStateMeasurement, false, ["|00⟩", "|01⟩", "|10⟩", "|11⟩"]);
+        if (isCorrect) {
+            Message("Correct!");
+        } else {
+            Message("Incorrect.");
+        }
+
+        isCorrect
+    }
+}

--- a/katas/content/distinguishing_states/four_basis_states/index.md
+++ b/katas/content/distinguishing_states/four_basis_states/index.md
@@ -1,0 +1,12 @@
+**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in one of the four basis states ($\ket{00}$, $\ket{01}$, $\ket{10}$, or $\ket{11}$).
+
+**Output:**
+
+* 0 if the qubits were in the $\ket{00}$ state,
+* 1 if they were in the $\ket{01}$ state,
+* 2 if they were in the $\ket{10}$ state,
+* 3 if they were in the $\ket{11}$ state.
+
+In this task and the subsequent ones the order of qubit states in task description matches the order of qubits in the array (i.e., $\ket{10}$ state corresponds to `qs[0]` in state $\ket{1}$ and `qs[1]` in state $\ket{0}$).
+
+The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/four_basis_states/solution.md
+++ b/katas/content/distinguishing_states/four_basis_states/solution.md
@@ -1,13 +1,13 @@
 Unlike in the previous task, this time measuring the first qubit won't give us any information on the second qubit, so we need to measure both qubits.
 
-First, we measure both qubits in the input array and store the result in `m1` and `m2`. We can decode these results like this:
+First, we measure both qubits in the input array and store the results in `m1` and `m2`. We can decode these results like this:
 
 * m1 is $\ket{0}$ and m2 is $\ket{0}$: we return $0\cdot2+0=0$
 * m1 is $\ket{0}$ and m2 is $\ket{1}$: we return $0\cdot2+1=1$
 * m1 is $\ket{1}$ and m2 is $\ket{0}$: we return $1\cdot2+0=2$
 * m1 is $\ket{1}$ and m2 is $\ket{1}$: we return $1\cdot2+1=3$
 
-In other words, we treat the measurement results as the binary notation of the return value in big endian notation.
+In other words, we treat the measurement results as the binary notation of the return value in big endian notation, with the most significant bit stored in `m1` and the least significant - in `m2`.
 
 @[solution]({
     "id": "distinguishing_states__four_basis_states_solution",

--- a/katas/content/distinguishing_states/four_basis_states/solution.md
+++ b/katas/content/distinguishing_states/four_basis_states/solution.md
@@ -1,0 +1,15 @@
+Unlike in the previous task, this time measuring the first qubit won't give us any information on the second qubit, so we need to measure both qubits.
+
+First, we measure both qubits in the input array and store the result in `m1` and `m2`. We can decode these results like this:
+
+* m1 is $\ket{0}$ and m2 is $\ket{0}$: we return $0\cdot2+0=0$
+* m1 is $\ket{0}$ and m2 is $\ket{1}$: we return $0\cdot2+1=1$
+* m1 is $\ket{1}$ and m2 is $\ket{0}$: we return $1\cdot2+0=2$
+* m1 is $\ket{1}$ and m2 is $\ket{1}$: we return $1\cdot2+1=3$
+
+In other words, we treat the measurement results as the binary notation of the return value in big endian notation.
+
+@[solution]({
+    "id": "distinguishing_states__four_basis_states_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_states/index.md
+++ b/katas/content/distinguishing_states/index.md
@@ -41,6 +41,33 @@ This kata is designed to get you familiar with the concept of measurements and u
     ]
 })
 
+@[exercise]({
+    "id": "distinguishing_states__a_b",
+    "title": "|A〉 or |B〉?",
+    "path": "./a_b/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "distinguishing_states__zerozero_oneone",
+    "title": "|00〉 or |11〉?",
+    "path": "./zerozero_oneone/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "distinguishing_states__four_basis_states",
+    "title": "Distinguish four basis states",
+    "path": "./four_basis_states/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
 @[section]({
     "id": "distinguishing_states__nonorthogonal_states",
     "title": "Distinguishing Non-orthogonal States"

--- a/katas/content/distinguishing_states/zerozero_oneone/Placeholder.qs
+++ b/katas/content/distinguishing_states/zerozero_oneone/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation ZeroZeroOrOneOne(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return 0;
+    }
+}

--- a/katas/content/distinguishing_states/zerozero_oneone/Solution.qs
+++ b/katas/content/distinguishing_states/zerozero_oneone/Solution.qs
@@ -1,0 +1,5 @@
+namespace Kata {
+    operation ZeroZeroOrOneOne(qs : Qubit[]) : Int {
+        return M(qs[0]) == One ? 1 | 0;
+    }
+}

--- a/katas/content/distinguishing_states/zerozero_oneone/Verification.qs
+++ b/katas/content/distinguishing_states/zerozero_oneone/Verification.qs
@@ -1,0 +1,22 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    operation StatePrep_ZeroZeroOrOneOne(qs : Qubit[], state : Int, dummyVar : Double) : Unit is Adj {
+        if state == 1 {
+            // |11⟩
+            X(qs[0]);
+            X(qs[1]);
+        }
+    }
+
+    operation CheckSolution() : Bool {
+        let isCorrect = DistinguishStates_MultiQubit(2, 2, StatePrep_ZeroZeroOrOneOne, Kata.ZeroZeroOrOneOne, true, ["|00⟩", "|11⟩"]);
+        if (isCorrect) {
+            Message("Correct!");
+        } else {
+            Message("Incorrect.");
+        }
+
+        isCorrect
+    }
+}

--- a/katas/content/distinguishing_states/zerozero_oneone/index.md
+++ b/katas/content/distinguishing_states/zerozero_oneone/index.md
@@ -1,0 +1,3 @@
+**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in either the $\ket{00}$ or the $\ket{11}$ state.
+
+**Output:** 0 if the qubits were in the $\ket{00}$ state, or 1 if they were in the $\ket{11}$ state. The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/zerozero_oneone/solution.md
+++ b/katas/content/distinguishing_states/zerozero_oneone/solution.md
@@ -1,0 +1,10 @@
+Both qubits in the input array are in the same state: for $\ket{00}$ each individual qubit is in state $\ket{0}$, for $\ket{11}$ each individual qubit is in state $\ket{1}$. Therefore, if we measure one qubit we will know the state of the other qubit.
+
+In other words, if the first qubit measures as `One`, we know that the qubits in the input array are in state $\ket{11}$, and if it measures as `Zero`, we know they are in state $\ket{00}$.
+
+> `condition ? truevalue | falsevalue` is Q#'s ternary operator: it returns `trueValue` if `condition` is true and `falseValue` otherwise.
+
+@[solution]({
+    "id": "distinguishing_states__zerozero_oneone_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_states/zerozero_oneone/solution.md
+++ b/katas/content/distinguishing_states/zerozero_oneone/solution.md
@@ -1,4 +1,4 @@
-Both qubits in the input array are in the same state: for $\ket{00}$ each individual qubit is in state $\ket{0}$, for $\ket{11}$ each individual qubit is in state $\ket{1}$. Therefore, if we measure one qubit we will know the state of the other qubit.
+Both qubits in the input array are in the same state: for $\ket{00}$ each individual qubit is in state $\ket{0}$, for $\ket{11}$ each individual qubit is in state $\ket{1}$. Therefore, if we measure one qubit, we will know the state of the other qubit.
 
 In other words, if the first qubit measures as `One`, we know that the qubits in the input array are in state $\ket{11}$, and if it measures as `Zero`, we know they are in state $\ket{00}$.
 


### PR DESCRIPTION
Migrate tasks 1.4, 1.5 & 1.6 from the Measurements workbook to Distinguishing States Kata.
This resolves a part of the [Issue 1185](https://github.com/microsoft/qsharp/issues/1185).

- Added folders a_b, four_basis_states, zerozero_oneone under distinguishing_states
- Added index, placeholder, solution, and verification files
- Updated index file under distinguishing_states to contain the above exercises