### PR TITLE
Fix to RCA panic when original tuple binding is dynamic

### DIFF
--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -1341,7 +1341,7 @@ impl<'a> Analyzer<'a> {
                 };
                 let application_instance = self.get_current_application_instance();
                 let expr_compute_kind = *application_instance.get_expr_compute_kind(expr_id);
-                let bound_compute_kind = ComputeKind::map_to_type(&expr_compute_kind, &pat.ty);
+                let bound_compute_kind = ComputeKind::map_to_type(expr_compute_kind, &pat.ty);
                 self.bind_compute_kind_to_ident(pat, ident, local_kind, bound_compute_kind);
             }
             PatKind::Tuple(pats) => match &expr.kind {
@@ -1375,7 +1375,7 @@ impl<'a> Analyzer<'a> {
                 };
                 let application_instance = self.get_current_application_instance();
                 let expr_compute_kind = *application_instance.get_expr_compute_kind(expr_id);
-                let bound_compute_kind = ComputeKind::map_to_type(&expr_compute_kind, &pat.ty);
+                let bound_compute_kind = ComputeKind::map_to_type(expr_compute_kind, &pat.ty);
                 self.bind_compute_kind_to_ident(pat, ident, local_kind, bound_compute_kind);
             }
             PatKind::Tuple(pats) => {
@@ -1569,14 +1569,7 @@ impl<'a> Analyzer<'a> {
                         )
                     }
                 };
-
-                if assignee_expr_id == ExprId::from(16u32) && value_expr_id == ExprId::from(18u32) {
-                    println!("{assignee_expr}");
-                    println!("{value_expr}");
-                    println!("{assigned_compute_kind}");
-                    println!("{updated_compute_kind}");
-                }
-                //updated_compute_kind = updated_compute_kind.aggregate(assigned_compute_kind);
+                updated_compute_kind = updated_compute_kind.aggregate(assigned_compute_kind);
 
                 // If a local is updated within a dynamic scope, the updated value of the local variable should be
                 // dynamic and additional runtime features may apply.

--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -1335,13 +1335,14 @@ impl<'a> Analyzer<'a> {
         let pat = self.get_pat(pat_id);
         match &pat.kind {
             PatKind::Bind(ident) => {
-                let application_instance = self.get_current_application_instance();
-                let compute_kind = *application_instance.get_expr_compute_kind(expr_id);
                 let local_kind = match mutability {
                     Mutability::Immutable => LocalKind::Immutable(expr_id),
                     Mutability::Mutable => LocalKind::Mutable,
                 };
-                self.bind_compute_kind_to_ident(pat, ident, local_kind, compute_kind);
+                let application_instance = self.get_current_application_instance();
+                let expr_compute_kind = *application_instance.get_expr_compute_kind(expr_id);
+                let bound_compute_kind = ComputeKind::map_to_type(&expr_compute_kind, &pat.ty);
+                self.bind_compute_kind_to_ident(pat, ident, local_kind, bound_compute_kind);
             }
             PatKind::Tuple(pats) => match &expr.kind {
                 ExprKind::Tuple(exprs) => {
@@ -1368,13 +1369,14 @@ impl<'a> Analyzer<'a> {
         let pat = self.get_pat(pat_id);
         match &pat.kind {
             PatKind::Bind(ident) => {
-                let application_instance = self.get_current_application_instance();
-                let compute_kind = *application_instance.get_expr_compute_kind(expr_id);
                 let local_kind = match mutability {
                     Mutability::Immutable => LocalKind::Immutable(expr_id),
                     Mutability::Mutable => LocalKind::Mutable,
                 };
-                self.bind_compute_kind_to_ident(pat, ident, local_kind, compute_kind);
+                let application_instance = self.get_current_application_instance();
+                let expr_compute_kind = *application_instance.get_expr_compute_kind(expr_id);
+                let bound_compute_kind = ComputeKind::map_to_type(&expr_compute_kind, &pat.ty);
+                self.bind_compute_kind_to_ident(pat, ident, local_kind, bound_compute_kind);
             }
             PatKind::Tuple(pats) => {
                 for pat_id in pats {
@@ -1523,6 +1525,7 @@ impl<'a> Analyzer<'a> {
         unanalyzed_stmts
     }
 
+    #[allow(clippy::too_many_lines)]
     fn update_locals_compute_kind(
         &mut self,
         assignee_expr_id: ExprId,
@@ -1552,16 +1555,28 @@ impl<'a> Analyzer<'a> {
                 // a UDT variable field since we do not track individual UDT fields).
                 let value_expr_compute_kind =
                     *application_instance.get_expr_compute_kind(value_expr_id);
-                let mut value_kind =
-                    ValueKind::new_static_from_type(&local_var_compute_kind.local.ty);
-                if let ComputeKind::Quantum(value_expr_quantum_properties) = value_expr_compute_kind
-                {
-                    value_expr_quantum_properties
-                        .value_kind
-                        .project_onto_variant(&mut value_kind);
+                let assigned_compute_kind = match &value_expr_compute_kind {
+                    ComputeKind::Classical => ComputeKind::Classical,
+                    ComputeKind::Quantum(value_expr_quantum_properties) => {
+                        let mut value_kind =
+                            ValueKind::new_static_from_type(&local_var_compute_kind.local.ty);
+                        value_expr_quantum_properties
+                            .value_kind
+                            .project_onto_variant(&mut value_kind);
+                        ComputeKind::new_with_runtime_features(
+                            value_expr_quantum_properties.runtime_features,
+                            value_kind,
+                        )
+                    }
+                };
+
+                if assignee_expr_id == ExprId::from(16u32) && value_expr_id == ExprId::from(18u32) {
+                    println!("{assignee_expr}");
+                    println!("{value_expr}");
+                    println!("{assigned_compute_kind}");
+                    println!("{updated_compute_kind}");
                 }
-                updated_compute_kind = updated_compute_kind
-                    .aggregate_runtime_features(value_expr_compute_kind, value_kind);
+                //updated_compute_kind = updated_compute_kind.aggregate(assigned_compute_kind);
 
                 // If a local is updated within a dynamic scope, the updated value of the local variable should be
                 // dynamic and additional runtime features may apply.
@@ -1631,6 +1646,7 @@ impl<'a> Analyzer<'a> {
                     let default_value_kind = ValueKind::new_static_from_type(&value_expr.ty);
                     let mut updated_compute_kind = ComputeKind::Classical;
                     for element_assignee_expr_id in assignee_exprs {
+                        // TODO (cesarzc): Fix here.
                         let element_update_compute_kind = self
                             .update_locals_compute_kind(*element_assignee_expr_id, value_expr_id);
                         updated_compute_kind = updated_compute_kind.aggregate_runtime_features(

--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -1525,7 +1525,6 @@ impl<'a> Analyzer<'a> {
         unanalyzed_stmts
     }
 
-    #[allow(clippy::too_many_lines)]
     fn update_locals_compute_kind(
         &mut self,
         assignee_expr_id: ExprId,
@@ -1555,20 +1554,10 @@ impl<'a> Analyzer<'a> {
                 // a UDT variable field since we do not track individual UDT fields).
                 let value_expr_compute_kind =
                     *application_instance.get_expr_compute_kind(value_expr_id);
-                let assigned_compute_kind = match &value_expr_compute_kind {
-                    ComputeKind::Classical => ComputeKind::Classical,
-                    ComputeKind::Quantum(value_expr_quantum_properties) => {
-                        let mut value_kind =
-                            ValueKind::new_static_from_type(&local_var_compute_kind.local.ty);
-                        value_expr_quantum_properties
-                            .value_kind
-                            .project_onto_variant(&mut value_kind);
-                        ComputeKind::new_with_runtime_features(
-                            value_expr_quantum_properties.runtime_features,
-                            value_kind,
-                        )
-                    }
-                };
+                let assigned_compute_kind = ComputeKind::map_to_type(
+                    value_expr_compute_kind,
+                    &local_var_compute_kind.local.ty,
+                );
                 updated_compute_kind = updated_compute_kind.aggregate(assigned_compute_kind);
 
                 // If a local is updated within a dynamic scope, the updated value of the local variable should be
@@ -1639,7 +1628,6 @@ impl<'a> Analyzer<'a> {
                     let default_value_kind = ValueKind::new_static_from_type(&value_expr.ty);
                     let mut updated_compute_kind = ComputeKind::Classical;
                     for element_assignee_expr_id in assignee_exprs {
-                        // TODO (cesarzc): Fix here.
                         let element_update_compute_kind = self
                             .update_locals_compute_kind(*element_assignee_expr_id, value_expr_id);
                         updated_compute_kind = updated_compute_kind.aggregate_runtime_features(

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -474,6 +474,24 @@ impl Display for ComputeKind {
 }
 
 impl ComputeKind {
+    pub(crate) fn map_to_type(compute_kind: &Self, ty: &Ty) -> Self {
+        match compute_kind {
+            ComputeKind::Classical => ComputeKind::Classical,
+            ComputeKind::Quantum(quantum_properties) => {
+                let runtime_features = quantum_properties.runtime_features;
+                let value_kind = if quantum_properties.value_kind.is_dynamic() {
+                    ValueKind::new_dynamic_from_type(ty)
+                } else {
+                    ValueKind::new_static_from_type(ty)
+                };
+                ComputeKind::Quantum(QuantumProperties {
+                    runtime_features,
+                    value_kind,
+                })
+            }
+        }
+    }
+
     pub(crate) fn new_with_runtime_features(
         runtime_features: RuntimeFeatureFlags,
         value_kind: ValueKind,

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -474,16 +474,15 @@ impl Display for ComputeKind {
 }
 
 impl ComputeKind {
-    pub(crate) fn map_to_type(compute_kind: &Self, ty: &Ty) -> Self {
+    pub(crate) fn map_to_type(compute_kind: Self, ty: &Ty) -> Self {
         match compute_kind {
             ComputeKind::Classical => ComputeKind::Classical,
             ComputeKind::Quantum(quantum_properties) => {
                 let runtime_features = quantum_properties.runtime_features;
-                let value_kind = if quantum_properties.value_kind.is_dynamic() {
-                    ValueKind::new_dynamic_from_type(ty)
-                } else {
-                    ValueKind::new_static_from_type(ty)
-                };
+                let mut value_kind = ValueKind::new_static_from_type(ty);
+                quantum_properties
+                    .value_kind
+                    .project_onto_variant(&mut value_kind);
                 ComputeKind::Quantum(QuantumProperties {
                     runtime_features,
                     value_kind,

--- a/compiler/qsc_rca/src/tests.rs
+++ b/compiler/qsc_rca/src/tests.rs
@@ -75,7 +75,6 @@ impl CompilationContext {
         self.lowerer
             .lower_and_update_package(fir_package, &increment.hir);
         self.compiler.update(increment);
-        println!("{}", fir_package);
 
         // Clear the compute properties of the package to update.
         let package_compute_properties = self.compute_properties.get_mut(package_id);

--- a/compiler/qsc_rca/src/tests.rs
+++ b/compiler/qsc_rca/src/tests.rs
@@ -75,6 +75,7 @@ impl CompilationContext {
         self.lowerer
             .lower_and_update_package(fir_package, &increment.hir);
         self.compiler.update(increment);
+        println!("{}", fir_package);
 
         // Clear the compute properties of the package to update.
         let package_compute_properties = self.compute_properties.get_mut(package_id);

--- a/compiler/qsc_rca/src/tests/assigns.rs
+++ b/compiler/qsc_rca/src/tests/assigns.rs
@@ -291,7 +291,12 @@ fn check_rca_for_assign_dynamic_static_mix_call_result_to_tuple_of_vars() {
     );
     check_last_statement_compute_properties(
         compilation_context.get_compute_properties(),
-        &expect![[r#""#]],
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                    value_kind: Array(Content: Dynamic, Size: Static)
+                dynamic_param_applications: <empty>"#]],
     );
     compilation_context.update(
         r#"
@@ -300,7 +305,12 @@ fn check_rca_for_assign_dynamic_static_mix_call_result_to_tuple_of_vars() {
     );
     check_last_statement_compute_properties(
         compilation_context.get_compute_properties(),
-        &expect![[r#""#]],
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
+                    value_kind: Array(Content: Dynamic, Size: Static)
+                dynamic_param_applications: <empty>"#]],
     );
 }
 

--- a/compiler/qsc_rca/src/tests/assigns.rs
+++ b/compiler/qsc_rca/src/tests/assigns.rs
@@ -276,6 +276,35 @@ fn check_rca_for_assign_dynamic_call_result_to_tuple_of_vars() {
 }
 
 #[test]
+fn check_rca_for_assign_dynamic_static_mix_call_result_to_tuple_of_vars() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        operation Foo(q : Qubit) : (Int[], Result[]) {
+            ([1, 2], [MResetZ(q)])
+        }
+        use q = Qubit();
+        mutable (a, b) = Foo(q);
+        set (a, b) = Foo(q);
+        a
+        "#,
+    );
+    check_last_statement_compute_properties(
+        compilation_context.get_compute_properties(),
+        &expect![[r#""#]],
+    );
+    compilation_context.update(
+        r#"
+        b
+        "#,
+    );
+    check_last_statement_compute_properties(
+        compilation_context.get_compute_properties(),
+        &expect![[r#""#]],
+    );
+}
+
+#[test]
 fn check_rca_for_mutable_classical_integer_assigned_updated_with_classical_integer() {
     let mut compilation_context = CompilationContext::default();
     compilation_context.update(


### PR DESCRIPTION
This change fixes a panic that happens during Runtime Capabilities Analysis (RCA).

The panic happens when the bound value of a tuple, in which at least one element is an array, is updated and the originally bound value is dynamic.