### PR TITLE
Fix BOM handling

### DIFF
--- a/pip/qsharp/_http.py
+++ b/pip/qsharp/_http.py
@@ -7,4 +7,4 @@ def fetch_github(owner: str, repo: str, ref: str, path: str) -> str:
 
     path_no_leading_slash = path[1:] if path.startswith("/") else path
     url = f"https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path_no_leading_slash}"
-    return urllib.request.urlopen(url).read().decode("utf-8")
+    return urllib.request.urlopen(url).read().decode("utf-8-sig")


### PR DESCRIPTION
Importing from files that have a BOM fails if `decode("utf-8")` is used, but `decode("utf-8-sig"` will work reliably for both BOM and BOM-less text.