### PR TITLE
Removing pr ado entry

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -7,8 +7,6 @@ trigger:
     include:
     - main
 
-pr: none
-
 # Run the pipeline every day at 6:00 AM to ensure
 # codeql and other governance checks are up-to-date.
 schedules:


### PR DESCRIPTION
I believe the `pr` entry is acting as an implicit filter preventing triggers on merges to main. 