### PR TITLE
Skip prereqs if already run, and skip wasm checks/install if not needed

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -118,7 +118,7 @@ extends:
           # build steps
 
           - script: |
-              python build.py --npm --wasm
+              python build.py --npm --wasm --no-check-prereqs
             displayName: Build VSCode Extension
 
           - script: |
@@ -165,7 +165,7 @@ extends:
         # build steps
 
         - script: |
-            python build.py --wasm --npm --vscode --integration-tests
+            python build.py --wasm --npm --vscode --integration-tests --no-check-prereqs
           displayName: Build VSCode Extension
 
         - script: |
@@ -204,11 +204,11 @@ extends:
             versionSpec: '3.11'
 
         - script: |
-            python ./prereqs.py --install && python ./version.py
+            python ./prereqs.py --skip-wasm && python ./version.py
           displayName: Install Prereqs and set version
 
         - script: |
-            python ./build.py --jupyterlab --widgets --no-check
+            python ./build.py --jupyterlab --widgets --no-check --no-check-prereqs
           displayName: Build JupyterLab Package
 
         - script: |
@@ -272,7 +272,7 @@ extends:
               versionSpec: '3.11'
 
           - script: |
-              python ./prereqs.py --install && python ./version.py
+              python ./prereqs.py --skip-wasm && python ./version.py
             displayName: Install Prereqs and set version
 
           - script: |

--- a/prereqs.py
+++ b/prereqs.py
@@ -157,13 +157,6 @@ def check_prereqs(install=False, skip_wasm=False):
 
 
 def wasm_checks(install, installed_rust_targets):
-    # Ensure the required wasm target is installed
-    if "wasm32-unknown-unknown" not in installed_rust_targets:
-        print("WASM rust target is not installed.")
-        print("Please install the missing target by running:")
-        print("rustup target add wasm32-unknown-unknown")
-        exit(1)
-
     ### Check the wasm_pack version ###
     try:
         wasm_pack_version = subprocess.check_output(["wasm-pack", "--version"])
@@ -212,6 +205,13 @@ def wasm_checks(install, installed_rust_targets):
             exit(1)
     else:
         print("Unable to determine the wasm-pack version")
+
+    # Ensure the required wasm target is installed
+    if "wasm32-unknown-unknown" not in installed_rust_targets:
+        print("WASM rust target is not installed.")
+        print("Please install the missing target by running:")
+        print("rustup target add wasm32-unknown-unknown")
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/prereqs.py
+++ b/prereqs.py
@@ -35,7 +35,7 @@ def get_installed_rust_targets() -> str:
         raise Exception(message)
 
 
-def check_prereqs(install=False):
+def check_prereqs(install=False, skip_wasm=False):
     ### Check the Python version ###
     if (
         sys.version_info.major != python_ver[0]
@@ -45,6 +45,28 @@ def check_prereqs(install=False):
             f"Python {python_ver[0]}.{python_ver[1]} or later is required. Please update"
         )
         exit(1)
+
+    ### Check the Node.js version ###
+    try:
+        node_version = subprocess.check_output(["node", "-v"])
+        print(f"Detected node.js version {node_version.decode()}")
+    except FileNotFoundError:
+        print("Node.js not found. Please install from https://nodejs.org/")
+        exit(1)
+
+    version_match = re.search(r"v(\d+)\.(\d+)\.\d+", node_version.decode())
+    if version_match:
+        node_major = int(version_match.group(1))
+        node_minor = int(version_match.group(2))
+        if node_major < node_ver[0] or (
+            node_major == node_ver[0] and node_minor < node_ver[1]
+        ):
+            print(
+                f"Node.js v{node_ver[0]}.{node_ver[1]} or later is required. Please update."
+            )
+            exit(1)
+    else:
+        raise Exception("Unable to determine the Node.js version.")
 
     ### Check the rustc compiler version ###
     try:
@@ -121,13 +143,6 @@ def check_prereqs(install=False):
 
     installed_rust_targets = get_installed_rust_targets()
 
-    # Ensure the required wasm target is installed
-    target = "wasm32-unknown-unknown"
-    if target not in installed_rust_targets:
-        print("WASM rust target is not installed.")
-        print("Please install the missing target by running:")
-        print("rustup target add wasm32-unknown-unknown")
-
     # On MacOS, ensure the required targets are installed
     if platform.system() == "Darwin":
         targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
@@ -137,27 +152,17 @@ def check_prereqs(install=False):
             print("rustup target add aarch64-apple-darwin")
             print("rustup target add x86_64-apple-darwin")
 
-    ### Check the Node.js version ###
-    try:
-        node_version = subprocess.check_output(["node", "-v"])
-        print(f"Detected node.js version {node_version.decode()}")
-    except FileNotFoundError:
-        print("Node.js not found. Please install from https://nodejs.org/")
-        exit(1)
+    if not skip_wasm:
+        wasm_checks(install, installed_rust_targets)
 
-    version_match = re.search(r"v(\d+)\.(\d+)\.\d+", node_version.decode())
-    if version_match:
-        node_major = int(version_match.group(1))
-        node_minor = int(version_match.group(2))
-        if node_major < node_ver[0] or (
-            node_major == node_ver[0] and node_minor < node_ver[1]
-        ):
-            print(
-                f"Node.js v{node_ver[0]}.{node_ver[1]} or later is required. Please update."
-            )
-            exit(1)
-    else:
-        raise Exception("Unable to determine the Node.js version.")
+
+def wasm_checks(install, installed_rust_targets):
+    # Ensure the required wasm target is installed
+    if "wasm32-unknown-unknown" not in installed_rust_targets:
+        print("WASM rust target is not installed.")
+        print("Please install the missing target by running:")
+        print("rustup target add wasm32-unknown-unknown")
+        exit(1)
 
     ### Check the wasm_pack version ###
     try:
@@ -210,7 +215,6 @@ def check_prereqs(install=False):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "--install":
-        check_prereqs(install=True)
-    else:
-        check_prereqs(install=False)
+    skip_wasm = "--skip-wasm" in sys.argv
+    install = "--install" in sys.argv
+    check_prereqs(install=install, skip_wasm=skip_wasm)

--- a/prereqs.py
+++ b/prereqs.py
@@ -207,12 +207,10 @@ def wasm_checks(install, installed_rust_targets):
         print("Unable to determine the wasm-pack version")
 
     # Ensure the required wasm target is installed
-    print(installed_rust_targets)
     if "wasm32-unknown-unknown" not in installed_rust_targets:
         print("WASM rust target is not installed.")
         print("Please install the missing target by running:")
         print("rustup target add wasm32-unknown-unknown")
-        exit(1)
 
 
 if __name__ == "__main__":

--- a/prereqs.py
+++ b/prereqs.py
@@ -207,6 +207,7 @@ def wasm_checks(install, installed_rust_targets):
         print("Unable to determine the wasm-pack version")
 
     # Ensure the required wasm target is installed
+    print(installed_rust_targets)
     if "wasm32-unknown-unknown" not in installed_rust_targets:
         print("WASM rust target is not installed.")
         print("Please install the missing target by running:")


### PR DESCRIPTION
As per description. This should reduce build times slightly, and avoid the wasm-pack failures on aarch64 where it's not needed anyway.