### PR TITLE
Completions: existing glob import will prevent an exact import with t…

### DIFF
--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -739,6 +739,9 @@ fn callable_decl_to_completion_item(
     // An exact import is an import that matches the namespace
     // and item name exactly
     let preexisting_exact_import = imports.iter().any(|import_item| {
+        if import_item.is_glob {
+            return false;
+        }
         let import_item_namespace = &import_item.path[..import_item.path.len() - 1];
         let import_item_name = import_item.path.last().map(|x| &**x);
         *import_item_namespace == namespace_as_strs[..] && import_item_name == Some(name)

--- a/language_service/src/completion/tests.rs
+++ b/language_service/src/completion/tests.rs
@@ -1405,6 +1405,62 @@ fn dont_import_if_already_glob_imported() {
     );
 }
 
+// expect an auto-import for `Foo.Bar`, separate from the preexisting glob import `Foo.Bar.*`
+#[test]
+fn glob_import_item_with_same_name() {
+    check(
+        r#"
+        namespace Foo {
+            operation Bar() : Unit {
+            }
+        }
+
+        namespace Foo.Bar {
+        }
+
+        namespace Baz {
+            import Foo.Bar.*;
+            operation Main(): Unit {
+                ↘
+            }
+        }"#,
+        &["Bar"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "Bar",
+                        kind: Function,
+                        sort_text: Some(
+                            "0600Bar",
+                        ),
+                        detail: Some(
+                            "operation Bar() : Unit",
+                        ),
+                        additional_text_edits: Some(
+                            [
+                                TextEdit {
+                                    new_text: "import Foo.Bar;\n            ",
+                                    range: Range {
+                                        start: Position {
+                                            line: 10,
+                                            column: 12,
+                                        },
+                                        end: Position {
+                                            line: 10,
+                                            column: 12,
+                                        },
+                                    },
+                                },
+                            ],
+                        ),
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
 // no additional text edits for Foo because Foo is directly imported,
 // but additional text edits for Bar because Bar is not directly imported
 #[test]


### PR DESCRIPTION
Completions: existing glob import will prevent an exact import with the same name from being auto-added

When an item and a namespace named `Foo.Bar` both exist, and the _namespace_ is glob-imported, the auto-import code "forgets" to include an auto-import text edit for `Foo.Bar`,  since it thinks `Foo.Bar` already imported.


```qsharp
 namespace Foo {
    operation Bar() : Unit {
    }
}

namespace Foo.Bar {
}

namespace Baz {
    import Foo.Bar.*;
    operation Main(): Unit {
        // selecting `Bar` from the completion list here should add an auto-import for `Foo.Bar` 
    }
}
```