### PR TITLE
Serialize logical post-layout overhead in resource estimation result

### DIFF
--- a/resource_estimator/src/estimates.rs
+++ b/resource_estimator/src/estimates.rs
@@ -19,6 +19,6 @@ pub use physical_estimation::{
 };
 mod layout;
 mod logical_qubit;
-pub use layout::Overhead;
+pub use layout::{Overhead, RealizedOverhead};
 pub use logical_qubit::LogicalPatch;
 pub mod optimization;

--- a/resource_estimator/src/estimates/layout.rs
+++ b/resource_estimator/src/estimates/layout.rs
@@ -26,6 +26,7 @@ pub trait Overhead {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RealizedOverhead {
     logical_qubits: u64,
     logical_depth: u64,

--- a/resource_estimator/src/estimates/layout.rs
+++ b/resource_estimator/src/estimates/layout.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use serde::Serialize;
+
 use super::ErrorBudget;
 
 /// Trait to model post-layout logical overhead
@@ -21,4 +23,60 @@ pub trait Overhead {
     /// The index is used to indicate the type of magic states and must be
     /// supported by available factory builders in the physical estimation.
     fn num_magic_states(&self, budget: &ErrorBudget, index: usize) -> u64;
+}
+
+#[derive(Serialize)]
+pub struct RealizedOverhead {
+    logical_qubits: u64,
+    logical_depth: u64,
+    num_magic_states: Vec<u64>,
+}
+
+impl RealizedOverhead {
+    pub fn from_overhead(
+        overhead: &impl Overhead,
+        budget: &ErrorBudget,
+        num_magic_state_types: usize,
+    ) -> Self {
+        let logical_qubits = overhead.logical_qubits();
+        let logical_depth = overhead.logical_depth(budget);
+        let num_magic_states = (0..num_magic_state_types)
+            .map(|index| overhead.num_magic_states(budget, index))
+            .collect();
+
+        Self {
+            logical_qubits,
+            logical_depth,
+            num_magic_states,
+        }
+    }
+
+    #[must_use]
+    pub fn logical_qubits(&self) -> u64 {
+        self.logical_qubits
+    }
+
+    #[must_use]
+    pub fn logical_depth(&self) -> u64 {
+        self.logical_depth
+    }
+
+    #[must_use]
+    pub fn num_magic_states(&self) -> &[u64] {
+        &self.num_magic_states
+    }
+}
+
+impl Overhead for RealizedOverhead {
+    fn logical_qubits(&self) -> u64 {
+        self.logical_qubits
+    }
+
+    fn logical_depth(&self, _budget: &ErrorBudget) -> u64 {
+        self.logical_depth
+    }
+
+    fn num_magic_states(&self, _budget: &ErrorBudget, index: usize) -> u64 {
+        self.num_magic_states[index]
+    }
 }

--- a/resource_estimator/src/estimates/layout.rs
+++ b/resource_estimator/src/estimates/layout.rs
@@ -25,6 +25,12 @@ pub trait Overhead {
     fn num_magic_states(&self, budget: &ErrorBudget, index: usize) -> u64;
 }
 
+/// This is the realized logical overhead after applying an error budget.  This
+/// structure has two purposes: 1) it is used to store the realized logical
+/// overhead, once the error budget partition is decided into the resource
+/// estimation result; 2) it can be used to pass a logical overhead to the
+/// resource estimation API, if it does not depend on the error budget, since it
+/// also implements the [`Overhead`] trait.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RealizedOverhead {

--- a/resource_estimator/src/estimates/physical_estimation.rs
+++ b/resource_estimator/src/estimates/physical_estimation.rs
@@ -253,6 +253,10 @@ impl<
         }
     }
 
+    pub fn error_correction(&self) -> &E {
+        &self.ftp
+    }
+
     pub fn layout_overhead(&self) -> &L {
         &self.layout_overhead
     }

--- a/resource_estimator/src/estimates/physical_estimation.rs
+++ b/resource_estimator/src/estimates/physical_estimation.rs
@@ -274,13 +274,15 @@ impl<
         self.max_physical_qubits = Some(max_physical_qubits);
     }
 
+    pub fn factory_builder(&self) -> &Builder {
+        &self.factory_builder
+    }
+
     pub fn factory_builder_mut(&mut self) -> &mut Builder {
         &mut self.factory_builder
     }
 
-    pub fn estimate(
-        &self,
-    ) -> Result<PhysicalResourceEstimationResult<E, Builder::Factory, L>, Error> {
+    pub fn estimate(&self) -> Result<PhysicalResourceEstimationResult<E, Builder::Factory>, Error> {
         match (self.max_duration, self.max_physical_qubits) {
             (None, None) => self.estimate_without_restrictions(),
             (None, Some(max_physical_qubits)) => {
@@ -294,7 +296,7 @@ impl<
     #[allow(clippy::too_many_lines, clippy::type_complexity)]
     pub fn build_frontier(
         &self,
-    ) -> Result<Vec<PhysicalResourceEstimationResult<E, Builder::Factory, L>>, Error> {
+    ) -> Result<Vec<PhysicalResourceEstimationResult<E, Builder::Factory>>, Error> {
         if self.factory_builder.num_magic_state_types() != 1 {
             return Err(Error::MultipleMagicStatesNotSupported);
         }
@@ -329,7 +331,7 @@ impl<
         }
 
         let mut best_estimation_results =
-            Population::<Point2D<PhysicalResourceEstimationResult<E, Builder::Factory, L>>>::new();
+            Population::<Point2D<PhysicalResourceEstimationResult<E, Builder::Factory>>>::new();
 
         let mut last_factories = Vec::new();
         let mut last_code_parameter = None;
@@ -455,7 +457,7 @@ impl<
 
     pub fn estimate_without_restrictions(
         &self,
-    ) -> Result<PhysicalResourceEstimationResult<E, Builder::Factory, L>, Error> {
+    ) -> Result<PhysicalResourceEstimationResult<E, Builder::Factory>, Error> {
         let mut num_cycles = self.compute_num_cycles()?;
 
         loop {
@@ -616,7 +618,7 @@ impl<
     pub fn estimate_with_max_duration(
         &self,
         max_duration_in_nanoseconds: u64,
-    ) -> Result<PhysicalResourceEstimationResult<E, Builder::Factory, L>, Error> {
+    ) -> Result<PhysicalResourceEstimationResult<E, Builder::Factory>, Error> {
         if self.factory_builder.num_magic_state_types() != 1 {
             return Err(Error::MultipleMagicStatesNotSupported);
         }
@@ -647,7 +649,7 @@ impl<
         }
 
         let mut best_estimation_result: Option<
-            PhysicalResourceEstimationResult<E, Builder::Factory, L>,
+            PhysicalResourceEstimationResult<E, Builder::Factory>,
         > = None;
 
         let mut last_factories = Vec::new();
@@ -767,7 +769,7 @@ impl<
     pub fn estimate_with_max_num_qubits(
         &self,
         max_num_qubits: u64,
-    ) -> Result<PhysicalResourceEstimationResult<E, Builder::Factory, L>, Error> {
+    ) -> Result<PhysicalResourceEstimationResult<E, Builder::Factory>, Error> {
         if self.factory_builder.num_magic_state_types() != 1 {
             return Err(Error::MultipleMagicStatesNotSupported);
         }
@@ -795,7 +797,7 @@ impl<
         }
 
         let mut best_estimation_result: Option<
-            PhysicalResourceEstimationResult<E, Builder::Factory, L>,
+            PhysicalResourceEstimationResult<E, Builder::Factory>,
         > = None;
 
         let mut last_factories = Vec::new();

--- a/resource_estimator/src/system.rs
+++ b/resource_estimator/src/system.rs
@@ -94,7 +94,7 @@ fn estimate_single<L: Overhead + LayoutReportData + PartitioningOverhead + Seria
             distillation_unit_templates,
             job_params.constraints().max_distillation_rounds,
         ),
-        logical_resources,
+        logical_resources.clone(),
         partitioning,
     );
     if let Some(logical_depth_factor) = job_params.constraints().logical_depth_factor {
@@ -125,11 +125,14 @@ fn estimate_single<L: Overhead + LayoutReportData + PartitioningOverhead + Seria
             let estimation_result = estimation
                 .build_frontier()
                 .map_err(std::convert::Into::into);
-            estimation_result.map(|result| data::Success::new_from_multiple(job_params, result))
+            estimation_result.map(|result| {
+                data::Success::new_from_multiple(job_params, logical_resources, result)
+            })
         }
         EstimateType::SinglePoint => {
             let estimation_result = estimation.estimate().map_err(std::convert::Into::into);
-            estimation_result.map(|result| data::Success::new(job_params, result))
+            estimation_result
+                .map(|result| data::Success::new(job_params, logical_resources, result))
         }
     }
 }

--- a/resource_estimator/src/system.rs
+++ b/resource_estimator/src/system.rs
@@ -87,6 +87,8 @@ fn estimate_single<L: Overhead + LayoutReportData + PartitioningOverhead + Seria
         .error_budget()
         .partitioning(logical_resources.as_ref())?;
 
+    // The clone on the logical resources is on an Rc and therefore inexpensive,
+    // the value is later used in creating the result object
     let mut estimation = PhysicalResourceEstimation::new(
         ftp,
         qubit,

--- a/resource_estimator/src/system/data/result.rs
+++ b/resource_estimator/src/system/data/result.rs
@@ -4,9 +4,7 @@
 use std::ops::Deref;
 use std::rc::Rc;
 
-use crate::estimates::{
-    ErrorBudget, FactoryPart, LogicalPatch, Overhead, PhysicalResourceEstimationResult,
-};
+use crate::estimates::{ErrorBudget, FactoryPart, LogicalPatch, PhysicalResourceEstimationResult};
 use crate::system::modeling::{Protocol, TFactory};
 
 use super::LayoutReportData;
@@ -19,7 +17,7 @@ use serde::{ser::SerializeMap, Serialize, Serializer};
 
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
-pub struct Success<L: Serialize> {
+pub struct Success<L: LayoutReportData + Serialize> {
     status: &'static str,
     job_params: JobParams,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -38,19 +36,24 @@ pub struct Success<L: Serialize> {
     frontier_entries: Vec<FrontierEntry>,
 }
 
-impl<L: Overhead + LayoutReportData + Serialize> Success<L> {
+impl<L: LayoutReportData + Serialize> Success<L> {
     pub fn new(
         job_params: JobParams,
-        result: PhysicalResourceEstimationResult<Protocol, TFactory, L>,
+        layout_report_data: Rc<L>,
+        result: PhysicalResourceEstimationResult<Protocol, TFactory>,
     ) -> Self {
-        let counts = create_physical_resource_counts(&result);
+        let counts = create_physical_resource_counts(&result, layout_report_data.as_ref());
 
         let formatted_counts: FormattedPhysicalResourceCounts =
-            FormattedPhysicalResourceCounts::new(&result, &job_params);
+            FormattedPhysicalResourceCounts::new(&result, &job_params, layout_report_data.as_ref());
 
-        let report_data = Report::new(&job_params, &result, &formatted_counts);
+        let report_data = Report::new(
+            &job_params,
+            layout_report_data.as_ref(),
+            &result,
+            &formatted_counts,
+        );
 
-        let logical_counts = result.layout_overhead().clone();
         let (logical_qubit, mut parts, error_budget) = result.take();
         let tfactory = parts.swap_remove(0).map(FactoryPart::into_factory);
 
@@ -62,7 +65,7 @@ impl<L: Overhead + LayoutReportData + Serialize> Success<L> {
             logical_qubit: Some(LogicalQubit(logical_qubit)),
             tfactory,
             error_budget: Some(error_budget),
-            logical_counts,
+            logical_counts: layout_report_data,
             report_data,
             frontier_entries: Vec::new(),
         }
@@ -70,19 +73,22 @@ impl<L: Overhead + LayoutReportData + Serialize> Success<L> {
 
     pub fn new_from_multiple(
         job_params: JobParams,
-        mut results: Vec<PhysicalResourceEstimationResult<Protocol, TFactory, L>>,
+        layout_report_data: Rc<L>,
+        mut results: Vec<PhysicalResourceEstimationResult<Protocol, TFactory>>,
     ) -> Self {
         let mut report_data: Option<Report> = None;
 
         let mut frontier_entries: Vec<FrontierEntry> = Vec::new();
 
-        let logical_counts = results[0].layout_overhead().clone();
-
         // we will pick the shortest runtime result as the first result.
         results.sort_by_key(PhysicalResourceEstimationResult::runtime);
         for result in results {
-            let (frontier_entry, report) =
-                create_frontier_entry(&job_params, result, report_data.is_none());
+            let (frontier_entry, report) = create_frontier_entry(
+                &job_params,
+                result,
+                layout_report_data.as_ref(),
+                report_data.is_none(),
+            );
 
             if report_data.is_none() {
                 report_data = Some(report.expect("error should have report"));
@@ -99,7 +105,7 @@ impl<L: Overhead + LayoutReportData + Serialize> Success<L> {
             logical_qubit: None,
             tfactory: None,
             error_budget: None,
-            logical_counts,
+            logical_counts: layout_report_data,
             report_data: report_data.expect("error should have report"), // Here we assume that at least a single solution was found.
             frontier_entries,
         }
@@ -118,16 +124,22 @@ pub struct FrontierEntry {
 
 fn create_frontier_entry(
     job_params: &JobParams,
-    result: PhysicalResourceEstimationResult<Protocol, TFactory, impl Overhead + LayoutReportData>,
+    result: PhysicalResourceEstimationResult<Protocol, TFactory>,
+    layout_report_data: &impl LayoutReportData,
     create_report: bool,
 ) -> (FrontierEntry, Option<Report>) {
-    let physical_counts = create_physical_resource_counts(&result);
+    let physical_counts = create_physical_resource_counts(&result, layout_report_data);
 
     let physical_counts_formatted: FormattedPhysicalResourceCounts =
-        FormattedPhysicalResourceCounts::new(&result, job_params);
+        FormattedPhysicalResourceCounts::new(&result, job_params, layout_report_data);
 
     let report_data = if create_report {
-        Some(Report::new(job_params, &result, &physical_counts_formatted))
+        Some(Report::new(
+            job_params,
+            layout_report_data,
+            &result,
+            &physical_counts_formatted,
+        ))
     } else {
         None
     };
@@ -148,9 +160,10 @@ fn create_frontier_entry(
 }
 
 fn create_physical_resource_counts(
-    result: &PhysicalResourceEstimationResult<Protocol, TFactory, impl Overhead + LayoutReportData>,
+    result: &PhysicalResourceEstimationResult<Protocol, TFactory>,
+    layout_report_data: &impl LayoutReportData,
 ) -> PhysicalResourceCounts {
-    let breakdown = create_physical_resource_counts_breakdown(result);
+    let breakdown = create_physical_resource_counts_breakdown(result, layout_report_data);
 
     PhysicalResourceCounts {
         physical_qubits: result.physical_qubits(),
@@ -161,24 +174,20 @@ fn create_physical_resource_counts(
 }
 
 fn create_physical_resource_counts_breakdown(
-    result: &PhysicalResourceEstimationResult<Protocol, TFactory, impl Overhead + LayoutReportData>,
+    result: &PhysicalResourceEstimationResult<Protocol, TFactory>,
+    layout_report_data: &impl LayoutReportData,
 ) -> PhysicalResourceCountsBreakdown {
-    let num_ts_per_rotation = result
-        .layout_overhead()
-        .num_ts_per_rotation(result.error_budget().rotations());
+    let num_ts_per_rotation =
+        layout_report_data.num_ts_per_rotation(result.error_budget().rotations());
 
     let part = result.factory_parts()[0].as_ref();
 
     PhysicalResourceCountsBreakdown {
         algorithmic_logical_qubits: result.layout_overhead().logical_qubits(),
-        algorithmic_logical_depth: result
-            .layout_overhead()
-            .logical_depth(result.error_budget()),
+        algorithmic_logical_depth: result.layout_overhead().logical_depth(),
         logical_depth: result.num_cycles(),
         clock_frequency: result.logical_patch().logical_cycles_per_second(),
-        num_tstates: result
-            .layout_overhead()
-            .num_magic_states(result.error_budget(), 0),
+        num_tstates: result.layout_overhead().num_magic_states()[0],
         num_tfactories: part.map_or(0, FactoryPart::copies),
         num_tfactory_runs: part.map_or(0, FactoryPart::runs),
         physical_qubits_for_tfactories: result.physical_qubits_for_factories(),

--- a/resource_estimator/src/system/tests.rs
+++ b/resource_estimator/src/system/tests.rs
@@ -209,9 +209,7 @@ fn hubbard_overhead_and_partitioning() -> Result<(LogicalResourceCounts, ErrorBu
     Ok((logical_counts, partitioning))
 }
 
-fn validate_result_invariants<L: Overhead>(
-    result: &PhysicalResourceEstimationResult<Protocol, TFactory, L>,
-) {
+fn validate_result_invariants(result: &PhysicalResourceEstimationResult<Protocol, TFactory>) {
     let part = get_factory(result);
 
     assert_eq!(
@@ -1056,7 +1054,7 @@ fn strip_numbers(value: &Value) -> Value {
 // In this system, there is only one magic state type, T states, and therefore
 // one factory part in the result with information on the factory.
 fn get_factory(
-    result: &PhysicalResourceEstimationResult<Protocol, TFactory, impl Overhead>,
+    result: &PhysicalResourceEstimationResult<Protocol, TFactory>,
 ) -> &FactoryPart<TFactory> {
     result.factory_parts()[0]
         .as_ref()


### PR DESCRIPTION
This change allows to serialize the logical post-layout overhead in the resource estimation result provided by the resource estimation API. Note that this was already possible in the system API that has a custom result for the VS Code and Python integration.

The change also simplified the type of the resource estimation result, which now is not any longer generic over the post-layout overhead trait.