### PR TITLE
Avoid errors in read-only GitHub sources

### DIFF
--- a/compiler/qsc_project/src/lib.rs
+++ b/compiler/qsc_project/src/lib.rs
@@ -23,5 +23,5 @@ pub use manifest::{Manifest, ManifestDescriptor, PackageRef, PackageType, MANIFE
 pub use project::FileSystemAsync;
 pub use project::{
     key_for_package_ref, package_ref_from_key, DependencyCycle, DirEntry, EntryType, Error,
-    FileSystem, PackageCache, PackageGraphSources, PackageInfo, Project,
+    FileSystem, PackageCache, PackageGraphSources, PackageInfo, Project, GITHUB_SCHEME,
 };

--- a/compiler/qsc_project/src/project.rs
+++ b/compiler/qsc_project/src/project.rs
@@ -18,6 +18,8 @@ use std::{
 };
 use thiserror::Error;
 
+pub const GITHUB_SCHEME: &str = "qsharp-github-source";
+
 /// Describes a Q# project with all its sources and dependencies resolved.
 #[derive(Debug, Clone)]
 pub struct Project {
@@ -414,7 +416,7 @@ pub trait FileSystemAsync {
         let manifest = serde_json::from_str::<Manifest>(&manifest_content).map_err(|e| {
             Error::GitHubManifestParse {
                 path: format!(
-                    "qsharp-github-source:{}/{}/{}{}/qsharp.json",
+                    "{GITHUB_SCHEME}:{}/{}/{}{}/qsharp.json",
                     dep.owner,
                     dep.repo,
                     dep.r#ref,
@@ -448,7 +450,7 @@ pub trait FileSystemAsync {
             // and open them using cached contents.
             sources.push((
                 format!(
-                    "qsharp-github-source:{}/{}/{}{path}",
+                    "{GITHUB_SCHEME}:{}/{}/{}{path}",
                     dep.owner, dep.repo, dep.r#ref
                 )
                 .into(),

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -139,13 +139,6 @@ impl<'a> CompilationStateUpdater<'a> {
         let doc_uri: Arc<str> = Arc::from(uri);
         let text: Arc<str> = Arc::from(text);
 
-        if doc_uri.starts_with(qsc_project::GITHUB_SCHEME) {
-            // Since this is a read only GitHub document provided by our own compilation,
-            // we don't need to track it in the open documents map. As a later feature,
-            // we could consider tracking these documents to provide a better user experience.
-            return;
-        }
-
         let project = match self.load_manifest(&doc_uri).await {
             Ok(Some(p)) => p,
             Ok(None) => Project::from_single_file(doc_uri.clone(), text.clone()),
@@ -289,11 +282,6 @@ impl<'a> CompilationStateUpdater<'a> {
     /// document was the last open document in a compilation,
     /// the compilation is also removed.
     fn remove_open_document(&mut self, uri: &str) -> bool {
-        if uri.starts_with(qsc_project::GITHUB_SCHEME) {
-            // We don't need to track GitHub documents in the open documents map
-            return false;
-        }
-
         let existing_compilation_uri = self.with_state_mut(|state| {
             state.compilations.remove(uri);
 
@@ -427,6 +415,12 @@ impl<'a> CompilationStateUpdater<'a> {
                         // When the same document is included in multiple compilations,
                         // only report the errors for one of them, the goal being
                         // a less confusing user experience.
+                        continue;
+                    }
+                    if uri.starts_with(qsc_project::GITHUB_SCHEME) {
+                        // Don't publish diagnostics for GitHub URIs.
+                        // This is temporary workaround to avoid spurious errors when a document
+                        // is opened in single file mode that is part of a read-only GitHub project.
                         continue;
                     }
 


### PR DESCRIPTION
This is an incremental improvement for viewing GitHub sources that avoids treating them as open documents since they are read-only buffers. In the future, we can do the work to associate them with the existing compilation taht contains those sources so that things like hover and goto-def work, but for now those code paths are user-code specific and need some reworking to handle navigation in a compile unit for a dependency.