### PR TITLE
UDT field completions

### DIFF
--- a/compiler/qsc_ast/src/ast.rs
+++ b/compiler/qsc_ast/src/ast.rs
@@ -835,6 +835,16 @@ impl WithSpan for Expr {
     }
 }
 
+/// The identifier in a field access expression.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum FieldAccess {
+    /// The field name.
+    Ok(Box<Ident>),
+    /// The field access was missing a field name.
+    #[default]
+    Err,
+}
+
 /// An expression kind.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum ExprKind {
@@ -862,7 +872,7 @@ pub enum ExprKind {
     /// A failure: `fail "message"`.
     Fail(Box<Expr>),
     /// A field accessor: `a::F` or `a.F`.
-    Field(Box<Expr>, Box<Ident>),
+    Field(Box<Expr>, FieldAccess),
     /// A for loop: `for a in b { ... }`.
     For(Box<Pat>, Box<Expr>, Box<Block>),
     /// An unspecified expression, _, which may indicate partial application or a typed hole.
@@ -1030,11 +1040,14 @@ fn display_conjugate(
     Ok(())
 }
 
-fn display_field(mut indent: Indented<Formatter>, expr: &Expr, id: &Ident) -> fmt::Result {
+fn display_field(mut indent: Indented<Formatter>, expr: &Expr, field: &FieldAccess) -> fmt::Result {
     write!(indent, "Field:")?;
     indent = set_indentation(indent, 1);
     write!(indent, "\n{expr}")?;
-    write!(indent, "\n{id}")?;
+    match field {
+        FieldAccess::Ok(i) => write!(indent, "\n{i}")?,
+        FieldAccess::Err => write!(indent, "\nErr")?,
+    }
     Ok(())
 }
 

--- a/compiler/qsc_ast/src/mut_visit.rs
+++ b/compiler/qsc_ast/src/mut_visit.rs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 use crate::ast::{
-    Attr, Block, CallableBody, CallableDecl, Expr, ExprKind, FieldAssign, FieldDef, FunctorExpr,
-    FunctorExprKind, Ident, Item, ItemKind, Namespace, Package, Pat, PatKind, Path, PathKind,
-    QubitInit, QubitInitKind, SpecBody, SpecDecl, Stmt, StmtKind, StringComponent, StructDecl,
-    TopLevelNode, Ty, TyDef, TyDefKind, TyKind,
+    Attr, Block, CallableBody, CallableDecl, Expr, ExprKind, FieldAccess, FieldAssign, FieldDef,
+    FunctorExpr, FunctorExprKind, Ident, Item, ItemKind, Namespace, Package, Pat, PatKind, Path,
+    PathKind, QubitInit, QubitInitKind, SpecBody, SpecDecl, Stmt, StmtKind, StringComponent,
+    StructDecl, TopLevelNode, Ty, TyDef, TyDefKind, TyKind,
 };
 use qsc_data_structures::span::Span;
 
@@ -288,7 +288,9 @@ pub fn walk_expr(vis: &mut impl MutVisitor, expr: &mut Expr) {
         ExprKind::Fail(msg) => vis.visit_expr(msg),
         ExprKind::Field(record, name) => {
             vis.visit_expr(record);
-            vis.visit_ident(name);
+            if let FieldAccess::Ok(name) = name {
+                vis.visit_ident(name);
+            }
         }
         ExprKind::For(pat, iter, block) => {
             vis.visit_pat(pat);

--- a/compiler/qsc_ast/src/visit.rs
+++ b/compiler/qsc_ast/src/visit.rs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 use crate::ast::{
-    Attr, Block, CallableBody, CallableDecl, Expr, ExprKind, FieldAssign, FieldDef, FunctorExpr,
-    FunctorExprKind, Ident, Item, ItemKind, Namespace, Package, Pat, PatKind, Path, PathKind,
-    QubitInit, QubitInitKind, SpecBody, SpecDecl, Stmt, StmtKind, StringComponent, StructDecl,
-    TopLevelNode, Ty, TyDef, TyDefKind, TyKind,
+    Attr, Block, CallableBody, CallableDecl, Expr, ExprKind, FieldAccess, FieldAssign, FieldDef,
+    FunctorExpr, FunctorExprKind, Ident, Item, ItemKind, Namespace, Package, Pat, PatKind, Path,
+    PathKind, QubitInit, QubitInitKind, SpecBody, SpecDecl, Stmt, StmtKind, StringComponent,
+    StructDecl, TopLevelNode, Ty, TyDef, TyDefKind, TyKind,
 };
 
 pub trait Visitor<'a>: Sized {
@@ -257,7 +257,9 @@ pub fn walk_expr<'a>(vis: &mut impl Visitor<'a>, expr: &'a Expr) {
         ExprKind::Fail(msg) => vis.visit_expr(msg),
         ExprKind::Field(record, name) => {
             vis.visit_expr(record);
-            vis.visit_ident(name);
+            if let FieldAccess::Ok(name) = name {
+                vis.visit_ident(name);
+            }
         }
         ExprKind::For(pat, iter, block) => {
             vis.visit_pat(pat);

--- a/compiler/qsc_codegen/src/qsharp.rs
+++ b/compiler/qsc_codegen/src/qsharp.rs
@@ -14,11 +14,11 @@ use std::io::Write;
 use std::vec;
 
 use qsc_ast::ast::{
-    self, Attr, BinOp, Block, CallableBody, CallableDecl, CallableKind, Expr, ExprKind, Functor,
-    FunctorExpr, FunctorExprKind, Ident, Idents, ImportOrExportItem, Item, ItemKind, Lit,
-    Mutability, Pat, PatKind, Path, PathKind, Pauli, QubitInit, QubitInitKind, QubitSource, SetOp,
-    SpecBody, SpecDecl, SpecGen, Stmt, StmtKind, StringComponent, TernOp, TopLevelNode, Ty, TyDef,
-    TyDefKind, TyKind, UnOp,
+    self, Attr, BinOp, Block, CallableBody, CallableDecl, CallableKind, Expr, ExprKind,
+    FieldAccess, Functor, FunctorExpr, FunctorExprKind, Ident, Idents, ImportOrExportItem, Item,
+    ItemKind, Lit, Mutability, Pat, PatKind, Path, PathKind, Pauli, QubitInit, QubitInitKind,
+    QubitSource, SetOp, SpecBody, SpecDecl, SpecGen, Stmt, StmtKind, StringComponent, TernOp,
+    TopLevelNode, Ty, TyDef, TyDefKind, TyKind, UnOp,
 };
 use qsc_ast::ast::{Namespace, Package};
 use qsc_ast::visit::Visitor;
@@ -483,7 +483,7 @@ impl<W: Write> Visitor<'_> for QSharpGen<W> {
                 self.write("fail ");
                 self.visit_expr(msg);
             }
-            ExprKind::Field(record, name) => {
+            ExprKind::Field(record, ast::FieldAccess::Ok(name)) => {
                 self.visit_expr(record);
                 self.write(".");
                 self.visit_ident(name);
@@ -716,7 +716,8 @@ impl<W: Write> Visitor<'_> for QSharpGen<W> {
             }
             ExprKind::Err
             | ExprKind::Path(PathKind::Err(_))
-            | ExprKind::Struct(PathKind::Err(_), ..) => {
+            | ExprKind::Struct(PathKind::Err(_), ..)
+            | ExprKind::Field(_, FieldAccess::Err) => {
                 unreachable!();
             }
         }

--- a/compiler/qsc_frontend/src/lower.rs
+++ b/compiler/qsc_frontend/src/lower.rs
@@ -10,7 +10,7 @@ use crate::{
     typeck::{self, convert},
 };
 use miette::Diagnostic;
-use qsc_ast::ast::{self, Ident, Idents, PathKind};
+use qsc_ast::ast::{self, FieldAccess, Ident, Idents, PathKind};
 use qsc_data_structures::{index_map::IndexMap, span::Span, target::TargetCapabilityFlags};
 use qsc_hir::{
     assigner::Assigner,
@@ -576,7 +576,7 @@ impl With<'_> {
                 hir::ExprKind::Conjugate(self.lower_block(within), self.lower_block(apply))
             }
             ast::ExprKind::Fail(message) => hir::ExprKind::Fail(Box::new(self.lower_expr(message))),
-            ast::ExprKind::Field(container, name) => {
+            ast::ExprKind::Field(container, FieldAccess::Ok(name)) => {
                 let container = self.lower_expr(container);
                 let field = self.lower_field(&container.ty, &name.name);
                 hir::ExprKind::Field(Box::new(container), field)
@@ -682,7 +682,8 @@ impl With<'_> {
             }
             ast::ExprKind::Err
             | &ast::ExprKind::Path(ast::PathKind::Err(_))
-            | ast::ExprKind::Struct(ast::PathKind::Err(_), ..) => hir::ExprKind::Err,
+            | ast::ExprKind::Struct(ast::PathKind::Err(_), ..)
+            | ast::ExprKind::Field(_, FieldAccess::Err) => hir::ExprKind::Err,
         };
 
         hir::Expr {

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -8,8 +8,9 @@ use super::{
 };
 use crate::resolve::{self, Names, Res};
 use qsc_ast::ast::{
-    self, BinOp, Block, Expr, ExprKind, Functor, Ident, Lit, NodeId, Pat, PatKind, Path, PathKind,
-    QubitInit, QubitInitKind, Spec, Stmt, StmtKind, StringComponent, TernOp, TyKind, UnOp,
+    self, BinOp, Block, Expr, ExprKind, FieldAccess, Functor, Ident, Idents, Lit, NodeId, Pat,
+    PatKind, Path, PathKind, QubitInit, QubitInitKind, Spec, Stmt, StmtKind, StringComponent,
+    TernOp, TyKind, UnOp,
 };
 use qsc_data_structures::span::Span;
 use qsc_hir::{
@@ -268,16 +269,20 @@ impl<'a> Context<'a> {
             }
             ExprKind::Field(record, name) => {
                 let record = self.infer_expr(record);
-                let item_ty = self.inferrer.fresh_ty(TySource::not_divergent(expr.span));
-                self.inferrer.class(
-                    expr.span,
-                    Class::HasField {
-                        record: record.ty,
-                        name: name.name.to_string(),
-                        item: item_ty.clone(),
-                    },
-                );
-                self.diverge_if(record.diverges, converge(item_ty))
+                if let FieldAccess::Ok(name) = name {
+                    let item_ty = self.inferrer.fresh_ty(TySource::not_divergent(expr.span));
+                    self.inferrer.class(
+                        expr.span,
+                        Class::HasField {
+                            record: record.ty,
+                            name: name.name.to_string(),
+                            item: item_ty.clone(),
+                        },
+                    );
+                    self.diverge_if(record.diverges, converge(item_ty))
+                } else {
+                    converge(Ty::Err)
+                }
             }
             ExprKind::For(item, container, body) => {
                 let item_ty = self.infer_pat(item);
@@ -394,7 +399,7 @@ impl<'a> Context<'a> {
                 Lit::String(_) => converge(Ty::Prim(Prim::String)),
             },
             ExprKind::Paren(expr) => self.infer_expr(expr),
-            ExprKind::Path(PathKind::Ok(path)) => self.infer_path(expr, path),
+            ExprKind::Path(path) => self.infer_path_kind(expr, path),
             ExprKind::Range(start, step, end) => {
                 let mut diverges = false;
                 for expr in start.iter().chain(step).chain(end) {
@@ -532,9 +537,7 @@ impl<'a> Context<'a> {
                 self.typed_holes.push((expr.id, expr.span));
                 converge(self.inferrer.fresh_ty(TySource::not_divergent(expr.span)))
             }
-            ExprKind::Err
-            | ast::ExprKind::Path(ast::PathKind::Err(_))
-            | ast::ExprKind::Struct(ast::PathKind::Err(_), ..) => converge(Ty::Err),
+            ExprKind::Err | ast::ExprKind::Struct(ast::PathKind::Err(_), ..) => converge(Ty::Err),
         };
 
         self.record(expr.id, ty.ty.clone());
@@ -570,24 +573,23 @@ impl<'a> Context<'a> {
         record
     }
 
-    fn infer_path(&mut self, expr: &Expr, path: &Path) -> Partial<Ty> {
-        match resolve::path_as_field_accessor(self.names, path) {
-            // If the path is a field accessor, we infer the type of first segment
-            // as an expr, and the rest as subsequent fields.
-            Some((first_id, parts)) => {
-                let record = converge(
-                    self.table
-                        .terms
-                        .get(first_id)
-                        .expect("local should have type")
-                        .clone(),
-                );
-                let (first, rest) = parts
-                    .split_first()
-                    .expect("path should have at least one part");
-                self.record(first.id, record.ty.clone());
-                self.infer_path_parts(record, rest, expr.span.lo)
+    fn infer_path_kind(&mut self, expr: &Expr, path: &PathKind) -> Partial<Ty> {
+        match path {
+            PathKind::Ok(path) => self.infer_path(expr, path),
+            PathKind::Err(incomplete_path) => {
+                if let Some(incomplete_path) = incomplete_path {
+                    // If this is a field access, infer the fields,
+                    // but leave the whole expression as `Err`.
+                    let _ = self.infer_path_as_field_access(&incomplete_path.segments, expr);
+                }
+                converge(Ty::Err)
             }
+        }
+    }
+
+    fn infer_path(&mut self, expr: &Expr, path: &Path) -> Partial<Ty> {
+        match self.infer_path_as_field_access(path, expr) {
+            Some(record) => record,
             // Otherwise we infer the path as a namespace path.
             None => match self.names.get(path.id) {
                 None => converge(Ty::Err),
@@ -617,6 +619,31 @@ impl<'a> Context<'a> {
                     panic!("expression should not resolve to type reference")
                 }
             },
+        }
+    }
+
+    fn infer_path_as_field_access(
+        &mut self,
+        path: &impl Idents,
+        expr: &Expr,
+    ) -> Option<Partial<Ty>> {
+        // If the path is a field accessor, we infer the type of first segment
+        // as an expr, and the rest as subsequent fields.
+        if let Some((first_id, parts)) = resolve::path_as_field_accessor(self.names, path) {
+            let record = converge(
+                self.table
+                    .terms
+                    .get(first_id)
+                    .expect("local should have type")
+                    .clone(),
+            );
+            let (first, rest) = parts
+                .split_first()
+                .expect("path should have at least one part");
+            self.record(first.id, record.ty.clone());
+            Some(self.infer_path_parts(record, rest, expr.span.lo))
+        } else {
+            None
         }
     }
 

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -12,7 +12,7 @@ use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_ast::{
     assigner::Assigner as AstAssigner,
-    ast::{Block, Expr, Idents, NodeId, Package, Pat, Path, QubitInit, TopLevelNode},
+    ast::{Block, Expr, Idents, NodeId, Package, Pat, Path, PathKind, QubitInit, TopLevelNode},
     mut_visit::MutVisitor,
     visit::{self, Visitor},
 };
@@ -36,6 +36,16 @@ impl<'a> Visitor<'a> for TyCollector<'a> {
         let ty = self.tys.get(expr.id);
         self.nodes.push((expr.id, expr.span, ty));
         visit::walk_expr(self, expr);
+    }
+
+    fn visit_path_kind(&mut self, path_kind: &'a PathKind) {
+        visit::walk_path_kind(self, path_kind);
+        if let PathKind::Err(Some(incomplete_path)) = path_kind {
+            for part in incomplete_path.segments.iter() {
+                let ty = self.tys.get(part.id);
+                self.nodes.push((part.id, part.span, ty));
+            }
+        }
     }
 
     fn visit_path(&mut self, path: &'a Path) {
@@ -67,7 +77,15 @@ impl<'a> Visitor<'a> for TyCollector<'a> {
 }
 
 fn check(input: &str, entry_expr: &str, expect: &Expect) {
-    let (package, tys, errors) = compile(input, entry_expr);
+    check_with_error_option(input, entry_expr, expect, false);
+}
+
+fn check_allow_parse_errors(input: &str, entry_expr: &str, expect: &Expect) {
+    check_with_error_option(input, entry_expr, expect, true);
+}
+
+fn check_with_error_option(input: &str, entry_expr: &str, expect: &Expect, allow_errors: bool) {
+    let (package, tys, errors) = compile(input, entry_expr, allow_errors);
     let mut collector = TyCollector {
         tys: &tys.terms,
         nodes: Vec::new(),
@@ -94,8 +112,12 @@ fn check(input: &str, entry_expr: &str, expect: &Expect) {
     expect.assert_eq(&actual);
 }
 
-fn compile(input: &str, entry_expr: &str) -> (Package, super::Table, Vec<compile::Error>) {
-    let mut package = parse(input, entry_expr);
+fn compile(
+    input: &str,
+    entry_expr: &str,
+    allow_errors: bool,
+) -> (Package, super::Table, Vec<compile::Error>) {
+    let mut package = parse(input, entry_expr, allow_errors);
     AstAssigner::new().visit_package(&mut package);
     let mut assigner = HirAssigner::new();
 
@@ -122,9 +144,12 @@ fn compile(input: &str, entry_expr: &str) -> (Package, super::Table, Vec<compile
     (package, tys, errors)
 }
 
-fn parse(input: &str, entry_expr: &str) -> Package {
+fn parse(input: &str, entry_expr: &str, allow_errors: bool) -> Package {
     let (namespaces, errors) = qsc_parse::namespaces(input, None, LanguageFeatures::default());
-    assert!(errors.is_empty(), "parsing input failed: {errors:#?}");
+    assert!(
+        allow_errors || errors.is_empty(),
+        "parsing input failed: {errors:#?}"
+    );
 
     let entry = if entry_expr.is_empty() {
         None
@@ -4412,6 +4437,262 @@ fn within_block_should_be_unit_error() {
             #5 19-24 "{ 0 }" : Int
             #7 21-22 "0" : Int
             Error(Type(Error(TyMismatch("Unit", "Int", Span { lo: 7, hi: 12 }))))
+        "##]],
+    );
+}
+
+#[test]
+fn path_field_access() {
+    check(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                function Foo() : Unit {
+                    let b = new B { C = 5 };
+                    b.C;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #14 55-57 "()" : Unit
+            #18 65-118 "{\n        let b = new B { C = 5 };\n        b.C;\n    }" : Unit
+            #20 79-80 "b" : UDT<"B": Item 1>
+            #22 83-98 "new B { C = 5 }" : UDT<"B": Item 1>
+            #27 95-96 "5" : Int
+            #29 108-111 "b.C" : Int
+            #31 108-109 "b" : UDT<"B": Item 1>
+            #32 110-111 "C" : Int
+        "##]],
+    );
+}
+
+#[test]
+fn field_access_chained() {
+    check(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                struct D { E : B }
+                function Foo() : Unit {
+                    let d = new D { E = new B { C = 5 } };
+                    d.E.C;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #22 78-80 "()" : Unit
+            #26 88-157 "{\n        let d = new D { E = new B { C = 5 } };\n        d.E.C;\n    }" : Unit
+            #28 102-103 "d" : UDT<"D": Item 2>
+            #30 106-135 "new D { E = new B { C = 5 } }" : UDT<"D": Item 2>
+            #35 118-133 "new B { C = 5 }" : UDT<"B": Item 1>
+            #40 130-131 "5" : Int
+            #42 145-150 "d.E.C" : Int
+            #44 145-146 "d" : UDT<"D": Item 2>
+            #45 147-148 "E" : UDT<"B": Item 1>
+            #46 149-150 "C" : Int
+        "##]],
+    );
+}
+
+#[test]
+fn expr_field_access() {
+    check(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                function Foo() : Unit {
+                    (new B { C = 5 }).C;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #14 55-57 "()" : Unit
+            #18 65-101 "{\n        (new B { C = 5 }).C;\n    }" : Unit
+            #20 75-94 "(new B { C = 5 }).C" : Int
+            #21 75-92 "(new B { C = 5 })" : UDT<"B": Item 1>
+            #22 76-91 "new B { C = 5 }" : UDT<"B": Item 1>
+            #27 88-89 "5" : Int
+        "##]],
+    );
+}
+
+#[test]
+fn expr_incomplete_field_access() {
+    check_allow_parse_errors(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                function Foo() : Unit {
+                    (new B { C = 5 }).;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #14 55-57 "()" : Unit
+            #18 65-100 "{\n        (new B { C = 5 }).;\n    }" : Unit
+            #20 75-93 "(new B { C = 5 })." : ?
+            #21 75-92 "(new B { C = 5 })" : UDT<"B": Item 1>
+            #22 76-91 "new B { C = 5 }" : UDT<"B": Item 1>
+            #27 88-89 "5" : Int
+        "##]],
+    );
+}
+
+#[test]
+fn expr_incomplete_field_access_no_semi() {
+    check_allow_parse_errors(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                function Foo() : Unit {
+                    (new B { C = 5 }).
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #14 55-57 "()" : Unit
+            #18 65-99 "{\n        (new B { C = 5 }).\n    }" : ?
+            #20 75-93 "(new B { C = 5 })." : ?
+            #21 75-92 "(new B { C = 5 })" : UDT<"B": Item 1>
+            #22 76-91 "new B { C = 5 }" : UDT<"B": Item 1>
+            #27 88-89 "5" : Int
+        "##]],
+    );
+}
+
+#[test]
+fn path_incomplete_field_access() {
+    check_allow_parse_errors(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                function Foo() : Unit {
+                    let b = new B { C = 5 };
+                    b.;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #14 55-57 "()" : Unit
+            #18 65-117 "{\n        let b = new B { C = 5 };\n        b.;\n    }" : Unit
+            #20 79-80 "b" : UDT<"B": Item 1>
+            #22 83-98 "new B { C = 5 }" : UDT<"B": Item 1>
+            #27 95-96 "5" : Int
+            #29 108-110 "b." : ?
+            #30 108-109 "b" : UDT<"B": Item 1>
+        "##]],
+    );
+}
+
+#[test]
+fn incomplete_field_access_chained() {
+    check_allow_parse_errors(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                struct D { E : B }
+                function Foo() : Unit {
+                    let d = new D { E = new B { C = 5 } };
+                    d.E.;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #22 78-80 "()" : Unit
+            #26 88-156 "{\n        let d = new D { E = new B { C = 5 } };\n        d.E.;\n    }" : Unit
+            #28 102-103 "d" : UDT<"D": Item 2>
+            #30 106-135 "new D { E = new B { C = 5 } }" : UDT<"D": Item 2>
+            #35 118-133 "new B { C = 5 }" : UDT<"B": Item 1>
+            #40 130-131 "5" : Int
+            #42 145-149 "d.E." : ?
+            #43 145-146 "d" : UDT<"D": Item 2>
+            #44 147-148 "E" : UDT<"B": Item 1>
+        "##]],
+    );
+}
+
+#[test]
+fn expr_field_access_chained() {
+    check(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                struct D { E : B }
+                function Foo() : Unit {
+                    (new D { E = new B { C = 5 } }).E.C;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #22 78-80 "()" : Unit
+            #26 88-140 "{\n        (new D { E = new B { C = 5 } }).E.C;\n    }" : Unit
+            #28 98-133 "(new D { E = new B { C = 5 } }).E.C" : Int
+            #29 98-131 "(new D { E = new B { C = 5 } }).E" : UDT<"B": Item 1>
+            #30 98-129 "(new D { E = new B { C = 5 } })" : UDT<"D": Item 2>
+            #31 99-128 "new D { E = new B { C = 5 } }" : UDT<"D": Item 2>
+            #36 111-126 "new B { C = 5 }" : UDT<"B": Item 1>
+            #41 123-124 "5" : Int
+        "##]],
+    );
+}
+
+#[test]
+fn incomplete_expr_field_access_chained() {
+    check_allow_parse_errors(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                struct D { E : B }
+                function Foo() : Unit {
+                    (new D { E = new B { C = 5 } }).E.;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #22 78-80 "()" : Unit
+            #26 88-139 "{\n        (new D { E = new B { C = 5 } }).E.;\n    }" : Unit
+            #28 98-132 "(new D { E = new B { C = 5 } }).E." : ?
+            #29 98-131 "(new D { E = new B { C = 5 } }).E" : UDT<"B": Item 1>
+            #30 98-129 "(new D { E = new B { C = 5 } })" : UDT<"D": Item 2>
+            #31 99-128 "new D { E = new B { C = 5 } }" : UDT<"D": Item 2>
+            #36 111-126 "new B { C = 5 }" : UDT<"B": Item 1>
+            #41 123-124 "5" : Int
+        "##]],
+    );
+}
+
+#[test]
+fn field_access_not_ident() {
+    check_allow_parse_errors(
+        indoc! {"
+            namespace A {
+                struct B { C : Int }
+                function Foo() : Unit {
+                    let b = new B { C = 5 };
+                    b.
+                    123;
+                }
+            }
+        "},
+        "",
+        &expect![[r##"
+            #14 55-57 "()" : Unit
+            #18 65-129 "{\n        let b = new B { C = 5 };\n        b.\n        123;\n    }" : Unit
+            #20 79-80 "b" : UDT<"B": Item 1>
+            #22 83-98 "new B { C = 5 }" : UDT<"B": Item 1>
+            #27 95-96 "5" : Int
+            #29 108-119 "b.\n        " : ?
+            #30 108-109 "b" : UDT<"B": Item 1>
+            #32 119-122 "123" : Int
         "##]],
     );
 }

--- a/compiler/qsc_parse/src/completion/word_kinds.rs
+++ b/compiler/qsc_parse/src/completion/word_kinds.rs
@@ -48,7 +48,8 @@ bitflags! {
         const PathSegment = 1 << 5;
         /// A type parameter, without the leading `'`.
         const TyParam = 1 << 6;
-        /// A field name that follows a `.` or `::` in a field access expression.
+        /// A field name. Can follow a `.` or `::` in a field access expression,
+        /// or can be in a field assignment.
         const Field = 1 << 7;
 
         //

--- a/compiler/qsc_parse/src/expr/tests.rs
+++ b/compiler/qsc_parse/src/expr/tests.rs
@@ -348,19 +348,24 @@ fn lit_int_hexadecimal_dot() {
         expr,
         "0x123.45",
         &expect![[r#"
-        Error(
-            Rule(
-                "identifier",
-                Int(
-                    Decimal,
+            Expr _id_ [0-6]: Field:
+                Expr _id_ [0-5]: Lit: Int(291)
+                Err
+
+            [
+                Error(
+                    Rule(
+                        "identifier",
+                        Int(
+                            Decimal,
+                        ),
+                        Span {
+                            lo: 6,
+                            hi: 8,
+                        },
+                    ),
                 ),
-                Span {
-                    lo: 6,
-                    hi: 8,
-                },
-            ),
-        )
-    "#]],
+            ]"#]],
     );
 }
 

--- a/language_service/src/completion/fields.rs
+++ b/language_service/src/completion/fields.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::{path_context::PathOrFieldAccess, Completion};
+use crate::{compilation::Compilation, protocol::CompletionItemKind};
+use qsc::{
+    display::Lookup,
+    hir::{
+        ty::{Ty, UdtDefKind},
+        ItemKind, Res,
+    },
+};
+
+/// If there is an incomplete field access expression (e.g. `foo.bar.`) at the cursor offset,
+/// provides the possible field names.
+pub(super) struct Fields<'a> {
+    compilation: &'a Compilation,
+    path_context: &'a PathOrFieldAccess<'a>,
+}
+
+impl<'a> Fields<'a> {
+    pub(crate) fn new(compilation: &'a Compilation, path_context: &'a PathOrFieldAccess) -> Self {
+        Self {
+            compilation,
+            path_context,
+        }
+    }
+
+    pub(crate) fn fields(&self) -> Vec<Completion> {
+        let Some(id) = self.path_context.field_access_context() else {
+            return vec![];
+        };
+
+        let mut completions = vec![];
+        let ty = self.compilation.get_ty(id);
+        if let Some(Ty::Udt(_, Res::Item(item_id))) = ty {
+            let (item, _, _) = self
+                .compilation
+                .resolve_item_relative_to_user_package(item_id);
+            if let ItemKind::Ty(_, udt) = &item.kind {
+                collect_fields(&mut completions, &udt.definition.kind);
+            }
+        }
+        completions
+    }
+}
+
+fn collect_fields(completions: &mut Vec<Completion>, field: &UdtDefKind) {
+    match field {
+        UdtDefKind::Field(field) => {
+            if let Some(name) = &field.name {
+                let detail = field.ty.display();
+                completions.push(Completion::with_detail(
+                    name.to_string(),
+                    CompletionItemKind::Field,
+                    Some(detail),
+                ));
+            }
+        }
+        UdtDefKind::Tuple(vec) => {
+            for f in vec {
+                collect_fields(completions, &f.kind);
+            }
+        }
+    }
+}

--- a/language_service/src/completion/tests.rs
+++ b/language_service/src/completion/tests.rs
@@ -3179,6 +3179,39 @@ fn open_does_not_match_pkg_alias() {
 }
 
 #[test]
+fn field_access_expr() {
+    check(
+        "namespace Test {
+        struct Foo {
+            bar : Int,
+        }
+
+        function Main() : Unit {
+            (new Foo { bar = 3 }).↘
+        }
+    }",
+        &["bar"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "bar",
+                        kind: Field,
+                        sort_text: Some(
+                            "0100bar",
+                        ),
+                        detail: Some(
+                            "Int",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
 fn input_type_missing() {
     check(
         "namespace Test { function Foo(x : FakeStdLib.↘ ) : Unit { body intrinsic; } }",
@@ -3260,6 +3293,40 @@ fn notebook_top_level_path_part() {
                         ),
                         detail: Some(
                             "operation FakeWithParam(x : Int) : Unit",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn field_access_path() {
+    check(
+        "namespace Test {
+        struct Foo {
+            bar : Int,
+        }
+
+        function Main() : Unit {
+            let foo = new Foo { bar = 3 };
+            foo.↘
+        }
+    }",
+        &["bar"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "bar",
+                        kind: Field,
+                        sort_text: Some(
+                            "0100bar",
+                        ),
+                        detail: Some(
+                            "Int",
                         ),
                         additional_text_edits: None,
                     },
@@ -3503,6 +3570,234 @@ fn path_segment_before_glob_with_alias() {
                         ),
                         detail: Some(
                             "struct StructFn { inner : (Int -> Int) }",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn field_in_initializer() {
+    check(
+        "namespace Test {
+        struct Foo {
+            bar : Int,
+        }
+
+        function Main() : Unit {
+            new Foo { ↘ };
+        }
+    }",
+        &["bar"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "bar",
+                        kind: Field,
+                        sort_text: Some(
+                            "0100bar",
+                        ),
+                        detail: Some(
+                            "Int",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn stdlib_struct_field_init() {
+    check(
+        "namespace Test {
+            import FakeStdLib.FakeStruct as StructAlias;
+            function Main() : Unit {
+                new StructAlias { ↘ };
+            }
+        }",
+        &["x"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "x",
+                        kind: Field,
+                        sort_text: Some(
+                            "0100x",
+                        ),
+                        detail: Some(
+                            "Int",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn newtype_named_field() {
+    check(
+        "namespace Test {
+            newtype Foo = (field : Int);
+            function Main() : Unit {
+                Foo(3).↘
+            }
+        }",
+        &["field"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "field",
+                        kind: Field,
+                        sort_text: Some(
+                            "0100field",
+                        ),
+                        detail: Some(
+                            "Int",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn field_access_path_chained() {
+    check(
+        "namespace Test {
+            newtype Foo = ( fieldFoo : Int );
+            struct Bar { fieldBar : Foo );
+            function Main() : Unit {
+                let bar = new Bar { fieldBar = Foo(3) };
+                bar.fieldBar.↘
+            }
+        }",
+        &["fieldFoo", "fieldBar"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "fieldFoo",
+                        kind: Field,
+                        sort_text: Some(
+                            "0100fieldFoo",
+                        ),
+                        detail: Some(
+                            "Int",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+                None,
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn field_access_expr_chained() {
+    check(
+        "namespace Test {
+            newtype Foo = ( fieldFoo : Int );
+            struct Bar { fieldBar : Foo );
+            function Main() : Unit {
+                (new Bar { fieldBar = Foo(3) }).fieldBar.↘
+            }
+        }",
+        &["fieldFoo", "fieldBar"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "fieldFoo",
+                        kind: Field,
+                        sort_text: Some(
+                            "0100fieldFoo",
+                        ),
+                        detail: Some(
+                            "Int",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+                None,
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn field_assignment_rhs() {
+    check(
+        "namespace Test {
+        struct Foo {
+            bar : Int,
+        }
+
+        function Main() : Unit {
+            let var = 3;
+            new Foo { bar = ↘ };
+        }
+    }",
+        &["bar", "var"],
+        &expect![[r#"
+            [
+                None,
+                Some(
+                    CompletionItem {
+                        label: "var",
+                        kind: Variable,
+                        sort_text: Some(
+                            "0100var",
+                        ),
+                        detail: Some(
+                            "var : Int",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn field_access_local_shadows_global() {
+    check(
+        "namespace Test {
+        struct Foo {
+            bar : Int,
+        }
+
+        function Main() : Unit {
+            let FakeStdLib = new Foo { bar = 3 };
+            FakeStdLib.↘
+        }
+    }",
+        &["Fake", "bar"],
+        &expect![[r#"
+            [
+                None,
+                Some(
+                    CompletionItem {
+                        label: "bar",
+                        kind: Field,
+                        sort_text: Some(
+                            "0100bar",
+                        ),
+                        detail: Some(
+                            "Int",
                         ),
                         additional_text_edits: None,
                     },

--- a/language_service/src/name_locator.rs
+++ b/language_service/src/name_locator.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use crate::compilation::Compilation;
 use qsc::ast::visit::{walk_expr, walk_namespace, walk_pat, walk_ty, walk_ty_def, Visitor};
-use qsc::ast::{Idents, PathKind};
+use qsc::ast::{FieldAccess, Idents, PathKind};
 use qsc::display::Lookup;
 use qsc::{ast, hir, resolve};
 
@@ -342,7 +342,9 @@ impl<'inner, 'package, T: Handler<'package>> Visitor<'package> for Locator<'inne
     fn visit_expr(&mut self, expr: &'package ast::Expr) {
         if expr.span.touches(self.offset) {
             match &*expr.kind {
-                ast::ExprKind::Field(udt, field_ref) if field_ref.span.touches(self.offset) => {
+                ast::ExprKind::Field(udt, FieldAccess::Ok(field_ref))
+                    if field_ref.span.touches(self.offset) =>
+                {
                     if let Some(hir::ty::Ty::Udt(_, res)) = &self.compilation.get_ty(udt.id) {
                         if let Some((item_id, field_def)) = self.get_field_def(res, field_ref) {
                             self.inner.at_field_ref(field_ref, &item_id, field_def);

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -68,6 +68,7 @@ pub enum CompletionItemKind {
     Property,
     Variable,
     TypeParameter,
+    Field,
 }
 
 #[derive(Debug, Default)]

--- a/language_service/src/references.rs
+++ b/language_service/src/references.rs
@@ -400,7 +400,7 @@ impl<'a> Visitor<'_> for FindFieldRefs<'a> {
 
     fn visit_expr(&mut self, expr: &ast::Expr) {
         match &*expr.kind {
-            ast::ExprKind::Field(qualifier, field_name) => {
+            ast::ExprKind::Field(qualifier, ast::FieldAccess::Ok(field_name)) => {
                 self.visit_expr(qualifier);
                 if field_name.name == self.field_name {
                     if let Some(Ty::Udt(_, Res::Item(id))) = self.compilation.get_ty(qualifier.id) {

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -284,6 +284,9 @@ function registerMonacoLanguageServiceProviders(
             case "property":
               kind = monaco.languages.CompletionItemKind.Property;
               break;
+            case "field":
+              kind = monaco.languages.CompletionItemKind.Field;
+              break;
           }
           return {
             label: i.label,

--- a/vscode/src/completion.ts
+++ b/vscode/src/completion.ts
@@ -73,6 +73,9 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
         case "property":
           kind = vscode.CompletionItemKind.Property;
           break;
+        case "field":
+          kind = vscode.CompletionItemKind.Field;
+          break;
       }
       const item = new CompletionItem(c.label, kind);
       item.sortText = c.sortText;

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -163,6 +163,7 @@ impl LanguageService {
                         qsls::protocol::CompletionItemKind::Property => "property",
                         qsls::protocol::CompletionItemKind::Variable => "variable",
                         qsls::protocol::CompletionItemKind::TypeParameter => "typeParameter",
+                        qsls::protocol::CompletionItemKind::Field => "field",
                     })
                     .to_string(),
                     sortText: i.sort_text,
@@ -407,7 +408,7 @@ serializable_type! {
     },
     r#"export interface ICompletionItem {
         label: string;
-        kind: "function" | "interface" | "keyword" | "module" | "property" | "variable" | "typeParameter";
+        kind: "function" | "interface" | "keyword" | "module" | "property" | "variable" | "typeParameter" | "field" ;
         sortText?: string;
         detail?: string;
         additionalTextEdits?: ITextEdit[];


### PR DESCRIPTION
Builds on #1947 .

Enables:

1. Field access completions, for example:

```qsharp
let x = Complex(1.0, 2.0);
x.| 
```

At the cursor location indicated by `|`, completions should include `Real` since it's a field of `Complex`.

2. Field assignment completions, for example:

```qsharp
struct Foo {
    bar: Int
}

new Foo { | }
```

Here, completions should include `Bar`.