### PR TITLE
Update `qsharp.json.schema` to include latest lints

### DIFF
--- a/vscode/qsharp.schema.json
+++ b/vscode/qsharp.schema.json
@@ -30,7 +30,15 @@
         "properties": {
           "lint": {
             "type": "string",
-            "enum": ["divisionByZero", "needlessParens", "redundantSemicolons", "deprecatedFunctionConstructor", "deprecatedWithOperator", "deprecatedDoubleColonOperator", "deprecatedNewtype"]
+            "enum": [
+              "divisionByZero",
+              "needlessParens",
+              "redundantSemicolons",
+              "deprecatedFunctionConstructor",
+              "deprecatedWithOperator",
+              "deprecatedDoubleColonOperator",
+              "deprecatedNewtype"
+            ]
           },
           "level": {
             "type": "string",

--- a/vscode/qsharp.schema.json
+++ b/vscode/qsharp.schema.json
@@ -30,7 +30,7 @@
         "properties": {
           "lint": {
             "type": "string",
-            "enum": ["divisionByZero", "needlessParens", "redundantSemicolons"]
+            "enum": ["divisionByZero", "needlessParens", "redundantSemicolons", "deprecatedFunctionConstructor", "deprecatedWithOperator", "deprecatedDoubleColonOperator", "deprecatedNewtype"]
           },
           "level": {
             "type": "string",


### PR DESCRIPTION
The schema file was not updated when new lints were added as a part of the newtype/struct rework. This PR updates the schema.
