### PR TITLE
Include CompareGTSI in the Signed math API

### DIFF
--- a/library/signed/src/Comparison.qs
+++ b/library/signed/src/Comparison.qs
@@ -27,3 +27,5 @@ operation CompareGTSI(xs : Qubit[], ys : Qubit[], result : Qubit) : Unit is Adj 
         CCNOT(tmp, Tail(ys), result);
     }
 }
+
+export CompareGTSI;


### PR DESCRIPTION
I forgot to export this as a part of the API in the initial PR (#1841). This is needed in the Fixed Point library (#1838).
