### PR TITLE
Fix typo in vscode extension's package.json

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -73,7 +73,7 @@
           {
             "id": "qsharp-vscode.welcome.starters",
             "title": "Starting points",
-            "description": "Expore Q# safely by opening files in the [Q# playground](command:qsharp-vscode.openPlayground), or work in Python by [creating a Jupyter Notebook](command:qsharp-vscode.createNotebook) from a template",
+            "description": "Explore Q# safely by opening files in the [Q# playground](command:qsharp-vscode.openPlayground), or work in Python by [creating a Jupyter Notebook](command:qsharp-vscode.createNotebook) from a template",
             "media": {
               "image": "resources/notebook.png",
               "altText": "Jupyter Notebooks"


### PR DESCRIPTION
Fix small typo that currently appears in Welcome page for the VS Code extension:

![image](https://github.com/user-attachments/assets/99715265-d098-4b5c-98f7-996d56c451f7)
