### PR TITLE
Reverse types in error message for struct field assign.

### DIFF
--- a/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/compiler/qsc_frontend/src/typeck/infer.rs
@@ -925,10 +925,10 @@ fn check_has_field(
             match udts.get(id).and_then(|udt| udt.field_ty_by_name(&name)) {
                 Some(ty) => (
                     vec![Constraint::Eq {
-                        expected: item,
-                        actual: id
+                        expected: id
                             .package
                             .map_or_else(|| ty.clone(), |package_id| ty.with_package(package_id)),
+                        actual: item,
                         span,
                     }],
                     Vec::new(),

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -2244,7 +2244,7 @@ fn struct_cons_wrong_input() {
             #25 88-124 "new Pair { First = 5.0, Second = 6 }" : UDT<"Pair": Item 1>
             #30 107-110 "5.0" : Double
             #33 121-122 "6" : Int
-            Error(Type(Error(TyMismatch("Double", "Int", Span { lo: 99, hi: 110 }))))
+            Error(Type(Error(TyMismatch("Int", "Double", Span { lo: 99, hi: 110 }))))
         "#]],
     );
 }


### PR DESCRIPTION
The types listed for the error messages when assigning the wrong type to a struct field during construction were reversed.

This fixes that issue by swapping "actual" and "expected" the types.