### PR TITLE
Don't throw missing entrypoint error if package type is library

### DIFF
--- a/compiler/qsc/src/packages/tests.rs
+++ b/compiler/qsc/src/packages/tests.rs
@@ -22,6 +22,7 @@ fn mock_program() -> Project {
                     Arc::from("SomeLibraryAlias"),
                     Arc::from("SomeLibraryKey"),
                 )]),
+                package_type: Some(qsc_project::PackageType::Exe),
             },
             packages: FxHashMap::from_iter(vec![(
                 Arc::from("SomeLibraryKey"),
@@ -32,6 +33,7 @@ fn mock_program() -> Project {
                     )],
                     language_features: LanguageFeatures::default(),
                     dependencies: FxHashMap::default(),
+                    package_type: Some(qsc_project::PackageType::Lib),
                 },
             )]),
         },

--- a/compiler/qsc_project/src/lib.rs
+++ b/compiler/qsc_project/src/lib.rs
@@ -19,7 +19,7 @@ pub use error::StdFsError;
 #[cfg(feature = "fs")]
 pub use fs::StdFs;
 pub use js::{JSFileEntry, JSProjectHost};
-pub use manifest::{Manifest, ManifestDescriptor, PackageRef, MANIFEST_FILE_NAME};
+pub use manifest::{Manifest, ManifestDescriptor, PackageRef, PackageType, MANIFEST_FILE_NAME};
 pub use project::FileSystemAsync;
 pub use project::{
     key_for_package_ref, package_ref_from_key, DirEntry, EntryType, Error, FileSystem,

--- a/compiler/qsc_project/src/manifest.rs
+++ b/compiler/qsc_project/src/manifest.rs
@@ -30,6 +30,16 @@ pub struct Manifest {
     pub dependencies: FxHashMap<String, PackageRef>,
     #[serde(default)]
     pub files: Vec<String>,
+    #[serde(default)]
+    pub package_type: Option<PackageType>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+pub enum PackageType {
+    #[serde(rename = "exe")]
+    Exe,
+    #[serde(rename = "lib")]
+    Lib,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/compiler/qsc_project/src/project.rs
+++ b/compiler/qsc_project/src/project.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::{manifest::GitHubRef, Manifest, ManifestDescriptor, PackageRef};
+use crate::{
+    manifest::{GitHubRef, PackageType},
+    Manifest, ManifestDescriptor, PackageRef,
+};
 use async_trait::async_trait;
 use futures::FutureExt;
 use miette::Diagnostic;
@@ -48,6 +51,7 @@ impl Project {
                     sources: vec![(name.clone(), contents)],
                     language_features: LanguageFeatures::default(),
                     dependencies: FxHashMap::default(),
+                    package_type: None,
                 },
                 packages: FxHashMap::default(),
             },
@@ -380,6 +384,7 @@ pub trait FileSystemAsync {
             sources,
             language_features: LanguageFeatures::from_iter(&manifest.manifest.language_features),
             dependencies,
+            package_type: manifest.manifest.package_type,
         })
     }
 
@@ -448,6 +453,7 @@ pub trait FileSystemAsync {
                 .into_iter()
                 .map(|(k, v)| (k.into(), key_for_package_ref(&v)))
                 .collect(),
+            package_type: manifest.package_type,
         })
     }
 
@@ -585,6 +591,7 @@ pub struct PackageInfo {
     pub sources: Sources,
     pub language_features: LanguageFeatures,
     pub dependencies: FxHashMap<PackageAlias, PackageKey>,
+    pub package_type: Option<PackageType>,
 }
 
 #[derive(Clone, Debug)]
@@ -655,12 +662,14 @@ impl PackageGraphSources {
     pub fn with_no_dependencies(
         sources: Vec<(Arc<str>, Arc<str>)>,
         language_features: LanguageFeatures,
+        package_type: Option<PackageType>,
     ) -> Self {
         Self {
             root: PackageInfo {
                 sources,
                 language_features,
                 dependencies: FxHashMap::default(),
+                package_type,
             },
             packages: FxHashMap::default(),
         }

--- a/compiler/qsc_project/src/tests.rs
+++ b/compiler/qsc_project/src/tests.rs
@@ -38,6 +38,7 @@ fn basic_manifest() {
                             0,
                         ),
                         dependencies: {},
+                        package_type: None,
                     },
                     packages: {},
                 },
@@ -75,6 +76,7 @@ fn circular_imports() {
                             0,
                         ),
                         dependencies: {},
+                        package_type: None,
                     },
                     packages: {},
                 },
@@ -112,6 +114,7 @@ fn different_files_same_manifest() {
                             0,
                         ),
                         dependencies: {},
+                        package_type: None,
                     },
                     packages: {},
                 },
@@ -141,6 +144,7 @@ fn empty_manifest() {
                             0,
                         ),
                         dependencies: {},
+                        package_type: None,
                     },
                     packages: {},
                 },
@@ -182,6 +186,7 @@ fn folder_structure() {
                             0,
                         ),
                         dependencies: {},
+                        package_type: None,
                     },
                     packages: {},
                 },
@@ -218,6 +223,7 @@ fn hidden_files() {
                             0,
                         ),
                         dependencies: {},
+                        package_type: None,
                     },
                     packages: {},
                 },
@@ -258,6 +264,7 @@ fn peer_file() {
                             0,
                         ),
                         dependencies: {},
+                        package_type: None,
                     },
                     packages: {},
                 },
@@ -287,6 +294,7 @@ fn language_feature() {
                             1,
                         ),
                         dependencies: {},
+                        package_type: None,
                     },
                     packages: {},
                 },
@@ -318,6 +326,7 @@ fn with_local_dep() {
                         dependencies: {
                             "MyDep": "{\"path\":\"local_dep\"}",
                         },
+                        package_type: None,
                     },
                     packages: {
                         "{\"path\":\"local_dep\"}": PackageInfo {
@@ -331,6 +340,7 @@ fn with_local_dep() {
                                 0,
                             ),
                             dependencies: {},
+                            package_type: None,
                         },
                     },
                 },
@@ -362,6 +372,7 @@ fn transitive_dep() {
                         dependencies: {
                             "MyDep": "{\"path\":\"with_local_dep\"}",
                         },
+                        package_type: None,
                     },
                     packages: {
                         "{\"path\":\"local_dep\"}": PackageInfo {
@@ -375,6 +386,7 @@ fn transitive_dep() {
                                 0,
                             ),
                             dependencies: {},
+                            package_type: None,
                         },
                         "{\"path\":\"with_local_dep\"}": PackageInfo {
                             sources: [
@@ -389,6 +401,7 @@ fn transitive_dep() {
                             dependencies: {
                                 "MyDep": "{\"path\":\"local_dep\"}",
                             },
+                            package_type: None,
                         },
                     },
                 },
@@ -418,6 +431,7 @@ fn explicit_files_list() {
                             0,
                         ),
                         dependencies: {},
+                        package_type: None,
                     },
                     packages: {},
                 },
@@ -449,6 +463,7 @@ fn circular_dep() {
                         dependencies: {
                             "MyCircularDep": "{\"path\":\"circular_dep\"}",
                         },
+                        package_type: None,
                     },
                     packages: {},
                 },

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -228,6 +228,12 @@ impl<'a> CompilationStateUpdater<'a> {
                     loaded_project.package_graph_sources.root.language_features,
                 ),
                 lints_config: loaded_project.lints,
+                package_type: loaded_project.package_graph_sources.root.package_type.map(
+                    |x| match x {
+                        qsc_project::PackageType::Exe => qsc::PackageType::Exe,
+                        qsc_project::PackageType::Lib => qsc::PackageType::Lib,
+                    },
+                ),
                 ..PartialConfiguration::default()
             };
 

--- a/language_service/src/test_utils.rs
+++ b/language_service/src/test_utils.rs
@@ -92,6 +92,7 @@ fn compile_project_with_fake_stdlib_and_markers_cursor_optional(
                         sources,
                         language_features: LanguageFeatures::default(),
                         dependencies: FxHashMap::default(),
+                        package_type: None,
                     },
                     packages: FxHashMap::default(),
                 },

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -125,6 +125,7 @@ impl Interpreter {
             let graph = PackageGraphSources::with_no_dependencies(
                 Vec::default(),
                 LanguageFeatures::from_iter(language_features),
+                None,
             );
             BuildableProgram::new(target.into(), graph)
         };

--- a/wasm/src/project_system.rs
+++ b/wasm/src/project_system.rs
@@ -227,6 +227,13 @@ impl From<qsc_project::PackageInfo> for PackageInfo {
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
+            package_type: value.package_type.map(|x| {
+                match x {
+                    qsc_project::PackageType::Exe => "exe",
+                    qsc_project::PackageType::Lib => "lib",
+                }
+                .into()
+            }),
         }
     }
 }
@@ -266,11 +273,15 @@ serializable_type! {
         pub sources: Vec<(String, String)>,
         pub language_features: Vec<String>,
         pub dependencies: FxHashMap<PackageAlias,PackageKey>,
+        pub package_type: Option<String>,
     },
-    r#"export interface IPackageInfo {
+    r#"
+    
+    export interface IPackageInfo {
         sources: [string, string][];
         languageFeatures: string[];
         dependencies: Record<string,string>;
+        packageType?: "exe" | "lib";
     }"#
 }
 
@@ -351,6 +362,13 @@ impl From<PackageInfo> for qsc_project::PackageInfo {
                 .into_iter()
                 .map(|(k, v)| (Arc::from(k), Arc::from(v)))
                 .collect(),
+            package_type: value.package_type.map(|x| match x.as_str() {
+                "exe" => qsc_project::PackageType::Exe,
+                "lib" => qsc_project::PackageType::Lib,
+                _ => unreachable!(
+                    "expected one of 'exe' or 'lib' -- should be guaranteed by TS types"
+                ),
+            }),
         }
     }
 }


### PR DESCRIPTION
The `packageType` property was not getting properly propagated from the manifest all the way to the `PackageInfo`. This PR fixes that.


https://github.com/microsoft/qsharp/assets/12157751/33395cde-5d81-4ff1-8b7c-d27400ac4edd

