### PR TITLE
Add target profile to QIR generation telemetry event

### DIFF
--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -82,7 +82,11 @@ export async function getQirForActiveWindow(
   try {
     const associationId = getRandomGuid();
     const start = performance.now();
-    sendTelemetryEvent(EventType.GenerateQirStart, { associationId }, {});
+    sendTelemetryEvent(
+      EventType.GenerateQirStart,
+      { associationId, targetProfile },
+      {},
+    );
 
     // Override the program config with the new target profile (if updated above)
     config.profile = getTarget();

--- a/vscode/src/telemetry.ts
+++ b/vscode/src/telemetry.ts
@@ -66,7 +66,7 @@ type EventTypes = {
     measurements: { timeToCompletionMs: number; completionListLength: number };
   };
   [EventType.GenerateQirStart]: {
-    properties: { associationId: string };
+    properties: { associationId: string; targetProfile: string };
     measurements: Empty;
   };
   [EventType.GenerateQirEnd]: {


### PR DESCRIPTION
This change adds a new property to the `GenerateQirStart` telemetry event to provide data about the selected target profile.