### PR TITLE
Fix edge case in unitary-hack lint

### DIFF
--- a/compiler/qsc_linter/src/lints/hir.rs
+++ b/compiler/qsc_linter/src/lints/hir.rs
@@ -93,6 +93,8 @@ impl Visitor<'_> for IsQuantumOperation {
                     if matches!(&callee.ty, Ty::Arrow(arrow) if arrow.kind == CallableKind::Operation)
                     {
                         self.is_op = true;
+                    } else {
+                        visit::walk_expr(self, expr);
                     }
                 }
                 ExprKind::Conjugate(..) | ExprKind::Repeat(..) => {

--- a/compiler/qsc_linter/src/tests.rs
+++ b/compiler/qsc_linter/src/tests.rs
@@ -266,6 +266,27 @@ fn needless_operation_partial_application() {
     );
 }
 
+#[test]
+fn needless_operation_nested_operations() {
+    check(
+        indoc! {"
+    operation Main() : Unit {
+        Wrapper(A());
+    }
+
+    function Wrapper(_: Unit) : Unit {}
+
+    operation A() : Unit {
+        use q = Qubit();
+        M(q);
+    }
+    "},
+        &expect![[r"
+            []
+        "]],
+    );
+}
+
 fn check(source: &str, expected: &Expect) {
     let source = wrap_in_namespace(source);
     let mut store = PackageStore::new(compile::core());

--- a/compiler/qsc_linter/src/tests.rs
+++ b/compiler/qsc_linter/src/tests.rs
@@ -267,7 +267,7 @@ fn needless_operation_partial_application() {
 }
 
 #[test]
-fn needless_operation_nested_operations() {
+fn needless_operation_inside_function_call() {
     check(
         indoc! {"
     operation Main() : Unit {


### PR DESCRIPTION
Closes #1661. The lint wasn't recursing if a `Call` was not an operation, therefore, ignoring the arguments of the `Call`.