### PR TITLE
add Q# package registry document

### DIFF
--- a/library/Registry.md
+++ b/library/Registry.md
@@ -1,0 +1,22 @@
+# Q# Package Registry
+
+This document is a list of all known (to us) Q# packages. If you have a package that you would like to add to this list, please open a pull request.
+
+## Unstable
+
+[link](https://github.com/microsoft/qsharp/tree/main/library/unstable)
+
+A general staging ground for some useful APIs that have not yet been stabailized into the standard library.
+
+## Signed
+
+[link](https://github.com/microsoft/qsharp/tree/main/library/signed)
+
+Defines types and functions to work with signed qubit-based integers.
+
+## FixedPoint
+
+[link](https://github.com/microsoft/qsharp/tree/main/library/fixed_point)
+
+Types and functions for fixed-point arithmetic with qubits.
+

--- a/library/Registry.md
+++ b/library/Registry.md
@@ -1,6 +1,6 @@
-# Q# Package Registry
+# Q# Library Registry
 
-This document is a list of notable Q# library projects. If you have a project that you would like to add to this list, please open a pull request.
+This document is a list of notable Q# library projects. If you have a library that you would like to add to this list, please open a pull request. If you have a Q# project that you'd like to share as a library, please see the [documentation on how to do this.](https://learn.microsoft.com/en-us/azure/quantum/how-to-work-with-qsharp-projects?tabs=tabid-qsharp%2Ctabid-qsharp-run#configuring-q-projects-as-external-dependencies).
 
 ## Unstable
 

--- a/library/Registry.md
+++ b/library/Registry.md
@@ -6,7 +6,7 @@ This document is a list of notable Q# library projects. If you have a project th
 
 [link](https://github.com/microsoft/qsharp/tree/main/library/unstable)
 
-A general staging ground for some useful APIs that have not yet been stabailized into the standard library.
+A general staging ground for some useful APIs that have not yet been stabilized into the standard library.
 
 ## Signed
 

--- a/library/Registry.md
+++ b/library/Registry.md
@@ -1,6 +1,6 @@
 # Q# Package Registry
 
-This document is a list of notable Q# library projects. If you have a package that you would like to add to this list, please open a pull request.
+This document is a list of notable Q# library projects. If you have a project that you would like to add to this list, please open a pull request.
 
 ## Unstable
 

--- a/library/Registry.md
+++ b/library/Registry.md
@@ -1,6 +1,6 @@
 # Q# Package Registry
 
-This document is a list of all known (to us) Q# packages. If you have a package that you would like to add to this list, please open a pull request.
+This document is a list of notable Q# library projects. If you have a package that you would like to add to this list, please open a pull request.
 
 ## Unstable
 


### PR DESCRIPTION
A basic document that serves the purpose of a package registry, listing all packages we are aware of.

Most information about the package should be on the package page itself, so here we can just list titles, summaries, and links.