### PR TITLE
Fix panic in hover on local variables of notebook cell

### DIFF
--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -1596,3 +1596,16 @@ fn notebook_callable_defined_in_later_cell() {
         ("cell2", "operation Callee() : Unit {}"),
     ]);
 }
+
+#[test]
+fn notebook_local_definition() {
+    check_notebook(
+        &[("cell1", "let x = 3;"), ("cell2", "let ◉↘y◉ = x + 1;")],
+        &expect![[r#"
+            local
+            ```qsharp
+            y : Int
+            ```
+        "#]],
+    );
+}


### PR DESCRIPTION
There was an assumption baked into the hover support that locals will always come from a callable scope, but in notebooks they can come from fragments with top-level statements. This avoids the panic by treating the callable name as optional until it is required for display.