### PR TITLE
print out identifier content instead of Ident [n...m] Blah in error message

### DIFF
--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -1054,7 +1054,7 @@ impl Resolver {
 
         let Some(ns) = ns else {
             self.errors.push(Error::GlobImportNamespaceNotFound(
-                item.path.name.to_string(),
+                item.path.name.name.to_string(),
                 item.path.span,
             ));
             return;

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -5114,3 +5114,21 @@ fn disallow_glob_alias_import() {
         "#]],
     );
 }
+
+#[test]
+fn glob_import_ns_not_found() {
+    check(
+        indoc! {r#"
+                namespace Main {
+                    import Bar.*;
+                }
+                "#},
+        &expect![[r#"
+            namespace namespace7 {
+                import Bar.*;
+            }
+
+            // GlobImportNamespaceNotFound("Bar", Span { lo: 28, hi: 31 })
+        "#]],
+    );
+}


### PR DESCRIPTION
We were using our `Display` for `Ident` impl instead of printing the ident contents in this error msg.
