### PR TITLE
Implicit Namespace Parsing Recovery

### DIFF
--- a/compiler/qsc/src/packages/tests.rs
+++ b/compiler/qsc/src/packages/tests.rs
@@ -191,6 +191,7 @@ fn missing_dependency_doesnt_force_failure() {
     .assert_debug_eq(&errors);
 }
 
+#[allow(clippy::too_many_lines)]
 #[test]
 fn dependency_error() {
     let mut program = mock_program();

--- a/compiler/qsc/src/packages/tests.rs
+++ b/compiler/qsc/src/packages/tests.rs
@@ -210,33 +210,58 @@ fn dependency_error() {
     );
 
     expect![[r#"
-            [
-                WithSource {
-                    sources: [
-                        Source {
-                            name: "librarymain",
-                            contents: "broken_syntax",
-                            offset: 0,
-                        },
-                    ],
-                    error: Frontend(
-                        Error(
-                            Parse(
-                                Error(
-                                    ExpectedItem(
-                                        Ident,
-                                        Span {
-                                            lo: 0,
-                                            hi: 0,
-                                        },
-                                    ),
+        [
+            WithSource {
+                sources: [
+                    Source {
+                        name: "librarymain",
+                        contents: "broken_syntax",
+                        offset: 0,
+                    },
+                ],
+                error: Frontend(
+                    Error(
+                        Parse(
+                            Error(
+                                Token(
+                                    Eof,
+                                    Ident,
+                                    Span {
+                                        lo: 0,
+                                        hi: 13,
+                                    },
                                 ),
                             ),
                         ),
                     ),
-                },
-            ]
-        "#]]
+                ),
+            },
+            WithSource {
+                sources: [
+                    Source {
+                        name: "librarymain",
+                        contents: "broken_syntax",
+                        offset: 0,
+                    },
+                ],
+                error: Frontend(
+                    Error(
+                        Parse(
+                            Error(
+                                ExpectedItem(
+                                    Eof,
+                                    Span {
+                                        lo: 0,
+                                        hi: 13,
+                                    },
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            },
+        ]
+    "#]]
     .assert_debug_eq(&buildable_program.dependency_errors);
 
     // compile the user code

--- a/compiler/qsc_parse/src/item.rs
+++ b/compiler/qsc_parse/src/item.rs
@@ -151,6 +151,7 @@ pub fn parse_implicit_namespace(source_name: &str, s: &mut ParserContext) -> Res
     }
     let lo = s.peek().span.lo;
     let items = parse_namespace_block_contents(s)?;
+    recovering_token(s, TokenKind::Eof);
     if items.is_empty() || s.peek().kind != TokenKind::Eof {
         return Err(Error(ErrorKind::ExpectedItem(s.peek().kind, s.span(lo))));
     }

--- a/compiler/qsc_parse/src/tests/implicit_namespace.rs
+++ b/compiler/qsc_parse/src/tests/implicit_namespace.rs
@@ -232,3 +232,171 @@ fn reject_bad_namespace_name_starts_with_number() {
         )"#]]
     .assert_eq(&result);
 }
+
+#[test]
+fn implicit_namespace_with_incomplete_items() {
+    let result = format!(
+        "{:#?}",
+        crate::namespaces(
+            "
+operation Main() : Unit {}
+oper",
+            Some("code/src/Foo.qs"),
+            LanguageFeatures::default()
+        )
+    );
+    expect![[r#"
+        (
+            [
+                Namespace {
+                    id: NodeId(
+                        4294967295,
+                    ),
+                    span: Span {
+                        lo: 1,
+                        hi: 32,
+                    },
+                    doc: "",
+                    name: Idents(
+                        [
+                            Ident {
+                                id: NodeId(
+                                    4294967295,
+                                ),
+                                span: Span {
+                                    lo: 1,
+                                    hi: 32,
+                                },
+                                name: "code",
+                            },
+                            Ident {
+                                id: NodeId(
+                                    4294967295,
+                                ),
+                                span: Span {
+                                    lo: 1,
+                                    hi: 32,
+                                },
+                                name: "src",
+                            },
+                            Ident {
+                                id: NodeId(
+                                    4294967295,
+                                ),
+                                span: Span {
+                                    lo: 1,
+                                    hi: 32,
+                                },
+                                name: "Foo",
+                            },
+                        ],
+                    ),
+                    items: [
+                        Item {
+                            id: NodeId(
+                                4294967295,
+                            ),
+                            span: Span {
+                                lo: 0,
+                                hi: 27,
+                            },
+                            doc: "",
+                            attrs: [],
+                            kind: Callable(
+                                CallableDecl {
+                                    id: NodeId(
+                                        4294967295,
+                                    ),
+                                    span: Span {
+                                        lo: 1,
+                                        hi: 27,
+                                    },
+                                    kind: Operation,
+                                    name: Ident {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 11,
+                                            hi: 15,
+                                        },
+                                        name: "Main",
+                                    },
+                                    generics: [],
+                                    input: Pat {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 15,
+                                            hi: 17,
+                                        },
+                                        kind: Tuple(
+                                            [],
+                                        ),
+                                    },
+                                    output: Ty {
+                                        id: NodeId(
+                                            4294967295,
+                                        ),
+                                        span: Span {
+                                            lo: 20,
+                                            hi: 24,
+                                        },
+                                        kind: Path(
+                                            Path {
+                                                id: NodeId(
+                                                    4294967295,
+                                                ),
+                                                span: Span {
+                                                    lo: 20,
+                                                    hi: 24,
+                                                },
+                                                segments: None,
+                                                name: Ident {
+                                                    id: NodeId(
+                                                        4294967295,
+                                                    ),
+                                                    span: Span {
+                                                        lo: 20,
+                                                        hi: 24,
+                                                    },
+                                                    name: "Unit",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    functors: None,
+                                    body: Block(
+                                        Block {
+                                            id: NodeId(
+                                                4294967295,
+                                            ),
+                                            span: Span {
+                                                lo: 25,
+                                                hi: 27,
+                                            },
+                                            stmts: [],
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ],
+                },
+            ],
+            [
+                Error(
+                    Token(
+                        Eof,
+                        Ident,
+                        Span {
+                            lo: 28,
+                            hi: 32,
+                        },
+                    ),
+                ),
+            ],
+        )"#]]
+    .assert_eq(&result);
+}

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -171,13 +171,29 @@ async fn close_last_doc_in_project() {
                             Error(
                                 Parse(
                                     Error(
-                                        ExpectedItem(
+                                        Token(
+                                            Eof,
                                             ClosedBinOp(
                                                 Slash,
                                             ),
                                             Span {
                                                 lo: 59,
-                                                hi: 59,
+                                                hi: 60,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Parse(
+                                    Error(
+                                        ExpectedItem(
+                                            Eof,
+                                            Span {
+                                                lo: 59,
+                                                hi: 140,
                                             },
                                         ),
                                     ),
@@ -296,11 +312,27 @@ async fn compile_error() {
                             Error(
                                 Parse(
                                     Error(
-                                        ExpectedItem(
+                                        Token(
+                                            Eof,
                                             Ident,
                                             Span {
                                                 lo: 0,
-                                                hi: 0,
+                                                hi: 9,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Parse(
+                                    Error(
+                                        ExpectedItem(
+                                            Eof,
+                                            Span {
+                                                lo: 0,
+                                                hi: 9,
                                             },
                                         ),
                                     ),
@@ -1362,13 +1394,29 @@ async fn close_doc_prioritizes_fs() {
                             Error(
                                 Parse(
                                     Error(
-                                        ExpectedItem(
+                                        Token(
+                                            Eof,
                                             ClosedBinOp(
                                                 Slash,
                                             ),
                                             Span {
                                                 lo: 59,
-                                                hi: 59,
+                                                hi: 60,
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Frontend(
+                            Error(
+                                Parse(
+                                    Error(
+                                        ExpectedItem(
+                                            Eof,
+                                            Span {
+                                                lo: 59,
+                                                hi: 140,
                                             },
                                         ),
                                     ),
@@ -2120,11 +2168,27 @@ async fn error_from_dependency_reported() {
                         Error(
                             Parse(
                                 Error(
-                                    ExpectedItem(
+                                    Token(
+                                        Eof,
                                         Ident,
                                         Span {
                                             lo: 0,
-                                            hi: 0,
+                                            hi: 13,
+                                        },
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    Frontend(
+                        Error(
+                            Parse(
+                                Error(
+                                    ExpectedItem(
+                                        Eof,
+                                        Span {
+                                            lo: 0,
+                                            hi: 13,
                                         },
                                     ),
                                 ),


### PR DESCRIPTION
Fixes an issue where implicit namespace parsing would not recover after incomplete items. This is fixed by adding the end-of-file character as a recovery token.

Fixes #1794