### PR TITLE
Add populate files command for qsharp.json

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -190,6 +190,10 @@
         {
           "command": "qsharp-vscode.webOpener",
           "when": "false"
+        },
+        {
+          "command": "qsharp-vscode.populateFilesList",
+          "when": "resourceFilename == qsharp.json"
         }
       ],
       "view/title": [
@@ -233,6 +237,10 @@
         {
           "command": "qsharp-vscode.createProject",
           "when": "explorerResourceIsFolder"
+        },
+        {
+          "command": "qsharp-vscode.populateFilesList",
+          "when": "resourceFilename == qsharp.json"
         }
       ]
     },
@@ -365,6 +373,11 @@
         "command": "qsharp-vscode.openPlayground",
         "category": "Q#",
         "title": "Open Q# playground"
+      },
+      {
+        "command": "qsharp-vscode.populateFilesList",
+        "category": "Q#",
+        "title": "Populate qsharp.json files list"
       }
     ],
     "breakpoints": [


### PR DESCRIPTION
Added a context menu when you right click on qsharp.json in explorer, and a command when you have a qsharp.json open, to populate the list of files in qsharp.json from all the .qs files under the src dir.


https://github.com/user-attachments/assets/12414e0a-b865-4231-a136-8df0c46b1193

