### PR TITLE
Fix display of CCX in a Circuit

### DIFF
--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -71,6 +71,33 @@ fn one_gate() {
 }
 
 #[test]
+fn toffoli() {
+    let mut interpreter = interpreter(
+        r"
+            namespace Test {
+                @EntryPoint()
+                operation Main() : Unit {
+                    use q = Qubit[3];
+                    CCNOT(q[0], q[1], q[2]);
+                }
+            }
+        ",
+        Profile::Unrestricted,
+    );
+
+    let circ = interpreter
+        .circuit(CircuitEntryPoint::EntryPoint, false)
+        .expect("circuit generation should succeed");
+
+    expect![[r"
+        q_0    ── ● ──
+        q_1    ── ● ──
+        q_2    ── X ──
+    "]]
+    .assert_eq(&circ.to_string());
+}
+
+#[test]
 fn rotation_gate() {
     let mut interpreter = interpreter(
         r"

--- a/compiler/qsc_circuit/src/builder.rs
+++ b/compiler/qsc_circuit/src/builder.rs
@@ -26,7 +26,7 @@ impl Backend for Builder {
         let ctl0 = self.map(ctl0);
         let ctl1 = self.map(ctl1);
         let q = self.map(q);
-        self.push_gate(controlled_gate("CX", [ctl0, ctl1], [q]));
+        self.push_gate(controlled_gate("X", [ctl0, ctl1], [q]));
     }
 
     fn cx(&mut self, ctl: usize, q: usize) {


### PR DESCRIPTION
A Toffoli/CCX in Q# code is currently displayed by the circuit generation code as a controlled-controlled-CNOT instead of a controlled-controlled-X.

I tried to add a test for this, but I'm not sure if I added it in the right place.

### Testing
Ran `cargo test` and `pytest` (including the integration tests dependent on qir-runner and pyqir)

Also manually tested with this script:
```python
import qsharp

qsharp.eval('''
open Microsoft.Quantum.Arrays;

operation Example() : Result[] {
    use q = Qubit[3];
    ApplyToEach(X, Most(q));
    CCNOT(q[0], q[1], q[2]);
    MResetEachZ(q)
}
''')

print(qsharp.circuit('Example()'))
```

which originally printed out:
```
q_0    ── X ──── ● ──── M ─── |0〉 ─                                                                                                                                                                               
                 │      ╘══════════
q_1    ── X ──── ● ──── M ─── |0〉 ─
                 │      ╘══════════
q_2    ──────── CX ──── M ─── |0〉 ─
                        ╘══════════
```
but now it prints out the following as expected:
```
q_0    ── X ──── ● ──── M ─── |0〉 ─
                 │      ╘══════════
q_1    ── X ──── ● ──── M ─── |0〉 ─
                 │      ╘══════════
q_2    ───────── X ──── M ─── |0〉 ─
                        ╘══════════
```