### PR TITLE
Support qubit count tracking within Q#

### DIFF
--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -1550,3 +1550,26 @@ fn start_counting_function_called_twice_before_stop_fails() {
         &expect!["callable already counted"],
     );
 }
+
+#[test]
+fn stop_counting_qubits_before_start_fails() {
+    check_intrinsic_output(
+        "",
+        indoc! {"{
+            Std.Diagnostics.StopCountingQubits();
+        }"},
+        &expect!["qubits not counted"],
+    );
+}
+
+#[test]
+fn start_counting_qubits_called_twice_before_stop_fails() {
+    check_intrinsic_output(
+        "",
+        indoc! {"{
+            Std.Diagnostics.StartCountingQubits();
+            Std.Diagnostics.StartCountingQubits();
+        }"},
+        &expect!["qubits already counted"],
+    );
+}

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -3724,7 +3724,7 @@ fn controlled_operation_with_duplicate_controls_fails() {
                                 1,
                             ),
                             item: LocalItemId(
-                                128,
+                                130,
                             ),
                         },
                         caller: PackageId(
@@ -3774,7 +3774,7 @@ fn controlled_operation_with_target_in_controls_fails() {
                                 1,
                             ),
                             item: LocalItemId(
-                                128,
+                                130,
                             ),
                         },
                         caller: PackageId(

--- a/library/std/src/diagnostics.qs
+++ b/library/std/src/diagnostics.qs
@@ -295,5 +295,42 @@ namespace Microsoft.Quantum.Diagnostics {
         body intrinsic;
     }
 
-    export DumpMachine, DumpRegister, CheckZero, CheckAllZero, Fact, CheckOperationsAreEqual, StartCountingOperation, StopCountingOperation, StartCountingFunction, StopCountingFunction;
+    /// # Summary
+    /// Starts counting the number of qubits allocated. Fails if qubits are already being counted.
+    ///
+    /// # Description
+    /// This operation allows you to count the number of qubits allocated until `StopCountingQubits` is called.
+    /// The counter is incremented only when a new unique qubit is allocated, so reusing the same qubit multiple times
+    /// across separate allocations does not increment the counter.
+    ///
+    /// # Remarks
+    /// This operation is useful for tracking the number of unique qubits allocated in a given scope. Along with
+    /// `StopCountingQubits`, it can be used to verify that a given operation does not allocate more qubits than
+    /// expected. For example,
+    /// ```qsharp
+    /// StartCountingQubits();
+    /// testOperation();
+    /// let qubitsAllocated = StopCountingQubits();
+    /// Fact(qubitsAllocated <= 4, "Operation should not allocate more than 4 qubits.");
+    /// ```
+    @Config(Unrestricted)
+    operation StartCountingQubits() : Unit {
+        body intrinsic;
+    }
+
+    /// # Summary
+    /// Stops counting the number of qubits allocated and returns the count. Fails if the qubits were not being counted.
+    ///
+    /// # Description
+    /// This operation allows you to stop counting the number of qubits allocated and returns the count since the
+    /// last call to `StartCountingQubits`. If the qubits were not being counted, it triggers a runtime failure.
+    ///
+    /// # Output
+    /// The number of unique qubits allocated since the last call to `StartCountingQubits`.
+    @Config(Unrestricted)
+    operation StopCountingQubits() : Int {
+        body intrinsic;
+    }
+
+    export DumpMachine, DumpRegister, CheckZero, CheckAllZero, Fact, CheckOperationsAreEqual, StartCountingOperation, StopCountingOperation, StartCountingFunction, StopCountingFunction, StartCountingQubits, StopCountingQubits;
 }


### PR DESCRIPTION
This introduces qubit count tracking APIs to the Diagnostics namespace that allow Q# code to get counts for how many unique qubits are used during a section of execution. This is useful in katas and auto-grading scenarios to verify that exercise restrictions are being appropriately followed.

Fixes #1155