### PR TITLE
support imports and exports in the formatter

### DIFF
--- a/compiler/qsc_formatter/src/formatter.rs
+++ b/compiler/qsc_formatter/src/formatter.rs
@@ -292,7 +292,7 @@ impl<'a> Formatter<'a> {
                 }
                 // else do nothing, preserving the user's spaces before the comment
             }
-            (Syntax(cooked_left), Syntax(cooked_right)) => match (&cooked_left, cooked_right) {
+            (Syntax(cooked_left), Syntax(cooked_right)) => match (cooked_left, cooked_right) {
                 (ClosedBinOp(ClosedBinOp::Minus), _) | (_, ClosedBinOp(ClosedBinOp::Minus)) => {
                     // This case is used to ignore the spacing around a `-`.
                     // This is done because we currently don't have the architecture
@@ -566,21 +566,14 @@ impl<'a> Formatter<'a> {
         use ConcreteTokenKind::*;
         use TokenKind::*;
 
-        // Based on the left-hand-side token, we determine if:
-        // 1. we are ending a type parameter list context
-        // 2. we are ending an import/export context
-        // 3. we are starting an import/export context
-        match left_kind {
-            // If we are leaving a type param list, reset the state
-            Syntax(Gt)
-                if matches!(
-                    self.type_param_state,
-                    TypeParameterListState::InTypeParamList
-                ) =>
-            {
-                self.type_param_state = TypeParameterListState::NoState;
-            }
-            _ => (),
+        // If we are leaving a type param list, reset the state
+        if matches!(left_kind, Syntax(Gt))
+            && matches!(
+                self.type_param_state,
+                TypeParameterListState::InTypeParamList
+            )
+        {
+            self.type_param_state = TypeParameterListState::NoState;
         }
 
         match right_kind {

--- a/compiler/qsc_formatter/src/formatter.rs
+++ b/compiler/qsc_formatter/src/formatter.rs
@@ -147,7 +147,7 @@ enum TypeParameterListState {
 
 /// Whether or not we are currently handling an import or export statement.
 #[derive(Clone, Copy)]
-enum WhethImportExportState {
+enum ImportExportState {
     /// Yes, this is an import or export statement.
     HandlingImportExportStatement,
     /// No, this is not an import or export statement.
@@ -766,6 +766,8 @@ fn is_newline_keyword_or_ampersat(cooked: &TokenKind) -> bool {
                     | Use
                     | Borrow
                     | Fixup
+                    | Import
+                    | Export
             )
     )
 }

--- a/compiler/qsc_formatter/src/formatter.rs
+++ b/compiler/qsc_formatter/src/formatter.rs
@@ -144,9 +144,13 @@ enum TypeParameterListState {
     /// starting `<`.
     InTypeParamList,
 }
+
+/// Whether or not we are currently handling an import or export statement.
 #[derive(Clone, Copy)]
-enum ImportExportState {
+enum WhethImportExportState {
+    /// Yes, this is an import or export statement.
     HandlingImportExportStatement,
+    /// No, this is not an import or export statement.
     NoState,
 }
 

--- a/compiler/qsc_formatter/src/formatter.rs
+++ b/compiler/qsc_formatter/src/formatter.rs
@@ -470,9 +470,6 @@ impl<'a> Formatter<'a> {
                 (_, Keyword(Keyword::Is)) => {
                     effect_single_space(left, whitespace, right, &mut edits);
                 }
-                (_, Keyword(Keyword::Export | Keyword::Import)) => {
-                    effect_single_space(left, whitespace, right, &mut edits);
-                }
                 (_, Keyword(keyword)) if is_starter_keyword(keyword) => {
                     effect_single_space(left, whitespace, right, &mut edits);
                 }

--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -1253,10 +1253,7 @@ fn format_glob_import() {
 fn no_newlines_glob() {
     let input = "import foo, bar, baz.quux.*;";
 
-    check(
-        input,
-        &expect!["import foo, bar, baz.quux. *;"],
-    );
+    check(input, &expect!["import foo, bar, baz.quux. *;"]);
 }
 
 #[test]

--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -1223,3 +1223,52 @@ fn sample_has_no_formatting_changes() {
         "#};
     assert!(super::calculate_format_edits(input).is_empty());
 }
+
+#[test]
+fn format_export_statement_no_newlines() {
+    let input = "export Microsoft.Quantum.Diagnostics, Foo.Bar.Baz;";
+
+    check(
+        input,
+        &expect![["export Microsoft.Quantum.Diagnostics, Foo.Bar.Baz;"]],
+    );
+}
+
+#[test]
+fn format_glob_import() {
+    let input = "import
+    Microsoft.Quantum.*, 
+        Foo.Bar.Baz as SomethingElse,
+        AnotherThing;";
+
+    check(
+        input,
+        &expect![[r#"
+            import Microsoft.Quantum. *,
+                Foo.Bar.Baz as SomethingElse,
+                AnotherThing;"#]],
+    );
+}
+#[test]
+fn no_newlines_glob() {
+    let input = "import foo, bar, baz.quux.*;";
+
+    check(
+        input,
+        &expect!["import foo, bar, baz.quux. *;"],
+    );
+}
+
+#[test]
+fn format_export_statement_newlines() {
+    let input = "export 
+    Microsoft.Quantum.Diagnostics, 
+        Foo.Bar.Baz;";
+
+    check(
+        input,
+        &expect![[r#"
+            export Microsoft.Quantum.Diagnostics,
+                Foo.Bar.Baz;"#]],
+    );
+}

--- a/compiler/qsc_formatter/src/formatter/tests.rs
+++ b/compiler/qsc_formatter/src/formatter/tests.rs
@@ -1244,7 +1244,8 @@ fn format_glob_import() {
     check(
         input,
         &expect![[r#"
-            import Microsoft.Quantum. *,
+            import
+                Microsoft.Quantum.*,
                 Foo.Bar.Baz as SomethingElse,
                 AnotherThing;"#]],
     );
@@ -1253,7 +1254,7 @@ fn format_glob_import() {
 fn no_newlines_glob() {
     let input = "import foo, bar, baz.quux.*;";
 
-    check(input, &expect!["import foo, bar, baz.quux. *;"]);
+    check(input, &expect!["import foo, bar, baz.quux.*;"]);
 }
 
 #[test]
@@ -1265,7 +1266,119 @@ fn format_export_statement_newlines() {
     check(
         input,
         &expect![[r#"
-            export Microsoft.Quantum.Diagnostics,
+            export
+                Microsoft.Quantum.Diagnostics,
                 Foo.Bar.Baz;"#]],
+    );
+}
+
+#[test]
+fn export_fmt_within_namespace() {
+    let input = r#"
+
+namespace Microsoft.Quantum.Arrays {
+    
+
+    export
+    All,
+    Any,
+    Chunks,
+    CircularlyShifted,
+    ColumnAt,
+    Count,
+    Diagonal,
+    DrawMany,
+    Enumerated,
+    Excluding,
+    Filtered,
+    FlatMapped,
+    Flattened,
+    Fold,
+    ForEach,
+    Head,
+    HeadAndRest,
+    IndexOf,
+    IndexRange,
+    Interleaved,
+    IsEmpty,
+    IsRectangularArray,
+    IsSorted,
+    IsSquareArray,
+    Mapped,
+    MappedByIndex,
+    MappedOverRange,
+    Most,
+    MostAndTail,
+    Padded,
+    Partitioned,
+    Rest,
+    Reversed,
+    SequenceI,
+    SequenceL,
+    Sorted,
+    Subarray,
+    Swapped,
+    Transposed,
+    Tail,
+    Unzipped,
+    Where,
+    Windows,
+    Zipped;
+}
+"#;
+
+    check(
+        input,
+        &expect![[r#"
+        namespace Microsoft.Quantum.Arrays {
+
+
+            export
+                All,
+                Any,
+                Chunks,
+                CircularlyShifted,
+                ColumnAt,
+                Count,
+                Diagonal,
+                DrawMany,
+                Enumerated,
+                Excluding,
+                Filtered,
+                FlatMapped,
+                Flattened,
+                Fold,
+                ForEach,
+                Head,
+                HeadAndRest,
+                IndexOf,
+                IndexRange,
+                Interleaved,
+                IsEmpty,
+                IsRectangularArray,
+                IsSorted,
+                IsSquareArray,
+                Mapped,
+                MappedByIndex,
+                MappedOverRange,
+                Most,
+                MostAndTail,
+                Padded,
+                Partitioned,
+                Rest,
+                Reversed,
+                SequenceI,
+                SequenceL,
+                Sorted,
+                Subarray,
+                Swapped,
+                Transposed,
+                Tail,
+                Unzipped,
+                Where,
+                Windows,
+                Zipped;
+        }
+    "#]],
     );
 }


### PR DESCRIPTION
This is one of the changes required for the imports/exports feature work, and this is particularly important for the standard library, which will make extensive use of long export lists and needs to be formatted well.

This PR adds a new context, similar to the existing open/close delim contexts, that is defined by `import` or `export`...`;`. 

If there is a newline after the `import` or `export` keyword, then we format with newlines. Otherwise, puts it all on one line. See the tests for examples.


before:
```qsharp

export
Foo,
Bar,
Baz;
```


after:
```qsharp
export
    Foo,
    Bar,
    Baz;
```
OR, in single-line mode,

```qsharp
export Foo, Bar, Baz;
```