### PR TITLE
Remove benchmarking comment bot; Run benches weekly and save results as an artifact

### DIFF
--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
           ref: alex/benching
       - name: setup rust
-        uses: actions-rs/toolchain@v3
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
       - name: setup cargo criterion

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -1,7 +1,6 @@
 name: Benchmark Reports
 
-on:
-  push
+on: push
 
 env:
   CARGO_TERM_COLOR: always
@@ -9,7 +8,8 @@ env:
   PYTHON_VERSION: "3.11"
   RUST_TOOLCHAIN_VERSION: "1.80"
 
-jobs: runBenchmark:
+jobs:
+  runBenchmark:
     runs-on: ubuntu-latest
     name: run benchmark
     permissions:
@@ -21,7 +21,7 @@ jobs: runBenchmark:
           fetch-depth: 0
           ref: alex/benching
       - name: setup rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v3
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
       - name: setup cargo criterion
@@ -32,5 +32,5 @@ jobs: runBenchmark:
         uses: actions/upload-artifact@v4
         with:
           name: benchmarks
-          path: *.json
-
+          path: |
+            *.json

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           fetch-depth: 0
           ref: alex/benching
+      - name: setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          components: ${{ env.RUST_TOOLCHAIN_COMPONENTS }}
+      - name: setup cargo criterion
+        run: cargo install cargo-criterion
       - name: run benching script
         run: ./bench.sh
       - name: preserve bench artifacts

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -1,15 +1,7 @@
 name: Benchmark Reports
 
 on:
-  pull_request:
-    branches: "main"
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-  merge_group:
-  workflow_dispatch:
+  push
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,7 +12,6 @@ env:
 
 jobs:
   runBenchmark:
-    if: ${{ !github.event.pull_request.draft }}
     name: run benchmark
     runs-on: ubuntu-latest
     permissions:
@@ -28,63 +19,11 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
-      - uses: boa-dev/criterion-compare-action@v3
+        run: ./bench.sh
+    - name: preserve bench artifacts
+        uses: actions/upload-artifact@v4
         with:
-          branchName: ${{ github.base_ref }}
-          cwd: "compiler/qsc"
-        if: ${{ github.base_ref != null }}
+          name: benchmarks
+          path: |
+            target/criterion/**/*
 
-  runMemoryProfile:
-    if: ${{ !github.event.pull_request.draft }}
-    name: run memory profile
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: main
-      - uses: Swatinem/rust-cache@v2
-      - run: |
-          MAIN_MEASUREMENT=$(cargo run --bin memtest)
-          echo "MAIN_MEASUREMENT<<EOF" >> $GITHUB_ENV
-          echo "$MAIN_MEASUREMENT" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-      - run: |
-          echo "${{env.MAIN_MEASUREMENT}}"
-          echo $MAIN_MEASUREMENT
-
-      - uses: actions/checkout@v2
-      - run: |
-          BRANCH_MEASUREMENT=$(cargo run --bin memtest)
-          echo "BRANCH_MEASUREMENT<<EOF" >> $GITHUB_ENV
-          echo "$BRANCH_MEASUREMENT" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-      - run: |
-          echo "${{env.BRANCH_MEASUREMENT}}"
-          echo $BRANCH_MEASUREMENT
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            if (${{ env.BRANCH_MEASUREMENT }} !== ${{ env.MAIN_MEASUREMENT }}) {
-              const difference = ${{ env.BRANCH_MEASUREMENT }} - ${{ env.MAIN_MEASUREMENT }};
-              try {
-                await github.rest.issues.createComment({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: `_Change in memory usage detected by benchmark._
-            ## Memory Report for ${{ github.sha }}
-
-            | Test                        | This Branch | On Main  | Difference |
-            |-----------------------------|-------------|----------| ---------- |
-            | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes | ${difference} bytes`
-                })
-              } catch (err) {
-                core.warning(`Failed writing comment on GitHub issue: ${err}`)
-              }
-            } else {
-              console.log("no change in memory usage detected by benchmark");
-            }
-        if: ${{ github.base_ref != null }}

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -8,7 +8,6 @@ env:
   NODE_VERSION: "18.17.1"
   PYTHON_VERSION: "3.11"
   RUST_TOOLCHAIN_VERSION: "1.80"
-  RUST_TOOLCHAIN_COMPONENTS: rustfmt clippy
 
 jobs:
   runBenchmark:
@@ -26,7 +25,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
-          components: ${{ env.RUST_TOOLCHAIN_COMPONENTS }}
       - name: setup cargo criterion
         run: cargo install cargo-criterion
       - name: run benching script

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -30,7 +30,7 @@ jobs:
       - name: setup cargo criterion
         run: cargo install cargo-criterion
       - name: run benching script
-        run: ./build.py --ci-bench
+        run: ./build.py --ci-bench --no-check
       - name: preserve bench artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
       - name: run benching script
         run: ./bench.sh
       - name: preserve bench artifacts

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -1,6 +1,8 @@
 name: Benchmark Reports
 
-on: push
+on:
+  schedule:
+    - cron: "0 0 * * MON"
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: alex/benching
+          ref: main
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: alex/benching
       - name: run benching script
         run: ./bench.sh
       - name: preserve bench artifacts

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -18,7 +18,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
       - name: run benching script
         run: ./bench.sh
       - name: preserve bench artifacts

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -35,4 +35,6 @@ jobs:
           name: benchmarks
           path: |
             target/criterion/**/*
+            week_ago.json
+            latest.json
 

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -12,15 +12,16 @@ env:
 
 jobs:
   runBenchmark:
-    name: run benchmark
     runs-on: ubuntu-latest
+    name: run benchmark
     permissions:
       contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
+      - name: run benching script
         run: ./bench.sh
-    - name: preserve bench artifacts
+      - name: preserve bench artifacts
         uses: actions/upload-artifact@v4
         with:
           name: benchmarks

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -30,7 +30,7 @@ jobs:
       - name: setup cargo criterion
         run: cargo install cargo-criterion
       - name: run benching script
-        run: ./build.py --ci-bench --no-check
+        run: ./build.py --ci-bench --no-check-prereqs
       - name: preserve bench artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: alex/benching
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: setup rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/bench-reports.yml
+++ b/.github/workflows/bench-reports.yml
@@ -9,8 +9,7 @@ env:
   PYTHON_VERSION: "3.11"
   RUST_TOOLCHAIN_VERSION: "1.80"
 
-jobs:
-  runBenchmark:
+jobs: runBenchmark:
     runs-on: ubuntu-latest
     name: run benchmark
     permissions:
@@ -28,13 +27,10 @@ jobs:
       - name: setup cargo criterion
         run: cargo install cargo-criterion
       - name: run benching script
-        run: ./bench.sh
+        run: ./build.py --ci-bench
       - name: preserve bench artifacts
         uses: actions/upload-artifact@v4
         with:
           name: benchmarks
-          path: |
-            target/criterion/**/*
-            week_ago.json
-            latest.json
+          path: *.json
 

--- a/.github/workflows/memory_profile.yml
+++ b/.github/workflows/memory_profile.yml
@@ -1,0 +1,75 @@
+name: Benchmark Reports
+
+on:
+  pull_request:
+    branches: "main"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  merge_group:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  NODE_VERSION: "18.17.1"
+  PYTHON_VERSION: "3.11"
+  RUST_TOOLCHAIN_VERSION: "1.80"
+  RUST_TOOLCHAIN_COMPONENTS: rustfmt clippy
+
+jobs:
+  runMemoryProfile:
+    if: ${{ !github.event.pull_request.draft }}
+    name: run memory profile
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          MAIN_MEASUREMENT=$(cargo run --bin memtest)
+          echo "MAIN_MEASUREMENT<<EOF" >> $GITHUB_ENV
+          echo "$MAIN_MEASUREMENT" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - run: |
+          echo "${{env.MAIN_MEASUREMENT}}"
+          echo $MAIN_MEASUREMENT
+
+      - uses: actions/checkout@v2
+      - run: |
+          BRANCH_MEASUREMENT=$(cargo run --bin memtest)
+          echo "BRANCH_MEASUREMENT<<EOF" >> $GITHUB_ENV
+          echo "$BRANCH_MEASUREMENT" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - run: |
+          echo "${{env.BRANCH_MEASUREMENT}}"
+          echo $BRANCH_MEASUREMENT
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            if (${{ env.BRANCH_MEASUREMENT }} !== ${{ env.MAIN_MEASUREMENT }}) {
+              const difference = ${{ env.BRANCH_MEASUREMENT }} - ${{ env.MAIN_MEASUREMENT }};
+              try {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: `_Change in memory usage detected by benchmark._
+            ## Memory Report for ${{ github.sha }}
+
+            | Test                        | This Branch | On Main  | Difference |
+            |-----------------------------|-------------|----------| ---------- |
+            | compile core + standard lib | ${{ env.BRANCH_MEASUREMENT }} bytes | ${{ env.MAIN_MEASUREMENT }} bytes | ${difference} bytes`
+                })
+              } catch (err) {
+                core.warning(`Failed writing comment on GitHub issue: ${err}`)
+              }
+            } else {
+              console.log("no change in memory usage detected by benchmark");
+            }
+        if: ${{ github.base_ref != null }}

--- a/bench.sh
+++ b/bench.sh
@@ -1,8 +1,0 @@
-branch="alex/benching"
-echo $(git rev-list --since="1 day ago" --pretty='format:%ad__%h' --date=short $branch | awk 'NR%2==0')
-for date_and_commit in $(git rev-list --since="1 week ago" --pretty='format:%ad__%h' --date=short $branch | awk 'NR%2==0')
-do
-  echo "benching commit" $date_and_commit
-  cargo criterion --message-format=json --history-id $date_and_commit > $date_and_commit.json
-done
-

--- a/bench.sh
+++ b/bench.sh
@@ -1,5 +1,6 @@
 branch=main
-for commit in $(git rev-list -n10 $branch)
+echo $(git rev-list --since="1 week ago" $branch)
+for commit in $(git rev-list --since="1 week ago" $branch)
 do
   echo "benching commit" . $commit
   cargo criterion --history-id $commit

--- a/bench.sh
+++ b/bench.sh
@@ -1,7 +1,9 @@
 branch="alex/benching"
-echo $(git rev-list --since="1 week ago" $branch)
-for commit in $(git rev-list --since="1 week ago" $branch)
-do
-  echo "benching commit" . $commit
-  cargo criterion --history-id $commit
-done
+commit_one_week_ago=$(git rev-list -n 1 --before="1 week ago" $branch)
+latest_commit=$(git rev-list -n 1 HEAD)
+
+echo "benching commit $commit_one_week_ago"
+cargo criterion --history-id $commit_one_week_ago
+
+echo "benching commit $latest_commit"
+cargo criterion --history-id $latest_commit

--- a/bench.sh
+++ b/bench.sh
@@ -1,9 +1,8 @@
 branch="alex/benching"
-commit_one_week_ago=$(git rev-list -n 1 --before="1 week ago" $branch)
-latest_commit=$(git rev-list -n 1 HEAD)
+echo $(git rev-list --since="1 day ago" --pretty='format:%ad__%h' --date=short $branch | awk 'NR%2==0')
+for date_and_commit in $(git rev-list --since="1 week ago" --pretty='format:%ad__%h' --date=short $branch | awk 'NR%2==0')
+do
+  echo "benching commit" $date_and_commit
+  cargo criterion --message-format=json --history-id $date_and_commit > $date_and_commit.json
+done
 
-echo "benching commit $commit_one_week_ago"
-cargo criterion --message-format=json --history-id $commit_one_week_ago > week_ago.json
-
-echo "benching commit $latest_commit"
-cargo criterion --message-format=json --history-id $latest_commit > latest.json

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,6 @@
+branch=main
+for commit in $(git rev-list -n10 $branch)
+do
+  echo "benching commit" . $commit
+  cargo criterion --history-id $commit
+done

--- a/bench.sh
+++ b/bench.sh
@@ -3,7 +3,7 @@ commit_one_week_ago=$(git rev-list -n 1 --before="1 week ago" $branch)
 latest_commit=$(git rev-list -n 1 HEAD)
 
 echo "benching commit $commit_one_week_ago"
-cargo criterion --history-id $commit_one_week_ago
+cargo criterion --message-format=json --history-id $commit_one_week_ago > week_ago.json
 
 echo "benching commit $latest_commit"
-cargo criterion --history-id $latest_commit
+cargo criterion --message-format=json --history-id $latest_commit > latest.json

--- a/bench.sh
+++ b/bench.sh
@@ -1,4 +1,4 @@
-branch=main
+branch="alex/benching"
 echo $(git rev-list --since="1 week ago" $branch)
 for commit in $(git rev-list --since="1 week ago" $branch)
 do

--- a/build.py
+++ b/build.py
@@ -303,7 +303,7 @@ def run_python_integration_tests(cwd, interpreter):
 def run_ci_historic_benchmark():
     branch = "main"
     output = subprocess.check_output(
-        ["git", "rev-list", "--since=1 day ago", "--pretty=format:%ad__%h", "--date=short", branch]
+        ["git", "rev-list", "--since=1 week ago", "--pretty=format:%ad__%h", "--date=short", branch]
     ).decode("utf-8")
     print('\n'.join([line for i, line in enumerate(output.split('\n')) if i % 2 == 1]))
 

--- a/build.py
+++ b/build.py
@@ -301,7 +301,7 @@ def run_python_integration_tests(cwd, interpreter):
 
 
 def run_ci_historic_benchmark():
-    branch = "alex/benching"
+    branch = "main"
     output = subprocess.check_output(
         ["git", "rev-list", "--since=1 day ago", "--pretty=format:%ad__%h", "--date=short", branch]
     ).decode("utf-8")

--- a/build.py
+++ b/build.py
@@ -68,6 +68,13 @@ parser.add_argument(
     help="Build and run the integration tests (default is --no-integration-tests)",
 )
 
+parser.add_argument(
+        "--ci-bench",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Run the benchmarking script that is run in CI (default is --no-ci-bench)",
+)
+
 args = parser.parse_args()
 
 if args.check_prereqs:
@@ -83,6 +90,7 @@ build_all = (
     and not args.play
     and not args.vscode
     and not args.jupyterlab
+    and not args.ci_bench
 )
 build_cli = build_all or args.cli
 build_pip = build_all or args.pip
@@ -92,6 +100,7 @@ build_npm = build_all or args.npm
 build_play = build_all or args.play
 build_vscode = build_all or args.vscode
 build_jupyterlab = build_all or args.jupyterlab
+ci_bench = args.ci_bench
 
 # JavaScript projects and eslint, prettier depend on npm_install
 # However the JupyterLab extension uses yarn in a separate workspace
@@ -290,6 +299,28 @@ def run_python_integration_tests(cwd, interpreter):
     command_args = [interpreter, "-m", "pytest"]
     subprocess.run(command_args, check=True, text=True, cwd=cwd)
 
+
+def run_ci_historic_benchmark():
+    branch = "alex/benching"
+    output = subprocess.check_output(
+        ["git", "rev-list", "--since=1 day ago", "--pretty=format:%ad__%h", "--date=short", branch]
+    ).decode("utf-8")
+    print('\n'.join([line for i, line in enumerate(output.split('\n')) if i % 2 == 1]))
+
+    output = subprocess.check_output(
+        ["git", "rev-list", "--since=1 week ago", "--pretty=format:%ad__%h", "--date=short", branch]
+    ).decode("utf-8")
+    date_and_commits = [line for i, line in enumerate(output.split('\n')) if i % 2 == 1]
+
+    for date_and_commit in date_and_commits:
+        print("benching commit", date_and_commit)
+        result = subprocess.run(
+            ["cargo", "criterion", "--message-format=json", "--history-id", date_and_commit],
+            capture_output=True,
+            text=True
+        )
+        with open(f"{date_and_commit}.json", "w") as f:
+            f.write(result.stdout)
 
 if build_pip:
     step_start("Building the pip package")
@@ -528,4 +559,9 @@ if build_pip and build_widgets and args.integration_tests:
 
     for test_project_dir in test_projects_directories:
         run_python_tests(test_project_dir, python_bin)
+    step_end()
+
+if ci_bench:
+    step_start("Running CI benchmarking script")
+    run_ci_historic_benchmark()
     step_end()


### PR DESCRIPTION
The benchmark comments have generally been pretty noisy and I think unpopular, especially when iterating on one open PR.

This PR removes the current benchmark commenting functionality and instead runs a once-weekly (Monday morning at midnight) benchmark on `main` and saves the results as JSON. These results can then be easily interpreted by a separate tool that I'm putting together. This will help us catch any performance regressions or trends, but in a once-weekly retrospective report of all merges into main, instead of every single commit. 

The key thing here is that after this PR goes in, we will have a mechanism to retrospect over performance data without having it commented on every commit of every PR.