### PR TITLE
Error budget pruning strategy in resource estimator core

### DIFF
--- a/resource_estimator/examples/basic_logical_counts.rs
+++ b/resource_estimator/examples/basic_logical_counts.rs
@@ -52,11 +52,13 @@ fn main() {
 
     // After we have set up all required inputs for the resource estimation
     // task, we can set up an estimation instance.
-    let estimation = PhysicalResourceEstimation::new(code, qubit, builder, logical_counts, budget);
+    let estimation = PhysicalResourceEstimation::new(code, qubit, builder, logical_counts);
 
     // In this example, we perform a standard estimation without any further
     // constraints.
-    let result = estimation.estimate().expect("estimation does not fail");
+    let result = estimation
+        .estimate(&budget)
+        .expect("estimation does not fail");
 
     // There is a lot of data contained in the resource estimation result
     // object, but in this sample we are only printing the total number of

--- a/resource_estimator/src/estimates.rs
+++ b/resource_estimator/src/estimates.rs
@@ -4,7 +4,7 @@
 mod error;
 pub use error::Error;
 mod error_budget;
-pub use error_budget::ErrorBudget;
+pub use error_budget::{ErrorBudget, ErrorBudgetStrategy};
 mod error_correction;
 pub use error_correction::{
     CodeWithThresholdAndDistance, CodeWithThresholdAndDistanceEvaluator, ErrorCorrection,

--- a/resource_estimator/src/estimates/error_budget.rs
+++ b/resource_estimator/src/estimates/error_budget.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ErrorBudget {
     /// Probability of at least one logical error
     logical: f64,
@@ -36,10 +36,18 @@ impl ErrorBudget {
         self.logical
     }
 
+    pub fn set_logical(&mut self, logical: f64) {
+        self.logical = logical;
+    }
+
     /// Get the error budget's tstates.
     #[must_use]
     pub fn magic_states(&self) -> f64 {
         self.magic_states
+    }
+
+    pub fn set_magic_states(&mut self, magic_states: f64) {
+        self.magic_states = magic_states;
     }
 
     /// Get the error budget's rotations.
@@ -47,4 +55,15 @@ impl ErrorBudget {
     pub fn rotations(&self) -> f64 {
         self.rotations
     }
+
+    pub fn set_rotations(&mut self, rotations: f64) {
+        self.rotations = rotations;
+    }
+}
+
+#[derive(Default, Copy, Clone)]
+pub enum ErrorBudgetStrategy {
+    #[default]
+    Static,
+    PruneLogicalAndRotations,
 }

--- a/resource_estimator/src/estimates/layout.rs
+++ b/resource_estimator/src/estimates/layout.rs
@@ -3,7 +3,7 @@
 
 use serde::Serialize;
 
-use super::ErrorBudget;
+use super::{ErrorBudget, ErrorBudgetStrategy};
 
 /// Trait to model post-layout logical overhead
 pub trait Overhead {
@@ -23,6 +23,11 @@ pub trait Overhead {
     /// The index is used to indicate the type of magic states and must be
     /// supported by available factory builders in the physical estimation.
     fn num_magic_states(&self, budget: &ErrorBudget, index: usize) -> u64;
+
+    /// When implemented, prunes the error budget with respect to the provided
+    /// strategy
+    #[allow(unused_variables)]
+    fn prune_error_budget(&self, budget: &mut ErrorBudget, strategy: ErrorBudgetStrategy) {}
 }
 
 /// This is the realized logical overhead after applying an error budget.  This

--- a/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
+++ b/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Cow, ops::Deref};
 
-use crate::estimates::{Error, ErrorCorrection, Factory, FactoryBuilder, LogicalPatch, Overhead};
+use crate::estimates::{
+    Error, ErrorBudget, ErrorBudgetStrategy, ErrorCorrection, Factory, FactoryBuilder,
+    LogicalPatch, Overhead,
+};
 
 use super::{
     FactoryForCycles, FactoryPart, PhysicalResourceEstimation, PhysicalResourceEstimationResult,
@@ -21,14 +24,39 @@ impl<
         Self { estimator }
     }
 
-    pub fn estimate(&self) -> Result<PhysicalResourceEstimationResult<E, B::Factory>, Error> {
-        let mut num_cycles = self.compute_num_cycles()?;
+    pub fn estimate(
+        &self,
+        error_budget: &ErrorBudget,
+    ) -> Result<PhysicalResourceEstimationResult<E, B::Factory>, Error> {
+        let mut num_cycles = self.compute_num_cycles(error_budget)?;
 
         loop {
-            let required_logical_error_rate = self.required_logical_error_rate(num_cycles);
+            let mut error_budget = error_budget.clone();
+
+            self.layout_overhead()
+                .prune_error_budget(&mut error_budget, self.error_budget_strategy());
+
+            let required_logical_error_rate =
+                self.required_logical_error_rate(error_budget.logical(), num_cycles);
             let code_parameter = self.compute_code_parameter(required_logical_error_rate)?;
-            let max_allowed_num_cycles_for_code_parameter =
-                self.logical_cycles_for_code_parameter(&code_parameter)?;
+
+            let max_allowed_num_cycles_for_code_parameter = match self.error_budget_strategy {
+                ErrorBudgetStrategy::Static => {
+                    self.logical_cycles_for_code_parameter(error_budget.logical(), &code_parameter)?
+                }
+                ErrorBudgetStrategy::PruneLogicalAndRotations => {
+                    let new_logical = self
+                        .ftp
+                        .logical_error_rate(&self.qubit, &code_parameter)
+                        .map_err(Error::LogicalErrorRateComputationFailed)?
+                        * (self.volume(num_cycles) as f64);
+                    let diff = error_budget.logical() - new_logical;
+                    error_budget.set_logical(new_logical);
+                    let new_magic_states = error_budget.magic_states() + diff;
+                    error_budget.set_magic_states(new_magic_states);
+                    num_cycles
+                }
+            };
 
             let logical_patch =
                 LogicalPatch::new(&self.ftp, code_parameter.clone(), self.qubit.clone())?;
@@ -40,6 +68,7 @@ impl<
                     &logical_patch,
                     num_cycles,
                     max_allowed_num_cycles_for_code_parameter,
+                    &error_budget,
                     index,
                 )? {
                     FactoryPartsResult::NoMagicStates => {
@@ -62,6 +91,7 @@ impl<
                 return Ok(PhysicalResourceEstimationResult::new(
                     self,
                     logical_patch,
+                    &error_budget,
                     num_cycles,
                     factory_parts,
                     required_logical_error_rate,
@@ -77,17 +107,16 @@ impl<
         logical_patch: &LogicalPatch<E>,
         min_cycles: u64,
         max_cycles: u64,
+        error_budget: &ErrorBudget,
         index: usize,
     ) -> Result<FactoryPartsResult<B::Factory>, Error> {
-        let num_magic_states = self
-            .layout_overhead
-            .num_magic_states(&self.error_budget, index);
+        let num_magic_states = self.layout_overhead.num_magic_states(error_budget, index);
 
         if num_magic_states == 0 {
             return Ok(FactoryPartsResult::NoMagicStates);
         }
 
-        let required_logical_magic_state_error_rate = (self.error_budget.magic_states()
+        let required_logical_magic_state_error_rate = (error_budget.magic_states()
             / self.factory_builder.num_magic_state_types() as f64)
             / (num_magic_states as f64);
 
@@ -111,10 +140,21 @@ impl<
         if let Some(FactoryForCycles {
             factory,
             num_cycles: num_cycles_required,
-        }) = self.find_factory(index, &factories, logical_patch, min_cycles, max_cycles)
-        {
-            let num_factories =
-                self.num_factories(logical_patch, index, &factory, num_cycles_required);
+        }) = self.find_factory(
+            index,
+            &factories,
+            logical_patch,
+            error_budget,
+            min_cycles,
+            max_cycles,
+        ) {
+            let num_factories = self.num_factories(
+                logical_patch,
+                index,
+                &factory,
+                error_budget,
+                num_cycles_required,
+            );
             Ok(FactoryPartsResult::Success {
                 factory_part: FactoryPart::new(
                     factory.into_owned(),
@@ -134,6 +174,7 @@ impl<
         magic_state_index: usize,
         factories: &[Cow<'b, B::Factory>],
         logical_patch: &LogicalPatch<E>,
+        error_budget: &ErrorBudget,
         min_cycles: u64,
         max_cycles: u64,
     ) -> Option<FactoryForCycles<'b, B::Factory>> {
@@ -147,6 +188,7 @@ impl<
                     && self.is_max_factories_constraint_satisfied(
                         logical_patch,
                         factory,
+                        error_budget,
                         min_cycles,
                     )
             })
@@ -161,6 +203,7 @@ impl<
             magic_state_index,
             factories,
             logical_patch,
+            error_budget,
             max_cycles,
         ) {
             return Some(factory);
@@ -174,6 +217,7 @@ impl<
         magic_state_index: usize,
         factories: &[Cow<'b, B::Factory>],
         logical_patch: &LogicalPatch<E>,
+        error_budget: &ErrorBudget,
         max_cycles: u64,
     ) -> Option<FactoryForCycles<'b, B::Factory>> {
         self.max_factories.map_or_else(
@@ -196,7 +240,7 @@ impl<
                         let magic_states_per_run = max_factories * factory.num_output_states();
                         let required_runs = self
                             .layout_overhead
-                            .num_magic_states(&self.error_budget, magic_state_index)
+                            .num_magic_states(error_budget, magic_state_index)
                             .div_ceil(magic_states_per_run);
                         let required_duration = required_runs * factory.duration();
                         let num = required_duration.div_ceil(logical_patch.logical_cycle_time());
@@ -215,10 +259,11 @@ impl<
         &self,
         logical_patch: &LogicalPatch<E>,
         factory: &B::Factory,
+        error_budget: &ErrorBudget,
         num_cycles: u64,
     ) -> bool {
         self.max_factories.map_or(true, |max_factories| {
-            max_factories >= self.num_factories(logical_patch, 0, factory, num_cycles)
+            max_factories >= self.num_factories(logical_patch, 0, factory, error_budget, num_cycles)
         })
     }
 }

--- a/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
+++ b/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
@@ -30,6 +30,15 @@ impl<
     ) -> Result<PhysicalResourceEstimationResult<E, B::Factory>, Error> {
         let mut num_cycles = self.compute_num_cycles(error_budget)?;
 
+        // NOTE: for now we reset the error_budget_strategy if also
+        // max_factories is set, because it may lead to an inconsistent
+        // configuration.
+        let adjusted_strategy = if self.max_factories.is_some() {
+            ErrorBudgetStrategy::Static
+        } else {
+            self.error_budget_strategy
+        };
+
         loop {
             let mut error_budget = error_budget.clone();
 
@@ -40,7 +49,7 @@ impl<
                 self.required_logical_error_rate(error_budget.logical(), num_cycles);
             let code_parameter = self.compute_code_parameter(required_logical_error_rate)?;
 
-            let max_allowed_num_cycles_for_code_parameter = match self.error_budget_strategy {
+            let max_allowed_num_cycles_for_code_parameter = match adjusted_strategy {
                 ErrorBudgetStrategy::Static => {
                     self.logical_cycles_for_code_parameter(error_budget.logical(), &code_parameter)?
                 }

--- a/resource_estimator/src/estimates/physical_estimation/result.rs
+++ b/resource_estimator/src/estimates/physical_estimation/result.rs
@@ -37,6 +37,7 @@ impl<E: ErrorCorrection<Parameter = impl Clone>, F: Factory<Parameter = E::Param
             impl Overhead,
         >,
         logical_patch: LogicalPatch<E>,
+        error_budget: &ErrorBudget,
         num_cycles: u64,
         factory_parts: Vec<Option<FactoryPart<F>>>,
         required_logical_error_rate: f64,
@@ -71,10 +72,10 @@ impl<E: ErrorCorrection<Parameter = impl Clone>, F: Factory<Parameter = E::Param
             rqops,
             layout_overhead: RealizedOverhead::from_overhead(
                 estimation.layout_overhead(),
-                estimation.error_budget(),
+                error_budget,
                 estimation.factory_builder().num_magic_state_types(),
             ),
-            error_budget: estimation.error_budget().clone(),
+            error_budget: error_budget.clone(),
         }
     }
 
@@ -85,12 +86,14 @@ impl<E: ErrorCorrection<Parameter = impl Clone>, F: Factory<Parameter = E::Param
             impl Overhead,
         >,
         logical_patch: LogicalPatch<E>,
+        error_budget: &ErrorBudget,
         num_cycles: u64,
         required_logical_patch_error_rate: f64,
     ) -> Self {
         Self::new(
             estimation,
             logical_patch,
+            error_budget,
             num_cycles,
             std::iter::repeat(())
                 .map(|()| None)

--- a/resource_estimator/src/system.rs
+++ b/resource_estimator/src/system.rs
@@ -98,7 +98,6 @@ fn estimate_single<L: Overhead + LayoutReportData + PartitioningOverhead + Seria
             job_params.constraints().max_distillation_rounds,
         ),
         logical_resources.clone(),
-        partitioning,
     );
     if let Some(logical_depth_factor) = job_params.constraints().logical_depth_factor {
         estimation.set_logical_depth_factor(logical_depth_factor);
@@ -126,14 +125,16 @@ fn estimate_single<L: Overhead + LayoutReportData + PartitioningOverhead + Seria
             }
 
             let estimation_result = estimation
-                .build_frontier()
+                .build_frontier(&partitioning)
                 .map_err(std::convert::Into::into);
             estimation_result.map(|result| {
                 data::Success::new_from_multiple(job_params, logical_resources, result)
             })
         }
         EstimateType::SinglePoint => {
-            let estimation_result = estimation.estimate().map_err(std::convert::Into::into);
+            let estimation_result = estimation
+                .estimate(&partitioning)
+                .map_err(std::convert::Into::into);
             estimation_result
                 .map(|result| data::Success::new(job_params, logical_resources, result))
         }


### PR DESCRIPTION
Resource estimation takes as input an error budget. This is a triplet of budget contribution to logical errors, rotation synthesis errors, and magic state distillation errors. The user can either specify each of these three values separately or provide a total value that is uniformly distributed among the three parts. So far, RE does not modify these provided values.

This PR implements a pruning strategy for the error budget that will decrease the budget for logical errors and rotation synthesis errors (without affecting the estimation), while increasing the budget for magic state distillation errors in order to reduce the resources required for factories.

For logical errors, we can reduce the budget by finding the largest value that still leads to the same code parameter (e.g., code distance). Similarly, for synthesis errors, we can reduce the budget by finding the largest value that still leads to the same number of magic states. The latter is layout dependent, and therefore a new function is added to the `Overhead` trait. The function has an empty default implementation, and therefore does not break existing layout implementations.

The strategy needs to be explicitly set for the resource estimation and only works for a resource estimation without any other constraints (e.g., maximum number of qubits or duration), and does not work for frontier based estimation. There is no job parameter yet to enable the behavior.