### PR TITLE
Skip errors on files with `pr` URI scheme

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -13,7 +13,8 @@ export function isQsharpDocument(document: TextDocument): boolean {
   return (
     document.languageId === qsharpLanguageId &&
     (Utils.extname(document.uri) === ".qs" || document.isUntitled) &&
-    document.uri.scheme !== "git"
+    document.uri.scheme !== "git" &&
+    document.uri.scheme !== "pr"
   );
 }
 


### PR DESCRIPTION
Much like git diffs with scheme `git`, viewing files surfaced from GitHub Pull Requests that come from a branch not currently checked out produces spurious errors since they are not real files on disk and have extra data in their filenames. This uses the same strategy as in #1754 to avoid them by not loading things with the custom `pr` URI scheme.