### PR TITLE
Disable needless operation lint for Katas

### DIFF
--- a/compiler/qsc_linter/src/linter.rs
+++ b/compiler/qsc_linter/src/linter.rs
@@ -75,7 +75,7 @@ impl Diagnostic for Lint {
 
 /// A lint level. This defines if a lint will be treated as a warning or an error,
 /// and if the lint level can be overriden by the user.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum LintLevel {
     /// The lint is effectively disabled.
@@ -103,7 +103,7 @@ impl Display for LintLevel {
 }
 
 /// End-user configuration for each lint level.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct LintConfig {
     #[serde(rename = "lint")]
     /// Represents the lint name.
@@ -113,7 +113,7 @@ pub struct LintConfig {
 }
 
 /// Represents a lint name.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum LintKind {
     /// AST lint name.

--- a/compiler/qsc_linter/src/linter/ast.rs
+++ b/compiler/qsc_linter/src/linter/ast.rs
@@ -135,7 +135,7 @@ macro_rules! declare_ast_lints {
         use serde::{Deserialize, Serialize};
 
         /// An enum listing all existing AST lints.
-        #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+        #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
         #[serde(rename_all = "camelCase")]
         pub enum AstLint {
             $(

--- a/compiler/qsc_linter/src/linter/hir.rs
+++ b/compiler/qsc_linter/src/linter/hir.rs
@@ -123,7 +123,7 @@ macro_rules! declare_hir_lints {
         use serde::{Deserialize, Serialize};
 
         /// An enum listing all existing HIR lints.
-        #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+        #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
         #[serde(rename_all = "camelCase")]
         pub enum HirLint {
             $(

--- a/compiler/qsc_linter/src/lints/hir.rs
+++ b/compiler/qsc_linter/src/lints/hir.rs
@@ -12,7 +12,7 @@ use crate::linter::hir::declare_hir_lints;
 use super::lint;
 
 declare_hir_lints! {
-    (NeedlessOperation, LintLevel::Warn, "operation does not contain any quantum operations", "this callable can be declared as a function instead")
+    (NeedlessOperation, LintLevel::Allow, "operation does not contain any quantum operations", "this callable can be declared as a function instead")
 }
 
 /// Helper to check if an operation has desired operation characteristics

--- a/compiler/qsc_linter/src/tests.rs
+++ b/compiler/qsc_linter/src/tests.rs
@@ -38,7 +38,7 @@ fn multiple_lints() {
                 },
                 SrcLint {
                     source: "RunProgram",
-                    level: Warn,
+                    level: Allow,
                     message: "operation does not contain any quantum operations",
                     help: "this callable can be declared as a function instead",
                 },
@@ -152,7 +152,7 @@ fn needless_operation_lambda_operations() {
             [
                 SrcLint {
                     source: "",
-                    level: Warn,
+                    level: Allow,
                     message: "operation does not contain any quantum operations",
                     help: "this callable can be declared as a function instead",
                 },
@@ -179,7 +179,7 @@ fn needless_operation_non_empty_op_and_no_specialization() {
             [
                 SrcLint {
                     source: "RunProgram",
-                    level: Warn,
+                    level: Allow,
                     message: "operation does not contain any quantum operations",
                     help: "this callable can be declared as a function instead",
                 },
@@ -203,7 +203,7 @@ fn needless_operation_non_empty_op_and_specialization() {
             [
                 SrcLint {
                     source: "Run",
-                    level: Warn,
+                    level: Allow,
                     message: "operation does not contain any quantum operations",
                     help: "this callable can be declared as a function instead",
                 },
@@ -257,7 +257,7 @@ fn needless_operation_partial_application() {
             [
                 SrcLint {
                     source: "PartialApplication",
-                    level: Warn,
+                    level: Allow,
                     message: "operation does not contain any quantum operations",
                     help: "this callable can be declared as a function instead",
                 },

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -2,15 +2,18 @@
 // Licensed under the MIT License.
 
 use qsc::line_column::Range;
-use qsc::{compile::Error, target::Profile, LanguageFeatures, PackageType};
+use qsc::PackageType;
+use qsc::{compile::Error, target::Profile, LanguageFeatures};
+use qsc_linter::LintConfig;
 use qsc_project::Manifest;
 
 /// A change to the workspace configuration
-#[derive(Clone, Debug, Default, Copy)]
+#[derive(Clone, Debug, Default)]
 pub struct WorkspaceConfigurationUpdate {
     pub target_profile: Option<Profile>,
     pub package_type: Option<PackageType>,
     pub language_features: Option<LanguageFeatures>,
+    pub lints_config: Option<Vec<LintConfig>>,
 }
 
 #[derive(Debug)]

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 use qsc::line_column::Range;
-use qsc::PackageType;
-use qsc::{compile::Error, target::Profile, LanguageFeatures};
-use qsc_linter::LintConfig;
-use qsc_project::Manifest;
+use qsc::{
+    compile::Error, linter::LintConfig, project::Manifest, target::Profile, LanguageFeatures,
+    PackageType,
+};
 
 /// A change to the workspace configuration
 #[derive(Clone, Debug, Default)]

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -8,6 +8,7 @@ use super::{CompilationState, CompilationStateUpdater};
 use crate::protocol::{DiagnosticUpdate, NotebookMetadata, WorkspaceConfigurationUpdate};
 use expect_test::{expect, Expect};
 use qsc::{compile::ErrorKind, target::Profile, PackageType};
+use qsc_linter::{AstLint, LintConfig, LintKind, LintLevel};
 use qsc_project::{EntryType, JSFileEntry, Manifest, ManifestDescriptor};
 use rustc_hash::FxHashMap;
 use std::{cell::RefCell, fmt::Write, future::ready, rc::Rc, sync::Arc};
@@ -314,7 +315,7 @@ async fn rca_errors_are_reported_when_compilation_succeeds() {
     updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: Some(Profile::AdaptiveRI),
         package_type: Some(PackageType::Lib),
-        language_features: None,
+        ..WorkspaceConfigurationUpdate::default()
     });
 
     updater
@@ -367,7 +368,7 @@ async fn base_profile_rca_errors_are_reported_when_compilation_succeeds() {
     updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: Some(Profile::Base),
         package_type: Some(PackageType::Lib),
-        language_features: None,
+        ..WorkspaceConfigurationUpdate::default()
     });
 
     updater
@@ -428,9 +429,8 @@ async fn package_type_update_causes_error() {
     let mut updater = new_updater(&errors);
 
     updater.update_configuration(WorkspaceConfigurationUpdate {
-        target_profile: None,
         package_type: Some(PackageType::Lib),
-        language_features: None,
+        ..WorkspaceConfigurationUpdate::default()
     });
 
     updater
@@ -449,9 +449,8 @@ async fn package_type_update_causes_error() {
     );
 
     updater.update_configuration(WorkspaceConfigurationUpdate {
-        target_profile: None,
         package_type: Some(PackageType::Exe),
-        language_features: None,
+        ..WorkspaceConfigurationUpdate::default()
     });
 
     expect_errors(
@@ -484,7 +483,7 @@ async fn target_profile_update_fixes_error() {
     updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: Some(Profile::Base),
         package_type: Some(PackageType::Lib),
-        language_features: None,
+        ..WorkspaceConfigurationUpdate::default()
     });
 
     updater
@@ -523,8 +522,7 @@ async fn target_profile_update_fixes_error() {
 
     updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: Some(Profile::Unrestricted),
-        package_type: None,
-        language_features: None,
+        ..WorkspaceConfigurationUpdate::default()
     });
 
     expect_errors(
@@ -563,8 +561,7 @@ async fn target_profile_update_causes_error_in_stdlib() {
 
     updater.update_configuration(WorkspaceConfigurationUpdate {
         target_profile: Some(Profile::Base),
-        package_type: None,
-        language_features: None,
+        ..WorkspaceConfigurationUpdate::default()
     });
 
     expect_errors(
@@ -1599,6 +1596,89 @@ async fn lints_update_after_manifest_change() {
                 ),
             ]"#]],
     );
+}
+
+#[tokio::test]
+async fn lints_prefer_workspace_over_defaults() {
+    let this_file_qs =
+        "namespace Foo { @EntryPoint() function Main() : Unit { let x = 5 / 0 + (2 ^ 4); } }";
+
+    let received_errors = RefCell::new(Vec::new());
+    let mut updater = new_updater(&received_errors);
+    updater.update_configuration(WorkspaceConfigurationUpdate {
+        lints_config: Some(vec![LintConfig {
+            kind: LintKind::Ast(AstLint::DivisionByZero),
+            level: LintLevel::Warn,
+        }]),
+        ..WorkspaceConfigurationUpdate::default()
+    });
+
+    // Triger a document update.
+    updater
+        .update_document("project/src/this_file.qs", 1, this_file_qs)
+        .await;
+
+    // Check generated lints.
+    let lints: &[ErrorKind] = &received_errors.take()[0].2;
+    check_lints(
+        lints,
+        &expect![[r#"
+            [
+                Lint(
+                    Lint {
+                        span: Span {
+                            lo: 134,
+                            hi: 139,
+                        },
+                        level: Warn,
+                        message: "attempt to divide by zero",
+                        help: "division by zero will fail at runtime",
+                        kind: Ast(
+                            DivisionByZero,
+                        ),
+                    },
+                ),
+            ]"#]],
+    );
+}
+
+#[tokio::test]
+async fn lints_prefer_manifest_over_workspace() {
+    let this_file_qs =
+        "namespace Foo { @EntryPoint() function Main() : Unit { let x = 5 / 0 + (2 ^ 4); } }";
+    let fs = FsNode::Dir(
+        [dir(
+            "project",
+            [
+                file(
+                    "qsharp.json",
+                    r#"{ "lints": [{ "lint": "divisionByZero", "level": "allow" }] }"#,
+                ),
+                dir("src", [file("this_file.qs", this_file_qs)]),
+            ],
+        )]
+        .into_iter()
+        .collect(),
+    );
+
+    let fs = Rc::new(RefCell::new(fs));
+    let received_errors = RefCell::new(Vec::new());
+    let mut updater = new_updater_with_file_system(&received_errors, &fs);
+    updater.update_configuration(WorkspaceConfigurationUpdate {
+        lints_config: Some(vec![LintConfig {
+            kind: LintKind::Ast(AstLint::DivisionByZero),
+            level: LintLevel::Warn,
+        }]),
+        ..WorkspaceConfigurationUpdate::default()
+    });
+
+    // Triger a document update.
+    updater
+        .update_document("project/src/this_file.qs", 1, this_file_qs)
+        .await;
+
+    // No lints expected ("allow" wins over "warn")
+    assert_eq!(received_errors.borrow().len(), 0);
 }
 
 type ErrorInfo = (String, Option<u32>, Vec<ErrorKind>);

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -1613,7 +1613,7 @@ async fn lints_prefer_workspace_over_defaults() {
         ..WorkspaceConfigurationUpdate::default()
     });
 
-    // Triger a document update.
+    // Trigger a document update.
     updater
         .update_document("project/src/this_file.qs", 1, this_file_qs)
         .await;

--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -285,6 +285,9 @@ export function Editor(props: {
     props.languageService.updateConfiguration({
       targetProfile: profile,
       packageType: props.kataExercise ? "lib" : "exe",
+      lints: props.kataExercise
+        ? []
+        : [{ lint: "needlessOperation", level: "warn" }],
     });
 
     function onDiagnostics(evt: LanguageServiceEvent) {
@@ -327,7 +330,6 @@ export function Editor(props: {
     // and run the tabs again.
     props.languageService.updateConfiguration({
       targetProfile: profile,
-      packageType: props.kataExercise ? "lib" : "exe",
     });
     irRef.current();
   }, [profile]);

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -328,6 +328,7 @@ async function updateLanguageServiceProfile(languageService: ILanguageService) {
 
   languageService.updateConfiguration({
     targetProfile: targetProfile,
+    lints: [{ lint: "needlessOperation", level: "warn" }],
   });
 }
 

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -11,7 +11,9 @@ use crate::{
     },
     serializable_type,
 };
-use qsc::{self, line_column::Encoding, target::Profile, LanguageFeatures, PackageType};
+use qsc::{
+    self, line_column::Encoding, linter::LintConfig, target::Profile, LanguageFeatures, PackageType,
+};
 use qsc_project::Manifest;
 use qsls::protocol::DiagnosticUpdate;
 use rustc_hash::FxHashMap;
@@ -103,6 +105,7 @@ impl LanguageService {
                 language_features: config
                     .languageFeatures
                     .map(|features| features.iter().collect::<LanguageFeatures>()),
+                lints_config: config.lints,
             });
     }
 
@@ -344,11 +347,13 @@ serializable_type! {
         pub targetProfile: Option<String>,
         pub packageType: Option<String>,
         pub languageFeatures: Option<Vec<String>>,
+        pub lints: Option<Vec<LintConfig>>
     },
     r#"export interface IWorkspaceConfiguration {
         targetProfile?: TargetProfile;
         packageType?: "exe" | "lib";
         languageFeatures?: LanguageFeatures[];
+        lints?: { lint: string; level: string }[];
     }"#,
     IWorkspaceConfiguration
 }


### PR DESCRIPTION
The katas contain a lot of placeholder code like this:

```qsharp
    operation ZZMeasurement(qs : Qubit[]) : Int {
        // Implement your solution here...

        return -1;
    }
```

And the "operation can be a function instead" lint, while generally helpful, can distract a learner.

In this PR:
- Add the ability to set the lint configuration per language service instance. (Anything in qsharp.json will still override these settings).
- Make needlessOperation "allow" by default (so that we don't need to make a QCOM change)
- Explicitly set needlessOperation to "warn" everywhere but the katas.