### PR TITLE
Ignore export of namespace from within itself

### DIFF
--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1489,6 +1489,5 @@ fn export_namespace_with_same_name_as_newtype_does_not_cause_panic() {
     );
 
     let unit = default_compile(sources);
-    expect![[r#"[Error(Resolve(Duplicate("A", "A", Span { lo: 40, hi: 41 })))]"#]]
-        .assert_eq(&format!("{:?}", unit.errors));
+    expect!["[]"].assert_eq(&format!("{:?}", unit.errors));
 }

--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -1656,6 +1656,11 @@ fn bind_global_item(
                     else {
                         continue;
                     };
+                    if ns == namespace {
+                        // A namespace exporting itself is meaningless, since it is already available as itself.
+                        // No need to bind it to an item here, so we skip it.
+                        continue;
+                    }
                     let item_id = next_id();
                     let res = Res::Item(item_id, ItemStatus::Available);
                     names.insert(decl_item.name().id, res.clone());

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -4840,12 +4840,12 @@ fn export_direct_cycle() {
         "},
         &expect![[r#"
             namespace namespace7 {
-                export item1;
+                export namespace7;
             }
 
             namespace namespace8 {
                 open namespace7;
-                operation item3() : Unit { }
+                operation item2() : Unit { }
             }
         "#]],
     );
@@ -5162,6 +5162,24 @@ fn export_of_item_with_same_name_as_namespace_resolves_to_item() {
             namespace namespace7 {
                 operation item1() : Unit {}
                 export item1;
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn export_of_item_with_same_name_as_namespace_resolves_to_item_even_when_before_item() {
+    check(
+        indoc! {r#"
+                namespace Foo {
+                    export Foo;
+                    operation Foo() : Unit {}
+                }
+                "#},
+        &expect![[r#"
+            namespace namespace7 {
+                export item1;
+                operation item1() : Unit {}
             }
         "#]],
     );

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -5114,3 +5114,37 @@ fn disallow_glob_alias_import() {
         "#]],
     );
 }
+
+#[test]
+fn allow_export_of_namespace_within_itself() {
+    check(
+        indoc! {r#"
+                namespace Foo {
+                    export Foo;
+                }
+                "#},
+        &expect![[r#"
+            namespace namespace7 {
+                export namespace7;
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn export_of_item_with_same_name_as_namespace_resolves_to_item() {
+    check(
+        indoc! {r#"
+                namespace Foo {
+                    operation Foo() : Unit {}
+                    export Foo;
+                }
+                "#},
+        &expect![[r#"
+            namespace namespace7 {
+                operation item1() : Unit {}
+                export item1;
+            }
+        "#]],
+    );
+}


### PR DESCRIPTION
Exporting a namespace from within itself is meaningless and should be ignored. This allows resolution to work as expected for the case where the namespace name is unique or where the name actually binds to an item within the namespace with the same name.