### PR TITLE
Update rust version to 1.80 second step

### DIFF
--- a/compiler/qsc_ast/src/ast.rs
+++ b/compiler/qsc_ast/src/ast.rs
@@ -129,7 +129,7 @@ impl Display for Package {
         if let Some(e) = &self.entry {
             write!(indent, "\nentry expression: {e}")?;
         }
-        for node in &*self.nodes {
+        for node in &self.nodes {
             write!(indent, "\n{node}")?;
         }
         Ok(())
@@ -196,7 +196,7 @@ impl Display for Namespace {
             indent = set_indentation(indent, 1);
         }
 
-        for i in &*self.items {
+        for i in &self.items {
             write!(indent, "\n{i}")?;
         }
 
@@ -244,7 +244,7 @@ impl Display for Item {
             indent = set_indentation(indent, 1);
         }
 
-        for attr in &*self.attrs {
+        for attr in &self.attrs {
             write!(indent, "\n{attr}")?;
         }
 
@@ -388,7 +388,7 @@ impl Display for TyDefKind {
                 } else {
                     write!(indent, "Tuple:")?;
                     indent = set_indentation(indent, 1);
-                    for t in &**ts {
+                    for t in ts {
                         write!(indent, "\n{t}")?;
                     }
                 }
@@ -420,7 +420,7 @@ impl Display for StructDecl {
             write!(indent, " <empty>")?;
         } else {
             indent = set_indentation(indent, 1);
-            for field in &*self.fields {
+            for field in &self.fields {
                 write!(indent, "\n{field}")?;
             }
         }
@@ -499,7 +499,7 @@ impl Display for CallableDecl {
         if !self.generics.is_empty() {
             write!(indent, "\ngenerics:")?;
             indent = set_indentation(indent, 2);
-            for param in &*self.generics {
+            for param in &self.generics {
                 write!(indent, "\n{param}")?;
             }
             indent = set_indentation(indent, 1);
@@ -531,7 +531,7 @@ impl Display for CallableBody {
                 let mut indent = set_indentation(indented(f), 0);
                 write!(indent, "Specializations:")?;
                 indent = set_indentation(indent, 1);
-                for spec in &**specs {
+                for spec in specs {
                     write!(indent, "\n{spec}")?;
                 }
             }
@@ -697,7 +697,7 @@ impl Display for TyKind {
                     indent = indent.with_format(Format::Uniform {
                         indentation: "    ",
                     });
-                    for t in &**ts {
+                    for t in ts {
                         write!(indent, "\n{t}")?;
                     }
                 }
@@ -727,7 +727,7 @@ impl Display for Block {
             let mut indent = set_indentation(indented(f), 0);
             write!(indent, "Block {} {}:", self.id, self.span)?;
             indent = set_indentation(indent, 1);
-            for s in &*self.stmts {
+            for s in &self.stmts {
                 write!(indent, "\n{s}")?;
             }
         }
@@ -1309,7 +1309,7 @@ impl Display for PatKind {
                 } else {
                     write!(indent, "Tuple:")?;
                     indent = set_indentation(indent, 1);
-                    for p in &**ps {
+                    for p in ps {
                         write!(indent, "\n{p}")?;
                     }
                 }
@@ -1380,7 +1380,7 @@ impl Display for QubitInitKind {
                 } else {
                     write!(indent, "Tuple:")?;
                     indent = set_indentation(indent, 1);
-                    for qi in &**qis {
+                    for qi in qis {
                         write!(indent, "\n{qi}")?;
                     }
                 }
@@ -1512,7 +1512,7 @@ impl Display for Idents {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut buf = Vec::with_capacity(self.0.len());
 
-        for ident in &*self.0 {
+        for ident in &self.0 {
             buf.push(format!("{ident}"));
         }
         if buf.len() > 1 {
@@ -1595,7 +1595,7 @@ impl Idents {
             return self.0[0].name.clone();
         }
         let mut buf = String::new();
-        for ident in &*self.0 {
+        for ident in &self.0 {
             if !buf.is_empty() {
                 buf.push('.');
             }

--- a/compiler/qsc_ast/src/visit.rs
+++ b/compiler/qsc_ast/src/visit.rs
@@ -116,7 +116,7 @@ pub fn walk_item<'a>(vis: &mut impl Visitor<'a>, item: &'a Item) {
         }
         ItemKind::Struct(decl) => vis.visit_struct_decl(decl),
         ItemKind::ImportOrExport(decl) => {
-            for item in &*decl.items {
+            for item in &decl.items {
                 vis.visit_path(&item.path);
                 if let Some(ref alias) = item.alias {
                     vis.visit_ident(alias);

--- a/compiler/qsc_doc_gen/src/display.rs
+++ b/compiler/qsc_doc_gen/src/display.rs
@@ -643,7 +643,7 @@ fn ast_callable_functors(callable: &ast::CallableDecl) -> ty::FunctorSetValue {
         });
 
     if let ast::CallableBody::Specs(specs) = callable.body.as_ref() {
-        for spec in &**specs {
+        for spec in specs {
             let spec_functors = match spec.spec {
                 ast::Spec::Body => ty::FunctorSetValue::Empty,
                 ast::Spec::Adj => ty::FunctorSetValue::Adj,
@@ -678,7 +678,7 @@ fn as_struct(ty_def: &ast::TyDef) -> Option<Vec<ast::FieldDef>> {
         ast::TyDefKind::Paren(inner) => as_struct(inner),
         ast::TyDefKind::Tuple(fields) => {
             let mut converted_fields = Vec::new();
-            for field in &**fields {
+            for field in fields {
                 let field = remove_parens(field);
                 match field.kind.as_ref() {
                     ast::TyDefKind::Field(Some(name), field_ty) => {

--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -100,7 +100,7 @@ impl With<'_> {
         namespaces: qsc_data_structures::namespaces::NamespaceTreeRoot,
     ) -> hir::Package {
         let mut stmts = Vec::new();
-        for node in &*package.nodes {
+        for node in &package.nodes {
             match node {
                 ast::TopLevelNode::Namespace(namespace) => self.lower_namespace(namespace),
                 ast::TopLevelNode::Stmt(stmt) => {
@@ -200,7 +200,7 @@ impl With<'_> {
                 if item.is_import() {
                     return None;
                 }
-                for item in &*item.items {
+                for item in &item.items {
                     let Some((id, alias)) = resolve_id(item.name().id) else {
                         continue;
                     };

--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -494,7 +494,7 @@ impl AstVisitor<'_> for ExportImportVisitor<'_> {
             // we are re-opening a namespace. This is important, as without this,
             // a re-opened namespace would only have knowledge of its scopes.
             visitor.resolver.bind_open(&namespace.name, &None, root_id);
-            for item in &*namespace.items {
+            for item in &namespace.items {
                 match &*item.kind {
                     ItemKind::ImportOrExport(decl) => {
                         visitor
@@ -1216,7 +1216,7 @@ impl AstVisitor<'_> for With<'_> {
 
         let kind = ScopeKind::Namespace(ns);
         self.with_scope(namespace.span, kind, |visitor| {
-            for item in &*namespace.items {
+            for item in &namespace.items {
                 match &*item.kind {
                     ItemKind::ImportOrExport(..) | ItemKind::Open(..) => {
                         // Global imports and exports should have been handled
@@ -1314,7 +1314,7 @@ impl AstVisitor<'_> for With<'_> {
 
     fn visit_block(&mut self, block: &ast::Block) {
         self.with_scope(block.span, ScopeKind::Block, |visitor| {
-            for stmt in &*block.stmts {
+            for stmt in &block.stmts {
                 if let ast::StmtKind::Item(item) = &*stmt.kind {
                     visitor
                         .resolver
@@ -1449,7 +1449,7 @@ impl GlobalTable {
         package: &ast::Package,
     ) -> Vec<Error> {
         let mut errors = Vec::new();
-        for node in &*package.nodes {
+        for node in &package.nodes {
             match node {
                 TopLevelNode::Namespace(namespace) => {
                     bind_global_items(
@@ -1601,7 +1601,7 @@ fn bind_global_items(
 
     let namespace_id = scope.insert_or_find_namespace(&namespace.name);
 
-    for item in &*namespace.items {
+    for item in &namespace.items {
         match bind_global_item(
             names,
             scope,
@@ -1674,7 +1674,7 @@ fn bind_global_item(
             if decl.is_import() {
                 Ok(())
             } else {
-                for decl_item in &*decl.items {
+                for decl_item in &decl.items {
                     // if the item is a namespace, bind it here as an item
                     let Some(ns) = scope
                         .namespaces

--- a/compiler/qsc_frontend/src/typeck/check.rs
+++ b/compiler/qsc_frontend/src/typeck/check.rs
@@ -142,7 +142,7 @@ impl Checker {
             ));
         }
 
-        for top_level_node in &*package.nodes {
+        for top_level_node in &package.nodes {
             if let TopLevelNode::Stmt(stmt) = top_level_node {
                 self.new.append(&mut rules::stmt(
                     names,
@@ -171,7 +171,7 @@ impl Checker {
                 },
             ),
             ast::CallableBody::Specs(specs) => {
-                for spec in &**specs {
+                for spec in specs {
                     if let ast::SpecBody::Impl(input, block) = &spec.body {
                         self.check_spec(
                             names,

--- a/compiler/qsc_frontend/src/typeck/convert.rs
+++ b/compiler/qsc_frontend/src/typeck/convert.rs
@@ -54,7 +54,7 @@ pub(crate) fn ty_from_ast(names: &Names, ty: &ast::Ty) -> (Ty, Vec<MissingTyErro
         TyKind::Tuple(items) => {
             let mut tys = Vec::new();
             let mut errors = Vec::new();
-            for item in &**items {
+            for item in items {
                 let (item_ty, item_errors) = ty_from_ast(names, item);
                 tys.push(item_ty);
                 errors.extend(item_errors);
@@ -132,7 +132,7 @@ fn ast_ty_def_base(names: &Names, def: &TyDef) -> (Ty, Vec<MissingTyError>) {
         TyDefKind::Tuple(items) => {
             let mut tys = Vec::new();
             let mut errors = Vec::new();
-            for item in &**items {
+            for item in items {
                 let (item_ty, item_errors) = ast_ty_def_base(names, item);
                 tys.push(item_ty);
                 errors.extend(item_errors);
@@ -285,7 +285,7 @@ pub(crate) fn ast_pat_ty(names: &Names, pat: &Pat) -> (Ty, Vec<MissingTyError>) 
         PatKind::Tuple(items) => {
             let mut tys = Vec::new();
             let mut errors = Vec::new();
-            for item in &**items {
+            for item in items {
                 let (item_ty, item_errors) = ast_pat_ty(names, item);
                 tys.push(item_ty);
                 errors.extend(item_errors);
@@ -303,7 +303,7 @@ pub(crate) fn ast_callable_functors(callable: &CallableDecl) -> FunctorSetValue 
         .map_or(FunctorSetValue::Empty, |f| eval_functor_expr(f.as_ref()));
 
     if let CallableBody::Specs(specs) = callable.body.as_ref() {
-        for spec in &**specs {
+        for spec in specs {
             let spec_functors = match spec.spec {
                 Spec::Body => FunctorSetValue::Empty,
                 Spec::Adj => FunctorSetValue::Adj,

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -143,7 +143,7 @@ impl<'a> Context<'a> {
     fn infer_block(&mut self, block: &Block) -> Partial<Ty> {
         let mut diverges = false;
         let mut last = None;
-        for stmt in &*block.stmts {
+        for stmt in &block.stmts {
             let stmt = self.infer_stmt(stmt);
             diverges = diverges || stmt.diverges;
             last = Some(stmt);
@@ -342,7 +342,7 @@ impl<'a> Context<'a> {
             }
             ExprKind::Interpolate(components) => {
                 let mut diverges = false;
-                for component in &**components {
+                for component in components {
                     match component {
                         StringComponent::Expr(expr) => {
                             let span = expr.span;
@@ -465,7 +465,7 @@ impl<'a> Context<'a> {
                     self.inferrer.eq(copy.span, container.clone(), copy_ty.ty);
                 }
 
-                for field in &**fields {
+                for field in fields {
                     self.infer_field_assign(
                         field.span,
                         container.clone(),
@@ -499,7 +499,7 @@ impl<'a> Context<'a> {
             ExprKind::Tuple(items) => {
                 let mut tys = Vec::new();
                 let mut diverges = false;
-                for item in &**items {
+                for item in items {
                     let item = self.infer_expr(item);
                     diverges = diverges || item.diverges;
                     tys.push(item.ty);
@@ -626,7 +626,7 @@ impl<'a> Context<'a> {
             ExprKind::Tuple(items) => {
                 let mut tys = Vec::new();
                 let mut diverges = false;
-                for item in &**items {
+                for item in items {
                     let item = self.infer_hole_tuple(hole, given, tuple, to_ty, item);
                     diverges = diverges || item.diverges;
                     tys.push(item.ty);
@@ -847,7 +847,7 @@ impl<'a> Context<'a> {
             QubitInitKind::Tuple(items) => {
                 let mut diverges = false;
                 let mut tys = Vec::new();
-                for item in &**items {
+                for item in items {
                     let item = self.infer_qubit_init(item);
                     diverges = diverges || item.diverges;
                     tys.push(item.ty);

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -1233,7 +1233,7 @@ impl Display for Idents {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut buf = Vec::with_capacity(self.0.len());
 
-        for ident in &*self.0 {
+        for ident in &self.0 {
             buf.push(format!("{ident}"));
         }
         if buf.len() > 1 {
@@ -1313,7 +1313,7 @@ impl Idents {
             return self.0[0].name.clone();
         }
         let mut buf = String::new();
-        for ident in &*self.0 {
+        for ident in &self.0 {
             if !buf.is_empty() {
                 buf.push('.');
             }

--- a/compiler/qsc_linter/src/linter/ast.rs
+++ b/compiler/qsc_linter/src/linter/ast.rs
@@ -31,7 +31,7 @@ pub fn run_ast_lints(package: &qsc_ast::ast::Package, config: Option<&[LintConfi
 
     let mut lints = CombinedAstLints::from_config(config);
 
-    for node in &*package.nodes {
+    for node in &package.nodes {
         match node {
             TopLevelNode::Namespace(namespace) => lints.visit_namespace(namespace),
             TopLevelNode::Stmt(stmt) => lints.visit_stmt(stmt),

--- a/compiler/qsc_linter/src/lints/ast.rs
+++ b/compiler/qsc_linter/src/lints/ast.rs
@@ -130,7 +130,7 @@ impl AstLintPass for RedundantSemicolons {
         // Some(_): one or more redundant semicolons
         let mut seq: Option<Span> = None;
 
-        for stmt in &*block.stmts {
+        for stmt in &block.stmts {
             match (&*stmt.kind, &mut seq) {
                 (StmtKind::Empty, None) => seq = Some(stmt.span),
                 (StmtKind::Empty, Some(span)) => span.hi = stmt.span.hi,

--- a/compiler/qsc_parse/src/item.rs
+++ b/compiler/qsc_parse/src/item.rs
@@ -371,7 +371,7 @@ fn try_tydef_as_ty(tydef: &TyDef) -> Option<Ty> {
         TyDefKind::Paren(tydef) => try_tydef_as_ty(tydef.as_ref()),
         TyDefKind::Tuple(tup) => {
             let mut ty_tup = Vec::new();
-            for tydef in &**tup {
+            for tydef in tup {
                 ty_tup.push(try_tydef_as_ty(tydef)?);
             }
             Some(Ty {

--- a/language_service/src/name_locator.rs
+++ b/language_service/src/name_locator.rs
@@ -361,7 +361,7 @@ impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inne
                         }
                     }
 
-                    for field in &**fields {
+                    for field in fields {
                         if field.span.touches(self.offset) {
                             if field.field.span.touches(self.offset) {
                                 if let Some(hir::ty::Ty::Udt(_, res)) =

--- a/language_service/src/references.rs
+++ b/language_service/src/references.rs
@@ -414,7 +414,7 @@ impl<'a> Visitor<'_> for FindFieldRefs<'a> {
                 if let Some(copy) = copy {
                     self.visit_expr(copy);
                 }
-                for field in &**fields {
+                for field in fields {
                     if field.field.name == self.field_name {
                         if let Some(Ty::Udt(_, Res::Item(id))) = self.compilation.get_ty(expr.id) {
                             if self.eq(id) {


### PR DESCRIPTION
PR #1805 changed all instances of `for elt in container.iter()` where container was a `&Box<[...]>` to `for elt in &**container`, which is equivalent, to be able to update our build and release pipelines to rust 1.80, you can see the full explanation there.

This is a subsequent PR that changes:
 - All instances of `for elt in &**container` to `for elt in container`.
 - All instances of `for elt in &*container` to `for elt in &container`.

These changes are due to rust 1.80 implementing `Iterator` for `Box<[...]>` and clippy enforcing a new style of iteration.