### PR TITLE
Fix ApplyPauliFromBitString error message

### DIFF
--- a/library/qs_source/src/std/canon.qs
+++ b/library/qs_source/src/std/canon.qs
@@ -348,7 +348,7 @@ namespace Microsoft.Quantum.Canon {
     /// ```
     operation ApplyPauliFromBitString(pauli : Pauli, bitApply : Bool, bits : Bool[], qubits : Qubit[]) : Unit is Adj + Ctl {
         let nBits = Length(bits);
-        Fact(nBits == Length(qubits), "Number of control bits must be equal to number of control qubits.");
+        Fact(nBits == Length(qubits), "Number of bits must be equal to number of qubits.");
         for i in 0..nBits - 1 {
             if bits[i] == bitApply {
                 ApplyP(pauli, qubits[i]);


### PR DESCRIPTION
The bits and qubits in this operation are not used as controls, so we shouldn't refer to them as such.

(I got this error message when working on a kata, and it took me longer than it should to figure out that it is not coming from any of the controlled gates.)