### PR TITLE
Fix bug preventing display of circuits where same qubit measured more than once

### DIFF
--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -94,7 +94,7 @@ fn measure_same_qubit_twice() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    expect![[r#"
+    expect![["
         q_0    ── H ──── M ──── M ──
                          ╘══════╪═══
                                 ╘═══

--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -73,6 +73,36 @@ fn one_gate() {
 }
 
 #[test]
+fn measure_same_qubit_twice() {
+    let mut interpreter = interpreter(
+        r"
+            namespace Test {
+                @EntryPoint()
+                operation Main() : Result[] {
+                    use q = Qubit();
+                    H(q);
+                    let r1 = M(q);
+                    let r2 = M(q);
+                    [r1, r2]
+                }
+            }
+        ",
+        Profile::Unrestricted,
+    );
+
+    let circ = interpreter
+        .circuit(CircuitEntryPoint::EntryPoint, false)
+        .expect("circuit generation should succeed");
+
+    expect![[r#"
+        q_0    ── H ──── M ──── M ──
+                         ╘══════╪═══
+                                ╘═══
+    "#]]
+    .assert_eq(&circ.to_string());
+}
+
+#[test]
 fn toffoli() {
     let mut interpreter = interpreter(
         r"

--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -98,7 +98,7 @@ fn measure_same_qubit_twice() {
         q_0    ── H ──── M ──── M ──
                          ╘══════╪═══
                                 ╘═══
-    "#]]
+    "]]
     .assert_eq(&circ.to_string());
 }
 


### PR DESCRIPTION
The logic for returning the count of measurements incorrectly reported every qubit as being measured only once no matter how many times it was measured. This was breaking circuit display for non-base profile programs.