### PR TITLE
Add ProtocolSpecification to API

### DIFF
--- a/resource_estimator/src/system.rs
+++ b/resource_estimator/src/system.rs
@@ -25,7 +25,7 @@ use std::rc::Rc;
 pub use self::modeling::{
     floquet_code, load_protocol_from_specification, surface_code_gate_based,
     surface_code_measurement_based, GateBasedPhysicalQubit, MajoranaQubit, PhysicalQubit, Protocol,
-    ProtocolEvaluator, TFactory,
+    ProtocolEvaluator, ProtocolSpecification, TFactory,
 };
 pub use self::optimization::TFactoryBuilder;
 pub use self::{data::LogicalResourceCounts, error::Error};


### PR DESCRIPTION
The type is used by the function `load_protocol_from_specification` which is already public.