### PR TITLE
Auto-inserted `import` in notebooks should include project aliases

### DIFF
--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -218,7 +218,7 @@ impl Compilation {
             compile_errors: errors,
             project_errors: project.as_ref().map_or_else(Vec::new, |p| p.errors.clone()),
             kind: CompilationKind::Notebook { project },
-            dependencies: FxHashMap::default(),
+            dependencies: dependencies.into_iter().collect(),
         }
     }
 


### PR DESCRIPTION
Simple oversight in not including the dependencies when returning the compilation object for the notebook case.

Fixes #1749