### PR TITLE
New DrawRandomBool operation

### DIFF
--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -100,6 +100,10 @@ pub(crate) fn call(
                 Ok(Value::Double(rng.gen_range(lo..=hi)))
             }
         }
+        "DrawRandomBool" => {
+            let p = arg.unwrap_double();
+            Ok(Value::Bool(rng.gen_bool(p)))
+        }
         #[allow(clippy::cast_possible_truncation)]
         "Truncate" => Ok(Value::Int(arg.unwrap_double() as i64)),
         "__quantum__rt__qubit_allocate" => Ok(Value::Qubit(Qubit(sim.qubit_allocate()))),

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -681,6 +681,20 @@ fn draw_random_double() {
 }
 
 #[test]
+fn draw_random_bool() {
+    check_intrinsic_value(
+        "",
+        "Microsoft.Quantum.Random.DrawRandomBool(0.0)",
+        &Value::Bool(false),
+    );
+    check_intrinsic_value(
+        "",
+        "Microsoft.Quantum.Random.DrawRandomBool(1.0)",
+        &Value::Bool(true),
+    );
+}
+
+#[test]
 fn truncate() {
     check_intrinsic_value("", "Microsoft.Quantum.Math.Truncate(3.1)", &Value::Int(3));
     check_intrinsic_value("", "Microsoft.Quantum.Math.Truncate(3.9)", &Value::Int(3));

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -1299,7 +1299,7 @@ impl<'a> PartialEvaluator<'a> {
             | "GlobalPhase" => Ok(Value::unit()),
             // The following intrinsic functions and operations should never make it past conditional compilation and
             // the capabilities check pass.
-            "CheckZero" | "DrawRandomInt" | "DrawRandomDouble" | "Length" => {
+            "CheckZero" | "DrawRandomInt" | "DrawRandomDouble" | "DrawRandomBool" | "Length" => {
                 Err(Error::Unexpected(
                     format!(
                         "`{}` is not a supported by partial evaluation",

--- a/compiler/qsc_partial_eval/tests/intrinsics.rs
+++ b/compiler/qsc_partial_eval/tests/intrinsics.rs
@@ -975,6 +975,22 @@ fn call_to_draw_random_double_panics() {
 }
 
 #[test]
+#[should_panic(expected = "`DrawRandomBool` is not a supported by partial evaluation")]
+fn call_to_draw_random_bool_panics() {
+    _ = get_rir_program(indoc! {
+        r#"
+        namespace Test {
+            open Microsoft.Quantum.Random;
+            @EntryPoint()
+            operation Main() : Unit {
+                let _ = DrawRandomBool(0.0);
+            }
+        }
+        "#,
+    });
+}
+
+#[test]
 fn call_to_length_in_inner_function_succeeds() {
     let program = get_rir_program(indoc! {
         r#"

--- a/compiler/qsc_rca/tests/intrinsics.rs
+++ b/compiler/qsc_rca/tests/intrinsics.rs
@@ -1149,6 +1149,31 @@ fn check_rca_for_draw_random_double() {
 }
 
 #[test]
+fn check_rca_for_draw_random_bool() {
+    let compilation_context = CompilationContext::default();
+    check_callable_compute_properties(
+        &compilation_context.fir_store,
+        compilation_context.get_compute_properties(),
+        "DrawRandomBool",
+        &expect![
+            r#"
+            Callable: CallableComputeProperties:
+                body: ApplicationsGeneratorSet:
+                    inherent: Quantum: QuantumProperties:
+                        runtime_features: RuntimeFeatureFlags(0x0)
+                        value_kind: Element(Dynamic)
+                    dynamic_param_applications:
+                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                            value_kind: Element(Dynamic)
+                adj: <none>
+                ctl: <none>
+                ctl-adj: <none>"#
+        ],
+    );
+}
+
+#[test]
 fn check_rca_for_begin_estimate_caching() {
     let compilation_context = CompilationContext::default();
     check_callable_compute_properties(

--- a/compiler/qsc_rca/tests/intrinsics.rs
+++ b/compiler/qsc_rca/tests/intrinsics.rs
@@ -1164,7 +1164,7 @@ fn check_rca_for_draw_random_bool() {
                         value_kind: Element(Dynamic)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Dynamic)
                 adj: <none>
                 ctl: <none>

--- a/library/std/random.qs
+++ b/library/std/random.qs
@@ -51,4 +51,25 @@ namespace Microsoft.Quantum.Random {
         body intrinsic;
     }
 
+    /// # Summary
+    /// Given a success probability, returns a single Bernoulli trial
+    /// that is true with the given probability.
+    ///
+    /// # Input
+    /// ## successProbability
+    /// The probability with which true should be returned.
+    ///
+    /// # Output
+    /// `true` with probability `successProbability`
+    /// and `false` with probability `1.0 - successProbability`.
+    ///
+    /// # Example
+    /// The following Q# snippet samples flips from a biased coin:
+    /// ```qsharp
+    /// let flips = DrawMany(DrawRandomBool, 10, 0.6);
+    /// ```
+    @Config(Unrestricted)
+    operation DrawRandomBool(successProbability : Double) : Bool {
+        body intrinsic;
+    }
 }


### PR DESCRIPTION
Adds new `DrawRandomBool` operation that was inspired by [this](https://learn.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.random.drawrandombool) page on the deprecated QDK. This change has the same documentation and functionality as the linked version.

Fixes #1170.