### PR TITLE
Use T gate time for physical factories

### DIFF
--- a/resource_estimator/src/system/modeling/physical_qubit.rs
+++ b/resource_estimator/src/system/modeling/physical_qubit.rs
@@ -102,6 +102,16 @@ impl PhysicalQubit {
     }
 
     #[must_use]
+    pub fn t_gate_time(&self) -> u64 {
+        match self {
+            Self::GateBased(gate_based) => {
+                gate_based.t_gate_time.expect("T gate time should be set")
+            }
+            Self::Majorana(majorana) => majorana.t_gate_time.expect("T gate time should be set"),
+        }
+    }
+
+    #[must_use]
     pub fn t_gate_error_rate(&self) -> f64 {
         match self {
             Self::GateBased(gate_based) => gate_based.t_gate_error_rate,

--- a/resource_estimator/src/system/modeling/tfactory.rs
+++ b/resource_estimator/src/system/modeling/tfactory.rs
@@ -37,7 +37,7 @@ impl<'a> TFactoryQubit<'a> {
     pub fn cycle_time(&self) -> u64 {
         match self {
             Self::Logical(qubit) => qubit.logical_cycle_time(),
-            Self::Physical(qubit) => qubit.one_qubit_measurement_time(),
+            Self::Physical(qubit) => qubit.t_gate_time(),
         }
     }
 


### PR DESCRIPTION
To compute the cycle time in physical T factories, we should use the T gate time qubit parameter instead of the measurement time. This change does not affect any experiments with our default models, since they are using the same time for both metrics.