### PR TITLE
Add 'Get a Link' to kata examples

### DIFF
--- a/playground/src/kata.tsx
+++ b/playground/src/kata.tsx
@@ -6,6 +6,7 @@ import { QscEventTarget } from "qsharp-lang";
 import { Editor, getProfile } from "./editor.js";
 import { OutputTabs } from "./tabs.js";
 import { Markdown } from "qsharp-lang/ux";
+import { Viewer } from "./viewer.js";
 
 import type {
   CompilerState,
@@ -93,11 +94,7 @@ function LessonElem(props: Props & { section: KataSection }) {
         {lesson.items.map((item) => {
           switch (item.type) {
             case "example":
-              return (
-                <pre>
-                  <code>{item.code}</code>
-                </pre>
-              );
+              return <Viewer code={item.code}></Viewer>;
             case "text-content":
               return <Markdown markdown={item.content}></Markdown>;
             case "question":

--- a/playground/src/main.css
+++ b/playground/src/main.css
@@ -7,3 +7,13 @@ pre:has(code) {
   margin: 5px 0px 5px 0px;
   padding: 0em 0em 0em 0.5em;
 }
+.viewer-column {
+  grid-area: editor;
+  margin: 16px;
+  margin-top: 32px;
+}
+.example-viewer {
+  height: 40vh;
+  min-height: 400px;
+  border: 1px solid var(--border-color);
+}

--- a/playground/src/viewer.tsx
+++ b/playground/src/viewer.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { codeToCompressedBase64 } from "./utils.js";
+
+export function Viewer(props: { code: string }) {
+  async function onGetLink(ev: MouseEvent) {
+    const code = props.code;
+    if (!code) return;
+
+    let messageText = "Unable to create the link";
+    try {
+      const encodedCode = await codeToCompressedBase64(code);
+      const escapedCode = encodeURIComponent(encodedCode);
+      // Get current URL without query parameters to use as the base URL
+      const newUrl = `${
+        window.location.href.split("?")[0]
+      }?code=${escapedCode}&profile=unrestricted`;
+
+      // Copy link to clipboard and update url without reloading the page
+      navigator.clipboard.writeText(newUrl);
+
+      window.history.pushState({}, "", newUrl);
+      messageText = "Link was copied to the clipboard";
+    } finally {
+      const popup = document.getElementById("popup") as HTMLDivElement;
+      popup.style.display = "block";
+      popup.innerText = messageText;
+      popup.style.left = `${ev.clientX - 120}px`;
+      popup.style.top = `${ev.clientY - 40}px`;
+
+      setTimeout(() => {
+        popup.style.display = "none";
+      }, 2000);
+    }
+  }
+
+  return (
+    <div class="viewer-column">
+      <div style="display: flex; justify-content: space-between; align-items: center">
+        <div></div>
+        <div class="icon-row">
+          <svg
+            onClick={onGetLink}
+            width="24px"
+            height="24px"
+            viewBox="0 0 24 24"
+            fill="none"
+          >
+            <title>Get a link to this code</title>
+            <path
+              d="M14 12C14 14.2091 12.2091 16 10 16H6C3.79086 16 2 14.2091 2 12C2 9.79086 3.79086 8 6 8H8M10 12C10 9.79086 11.7909 8 14 8H18C20.2091 8 22 9.79086 22 12C22 14.2091 20.2091 16 18 16H16"
+              stroke="#000000"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </div>
+      </div>
+      <pre class="example-viewer">
+        <code>{props.code}</code>
+      </pre>
+    </div>
+  );
+}


### PR DESCRIPTION
An alternative approach to address "Kata examples should be editable and runnable" https://github.com/microsoft/qsharp/issues/591

Kata example window has "Get a link to this code" icon and is scrollable (saves physical space in kata lesson for long examples).