### PR TITLE
fix panic in typeck which was causing language service to go into a bad state

### DIFF
--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1471,3 +1471,23 @@ fn test_longest_common_prefix_only_root_common() {
 fn test_longest_common_prefix_only_root_common_no_leading() {
     expect![""].assert_eq(longest_common_prefix(&["a/b", "b/c"]));
 }
+
+#[test]
+fn export_namespace_with_same_name_as_newtype_does_not_cause_panic() {
+    let sources = SourceMap::new(
+        [(
+            "test".into(),
+            indoc! {"
+                namespace A {
+                    export A;
+                    newtype A = Int;
+                }
+            "}
+            .into(),
+        )],
+        None,
+    );
+
+    let unit = default_compile(sources);
+    expect![[r#"[Error(Resolve(Duplicate("A", "A", Span { lo: 40, hi: 41 })))]"#]].assert_eq(&format!("{:?}", unit.errors));
+}

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1489,5 +1489,6 @@ fn export_namespace_with_same_name_as_newtype_does_not_cause_panic() {
     );
 
     let unit = default_compile(sources);
-    expect![[r#"[Error(Resolve(Duplicate("A", "A", Span { lo: 40, hi: 41 })))]"#]].assert_eq(&format!("{:?}", unit.errors));
+    expect![[r#"[Error(Resolve(Duplicate("A", "A", Span { lo: 40, hi: 41 })))]"#]]
+        .assert_eq(&format!("{:?}", unit.errors));
 }

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -576,7 +576,9 @@ impl<'a> Context<'a> {
             None => match self.names.get(path.id) {
                 None => converge(Ty::Err),
                 Some(Res::Item(item, _)) => {
-                    let scheme = self.globals.get(item).expect("item should have scheme");
+                    let Some(scheme) = self.globals.get(item) else {
+                        return converge(Ty::Err);
+                    };
                     let (ty, args) = self.inferrer.instantiate(scheme, expr.span);
                     self.table.generics.insert(expr.id, args);
                     converge(Ty::Arrow(Box::new(ty)))


### PR DESCRIPTION
As the title says, this fixes a panic that was causing the language service to go into a bad state. We were assuming that all paths have type schemes, but that's not the case as they can point to namespaces. This should close #1762. Those failures in #1762 were arising from a compilation update worker crashing (due to the aforementioned panic) while holding a lock to the refcell.