### PR TITLE
Revert "Phantom "entry point not found" error in the Playground"

### DIFF
--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -256,7 +256,7 @@ export function Editor(props: {
 
       performance.mark("update-document-start");
       await props.languageService.updateDocument(
-        "code.qs",
+        srcModel.uri.toString(),
         srcModel.getVersionId(),
         srcModel.getValue(),
       );


### PR DESCRIPTION
Reverts microsoft/qsharp#1628