### PR TITLE
Fix type inference for nested generics

### DIFF
--- a/compiler/qsc_frontend/src/typeck/infer.rs
+++ b/compiler/qsc_frontend/src/typeck/infer.rs
@@ -544,9 +544,16 @@ impl Solver {
     }
 
     fn eq(&mut self, mut expected: Ty, mut actual: Ty, span: Span) -> Vec<Constraint> {
-        substitute_ty(&self.solution, &mut expected);
-        substitute_ty(&self.solution, &mut actual);
-        self.unify(&expected, &actual, span)
+        // Only attempt to unify the types if they are fully substituted. If they are not,
+        // this usually indicates an infinite recursion in the type inference, so further
+        // unification would get stuck in a loop by creating recursive constraints.
+        if substitute_ty(&self.solution, &mut expected)
+            && substitute_ty(&self.solution, &mut actual)
+        {
+            self.unify(&expected, &actual, span)
+        } else {
+            Vec::new()
+        }
     }
 
     fn superset(&mut self, expected: FunctorSetValue, mut actual: FunctorSet, span: Span) {
@@ -644,15 +651,24 @@ impl Solver {
     }
 
     fn bind_ty(&mut self, infer: InferTyId, ty: Ty, span: Span) -> Vec<Constraint> {
-        self.solution.tys.insert(infer, ty);
-        self.pending_tys
-            .remove(&infer)
-            .map_or(Vec::new(), |pending| {
-                pending
-                    .into_iter()
-                    .map(|class| Constraint::Class(class, span))
-                    .collect()
-            })
+        self.solution.tys.insert(infer, ty.clone());
+        let mut constraint = vec![Constraint::Eq {
+            expected: ty,
+            actual: Ty::Infer(infer),
+            span,
+        }];
+        constraint.append(
+            &mut self
+                .pending_tys
+                .remove(&infer)
+                .map_or(Vec::new(), |pending| {
+                    pending
+                        .into_iter()
+                        .map(|class| Constraint::Class(class, span))
+                        .collect()
+                }),
+        );
+        constraint
     }
 
     fn bind_functor(
@@ -688,36 +704,43 @@ impl Solver {
     }
 }
 
-fn substitute_ty(solution: &Solution, ty: &mut Ty) {
-    fn substitute_ty_recursive(solution: &Solution, ty: &mut Ty, limit: i8) {
+fn substitute_ty(solution: &Solution, ty: &mut Ty) -> bool {
+    fn substitute_ty_recursive(solution: &Solution, ty: &mut Ty, limit: i8) -> bool {
         if limit == 0 {
             // We've hit the recursion limit. Give up and leave the inferred types
             // as is. This should trigger an ambiguous type error later.
-            return;
+            // Return false only when recursion limit is hit so the caller can know
+            // types have not been fully substituted.
+            return false;
         }
         match ty {
-            Ty::Err | Ty::Param(_, _) | Ty::Prim(_) | Ty::Udt(_, _) => {}
+            Ty::Err | Ty::Param(_, _) | Ty::Prim(_) | Ty::Udt(_, _) => true,
             Ty::Array(item) => substitute_ty_recursive(solution, item, limit - 1),
             Ty::Arrow(arrow) => {
-                substitute_ty_recursive(solution, &mut arrow.input, limit - 1);
-                substitute_ty_recursive(solution, &mut arrow.output, limit - 1);
+                let a = substitute_ty_recursive(solution, &mut arrow.input, limit - 1);
+                let b = substitute_ty_recursive(solution, &mut arrow.output, limit - 1);
                 substitute_functor(solution, &mut arrow.functors);
+                a && b
             }
             Ty::Tuple(items) => {
+                let mut all_known = true;
                 for item in items {
-                    substitute_ty_recursive(solution, item, limit - 1);
+                    all_known = substitute_ty_recursive(solution, item, limit - 1) && all_known;
                 }
+                all_known
             }
             &mut Ty::Infer(infer) => {
                 if let Some(new_ty) = solution.tys.get(infer) {
                     *ty = new_ty.clone();
-                    substitute_ty_recursive(solution, ty, limit - 1);
+                    substitute_ty_recursive(solution, ty, limit - 1)
+                } else {
+                    true
                 }
             }
         }
     }
 
-    substitute_ty_recursive(solution, ty, MAX_TY_RECURSION_DEPTH);
+    substitute_ty_recursive(solution, ty, MAX_TY_RECURSION_DEPTH)
 }
 
 fn substituted_ty(solution: &Solution, mut ty: Ty) -> Ty {

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -315,6 +315,65 @@ fn call_generic_length() {
 }
 
 #[test]
+fn nested_generic_with_lambda() {
+    check(
+        indoc! {"
+            namespace A {
+                function Foo<'I, 'O>(f : 'I -> 'O, x : 'I) : 'O { f(x) }
+                function Bar() : Unit {
+                    let r0 = Foo(Foo, (() -> (), ()));
+                    let r1 = Foo(Foo, (a -> (), ()));
+                    let r2 = Foo(Foo, (b -> b, ()));
+                }
+        }"
+        },
+        "",
+        &expect![[r##"
+            #8 46-68 "(f : 'I -> 'O, x : 'I)" : ((Param<"'I": 0> -> Param<"'O": 1>), Param<"'I": 0>)
+            #9 47-59 "f : 'I -> 'O" : (Param<"'I": 0> -> Param<"'O": 1>)
+            #16 61-67 "x : 'I" : Param<"'I": 0>
+            #22 74-82 "{ f(x) }" : Param<"'O": 1>
+            #24 76-80 "f(x)" : Param<"'O": 1>
+            #25 76-77 "f" : (Param<"'I": 0> -> Param<"'O": 1>)
+            #28 77-80 "(x)" : Param<"'I": 0>
+            #29 78-79 "x" : Param<"'I": 0>
+            #35 103-105 "()" : Unit
+            #39 113-262 "{\n            let r0 = Foo(Foo, (() -> (), ()));\n            let r1 = Foo(Foo, (a -> (), ()));\n            let r2 = Foo(Foo, (b -> b, ()));\n        }" : Unit
+            #41 131-133 "r0" : Unit
+            #43 136-160 "Foo(Foo, (() -> (), ()))" : Unit
+            #44 136-139 "Foo" : (((((Unit -> Unit), Unit) -> Unit), ((Unit -> Unit), Unit)) -> Unit)
+            #47 139-160 "(Foo, (() -> (), ()))" : ((((Unit -> Unit), Unit) -> Unit), ((Unit -> Unit), Unit))
+            #48 140-143 "Foo" : (((Unit -> Unit), Unit) -> Unit)
+            #51 145-159 "(() -> (), ())" : ((Unit -> Unit), Unit)
+            #52 146-154 "() -> ()" : (Unit -> Unit)
+            #53 146-148 "()" : Unit
+            #54 152-154 "()" : Unit
+            #55 156-158 "()" : Unit
+            #57 178-180 "r1" : Unit
+            #59 183-206 "Foo(Foo, (a -> (), ()))" : Unit
+            #60 183-186 "Foo" : (((((Unit -> Unit), Unit) -> Unit), ((Unit -> Unit), Unit)) -> Unit)
+            #63 186-206 "(Foo, (a -> (), ()))" : ((((Unit -> Unit), Unit) -> Unit), ((Unit -> Unit), Unit))
+            #64 187-190 "Foo" : (((Unit -> Unit), Unit) -> Unit)
+            #67 192-205 "(a -> (), ())" : ((Unit -> Unit), Unit)
+            #68 193-200 "a -> ()" : (Unit -> Unit)
+            #69 193-194 "a" : Unit
+            #71 198-200 "()" : Unit
+            #72 202-204 "()" : Unit
+            #74 224-226 "r2" : Unit
+            #76 229-251 "Foo(Foo, (b -> b, ()))" : Unit
+            #77 229-232 "Foo" : (((((Unit -> Unit), Unit) -> Unit), ((Unit -> Unit), Unit)) -> Unit)
+            #80 232-251 "(Foo, (b -> b, ()))" : ((((Unit -> Unit), Unit) -> Unit), ((Unit -> Unit), Unit))
+            #81 233-236 "Foo" : (((Unit -> Unit), Unit) -> Unit)
+            #84 238-250 "(b -> b, ())" : ((Unit -> Unit), Unit)
+            #85 239-245 "b -> b" : (Unit -> Unit)
+            #86 239-240 "b" : Unit
+            #88 244-245 "b" : Unit
+            #91 247-249 "()" : Unit
+        "##]],
+    );
+}
+
+#[test]
 fn add_wrong_types() {
     check(
         indoc! {"
@@ -4149,7 +4208,7 @@ fn inference_infinite_recursion_should_fail() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #8 41-59 "(x : ('T1 -> 'U1))" : (Param<"'T1": 0> -> Param<"'U1": 1>)
             #9 42-58 "x : ('T1 -> 'U1)" : (Param<"'T1": 0> -> Param<"'U1": 1>)
             #20 68-75 "{\n    }" : Unit
@@ -4163,10 +4222,8 @@ fn inference_infinite_recursion_should_fail() {
             #54 186-187 "B" : (((?1[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][], ?3) -> ?1[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][]) -> ?2[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][])
             Error(Type(Error(TyMismatch("Unit", "'U1[]", Span { lo: 62, hi: 67 }))))
             Error(Type(Error(TyMismatch("Unit", "'T2", Span { lo: 129, hi: 132 }))))
-            Error(Type(Error(TyMismatch("Bool", "(((?[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][], ?) -> ?[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][]) -> ?[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][])", Span { lo: 180, hi: 181 }))))
-            Error(Type(Error(TyMismatch("Unit", "(((?[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][], ?) -> ?[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][]) -> ?[][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][][])", Span { lo: 180, hi: 187 }))))
             Error(Type(Error(AmbiguousTy(Span { lo: 186, hi: 187 }))))
-        "#]],
+        "##]],
     );
 }
 


### PR DESCRIPTION
This change fixes a subtle bug in type inference where nested generic callables could finish satisfying constraints without fully resolving one of the generic types. By setting up an equality constraint when binding the inference type it forces the solver to come back to the inference type later and ensure it is resolved. This also required a fix to the type substituion recursion limit check to ensure we don't end up trying to repeatedly unify infinite types.