### PR TITLE
Bug fixes found during bash

### DIFF
--- a/build.py
+++ b/build.py
@@ -514,7 +514,7 @@ if build_pip and build_widgets and args.integration_tests:
         "ipykernel",
         "nbconvert",
         "pandas",
-        "qiskit>=1.2.0,<1.3.0",
+        "qiskit>=1.2.0,<2.0.0",
     ]
     subprocess.run(pip_install_args, check=True, text=True, cwd=root_dir, env=pip_env)
 

--- a/compiler/qsc_qasm3/src/lib.rs
+++ b/compiler/qsc_qasm3/src/lib.rs
@@ -440,7 +440,7 @@ impl Default for CompilerConfig {
     }
 }
 
-/// Represents the type of compilation out to create
+/// Represents the type of compilation output to create
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProgramType {
     /// Creates an operation in a namespace as if the program is a standalone

--- a/compiler/qsc_qasm3/src/lib.rs
+++ b/compiler/qsc_qasm3/src/lib.rs
@@ -454,7 +454,7 @@ pub enum ProgramType {
     /// Creates a list of statements from the program. This is useful for
     /// interactive environments where the program is a list of statements
     /// imported into the current scope.
-    /// This is also useful for testing indifidual statements compilation.
+    /// This is also useful for testing individual statements compilation.
     Fragments,
 }
 

--- a/compiler/qsc_qasm3/src/lib.rs
+++ b/compiler/qsc_qasm3/src/lib.rs
@@ -16,7 +16,7 @@ mod types;
 #[cfg(test)]
 pub(crate) mod tests;
 
-use std::fmt::Write;
+use std::{fmt::Write, sync::Arc};
 
 use miette::Diagnostic;
 use qsc::Span;
@@ -393,6 +393,8 @@ pub struct CompilerConfig {
     pub qubit_semantics: QubitSemantics,
     pub output_semantics: OutputSemantics,
     pub program_ty: ProgramType,
+    operation_name: Option<Arc<str>>,
+    namespace: Option<Arc<str>>,
 }
 
 impl CompilerConfig {
@@ -401,12 +403,28 @@ impl CompilerConfig {
         qubit_semantics: QubitSemantics,
         output_semantics: OutputSemantics,
         program_ty: ProgramType,
+        operation_name: Option<Arc<str>>,
+        namespace: Option<Arc<str>>,
     ) -> Self {
         Self {
             qubit_semantics,
             output_semantics,
             program_ty,
+            operation_name,
+            namespace,
         }
+    }
+
+    fn operation_name(&self) -> Arc<str> {
+        self.operation_name
+            .clone()
+            .unwrap_or_else(|| Arc::from("program"))
+    }
+
+    fn namespace(&self) -> Arc<str> {
+        self.namespace
+            .clone()
+            .unwrap_or_else(|| Arc::from("qasm3_import"))
     }
 }
 
@@ -416,6 +434,8 @@ impl Default for CompilerConfig {
             qubit_semantics: QubitSemantics::Qiskit,
             output_semantics: OutputSemantics::Qiskit,
             program_ty: ProgramType::Fragments,
+            operation_name: None,
+            namespace: None,
         }
     }
 }
@@ -424,15 +444,13 @@ impl Default for CompilerConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProgramType {
     /// Creates an operation in a namespace as if the program is a standalone
-    /// file. The param is the name of the operation to create. Input are
-    /// lifted to the operation params. Output are lifted to the operation
-    /// return type. The operation is marked as `@EntryPoint` as long as there
-    /// are no input parameters.
-    File(String),
-    /// Creates an operation program is a standalone function. The param is the
-    /// name of the operation to create. Input are lifted to the operation
-    /// params. Output are lifted to the operation return type.
-    Operation(String),
+    /// file. Inputs are lifted to the operation params. Output are lifted to
+    /// the operation return type. The operation is marked as `@EntryPoint`
+    /// as long as there are no input parameters.
+    File,
+    /// Programs are compiled to a standalone function. Inputs are lifted to
+    /// the operation params. Output are lifted to the operation return type.
+    Operation,
     /// Creates a list of statements from the program. This is useful for
     /// interactive environments where the program is a list of statements
     /// imported into the current scope.

--- a/compiler/qsc_qasm3/src/tests.rs
+++ b/compiler/qsc_qasm3/src/tests.rs
@@ -78,11 +78,13 @@ fn compile_qasm_to_qir(source: &str, profile: Profile) -> Result<String, Vec<Rep
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::Qiskit,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::Qiskit,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     fail_on_compilation_errors(&unit);
     let package = unit.package.expect("no package found");
@@ -150,11 +152,13 @@ pub fn qasm_to_program_fragments(source: QasmSource, source_map: SourceMap) -> Q
     qasm_to_program(
         source,
         source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            program_ty: ProgramType::Fragments,
-            output_semantics: OutputSemantics::OpenQasm,
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::OpenQasm,
+            ProgramType::Fragments,
+            None,
+            None,
+        ),
     )
 }
 
@@ -164,11 +168,13 @@ pub fn compile_qasm_to_qsharp_file(source: &str) -> miette::Result<String, Vec<R
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::OpenQasm,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::OpenQasm,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     if unit.has_errors() {
         let errors = unit.errors.into_iter().map(Report::new).collect();
@@ -187,11 +193,13 @@ pub fn compile_qasm_to_qsharp_operation(source: &str) -> miette::Result<String, 
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::OpenQasm,
-            program_ty: ProgramType::Operation("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::OpenQasm,
+            ProgramType::Operation,
+            Some("Test".into()),
+            None,
+        ),
     );
     if unit.has_errors() {
         let errors = unit.errors.into_iter().map(Report::new).collect();
@@ -217,11 +225,13 @@ pub fn compile_qasm_to_qsharp_with_semantics(
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
+        CompilerConfig::new(
             qubit_semantics,
-            output_semantics: OutputSemantics::Qiskit,
-            program_ty: ProgramType::Fragments,
-        },
+            OutputSemantics::Qiskit,
+            ProgramType::Fragments,
+            None,
+            None,
+        ),
     );
     qsharp_from_qasm_compilation(unit)
 }
@@ -251,11 +261,13 @@ pub fn compile_qasm_stmt_to_qsharp_with_semantics(
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
+        CompilerConfig::new(
             qubit_semantics,
-            output_semantics: OutputSemantics::Qiskit,
-            program_ty: ProgramType::Fragments,
-        },
+            OutputSemantics::Qiskit,
+            ProgramType::Fragments,
+            None,
+            None,
+        ),
     );
     if unit.has_errors() {
         let errors = unit.errors.into_iter().map(Report::new).collect();

--- a/compiler/qsc_qasm3/src/tests/declaration.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration.rs
@@ -67,11 +67,13 @@ fn duration_literal() -> miette::Result<(), Vec<Report>> {
     let unit = crate::qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::OpenQasm,
-            program_ty: ProgramType::Fragments,
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::OpenQasm,
+            ProgramType::Fragments,
+            None,
+            None,
+        ),
     );
     println!("{:?}", unit.errors);
     assert!(unit.errors.len() == 5);
@@ -100,11 +102,13 @@ fn stretch() {
     let unit = crate::compile::qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::OpenQasm,
-            program_ty: ProgramType::Fragments,
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::OpenQasm,
+            ProgramType::Fragments,
+            None,
+            None,
+        ),
     );
     assert!(unit.has_errors());
     println!("{:?}", unit.errors);

--- a/compiler/qsc_qasm3/src/tests/output.rs
+++ b/compiler/qsc_qasm3/src/tests/output.rs
@@ -37,11 +37,13 @@ fn using_re_semantics_removes_output() -> miette::Result<(), Vec<Report>> {
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::ResourceEstimation,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::ResourceEstimation,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     fail_on_compilation_errors(&unit);
     let qsharp = gen_qsharp(&unit.package.expect("no package found"));
@@ -90,11 +92,13 @@ fn using_qasm_semantics_captures_all_classical_decls_as_output() -> miette::Resu
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::OpenQasm,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::OpenQasm,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     fail_on_compilation_errors(&unit);
     let qsharp = gen_qsharp(&unit.package.expect("no package found"));
@@ -144,11 +148,13 @@ fn using_qiskit_semantics_only_bit_array_is_captured_and_reversed(
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::Qiskit,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::Qiskit,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     fail_on_compilation_errors(&unit);
     let qsharp = gen_qsharp(&unit.package.expect("no package found"));
@@ -205,11 +211,13 @@ c2[2] = measure q[4];
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::Qiskit,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::Qiskit,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     fail_on_compilation_errors(&unit);
     let package = unit.package.expect("no package found");

--- a/compiler/qsc_qasm3/src/tests/sample_circuits/bell_pair.rs
+++ b/compiler/qsc_qasm3/src/tests/sample_circuits/bell_pair.rs
@@ -28,11 +28,13 @@ fn it_compiles() {
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::OpenQasm,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::OpenQasm,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     print_compilation_errors(&unit);
     assert!(!unit.has_errors());

--- a/compiler/qsc_qasm3/src/tests/sample_circuits/rgqft_multiplier.rs
+++ b/compiler/qsc_qasm3/src/tests/sample_circuits/rgqft_multiplier.rs
@@ -16,11 +16,13 @@ fn it_compiles() {
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::OpenQasm,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::OpenQasm,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     print_compilation_errors(&unit);
     assert!(!unit.has_errors());

--- a/compiler/qsc_qasm3/src/tests/statement/include.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/include.rs
@@ -37,11 +37,13 @@ fn programs_with_includes_can_be_parsed() -> miette::Result<(), Vec<Report>> {
     let r = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::Qiskit,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::Qiskit,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     let qsharp = qsharp_from_qasm_compilation(r)?;
     expect![

--- a/compiler/qsc_qasm3/src/tests/statement/reset.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/reset.rs
@@ -31,11 +31,13 @@ fn reset_calls_are_generated_from_qasm() -> miette::Result<(), Vec<Report>> {
     let unit = qasm_to_program(
         res.source,
         res.source_map,
-        CompilerConfig {
-            qubit_semantics: QubitSemantics::Qiskit,
-            output_semantics: OutputSemantics::Qiskit,
-            program_ty: ProgramType::File("Test".to_string()),
-        },
+        CompilerConfig::new(
+            QubitSemantics::Qiskit,
+            OutputSemantics::Qiskit,
+            ProgramType::File,
+            Some("Test".into()),
+            None,
+        ),
     );
     fail_on_compilation_errors(&unit);
     let qsharp = gen_qsharp(&unit.package.expect("no package found"));

--- a/pip/pyproject.toml
+++ b/pip/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 [project.optional-dependencies]
 jupyterlab = ["qsharp-jupyterlab"]
 widgets = ["qsharp-widgets"]
-qiskit = ["qiskit>=1.2.0,<1.3.0"]
+qiskit = ["qiskit>=1.2.0,<2.0.0"]
 
 [build-system]
 requires = ["maturin ~= 1.2.0"]

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -8,6 +8,62 @@ from typing import Any, Callable, Optional, Dict, List, Tuple
 # E302 is fighting with the formatter for number of blank lines
 # flake8: noqa: E302
 
+class OutputSemantics(Enum):
+    """
+    Represents the output semantics for OpenQASM 3 compilation.
+    Each has implications on the output of the compilation
+    and the semantic checks that are performed.
+    """
+
+    Qiskit: OutputSemantics
+    """
+    The output is in Qiskit format meaning that the output
+    is all of the classical registers, in reverse order
+    in which they were added to the circuit with each
+    bit within each register in reverse order.
+    """
+
+    OpenQasm: OutputSemantics
+    """
+    [OpenQASM 3 has two output modes](https://openqasm.com/language/directives.html#input-output)
+    - If the programmer provides one or more `output` declarations, then
+        variables described as outputs will be returned as output.
+        The spec make no mention of endianness or order of the output.
+    - Otherwise, assume all of the declared variables are returned as output.
+    """
+
+    ResourceEstimation: OutputSemantics
+    """
+    No output semantics are applied. The entry point returns `Unit`.
+    """
+
+class ProgramType(Enum):
+    """
+    Represents the type of compilation out to create
+    """
+
+    File: ProgramType
+    """
+    Creates an operation in a namespace as if the program is a standalone
+    file. Inputs are lifted to the operation params. Output are lifted to
+    the operation return type. The operation is marked as `@EntryPoint`
+    as long as there are no input parameters.
+    """
+
+    Operation: ProgramType
+    """
+    Programs are compiled to a standalone function. Inputs are lifted to
+    the operation params. Output are lifted to the operation return type.
+    """
+
+    Fragments: ProgramType
+    """
+    Creates a list of statements from the program. This is useful for
+    interactive environments where the program is a list of statements
+    imported into the current scope.
+    This is also useful for testing indifidual statements compilation.
+    """
+
 class TargetProfile(Enum):
     """
     A Q# target profile.

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -61,7 +61,7 @@ class ProgramType(Enum):
     Creates a list of statements from the program. This is useful for
     interactive environments where the program is a list of statements
     imported into the current scope.
-    This is also useful for testing indifidual statements compilation.
+    This is also useful for testing individual statements compilation.
     """
 
 class TargetProfile(Enum):

--- a/pip/qsharp/_native.pyi
+++ b/pip/qsharp/_native.pyi
@@ -39,7 +39,7 @@ class OutputSemantics(Enum):
 
 class ProgramType(Enum):
     """
-    Represents the type of compilation out to create
+    Represents the type of compilation output to create
     """
 
     File: ProgramType

--- a/pip/qsharp/interop/qiskit/__init__.py
+++ b/pip/qsharp/interop/qiskit/__init__.py
@@ -5,7 +5,7 @@ import json
 from typing import Any, Dict, List, Optional, Union
 
 from ...estimator import EstimatorParams, EstimatorResult
-from ..._native import QasmError, TargetProfile
+from ..._native import OutputSemantics, ProgramType, QasmError
 from .backends import QSharpBackend, ResourceEstimatorBackend, QirTarget
 from .jobs import QsJob, QsSimJob, ReJob, QsJobSet
 from .execution import DetaultExecutor

--- a/pip/qsharp/interop/qiskit/backends/backend_base.py
+++ b/pip/qsharp/interop/qiskit/backends/backend_base.py
@@ -454,7 +454,7 @@ class BackendBase(BackendV2, ABC):
             "name": kwargs.get("name", circuit.name),
             "search_path": kwargs.get("search_path", "."),
         }
-        qsharp_source = self._qsharp(qasm3_source, **args)
+        qsharp_source = self._qasm3_to_qsharp(qasm3_source, **args)
         return qsharp_source
 
     def qir(
@@ -515,7 +515,7 @@ class BackendBase(BackendV2, ABC):
             **kwargs,
         )
 
-    def _qsharp(
+    def _qasm3_to_qsharp(
         self,
         source: str,
         **kwargs,

--- a/pip/qsharp/interop/qiskit/backends/backend_base.py
+++ b/pip/qsharp/interop/qiskit/backends/backend_base.py
@@ -439,7 +439,8 @@ class BackendBase(BackendV2, ABC):
                   configuration. Defaults to backend config values. Common
                   values include: 'optimization_level', 'basis_gates',
                   'includes', 'search_path'.
-
+              - output_semantics (OutputSemantics, optional): The output semantics for the QIR conversion. Defaults to None (Qiskit).
+              - program_ty (ProgramType, optional): The program type to generate. Defaults to None (File(name)).
         Returns:
             str: The converted QASM3 code as a string. Any supplied includes
             are emitted as include statements at the top of the program.
@@ -454,6 +455,14 @@ class BackendBase(BackendV2, ABC):
             "name": kwargs.get("name", circuit.name),
             "search_path": kwargs.get("search_path", "."),
         }
+        output_semantics = kwargs.pop("output_semantics", None)
+        if output_semantics is not None:
+            args["output_semantics"] = output_semantics
+
+        program_ty = kwargs.pop("program_ty", None)
+        if program_ty is not None:
+            args["program_ty"] = program_ty
+
         qsharp_source = self._qasm3_to_qsharp(qasm3_source, **args)
         return qsharp_source
 
@@ -471,7 +480,8 @@ class BackendBase(BackendV2, ABC):
               - params (str, optional): The entry expression for the QIR conversion. Defaults to None.
               - target_profile (TargetProfile, optional): The target profile for the backend. Defaults to backend config value.
               - search_path (str, optional): The search path for the backend. Defaults to '.'.
-
+              - output_semantics (OutputSemantics, optional): The output semantics for the QIR conversion. Defaults to None (Qiskit).
+              - program_ty (ProgramType, optional): The program type to generate. Defaults to None (File(name)).
         Returns:
             str: The converted QIR code as a string.
 
@@ -495,9 +505,17 @@ class BackendBase(BackendV2, ABC):
         if params is not None:
             qir_args["params"] = params
 
-        return self._qir(qasm3_source, **qir_args)
+        output_semantics = kwargs.pop("output_semantics", None)
+        if output_semantics is not None:
+            qir_args["output_semantics"] = output_semantics
 
-    def _qir(
+        program_ty = kwargs.pop("program_ty", None)
+        if program_ty is not None:
+            qir_args["program_ty"] = program_ty
+
+        return self._qasm3_to_qir(qasm3_source, **qir_args)
+
+    def _qasm3_to_qir(
         self,
         source: str,
         **kwargs,

--- a/pip/qsharp/interop/qiskit/backends/backend_base.py
+++ b/pip/qsharp/interop/qiskit/backends/backend_base.py
@@ -434,13 +434,12 @@ class BackendBase(BackendV2, ABC):
 
         Args:
             circuit (QuantumCircuit): The QuantumCircuit to be executed.
-            **options: Additional options for the execution.
+            **options: Additional options for the execution. Defaults to backend config values.
               - Any options for the transpiler, exporter, or Qiskit passes
                   configuration. Defaults to backend config values. Common
                   values include: 'optimization_level', 'basis_gates',
                   'includes', 'search_path'.
-              - output_semantics (OutputSemantics, optional): The output semantics for the QIR conversion. Defaults to None (Qiskit).
-              - program_ty (ProgramType, optional): The program type to generate. Defaults to None (File(name)).
+              - output_semantics (OutputSemantics, optional): The output semantics for the compilation.
         Returns:
             str: The converted QASM3 code as a string. Any supplied includes
             are emitted as include statements at the top of the program.
@@ -453,15 +452,15 @@ class BackendBase(BackendV2, ABC):
 
         args = {
             "name": kwargs.get("name", circuit.name),
-            "search_path": kwargs.get("search_path", "."),
         }
-        output_semantics = kwargs.pop("output_semantics", None)
-        if output_semantics is not None:
-            args["output_semantics"] = output_semantics
 
-        program_ty = kwargs.pop("program_ty", None)
-        if program_ty is not None:
-            args["program_ty"] = program_ty
+        if search_path := kwargs.pop("search_path", "."):
+            args["search_path"] = search_path
+
+        if output_semantics := kwargs.pop(
+            "output_semantics", self.options.get("output_semantics", default=None)
+        ):
+            args["output_semantics"] = output_semantics
 
         qsharp_source = self._qasm3_to_qsharp(qasm3_source, **args)
         return qsharp_source
@@ -479,9 +478,8 @@ class BackendBase(BackendV2, ABC):
             **kwargs: Additional options for the execution.
               - params (str, optional): The entry expression for the QIR conversion. Defaults to None.
               - target_profile (TargetProfile, optional): The target profile for the backend. Defaults to backend config value.
+              - output_semantics (OutputSemantics, optional): The output semantics for the compilation. Defaults to backend config value.
               - search_path (str, optional): The search path for the backend. Defaults to '.'.
-              - output_semantics (OutputSemantics, optional): The output semantics for the QIR conversion. Defaults to None (Qiskit).
-              - program_ty (ProgramType, optional): The program type to generate. Defaults to None (File(name)).
         Returns:
             str: The converted QIR code as a string.
 
@@ -496,24 +494,23 @@ class BackendBase(BackendV2, ABC):
 
         qasm3_source = self._qasm3(circuit, **kwargs)
 
-        qir_args = {
+        args = {
             "name": name,
             "target_profile": target_profile,
-            "search_path": kwargs.pop("search_path", "."),
         }
-        params = kwargs.pop("params", None)
-        if params is not None:
-            qir_args["params"] = params
 
-        output_semantics = kwargs.pop("output_semantics", None)
-        if output_semantics is not None:
-            qir_args["output_semantics"] = output_semantics
+        if search_path := kwargs.pop("search_path", "."):
+            args["search_path"] = search_path
 
-        program_ty = kwargs.pop("program_ty", None)
-        if program_ty is not None:
-            qir_args["program_ty"] = program_ty
+        if params := kwargs.pop("params", None):
+            args["params"] = params
 
-        return self._qasm3_to_qir(qasm3_source, **qir_args)
+        if output_semantics := kwargs.pop(
+            "output_semantics", self.options.get("output_semantics", default=None)
+        ):
+            args["output_semantics"] = output_semantics
+
+        return self._qasm3_to_qir(qasm3_source, **args)
 
     def _qasm3_to_qir(
         self,

--- a/pip/qsharp/interop/qiskit/backends/re_backend.py
+++ b/pip/qsharp/interop/qiskit/backends/re_backend.py
@@ -14,6 +14,7 @@ from qiskit.transpiler.target import Target
 from .compilation import Compilation
 from .errors import Errors
 from .backend_base import BackendBase
+from .. import OutputSemantics
 from ..jobs import ReJob
 from ..execution import DetaultExecutor
 from ...._fs import read_file, list_directory, resolve
@@ -56,7 +57,6 @@ class ResourceEstimatorBackend(BackendBase):
                 - name (str): The name of the circuit. This is used as the entry point for the program.
                         The circuit name will be used if not specified.
                 - search_path (str): Path to search in for qasm3 imports. Defaults to '.'.
-                - target_profile (TargetProfile): The target profile to use for the backend.
                 - executor(ThreadPoolExecutor or other Executor):
                         The executor to be used to submit the job. Defaults to SynchronousExecutor.
         """
@@ -84,6 +84,7 @@ class ResourceEstimatorBackend(BackendBase):
             name="program",
             search_path=".",
             target_profile=TargetProfile.Unrestricted,
+            output_semantics=OutputSemantics.ResourceEstimation,
             executor=DetaultExecutor(),
         )
 

--- a/pip/src/interop.rs
+++ b/pip/src/interop.rs
@@ -177,13 +177,16 @@ pub(crate) fn resource_estimate_qasm3(
 
     let program_type = ProgramType::File(name.to_string());
     let output_semantics = OutputSemantics::ResourceEstimation;
-    let unit = compile_qasm(source, &name, &resolver, program_type, output_semantics)?;
-    let (source_map, _, package, _) = unit.into_tuple();
-    match crate::interop::estimate_qasm3(
-        package.expect("Package must exist when there are no errors"),
-        source_map,
-        job_params,
-    ) {
+    let (package, source_map, _) = compile_qasm_enriching_errors(
+        source,
+        &name,
+        &resolver,
+        program_type,
+        output_semantics,
+        false,
+    )?;
+
+    match crate::interop::estimate_qasm3(package, source_map, job_params) {
         Ok(estimate) => Ok(estimate),
         Err(errors) if matches!(errors[0], re::Error::Interpreter(_)) => {
             Err(QSharpError::new_err(format_errors(

--- a/pip/src/interop.rs
+++ b/pip/src/interop.rs
@@ -615,7 +615,7 @@ pub(crate) fn get_search_path(kwargs: &Bound<'_, PyDict>) -> PyResult<String> {
 /// Extracts the program type from the kwargs dictionary.
 pub(crate) fn get_program_type(kwargs: &Bound<'_, PyDict>) -> PyResult<ProgramType> {
     let target = kwargs
-        .get_item("program_type")?
+        .get_item("program_ty")?
         .map_or_else(|| Ok(ProgramType::File), |x| x.extract::<ProgramType>())?;
     Ok(target)
 }

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -170,7 +170,7 @@ pub enum ProgramType {
     /// Creates a list of statements from the program. This is useful for
     /// interactive environments where the program is a list of statements
     /// imported into the current scope.
-    /// This is also useful for testing indifidual statements compilation.
+    /// This is also useful for testing individual statements compilation.
     Fragments,
 }
 

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -157,7 +157,7 @@ impl From<OutputSemantics> for qsc_qasm3::OutputSemantics {
 #[derive(Clone, PartialEq)]
 #[pyclass(eq)]
 #[allow(non_camel_case_types)]
-/// Represents the type of compilation out to create
+/// Represents the type of compilation output to create
 pub enum ProgramType {
     /// Creates an operation in a namespace as if the program is a standalone
     /// file. Inputs are lifted to the operation params. Output are lifted to

--- a/pip/tests-integration/interop_qiskit/test_qsharp.py
+++ b/pip/tests-integration/interop_qiskit/test_qsharp.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pytest
+
+from . import QISKIT_AVAILABLE, SKIP_REASON
+
+
+if QISKIT_AVAILABLE:
+    from qsharp.interop.qiskit import (
+        OutputSemantics,
+        ProgramType,
+        QSharpBackend,
+    )
+    from qiskit.circuit import QuantumCircuit
+
+
+@pytest.mark.skipif(not QISKIT_AVAILABLE, reason=SKIP_REASON)
+def test_qsharp_smoke() -> None:
+    circuit = QuantumCircuit(2, 2)
+    circuit.x(0)
+    circuit.cx(0, 1)
+    circuit.measure_all(add_bits=False)
+    circuit.name = "smoke"
+
+    backend = QSharpBackend()
+    res = backend._qsharp(circuit)
+    assert res is not None
+    assert "qasm3_import" in res
+    assert "operation smoke() : Result[]" in res
+    assert "Microsoft.Quantum.Arrays.Reversed" in res
+
+
+@pytest.mark.skipif(not QISKIT_AVAILABLE, reason=SKIP_REASON)
+def test_qsharp_disable_output() -> None:
+    circuit = QuantumCircuit(2, 2)
+    circuit.x(0)
+    circuit.cx(0, 1)
+    circuit.measure_all(add_bits=False)
+    circuit.name = "circuit_with_unit_output"
+    backend = QSharpBackend()
+    output_semantics = OutputSemantics.ResourceEstimation
+
+    res = backend._qsharp(circuit, output_semantics=output_semantics)
+    assert "operation circuit_with_unit_output() : Unit" in res
+
+
+@pytest.mark.skipif(not QISKIT_AVAILABLE, reason=SKIP_REASON)
+def test_qsharp_openqasm_output_semantics() -> None:
+    circuit = QuantumCircuit(2, 2)
+    circuit.x(0)
+    circuit.cx(0, 1)
+    circuit.measure_all(add_bits=False)
+    circuit.name = "circuit_with_unit_output"
+    backend = QSharpBackend()
+    output_semantics = OutputSemantics.OpenQasm
+
+    res = backend._qsharp(circuit, output_semantics=output_semantics)
+    assert "Microsoft.Quantum.Arrays.Reversed" not in res


### PR DESCRIPTION
- Qiskit dep version set in lock step with aqp
- output semantics can be configured on the backends needed for QIR generation. Program type exported as well.
- Program type is separated from name of operation.
- Updating to use walrus operator to simplify logic (supported by Python 3.8+).
- Fixed doc comments
- Fixed Q# code generation for debugging
- RE now uses `compile_qasm_enriching_errors` so that entry points with input vars are rejected.