### PR TITLE
Support Adjoint of `Relabel`

### DIFF
--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -77,7 +77,7 @@ pub(crate) fn call(
                 Err(_) => Err(Error::OutputFail(name_span)),
             }
         }
-        "Relabel" => qubit_relabel(arg, arg_span, |q0, q1| sim.qubit_swap_id(q0, q1)),
+        "PermuteLabels" => qubit_relabel(arg, arg_span, |q0, q1| sim.qubit_swap_id(q0, q1)),
         "Message" => match out.message(&arg.unwrap_string()) {
             Ok(()) => Ok(Value::unit()),
             Err(_) => Err(Error::OutputFail(name_span)),

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -3724,7 +3724,7 @@ fn controlled_operation_with_duplicate_controls_fails() {
                                 1,
                             ),
                             item: LocalItemId(
-                                131,
+                                132,
                             ),
                         },
                         caller: PackageId(
@@ -3774,7 +3774,7 @@ fn controlled_operation_with_target_in_controls_fails() {
                                 1,
                             ),
                             item: LocalItemId(
-                                131,
+                                132,
                             ),
                         },
                         caller: PackageId(

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -1293,7 +1293,7 @@ impl<'a> PartialEvaluator<'a> {
             // Qubit allocations and measurements have special handling.
             "__quantum__rt__qubit_allocate" => Ok(self.allocate_qubit()),
             "__quantum__rt__qubit_release" => Ok(self.release_qubit(args_value)),
-            "Relabel" => qubit_relabel(args_value, args_span, |q0, q1| {
+            "PermuteLabels" => qubit_relabel(args_value, args_span, |q0, q1| {
                 self.resource_manager.swap_qubit_ids(Qubit(q0), Qubit(q1));
             })
             .map_err(std::convert::Into::into),

--- a/library/src/tests/canon.rs
+++ b/library/src/tests/canon.rs
@@ -177,6 +177,27 @@ fn check_relabel_four_qubit_shuffle_permutation() {
 }
 
 #[test]
+fn check_relabel_adjoint_undoes_permutation() {
+    test_expression(
+        "{
+                use qs = Qubit[3];
+                // Prepare |01+⟩
+                X(qs[1]);
+                H(qs[2]);
+                Relabel([qs[0], qs[1], qs[2]], [qs[1], qs[2], qs[0]]);
+                // Expected state is |1+0⟩, perform part of the adjoint to correct one of the qubits.
+                X(qs[0]);
+                Adjoint Relabel([qs[0], qs[1], qs[2]], [qs[1], qs[2], qs[0]]);
+                // Expected state is now |00+⟩, perform the rest of the adjoint to get back to ground state,
+                // using the original qubit ids.
+                H(qs[2]);
+                // Qubit release will fail if the state is not |000⟩
+            }",
+        &Value::unit(),
+    );
+}
+
+#[test]
 fn check_apply_cnot_chain_2() {
     test_expression(
         {

--- a/library/std/src/canon.qs
+++ b/library/std/src/canon.qs
@@ -275,7 +275,18 @@ namespace Microsoft.Quantum.Canon {
     /// use (q0, q1) = (Qubit(), Qubit());
     /// Relabel([q0, q1], [q1, q0]);
     /// ```
-    operation Relabel(current : Qubit[], updated : Qubit[]) : Unit {
+    /// Note that the adjoint of this operation effectively changes the order of arguments, such that
+    /// `Adjoint Relabel(qubits, newOrder)` is equivalent to `Relabel(newOrder, qubits)`.
+    operation Relabel(current : Qubit[], updated : Qubit[]) : Unit is Adj {
+        body ... {
+            PermuteLabels(current, updated);
+        }
+        adjoint ... {
+            PermuteLabels(updated, current);
+        }
+    }
+
+    operation PermuteLabels(current : Qubit[], updated : Qubit[]) : Unit {
         body intrinsic;
     }
 


### PR DESCRIPTION
This change adds one layer of indirection in the library implementation of `Relabel` so that the operation can be adjointable. The adjoint is just a switch of the qubit arrays such that `Adjoint Relabel(current, updated)` is the same as `Relabel(updated, current)`.