### PR TITLE
Playground: Fix error squiggle updates getting dropped

### DIFF
--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -255,11 +255,7 @@ export function Editor(props: {
     // will be invalid as it captures the *original* props.languageService
     // and not the updated one. Not a problem currently since the language
     // service is never updated, but not correct either.
-    srcModel.onDidChangeContent(async (e) => {
-      e.changes.forEach((change) => {
-        log.debug("changes for version %d are: %o", e.versionId, change);
-      });
-
+    srcModel.onDidChangeContent(async () => {
       // Reset the shot errors whenever the document changes.
       // The markers will be refreshed by the onDiagnostics callback
       // when the language service finishes checking the document.


### PR DESCRIPTION
In some cases where the user is typing fast, diagnostic updates (a.k.a. error squiggles) will get dropped. This can happen when the current document version is greater than the version that the diagnostics event pertains to.

I'm removing the version check since it was overkill anyway. As long as the diagnostics updates are received in order, the state should remain consistent.

Repro for future reference:

![squiggle-dropped](https://github.com/user-attachments/assets/f37cd9e2-5b47-469c-a518-bcc8df6ce2d2)


Interaction between the editor and the language service. Correct behavior:

- user types `Foo` in the editor, document version is updated to 1
- `updateDocument` command with contents `Foo` version=1
- `diagnostics` event with a type error version=1
- user types `(` in the editor, document version is updated to 2
- `updateDocument` command with contents `Foo()`  version=2
- **`diagnostics` event that clears the errors in the file version=2**
- **user types `)` in the editor, document version is updated to 3**
- `updateDocument` command with contents `Foo()` (no change) version=3
- no diagnostics event is raised since there was no change in the document

Now consider the case where the user types so fast that the events above that are in bold get flipped:

- user types `Foo` in the editor, document version is updated to 1
- `updateDocument` command with contents `Foo`   version=1
- `diagnostics` event with a type error version=1
- user types `(` in the editor, document version is updated to 2
- `updateDocument` command with contents `Foo()`  version=2
- **user types `)` in the editor, document version is updated to 3**
- **`diagnostics` event that clears the errors in the file version=2**
  - **this event gets dropped since the version doesn't match the current document version**
- `updateDocument` command with contents `Foo()` (no change) version=3
- no diagnostics event is raised since there was no change in the document

