### PR TITLE
Fix spans for lifted lambda idents

### DIFF
--- a/compiler/qsc_frontend/src/closure.rs
+++ b/compiler/qsc_frontend/src/closure.rs
@@ -124,7 +124,7 @@ pub(super) fn lift(
         kind: lambda.kind,
         name: Ident {
             id: assigner.next_node(),
-            span: Span::default(),
+            span,
             name: "lambda".into(),
         },
         generics: Vec::new(),

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -965,7 +965,7 @@ fn lambda_function_empty_closure() {
                 Item 2 [57-67] (Internal):
                     Parent: 1
                     Callable 15 [57-67] (function):
-                        name: Ident 16 [0-0] "lambda"
+                        name: Ident 16 [57-67] "lambda"
                         input: Pat 14 [57-67] [Type (Int,)]: Tuple:
                             Pat 9 [57-58] [Type Int]: Bind: Ident 10 [57-58] "x"
                         output: Int
@@ -1027,7 +1027,7 @@ fn lambda_function_empty_closure_passed() {
                 Item 3 [93-103] (Internal):
                     Parent: 2
                     Callable 25 [93-103] (function):
-                        name: Ident 26 [0-0] "lambda"
+                        name: Ident 26 [93-103] "lambda"
                         input: Pat 24 [93-103] [Type (Int,)]: Tuple:
                             Pat 19 [93-94] [Type Int]: Bind: Ident 20 [93-94] "x"
                         output: Int
@@ -1083,7 +1083,7 @@ fn lambda_function_closure() {
                 Item 2 [76-86] (Internal):
                     Parent: 1
                     Callable 21 [76-86] (function):
-                        name: Ident 22 [0-0] "lambda"
+                        name: Ident 22 [76-86] "lambda"
                         input: Pat 19 [76-86] [Type (Int, Int)]: Tuple:
                             Pat 20 [53-54] [Type Int]: Bind: Ident 18 [53-54] "x"
                             Pat 13 [76-77] [Type Int]: Bind: Ident 14 [76-77] "y"
@@ -1140,7 +1140,7 @@ fn lambda_function_closure_repeated_var() {
                 Item 2 [76-90] (Internal):
                     Parent: 1
                     Callable 23 [76-90] (function):
-                        name: Ident 24 [0-0] "lambda"
+                        name: Ident 24 [76-90] "lambda"
                         input: Pat 21 [76-90] [Type (Int, Int)]: Tuple:
                             Pat 22 [53-54] [Type Int]: Bind: Ident 20 [53-54] "x"
                             Pat 13 [76-77] [Type Int]: Bind: Ident 14 [76-77] "y"
@@ -1211,7 +1211,7 @@ fn lambda_function_closure_passed() {
                 Item 3 [120-130] (Internal):
                     Parent: 2
                     Callable 31 [120-130] (function):
-                        name: Ident 32 [0-0] "lambda"
+                        name: Ident 32 [120-130] "lambda"
                         input: Pat 29 [120-130] [Type (Int, Int)]: Tuple:
                             Pat 30 [101-102] [Type Int]: Bind: Ident 28 [101-102] "x"
                             Pat 23 [120-121] [Type Int]: Bind: Ident 24 [120-121] "y"
@@ -1285,7 +1285,7 @@ fn lambda_function_nested_closure() {
                 Item 3 [172-190] (Internal):
                     Parent: 2
                     Callable 51 [172-190] (function):
-                        name: Ident 52 [0-0] "lambda"
+                        name: Ident 52 [172-190] "lambda"
                         input: Pat 47 [172-190] [Type (Int, Int, Int, Int)]: Tuple:
                             Pat 48 [111-112] [Type Int]: Bind: Ident 44 [111-112] "a"
                             Pat 49 [130-131] [Type Int]: Bind: Ident 45 [130-131] "b"
@@ -1308,7 +1308,7 @@ fn lambda_function_nested_closure() {
                 Item 4 [130-200] (Internal):
                     Parent: 2
                     Callable 59 [130-200] (function):
-                        name: Ident 60 [0-0] "lambda"
+                        name: Ident 60 [130-200] "lambda"
                         input: Pat 57 [130-200] [Type (Int, Int)]: Tuple:
                             Pat 58 [111-112] [Type Int]: Bind: Ident 56 [111-112] "a"
                             Pat 25 [130-131] [Type Int]: Bind: Ident 26 [130-131] "b"
@@ -1384,7 +1384,7 @@ fn lambda_operation_empty_closure() {
                 Item 3 [137-144] (Internal):
                     Parent: 2
                     Callable 27 [137-144] (operation):
-                        name: Ident 28 [0-0] "lambda"
+                        name: Ident 28 [137-144] "lambda"
                         input: Pat 26 [137-144] [Type (Qubit,)]: Tuple:
                             Pat 23 [137-138] [Type Qubit]: Bind: Ident 24 [137-138] "q"
                         output: Unit
@@ -1467,7 +1467,7 @@ fn lambda_operation_closure() {
                 Item 4 [199-215] (Internal):
                     Parent: 3
                     Callable 35 [199-215] (operation):
-                        name: Ident 36 [0-0] "lambda"
+                        name: Ident 36 [199-215] "lambda"
                         input: Pat 33 [199-215] [Type (Qubit, Unit)]: Tuple:
                             Pat 34 [174-175] [Type Qubit]: Bind: Ident 32 [174-175] "q"
                             Pat 28 [199-201] [Type Unit]: Unit
@@ -1545,7 +1545,7 @@ fn lambda_adj() {
                 Item 4 [138-147] (Internal):
                     Parent: 3
                     Callable 27 [138-147] (operation):
-                        name: Ident 28 [0-0] "lambda"
+                        name: Ident 28 [138-147] "lambda"
                         input: Pat 26 [138-147] [Type (Qubit,)]: Tuple:
                             Pat 21 [138-139] [Type Qubit]: Bind: Ident 22 [138-139] "q"
                         output: Unit
@@ -1613,7 +1613,7 @@ fn partial_app_one_hole() {
                 Item 3 [99-108] (Internal):
                     Parent: 2
                     Callable 37 [99-108] (function):
-                        name: Ident 38 [0-0] "lambda"
+                        name: Ident 38 [99-108] "lambda"
                         input: Pat 35 [99-108] [Type (Int, Int)]: Tuple:
                             Pat 36 [106-107] [Type Int]: Bind: Ident 34 [106-107] "arg"
                             Pat 24 [103-104] [Type Int]: Bind: Ident 23 [103-104] "hole"
@@ -1681,7 +1681,7 @@ fn partial_app_two_holes() {
                 Item 3 [99-108] (Internal):
                     Parent: 2
                     Callable 33 [99-108] (function):
-                        name: Ident 34 [0-0] "lambda"
+                        name: Ident 34 [99-108] "lambda"
                         input: Pat 32 [99-108] [Type ((Int, Int),)]: Tuple:
                             Pat 30 [102-108] [Type (Int, Int)]: Tuple:
                                 Pat 24 [103-104] [Type Int]: Bind: Ident 23 [103-104] "hole"
@@ -1754,7 +1754,7 @@ fn partial_app_nested_tuple() {
                 Item 3 [130-152] (Internal):
                     Parent: 2
                     Callable 52 [130-152] (function):
-                        name: Ident 53 [0-0] "lambda"
+                        name: Ident 53 [130-152] "lambda"
                         input: Pat 50 [130-152] [Type (Double, (Int, (Bool, String), Result))]: Tuple:
                             Pat 51 [141-144] [Type Double]: Bind: Ident 49 [141-144] "arg"
                             Pat 47 [133-152] [Type (Int, (Bool, String), Result)]: Tuple:
@@ -1838,7 +1838,7 @@ fn partial_app_nested_tuple_singleton_unwrap() {
                 Item 3 [130-155] (Internal):
                     Parent: 2
                     Callable 56 [130-155] (function):
-                        name: Ident 57 [0-0] "lambda"
+                        name: Ident 57 [130-155] "lambda"
                         input: Pat 53 [130-155] [Type (Bool, Double, (Int, String, Result))]: Tuple:
                             Pat 54 [138-142] [Type Bool]: Bind: Ident 51 [138-142] "arg"
                             Pat 55 [144-147] [Type Double]: Bind: Ident 52 [144-147] "arg"
@@ -2093,7 +2093,7 @@ fn partial_app_bound_to_non_arrow_ty() {
                 Item 3 [113-122] (Internal):
                     Parent: 2
                     Callable 37 [113-122] (function):
-                        name: Ident 38 [0-0] "lambda"
+                        name: Ident 38 [113-122] "lambda"
                         input: Pat 35 [113-122] [Type (Int, Int)]: Tuple:
                             Pat 36 [117-118] [Type Int]: Bind: Ident 34 [117-118] "arg"
                             Pat 30 [120-121] [Type Int]: Bind: Ident 29 [120-121] "hole"
@@ -2318,7 +2318,7 @@ fn lambda_with_invalid_free_variable() {
                 Item 2 [52-67] (Internal):
                     Parent: 1
                     Callable 12 [52-67] (operation):
-                        name: Ident 13 [0-0] "lambda"
+                        name: Ident 13 [52-67] "lambda"
                         input: Pat 11 [52-67] [Type (Unit,)]: Tuple:
                             Pat 7 [52-54] [Type Unit]: Unit
                         output: Unit

--- a/compiler/qsc_linter/src/tests.rs
+++ b/compiler/qsc_linter/src/tests.rs
@@ -270,7 +270,7 @@ fn needless_operation_lambda_operations() {
         &expect![[r#"
             [
                 SrcLint {
-                    source: "",
+                    source: "(a) => a + 1",
                     level: Allow,
                     message: "operation does not contain any quantum operations",
                     help: "this callable can be declared as a function instead",

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -1907,7 +1907,7 @@ fn lambda_adj_calls_adj() {
                 Item 4 [138-147] (Internal):
                     Parent: 3
                     Callable 27 [138-147] (operation):
-                        name: Ident 28 [0-0] "lambda"
+                        name: Ident 28 [138-147] "lambda"
                         input: Pat 26 [138-147] [Type (Qubit,)]: Tuple:
                             Pat 21 [138-139] [Type Qubit]: Bind: Ident 22 [138-139] "q"
                         output: Unit
@@ -2033,7 +2033,7 @@ fn op_array_forget_functors_with_lambdas() {
                 Item 5 [270-281] (Internal):
                     Parent: 4
                     Callable 35 [270-281] (operation):
-                        name: Ident 36 [0-0] "lambda"
+                        name: Ident 36 [270-281] "lambda"
                         input: Pat 34 [270-281] [Type (Qubit,)]: Tuple:
                             Pat 29 [270-271] [Type Qubit]: Bind: Ident 30 [270-271] "q"
                         output: Unit
@@ -2049,7 +2049,7 @@ fn op_array_forget_functors_with_lambdas() {
                 Item 6 [283-294] (Internal):
                     Parent: 4
                     Callable 47 [283-294] (operation):
-                        name: Ident 48 [0-0] "lambda"
+                        name: Ident 48 [283-294] "lambda"
                         input: Pat 46 [283-294] [Type (Qubit,)]: Tuple:
                             Pat 41 [283-284] [Type Qubit]: Bind: Ident 42 [283-284] "q"
                         output: Unit


### PR DESCRIPTION
This change gets rid of the default span on lifted lambda names by setting it to the entire lamba. This ends up working well with error and lints that try to underline the lambda, which previously could end up highlighting the first character (sometimes of the wrong file).

Before:
<img width="447" alt="image" src="https://github.com/user-attachments/assets/1aaad022-aa33-4329-9eb5-08c0640d9260">

After:
<img width="627" alt="image" src="https://github.com/user-attachments/assets/91fd4b90-d7ef-4633-9586-4df317494a64">
