### PR TITLE
generate auto imports for core callables

### DIFF
--- a/compiler/qsc_data_structures/src/index_map.rs
+++ b/compiler/qsc_data_structures/src/index_map.rs
@@ -227,6 +227,16 @@ pub struct IterMut<'a, K, V> {
     base: Enumerate<slice::IterMut<'a, Option<V>>>,
 }
 
+impl<K: From<usize>, V> DoubleEndedIterator for Iter<'_, K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            if let (index, Some(value)) = self.base.next_back()? {
+                break Some((index.into(), value));
+            }
+        }
+    }
+}
+
 impl<'a, K: From<usize>, V> Iterator for IterMut<'a, K, V> {
     type Item = (K, &'a mut V);
 

--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -334,6 +334,12 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
+impl DoubleEndedIterator for Iter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back()
+    }
+}
+
 pub(super) struct Offsetter(pub(super) u32);
 
 impl MutVisitor for Offsetter {

--- a/language_service/src/code_lens/tests.rs
+++ b/language_service/src/code_lens/tests.rs
@@ -14,7 +14,7 @@ use expect_test::{expect, Expect};
 
 fn check(source_with_markers: &str, expect: &Expect) {
     let (compilation, expected_code_lens_ranges) =
-        compile_with_fake_stdlib_and_markers_no_cursor(source_with_markers);
+        compile_with_fake_stdlib_and_markers_no_cursor(source_with_markers, true);
     let mut actual_code_lenses = get_code_lenses(&compilation, "<source>", Encoding::Utf8);
 
     for expected_range in &expected_code_lens_ranges {

--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -337,25 +337,10 @@ impl CompletionListBuilder {
         current_namespace_name: &Option<Vec<Rc<str>>>,
         indent: &String,
     ) {
-        let core = &compilation
-            .package_store
-            .get(PackageId::CORE)
-            .expect("expected to find core package")
-            .package;
-
-        let mut all_except_core = compilation
-            .package_store
-            .iter()
-            .filter(|p| p.0 != PackageId::CORE)
-            .collect::<Vec<_>>();
-
-        // Reverse to collect symbols starting at the current package backwards
-        all_except_core.reverse();
-
-        for (package_id, _) in &all_except_core {
+        for (package_id, _) in &compilation.package_store {
             self.push_sorted_completions(Self::get_callables(
                 compilation,
-                *package_id,
+                package_id,
                 imports,
                 insert_open_range,
                 current_namespace_name.as_deref(),
@@ -363,14 +348,10 @@ impl CompletionListBuilder {
             ));
         }
 
-        self.push_sorted_completions(Self::get_core_callables(compilation, core));
-
-        for (id, unit) in &all_except_core {
-            let alias = compilation.dependencies.get(id).cloned().flatten();
+        for (id, unit) in &compilation.package_store {
+            let alias = compilation.dependencies.get(&id).cloned().flatten();
             self.push_completions(Self::get_namespaces(&unit.package, alias));
         }
-
-        self.push_completions(Self::get_namespaces(core, None));
     }
 
     fn push_locals(
@@ -497,34 +478,6 @@ impl CompletionListBuilder {
                 insert_open_at,
                 indent,
             )
-        })
-    }
-
-    /// Get all callables in the core package
-    fn get_core_callables<'a>(
-        compilation: &'a Compilation,
-        package: &'a Package,
-    ) -> impl Iterator<Item = (CompletionItem, SortPriority)> + 'a {
-        let display = CodeDisplay { compilation };
-
-        package.items.values().filter_map(move |i| match &i.kind {
-            ItemKind::Callable(callable_decl) => {
-                let name = callable_decl.name.name.as_ref();
-                let detail = Some(display.hir_callable_decl(callable_decl).to_string());
-                // Everything that starts with a __ goes last in the list
-                let sort_group = SortPriority::from(name.starts_with("__"));
-                Some((
-                    CompletionItem {
-                        label: name.to_string(),
-                        kind: CompletionItemKind::Function,
-                        sort_text: None, // This will get filled in during `push_sorted_completions`
-                        detail,
-                        additional_text_edits: None,
-                    },
-                    sort_group,
-                ))
-            }
-            _ => None,
         })
     }
 

--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -337,7 +337,7 @@ impl CompletionListBuilder {
         current_namespace_name: &Option<Vec<Rc<str>>>,
         indent: &String,
     ) {
-        for (package_id, _) in &compilation.package_store {
+        for (package_id, _) in compilation.package_store.iter().rev() {
             self.push_sorted_completions(Self::get_callables(
                 compilation,
                 package_id,
@@ -348,7 +348,7 @@ impl CompletionListBuilder {
             ));
         }
 
-        for (id, unit) in &compilation.package_store {
+        for (id, unit) in compilation.package_store.iter().rev() {
             let alias = compilation.dependencies.get(&id).cloned().flatten();
             self.push_completions(Self::get_namespaces(&unit.package, alias));
         }

--- a/language_service/src/completion/tests.rs
+++ b/language_service/src/completion/tests.rs
@@ -498,7 +498,7 @@ fn in_block_from_other_namespace() {
                         label: "Foo",
                         kind: Function,
                         sort_text: Some(
-                            "0800Foo",
+                            "0600Foo",
                         ),
                         detail: Some(
                             "operation Foo() : Unit",
@@ -550,7 +550,7 @@ fn auto_open_multiple_files() {
                         label: "FooOperation",
                         kind: Function,
                         sort_text: Some(
-                            "0800FooOperation",
+                            "0600FooOperation",
                         ),
                         detail: Some(
                             "operation FooOperation() : Unit",
@@ -1379,7 +1379,7 @@ fn dont_import_if_already_glob_imported() {
                         label: "Foo",
                         kind: Function,
                         sort_text: Some(
-                            "0800Foo",
+                            "0600Foo",
                         ),
                         detail: Some(
                             "operation Foo() : Unit",
@@ -1392,7 +1392,7 @@ fn dont_import_if_already_glob_imported() {
                         label: "Bar",
                         kind: Function,
                         sort_text: Some(
-                            "0800Bar",
+                            "0600Bar",
                         ),
                         detail: Some(
                             "operation Bar() : Unit",
@@ -1443,7 +1443,7 @@ fn dont_import_if_already_directly_imported() {
                         label: "Bar",
                         kind: Function,
                         sort_text: Some(
-                            "0800Bar",
+                            "0600Bar",
                         ),
                         detail: Some(
                             "operation Bar() : Unit",
@@ -1489,7 +1489,7 @@ fn auto_import_from_qir_runtime() {
                         label: "AllocateQubitArray",
                         kind: Function,
                         sort_text: Some(
-                            "0600AllocateQubitArray",
+                            "0800AllocateQubitArray",
                         ),
                         detail: Some(
                             "operation AllocateQubitArray(size : Int) : Qubit[]",
@@ -1536,7 +1536,7 @@ fn dont_generate_import_for_core_prelude() {
                         label: "Length",
                         kind: Function,
                         sort_text: Some(
-                            "0600Length",
+                            "0800Length",
                         ),
                         detail: Some(
                             "function Length<'T>(a : 'T[]) : Int",

--- a/language_service/src/definition/tests.rs
+++ b/language_service/src/definition/tests.rs
@@ -8,9 +8,7 @@ use qsc::location::Location;
 
 use super::get_definition;
 use crate::{
-    test_utils::{
-        compile_notebook_with_fake_stdlib_and_markers, compile_with_fake_stdlib_and_markers,
-    },
+    test_utils::{compile_notebook_with_markers, compile_with_markers},
     Encoding,
 };
 
@@ -19,7 +17,7 @@ use crate::{
 /// The expected definition range is indicated by `◉` markers in the source text.
 fn assert_definition(source_with_markers: &str) {
     let (compilation, cursor_position, target_spans) =
-        compile_with_fake_stdlib_and_markers(source_with_markers);
+        compile_with_markers(source_with_markers, true);
     let actual_definition =
         get_definition(&compilation, "<source>", cursor_position, Encoding::Utf8);
     let expected_definition = if target_spans.is_empty() {
@@ -35,7 +33,7 @@ fn assert_definition(source_with_markers: &str) {
 
 fn assert_definition_notebook(cells_with_markers: &[(&str, &str)]) {
     let (compilation, cell_uri, position, target_spans) =
-        compile_notebook_with_fake_stdlib_and_markers(cells_with_markers);
+        compile_notebook_with_markers(cells_with_markers);
     let actual_definition = get_definition(&compilation, &cell_uri, position, Encoding::Utf8);
     let expected_definition = if target_spans.is_empty() {
         None
@@ -46,8 +44,7 @@ fn assert_definition_notebook(cells_with_markers: &[(&str, &str)]) {
 }
 
 fn check(source_with_markers: &str, expect: &Expect) {
-    let (compilation, cursor_position, _) =
-        compile_with_fake_stdlib_and_markers(source_with_markers);
+    let (compilation, cursor_position, _) = compile_with_markers(source_with_markers, true);
     let actual_definition =
         get_definition(&compilation, "<source>", cursor_position, Encoding::Utf8);
     expect.assert_debug_eq(&actual_definition);

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -4,9 +4,7 @@
 #![allow(clippy::needless_raw_string_hashes)]
 
 use super::get_hover;
-use crate::test_utils::{
-    compile_notebook_with_fake_stdlib_and_markers, compile_with_fake_stdlib_and_markers,
-};
+use crate::test_utils::{compile_notebook_with_markers, compile_with_markers};
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc::line_column::Encoding;
@@ -16,7 +14,7 @@ use qsc::line_column::Encoding;
 /// The expected hover span is indicated by two `◉` markers in the source text.
 fn check(source_with_markers: &str, expect: &Expect) {
     let (compilation, cursor_position, target_spans) =
-        compile_with_fake_stdlib_and_markers(source_with_markers);
+        compile_with_markers(source_with_markers, true);
     let actual = get_hover(&compilation, "<source>", cursor_position, Encoding::Utf8)
         .expect("Expected a hover.");
     assert_eq!(&actual.span, &target_spans[0]);
@@ -25,15 +23,14 @@ fn check(source_with_markers: &str, expect: &Expect) {
 
 /// Asserts that there is no hover for the given test case.
 fn check_none(source_with_markers: &str) {
-    let (compilation, cursor_position, _) =
-        compile_with_fake_stdlib_and_markers(source_with_markers);
+    let (compilation, cursor_position, _) = compile_with_markers(source_with_markers, true);
     let actual = get_hover(&compilation, "<source>", cursor_position, Encoding::Utf8);
     assert!(actual.is_none());
 }
 
 fn check_notebook(cells_with_markers: &[(&str, &str)], expect: &Expect) {
     let (compilation, cell_uri, position, target_spans) =
-        compile_notebook_with_fake_stdlib_and_markers(cells_with_markers);
+        compile_notebook_with_markers(cells_with_markers);
 
     let actual =
         get_hover(&compilation, &cell_uri, position, Encoding::Utf8).expect("Expected a hover.");
@@ -42,8 +39,7 @@ fn check_notebook(cells_with_markers: &[(&str, &str)], expect: &Expect) {
 }
 
 fn check_notebook_none(cells_with_markers: &[(&str, &str)]) {
-    let (compilation, cell_uri, position, _) =
-        compile_notebook_with_fake_stdlib_and_markers(cells_with_markers);
+    let (compilation, cell_uri, position, _) = compile_notebook_with_markers(cells_with_markers);
 
     let actual = get_hover(&compilation, &cell_uri, position, Encoding::Utf8);
     assert!(actual.is_none());

--- a/language_service/src/references/tests.rs
+++ b/language_service/src/references/tests.rs
@@ -5,9 +5,7 @@
 
 use super::get_references;
 use crate::{
-    test_utils::{
-        compile_notebook_with_fake_stdlib_and_markers, compile_with_fake_stdlib_and_markers,
-    },
+    test_utils::{compile_notebook_with_markers, compile_with_markers},
     Encoding,
 };
 use expect_test::{expect, Expect};
@@ -16,8 +14,7 @@ use indoc::indoc;
 /// Asserts that the reference locations given at the cursor position matches the expected reference locations.
 /// The cursor position is indicated by a `↘` marker in the source text.
 fn check_with_std(source_with_markers: &str, expect: &Expect) {
-    let (compilation, cursor_position, _) =
-        compile_with_fake_stdlib_and_markers(source_with_markers);
+    let (compilation, cursor_position, _) = compile_with_markers(source_with_markers, true);
     let actual = get_references(
         &compilation,
         "<source>",
@@ -33,7 +30,7 @@ fn check_with_std(source_with_markers: &str, expect: &Expect) {
 /// The expected reference location ranges are indicated by `◉` markers in the source text.
 fn check(source_with_markers: &str, include_declaration: bool) {
     let (compilation, cursor_position, target_spans) =
-        compile_with_fake_stdlib_and_markers(source_with_markers);
+        compile_with_markers(source_with_markers, true);
     let actual = get_references(
         &compilation,
         "<source>",
@@ -63,7 +60,7 @@ fn check_exclude_decl(source_with_markers: &str) {
 
 fn check_notebook_exclude_decl(cells_with_markers: &[(&str, &str)]) {
     let (compilation, cell_uri, position, target_spans) =
-        compile_notebook_with_fake_stdlib_and_markers(cells_with_markers);
+        compile_notebook_with_markers(cells_with_markers);
 
     let actual = get_references(&compilation, &cell_uri, position, Encoding::Utf8, false)
         .into_iter()

--- a/language_service/src/rename/tests.rs
+++ b/language_service/src/rename/tests.rs
@@ -5,9 +5,7 @@
 
 use super::{get_rename, prepare_rename};
 use crate::{
-    test_utils::{
-        compile_notebook_with_fake_stdlib_and_markers, compile_with_fake_stdlib_and_markers,
-    },
+    test_utils::{compile_notebook_with_markers, compile_with_markers},
     Encoding,
 };
 use expect_test::{expect, Expect};
@@ -17,7 +15,7 @@ use expect_test::{expect, Expect};
 /// The expected rename location ranges are indicated by `◉` markers in the source text.
 fn check(source_with_markers: &str) {
     let (compilation, cursor_position, target_spans) =
-        compile_with_fake_stdlib_and_markers(source_with_markers);
+        compile_with_markers(source_with_markers, true);
     let actual = get_rename(&compilation, "<source>", cursor_position, Encoding::Utf8)
         .into_iter()
         .map(|l| l.range)
@@ -31,22 +29,19 @@ fn check(source_with_markers: &str) {
 /// Asserts that the prepare rename given at the cursor position returns None.
 /// The cursor position is indicated by a `↘` marker in the source text.
 fn assert_no_rename(source_with_markers: &str) {
-    let (compilation, cursor_position, _) =
-        compile_with_fake_stdlib_and_markers(source_with_markers);
+    let (compilation, cursor_position, _) = compile_with_markers(source_with_markers, true);
     let actual = prepare_rename(&compilation, "<source>", cursor_position, Encoding::Utf8);
     assert!(actual.is_none());
 }
 
 fn check_notebook(cells_with_markers: &[(&str, &str)], expect: &Expect) {
-    let (compilation, cell_uri, position, _) =
-        compile_notebook_with_fake_stdlib_and_markers(cells_with_markers);
+    let (compilation, cell_uri, position, _) = compile_notebook_with_markers(cells_with_markers);
     let actual = get_rename(&compilation, &cell_uri, position, Encoding::Utf8);
     expect.assert_debug_eq(&actual);
 }
 
 fn check_prepare_notebook(cells_with_markers: &[(&str, &str)], expect: &Expect) {
-    let (compilation, cell_uri, position, _) =
-        compile_notebook_with_fake_stdlib_and_markers(cells_with_markers);
+    let (compilation, cell_uri, position, _) = compile_notebook_with_markers(cells_with_markers);
     let actual = prepare_rename(&compilation, &cell_uri, position, Encoding::Utf8);
     expect.assert_debug_eq(&actual);
 }

--- a/language_service/src/signature_help/tests.rs
+++ b/language_service/src/signature_help/tests.rs
@@ -4,15 +4,14 @@
 #![allow(clippy::needless_raw_string_hashes)]
 
 use super::get_signature_help;
-use crate::{test_utils::compile_with_fake_stdlib_and_markers, Encoding};
+use crate::{test_utils::compile_with_markers, Encoding};
 use expect_test::{expect, Expect};
 use indoc::indoc;
 
 /// Asserts that the signature help given at the cursor position matches the expected signature help.
 /// The cursor position is indicated by a `↘` marker in the source text.
 fn check(source_with_markers: &str, expect: &Expect) {
-    let (compilation, cursor_position, _) =
-        compile_with_fake_stdlib_and_markers(source_with_markers);
+    let (compilation, cursor_position, _) = compile_with_markers(source_with_markers, true);
     let actual = get_signature_help(&compilation, "<source>", cursor_position, Encoding::Utf8)
         .expect("Expected a signature help.");
     expect.assert_debug_eq(&actual);


### PR DESCRIPTION
Closes #1860

Currently, we have a separate code path for generating completions for core callables. This code path just hard-codes the callables to
not include any auto-generated imports. This may have been necessary at some point, but it no longer is and it is preventing us from generating
the correct auto-imports for `QIR.Runtime`. We now have a function that generates completions from a package and is aware of if imports are
needed or not, so I just went ahead and used that instead of special casing `Core`.

This PR:
- Uses the standard completion codepath to generate completions for `Core`
- Adds the ability to unit test completions with the real stdlib, not just the fake stdlib
- Adds tests to ensure auto-imports are generated for items that are not already in scope (e.g. `QIR.Runtime.*`) and are _not_ generated for items already
  in scope (e.g. `Length`).
