### PR TITLE
Allow the parser to add contextual help text to errors; Add contextual help text for parenthesized for loops

### DIFF
--- a/compiler/qsc_parse/src/expr.rs
+++ b/compiler/qsc_parse/src/expr.rs
@@ -170,7 +170,11 @@ fn expr_base(s: &mut ParserContext) -> Result<Box<Expr>> {
         let vars = match pat(s) {
             Ok(o) => o,
             Err(e) => {
-                if let (TokenKind::Open(Delim::Paren), ErrorKind::Token(..)) = (peeked.kind, &e.0) {
+                if let (
+                    TokenKind::Open(Delim::Paren),
+                    ErrorKind::Token(_, TokenKind::Keyword(Keyword::In), _),
+                ) = (peeked.kind, &e.0)
+                {
                     return Err(
                         e.with_help("parenthesis are not permitted around for-loop iterations")
                     );

--- a/compiler/qsc_parse/src/expr/tests.rs
+++ b/compiler/qsc_parse/src/expr/tests.rs
@@ -2527,6 +2527,24 @@ fn friendly_error_on_parenthesized_for() {
     check(
         expr,
         "for (x in xs) { () }",
-        &expect![[r#""#]]
+        &expect![[r#"
+            Error(
+                Token(
+                    Close(
+                        Paren,
+                    ),
+                    Keyword(
+                        In,
+                    ),
+                    Span {
+                        lo: 7,
+                        hi: 9,
+                    },
+                ),
+                Some(
+                    "parenthesis are not permitted around for-loop iterations",
+                ),
+            )
+        "#]],
     );
 }

--- a/compiler/qsc_parse/src/expr/tests.rs
+++ b/compiler/qsc_parse/src/expr/tests.rs
@@ -2548,3 +2548,56 @@ fn friendly_error_on_parenthesized_for() {
         "#]],
     );
 }
+
+#[test]
+fn no_help_text_on_non_parenthesized_for() {
+    check(
+        expr,
+        "for x in invalid syntax { () }",
+        &expect![[r#"
+            Error(
+                Token(
+                    Open(
+                        Brace,
+                    ),
+                    Ident,
+                    Span {
+                        lo: 17,
+                        hi: 23,
+                    },
+                ),
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn parenthesized_pat_in_for_is_valid() {
+    check(
+        expr,
+        "for (x) in xs { () }",
+        &expect![[r#"
+            Expr _id_ [0-20]: For:
+                Pat _id_ [4-7]: Paren:
+                    Pat _id_ [5-6]: Bind:
+                        Ident _id_ [5-6] "x"
+                Expr _id_ [11-13]: Path: Path _id_ [11-13] (Ident _id_ [11-13] "xs")
+                Block _id_ [14-20]:
+                    Stmt _id_ [16-18]: Expr: Expr _id_ [16-18]: Unit"#]],
+    );
+}
+
+#[test]
+fn parenthesized_expr_in_for_is_valid() {
+    check(
+        expr,
+        "for x in (xs) { () }",
+        &expect![[r#"
+            Expr _id_ [0-20]: For:
+                Pat _id_ [4-5]: Bind:
+                    Ident _id_ [4-5] "x"
+                Expr _id_ [9-13]: Paren: Expr _id_ [10-12]: Path: Path _id_ [10-12] (Ident _id_ [10-12] "xs")
+                Block _id_ [14-20]:
+                    Stmt _id_ [16-18]: Expr: Expr _id_ [16-18]: Unit"#]],
+    );
+}

--- a/compiler/qsc_parse/src/expr/tests.rs
+++ b/compiler/qsc_parse/src/expr/tests.rs
@@ -2521,3 +2521,12 @@ fn invalid_initial_commas_in_pattern() {
             ]"#]],
     );
 }
+
+#[test]
+fn friendly_error_on_parenthesized_for() {
+    check(
+        expr,
+        "for (x in xs) { () }",
+        &expect![[r#""#]]
+    );
+}

--- a/compiler/qsc_parse/src/prim.rs
+++ b/compiler/qsc_parse/src/prim.rs
@@ -39,7 +39,11 @@ pub(super) fn token(s: &mut ParserContext, t: TokenKind) -> Result<()> {
         s.advance();
         Ok(())
     } else {
-        Err(Error(ErrorKind::Token(t, s.peek().kind, s.peek().span)))
+        Err(Error::new(ErrorKind::Token(
+            t,
+            s.peek().kind,
+            s.peek().span,
+        )))
     }
 }
 
@@ -54,7 +58,7 @@ pub(super) fn apos_ident(s: &mut ParserContext) -> Result<Box<Ident>> {
             name,
         }))
     } else {
-        Err(Error(ErrorKind::Rule(
+        Err(Error::new(ErrorKind::Rule(
             "generic parameter",
             peek.kind,
             peek.span,
@@ -73,7 +77,11 @@ pub(super) fn ident(s: &mut ParserContext) -> Result<Box<Ident>> {
             name,
         }))
     } else {
-        Err(Error(ErrorKind::Rule("identifier", peek.kind, peek.span)))
+        Err(Error::new(ErrorKind::Rule(
+            "identifier",
+            peek.kind,
+            peek.span,
+        )))
     }
 }
 
@@ -187,7 +195,7 @@ where
     while s.peek().kind == TokenKind::Comma {
         let mut span = s.peek().span;
         span.hi = span.lo;
-        s.push_error(Error(ErrorKind::MissingSeqEntry(span)));
+        s.push_error(Error::new(ErrorKind::MissingSeqEntry(span)));
         xs.push(T::default().with_span(span));
         s.advance();
     }
@@ -197,7 +205,7 @@ where
             while s.peek().kind == TokenKind::Comma {
                 let mut span = s.peek().span;
                 span.hi = span.lo;
-                s.push_error(Error(ErrorKind::MissingSeqEntry(span)));
+                s.push_error(Error::new(ErrorKind::MissingSeqEntry(span)));
                 xs.push(T::default().with_span(span));
                 s.advance();
             }
@@ -262,7 +270,7 @@ fn advanced(s: &ParserContext, from: u32) -> bool {
 }
 
 fn map_rule_name(name: &'static str, error: Error) -> Error {
-    Error(match error.0 {
+    Error::new(match error.0 {
         ErrorKind::Rule(_, found, span) => ErrorKind::Rule(name, found, span),
         ErrorKind::Convert(_, found, span) => ErrorKind::Convert(name, found, span),
         kind => kind,

--- a/compiler/qsc_parse/src/prim/tests.rs
+++ b/compiler/qsc_parse/src/prim/tests.rs
@@ -63,7 +63,7 @@ fn ident_keyword() {
                 .expect("keyword length should fit into u32"),
         };
 
-        let expected = Error(match keyword {
+        let expected = Error::new(match keyword {
             Keyword::And => {
                 ErrorKind::Rule("identifier", TokenKind::ClosedBinOp(ClosedBinOp::And), span)
             }

--- a/compiler/qsc_parse/src/scan.rs
+++ b/compiler/qsc_parse/src/scan.rs
@@ -95,7 +95,7 @@ impl<'a> Scanner<'a> {
             barriers: Vec::new(),
             errors: errors
                 .into_iter()
-                .map(|e| Error(ErrorKind::Lex(e)))
+                .map(|e| Error::new(ErrorKind::Lex(e)))
                 .collect(),
             recovered_eof: false,
             peek: peek.unwrap_or_else(|| eof(input.len())),
@@ -123,7 +123,7 @@ impl<'a> Scanner<'a> {
             self.offset = self.peek.span.hi;
             let (peek, errors) = next_ok(&mut self.tokens);
             self.errors
-                .extend(errors.into_iter().map(|e| Error(ErrorKind::Lex(e))));
+                .extend(errors.into_iter().map(|e| Error::new(ErrorKind::Lex(e))));
             self.peek = peek.unwrap_or_else(|| eof(self.input.len()));
         }
     }

--- a/compiler/qsc_parse/src/stmt.rs
+++ b/compiler/qsc_parse/src/stmt.rs
@@ -82,7 +82,7 @@ fn parse_local(s: &mut ParserContext) -> Result<Box<StmtKind>> {
         Mutability::Mutable
     } else {
         let token = s.peek();
-        return Err(Error(ErrorKind::Rule(
+        return Err(Error::new(ErrorKind::Rule(
             "variable binding",
             token.kind,
             token.span,
@@ -102,7 +102,7 @@ fn parse_qubit(s: &mut ParserContext) -> Result<Box<StmtKind>> {
     } else if token(s, TokenKind::Keyword(Keyword::Borrow)).is_ok() {
         QubitSource::Dirty
     } else {
-        return Err(Error(ErrorKind::Rule(
+        return Err(Error::new(ErrorKind::Rule(
             "qubit binding",
             s.peek().kind,
             s.peek().span,
@@ -129,7 +129,7 @@ fn parse_qubit_init(s: &mut ParserContext) -> Result<Box<QubitInit>> {
     let lo = s.peek().span.lo;
     let kind = if let Ok(name) = ident(s) {
         if name.name.as_ref() != "Qubit" {
-            return Err(Error(ErrorKind::Convert(
+            return Err(Error::new(ErrorKind::Convert(
                 "qubit initializer",
                 "identifier",
                 name.span,
@@ -143,7 +143,7 @@ fn parse_qubit_init(s: &mut ParserContext) -> Result<Box<QubitInit>> {
             QubitInitKind::Array(size)
         } else {
             let token = s.peek();
-            return Err(Error(ErrorKind::Rule(
+            return Err(Error::new(ErrorKind::Rule(
                 "qubit suffix",
                 token.kind,
                 token.span,
@@ -155,7 +155,7 @@ fn parse_qubit_init(s: &mut ParserContext) -> Result<Box<QubitInit>> {
         final_sep.reify(inits, QubitInitKind::Paren, QubitInitKind::Tuple)
     } else {
         let token = s.peek();
-        return Err(Error(ErrorKind::Rule(
+        return Err(Error::new(ErrorKind::Rule(
             "qubit initializer",
             token.kind,
             token.span,
@@ -177,7 +177,7 @@ pub(super) fn check_semis(s: &mut ParserContext, stmts: &[Box<Stmt>]) {
                 lo: stmt.span.hi,
                 hi: stmt.span.hi,
             };
-            s.push_error(Error(ErrorKind::MissingSemi(span)));
+            s.push_error(Error::new(ErrorKind::MissingSemi(span)));
         }
     }
 }

--- a/compiler/qsc_parse/src/ty.rs
+++ b/compiler/qsc_parse/src/ty.rs
@@ -74,7 +74,7 @@ fn arrow(s: &mut ParserContext) -> Result<CallableKind> {
     } else if token(s, TokenKind::FatArrow).is_ok() {
         Ok(CallableKind::Operation)
     } else {
-        Err(Error(ErrorKind::Rule(
+        Err(Error::new(ErrorKind::Rule(
             "arrow type",
             s.peek().kind,
             s.peek().span,
@@ -96,7 +96,11 @@ fn base(s: &mut ParserContext) -> Result<Ty> {
         token(s, TokenKind::Close(Delim::Paren))?;
         Ok(final_sep.reify(tys, |t| TyKind::Paren(Box::new(t)), TyKind::Tuple))
     } else {
-        Err(Error(ErrorKind::Rule("type", s.peek().kind, s.peek().span)))
+        Err(Error::new(ErrorKind::Rule(
+            "type",
+            s.peek().kind,
+            s.peek().span,
+        )))
     }?;
 
     Ok(Ty {
@@ -124,7 +128,7 @@ fn functor_base(s: &mut ParserContext) -> Result<FunctorExpr> {
     } else if token(s, TokenKind::Keyword(Keyword::Ctl)).is_ok() {
         Ok(FunctorExprKind::Lit(Functor::Ctl))
     } else {
-        Err(Error(ErrorKind::Rule(
+        Err(Error::new(ErrorKind::Rule(
             "functor literal",
             s.peek().kind,
             s.peek().span,


### PR DESCRIPTION
Given the problems users have faced with non-parenthesized for loop iterators ([like this one](https://stackoverflow.com/questions/78592805/q-sharp-syntax-error-in-quantum-hhl-algorithm)), we wanted to provide some help text for the user in this situation.

Instead of just patching in a fix for precisely this situation, I wanted to use `miette`'s great functionality for composable errors. So, with this change, can now compose any parse error with help text.

I also manually implemented `Debug` for `Error` to omit the help text if it isn't present. This is primarily so this PR doesn't add `None` to every single parser expect test which tests errors. (Happy to revert this and update the tests if desired, but I really don't like spraying the diff with 1k lines of expect-test changes that just say `None`)