### PR TITLE
Languages Service loads project and dependencies in Notebooks

### DIFF
--- a/compiler/qsc_project/src/project.rs
+++ b/compiler/qsc_project/src/project.rs
@@ -19,7 +19,7 @@ use std::{
 use thiserror::Error;
 
 /// Describes a Q# project with all its sources and dependencies resolved.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Project {
     /// Friendly name, typically based on project directory name
     /// Not guaranteed to be unique. Don't use as a key.

--- a/language_service/src/code_lens.rs
+++ b/language_service/src/code_lens.rs
@@ -20,7 +20,7 @@ pub(crate) fn get_code_lenses(
     source_name: &str,
     position_encoding: Encoding,
 ) -> Vec<CodeLens> {
-    if matches!(compilation.kind, CompilationKind::Notebook) {
+    if matches!(compilation.kind, CompilationKind::Notebook { .. }) {
         // entrypoint actions don't work in notebooks
         return vec![];
     }

--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -167,9 +167,9 @@ impl Compilation {
             Ok(compiler) => compiler,
             Err(user_errors) => {
                 errors.extend(user_errors);
-                // Because there were errors in the leaf project, we need to create a new compiler with no sources
+                // Because there were errors in the user code project, we need to create a new compiler with no sources
                 // to do a best effort compilation of the cells.
-                trace!("falling back stdlib only only after leaf project errors");
+                trace!("falling back stdlib only only after user code project errors");
                 let (std_id, store) =
                     qsc::compile::package_store_with_stdlib(target_profile.into());
 

--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -54,7 +54,9 @@ pub(crate) fn get_completions(
         // Since notebooks don't typically contain namespace declarations,
         // open statements should just get before the first non-whitespace
         // character (i.e. at the top of the cell)
-        CompilationKind::Notebook => Some(get_first_non_whitespace_in_source(compilation, offset)),
+        CompilationKind::Notebook { .. } => {
+            Some(get_first_non_whitespace_in_source(compilation, offset))
+        }
     };
 
     let insert_open_range = insert_open_at.map(|o| {
@@ -124,7 +126,7 @@ pub(crate) fn get_completions(
         }
         Context::NoCompilation | Context::TopLevel => match compilation.kind {
             CompilationKind::OpenProject { .. } => builder.push_namespace_keyword(),
-            CompilationKind::Notebook => {
+            CompilationKind::Notebook { .. } => {
                 // For notebooks, the top-level allows for
                 // more syntax.
 

--- a/language_service/src/lib.rs
+++ b/language_service/src/lib.rs
@@ -429,13 +429,17 @@ async fn apply_update(updater: &mut CompilationStateUpdater<'_>, update: Update)
             notebook_uri,
             notebook_metadata,
             cells,
-        } => updater.update_notebook_document(
-            &notebook_uri,
-            &notebook_metadata,
-            cells
-                .iter()
-                .map(|(uri, version, contents)| (uri.as_ref(), *version, contents.as_ref())),
-        ),
+        } => {
+            updater
+                .update_notebook_document(
+                    &notebook_uri,
+                    &notebook_metadata,
+                    cells.iter().map(|(uri, version, contents)| {
+                        (uri.as_ref(), *version, contents.as_ref())
+                    }),
+                )
+                .await;
+        }
         Update::CloseNotebookDocument { notebook_uri } => {
             updater.close_notebook_document(&notebook_uri);
         }

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -166,6 +166,7 @@ pub struct NotebookMetadata {
     pub target_profile: Option<Profile>,
     pub language_features: LanguageFeatures,
     pub manifest: Option<Manifest>,
+    pub project_root: Option<String>,
 }
 
 #[derive(Debug)]

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -605,20 +605,22 @@ async fn target_profile_update_causes_error_in_stdlib() {
     );
 }
 
-#[test]
-fn notebook_document_no_errors() {
+#[tokio::test]
+async fn notebook_document_no_errors() {
     let errors = RefCell::new(Vec::new());
     let mut updater = new_updater(&errors);
 
-    updater.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [
-            ("cell1", 1, "operation Main() : Unit {}"),
-            ("cell2", 1, "Main()"),
-        ]
-        .into_iter(),
-    );
+    updater
+        .update_notebook_document(
+            "notebook.ipynb",
+            &NotebookMetadata::default(),
+            [
+                ("cell1", 1, "operation Main() : Unit {}"),
+                ("cell2", 1, "Main()"),
+            ]
+            .into_iter(),
+        )
+        .await;
 
     expect_errors(
         &errors,
@@ -628,20 +630,22 @@ fn notebook_document_no_errors() {
     );
 }
 
-#[test]
-fn notebook_document_errors() {
+#[tokio::test]
+async fn notebook_document_errors() {
     let errors = RefCell::new(Vec::new());
     let mut updater = new_updater(&errors);
 
-    updater.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [
-            ("cell1", 1, "operation Main() : Unit {}"),
-            ("cell2", 1, "Foo()"),
-        ]
-        .into_iter(),
-    );
+    updater
+        .update_notebook_document(
+            "notebook.ipynb",
+            &NotebookMetadata::default(),
+            [
+                ("cell1", 1, "operation Main() : Unit {}"),
+                ("cell2", 1, "Foo()"),
+            ]
+            .into_iter(),
+        )
+        .await;
 
     expect_errors(
         &errors,
@@ -688,20 +692,22 @@ fn notebook_document_errors() {
     );
 }
 
-#[test]
-fn notebook_document_lints() {
+#[tokio::test]
+async fn notebook_document_lints() {
     let errors = RefCell::new(Vec::new());
     let mut updater = new_updater(&errors);
 
-    updater.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [
-            ("cell1", 1, "function Foo() : Unit { let x = 4;;;; }"),
-            ("cell2", 1, "function Bar() : Unit { let y = 5 / 0; }"),
-        ]
-        .into_iter(),
-    );
+    updater
+        .update_notebook_document(
+            "notebook.ipynb",
+            &NotebookMetadata::default(),
+            [
+                ("cell1", 1, "function Foo() : Unit { let x = 4;;;; }"),
+                ("cell2", 1, "function Bar() : Unit { let y = 5 / 0; }"),
+            ]
+            .into_iter(),
+        )
+        .await;
 
     expect_errors(
         &errors,
@@ -768,20 +774,22 @@ fn notebook_document_lints() {
     );
 }
 
-#[test]
-fn notebook_update_remove_cell_clears_errors() {
+#[tokio::test]
+async fn notebook_update_remove_cell_clears_errors() {
     let errors = RefCell::new(Vec::new());
     let mut updater = new_updater(&errors);
 
-    updater.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [
-            ("cell1", 1, "operation Main() : Unit {}"),
-            ("cell2", 1, "Foo()"),
-        ]
-        .into_iter(),
-    );
+    updater
+        .update_notebook_document(
+            "notebook.ipynb",
+            &NotebookMetadata::default(),
+            [
+                ("cell1", 1, "operation Main() : Unit {}"),
+                ("cell2", 1, "Foo()"),
+            ]
+            .into_iter(),
+        )
+        .await;
 
     expect_errors(
         &errors,
@@ -827,11 +835,13 @@ fn notebook_update_remove_cell_clears_errors() {
         "#]],
     );
 
-    updater.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [("cell1", 1, "operation Main() : Unit {}")].into_iter(),
-    );
+    updater
+        .update_notebook_document(
+            "notebook.ipynb",
+            &NotebookMetadata::default(),
+            [("cell1", 1, "operation Main() : Unit {}")].into_iter(),
+        )
+        .await;
 
     expect_errors(
         &errors,
@@ -848,20 +858,22 @@ fn notebook_update_remove_cell_clears_errors() {
     );
 }
 
-#[test]
-fn close_notebook_clears_errors() {
+#[tokio::test]
+async fn close_notebook_clears_errors() {
     let errors = RefCell::new(Vec::new());
     let mut updater = new_updater(&errors);
 
-    updater.update_notebook_document(
-        "notebook.ipynb",
-        &NotebookMetadata::default(),
-        [
-            ("cell1", 1, "operation Main() : Unit {}"),
-            ("cell2", 1, "Foo()"),
-        ]
-        .into_iter(),
-    );
+    updater
+        .update_notebook_document(
+            "notebook.ipynb",
+            &NotebookMetadata::default(),
+            [
+                ("cell1", 1, "operation Main() : Unit {}"),
+                ("cell2", 1, "Foo()"),
+            ]
+            .into_iter(),
+        )
+        .await;
 
     expect_errors(
         &errors,

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -973,9 +973,12 @@ async fn update_notebook_with_valid_dependencies() {
         )
         .await;
 
-    expect_errors(&errors, &expect![[r#"
+    expect_errors(
+        &errors,
+        &expect![[r#"
         []
-    "#]]);
+    "#]],
+    );
 }
 
 #[tokio::test]
@@ -1015,7 +1018,9 @@ async fn update_notebook_reports_errors_from_dependencies() {
         )
         .await;
 
-    expect_errors(&errors, &expect![[r#"
+    expect_errors(
+        &errors,
+        &expect![[r#"
         [
             (
                 "project/src/file.qs",
@@ -1041,38 +1046,44 @@ async fn update_notebook_reports_errors_from_dependencies() {
                 [],
             ),
         ]
-    "#]]);
+    "#]],
+    );
 }
 
 #[tokio::test]
 async fn update_notebook_reports_errors_from_dependency_of_dependencies() {
     let fs = FsNode::Dir(
-        [dir(
-            "project",
-            [
-                file("qsharp.json", r#"{ "dependencies" : { "MyDep" : { "path" : "../project2" } } }"#),
-                dir(
-                    "src",
-                    [file(
-                        "file.qs",
-                        r#"namespace Foo { function Bar() : Unit { } }"#,
-                    )],
-                ),
-            ],
-        ),
-        dir(
-            "project2",
-            [
-                file("qsharp.json", r#"{ }"#),
-                dir(
-                    "src",
-                    [file(
-                        "file.qs",
-                        r#"namespace Foo { function Baz() : Int { } }"#,
-                    )],
-                ),
-            ],
-        )]
+        [
+            dir(
+                "project",
+                [
+                    file(
+                        "qsharp.json",
+                        r#"{ "dependencies" : { "MyDep" : { "path" : "../project2" } } }"#,
+                    ),
+                    dir(
+                        "src",
+                        [file(
+                            "file.qs",
+                            r#"namespace Foo { function Bar() : Unit { } }"#,
+                        )],
+                    ),
+                ],
+            ),
+            dir(
+                "project2",
+                [
+                    file("qsharp.json", r#"{ }"#),
+                    dir(
+                        "src",
+                        [file(
+                            "file.qs",
+                            r#"namespace Foo { function Baz() : Int { } }"#,
+                        )],
+                    ),
+                ],
+            ),
+        ]
         .into_iter()
         .collect(),
     );
@@ -1094,7 +1105,9 @@ async fn update_notebook_reports_errors_from_dependency_of_dependencies() {
         )
         .await;
 
-    expect_errors(&errors, &expect![[r#"
+    expect_errors(
+        &errors,
+        &expect![[r#"
         [
             (
                 "project2/src/file.qs",
@@ -1120,7 +1133,8 @@ async fn update_notebook_reports_errors_from_dependency_of_dependencies() {
                 [],
             ),
         ]
-    "#]]);
+    "#]],
+    );
 }
 
 #[tokio::test]

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 // expect-test updates these strings automatically
-#![allow(clippy::needless_raw_string_hashes)]
+#![allow(clippy::needless_raw_string_hashes, clippy::too_many_lines)]
 
 use super::{CompilationState, CompilationStateUpdater};
 use crate::{
@@ -1021,32 +1021,94 @@ async fn update_notebook_reports_errors_from_dependencies() {
     expect_errors(
         &errors,
         &expect![[r#"
-        [
-            (
-                "project/src/file.qs",
-                None,
-                [
-                    Frontend(
-                        Error(
-                            Type(
-                                Error(
-                                    TyMismatch(
-                                        "Unit",
-                                        "Int",
+            [
+                (
+                    "cell1",
+                    Some(
+                        1,
+                    ),
+                    [
+                        Frontend(
+                            Error(
+                                Resolve(
+                                    NotFound(
+                                        "Foo",
                                         Span {
-                                            lo: 33,
-                                            hi: 36,
+                                            lo: 5,
+                                            hi: 8,
                                         },
                                     ),
                                 ),
                             ),
                         ),
-                    ),
-                ],
-                [],
-            ),
-        ]
-    "#]],
+                        Frontend(
+                            Error(
+                                Resolve(
+                                    NotFound(
+                                        "Foo",
+                                        Span {
+                                            lo: 5,
+                                            hi: 8,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Resolve(
+                                    NotFound(
+                                        "Bar",
+                                        Span {
+                                            lo: 9,
+                                            hi: 12,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Type(
+                                    Error(
+                                        AmbiguousTy(
+                                            Span {
+                                                lo: 9,
+                                                hi: 14,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                    [],
+                ),
+                (
+                    "project/src/file.qs",
+                    None,
+                    [
+                        Frontend(
+                            Error(
+                                Type(
+                                    Error(
+                                        TyMismatch(
+                                            "Unit",
+                                            "Int",
+                                            Span {
+                                                lo: 33,
+                                                hi: 36,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                    [],
+                ),
+            ]
+        "#]],
     );
 }
 

--- a/language_service/src/test_utils.rs
+++ b/language_service/src/test_utils.rs
@@ -165,7 +165,7 @@ where
         package_store,
         user_package_id: package_id,
         compile_errors: errors,
-        kind: CompilationKind::Notebook,
+        kind: CompilationKind::Notebook { project: None },
         project_errors: Vec::new(),
     }
 }

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -53,7 +53,8 @@ class Config:
 
         self._config["languageFeatures"] = language_features
         self._config["manifest"] = manifest
-        self._config["projectRoot"] = "file://" + project_root
+        if project_root:
+            self._config["projectRoot"] = "file://" + project_root
 
     def __repr__(self) -> str:
         return "Q# initialized with configuration: " + str(self._config)

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -54,6 +54,9 @@ class Config:
         self._config["languageFeatures"] = language_features
         self._config["manifest"] = manifest
         if project_root:
+            # For now, we only support local project roots, so use a file schema in the URI.
+            # In the future, we may support other schemes, such as github, if/when
+            # we have VS Code Web + Jupyter support.
             self._config["projectRoot"] = "file://" + project_root
 
     def __repr__(self) -> str:

--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -42,6 +42,7 @@ class Config:
         target_profile: TargetProfile,
         language_features: Optional[List[str]],
         manifest: Optional[str],
+        project_root: Optional[str],
     ):
         if target_profile == TargetProfile.Adaptive_RI:
             self._config = {"targetProfile": "adaptive_ri"}
@@ -52,6 +53,7 @@ class Config:
 
         self._config["languageFeatures"] = language_features
         self._config["manifest"] = manifest
+        self._config["projectRoot"] = "file://" + project_root
 
     def __repr__(self) -> str:
         return "Q# initialized with configuration: " + str(self._config)
@@ -132,7 +134,7 @@ def init(
 
     # Return the configuration information to provide a hint to the
     # language service through the cell output.
-    return Config(target_profile, language_features, manifest_contents)
+    return Config(target_profile, language_features, manifest_contents, project_root)
 
 
 def get_interpreter() -> Interpreter:

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -125,6 +125,7 @@ impl LanguageService {
                     .map(|s| Profile::from_str(&s).expect("invalid target profile")),
                 language_features: LanguageFeatures::from_iter(language_features),
                 manifest,
+                project_root: notebook_metadata.projectRoot,
             },
             cells
                 .iter()
@@ -566,11 +567,13 @@ serializable_type! {
         pub targetProfile: Option<String>,
         pub languageFeatures: Option<Vec<String>>,
         pub manifest: Option<String>,
+        pub projectRoot: Option<String>,
     },
     r#"export interface INotebookMetadata {
         targetProfile?: "base" | "adaptive_ri" | "unrestricted";
         languageFeatures?: "v2-preview-syntax"[];
         manifest?: string;
+        projectRoot?: string;
     }"#,
     INotebookMetadata
 }


### PR DESCRIPTION
This updates the compilation logic for the language service when the active document is a notebook to include any specificed project root folder such that dependencies are correctly resolved. This avoids spurious error squiggles on items that come from dependencies and even enables go to definition and hover for those items.