### PR TITLE
Migrate tasks 1.10-1.15 from Measurements to Distinguishing States kata

### DIFF
--- a/katas/content/KatasLibrary.qs
+++ b/katas/content/KatasLibrary.qs
@@ -342,5 +342,40 @@ namespace Microsoft.Quantum.Katas {
             }
         }
         return true;
-    }    
+    }   
+    
+    operation StatePrep_BasisStateMeasurement(
+        qs : Qubit[],
+        state : Int
+    ) : Unit is Adj {
+        if state / 2 == 1 {
+            // |10⟩ or |11⟩
+            X(qs[0]);
+        }
+
+        if state % 2 == 1 {
+            // |01⟩ or |11⟩
+            X(qs[1]);
+        }
+    }
+
+    operation WState_Arbitrary_Reference(qs : Qubit[]) : Unit is Adj + Ctl {
+        let N = Length(qs);
+
+        if N == 1 {
+            // base case of recursion: |1⟩
+            X(qs[0]);
+        } else {
+            // |W_N⟩ = |0⟩|W_(N-1)⟩ + |1⟩|0...0⟩
+            // do a rotation on the first qubit to split it into |0⟩ and |1⟩ with proper weights
+            // |0⟩ -> sqrt((N-1)/N) |0⟩ + 1/sqrt(N) |1⟩
+            let theta = ArcSin(1.0 / Sqrt(IntAsDouble(N)));
+            Ry(2.0 * theta, qs[0]);
+
+            // do a zero-controlled W-state generation for qubits 1..N-1
+            X(qs[0]);
+            Controlled WState_Arbitrary_Reference(qs[0..0], qs[1..N - 1]);
+            X(qs[0]);
+        }
+    }
 }

--- a/katas/content/KatasLibrary.qs
+++ b/katas/content/KatasLibrary.qs
@@ -342,21 +342,6 @@ namespace Microsoft.Quantum.Katas {
             }
         }
         return true;
-    }   
-    
-    operation StatePrep_BasisStateMeasurement(
-        qs : Qubit[],
-        state : Int
-    ) : Unit is Adj {
-        if state / 2 == 1 {
-            // |10⟩ or |11⟩
-            X(qs[0]);
-        }
-
-        if state % 2 == 1 {
-            // |01⟩ or |11⟩
-            X(qs[1]);
-        }
     }
 
     operation WState_Arbitrary_Reference(qs : Qubit[]) : Unit is Adj + Ctl {

--- a/katas/content/distinguishing_states/Common.qs
+++ b/katas/content/distinguishing_states/Common.qs
@@ -1,0 +1,17 @@
+namespace Kata.Verification{
+    operation StatePrep_BasisStateMeasurement(
+        qs : Qubit[],
+        state : Int,
+        dummyVar : Double
+    ) : Unit is Adj {
+        if state / 2 == 1 {
+            // |10⟩ or |11⟩
+            X(qs[0]);
+        }
+
+        if state % 2 == 1 {
+            // |01⟩ or |11⟩
+            X(qs[1]);
+        }
+    }
+}

--- a/katas/content/distinguishing_states/all_zeros_w/Placeholder.qs
+++ b/katas/content/distinguishing_states/all_zeros_w/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation AllZerosOrWState(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/distinguishing_states/all_zeros_w/SolutionA.qs
+++ b/katas/content/distinguishing_states/all_zeros_w/SolutionA.qs
@@ -1,0 +1,13 @@
+namespace Kata {
+    operation AllZerosOrWState(qs : Qubit[]) : Int {
+        mutable countOnes = 0;
+
+        for q in qs {
+            if M(q) == One {
+                set countOnes += 1;
+            }
+        }
+
+        return countOnes == 0 ? 0 | 1;
+    }
+}

--- a/katas/content/distinguishing_states/all_zeros_w/SolutionB.qs
+++ b/katas/content/distinguishing_states/all_zeros_w/SolutionB.qs
@@ -1,0 +1,5 @@
+namespace Kata {
+    operation AllZerosOrWState(qs : Qubit[]) : Int {
+        return MeasureInteger(qs) == 0 ? 0 | 1;
+    }
+}

--- a/katas/content/distinguishing_states/all_zeros_w/Verification.qs
+++ b/katas/content/distinguishing_states/all_zeros_w/Verification.qs
@@ -1,0 +1,34 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    operation StatePrep_AllZerosOrWState(
+        qs : Qubit[],
+        state : Int,
+        dummyVar : Double
+    ) : Unit is Adj {
+        if state == 1 {
+            // Prepare W state
+            WState_Arbitrary_Reference(qs);
+        }
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        for i in 2 .. 6 {
+            let isCorrect = DistinguishStates_MultiQubit(
+                i, 2,
+                StatePrep_AllZerosOrWState,
+                Kata.AllZerosOrWState,
+                false,
+                ["|0...0⟩", "|W⟩"]);
+
+            if not isCorrect {
+                Message("Incorrect!");
+                return false;
+            }
+        }
+
+        Message("Correct!");
+        return true;
+    }
+}

--- a/katas/content/distinguishing_states/all_zeros_w/Verification.qs
+++ b/katas/content/distinguishing_states/all_zeros_w/Verification.qs
@@ -23,7 +23,7 @@ namespace Kata.Verification {
                 ["|0...0⟩", "|W⟩"]);
 
             if not isCorrect {
-                Message("Incorrect!");
+                Message("Incorrect.");
                 return false;
             }
         }

--- a/katas/content/distinguishing_states/all_zeros_w/index.md
+++ b/katas/content/distinguishing_states/all_zeros_w/index.md
@@ -1,0 +1,8 @@
+**Input:** 
+$N$ qubits (stored in an array of length $N$) which are guaranteed to be either in the $\ket{0...0}$ state or in the [W state](https://en.wikipedia.org/wiki/W_state) state (an equal superposition of all basis states that have exactly one $\ket{1}$ in them).
+
+**Output:**
+* 0 if the qubits were in the $\ket{0...0}$ state,
+* 1 if they were in the W state.
+
+The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/all_zeros_w/index.md
+++ b/katas/content/distinguishing_states/all_zeros_w/index.md
@@ -1,5 +1,5 @@
 **Input:** 
-$N$ qubits (stored in an array of length $N$) which are guaranteed to be either in the $\ket{0...0}$ state or in the [W state](https://en.wikipedia.org/wiki/W_state) state (an equal superposition of all basis states that have exactly one $\ket{1}$ in them).
+$N$ qubits (stored in an array of length $N$) which are guaranteed to be either in the $\ket{0...0}$ state or in the W state - an equal superposition of all $N$ basis states that have exactly one $\ket{1}$ in them. (For example, for $N = 3$ the W state is $\frac1{\sqrt3} (\ket{100} + \ket{010} + \ket{001})$).
 
 **Output:**
 * 0 if the qubits were in the $\ket{0...0}$ state,

--- a/katas/content/distinguishing_states/all_zeros_w/solution.md
+++ b/katas/content/distinguishing_states/all_zeros_w/solution.md
@@ -1,0 +1,17 @@
+Here is an example of the W state for $N = 3: \frac{1}{\sqrt{3}}(\ket{001}+\ket{010}+\ket{100})$. We can see that each basis state in this expression always has exactly one qubit in the $\ket{1}$ state, while in the $\ket{0...0}$ state, all qubits are in the $\ket{0}$ state.
+
+We can use this to arrive to the solution: we will count the number of qubits that were measured in `One` state; if this number equals 1, we had a W state, if it equals 0, we know it was the $\ket{0...0}$ state.
+
+> Note the use of a mutable variable `countOnes` to store the number of qubits measured in `One` state, and the use of a ternary operator `condition ? trueValue | falseValue` to express the return value.
+
+@[solution]({
+    "id": "distinguishing_states__all_zeros_w_solution_A",
+    "codePath": "SolutionA.qs"
+})
+
+`MeasureInteger()` can also be used in this task to make the solution shorter.
+
+@[solution]({
+    "id": "distinguishing_states__all_zeros_w_solution_B",
+    "codePath": "SolutionB.qs"
+})

--- a/katas/content/distinguishing_states/all_zeros_w/solution.md
+++ b/katas/content/distinguishing_states/all_zeros_w/solution.md
@@ -1,4 +1,4 @@
-Here is an example of the W state for $N = 3: \frac{1}{\sqrt{3}}(\ket{001}+\ket{010}+\ket{100})$. We can see that each basis state in this expression always has exactly one qubit in the $\ket{1}$ state, while in the $\ket{0...0}$ state, all qubits are in the $\ket{0}$ state.
+We can see that each basis state in the W state always has exactly one qubit in the $\ket{1}$ state, while in the $\ket{0...0}$ state, all qubits are in the $\ket{0}$ state.
 
 We can use this to arrive to the solution: we will count the number of qubits that were measured in `One` state; if this number equals 1, we had a W state, if it equals 0, we know it was the $\ket{0...0}$ state.
 

--- a/katas/content/distinguishing_states/four_basis_states/Verification.qs
+++ b/katas/content/distinguishing_states/four_basis_states/Verification.qs
@@ -3,19 +3,6 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Katas;
 
-    operation StatePrep_BasisStateMeasurement(qs : Qubit[], state : Int, dummyVar : Double) : Unit is Adj {
-
-        if state / 2 == 1 {
-            // |10⟩ or |11⟩
-            X(qs[0]);
-        }
-
-        if state % 2 == 1 {
-            // |01⟩ or |11⟩
-            X(qs[1]);
-        }
-    }
-
     operation CheckSolution() : Bool {
         let isCorrect = DistinguishStates_MultiQubit(2, 4, StatePrep_BasisStateMeasurement, Kata.BasisStateMeasurement, false, ["|00⟩", "|01⟩", "|10⟩", "|11⟩"]);
         if (isCorrect) {

--- a/katas/content/distinguishing_states/four_bell_states/Placeholder.qs
+++ b/katas/content/distinguishing_states/four_bell_states/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation BellState(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/distinguishing_states/four_bell_states/Solution.qs
+++ b/katas/content/distinguishing_states/four_bell_states/Solution.qs
@@ -1,0 +1,11 @@
+namespace Kata {
+    operation BellState(qs : Qubit[]) : Int {
+        CNOT(qs[0], qs[1]);
+        H(qs[0]);
+
+        let m1 = M(qs[0]) == Zero ? 0 | 1;
+        let m2 = M(qs[1]) == Zero ? 0 | 1;
+
+        return m2 * 2 + m1;
+    }
+}

--- a/katas/content/distinguishing_states/four_bell_states/Verification.qs
+++ b/katas/content/distinguishing_states/four_bell_states/Verification.qs
@@ -1,0 +1,45 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    // 0 - |Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2)
+    // 1 - |Φ⁻⟩ = (|00⟩ - |11⟩) / sqrt(2)
+    // 2 - |Ψ⁺⟩ = (|01⟩ + |10⟩) / sqrt(2)
+    // 3 - |Ψ⁻⟩ = (|01⟩ - |10⟩) / sqrt(2)
+    operation StatePrep_BellState(
+        qs : Qubit[],
+        state : Int,
+        dummyVar : Double
+    ) : Unit is Adj {
+        H(qs[0]);
+        CNOT(qs[0], qs[1]);
+
+        // Now we have |00⟩ + |11⟩ - modify it based on state arg
+        if state % 2 == 1 {
+            // negative phase
+            Z(qs[1]);
+        }
+        if state / 2 == 1 {
+            X(qs[1]);
+        }
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        let isCorrect = DistinguishStates_MultiQubit(
+            2,
+            4,
+            StatePrep_BellState,
+            Kata.BellState,
+            false,
+            ["|Φ⁺⟩ = (|00⟩ + |11⟩) / sqrt(2)", "|Φ⁻⟩ = (|00⟩ - |11⟩) / sqrt(2)", "|Ψ⁺⟩ = (|01⟩ + |10⟩) / sqrt(2)", "|Ψ⁻⟩ = (|01⟩ - |10⟩) / sqrt(2)"]
+        );
+
+        if not isCorrect {
+            Message("Incorrect!");
+        } else {
+            Message("Correct!");
+        }
+
+        return isCorrect;
+    }
+}

--- a/katas/content/distinguishing_states/four_bell_states/Verification.qs
+++ b/katas/content/distinguishing_states/four_bell_states/Verification.qs
@@ -35,7 +35,7 @@ namespace Kata.Verification {
         );
 
         if not isCorrect {
-            Message("Incorrect!");
+            Message("Incorrect.");
         } else {
             Message("Correct!");
         }

--- a/katas/content/distinguishing_states/four_bell_states/index.md
+++ b/katas/content/distinguishing_states/four_bell_states/index.md
@@ -1,0 +1,9 @@
+**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in one of the four Bell states.
+
+Output:
+* 0 if they were in the state $\ket{\Phi^{+}} = \frac{1}{\sqrt{2}} \big(\ket{00} + \ket{11}\big)$,
+* 1 if they were in the state $\ket{\Phi^{-}} = \frac{1}{\sqrt{2}} \big(\ket{00} - \ket{11}\big)$,
+* 2 if they were in the state $\ket{\Psi^{+}} = \frac{1}{\sqrt{2}} \big(\ket{01} + \ket{10}\big)$,
+* 3 if they were in the state $\ket{\Psi^{-}} = \frac{1}{\sqrt{2}} \big(\ket{01} - \ket{10}\big)$.
+  
+The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/four_bell_states/solution.md
+++ b/katas/content/distinguishing_states/four_bell_states/solution.md
@@ -11,12 +11,34 @@ $$\text{CNOT}\cdot(H \otimes I) = \frac{1}{\sqrt2} \begin{bmatrix} 1 & 0 & 1 & 0
 To transform the Bell states back to the basis states, you can apply adjoint of this transformation, which will undo its effects. In this case, both gates used are self-adjoint, so the adjoint transformation will require applying the same gates in reverse order (first $\text{CNOT}$, then $H$).
 
 After this the original states will be transformed as follows:
-| Return value | Original state | Maps to basis state |
-|     :---:    |     :---:      |        :---:        |
-| 0     | $\ket{\Phi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{00} + \ket{11}\big)$        | $\ket{00}$      |
-| 1     | $\ket{\Phi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{00} - \ket{11}\big)$        | $\ket{10}$      |
-| 2     | $\ket{\Psi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{01} + \ket{10}\big)$        | $\ket{01}$      |
-| 3     | $\ket{\Psi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{01} - \ket{10}\big)$        | $\ket{11}$      |
+
+<table>
+      <tr>
+        <th>Return value</th>
+        <th>Original state</th>
+        <th>Maps to basis state</th>
+      </tr>
+      <tr>
+        <td>0</td>
+        <td>$\ket{\Phi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{00} + \ket{11}\big)$</td>
+        <td>$\ket{00}$</td>
+      </tr>
+      <tr>
+        <td>1</td>
+        <td>$\ket{\Phi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{00} - \ket{11}\big)$</td>
+        <td>$\ket{10}$</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>$\ket{\Psi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{01} + \ket{10}\big)$</td>
+        <td>$\ket{01}$</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>$\ket{\Psi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{01} - \ket{10}\big)$</td>
+        <td>$\ket{11}$</td>
+      </tr>
+    </table>
 
 These are the same four two-qubit basis states we've seen in the task "Distinguish Four Basis States", though in a different order compared to that task, so mapping the measurement results to the return values will differ slightly.
 

--- a/katas/content/distinguishing_states/four_bell_states/solution.md
+++ b/katas/content/distinguishing_states/four_bell_states/solution.md
@@ -2,7 +2,7 @@ If the qubits are entangled in one of the Bell states, you can't simply measure 
 
 First, let's take a look at the preparation of the Bell states starting with the $\ket{00}$ basis state.
 
->A more detailed discussion of preparing all the Bell states can be found in the task All Bell states of the Superposition kata.
+> A more detailed discussion of preparing all the Bell states can be found in the task "All Bell States" of the Preparing Quantum States kata.
 
 The unitary transformation $\text{CNOT}\cdot(H \otimes I)$ (which corresponds to applying the $H$ gate to the first qubit, followed by applying the $\text{CNOT}$ gate with the first qubit as control and the second qubit as target) transforms the 4 basis vectors of the computational basis into the 4 Bell states.
 
@@ -18,7 +18,7 @@ After this the original states will be transformed as follows:
 | 2     | $\ket{\Psi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{01} + \ket{10}\big)$        | $\ket{01}$      |
 | 3     | $\ket{\Psi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{01} - \ket{10}\big)$        | $\ket{11}$      |
 
-These are the same four 2-qubit basis states we've seen in task Distinguish four basis states, though in different order compared to that task, so mapping the measurement results to the return values will differ slightly.
+These are the same four two-qubit basis states we've seen in the task "Distinguish Four Basis States", though in a different order compared to that task, so mapping the measurement results to the return values will differ slightly.
 
 @[solution]({
     "id": "distinguishing_states__four_bell_states_solution",

--- a/katas/content/distinguishing_states/four_bell_states/solution.md
+++ b/katas/content/distinguishing_states/four_bell_states/solution.md
@@ -1,0 +1,26 @@
+If the qubits are entangled in one of the Bell states, you can't simply measure individual qubits to distinguish the states: if you do, the first two states will both give you 00 or 11, and the last two: 01 or 10. We need to come up with a way to transform the original states to states that are easy to distinguish before measuring them.
+
+First, let's take a look at the preparation of the Bell states starting with the $\ket{00}$ basis state.
+
+>A more detailed discussion of preparing all the Bell states can be found in the task All Bell states of the Superposition kata.
+
+The unitary transformation $\text{CNOT}\cdot(H \otimes I)$ (which corresponds to applying the $H$ gate to the first qubit, followed by applying the $\text{CNOT}$ gate with the first qubit as control and the second qubit as target) transforms the 4 basis vectors of the computational basis into the 4 Bell states.
+
+$$\text{CNOT}\cdot(H \otimes I) = \frac{1}{\sqrt2} \begin{bmatrix} 1 & 0 & 1 & 0 \\ 0 & 1 & 0 & 1 \\ 0 & 1 & 0 & -1 \\ \underset{\ket{\Phi^{+}}}{\underbrace{1}} & \underset{\ket{\Psi^{+}}}{\underbrace{0}} & \underset{\ket{\Phi^{-}}}{\underbrace{-1}} & \underset{\ket{\Psi^{-}}}{\underbrace{0}} \end{bmatrix}$$
+
+To transform the Bell states back to the basis states, you can apply adjoint of this transformation, which will undo its effects. In this case, both gates used are self-adjoint, so the adjoint transformation will require applying the same gates in reverse order (first $\text{CNOT}$, then $H$).
+
+After this the original states will be transformed as follows:
+| Return value | Original state | Maps to basis state |
+|     :---:    |     :---:      |        :---:        |
+| 0     | $\ket{\Phi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{00} + \ket{11}\big)$        | $\ket{00}$      |
+| 1     | $\ket{\Phi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{00} - \ket{11}\big)$        | $\ket{10}$      |
+| 2     | $\ket{\Psi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{01} + \ket{10}\big)$        | $\ket{01}$      |
+| 3     | $\ket{\Psi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{01} - \ket{10}\big)$        | $\ket{11}$      |
+
+These are the same four 2-qubit basis states we've seen in task Distinguish four basis states, though in different order compared to that task, so mapping the measurement results to the return values will differ slightly.
+
+@[solution]({
+    "id": "distinguishing_states__four_bell_states_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit/Placeholder.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit/Placeholder.qs
@@ -1,0 +1,15 @@
+namespace Kata {
+    operation TwoQubitState(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+
+    // You might find this helper operation from an earlier task - Distinguish four basis states, useful.
+    operation BasisStateMeasurement(qs : Qubit[]) : Int {
+        let m1 = M(qs[0]) == Zero ? 0 | 1;
+        let m2 = M(qs[1]) == Zero ? 0 | 1;
+
+        return m1 * 2 + m2;
+    }
+}

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit/Placeholder.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit/Placeholder.qs
@@ -5,7 +5,7 @@ namespace Kata {
         return -1;
     }
 
-    // You might find this helper operation from an earlier task - Distinguish four basis states, useful.
+    // You might find this helper operation from an earlier task useful.
     operation BasisStateMeasurement(qs : Qubit[]) : Int {
         let m1 = M(qs[0]) == Zero ? 0 | 1;
         let m2 = M(qs[1]) == Zero ? 0 | 1;

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit/Solution.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit/Solution.qs
@@ -1,0 +1,15 @@
+namespace Kata {
+    operation TwoQubitState(qs : Qubit[]) : Int {
+        H(qs[0]);
+        H(qs[1]);
+
+        return BasisStateMeasurement(qs);
+    }
+
+    operation BasisStateMeasurement(qs : Qubit[]) : Int {
+        let m1 = M(qs[0]) == Zero ? 0 | 1;
+        let m2 = M(qs[1]) == Zero ? 0 | 1;
+
+        return m1 * 2 + m2;
+    }
+}

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit/Verification.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit/Verification.qs
@@ -1,0 +1,38 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    // 0 - (|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2
+    // 1 - (|00⟩ - |01⟩ + |10⟩ - |11⟩) / 2
+    // 2 - (|00⟩ + |01⟩ - |10⟩ - |11⟩) / 2
+    // 3 - (|00⟩ - |01⟩ - |10⟩ + |11⟩) / 2
+    operation StatePrep_TwoQubitState(
+        qs : Qubit[],
+        state : Int,
+        dummyVar : Double
+    ) : Unit is Adj {
+        StatePrep_BasisStateMeasurement(qs, state);
+
+        H(qs[0]);
+        H(qs[1]);
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        let isCorrect = DistinguishStates_MultiQubit(
+            2,
+            4,
+            StatePrep_TwoQubitState,
+            Kata.TwoQubitState,
+            false,
+            ["(|00⟩ + |01⟩ + |10⟩ + |11⟩) / 2", "(|00⟩ - |01⟩ + |10⟩ - |11⟩) / 2", "(|00⟩ + |01⟩ - |10⟩ - |11⟩) / 2", "(|00⟩ - |01⟩ - |10⟩ + |11⟩) / 2"]
+        );
+
+        if not isCorrect {
+            Message("Incorrect!");
+        } else {
+            Message("Correct!");
+        }
+
+        return isCorrect
+    }
+}

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit/Verification.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit/Verification.qs
@@ -28,7 +28,7 @@ namespace Kata.Verification {
         );
 
         if not isCorrect {
-            Message("Incorrect!");
+            Message("Incorrect.");
         } else {
             Message("Correct!");
         }

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit/Verification.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit/Verification.qs
@@ -10,7 +10,7 @@ namespace Kata.Verification {
         state : Int,
         dummyVar : Double
     ) : Unit is Adj {
-        StatePrep_BasisStateMeasurement(qs, state);
+        StatePrep_BasisStateMeasurement(qs, state, dummyVar);
 
         H(qs[0]);
         H(qs[1]);

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit/index.md
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit/index.md
@@ -1,0 +1,13 @@
+**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in one of the four orthogonal states.
+
+**Output:**
+* 0 if they were in the state 
+  $\ket{S_0} = \frac{1}{2} \big(\ket{00} + \ket{01} + \ket{10} + \ket{11}\big)$,
+* 1 if they were in the state 
+  $\ket{S_1} = \frac{1}{2} \big(\ket{00} - \ket{01} + \ket{10} - \ket{11}\big)$,
+* 2 if they were in the state 
+  $\ket{S_2} = \frac{1}{2} \big(\ket{00} + \ket{01} - \ket{10} - \ket{11}\big)$,
+* 3 if they were in the state 
+  $\ket{S_3} = \frac{1}{2} \big(\ket{00} - \ket{01} - \ket{10} + \ket{11}\big)$.
+  
+The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit/solution.md
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit/solution.md
@@ -1,0 +1,27 @@
+Similarly to the previous task, let's see whether these states can be converted back to the basis states from the task Distinguish four basis states.
+
+To find a transformation that would convert the basis states to $\ket{S_0},...\ket{S_3}$, let's write out the coefficients of these states as column vectors side by side, so that they form a matrix.
+
+ $$\frac12 \begin{bmatrix} 1 & 1 & 1 & 1 \\ 1 & -1 & 1 & -1 \\ 1 & 1 & -1 & -1 \\
+\underset{\ket{S_0}}{\underbrace{1}} & \underset{\ket{S_1}}{\underbrace{-1}} & \underset{\ket{S_2}}{\underbrace{-1}} & \underset{\ket{S_3}}{\underbrace{1}} \end{bmatrix}$$
+
+Applying this matrix to each of the basis states will produce the given states. You can check explicitly that applying this transformation to the basis state $\ket{00}$ gives:
+
+$$\frac{1}{2} \begin{bmatrix} 1 & 1 & 1 & 1 \\ 1 & -1 & 1 & -1 \\ 1 & 1 & -1 & -1 \\ 1 & -1 & -1 & 1 \end{bmatrix} \cdot \begin{bmatrix}1 \\ 0 \\ 0 \\ 0 \end{bmatrix} = 
+\frac{1}{2}\begin{bmatrix}1 \\ 1 \\ 1 \\ 1 \end{bmatrix} = 
+\frac{1}{2} \big(\ket{00} + \ket{01} + \ket{10} + \ket{11}\big) = \ket{S_0}$$
+
+and similarly for the rest of the states.
+
+Notice that the top left $2\times2$ block of this matrix is the same as the top right and the bottom left, and same as the bottom right block multiplied by $-1$. This means that we can represent this transformation as a tensor product of two $H$ gates (for background on this, check Multi-Qubit Gates):
+
+$$ H \otimes H = 
+\frac{1}{\sqrt{2}} \begin{bmatrix} 1 & 1 \\ 1 & -1 \end{bmatrix} \otimes \frac{1}{\sqrt{2}} \begin{bmatrix} 1 & 1 \\ 1 & -1 \end{bmatrix} = 
+\frac{1}{2} \begin{bmatrix} 1 & 1 & 1 & 1 \\ 1 & -1 & 1 & -1 \\ 1 & 1 & -1 & -1 \\ 1 & -1 & -1 & 1 \end{bmatrix}  $$
+
+Knowing how to prepare the given states, we can convert the input state back to the corresponding basis state, like we've done in the previous task, and measure both qubits to get the answer.
+
+@[solution]({
+    "id": "distinguishing_states__four_orthogonal_two_qubit_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit/solution.md
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit/solution.md
@@ -1,4 +1,4 @@
-Similarly to the previous task, let's see whether these states can be converted back to the basis states from the task Distinguish four basis states.
+Similarly to the previous task, let's see whether these states can be converted back to the basis states from the task "Distinguish Four Basis States".
 
 To find a transformation that would convert the basis states to $\ket{S_0},...\ket{S_3}$, let's write out the coefficients of these states as column vectors side by side, so that they form a matrix.
 
@@ -13,7 +13,7 @@ $$\frac{1}{2} \begin{bmatrix} 1 & 1 & 1 & 1 \\ 1 & -1 & 1 & -1 \\ 1 & 1 & -1 & -
 
 and similarly for the rest of the states.
 
-Notice that the top left $2\times2$ block of this matrix is the same as the top right and the bottom left, and same as the bottom right block multiplied by $-1$. This means that we can represent this transformation as a tensor product of two $H$ gates (for background on this, check Multi-Qubit Gates):
+Notice that the top left $2\times2$ block of this matrix is the same as the top right and the bottom left, and same as the bottom right block multiplied by $-1$. This means that we can represent this transformation as a tensor product of two $H$ gates (for background on this, check the Multi-Qubit Gates kata):
 
 $$ H \otimes H = 
 \frac{1}{\sqrt{2}} \begin{bmatrix} 1 & 1 \\ 1 & -1 \end{bmatrix} \otimes \frac{1}{\sqrt{2}} \begin{bmatrix} 1 & 1 \\ 1 & -1 \end{bmatrix} = 

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Placeholder.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation TwoQubitStatePartTwo(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Placeholder.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation TwoQubitStatePartTwo(qs : Qubit[]) : Int {
+    operation TwoQubitStateTwo(qs : Qubit[]) : Int {
         // Implement your solution here...
 
         return -1;

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Solution.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Solution.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation TwoQubitStatePartTwo(qs : Qubit[]) : Int {
+    operation TwoQubitStateTwo(qs : Qubit[]) : Int {
         H(qs[1]);
 
         CNOT(qs[0], qs[1]);

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Solution.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Solution.qs
@@ -1,0 +1,13 @@
+namespace Kata {
+    operation TwoQubitStatePartTwo(qs : Qubit[]) : Int {
+        H(qs[1]);
+
+        CNOT(qs[0], qs[1]);
+        H(qs[0]);
+
+        let m1 = M(qs[0]) == One ? 0 | 1;
+        let m2 = M(qs[1]) == One ? 0 | 1;
+
+        return m2 * 2 + m1;
+    }
+}

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Verification.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Verification.qs
@@ -5,7 +5,7 @@ namespace Kata.Verification {
     // 1 - (-|00⟩ + |01⟩ - |10⟩ - |11⟩) / 2
     // 2 - (-|00⟩ - |01⟩ + |10⟩ - |11⟩) / 2
     // 3 - (-|00⟩ - |01⟩ - |10⟩ + |11⟩) / 2
-    operation StatePrep_TwoQubitStatePartTwo(
+    operation StatePrep_TwoQubitStateTwo(
         qs : Qubit[],
         state : Int,
         dummyVar : Double
@@ -26,18 +26,16 @@ namespace Kata.Verification {
 
     @EntryPoint()
     operation CheckSolution() : Bool {
-        let solution = Kata.TwoQubitStatePartTwo;
-        let reference = StatePrep_TwoQubitStatePartTwo;
         let isCorrect = DistinguishStates_MultiQubit(
             2, 4,
-            reference,
-            solution,
+            StatePrep_TwoQubitStateTwo,
+            Kata.TwoQubitStateTwo,
             false,
             ["(+|00⟩ - |01⟩ - |10⟩ - |11⟩) / 2", "(-|00⟩ + |01⟩ - |10⟩ - |11⟩) / 2", "(-|00⟩ - |01⟩ + |10⟩ - |11⟩) / 2", "(-|00⟩ - |01⟩ - |10⟩ + |11⟩) / 2"]
         );
 
         if not isCorrect {
-            Message("Incorrect!");
+            Message("Incorrect.");
         } else {
             Message("Correct!");
         }

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Verification.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Verification.qs
@@ -10,7 +10,7 @@ namespace Kata.Verification {
         state : Int,
         dummyVar : Double
     ) : Unit is Adj {
-        StatePrep_BasisStateMeasurement(qs, state);
+        StatePrep_BasisStateMeasurement(qs, state, dummyVar);
 
         // Now apply all gates for unitary in reference impl (in reverse + adjoint)
         within {

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Verification.qs
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/Verification.qs
@@ -1,0 +1,47 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    // 0 - ( |00⟩ - |01⟩ - |10⟩ - |11⟩) / 2
+    // 1 - (-|00⟩ + |01⟩ - |10⟩ - |11⟩) / 2
+    // 2 - (-|00⟩ - |01⟩ + |10⟩ - |11⟩) / 2
+    // 3 - (-|00⟩ - |01⟩ - |10⟩ + |11⟩) / 2
+    operation StatePrep_TwoQubitStatePartTwo(
+        qs : Qubit[],
+        state : Int,
+        dummyVar : Double
+    ) : Unit is Adj {
+        StatePrep_BasisStateMeasurement(qs, state);
+
+        // Now apply all gates for unitary in reference impl (in reverse + adjoint)
+        within {
+            ApplyToEachA(X, qs);
+            Controlled Z([qs[0]], qs[1]);
+            ApplyToEachA(X, qs);
+        } apply {
+            ApplyToEachCA(H, qs);
+        }
+
+        SWAP(qs[0], qs[1]);
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        let solution = Kata.TwoQubitStatePartTwo;
+        let reference = StatePrep_TwoQubitStatePartTwo;
+        let isCorrect = DistinguishStates_MultiQubit(
+            2, 4,
+            reference,
+            solution,
+            false,
+            ["(+|00⟩ - |01⟩ - |10⟩ - |11⟩) / 2", "(-|00⟩ + |01⟩ - |10⟩ - |11⟩) / 2", "(-|00⟩ - |01⟩ + |10⟩ - |11⟩) / 2", "(-|00⟩ - |01⟩ - |10⟩ + |11⟩) / 2"]
+        );
+
+        if not isCorrect {
+            Message("Incorrect!");
+        } else {
+            Message("Correct!");
+        }
+
+        return isCorrect
+    }
+}

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/index.md
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/index.md
@@ -1,0 +1,13 @@
+**Input:** Two qubits (stored in an array of length 2) which are guaranteed to be in one of the four orthogonal states.
+
+**Output:**
+* 0 if they were in the state 
+  $\ket{S_0} = \frac{1}{2} \big(+\ket{00} - \ket{01} - \ket{10} - \ket{11}\big)$,
+* 1 if they were in the state 
+  $\ket{S_1} = \frac{1}{2} \big(-\ket{00} + \ket{01} - \ket{10} - \ket{11}\big)$,
+* 2 if they were in the state 
+  $\ket{S_2} = \frac{1}{2} \big(-\ket{00} - \ket{01} + \ket{10} - \ket{11}\big)$,
+* 3 if they were in the state 
+  $\ket{S_3} = \frac{1}{2} \big(-\ket{00} - \ket{01} - \ket{10} + \ket{11}\big)$.
+  
+The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/solution.md
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/solution.md
@@ -6,7 +6,7 @@ It is a lot harder to recognize the necessary transformation, though. The coeffi
   <tr>
     <th>Basis state</th>
     <th>Bell state</th>
-    <th>Input state (after applying $H$ gate to the second qubit)</th>
+    <th>State after applying $H$ gate</th>
     <th>Return value</th>
   </tr>
   <tr>

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/solution.md
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/solution.md
@@ -2,12 +2,38 @@ Here we can leverage the same method as used in the previous exercise: find a tr
 
 It is a lot harder to recognize the necessary transformation, though. The coefficient $\frac{1}{2}$ hints that there are still two $H$ gates involved, but this transformation is not a tensor product. After some experimentation you can find that the given states can be prepared by applying the $H$ gate to the second qubit of the matching Bell states:
 
-| Basis state | Bell state  | Input state (after applying $H$ gate to the second qubit) | Return value |
-|     :---:    |     :---:      |        :---:        |      :---:        |
-| $\ket{00}$     | $\ket{\Phi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{00} + \ket{11}\big)$        | $\frac{1}{2} \big (\ket{00} + \ket{01} + \ket{10} - \ket{11}\big) = -\ket{S_3}$      | 3 |
-| $\ket{10}$     | $\ket{\Phi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{00} - \ket{11}\big)$        | $\frac{1}{2} \big (\ket{00} + \ket{01} - \ket{10} + \ket{11}\big) = -\ket{S_2}$      | 2 |
-| $\ket{01}$     | $\ket{\Psi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{01} + \ket{10}\big)$        | $\frac{1}{2} \big (\ket{00} - \ket{01} + \ket{10} + \ket{11}\big) = -\ket{S_1}$      | 1 |
-| $\ket{11}$     | $\ket{\Psi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{01} - \ket{10}\big)$        | $\frac{1}{2} \big (\ket{00} - \ket{01} - \ket{10} - \ket{11}\big) = \ket{S_0}$      | 0 |
+<table>
+  <tr>
+    <th>Basis state</th>
+    <th>Bell state</th>
+    <th>Input state (after applying $H$ gate to the second qubit)</th>
+    <th>Return value</th>
+  </tr>
+  <tr>
+    <td>$\ket{00}$</td>
+    <td>$\ket{\Phi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{00} + \ket{11}\big)$</td>
+    <td>$\frac{1}{2} \big (\ket{00} + \ket{01} + \ket{10} - \ket{11}\big) = -\ket{S_3}$</td>
+    <td>3</td>
+  </tr>
+  <tr>
+    <td>$\ket{10}$ </td>
+    <td>$\ket{\Phi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{00} - \ket{11}\big)$</td>
+    <td>$\frac{1}{2} \big (\ket{00} + \ket{01} - \ket{10} + \ket{11}\big) = -\ket{S_2}$</td>
+    <td>2</td>
+  </tr>
+  <tr>
+    <td>$\ket{01}$</td>
+    <td>$\ket{\Psi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{01} + \ket{10}\big)$</td>
+    <td>$\frac{1}{2} \big (\ket{00} - \ket{01} + \ket{10} + \ket{11}\big) = -\ket{S_1}$</td>
+    <td>1</td>
+  </tr>
+  <tr>
+    <td>$\ket{11}$</td>
+    <td>$|\\Psi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|01\\rangle - |10\\rangle\\big)$</td>
+    <td>$\frac{1}{2} \big (\ket{00} - \ket{01} - \ket{10} - \ket{11}\big) = \ket{S_0}$</td>
+    <td>0</td>
+  </tr>
+</table>
 
 @[solution]({
     "id": "distinguishing_states__four_orthogonal_two_qubit_part_two_solution",

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/solution.md
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/solution.md
@@ -1,0 +1,15 @@
+Here we can leverage the same method as used in the previous exercise: find a transformation that maps the basis states to the given states and apply its adjoint to the input state before measuring.
+
+It is a lot harder to recognize the necessary transformation, though. The coefficient $\frac{1}{2}$ hints that there are still two $H$ gates involved, but this transformation is not a tensor product. After some experimentation you can find that the given states can be prepared by applying the $H$ gate to the second qubit of the matching Bell states:
+
+| Basis state | Bell state  | Input state (after applying $H$ gate to the second qubit) | Return value |
+|     :---:    |     :---:      |        :---:        |      :---:        |
+| $\ket{00}$     | $\ket{\Phi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{00} + \ket{11}\big)$        | $\frac{1}{2} \big (\ket{00} + \ket{01} + \ket{10} - \ket{11}\big) = -\ket{S_3}$      | 3 |
+| $\ket{10}$     | $\ket{\Phi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{00} - \ket{11}\big)$        | $\frac{1}{2} \big (\ket{00} + \ket{01} - \ket{10} + \ket{11}\big) = -\ket{S_2}$      | 2 |
+| $\ket{01}$     | $\ket{\Psi^{+}} = \frac{1}{\sqrt{2}} \big (\ket{01} + \ket{10}\big)$        | $\frac{1}{2} \big (\ket{00} - \ket{01} + \ket{10} + \ket{11}\big) = -\ket{S_1}$      | 1 |
+| $\ket{11}$     | $\ket{\Psi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{01} - \ket{10}\big)$        | $\frac{1}{2} \big (\ket{00} - \ket{01} - \ket{10} - \ket{11}\big) = \ket{S_0}$      | 0 |
+
+@[solution]({
+    "id": "distinguishing_states__four_orthogonal_two_qubit_part_two_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/solution.md
+++ b/katas/content/distinguishing_states/four_orthogonal_two_qubit_part_two/solution.md
@@ -29,7 +29,7 @@ It is a lot harder to recognize the necessary transformation, though. The coeffi
   </tr>
   <tr>
     <td>$\ket{11}$</td>
-    <td>$|\\Psi^{-}\\rangle = \\frac{1}{\\sqrt{2}} \\big (|01\\rangle - |10\\rangle\\big)$</td>
+    <td>$\ket{\Psi^{-}} = \frac{1}{\sqrt{2}} \big (\ket{01} - \ket{10}\big)$</td>
     <td>$\frac{1}{2} \big (\ket{00} - \ket{01} - \ket{10} - \ket{11}\big) = \ket{S_0}$</td>
     <td>0</td>
   </tr>

--- a/katas/content/distinguishing_states/ghz_w/Placeholder.qs
+++ b/katas/content/distinguishing_states/ghz_w/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation GHZOrWState(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/distinguishing_states/ghz_w/Solution.qs
+++ b/katas/content/distinguishing_states/ghz_w/Solution.qs
@@ -1,0 +1,13 @@
+namespace Kata {
+    operation GHZOrWState(qs : Qubit[]) : Int {
+        mutable countOnes = 0;
+
+        for q in qs {
+            if M(q) == One {
+                set countOnes += 1;
+            }
+        }
+
+        return countOnes == 1 ? 1 | 0;
+    }
+}

--- a/katas/content/distinguishing_states/ghz_w/Verification.qs
+++ b/katas/content/distinguishing_states/ghz_w/Verification.qs
@@ -1,0 +1,45 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    operation GHZ_State_Reference(qs : Qubit[]) : Unit is Adj {
+        H(Head(qs));
+        for q in Rest(qs) {
+            CNOT(Head(qs), q);
+        }
+    }
+
+    operation StatePrep_GHZOrWState(
+        qs : Qubit[],
+        state : Int,
+        dummyVar : Double
+    ) : Unit is Adj {
+        if state == 0 {
+            // Prepare GHZ state
+            GHZ_State_Reference(qs);
+        } else {
+            // Prepare W state
+            WState_Arbitrary_Reference(qs);
+        }
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+
+        for i in 2 .. 6 {
+            let isCorrect = DistinguishStates_MultiQubit(
+                i, 2,
+                StatePrep_GHZOrWState,
+                Kata.GHZOrWState,
+                false,
+                ["|GHZ⟩", "|W⟩"]);
+
+            if not isCorrect {
+                Message("Incorrect!");
+                return false;
+            }
+        }
+
+        Message("Correct!");
+        return true;
+    }
+}

--- a/katas/content/distinguishing_states/ghz_w/Verification.qs
+++ b/katas/content/distinguishing_states/ghz_w/Verification.qs
@@ -2,9 +2,9 @@ namespace Kata.Verification {
     open Microsoft.Quantum.Katas;
 
     operation GHZ_State_Reference(qs : Qubit[]) : Unit is Adj {
-        H(Head(qs));
-        for q in Rest(qs) {
-            CNOT(Head(qs), q);
+        H(qs[0]);
+        for q in qs[1 ... ] {
+            CNOT(qs[0], q);
         }
     }
 

--- a/katas/content/distinguishing_states/ghz_w/Verification.qs
+++ b/katas/content/distinguishing_states/ghz_w/Verification.qs
@@ -34,7 +34,7 @@ namespace Kata.Verification {
                 ["|GHZ⟩", "|W⟩"]);
 
             if not isCorrect {
-                Message("Incorrect!");
+                Message("Incorrect.");
                 return false;
             }
         }

--- a/katas/content/distinguishing_states/ghz_w/index.md
+++ b/katas/content/distinguishing_states/ghz_w/index.md
@@ -1,0 +1,7 @@
+**Input:** $N \ge 2$ qubits (stored in an array of length $N$) which are guaranteed to be either in the [GHZ state](https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state) or in the [W state](https://en.wikipedia.org/wiki/W_state).
+
+**Output:**
+* 0 if the qubits were in the GHZ state,
+* 1 if they were in the W state.
+
+The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/ghz_w/index.md
+++ b/katas/content/distinguishing_states/ghz_w/index.md
@@ -1,4 +1,4 @@
-**Input:** $N \ge 2$ qubits (stored in an array of length $N$) which are guaranteed to be either in the [GHZ state](https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state) or in the [W state](https://en.wikipedia.org/wiki/W_state).
+**Input:** $N \ge 2$ qubits (stored in an array of length $N$) which are guaranteed to be either in the GHZ state - an even superposition of $\ket{0...0}$ and $\ket{1...1}$ states - or in the W state we saw in the previous task. (For example, for $N = 3$ GHZ state is $\frac1{\sqrt2}(\ket{000} + \ket{111})$.
 
 **Output:**
 * 0 if the qubits were in the GHZ state,

--- a/katas/content/distinguishing_states/ghz_w/solution.md
+++ b/katas/content/distinguishing_states/ghz_w/solution.md
@@ -1,5 +1,3 @@
-Here is an example of the GHZ state for $N = 3: \frac{1}{\sqrt{2}}(\ket{000}+\ket{111})$.
-
 As we've seen in the previous task, each of the basis states that form the W state will have exactly one qubit in the $\ket{1}$ state. Basis states that forms the GHZ state will either have all qubits in the $\ket{1}$ state or all qubits in the $\ket{0}$ state.
 
 This means that if we count the number of qubits that were measured in the `One` state, we'll get 1 for the W state, and 0 or $N$ for the GHZ state. The code ends up almost the same as in the previous task (in fact, you can use this exact code to solve the previous task).

--- a/katas/content/distinguishing_states/ghz_w/solution.md
+++ b/katas/content/distinguishing_states/ghz_w/solution.md
@@ -1,0 +1,10 @@
+Here is an example of the GHZ state for $N = 3: \frac{1}{\sqrt{2}}(\ket{000}+\ket{111})$.
+
+As we've seen in the previous task, each of the basis states that form the W state will have exactly one qubit in the $\ket{1}$ state. Basis states that forms the GHZ state will either have all qubits in the $\ket{1}$ state or all qubits in the $\ket{0}$ state.
+
+This means that if we count the number of qubits that were measured in the `One` state, we'll get 1 for the W state, and 0 or $N$ for the GHZ state. The code ends up almost the same as in the previous task (in fact, you can use this exact code to solve the previous task).
+
+@[solution]({
+    "id": "distinguishing_states__ghz_w_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_states/index.md
+++ b/katas/content/distinguishing_states/index.md
@@ -68,6 +68,60 @@ This kata is designed to get you familiar with the concept of measurements and u
     ]
 })
 
+@[exercise]({
+    "id": "distinguishing_states__all_zeros_w",
+    "title": "|0.. .0〉 state or W state?",
+    "path": "./all_zeros_w/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "distinguishing_states__ghz_w",
+    "title": "GHZ state or W state?",
+    "path": "./ghz_w/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "distinguishing_states__four_bell_states",
+    "title": "Distinguish four Bell states",
+    "path": "./four_bell_states/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "distinguishing_states__four_orthogonal_two_qubit",
+    "title": "Distinguish four orthogonal 2-qubit states",
+    "path": "./four_orthogonal_two_qubit/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "distinguishing_states__four_orthogonal_two_qubit_part_two",
+    "title": "Distinguish four orthogonal 2-qubit states, part 2",
+    "path": "./four_orthogonal_two_qubit_part_two/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "distinguishing_states__two_orthogonal_three_qubit",
+    "title": "Distinguish two orthogonal states on three qubits",
+    "path": "./two_orthogonal_three_qubit/",
+    "qsDependencies": [
+        "../KatasLibrary.qs"
+    ]
+})
+
 @[section]({
     "id": "distinguishing_states__nonorthogonal_states",
     "title": "Distinguishing Non-orthogonal States"

--- a/katas/content/distinguishing_states/index.md
+++ b/katas/content/distinguishing_states/index.md
@@ -70,7 +70,7 @@ This kata is designed to get you familiar with the concept of measurements and u
 
 @[exercise]({
     "id": "distinguishing_states__all_zeros_w",
-    "title": "|0.. .0〉 state or W state?",
+    "title": "|0...0〉 State or W State?",
     "path": "./all_zeros_w/",
     "qsDependencies": [
         "../KatasLibrary.qs"
@@ -79,7 +79,7 @@ This kata is designed to get you familiar with the concept of measurements and u
 
 @[exercise]({
     "id": "distinguishing_states__ghz_w",
-    "title": "GHZ state or W state?",
+    "title": "GHZ State or W State?",
     "path": "./ghz_w/",
     "qsDependencies": [
         "../KatasLibrary.qs"
@@ -88,7 +88,7 @@ This kata is designed to get you familiar with the concept of measurements and u
 
 @[exercise]({
     "id": "distinguishing_states__four_bell_states",
-    "title": "Distinguish four Bell states",
+    "title": "Distinguish Four Bell States",
     "path": "./four_bell_states/",
     "qsDependencies": [
         "../KatasLibrary.qs"
@@ -97,7 +97,7 @@ This kata is designed to get you familiar with the concept of measurements and u
 
 @[exercise]({
     "id": "distinguishing_states__four_orthogonal_two_qubit",
-    "title": "Distinguish four orthogonal 2-qubit states",
+    "title": "Distinguish Four Two-Qubit States",
     "path": "./four_orthogonal_two_qubit/",
     "qsDependencies": [
         "../KatasLibrary.qs"
@@ -106,7 +106,7 @@ This kata is designed to get you familiar with the concept of measurements and u
 
 @[exercise]({
     "id": "distinguishing_states__four_orthogonal_two_qubit_part_two",
-    "title": "Distinguish four orthogonal 2-qubit states, part 2",
+    "title": "Distinguish Four Two-Qubit States - 2",
     "path": "./four_orthogonal_two_qubit_part_two/",
     "qsDependencies": [
         "../KatasLibrary.qs"
@@ -115,7 +115,7 @@ This kata is designed to get you familiar with the concept of measurements and u
 
 @[exercise]({
     "id": "distinguishing_states__two_orthogonal_three_qubit",
-    "title": "Distinguish two orthogonal states on three qubits",
+    "title": "Distinguish Two Three-Qubit States",
     "path": "./two_orthogonal_three_qubit/",
     "qsDependencies": [
         "../KatasLibrary.qs"

--- a/katas/content/distinguishing_states/index.md
+++ b/katas/content/distinguishing_states/index.md
@@ -61,10 +61,11 @@ This kata is designed to get you familiar with the concept of measurements and u
 
 @[exercise]({
     "id": "distinguishing_states__four_basis_states",
-    "title": "Distinguish four basis states",
+    "title": "Distinguish Four Basis States",
     "path": "./four_basis_states/",
     "qsDependencies": [
-        "../KatasLibrary.qs"
+        "../KatasLibrary.qs",
+        "./Common.qs"
     ]
 })
 
@@ -100,7 +101,8 @@ This kata is designed to get you familiar with the concept of measurements and u
     "title": "Distinguish Four Two-Qubit States",
     "path": "./four_orthogonal_two_qubit/",
     "qsDependencies": [
-        "../KatasLibrary.qs"
+        "../KatasLibrary.qs",
+        "./Common.qs"
     ]
 })
 
@@ -109,7 +111,8 @@ This kata is designed to get you familiar with the concept of measurements and u
     "title": "Distinguish Four Two-Qubit States - 2",
     "path": "./four_orthogonal_two_qubit_part_two/",
     "qsDependencies": [
-        "../KatasLibrary.qs"
+        "../KatasLibrary.qs",
+        "./Common.qs"
     ]
 })
 

--- a/katas/content/distinguishing_states/two_orthogonal_three_qubit/Placeholder.qs
+++ b/katas/content/distinguishing_states/two_orthogonal_three_qubit/Placeholder.qs
@@ -1,0 +1,32 @@
+namespace Kata {
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Measurement;
+    operation ThreeQubitMeasurement(qs : Qubit[]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+
+    // You might find this helper operation from the task
+    // W state on an arbitrary number of qubits of the Superposition kata useful.
+    operation WState_Arbitrary(qs : Qubit[]) : Unit is Adj + Ctl {
+        let N = Length(qs);
+
+        if N == 1 {
+            // Base case of recursion: |1⟩
+            X(qs[0]);
+        } else {
+            // |W_N⟩ = |0⟩|W_(N-1)⟩ + |1⟩|0...0⟩
+            // Do a rotation on the first qubit to split it into |0⟩ and |1⟩ with proper weights
+            // |0⟩ -> sqrt((N-1)/N) |0⟩ + 1/sqrt(N) |1⟩
+            let theta = ArcSin(1.0 / Sqrt(IntAsDouble(N)));
+            Ry(2.0 * theta, qs[0]);
+
+            // Do a zero-controlled W-state generation for qubits 1..N-1
+            X(qs[0]);
+            Controlled WState_Arbitrary(qs[0..0], qs[1..N - 1]);
+            X(qs[0]);
+        }
+    }
+}

--- a/katas/content/distinguishing_states/two_orthogonal_three_qubit/Placeholder.qs
+++ b/katas/content/distinguishing_states/two_orthogonal_three_qubit/Placeholder.qs
@@ -9,21 +9,15 @@ namespace Kata {
     }
 
     // You might find this helper operation from the task
-    // W state on an arbitrary number of qubits of the Superposition kata useful.
+    // "W State on Arbitrary Number of Qubits" from the "Preparing Quantum States" kata useful.
     operation WState_Arbitrary(qs : Qubit[]) : Unit is Adj + Ctl {
         let N = Length(qs);
 
         if N == 1 {
-            // Base case of recursion: |1⟩
             X(qs[0]);
         } else {
-            // |W_N⟩ = |0⟩|W_(N-1)⟩ + |1⟩|0...0⟩
-            // Do a rotation on the first qubit to split it into |0⟩ and |1⟩ with proper weights
-            // |0⟩ -> sqrt((N-1)/N) |0⟩ + 1/sqrt(N) |1⟩
             let theta = ArcSin(1.0 / Sqrt(IntAsDouble(N)));
             Ry(2.0 * theta, qs[0]);
-
-            // Do a zero-controlled W-state generation for qubits 1..N-1
             X(qs[0]);
             Controlled WState_Arbitrary(qs[0..0], qs[1..N - 1]);
             X(qs[0]);

--- a/katas/content/distinguishing_states/two_orthogonal_three_qubit/Solution.qs
+++ b/katas/content/distinguishing_states/two_orthogonal_three_qubit/Solution.qs
@@ -1,0 +1,37 @@
+namespace Kata {
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Measurement;
+
+    operation ThreeQubitMeasurement(qs : Qubit[]) : Int {
+        R1(-2.0 * PI() / 3.0, qs[1]);
+        R1(-4.0 * PI() / 3.0, qs[2]);
+
+        // Apply inverse state prep of 1/sqrt(3) ( |100⟩ + |010⟩ + |001⟩ )
+        Adjoint WState_Arbitrary(qs);
+
+        // Measure all qubits: if all of them are 0, we have the first state,
+        // if at least one of them is 1, we have the second state
+        return MeasureInteger(qs) == 0 ? 0 | 1;
+    }
+
+    operation WState_Arbitrary(qs : Qubit[]) : Unit is Adj + Ctl {
+        let N = Length(qs);
+
+        if N == 1 {
+            // Base case of recursion: |1⟩
+            X(qs[0]);
+        } else {
+            // |W_N⟩ = |0⟩|W_(N-1)⟩ + |1⟩|0...0⟩
+            // Do a rotation on the first qubit to split it into |0⟩ and |1⟩ with proper weights
+            // |0⟩ -> sqrt((N-1)/N) |0⟩ + 1/sqrt(N) |1⟩
+            let theta = ArcSin(1.0 / Sqrt(IntAsDouble(N)));
+            Ry(2.0 * theta, qs[0]);
+
+            // Do a zero-controlled W-state generation for qubits 1..N-1
+            X(qs[0]);
+            Controlled WState_Arbitrary(qs[0..0], qs[1..N - 1]);
+            X(qs[0]);
+        }
+    }
+}

--- a/katas/content/distinguishing_states/two_orthogonal_three_qubit/Solution.qs
+++ b/katas/content/distinguishing_states/two_orthogonal_three_qubit/Solution.qs
@@ -7,11 +7,8 @@ namespace Kata {
         R1(-2.0 * PI() / 3.0, qs[1]);
         R1(-4.0 * PI() / 3.0, qs[2]);
 
-        // Apply inverse state prep of 1/sqrt(3) ( |100⟩ + |010⟩ + |001⟩ )
         Adjoint WState_Arbitrary(qs);
 
-        // Measure all qubits: if all of them are 0, we have the first state,
-        // if at least one of them is 1, we have the second state
         return MeasureInteger(qs) == 0 ? 0 | 1;
     }
 
@@ -19,16 +16,11 @@ namespace Kata {
         let N = Length(qs);
 
         if N == 1 {
-            // Base case of recursion: |1⟩
             X(qs[0]);
         } else {
-            // |W_N⟩ = |0⟩|W_(N-1)⟩ + |1⟩|0...0⟩
-            // Do a rotation on the first qubit to split it into |0⟩ and |1⟩ with proper weights
-            // |0⟩ -> sqrt((N-1)/N) |0⟩ + 1/sqrt(N) |1⟩
             let theta = ArcSin(1.0 / Sqrt(IntAsDouble(N)));
             Ry(2.0 * theta, qs[0]);
 
-            // Do a zero-controlled W-state generation for qubits 1..N-1
             X(qs[0]);
             Controlled WState_Arbitrary(qs[0..0], qs[1..N - 1]);
             X(qs[0]);

--- a/katas/content/distinguishing_states/two_orthogonal_three_qubit/Verification.qs
+++ b/katas/content/distinguishing_states/two_orthogonal_three_qubit/Verification.qs
@@ -30,7 +30,7 @@ namespace Kata.Verification {
             ["1/sqrt(3) (|100⟩ + ω |010⟩ + ω² |001⟩)", "1/sqrt(3) (|100⟩ + ω² |010⟩ + ω |001⟩)"]);
 
         if not isCorrect {
-            Message("Incorrect!");
+            Message("Incorrect.");
         } else {
             Message("Correct!");
         }

--- a/katas/content/distinguishing_states/two_orthogonal_three_qubit/Verification.qs
+++ b/katas/content/distinguishing_states/two_orthogonal_three_qubit/Verification.qs
@@ -1,0 +1,40 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+    open Microsoft.Quantum.Math;
+
+    operation StatePrep_ThreeQubitMeasurement(
+        qs : Qubit[],
+        state : Int,
+        dummyVar : Double
+    ) : Unit is Adj {
+        WState_Arbitrary_Reference(qs);
+
+        if state == 0 {
+            // prep 1/sqrt(3) ( |100⟩ + ω |010⟩ + ω² |001⟩ )
+            R1(2.0 * PI() / 3.0, qs[1]);
+            R1(4.0 * PI() / 3.0, qs[2]);
+        } else {
+            //  prep 1/sqrt(3) ( |100⟩ + ω² |010⟩ + ω |001⟩ )
+            R1(4.0 * PI() / 3.0, qs[1]);
+            R1(2.0 * PI() / 3.0, qs[2]);
+        }
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        let isCorrect = DistinguishStates_MultiQubit(
+            3, 2,
+            StatePrep_ThreeQubitMeasurement,
+            Kata.ThreeQubitMeasurement,
+            false,
+            ["1/sqrt(3) (|100⟩ + ω |010⟩ + ω² |001⟩)", "1/sqrt(3) (|100⟩ + ω² |010⟩ + ω |001⟩)"]);
+
+        if not isCorrect {
+            Message("Incorrect!");
+        } else {
+            Message("Correct!");
+        }
+
+        return isCorrect
+    }
+}

--- a/katas/content/distinguishing_states/two_orthogonal_three_qubit/index.md
+++ b/katas/content/distinguishing_states/two_orthogonal_three_qubit/index.md
@@ -1,0 +1,11 @@
+**Input:** Three qubits (stored in an array of length 3) which are guaranteed to be in one of the two orthogonal states.
+
+**Output:**
+* 0 if they were in the state 
+  $\ket{S_0} = \frac{1}{\sqrt{3}} \big(\ket{100} + \omega \ket{010} + \omega^2 \ket{001} \big)$,
+* 1 if they were in the state 
+  $\ket{S_1} = \frac{1}{\sqrt{3}} \big(\ket{100} + \omega^2 \ket{010} + \omega \ket{001} \big)$.
+
+Here $\omega = e^{2i \pi/3}$.
+
+The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/two_orthogonal_three_qubit/solution.md
+++ b/katas/content/distinguishing_states/two_orthogonal_three_qubit/solution.md
@@ -1,10 +1,10 @@
 Let's find a unitary transformation that converts the state $\ket{S_0}$ to the basis state $\ket{000}$. To do this, we first apply a unitary operation that maps the first state to the W state 
 $\frac{1}{\sqrt{3}} \big(\ket{100} + \ket{010} + \ket{001}\big)$.
 
-> We will use a convenient rotation gate $R_1$ which applies a relative phase to the $\ket{1}$ state and doesn't change the $\ket{0}$ state.
-> In matrix form: 
->
-> $$R_1(\theta) = \begin{bmatrix} 1 & 0 \\ 0 & e^{i\theta} \end{bmatrix} $$
+After this, we will use a convenient rotation gate $R_1$ which applies a relative phase to the $\ket{1}$ state and doesn't change the $\ket{0}$ state.
+In matrix form: 
+
+$$R_1(\theta) = \begin{bmatrix} 1 & 0 \\ 0 & e^{i\theta} \end{bmatrix} $$
 
 This can be accomplished by a tensor product 
 $I \otimes R_1(-\frac{2\pi}{3}) \otimes R_1(-\frac{4\pi}{3})$, where
@@ -15,7 +15,7 @@ $I \otimes R_1(-\frac{2\pi}{3}) \otimes R_1(-\frac{4\pi}{3})$, where
 
 > Note that applying this operation to the state $\ket{S_1}$ converts it to $\frac{1}{\sqrt{3}} \big (\ket{100} + \omega \ket{010} + \omega^2 \ket{001} \big)$.
 
-Now we can use adjoint of the state preparation routine for W state (from task W state on an arbitrary number of qubits of the Superposition kata), which will map the W state to the state $\ket{000}$ and the second state to some other state $\ket{S'_1}$.
+Now we can use adjoint of the state preparation routine for W state (from task "W State on Arbitrary Number of Qubits" of the Preparing Quantum States kata), which will map the W state to the state $\ket{000}$ and the second state to some other state $\ket{S'_1}$.
 
 We don't need to do the math to figure out the exact state $\ket{S'_1}$ in which $\ket{S_1}$ will end up after those two transformations. Remember that our transformations are unitary, i.e., they preserve the inner products of vectors. Since the states $\ket{S_0}$ and $\ket{S_1}$ were orthogonal, their inner product $\braket{S_0|S_1} = 0$ is preserved when applying unitary transformations, and the states after the transformation will remain orthogonal.
 

--- a/katas/content/distinguishing_states/two_orthogonal_three_qubit/solution.md
+++ b/katas/content/distinguishing_states/two_orthogonal_three_qubit/solution.md
@@ -1,0 +1,27 @@
+Let's find a unitary transformation that converts the state $\ket{S_0}$ to the basis state $\ket{000}$. To do this, we first apply a unitary operation that maps the first state to the W state 
+$\frac{1}{\sqrt{3}} \big(\ket{100} + \ket{010} + \ket{001}\big)$.
+
+> We will use a convenient rotation gate $R_1$ which applies a relative phase to the $\ket{1}$ state and doesn't change the $\ket{0}$ state.
+> In matrix form: 
+>
+> $$R_1(\theta) = \begin{bmatrix} 1 & 0 \\ 0 & e^{i\theta} \end{bmatrix} $$
+
+This can be accomplished by a tensor product 
+$I \otimes R_1(-\frac{2\pi}{3}) \otimes R_1(-\frac{4\pi}{3})$, where
+
+* $I$ is the identity gate applied to qubit 0,
+* $R_1(-\frac{2\pi}{3}) = \begin{bmatrix} 1 & 0 \\ 0 & \omega^{-1} \end{bmatrix}$, applied to qubit 1,
+* $R_1(-\frac{4\pi}{3}) = \begin{bmatrix} 1 & 0 \\ 0 & \omega^{-2} \end{bmatrix}$, applied to qubit 2.
+
+> Note that applying this operation to the state $\ket{S_1}$ converts it to $\frac{1}{\sqrt{3}} \big (\ket{100} + \omega \ket{010} + \omega^2 \ket{001} \big)$.
+
+Now we can use adjoint of the state preparation routine for W state (from task W state on an arbitrary number of qubits of the Superposition kata), which will map the W state to the state $\ket{000}$ and the second state to some other state $\ket{S'_1}$.
+
+We don't need to do the math to figure out the exact state $\ket{S'_1}$ in which $\ket{S_1}$ will end up after those two transformations. Remember that our transformations are unitary, i.e., they preserve the inner products of vectors. Since the states $\ket{S_0}$ and $\ket{S_1}$ were orthogonal, their inner product $\braket{S_0|S_1} = 0$ is preserved when applying unitary transformations, and the states after the transformation will remain orthogonal.
+
+The state $\ket{S'_1}$ is guaranteed to be orthogonal to the state $\ket{000}$, i.e., $\ket{S_1}$ gets mapped to a superposition that does not include basis state $\ket{000}$. To distinguish the states $\ket{000}$ and $\ket{S'_1}$, we measure all qubits; if all measurement results were 0, the state was $\ket{000}$ and we return 0, otherwise we return 1.
+
+@[solution]({
+    "id": "distinguishing_states__two_orthogonal_three_qubit_solution",
+    "codePath": "Solution.qs"
+})


### PR DESCRIPTION
Migrate tasks 1.10 - 1.15 from the Measurements workbook to Distinguishing States Kata.
This resolves a part of the [Issue 1185](https://github.com/microsoft/qsharp/issues/1185).