### PR TITLE
Gracefully fail in compiler if dependency cycle exists

### DIFF
--- a/compiler/qsc/src/compile.rs
+++ b/compiler/qsc/src/compile.rs
@@ -14,23 +14,29 @@ use thiserror::Error;
 pub type Error = WithSource<ErrorKind>;
 
 #[derive(Clone, Debug, Diagnostic, Error)]
-#[diagnostic(transparent)]
 #[error(transparent)]
 /// `ErrorKind` represents the different kinds of errors that can occur in the compiler.
 /// Each variant of the enum corresponds to a different stage of the compilation process.
 pub enum ErrorKind {
     /// `Frontend` variant represents errors that occur during the frontend stage of the compiler.
     /// These errors are typically related to syntax and semantic checks.
+    #[diagnostic(transparent)]
     Frontend(#[from] qsc_frontend::compile::Error),
 
     /// `Pass` variant represents errors that occur during the `qsc_passes` stage of the compiler.
     /// These errors are typically related to optimization, transformation, code generation, passes,
     /// and static analysis passes.
+    #[diagnostic(transparent)]
     Pass(#[from] qsc_passes::Error),
 
     /// `Lint` variant represents lints generated during the linting stage. These diagnostics are
     /// typically emitted from the language server and happens after all other compilation passes.
+    #[diagnostic(transparent)]
     Lint(#[from] qsc_linter::Lint),
+
+    #[error("Cycle in dependency graph")]
+    /// `DependencyCycle` occurs when there is a cycle in the dependency graph.
+    DependencyCycle,
 }
 
 /// Compiles a package from its AST representation.

--- a/compiler/qsc_project/src/lib.rs
+++ b/compiler/qsc_project/src/lib.rs
@@ -22,6 +22,6 @@ pub use js::{JSFileEntry, JSProjectHost};
 pub use manifest::{Manifest, ManifestDescriptor, PackageRef, PackageType, MANIFEST_FILE_NAME};
 pub use project::FileSystemAsync;
 pub use project::{
-    key_for_package_ref, package_ref_from_key, DirEntry, EntryType, Error, FileSystem,
-    PackageCache, PackageGraphSources, PackageInfo, Project,
+    key_for_package_ref, package_ref_from_key, DependencyCycle, DirEntry, EntryType, Error,
+    FileSystem, PackageCache, PackageGraphSources, PackageInfo, Project,
 };


### PR DESCRIPTION
We currently assume/hope the front-end scenario will catch dependency cycles (the JS, Python, or whatever scenario is feeding the dependencies in) and panic otherwise.

Upon retrospection, this was naive, and we should handle dependency cycles gracefully if they're passed through to the back-end. It certainly doesn't hurt. @idavis found a panic which was not detected by the front-end, and therefore caused the backend to panic, and the language service to crash.

This PR updates the compiler to report a `DependencyCycle` error, which ultimately shows up in the _Problems_ tab, if one is detected in the backend. 
