### PR TITLE
Simplify display of evaluation results in VS Code

### DIFF
--- a/vscode/src/debugger/output.ts
+++ b/vscode/src/debugger/output.ts
@@ -59,8 +59,7 @@ export function createDebugConsoleEventTarget(out: (message: string) => void) {
   });
 
   eventTarget.addEventListener("Result", (evt) => {
-    const resultJson = JSON.stringify(evt.detail.value, null, 2);
-    out(`Result: ${resultJson}`);
+    out(`\n${evt.detail.value}`);
   });
   return eventTarget;
 }


### PR DESCRIPTION
Skips prepending "Result: " and json stringify-ing the response from evaluation, since it is already a string.

Error before:
<img width="717" alt="image" src="https://github.com/user-attachments/assets/3ef3672b-7e37-41de-a96c-d228c7231e79">

Error after:
<img width="802" alt="image" src="https://github.com/user-attachments/assets/e99cad0c-29d8-4fa8-a317-9e1107e3f12f">

Success before:
<img width="764" alt="image" src="https://github.com/user-attachments/assets/3d520440-358d-4303-9b44-b3bdf3177595">

Success after:
<img width="764" alt="image" src="https://github.com/user-attachments/assets/e8eabe93-f3c7-4230-b19d-15ce7a024cf5">

Fixes #1871