### PR TITLE
Migrate tasks 1.07-1.09 from Measurements to Distinguishing States kata

### DIFF
--- a/katas/content/KatasLibrary.qs
+++ b/katas/content/KatasLibrary.qs
@@ -343,24 +343,4 @@ namespace Microsoft.Quantum.Katas {
         }
         return true;
     }
-
-    operation WState_Arbitrary_Reference(qs : Qubit[]) : Unit is Adj + Ctl {
-        let N = Length(qs);
-
-        if N == 1 {
-            // base case of recursion: |1⟩
-            X(qs[0]);
-        } else {
-            // |W_N⟩ = |0⟩|W_(N-1)⟩ + |1⟩|0...0⟩
-            // do a rotation on the first qubit to split it into |0⟩ and |1⟩ with proper weights
-            // |0⟩ -> sqrt((N-1)/N) |0⟩ + 1/sqrt(N) |1⟩
-            let theta = ArcSin(1.0 / Sqrt(IntAsDouble(N)));
-            Ry(2.0 * theta, qs[0]);
-
-            // do a zero-controlled W-state generation for qubits 1..N-1
-            X(qs[0]);
-            Controlled WState_Arbitrary_Reference(qs[0..0], qs[1..N - 1]);
-            X(qs[0]);
-        }
-    }
 }

--- a/katas/content/distinguishing_states/Common.qs
+++ b/katas/content/distinguishing_states/Common.qs
@@ -1,4 +1,10 @@
 namespace Kata.Verification{
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Math;
+
     operation StatePrep_BasisStateMeasurement(
         qs : Qubit[],
         state : Int,
@@ -12,6 +18,143 @@ namespace Kata.Verification{
         if state % 2 == 1 {
             // |01⟩ or |11⟩
             X(qs[1]);
+        }
+    }
+
+    operation WState_Arbitrary_Reference(qs : Qubit[]) : Unit is Adj + Ctl {
+        let N = Length(qs);
+
+        if N == 1 {
+            // base case of recursion: |1⟩
+            X(qs[0]);
+        } else {
+            // |W_N⟩ = |0⟩|W_(N-1)⟩ + |1⟩|0...0⟩
+            // do a rotation on the first qubit to split it into |0⟩ and |1⟩ with proper weights
+            // |0⟩ -> sqrt((N-1)/N) |0⟩ + 1/sqrt(N) |1⟩
+            let theta = ArcSin(1.0 / Sqrt(IntAsDouble(N)));
+            Ry(2.0 * theta, qs[0]);
+
+            // do a zero-controlled W-state generation for qubits 1..N-1
+            X(qs[0]);
+            Controlled WState_Arbitrary_Reference(qs[0..0], qs[1..N - 1]);
+            X(qs[0]);
+        }
+    }
+
+    // Helper function to convert a boolean array to its ket state representation
+    function BoolArrayAsKetState (bits : Bool[]) : String {
+        mutable stateName = "|";
+        for i in 0 .. Length(bits) - 1 {
+            set stateName += (bits[i] ? "1" | "0");
+        }
+
+        return stateName + "⟩";
+    }
+
+    // Helper function to convert an array of bit strings to its ket state representation
+    function IntArrayAsStateName (
+        qubits : Int,
+        bitStrings : Bool[][]
+    ) : String {
+        mutable statename = "";
+        for i in 0 .. Length(bitStrings) - 1 {
+            if i > 0 {
+                set statename += " + ";
+            }
+            set statename += BoolArrayAsKetState(bitStrings[i]);
+        }
+
+        return statename;
+    }
+
+    function StatePrep_FindFirstDiff (
+        bits1 : Bool[],
+        bits2 : Bool[]
+    ) : Int {
+        for i in 0 .. Length(bits1) - 1 {
+            if bits1[i] != bits2[i] {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    operation StatePrep_SuperpositionMeasurement (
+        qs : Qubit[],
+        bits1 : Bool[][],
+        bits2 : Bool[][],
+        state : Int,
+        dummyVar: Double
+    ) : Unit is Adj {
+        let bits = state == 0 ? bits1 | bits2;
+        StatePrep_BitstringSuperposition(qs, bits);
+    }
+
+    // A combination of tasks 14 and 15 from the Superposition kata
+    operation StatePrep_BitstringSuperposition (
+        qs : Qubit[],
+        bits : Bool[][]
+    ) : Unit is Adj + Ctl {
+        let L = Length(bits);
+        Fact(L == 1 or L == 2 or L == 4, "State preparation only supports arrays of 1, 2 or 4 bit strings.");
+        if L == 1 {
+            for i in 0 .. Length(qs) - 1 {
+                if bits[0][i] {
+                    X(qs[i]);
+                }
+            }
+        }
+        if L == 2 {
+            // find the index of the first bit at which the bit strings are different
+            let firstDiff = StatePrep_FindFirstDiff(bits[0], bits[1]);
+
+            // Hadamard corresponding qubit to create superposition
+            H(qs[firstDiff]);
+
+            // iterate through the bit strings again setting the final state of qubits
+            for i in 0 .. Length(qs) - 1 {
+                if bits[0][i] == bits[1][i] {
+                    // if two bits are the same, apply X or nothing
+                    if bits[0][i] {
+                        X(qs[i]);
+                    }
+                } else {
+                    // if two bits are different, set their difference using CNOT
+                    if i > firstDiff {
+                        CNOT(qs[firstDiff], qs[i]);
+                        if bits[0][i] != bits[0][firstDiff] {
+                            X(qs[i]);
+                        }
+                    }
+                }
+            }
+        }
+        if L == 4 {
+            let N = Length(qs);
+
+            use anc = Qubit[2];
+            // Put two ancillas into equal superposition of 2-qubit basis states
+            ApplyToEachCA(H, anc);
+
+            // Set up the right pattern on the main qubits with control on ancillas
+            for i in 0 .. 3 {
+                for j in 0 .. N - 1 {
+                    if bits[i][j] {
+                        ApplyControlledOnInt(i, X, anc, qs[j]);
+                    }
+                }
+            }
+
+            // Uncompute the ancillas, using patterns on main qubits as control
+            for i in 0 .. 3 {
+                if i % 2 == 1 {
+                    ApplyControlledOnBitString(bits[i], X, qs, anc[0]);
+                }
+                if i / 2 == 1 {
+                    ApplyControlledOnBitString(bits[i], X, qs, anc[1]);
+                }
+            }
         }
     }
 }

--- a/katas/content/distinguishing_states/index.md
+++ b/katas/content/distinguishing_states/index.md
@@ -70,11 +70,42 @@ This kata is designed to get you familiar with the concept of measurements and u
 })
 
 @[exercise]({
+    "id": "distinguishing_states__two_basis_states_bit_strings",
+    "title": "Distinguish Two Basis States Given By Bit Strings",
+    "path": "./two_basis_states_bit_strings/",
+    "qsDependencies": [
+        "../KatasLibrary.qs",
+        "./Common.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "distinguishing_states__two_superposition_states_bit_strings_one",
+    "title": "Distinguish Two Superposition States Given By Two Arrays Of Bit Strings - 1 Measurement",
+    "path": "./two_superposition_states_bit_strings_one/",
+    "qsDependencies": [
+        "../KatasLibrary.qs",
+        "./Common.qs"
+    ]
+})
+
+@[exercise]({
+    "id": "distinguishing_states__two_superposition_states_bit_strings",
+    "title": "Distinguish Two Superposition States Given By Two Arrays Of Bit Strings",
+    "path": "./two_superposition_states_bit_strings/",
+    "qsDependencies": [
+        "../KatasLibrary.qs",
+        "./Common.qs"
+    ]
+})
+
+@[exercise]({
     "id": "distinguishing_states__all_zeros_w",
     "title": "|0...0〉 State or W State?",
     "path": "./all_zeros_w/",
     "qsDependencies": [
-        "../KatasLibrary.qs"
+        "../KatasLibrary.qs",
+        "./Common.qs"
     ]
 })
 
@@ -83,7 +114,8 @@ This kata is designed to get you familiar with the concept of measurements and u
     "title": "GHZ State or W State?",
     "path": "./ghz_w/",
     "qsDependencies": [
-        "../KatasLibrary.qs"
+        "../KatasLibrary.qs",
+        "./Common.qs"
     ]
 })
 
@@ -121,7 +153,8 @@ This kata is designed to get you familiar with the concept of measurements and u
     "title": "Distinguish Two Three-Qubit States",
     "path": "./two_orthogonal_three_qubit/",
     "qsDependencies": [
-        "../KatasLibrary.qs"
+        "../KatasLibrary.qs",
+        "./Common.qs"
     ]
 })
 

--- a/katas/content/distinguishing_states/two_basis_states_bit_strings/Placeholder.qs
+++ b/katas/content/distinguishing_states/two_basis_states_bit_strings/Placeholder.qs
@@ -1,0 +1,7 @@
+namespace Kata {
+    operation TwoBitstringsMeasurement(qs : Qubit[], bits1 : Bool[], bits2 : Bool[]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/distinguishing_states/two_basis_states_bit_strings/Solution.qs
+++ b/katas/content/distinguishing_states/two_basis_states_bit_strings/Solution.qs
@@ -1,0 +1,17 @@
+namespace Kata {
+    function FindFirstDiff(bits1 : Bool[], bits2 : Bool[]) : Int {
+        for i in 0 .. Length(bits1) - 1 {
+            if bits1[i] != bits2[i] {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    operation TwoBitstringsMeasurement(qs : Qubit[], bits1 : Bool[], bits2 : Bool[]) : Int {
+        let firstDiff = FindFirstDiff(bits1, bits2);
+        let res = M(qs[firstDiff]) == One;
+
+        return res == bits1[firstDiff] ? 0 | 1;
+    }
+}

--- a/katas/content/distinguishing_states/two_basis_states_bit_strings/Verification.qs
+++ b/katas/content/distinguishing_states/two_basis_states_bit_strings/Verification.qs
@@ -1,0 +1,66 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Katas;
+
+    operation StatePrep_Bitstring(
+        qs : Qubit[],
+        bits : Bool[]
+    ) : Unit is Adj {
+        for i in 0 .. Length(qs) - 1 {
+            if bits[i] {
+                X(qs[i]);
+            }
+        }
+    }
+
+    operation StatePrep_TwoBitstringsMeasurement(
+        qs : Qubit[],
+        bits1 : Bool[],
+        bits2 : Bool[],
+        state : Int,
+        dummyVar : Double
+    ) : Unit is Adj {
+        let bits = state == 0 ? bits1 | bits2;
+        StatePrep_Bitstring(qs, bits);
+    }
+
+    operation CheckTwoBitstringsMeasurement(b1 : Bool[], b2 : Bool[]) : Bool {
+        let stateNames = [BoolArrayAsKetState(b1), BoolArrayAsKetState(b2)];
+        let isCorrect = DistinguishStates_MultiQubit(
+            Length(b1),
+            2,
+            StatePrep_TwoBitstringsMeasurement(_, b1, b2, _, _),
+            Kata.TwoBitstringsMeasurement(_, b1, b2),
+            true,
+            stateNames
+        );
+
+        if (isCorrect) {
+            Message("Correct!");
+        } else {
+            Message($"Incorrect for [{stateNames[0]}, {stateNames[1]}].");
+        }
+
+        return isCorrect;
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        mutable isCorrect = true;
+
+        mutable b1 = [false, true];
+        mutable b2 = [true, false];
+        set isCorrect = isCorrect and CheckTwoBitstringsMeasurement(b1, b2);
+
+        set b1 = [true, true, false];
+        set b2 = [false, true, true];
+        set isCorrect = isCorrect and CheckTwoBitstringsMeasurement(b1, b2);
+
+        set b1 = [false, true, true, false];
+        set b2 = [false, true, true, true];
+        set isCorrect = isCorrect and CheckTwoBitstringsMeasurement(b1, b2);
+
+        set b1 = [true, false, false, false];
+        set b2 = [true, false, true, true];
+        return isCorrect and CheckTwoBitstringsMeasurement(b1, b2);
+    }
+}

--- a/katas/content/distinguishing_states/two_basis_states_bit_strings/index.md
+++ b/katas/content/distinguishing_states/two_basis_states_bit_strings/index.md
@@ -1,0 +1,15 @@
+**Inputs:**
+
+1. $N$ qubits (stored in an array of length $N$) which are guaranteed to be in one of the two basis states described by the given bit strings.
+2. Two bit strings represented as `Bool[]`s.
+
+**Output:**
+
+* 0 if the qubits were in the basis state described by the first bit string,
+* 1 if they were in the basis state described by the second bit string.
+
+Bit values `false` and `true` correspond to $\ket{0}$ and $\ket{1}$ states. You are guaranteed that both bit strings have the same length as the qubit array, and that the bit strings differ in at least one bit.
+
+**You can use exactly one measurement.** The state of the qubits at the end of the operation does not matter.
+
+> Example: for bit strings `[false, true, false]` and `[false, false, true]` return 0 corresponds to state $\ket{010}$, and return 1 corresponds to state $\ket{001}$.

--- a/katas/content/distinguishing_states/two_basis_states_bit_strings/solution.md
+++ b/katas/content/distinguishing_states/two_basis_states_bit_strings/solution.md
@@ -1,0 +1,15 @@
+To solve this task we will use two steps. Like many other programming languages, Q# allows you to write functions to make code more readable and reusable.
+
+The first step is to find first bit that differs between bit strings `bit1` and `bit2`. For that we define a function `FindFirstDiff()` which loops through both `Bool[]`s and returns the first index where the bit strings differ.
+
+The second step is implementing the main operation: once we have found the first different bit, we measure the qubit in the corresponding position to see whether it is in state $\ket{0}$ or $\ket{1}$. If it is in state $\ket{0}$, `res` takes the value `false`, if it is in state $\ket{1}$ it takes the value `true`.
+
+`res == bits1[firstDiff]` compares the measurement result with the bit of `bits1` in the differing position. This effectively checks if the qubits are in the basis state described by the first or by the second bit string. The two possible outcomes are:
+
+1. The qubits are in the state described by the first bit string; then `res` will be equal to `bits1[firstDiff]` and the method will return `0`.
+2. The qubits are in the state described by the second bit string; then `res` will be not equal to `bits1[firstDiff]` (we know it has to be equal to `bits2[firstDiff]` which does not equal `bits1[firstDiff]`), and the method will return `1`.
+
+@[solution]({
+    "id": "distinguishing_states__two_basis_states_bit_strings_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings/Placeholder.qs
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings/Placeholder.qs
@@ -1,0 +1,10 @@
+namespace Kata{
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Measurement;
+
+    operation SuperpositionMeasurement (qs : Qubit[], bits1 : Bool[][], bits2 : Bool[][]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings/Solution.qs
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings/Solution.qs
@@ -1,0 +1,15 @@
+namespace Kata{
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Measurement;
+
+    operation SuperpositionMeasurement (qs : Qubit[], bits1 : Bool[][], bits2 : Bool[][]) : Int {
+        let measuredState = MeasureInteger(qs);
+        for s in bits1 {
+            if BoolArrayAsInt(s) == measuredState {
+                return 0;
+            }
+        }
+
+        return 1;
+    }
+}

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings/Verification.qs
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings/Verification.qs
@@ -1,0 +1,87 @@
+namespace Kata.Verification{
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Katas;
+
+    operation CheckSuperpositionBitstringsMeasurement (
+        nQubits : Int,
+        ints1 : Int[],
+        ints2 : Int[]
+    ): Bool {
+        let bits1 = Mapped(IntAsBoolArray(_, nQubits), ints1);
+        let bits2 = Mapped(IntAsBoolArray(_, nQubits), ints2);
+
+        let stateNames = [IntArrayAsStateName(nQubits, bits1), IntArrayAsStateName(nQubits, bits2)];
+
+        let isCorrect = DistinguishStates_MultiQubit(nQubits, 2, StatePrep_SuperpositionMeasurement(_, bits1, bits2, _, _),
+                                     Kata.SuperpositionMeasurement(_, bits1, bits2), false,
+                                     stateNames);
+
+        if isCorrect {
+            Message("Correct!");
+        } else{
+            Message($"Incorrect for: [{stateNames[0]}, {stateNames[1]}]")
+        }
+
+        return isCorrect;
+    }
+
+    operation CheckSolution () : Bool {
+        mutable isCorrect = true;
+
+        // note that bit strings in the comments (big endian) are the reverse of the bit strings passed to the solutions (little endian)
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsMeasurement(
+            2,
+            [2],  // [10]
+            [1]
+        ); // [01]
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsMeasurement(
+            2,
+            [2,1], // [10,01]
+            [3,0] // [11,00]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsMeasurement(
+            2,
+            [2],    // [10]
+            [3,0]) // [11,00]
+        ;
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsMeasurement(
+            4,
+            [15,6], // [1111,0110]
+            [0,14] // [0000,1110]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsMeasurement(
+            4,
+            [15,7],      // [1111,0111]
+            [0,8,10,13] // [0000,1000,1010,1101]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsMeasurement(
+            5,
+            [30,14,10,7], // [11110,01110,01010,00111]
+            [1,17,21,27] // [00001,10001,10101,11011]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsMeasurement(
+            2,
+            [2,1], // [10,01]
+            [3] // [11]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsMeasurement(
+            3,
+            [7,5], // [111,101]
+            [2] // [010]
+        );
+
+        return isCorrect and CheckSuperpositionBitstringsMeasurement(
+            4,
+            [13,11,7,3], // [1101,1011,0111,0011]
+            [5,2] // [0101,0010]
+        );
+    }
+}

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings/index.md
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings/index.md
@@ -1,0 +1,18 @@
+**Inputs:**
+
+* $N$ qubits (stored in an array of length $N$) which are guaranteed to be in one of the two superposition states described by the given arrays of bit strings.
+* Two arrays of bit strings represented as `Bool[][]`s.
+  The arrays describe the superposition states in the same way as in the previous task, i.e. they have dimensions $M_1 \times N$ and $M_2 \times N$ respectively, $N$ being the number of qubits.
+
+The only constraint on the bit strings is that **all bit strings in the two arrays are distinct**.
+
+> Example: for bit strings `[[false, true, false], [false, false, true]]` and `[[true, true, true], [false, true, true]]` return 0 corresponds to state 
+$\frac{1}{\sqrt2}\big(\ket{010} + \ket{001}\big)$, 
+return 1 to state 
+$\frac{1}{\sqrt2}\big(\ket{111} + \ket{011}\big)$.
+
+**Output:**
+* 0 if qubits were in the superposition state, described by the first array,
+* 1 if they were in the superposition state, described by the second array.
+
+**You can use as many measurements as you wish**. The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings/solution.md
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings/solution.md
@@ -1,0 +1,14 @@
+Because all the bit strings are guaranteed to be different and we are not limited in the number of measurements we can do, we can use a simpler solution than before.
+
+When we measure all qubits of a certain superposition state, it collapses to one of the basis vectors that comprised the superposition. We can do exactly that and compare the resulting state to the given bit strings to see which array it belongs to.
+
+We use the built-in library primitives. First, we measure the quantum register with respect to the standard computational basis, i.e., the eigenbasis of `PauliZ` using `MeasureInteger()` operation, which converts it to an integer.
+
+Next, we convert each of the input bit strings to an integer using the `BoolArrayAsInt()` function. Both the functions use little-endian encoding when converting bits to integers.
+
+Now that we have two integers, we can easily compare the measurement results to each of the bit strings in the first array to check whether they belong to it; if they do, we know we were given the first state, otherwise it was the second state.
+
+@[solution]({
+    "id": "distinguishing_states__two_superposition_states_bit_strings_solution",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/Placeholder.qs
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/Placeholder.qs
@@ -1,0 +1,9 @@
+namespace Kata {
+    open Microsoft.Quantum.Convert;
+
+    operation SuperpositionOneMeasurement(qs : Qubit[], bits1 : Bool[][], bits2 : Bool[][]) : Int {
+        // Implement your solution here...
+
+        return -1;
+    }
+}

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/Solution.qs
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/Solution.qs
@@ -1,0 +1,38 @@
+namespace Kata {
+    open Microsoft.Quantum.Convert;
+
+    function FindFirstSuperpositionDiff (bits1 : Bool[][], bits2 : Bool[][], nQubits : Int) : Int {
+        for i in 0 .. nQubits - 1 {
+            // count the number of 1s in i-th position in bit strings of both arrays
+            mutable val1 = 0;
+            mutable val2 = 0;
+            for j in 0 .. Length(bits1) - 1 {
+                if bits1[j][i] {
+                    set val1 += 1;
+                }
+            }
+            for k in 0 .. Length(bits2) - 1 {
+                if bits2[k][i] {
+                    set val2 += 1;
+                }
+            }
+            if ((val1 == Length(bits1) and val2 == 0) or (val1 == 0 and val2 == Length(bits2))) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    operation SuperpositionOneMeasurement (qs : Qubit[], bits1 : Bool[][], bits2 : Bool[][]) : Int {
+        let diff = FindFirstSuperpositionDiff(bits1, bits2, Length(qs));
+
+        let res = ResultAsBool(M(qs[diff]));
+
+        if res == bits1[0][diff] {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+}

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/Verification.qs
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/Verification.qs
@@ -1,0 +1,93 @@
+namespace Kata.Verification {
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Katas;
+
+    operation CheckSuperpositionBitstringsOneMeasurement (
+        nQubits : Int,
+        ints1 : Int[],
+        ints2 : Int[]
+    ): Bool {
+        let bits1 = Mapped(IntAsBoolArray(_, nQubits), ints1);
+        let bits2 = Mapped(IntAsBoolArray(_, nQubits), ints2);
+
+        let stateNames = [IntArrayAsStateName(nQubits, bits1), IntArrayAsStateName(nQubits, bits2)];
+
+        let isCorrect =  DistinguishStates_MultiQubit(
+            nQubits,
+            2,
+            StatePrep_SuperpositionMeasurement(_, bits1, bits2, _, _),
+            Kata.SuperpositionOneMeasurement(_, bits1, bits2),
+            true,
+            stateNames
+        );
+
+        if isCorrect {
+            Message("Correct!");
+        } else{
+            Message($"Incorrect for: [{stateNames[0]}, {stateNames[1]}]")
+        }
+
+        return isCorrect;
+    }
+
+    @EntryPoint()
+    operation CheckSolution() : Bool {
+        mutable isCorrect = true;
+
+        // note that bit strings in the comments (big endian) are the reverse of the bit strings passed to the solutions (little endian)
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsOneMeasurement(
+            2,
+            [2], // [10]
+            [1] // [01]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsOneMeasurement(
+            2,
+            [2, 3], // [10,11]
+            [1, 0] // [01,00]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsOneMeasurement(
+            2,
+            [2], // [10]
+            [1, 0] // [01,00]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsOneMeasurement(
+            4,
+            [15, 7], // [1111,0111]
+            [0, 8] // [0000,1000]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsOneMeasurement(
+            4,
+            [15, 7],       // [1111,0111]
+            [0, 8, 10, 12] // [0000,1000,1010,1100]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsOneMeasurement(
+            5,
+            [30, 14, 10, 6], // [11110,01110,01010,00110]
+            [1, 17, 21, 25] // [00001,10001,10101,11001]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsOneMeasurement(
+            2,
+            [0, 2], // [00,10]
+            [3] // [11]
+        );
+
+        set isCorrect = isCorrect and CheckSuperpositionBitstringsOneMeasurement(
+            3,
+            [5, 7], // [101,111]
+            [2] // [010]
+        );
+
+        return isCorrect and CheckSuperpositionBitstringsOneMeasurement(
+            4,
+            [13, 11, 7, 3], // [1101,1011,0111,0011]
+            [2, 4] // [0010,0100]
+        );
+    }
+}

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/index.md
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/index.md
@@ -1,0 +1,22 @@
+**Inputs:**
+
+1. $N$ qubits (stored in an array of length $N$) which are guaranteed to be in one of the two superposition states described by the given arrays of bit strings.
+2. Two arrays of bit strings represented as `Bool[][]`s.
+The arrays have dimensions $M_1 \times N$ and $M_2 \times N$
+ respectively, where $N$ is the number of qubits and $M_1$ and $M_2$ are the numbers of bit strings in each array. Note that in general $M_1 \neq M_2$.
+An array of bit strings `[b₁, ..., bₘ]` defines a state that is an equal superposition of all basis states defined by bit strings $b_1, ..., b_m$.
+For example, an array of bit strings `[[false, true, false], [false, true, true]]` defines a superposition state $\frac{1}{\sqrt2}\big(\ket{010} + \ket{011}\big)$.
+
+You are guaranteed that there exists an index of a qubit Q for which:
+
+* all the bit strings in the first array have the same value in this position (all `bits1[j][Q]` are the same),
+* all the bit strings in the second array have the same value in this position (all `bits2[j][Q]` are the same),
+* these values are different for the first and the second arrays.
+> For example, for arrays `[[false, true, false], [false, true, true]]` and `[[true, false, true], [false, false, true]]` return 0 corresponds to state $\frac{1}{\sqrt2}\big(\ket{010} + \ket{011}\big)$, return 1 corresponds to state $\frac{1}{\sqrt2}\big(\ket{101} + \ket{001}\big)$, and you can distinguish these states perfectly by measuring the second qubit.
+
+**Output:**
+
+* 0 if qubits were in the superposition state described by the first array,
+* 1 if they were in the superposition state described by the second array.
+
+**You are allowed to use exactly one measurement.** The state of the qubits at the end of the operation does not matter.

--- a/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/solution.md
+++ b/katas/content/distinguishing_states/two_superposition_states_bit_strings_one/solution.md
@@ -1,0 +1,20 @@
+Like in the previous solution, we are looking for the index Q where the two bit strings differ. Let's define a function `FindFirstSuperpositionDiff()` which searches for an index Q which has 2 properties:
+
+1. The value of all arrays in `bits1` at the index Q is either `true` or `false`, and the value of all arrays in `bits2` at the index Q is either `true` or `false`. If this is not the case, you cannot be sure that measuring the corresponding qubit will always return the same result.
+2. This value is different for `bits1` and `bits2`.
+> Indeed, if you want to distinguish states $\frac{1}{\sqrt2}\big(\ket{010} + \ket{011}\big)$ and $\frac{1}{\sqrt2}\big(\ket{000} + \ket{001}\big)$, there are two qubits that will produce a fixed measurement result for each state - the first one and the second one. However, measuring the first qubit will give $0$ for both states, while measuring the second qubit will give $1$ for the first state and $0$ for the second state, allowing to distinguish the states.
+
+> For example, if you are given the state $\frac{1}{\sqrt2}\big(\ket{010} + \ket{011}\big)$, and if you measure the third qubit, $50\%$ of the time you will get $0$ and $50\%$ of the time $1$, therefore to get reliable information you want to measure one of the first two qubits.
+
+To do this, we will iterate over all qubit indices, and for each of them we'll calculate the number of 1s in that position in `bits1` and `bits2`.
+
+1. The first condition means that this count should equal 0 (if all bit strings have 0 bit in this position) or the length of the array of bit strings (if all bit strings have 1 bit in this position).
+2. The second condition means that this count is different for `bits1` and `bits2`, i.e., one of the counts should equal 0 and another one - the length of the corresponding array of bit strings.
+
+The second step is very similar to the previous exercise: given the index we just found, we measure the qubit on that position.
+Here we use the library function `ResultAsBool(M(qs[diff]))` that returns `true` if the measurement result is `One` and `false` if the result is `Zero`; a call to this library function is equivalent to comparison `M(qs[diff]) == One` that was used in the previous task.
+
+@[solution]({
+    "id": "distinguishing_states__two_superposition_states_bit_strings_solution_one",
+    "codePath": "Solution.qs"
+})

--- a/katas/content/index.json
+++ b/katas/content/index.json
@@ -9,6 +9,7 @@
   "preparing_states",
   "single_qubit_measurements",
   "multi_qubit_measurements",
+  "distinguishing_states",
   "distinguishing_unitaries",
   "random_numbers",
   "key_distribution",


### PR DESCRIPTION
Migrate tasks 1.07 - 1.09 from the Measurements workbook to Distinguishing States Kata.
This resolves a part of the [Issue 1185](https://github.com/microsoft/qsharp/issues/1185).