### PR TITLE
Fix rendering read-only source buffer for Github dependencies that are in subdirectories of repos

### DIFF
--- a/compiler/qsc_project/src/project.rs
+++ b/compiler/qsc_project/src/project.rs
@@ -414,8 +414,15 @@ pub trait FileSystemAsync {
         let manifest = serde_json::from_str::<Manifest>(&manifest_content).map_err(|e| {
             Error::GitHubManifestParse {
                 path: format!(
-                    "qsharp-github-source:{}/{}/{}/{path_trimmed_seps}/qsharp.json",
-                    dep.owner, dep.repo, dep.r#ref
+                    "qsharp-github-source:{}/{}/{}{}/qsharp.json",
+                    dep.owner,
+                    dep.repo,
+                    dep.r#ref,
+                    if path_trimmed_seps.is_empty() {
+                        String::new()
+                    } else {
+                        format!("/{path_trimmed_seps}")
+                    }
                 ),
                 owner: dep.owner.clone(),
                 repo: dep.repo.clone(),
@@ -426,7 +433,11 @@ pub trait FileSystemAsync {
         // Look at the files field in the manifest to find the sources.
         let mut sources = vec![];
         for file in &manifest.files {
-            let path = format!("{path_trimmed_seps}/{file}");
+            let path = if path_trimmed_seps.is_empty() {
+                format!("/{file}")
+            } else {
+                format!("/{path_trimmed_seps}/{file}")
+            };
             let contents = self
                 .fetch_github(&dep.owner, &dep.repo, &dep.r#ref, &path)
                 .await


### PR DESCRIPTION
There was just one missing slash! Tested locally: go-to-def,  debugging, stepping into, etc all work.


