### PR TITLE
Show no quantum state when debugging code with no qubits

### DIFF
--- a/vscode/src/debugger/session.ts
+++ b/vscode/src/debugger/session.ts
@@ -795,6 +795,22 @@ export class QscDebugSession extends LoggingDebugSession {
             {},
           );
           const state = await this.debugService.captureQuantumState();
+
+          // When there is no quantum state, return a single variable with a message
+          // for the user.
+          if (state.length == 0) {
+            response.body = {
+              variables: [
+                {
+                  name: "None",
+                  value: "No qubits allocated",
+                  variablesReference: 0,
+                },
+              ],
+            };
+            break;
+          }
+
           const variables: DebugProtocol.Variable[] = state.map((entry) => {
             const variable: DebugProtocol.Variable = {
               name: entry.name,

--- a/wasm/src/debug_service.rs
+++ b/wasm/src/debug_service.rs
@@ -38,14 +38,18 @@ impl DebugService {
 
     pub fn capture_quantum_state(&mut self) -> IQuantumStateList {
         let state = self.debugger_mut().capture_quantum_state();
-        let entries = state
-            .0
-            .iter()
-            .map(|(id, value)| QuantumState {
-                name: qsc::format_state_id(id, state.1),
-                value: fmt_complex(value),
-            })
-            .collect::<Vec<_>>();
+        let entries = if state.1 > 0 {
+            state
+                .0
+                .iter()
+                .map(|(id, value)| QuantumState {
+                    name: qsc::format_state_id(id, state.1),
+                    value: fmt_complex(value),
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
 
         QuantumStateList { entries }.into()
     }


### PR DESCRIPTION
Instead of showing a single bit zero state, this change makes the debugger quantum state view show a message when no qubits are allocated on the system:
![image](https://github.com/user-attachments/assets/25612e0f-a886-4396-b729-db5b90a7c160)

Fixes #1922