### PR TITLE
Fix for "Simplify dependencies handling for exercises in katas" #1640

### DIFF
--- a/katas/README.md
+++ b/katas/README.md
@@ -35,7 +35,8 @@ The following macros are available for katas composition:
         - `Placeholder.qs`: the Q# code that is given to the learner to start with.
         - `Verification.qs`: the Q# code that checks whether the learner's solution is correct.
         - `solution.md`: the Markdown description of the solution(s) to the exercise.
-        - `Solution.qs`: the Q# code that contains a "reference solution" described in `solution.md`. 
+        - `Solution.qs`: the Q# code that contains a "reference solution" described in `solution.md`.
+    The @EntryPoint operation is called to check the solution (eventually, for the convention is to call Kata.Verification.CheckSolution). 
 - @[example]: Standalone Q# code snippets that can be referenced from markdown files.
     - id: Unique identifier for the example.
     - codePath: Path to a Q# file that contains the example code.

--- a/katas/README.md
+++ b/katas/README.md
@@ -36,7 +36,6 @@ The following macros are available for katas composition:
         - `Verification.qs`: the Q# code that checks whether the learner's solution is correct.
         - `solution.md`: the Markdown description of the solution(s) to the exercise.
         - `Solution.qs`: the Q# code that contains a "reference solution" described in `solution.md`. 
-    - qsDependencies: Q# file paths used in addition to `Verification.qs`. This code is not shown to the learner but is used to build the learner's code. The @EntryPoint operation is called to check the solution (eventually, for the convention is to call Kata.Verification.CheckSolution).
 - @[example]: Standalone Q# code snippets that can be referenced from markdown files.
     - id: Unique identifier for the example.
     - codePath: Path to a Q# file that contains the example code.

--- a/katas/README.md
+++ b/katas/README.md
@@ -36,7 +36,7 @@ The following macros are available for katas composition:
         - `Verification.qs`: the Q# code that checks whether the learner's solution is correct.
         - `solution.md`: the Markdown description of the solution(s) to the exercise.
         - `Solution.qs`: the Q# code that contains a "reference solution" described in `solution.md`.
-    The @EntryPoint operation is called to check the solution (eventually, for the convention is to call Kata.Verification.CheckSolution). 
+    The @EntryPoint operation is called to check the solution (eventually, for the convention is to call Kata.Verification.CheckSolution).
 - @[example]: Standalone Q# code snippets that can be referenced from markdown files.
     - id: Unique identifier for the example.
     - codePath: Path to a Q# file that contains the example code.

--- a/katas/content/complex_arithmetic/index.md
+++ b/katas/content/complex_arithmetic/index.md
@@ -50,8 +50,7 @@ We'll call the number $i$ and its real multiples (numbers obtained by multiplyin
 @[exercise]({ 
     "id": "complex_arithmetic__powers_of_i", 
     "title": "Powers of Imaginary Unit", 
-    "path": "./powers_of_i/", 
-    "qsDependencies": [] 
+    "path": "./powers_of_i/"
 })
 
 @[section]({ 
@@ -78,19 +77,13 @@ Let's see how to do the main arithmetic operations on complex numbers.
 @[exercise]({ 
     "id": "complex_arithmetic__complex_addition", 
     "title": "Add Complex Numbers", 
-    "path": "./complex_addition/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./complex_addition/"
 })
 
 @[exercise]({ 
     "id": "complex_arithmetic__complex_multiplication", 
     "title": "Multiply Complex Numbers", 
-    "path": "./complex_multiplication/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./complex_multiplication/"
 })
 
 @[section]({ 
@@ -118,10 +111,7 @@ $$\overline{x \cdot y} = \overline{x} \cdot \overline{y}$$
 @[exercise]({ 
     "id": "complex_arithmetic__complex_conjugate_exercise", 
     "title": "Find Conjugate", 
-    "path": "./complex_conjugate/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./complex_conjugate/"
 })
 
 @[section]({ 
@@ -146,10 +136,7 @@ $$\frac{a + bi}{r} = \frac{a}{r} + \frac{b}{r}i$$
 @[exercise]({ 
     "id": "complex_arithmetic__complex_division_exercise", 
     "title": "Divide Complex Numbers", 
-    "path": "./complex_division/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./complex_division/"
 })
 
 @[section]({ 
@@ -184,10 +171,7 @@ $$|x + y| \leq |x| + |y|$$
 @[exercise]({ 
     "id": "complex_arithmetic__complex_modulus_exercise", 
     "title": "Find Modulus", 
-    "path": "./complex_modulus/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./complex_modulus/"
 })
 
 @[section]({ 
@@ -227,19 +211,13 @@ Finally, using logarithms to express the base of the exponent as $r = e^{\ln r}$
 @[exercise]({ 
     "id": "complex_arithmetic__complex_exponents_exercise", 
     "title": "Find Complex Exponent", 
-    "path": "./complex_exponents/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./complex_exponents/"
 })
 
 @[exercise]({ 
     "id": "complex_arithmetic__complex_powers_real_exercise", 
     "title": "Find Complex Power of Real Number", 
-    "path": "./complex_powers_real/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./complex_powers_real/"
 })
 
 @[section]({ 
@@ -266,28 +244,19 @@ Sometimes $\theta$ will be referred to as the number's **argument** or **phase**
 @[exercise]({ 
     "id": "complex_arithmetic__cartesian_to_polar", 
     "title": "Convert Cartesian to Polar", 
-    "path": "./cartesian_to_polar/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./cartesian_to_polar/"
 })
 
 @[exercise]({ 
     "id": "complex_arithmetic__polar_to_cartesian", 
     "title": "Convert Polar to Cartesian", 
-    "path": "./polar_to_cartesian/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./polar_to_cartesian/"
 })
 
 @[exercise]({ 
     "id": "complex_arithmetic__polar_multiplication", 
     "title": "Multiply Polar Numbers", 
-    "path": "./polar_multiplication/", 
-    "qsDependencies": [ 
-        "./Common.qs"
-    ] 
+    "path": "./polar_multiplication/"
 })
 
 

--- a/katas/content/deutsch_algo/index.md
+++ b/katas/content/deutsch_algo/index.md
@@ -99,10 +99,7 @@ After that, you'll try to implement the oracle for the fourth function on your o
 @[exercise]({
     "id": "deutsch_algo__one_minus_x_oracle",
     "title": "Oracle for f(x) = 1 - x",
-    "path": "./one_minus_x_oracle/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./one_minus_x_oracle/"
 })
 
 
@@ -160,10 +157,7 @@ We can follow the steps of the algorithm for the constant and the balanced scena
 @[exercise]({
     "id": "deutsch_algo__implement_algo",
     "title": "Implement Deutsch Algorithm",
-    "path": "./implement_algo/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./implement_algo/"
 })
 
 

--- a/katas/content/deutsch_jozsa/index.md
+++ b/katas/content/deutsch_jozsa/index.md
@@ -111,19 +111,13 @@ After that, you'll try to implement the oracles for two more functions on your o
 @[exercise]({
     "id": "deutsch_jozsa__msb_oracle",
     "title": "Oracle for f(x) = most significant bit of x",
-    "path": "./msb_oracle/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./msb_oracle/"
 })
 
 @[exercise]({
     "id": "deutsch_jozsa__parity_oracle",
     "title": "Oracle for f(x) = parity of the number of 1 bits in x",
-    "path": "./parity_oracle/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./parity_oracle/"
 })
 
 
@@ -212,10 +206,7 @@ Note that this algorithm requires only $1$ oracle call, and always produces the 
 @[exercise]({
     "id": "deutsch_jozsa__implement_dj",
     "title": "Implement Deutsch-Jozsa Algorithm",
-    "path": "./implement_dj/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./implement_dj/"
 })
 
 
@@ -307,10 +298,7 @@ And, same as Deutsch-Jozsa algorithm, Bernstein-Vazirani algorithm takes only on
 @[exercise]({
     "id": "deutsch_jozsa__implement_bv",
     "title": "Implement Bernstein-Vazirani Algorithm",
-    "path": "./implement_bv/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./implement_bv/"
 })
 
 

--- a/katas/content/distinguishing_states/index.md
+++ b/katas/content/distinguishing_states/index.md
@@ -29,136 +29,85 @@ In this scenario, the states can be distinguished perfectly, with 100% accuracy.
 @[exercise]({
     "id": "distinguishing_states__zero_one",
     "title": "|0〉 or |1〉?",
-    "path": "./zero_one/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./zero_one/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__plus_minus",
     "title": "|+〉 or |-〉?",
-    "path": "./plus_minus/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./plus_minus/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__a_b",
     "title": "|A〉 or |B〉?",
-    "path": "./a_b/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./a_b/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__zerozero_oneone",
     "title": "|00〉 or |11〉?",
-    "path": "./zerozero_oneone/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./zerozero_oneone/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__four_basis_states",
     "title": "Distinguish Four Basis States",
-    "path": "./four_basis_states/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./four_basis_states/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__two_basis_states_bit_strings",
     "title": "Distinguish Two Basis States Given by Bit Strings",
-    "path": "./two_basis_states_bit_strings/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./two_basis_states_bit_strings/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__two_superposition_states_bit_strings_one",
     "title": "Distinguish Two States Given by Two Arrays of Bit Strings in One Measurement",
-    "path": "./two_superposition_states_bit_strings_one/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./two_superposition_states_bit_strings_one/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__two_superposition_states_bit_strings",
     "title": "Distinguish Two States Given by Two Arrays of Bit Strings",
-    "path": "./two_superposition_states_bit_strings/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./two_superposition_states_bit_strings/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__all_zeros_w",
     "title": "|0...0〉 State or W State?",
-    "path": "./all_zeros_w/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./all_zeros_w/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__ghz_w",
     "title": "GHZ State or W State?",
-    "path": "./ghz_w/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./ghz_w/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__four_bell_states",
     "title": "Distinguish Four Bell States",
-    "path": "./four_bell_states/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./four_bell_states/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__four_orthogonal_two_qubit",
     "title": "Distinguish Four Two-Qubit States",
-    "path": "./four_orthogonal_two_qubit/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./four_orthogonal_two_qubit/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__four_orthogonal_two_qubit_part_two",
     "title": "Distinguish Four Two-Qubit States - 2",
-    "path": "./four_orthogonal_two_qubit_part_two/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./four_orthogonal_two_qubit_part_two/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__two_orthogonal_three_qubit",
     "title": "Distinguish Two Three-Qubit States",
-    "path": "./two_orthogonal_three_qubit/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./two_orthogonal_three_qubit/"
 })
 
 @[section]({
@@ -171,28 +120,19 @@ This lesson offers you several variants of the task of distinguishing sets of st
 @[exercise]({
     "id": "distinguishing_states__zero_plus",
     "title": "|0〉 or |+〉?",
-    "path": "./zero_plus/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./zero_plus/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__zero_plus_inc",
     "title": "|0〉, |+〉 or Inconclusive?",
-    "path": "./zero_plus_inc/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./zero_plus_inc/"
 })
 
 @[exercise]({
     "id": "distinguishing_states__peres_wooters_game",
     "title": "Peres/Wooters game",
-    "path": "./peres_wooters_game/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./peres_wooters_game/"
 })
 
 @[section]({

--- a/katas/content/distinguishing_unitaries/index.md
+++ b/katas/content/distinguishing_unitaries/index.md
@@ -28,101 +28,61 @@ To start with, let's look at some problems involving distinguishing single-qubit
 @[exercise]({
     "id": "distinguishing_unitaries__i_x",
     "title": "Identity or X?",
-    "path": "./i_x/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./i_x/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__i_z",
     "title": "Identity or Z?",
-    "path": "./i_z/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./i_z/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__z_s",
     "title": "Z or S?",
-    "path": "./z_s/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./z_s/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__h_x",
     "title": "Hadamard or X?",
-    "path": "./h_x/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./h_x/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__z_minusz",
     "title": "Z or -Z?",
-    "path": "./z_minusz/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./z_minusz/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__rz_r1",
     "title": "Rz or R1?",
-    "path": "./rz_r1/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./rz_r1/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__y_xz",
     "title": "Y or XZ?",
-    "path": "./y_xz/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./y_xz/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__y_xz_minusy_minusxz",
     "title": "Y or XZ or -Y or -XZ?",
-    "path": "./y_xz_minusy_minusxz/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./y_xz_minusy_minusxz/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__i_x_y_z",
     "title": "Distinguish Four Pauli Unitaries",
-    "path": "./i_x_y_z/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./i_x_y_z/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__rz_ry",
     "title": "Rz or Ry?",
-    "path": "./rz_ry/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./rz_ry/"
 })
 
 @[section]({
@@ -135,41 +95,25 @@ In this lesson, the exercises focus on distinguishing multi-qubit gates.
 @[exercise]({
     "id": "distinguishing_unitaries__ix_cnot",
     "title": "I⊗X or CNOT?",
-    "path": "./ix_cnot/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./ix_cnot/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__cnot_direction",
     "title": "CNOT Direction",
-    "path": "./cnot_direction/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./cnot_direction/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__cnot_swap",
     "title": "CNOT or SWAP?",
-    "path": "./cnot_swap/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./cnot_swap/"
 })
 
 @[exercise]({
     "id": "distinguishing_unitaries__i_cnot_swap",
     "title": "Distinguish Two-Qubit Unitaries",
-    "path": "./i_cnot_swap/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./i_cnot_swap/"
 })
 
 @[section]({

--- a/katas/content/getting_started/index.md
+++ b/katas/content/getting_started/index.md
@@ -60,8 +60,5 @@ _The Japanese word for "form", a pattern of learning and practicing new skills._
 @[exercise]({
     "id": "getting_started__flip_qubit",
     "title": "Flip a Qubit",
-    "path": "./flip_qubit/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./flip_qubit/"
 })

--- a/katas/content/key_distribution/index.md
+++ b/katas/content/key_distribution/index.md
@@ -66,35 +66,25 @@ Now that we've learned the theory behind the BB84 protocol, let's implement its 
 @[exercise]({
     "id": "key_distribution__random_array",
     "title": "Generate Random Array",
-    "path": "./random_array/",
-    "qsDependencies": []
+    "path": "./random_array/"
 })
 
 @[exercise]({
     "id": "key_distribution__prepare_qubits",
     "title": "Prepare Qubits (Alice's Task)",
-    "path": "./prepare_qubits/",
-    "qsDependencies": [
-        "./Common.qs"
-    ]
+    "path": "./prepare_qubits/"
 })
 
 @[exercise]({
     "id": "key_distribution__measure_qubits",
     "title": "Measure Qubits (Bob's Task)",
-    "path": "./measure_qubits/",
-    "qsDependencies": [
-        "./Common.qs"
-    ]
+    "path": "./measure_qubits/"
 })
 
 @[exercise]({
     "id": "key_distribution__shared_key",
     "title": "Generate the Shared Key",
-    "path": "./shared_key/",
-    "qsDependencies": [
-        "./Common.qs"
-    ]
+    "path": "./shared_key/"
 })
 
 

--- a/katas/content/linear_algebra/index.md
+++ b/katas/content/linear_algebra/index.md
@@ -96,10 +96,7 @@ Matrix addition has the following properties:
 @[exercise]({ 
     "id": "linear_algebra__addition", 
     "title": "Add Matrices", 
-    "path": "./addition/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./addition/"
 })
 
 
@@ -133,10 +130,7 @@ Scalar multiplication has the following properties:
 @[exercise]({ 
     "id": "linear_algebra__scalar_multiplication_ex", 
     "title": "Multiply a Matrix by a Scalar", 
-    "path": "./scalar_multiplication/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./scalar_multiplication/"
 })
 
 
@@ -201,10 +195,7 @@ This is why $I_n$ is called an identity matrix - it acts as a **multiplicative i
 @[exercise]({ 
     "id": "linear_algebra__matrix_multiplication_ex", 
     "title": "Multiply Two Matrices", 
-    "path": "./multiplication/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./multiplication/"
 })
 
 
@@ -233,10 +224,7 @@ For larger matrices, the determinant is defined through determinants of sub-matr
 @[exercise]({ 
     "id": "linear_algebra__inverse_matrix_ex", 
     "title": "Invert a Matrix", 
-    "path": "./inverse/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./inverse/"
 })
 
 
@@ -294,10 +282,7 @@ $$(AB)^T = B^TA^T$$
 @[exercise]({ 
     "id": "linear_algebra__transpose_ex", 
     "title": "Transpose a Matrix", 
-    "path": "./transpose/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./transpose/"
 })
 
 
@@ -335,10 +320,7 @@ $$\overline{AB} = (\overline{A})(\overline{B})$$
 @[exercise]({ 
     "id": "linear_algebra__conjugate_ex", 
     "title": "Conjugate of a Matrix", 
-    "path": "./conjugate/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./conjugate/"
 })
 
 
@@ -363,10 +345,7 @@ $$(AB)^\dagger = B^\dagger A^\dagger$$
 @[exercise]({ 
     "id": "linear_algebra__adjoint_ex", 
     "title": "Adjoint of a Matrix", 
-    "path": "./adjoint/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./adjoint/"
 })
 
 
@@ -456,19 +435,13 @@ The inner product has the following properties:
 @[exercise]({ 
     "id": "linear_algebra__inner_product_ex", 
     "title": "Inner Product of Two Vectors", 
-    "path": "./inner_product/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./inner_product/"
 })
 
 @[exercise]({ 
     "id": "linear_algebra__normalized_vector", 
     "title": "Normalized Vector", 
-    "path": "./normalized_vector/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./normalized_vector/"
 })
 
 
@@ -482,10 +455,7 @@ The **outer product** of two vectors $V$ and $W$ is defined as $VW^\dagger$. Tha
 @[exercise]({ 
     "id": "linear_algebra__outer_product_ex", 
     "title": "Outer Product of Two Vectors", 
-    "path": "./outer_product/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./outer_product/"
 })
 
 
@@ -533,10 +503,7 @@ The tensor product has the following properties:
 @[exercise]({ 
     "id": "linear_algebra__tensor_product_ex", 
     "title": "Tensor Product of Two Matrices", 
-    "path": "./tensor_product/", 
-    "qsDependencies": [
-        "./Common.qs"
-    ] 
+    "path": "./tensor_product/"
 })
 
 

--- a/katas/content/marking_oracles/index.md
+++ b/katas/content/marking_oracles/index.md
@@ -23,141 +23,85 @@ This kata continues the exploration of quantum oracles started in the Oracles ka
 @[exercise]({
     "id": "marking_oracles__kth_bit",
     "title": "K-th Bit",
-    "path": "./kth_bit/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./kth_bit/"
 })
 
 @[exercise]({
     "id": "marking_oracles__parity",
     "title": "Parity Function",
-    "path": "./parity/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./parity/"
 })
 
 @[exercise]({
     "id": "marking_oracles__product",
     "title": "Product Function",
-    "path": "./product/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./product/"
 })
 
 @[exercise]({
     "id": "marking_oracles__product_negation",
     "title": "Product Function with Negation",
-    "path": "./product_negation/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./product_negation/"
 })
 
 @[exercise]({
     "id": "marking_oracles__palindrome",
     "title": "Palindrome Checker",
-    "path": "./palindrome/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./palindrome/"
 })
 
 @[exercise]({
     "id": "marking_oracles__periodic_p",
     "title": "Is Bit String Periodic with Period P?",
-    "path": "./periodic_p/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./periodic_p/"
 })
 
 @[exercise]({
     "id": "marking_oracles__periodic",
     "title": "Is Bit String Periodic?",
-    "path": "./periodic/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./periodic/"
 })
 
 @[exercise]({
     "id": "marking_oracles__contains_substring_p",
     "title": "Does Bit String Contain Substring At Position?",
-    "path": "./contains_substring_p/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./contains_substring_p/"
 })
 
 @[exercise]({
     "id": "marking_oracles__pattern_match",
     "title": "Pattern Matching",
-    "path": "./pattern_match/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./pattern_match/"
 })
 
 @[exercise]({
     "id": "marking_oracles__contains_substring",
     "title": "Does Bit String Contain Substring?",
-    "path": "./contains_substring/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./contains_substring/"
 })
 
 @[exercise]({
     "id": "marking_oracles__balanced",
     "title": "Is Bit String Balanced?",
-    "path": "./balanced/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./balanced/"
 })
 
 @[exercise]({
     "id": "marking_oracles__majority",
     "title": "Majority Function",
-    "path": "./majority/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./majority/"
 })
 
 @[exercise]({
     "id": "marking_oracles__bit_sum_div_3",
     "title": "Is Bit Sum Divisible by 3?",
-    "path": "./bit_sum_div_3/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./bit_sum_div_3/"
 })
 
 @[exercise]({
     "id": "marking_oracles__num_div_3",
     "title": "Is Number Divisible by 3?",
-    "path": "./num_div_3/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./num_div_3/"
 })
 
 @[section]({

--- a/katas/content/multi_qubit_gates/index.md
+++ b/katas/content/multi_qubit_gates/index.md
@@ -73,10 +73,7 @@ It can be less straightforward when a multi-qubit gate is applied to a subset of
 @[exercise]({
     "id": "multi_qubit_gates__compound_gate",
     "title": "Compound Gate",
-    "path": "./compound_gate/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./compound_gate/"
 })
 
 @[section]({
@@ -125,19 +122,13 @@ The $CNOT$ gate is self-adjoint: applying it for the second time reverses its ef
 @[exercise]({
     "id": "multi_qubit_gates__entangle_qubits",
     "title": "Entangle Qubits",
-    "path": "./entangle_qubits/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./entangle_qubits/"
 })
 
 @[exercise]({
     "id": "multi_qubit_gates__preparing_bell_state",
     "title": "Preparing a Bell State",
-    "path": "./preparing_bell_state/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./preparing_bell_state/"
 })
 
 @[section]({
@@ -190,10 +181,7 @@ The $CZ$ gate is also self-adjoint: applying it a second time reverses its effec
 @[exercise]({
     "id": "multi_qubit_gates__relative_phase_minusone",
     "title": "Relative Phase -1",
-    "path": "./relative_phase_minusone/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./relative_phase_minusone/"
 })
 
 @[section]({
@@ -329,10 +317,7 @@ The $SWAP$ gate acts on two qubits, and, as the name implies, swaps their quantu
 @[exercise]({
     "id": "multi_qubit_gates__qubit_swap",
     "title": "Qubit SWAP",
-    "path": "./qubit_swap/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./qubit_swap/"
 })
 
 @[section]({
@@ -527,18 +512,12 @@ In other cases, you'll need to define the controlled version of an operation man
 @[exercise]({
     "id": "multi_qubit_gates__fredkin_gate",
     "title": "Fredkin Gate",
-    "path": "./fredkin_gate/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./fredkin_gate/"
 })
 @[exercise]({
     "id": "multi_qubit_gates__controlled_rotation",
     "title": "Controlled Rotation",
-    "path": "./controlled_rotation/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./controlled_rotation/"
 })
 
 @[section]({
@@ -569,10 +548,7 @@ To construct a multi-controlled version of an operation in Q#, you can use the C
 @[exercise]({
     "id": "multi_qubit_gates__toffoli_gate",
     "title": "Toffoli Gate",
-    "path": "./toffoli_gate/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./toffoli_gate/"
 })
 
 @[section]({
@@ -647,19 +623,13 @@ The sequence of steps that implement this variant are:
 @[exercise]({
     "id": "multi_qubit_gates__anti_controlled_gate",
     "title": "Anti-Controlled Gate",
-    "path": "./anti_controlled_gate/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./anti_controlled_gate/"
 })
 
 @[exercise]({
     "id": "multi_qubit_gates__arbitrary_controls",
     "title": "Arbitrary Controls",
-    "path": "./arbitrary_controls/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./arbitrary_controls/"
 })
 
 @[section]({

--- a/katas/content/multi_qubit_measurements/index.md
+++ b/katas/content/multi_qubit_measurements/index.md
@@ -235,10 +235,7 @@ Full measurements can also be used to identify the state of the system, if it is
 @[exercise]({
     "id": "multi_qubit_measurements__full_measurements",
     "title":  "Distinguish Four Basis States",
-    "path": "./full_measurements/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./full_measurements/"
 })
 
 @[section]({
@@ -346,10 +343,7 @@ In certain situations, it is possible to distinguish between orthogonal states o
 @[exercise]({
     "id": "multi_qubit_measurements__partial_measurements_for_system",
     "title": "Distinguish Orthogonal States Using Partial Measurements",
-    "path": "./partial_measurements_for_system/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./partial_measurements_for_system/"
 })
 
 @[section]({
@@ -402,10 +396,7 @@ For certain multi-qubit systems prepared in a superposition state, it is possibl
 @[exercise]({
     "id": "multi_qubit_measurements__state_modification",
     "title": "State Selection Using Partial Measurements",
-    "path": "./state_modification/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./state_modification/"
 })
 
 @[section]({
@@ -420,10 +411,7 @@ You could prepare a simpler state involving additional qubits, which, when measu
 @[exercise]({
     "id": "multi_qubit_measurements__state_preparation_using_partial_measurements",
     "title": "State Preparation Using Partial Measurements",
-    "path": "./state_preparation/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./state_preparation/"
 })
 
 @[section]({
@@ -548,10 +536,7 @@ Similarly, a parity measurement on a higher number of qubits can be implemented 
 @[exercise]({
     "id": "multi_qubit_measurements__two_qubit_parity_measurement",
     "title": "Two-Qubit Parity Measurement",
-    "path": "./joint_measurements/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./joint_measurements/"
 })
 
 @[section]({

--- a/katas/content/multi_qubit_systems/index.md
+++ b/katas/content/multi_qubit_systems/index.md
@@ -307,10 +307,7 @@ If they are not in zero state by that time, they can potentially be still entang
 @[exercise]({
     "id": "multi_qubit_systems__learn_basis_state_amplitudes",
     "title": "Learn Basis State Amplitudes Using DumpMachine",
-    "path": "./learn_basis_state_amplitudes/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./learn_basis_state_amplitudes/"
 })
 
 @[section]({
@@ -327,37 +324,25 @@ Array elements are indexed starting with 0, the first array element corresponds 
 @[exercise]({
     "id": "multi_qubit_systems__prepare_basis_state",
     "title": "Prepare a Basis State",
-    "path": "./prepare_basis_state/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./prepare_basis_state/"
 })
 
 @[exercise]({
     "id": "multi_qubit_systems__prepare_superposition",
     "title": "Prepare a Superposition of Two Basis States",
-    "path": "./prepare_superposition/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./prepare_superposition/"
 })
 
 @[exercise]({
     "id": "multi_qubit_systems__prepare_with_real",
     "title": " Prepare a Superposition with Real Amplitudes",
-    "path": "./prepare_with_real/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./prepare_with_real/"
 })
 
 @[exercise]({
     "id": "multi_qubit_systems__prepare_with_complex",
     "title": "Prepare a Superposition with Complex Amplitudes",
-    "path": "./prepare_with_complex/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./prepare_with_complex/"
 })
 
 @[section]({
@@ -370,28 +355,19 @@ Entangled quantum states can be manipulated using single-qubit gates. For exampl
 @[exercise]({
     "id": "multi_qubit_systems__bell_state_change_1 ",
     "title": "Bell State Change 1",
-    "path": "./bell_state_change_1/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./bell_state_change_1/"
 })
 
 @[exercise]({
     "id": "multi_qubit_systems__bell_state_change_2 ",
     "title": "Bell State Change 2",
-    "path": "./bell_state_change_2/",
-    "qsDependencies": [
-    "../KatasLibrary.qs"
-    ]
+    "path": "./bell_state_change_2/"
 })
 
 @[exercise]({
     "id": "multi_qubit_systems__bell_state_change_3 ",
     "title": "Bell State Change 3",
-    "path": "./bell_state_change_3/",
-    "qsDependencies": [
-    "../KatasLibrary.qs"
-    ]
+    "path": "./bell_state_change_3/"
 })
 
 @[section]({

--- a/katas/content/oracles/index.md
+++ b/katas/content/oracles/index.md
@@ -39,11 +39,7 @@ Some classical problems (typically <a href="https://en.wikipedia.org/wiki/Decisi
 @[exercise]({
     "id": "oracles__implement_classical_oracles",
     "title": "Implement a Classical Oracle",
-    "path": "./classical_oracles/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./classical_oracles/"
 })
 
 @[section]({
@@ -113,11 +109,7 @@ In the next exercise you will implement the classical oracle that you've impleme
 @[exercise]({
     "id": "oracles__phase_oracle_seven",
     "title": "Implement a Phase Oracle",
-    "path": "./phase_oracle_seven/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./phase_oracle_seven/"
 })
 
 @[section]({
@@ -157,11 +149,7 @@ Now you will implement the same function you've seen in the first two exercises 
 @[exercise]({
     "id": "oracles__marking_oracle_seven",
     "title": "Implement a Marking Oracle",
-    "path": "./marking_oracle_seven/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./marking_oracle_seven/"
 })
 
 @[section]({
@@ -245,11 +233,7 @@ We can see that these two equations are identical, except for the $-1$ phase tha
 @[exercise]({
     "id": "oracles__marking_oracle_as_phase",
     "title": "Apply the Marking Oracle as a Phase Oracle",
-    "path": "./marking_oracle_as_phase/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./marking_oracle_as_phase/"
 })
 
 @[section]({
@@ -281,61 +265,37 @@ You will practice that in some of the exercises below.
 @[exercise]({
     "id": "oracles__or_oracle",
     "title": "Implement the OR Oracle",
-    "path": "./or_oracle/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./or_oracle/"
 })
 
 @[exercise]({
     "id": "oracles__kth_bit_oracle",
     "title": "Implement the K-th Bit Oracle",
-    "path": "./kth_bit_oracle/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./kth_bit_oracle/"
 })
 
 @[exercise]({
     "id": "oracles__or_but_kth_oracle",
     "title": "Implement the OR Oracle of All Bits Except the K-th",
-    "path": "./or_but_kth_oracle/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./or_but_kth_oracle/"
 })
 
 @[exercise]({
     "id": "oracles__bit_pattern_oracle",
     "title": "Implement the Arbitrary Bit Pattern Oracle",
-    "path": "./bit_pattern_oracle/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./bit_pattern_oracle/"
 })
 
 @[exercise]({
     "id": "oracles__bit_pattern_challenge",
     "title": "Implement the Arbitrary Bit Pattern Oracle (Challenge Version)",
-    "path": "./bit_pattern_challenge/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./bit_pattern_challenge/"
 })
 
 @[exercise]({
     "id": "oracles__meeting_oracle",
     "title": "Implement the Meeting Oracle",
-    "path": "./meeting_oracle/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./meeting_oracle/"
 })
 
 @[section]({

--- a/katas/content/preparing_states/index.md
+++ b/katas/content/preparing_states/index.md
@@ -28,141 +28,85 @@ In this lesson, you'll practice preparing states that are even superpositions of
 @[exercise]({
     "id": "preparing_states__plus_state",
     "title": "Plus State",
-    "path": "./plus_state/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./plus_state/"
 })
 
 @[exercise]({
     "id": "preparing_states__minus_state",
     "title": "Minus State",
-    "path": "./minus_state/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./minus_state/"
 })
 
 @[exercise]({
     "id": "preparing_states__even_sup_two_qubits",
     "title": "All Two-Qubit Basis Vectors",
-    "path": "./even_sup_two_qubits/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./even_sup_two_qubits/"
 })
 
 @[exercise]({
     "id": "preparing_states__even_sup_two_qubits_phase_flip",
     "title": "All Two-Qubit Basis Vectors with Phase Flip",
-    "path": "./even_sup_two_qubits_phase_flip/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./even_sup_two_qubits_phase_flip/"
 })
 
 @[exercise]({
     "id": "preparing_states__even_sup_two_qubits_complex_phases",
     "title": "All Two-Qubit Basis Vectors with Complex Phases",
-    "path": "./even_sup_two_qubits_complex_phases/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./even_sup_two_qubits_complex_phases/"
 })
 
 @[exercise]({
     "id": "preparing_states__bell_state",
     "title": "Bell State",
-    "path": "./bell_state/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./bell_state/"
 })
 
 @[exercise]({
     "id": "preparing_states__all_bell_states",
     "title": "All Bell States",
-    "path": "./all_bell_states/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./all_bell_states/"
 })
 
 @[exercise]({
     "id": "preparing_states__ghz_state",
     "title": "Greenberger-Horne-Zellinger State",
-    "path": "./greenberger_horne_zeilinger/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./greenberger_horne_zeilinger/"
 })
 
 @[exercise]({
     "id": "preparing_states__all_basis_vectors",
     "title": "All N-Qubit Basis Vectors",
-    "path": "./all_basis_vectors/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./all_basis_vectors/"
 })
 
 @[exercise]({
     "id": "preparing_states__even_odd",
     "title": "Even or Odd Basis Vectors",
-    "path": "./even_odd/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./even_odd/"
 })
 
 @[exercise]({
     "id": "preparing_states__zero_and_bitstring",
     "title": "Zero and Bitstring",
-    "path": "./zero_and_bitstring/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./zero_and_bitstring/"
 })
 
 @[exercise]({
     "id": "preparing_states__two_bitstrings",
     "title": "Two Bitstrings",
-    "path": "./two_bitstrings/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./two_bitstrings/"
 })
 
 @[exercise]({
     "id": "preparing_states__four_bitstrings",
     "title": "Four Bit Strings",
-    "path": "./four_bitstrings/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./four_bitstrings/"
 })
 
 @[exercise]({
     "id": "preparing_states__parity_bitstrings",
     "title": "Same Parity Bit Strings",
-    "path": "./parity_bitstrings/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./parity_bitstrings/"
 })
 
 
@@ -179,69 +123,43 @@ In this lesson, you'll practice preparing more interesting states that require t
 @[exercise]({
     "id": "preparing_states__unequal_superposition",
     "title": "Unequal Superposition",
-    "path": "./unequal_superposition/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./unequal_superposition/"
 })
 
 @[exercise]({
     "id": "preparing_states__controlled_rotation",
     "title": "Controlled Rotation",
-    "path": "./controlled_rotation/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./controlled_rotation/"
 })
 
 @[exercise]({
     "id": "preparing_states__three_states_two_qubits",
     "title": "Three Two-Qubit Basis States",
-    "path": "./three_states_two_qubits/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./three_states_two_qubits/"
 })
 
 @[exercise]({
     "id": "preparing_states__three_states_two_qubits_phases",
     "title": "Three Two-Qubit Basis States with Complex Phases",
-    "path": "./three_states_two_qubits_phases/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./three_states_two_qubits_phases/"
 })
 
 @[exercise]({
     "id": "preparing_states__hardy_state",
     "title": "Hardy State",
-    "path": "./hardy_state/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./hardy_state/"
 })
 
 @[exercise]({
     "id": "preparing_states__wstate_power_of_two",
     "title": "W State on Power of Two Number of Qubits",
-    "path": "./wstate_power_of_two/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./wstate_power_of_two/"
 })
 
 @[exercise]({
     "id": "preparing_states__wstate_arbitrary",
     "title": "W State on Arbitrary Number of Qubits",
-    "path": "./wstate_arbitrary/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./wstate_arbitrary/"
 })
 
 

--- a/katas/content/qec_shor/index.md
+++ b/katas/content/qec_shor/index.md
@@ -115,19 +115,13 @@ It takes two parameters: the array of `Pauli` constants (`PauliI`, `PauliX`, `Pa
 @[exercise]({
     "id": "qec_shor__zz_measurement",
     "title": "Measurement in ZZ basis",
-    "path": "./zz_measurement/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./zz_measurement/"
 })
 
 @[exercise]({
     "id": "qec_shor__xx_measurement",
     "title": "Measurement in XX basis",
-    "path": "./xx_measurement/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./xx_measurement/"
 })
 
 
@@ -192,20 +186,13 @@ However, if a $Z$ error happens on any one of these qubits, we won't be able to 
 @[exercise]({
     "id": "qec_shor__bitflip_encode",
     "title": "Bit Flip Code: Encode Codewords",
-    "path": "./bitflip_encode/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./bitflip_encode/"
 })
 
 @[exercise]({
     "id": "qec_shor__bitflip_detect",
     "title": "Bit Flip Code: Detect X Error",
-    "path": "./bitflip_detect/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./bitflip_detect/"
 })
 
 
@@ -265,20 +252,13 @@ However, if an $X$ error happens on any one of these qubits, we won't be able to
 @[exercise]({
     "id": "qec_shor__phaseflip_encode",
     "title": "Phase Flip Code: Encode Codewords",
-    "path": "./phaseflip_encode/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./phaseflip_encode/"
 })
 
 @[exercise]({
     "id": "qec_shor__phaseflip_detect",
     "title": "Phase Flip Code: Detect Z Error",
-    "path": "./phaseflip_detect/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./phaseflip_detect/"
 })
 
 
@@ -336,19 +316,13 @@ To correct a $Z$ error, we can no longer simply apply a $Z$ gate to the affected
 @[exercise]({
     "id": "qec_shor__shor_encode",
     "title": "Shor Code: Encode Codewords",
-    "path": "./shor_encode/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./shor_encode/"
 })
 
 @[exercise]({
     "id": "qec_shor__shor_detect",
     "title": "Shor Code: Detect X, Y, and Z Errors",
-    "path": "./shor_detect/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./shor_detect/"
 })
 
 

--- a/katas/content/qubit/index.md
+++ b/katas/content/qubit/index.md
@@ -221,10 +221,7 @@ For example, the state $\ket{0}$ would be represented as follows:
 @[exercise]({
     "id": "qubit__learn_single_qubit_state",
     "title": "Learn the State of a Single Qubit Using DumpMachine",
-    "path": "./learn_single_qubit_state/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./learn_single_qubit_state/"
 })
 
 @[section]({

--- a/katas/content/random_numbers/index.md
+++ b/katas/content/random_numbers/index.md
@@ -34,51 +34,31 @@ This knowledge is sufficient to implement a simple random number generator!
 @[exercise]({
     "id": "random_numbers__random_bit",
     "title": "Generate a Single Random Bit",
-    "path": "./random_bit/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./random_bit/"
 })
 
 @[exercise]({
     "id": "random_numbers__random_two_bits",
     "title": "Generate a Random Two-Bit Number",
-    "path": "./random_two_bits/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./random_two_bits/"
 })
 
 @[exercise]({
     "id": "random_numbers__random_n_bits",
     "title": "Generate a Number of Arbitrary Size",
-    "path": "./random_n_bits/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./random_n_bits/"
 })
 
 @[exercise]({
     "id": "random_numbers__weighted_random_bit",
     "title": "Generate a Weighted Bit",
-    "path": "./weighted_random_bit/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./weighted_random_bit/"
 })
 
 @[exercise]({
     "id": "random_numbers__random_number",
     "title": "Generate a Random Number Between Min and Max",
-    "path": "./random_number/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./random_number/"
 })
 
 @[section]({"id": "random_numbers__whats_next", "title": "What's Next?"})

--- a/katas/content/single_qubit_gates/index.md
+++ b/katas/content/single_qubit_gates/index.md
@@ -328,55 +328,37 @@ All the basic gates we will be covering in this kata are part of the Intrinsic n
 @[exercise]({
     "id": "single_qubit_gates__state_flip",
     "title": "State Flip",
-    "path": "./state_flip/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./state_flip/"
 })
 
 @[exercise]({
     "id": "single_qubit_gates__sign_flip",
     "title": "Sign Flip",
-    "path": "./sign_flip/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./sign_flip/"
 })
 
 @[exercise]({
     "id": "single_qubit_gates__y_gate",
     "title": "The Y Gate",
-    "path": "./y_gate/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./y_gate/"
 })
 
 @[exercise]({
     "id": "single_qubit_gates__sign_flip_on_zero",
     "title": "Sign Flip on Zero",
-    "path": "./sign_flip_on_zero/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./sign_flip_on_zero/"
 })
 
 @[exercise]({
     "id": "single_qubit_gates__global_phase_minusone",
     "title": "Global Phase -1",
-    "path": "./global_phase_minusone/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./global_phase_minusone/"
 })
 
 @[exercise]({
     "id": "single_qubit_gates__global_phase_i",
     "title": "Global Phase i",
-    "path": "./global_phase_i/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./global_phase_i/"
 })
 
 
@@ -438,20 +420,14 @@ $H\ket{-i} = e^{-i\pi/4}\ket{i} $ <br>
 @[exercise]({
     "id": "single_qubit_gates__basis_change",
     "title": "Basis Change",
-    "path": "./basis_change/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./basis_change/"
 })
 
 
 @[exercise]({
     "id": "single_qubit_gates__prepare_minus",
     "title": "Prepare Minus",
-    "path": "./prepare_minus/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./prepare_minus/"
 })
 
 @[section]({
@@ -501,19 +477,13 @@ $$T^2 = S, S^2 = Z$$
 @[exercise]({
     "id": "single_qubit_gates__phase_i",
     "title": "Relative Phase i",
-    "path": "./phase_i/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./phase_i/"
 })
 
 @[exercise]({
     "id": "single_qubit_gates__three_quarters_pi_phase",
     "title": "Three-Fourths Phase",
-    "path": "./three_quarters_pi_phase/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./three_quarters_pi_phase/"
 })
 
 @[section]({
@@ -593,37 +563,25 @@ $$X = iR_x(\pi), Y = iR_y(\pi), Z = iR_z(\pi)$$
 @[exercise]({
     "id": "single_qubit_gates__complex_phase",
     "title": "Complex Relative Phase",
-    "path": "./complex_phase/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./complex_phase/"
 })
 
 @[exercise]({
     "id": "single_qubit_gates__amplitude_change",
     "title": "Amplitude Change",
-    "path": "./amplitude_change/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./amplitude_change/"
 })
 
 @[exercise]({
     "id": "single_qubit_gates__prepare_rotated_state",
     "title": "Prepare Rotated State",
-    "path": "./prepare_rotated_state/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./prepare_rotated_state/"
 })
 
 @[exercise]({
     "id": "single_qubit_gates__prepare_arbitrary_state",
     "title": "Prepare Arbitrary State",
-    "path": "./prepare_arbitrary_state/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./prepare_arbitrary_state/"
 })
 
 @[section]({

--- a/katas/content/single_qubit_measurements/index.md
+++ b/katas/content/single_qubit_measurements/index.md
@@ -107,10 +107,7 @@ Measurements can be used to distinguish orthogonal states. We start with an exer
 @[exercise]({
     "id": "single_qubit_measurements__distinguish_0_and_1",
     "title": "Distinguish |0〉 and |1〉",
-    "path": "./distinguish_0_and_1/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./distinguish_0_and_1/"
 })
 
 @[section]({
@@ -136,10 +133,7 @@ The probabilities of outcomes $\ket{b_0}$ and $\ket{b_1}$ will be defined as $|c
 @[exercise]({
     "id": "single_qubit_measurements__distinguish_plus_and_minus",
     "title": "Distinguish |+〉 and |-〉",
-    "path": "./distinguish_plus_and_minus/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./distinguish_plus_and_minus/"
 })
 
 @[section]({
@@ -295,28 +289,19 @@ This procedure can be used to distinguish arbitrary orthogonal states as well, a
 @[exercise]({
     "id": "single_qubit_measurements__distinguish_orthogonal_states_1",
     "title": "Distinguishing Orthogonal States: 1",
-    "path": "./distinguish_orthogonal_states_1/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./distinguish_orthogonal_states_1/"
 })
 
 @[exercise]({
     "id": "single_qubit_measurements__distinguish_orthogonal_states_2",
     "title": "Distinguishing Orthogonal States: 2",
-    "path": "./distinguish_orthogonal_states_2/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./distinguish_orthogonal_states_2/"
 })
 
 @[exercise]({
     "id": "single_qubit_measurements__a_b_basis_measurements",
     "title": "Measurement in the |A〉, |B〉 Basis",
-    "path": "./a_b_basis_measurements/",
-    "qsDependencies": [
-        "../KatasLibrary.qs"
-    ]
+    "path": "./a_b_basis_measurements/"
 })
 
 @[section]({

--- a/katas/content/superdense_coding/index.md
+++ b/katas/content/superdense_coding/index.md
@@ -20,38 +20,25 @@ We split the superdense coding protocol into several steps:
 @[exercise]({
     "id": "superdense_coding__entangled_pair",
     "title": "Entangled Pair",
-    "path": "entangled_pair",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "entangled_pair"
 })
 
 @[exercise]({
     "id": "superdense_coding__alice_sends_message",
     "title": "Alice's Task: Encode Message",
-    "path": "alice_sends_message",
-    "qsDependencies": [
-        "./Common.qs"
-    ]
+    "path": "alice_sends_message"
 })
 
 @[exercise]({
     "id": "superdense_coding__bob_decodes_message",
     "title": "Bob's Task: Decode Message",
-    "path": "bob_decodes_message",
-    "qsDependencies": [
-        "./Common.qs"
-    ]
+    "path": "bob_decodes_message"
 })
 
 @[exercise]({
     "id": "superdense_coding__protocol_e2e",
     "title": "Superdense Coding Protocol: End to End",
-    "path": "protocol_e2e",
-    "qsDependencies": [
-        "./Common.qs"
-    ]
+    "path": "protocol_e2e"
 })
 
 @[section]({

--- a/katas/content/teleportation/index.md
+++ b/katas/content/teleportation/index.md
@@ -27,61 +27,37 @@ We split the teleportation protocol into several steps:
 @[exercise]({
     "id": "teleportation__entangled_pair",
     "title": "Entangled Pair",
-    "path": "./entangled_pair/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./entangled_pair/"
 })
 
 @[exercise]({
     "id": "teleportation__send_message",
     "title": "Send Message (Alice's Task)",
-    "path": "./send_message/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./send_message/"
 })
 
 @[exercise]({
     "id": "teleportation__reconstruct_message",
     "title": "Reconstruct Message (Bob's Task)",
-    "path": "./reconstruct_message/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./reconstruct_message/"
 })
 
 @[exercise]({
     "id": "teleportation__standard_teleportation_protocol",
     "title": "Standard Teleportation Protocol",
-    "path": "./standard_teleportation_protocol/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./standard_teleportation_protocol/"
 })
 
 @[exercise]({
     "id": "teleportation__prepare_and_send_message",
     "title": "Prepare Message and Send It",
-    "path": "./prepare_and_send_message/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./prepare_and_send_message/"
 })
 
 @[exercise]({
     "id": "teleportation__reconstruct_and_measure_message",
     "title": "Reconstruct Message and Measure It",
-    "path": "./reconstruct_and_measure_message/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./reconstruct_and_measure_message/"
 })
 
 @[section]({
@@ -118,31 +94,19 @@ The goal is to transform Bob's qubit `qBob` into the state in which the message 
 @[exercise]({
     "id": "teleportation__reconstruct_message_phi_minus",
     "title": "Reconstruct Message with |Φ⁻⟩",
-    "path": "./reconstruct_message_phi_minus",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./reconstruct_message_phi_minus"
 })
 
 @[exercise]({
     "id": "teleportation__reconstruct_message_psi_plus",
     "title": "Reconstruct Message with |Ψ⁺⟩",
-    "path": "./reconstruct_message_psi_plus",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./reconstruct_message_psi_plus"
 })
 
 @[exercise]({
     "id": "teleportation__reconstruct_message_psi_minus",
     "title": "Reconstruct Message with |Ψ⁻⟩",
-    "path": "./reconstruct_message_psi_minus",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./reconstruct_message_psi_minus"
 })
 
 
@@ -159,31 +123,19 @@ There are multiple variants of teleportation protocol that involve more than two
 @[exercise]({
     "id": "teleportation__entanglement_swapping",
     "title": "Entanglement Swapping",
-    "path": "./entanglement_swapping/",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./entanglement_swapping/"
 })
 
 @[exercise]({
     "id": "teleportation__entangled_trio",
     "title": "Entangled Trio",
-    "path": "./entangled_trio",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./entangled_trio"
 })
 
 @[exercise]({
     "id": "teleportation__reconstruct_message_charlie",
     "title": "Reconstruct Message (Charlie's Task)",
-    "path": "./reconstruct_message_charlie",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./reconstruct_message_charlie"
 })
 
 @[section]({
@@ -200,11 +152,7 @@ However, teleportation protocol makes for a nice simple example of applying the 
 @[exercise]({
     "id": "teleportation__measurement_free_teleportation",
     "title": "Measurement-Free Teleportation",
-    "path": "./measurement_free_teleportation",
-    "qsDependencies": [
-        "../KatasLibrary.qs",
-        "./Common.qs"
-    ]
+    "path": "./measurement_free_teleportation"
 })
 
 @[section]({

--- a/npm/qsharp/generate_katas_content.js
+++ b/npm/qsharp/generate_katas_content.js
@@ -437,7 +437,7 @@ function createExerciseSection(kataPath, properties, globalCodeSources) {
   // Aggregate the exercise sources. The verification source file is Verification.qs.
   let resolvedVerificationFile = join(exercisePath, "Verification.qs");
 
-  // These are implicit dependencies (added to simplify dependency handling per https://github.com/microsoft/qsharp/issues/1640)
+  // Implicit dependencies to simplify dependency handling:
   // ../KatasLibrary.qs must be included
   // ./Common.qs must be included if present in current kata
   const implicitDependencies = ["../KatasLibrary.qs"];

--- a/npm/qsharp/generate_katas_content.js
+++ b/npm/qsharp/generate_katas_content.js
@@ -411,7 +411,7 @@ function createQuestion(kataPath, properties) {
 
 function createExerciseSection(kataPath, properties, globalCodeSources) {
   // Validate that the data contains the required properties.
-  const requiredProperties = ["id", "title", "path", "qsDependencies"];
+  const requiredProperties = ["id", "title", "path"];
   const missingProperties = identifyMissingProperties(
     properties,
     requiredProperties,
@@ -434,10 +434,18 @@ function createExerciseSection(kataPath, properties, globalCodeSources) {
   );
   const description = createTextContent(descriptionMarkdown);
 
-  // Aggregate the exercise sources. The verification source file is Verification.qs and additional dependecies are
-  // explicitly listed as source code file paths in the qsDependencies property.
+  // Aggregate the exercise sources. The verification source file is Verification.qs.
   let resolvedVerificationFile = join(exercisePath, "Verification.qs");
-  const resolvedDependencies = properties.qsDependencies.map((path) =>
+
+  // These are implicit dependencies (added to simplify dependency handling per https://github.com/microsoft/qsharp/issues/1640)
+  // ../KatasLibrary.qs must be included
+  // ./Common.qs must be included if present in current kata
+  const implicitDependencies = ["../KatasLibrary.qs"];
+  if (existsSync(join(kataPath, "./Common.qs"))) {
+    implicitDependencies.push("./Common.qs");
+  }
+
+  const resolvedDependencies = implicitDependencies.map((path) =>
     join(kataPath, path),
   );
   const resolvedSources = [resolvedVerificationFile].concat(


### PR DESCRIPTION
Link to the issue: https://github.com/microsoft/qsharp/issues/1640

The following changes were done:
1. qsDependencies property is no longer processing (generate_katas_content.js)
2. ../KatasLibrary.qs is included as implicit dependency
3. ./Common.qs is included as implicit dependency if present in current kata
4. All qsDependencies properties are removed from index.md's
5. README.md is updated - reference to qsDependencies is removed

Testing done:
1. "Happy path": Windows cmd build: "python ./build.py --wasm --npm --play" - success
   Local playground manual testing - no impact (Chrome and Edge)
2. No impact when qsDependencies are present in index.md
3. No impact when qsDependencies are present and empty in index.md

Question: should Ubuntu build be tested?