### PR TITLE
Clean unsupported chars from implicit namespace name

### DIFF
--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -602,7 +602,10 @@ pub fn longest_common_prefix<'a>(strs: &'a [&'a str]) -> &'a str {
 }
 
 fn truncate_to_path_separator(prefix: &str) -> &str {
-    let last_separator_index = prefix.rfind('/').or_else(|| prefix.rfind('\\'));
+    let last_separator_index = prefix
+        .rfind('/')
+        .or_else(|| prefix.rfind('\\'))
+        .or_else(|| prefix.rfind(':'));
     if let Some(last_separator_index) = last_separator_index {
         // Return the prefix up to and including the last path separator
         return &prefix[0..=last_separator_index];

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1330,9 +1330,10 @@ fn implicit_namespace_basic() {
 }
 
 #[test]
-fn reject_bad_filename_implicit_namespace() {
+fn bad_filename_implicit_namespace_best_effort_fixup() {
     let sources = SourceMap::new(
         [
+            // Rejected for starting with number
             (
                 "123Test.qs".into(),
                 indoc! {"
@@ -1340,6 +1341,7 @@ fn reject_bad_filename_implicit_namespace() {
             "}
                 .into(),
             ),
+            // Cleaned up by replacing '-' with '_'
             (
                 "Test-File.qs".into(),
                 indoc! {"
@@ -1348,6 +1350,7 @@ fn reject_bad_filename_implicit_namespace() {
             "}
                 .into(),
             ),
+            // Rejected for containing '.'
             (
                 "Namespace.Foo.qs".into(),
                 indoc! {"
@@ -1370,19 +1373,6 @@ fn reject_bad_filename_implicit_namespace() {
                                 hi: 25,
                             },
                             "123Test",
-                        ),
-                    ),
-                ),
-            ),
-            Error(
-                Parse(
-                    Error(
-                        InvalidFileName(
-                            Span {
-                                lo: 27,
-                                hi: 53,
-                            },
-                            "Test-File",
                         ),
                     ),
                 ),

--- a/compiler/qsc_parse/src/item.rs
+++ b/compiler/qsc_parse/src/item.rs
@@ -170,6 +170,7 @@ pub fn parse_implicit_namespace(source_name: &str, s: &mut ParserContext) -> Res
 
 /// Given a file name, convert it to a namespace name.
 /// For example, `foo/bar.qs` becomes `foo.bar`.
+/// Invalid or disallowed characters are cleaned up in a best effort manner.
 fn source_name_to_namespace_name(raw: &str, span: Span) -> Result<Idents> {
     let path = std::path::Path::new(raw);
     let mut namespace = Vec::new();
@@ -199,9 +200,19 @@ fn source_name_to_namespace_name(raw: &str, span: Span) -> Result<Idents> {
     Ok(namespace.into())
 }
 
+fn clean_namespace_name(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            ' ' | '-' | ':' => '_',
+            _ => c,
+        })
+        .collect()
+}
+
 /// Validates that a string could be a valid namespace name component
 fn validate_namespace_name(error_span: Span, name: &str) -> Result<Ident> {
-    let mut s = ParserContext::new(name, LanguageFeatures::default());
+    let name = clean_namespace_name(name);
+    let mut s = ParserContext::new(&name, LanguageFeatures::default());
     // if it could be a valid identifier, then it is a valid namespace name
     // we just directly use the ident parser here instead of trying to recreate
     // validation rules

--- a/compiler/qsc_parse/src/item.rs
+++ b/compiler/qsc_parse/src/item.rs
@@ -203,7 +203,7 @@ fn source_name_to_namespace_name(raw: &str, span: Span) -> Result<Idents> {
 fn clean_namespace_name(name: &str) -> String {
     name.chars()
         .map(|c| match c {
-            ' ' | '-' | ':' => '_',
+            '-' => '_',
             _ => c,
         })
         .collect()

--- a/compiler/qsc_parse/src/tests/implicit_namespace.rs
+++ b/compiler/qsc_parse/src/tests/implicit_namespace.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::too_many_lines)]
+
 use expect_test::expect;
 use qsc_data_structures::language_features::LanguageFeatures;
 
@@ -49,7 +51,7 @@ fn explicit_namespace_overrides_implicit() {
 }
 
 #[test]
-fn reject_bad_namespace_name_1() {
+fn fixup_bad_namespace_name_with_dash() {
     let result = format!(
         "{:#?}",
         crate::namespaces(
@@ -60,24 +62,152 @@ fn reject_bad_namespace_name_1() {
     );
     expect![[r#"
         (
-            [],
             [
-                Error(
-                    InvalidFileName(
-                        Span {
-                            lo: 0,
-                            hi: 26,
-                        },
-                        "Foo-Bar",
+                Namespace {
+                    id: NodeId(
+                        4294967295,
                     ),
-                ),
+                    span: Span {
+                        lo: 0,
+                        hi: 26,
+                    },
+                    doc: "",
+                    name: Idents(
+                        [
+                            Ident {
+                                id: NodeId(
+                                    4294967295,
+                                ),
+                                span: Span {
+                                    lo: 0,
+                                    hi: 26,
+                                },
+                                name: "code",
+                            },
+                            Ident {
+                                id: NodeId(
+                                    4294967295,
+                                ),
+                                span: Span {
+                                    lo: 0,
+                                    hi: 26,
+                                },
+                                name: "src",
+                            },
+                            Ident {
+                                id: NodeId(
+                                    4294967295,
+                                ),
+                                span: Span {
+                                    lo: 0,
+                                    hi: 26,
+                                },
+                                name: "Foo_Bar",
+                            },
+                        ],
+                    ),
+                    items: [
+                        Item {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 0,
+                                hi: 26,
+                            },
+                            doc: "",
+                            attrs: [],
+                            visibility: None,
+                            kind: Callable(
+                                CallableDecl {
+                                    id: NodeId(
+                                        4294967295,
+                                    ),
+                                    span: Span {
+                                        lo: 0,
+                                        hi: 26,
+                                    },
+                                    kind: Operation,
+                                    name: Ident {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 10,
+                                            hi: 14,
+                                        },
+                                        name: "Main",
+                                    },
+                                    generics: [],
+                                    input: Pat {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 14,
+                                            hi: 16,
+                                        },
+                                        kind: Tuple(
+                                            [],
+                                        ),
+                                    },
+                                    output: Ty {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 19,
+                                            hi: 23,
+                                        },
+                                        kind: Path(
+                                            Path {
+                                                id: NodeId(
+                                                    4294967295,
+                                                ),
+                                                span: Span {
+                                                    lo: 19,
+                                                    hi: 23,
+                                                },
+                                                namespace: None,
+                                                name: Ident {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 19,
+                                                        hi: 23,
+                                                    },
+                                                    name: "Unit",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    functors: None,
+                                    body: Block(
+                                        Block {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 24,
+                                                hi: 26,
+                                            },
+                                            stmts: [],
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ],
+                },
             ],
+            [],
         )"#]]
     .assert_eq(&result);
 }
 
 #[test]
-fn reject_bad_namespace_name_2() {
+fn reject_bad_namespace_name_starts_with_number() {
     let result = format!(
         "{:#?}",
         crate::namespaces(


### PR DESCRIPTION
This change adds some simple logic to clean up unsupported characters from file names before they are used as implicit namespace names. It is by no means exhaustive, but at least takes any `-` replaces them with `_`. This will applied for all files, including unsaved ones, so a file saved to disk as `MyCool-File.qs` would become the namespace `MyCool_File` and VS Code's somewhat quirky names for new unsaved file buffers like `untitled:Untitled-1` becomes `Untitled_1`. This allows skipping explicit namespaces in unsaved new files, fixes #1582.