### PR TITLE
Use all github dependencies in published libraries

### DIFF
--- a/library/fixed_point/qsharp.json
+++ b/library/fixed_point/qsharp.json
@@ -3,13 +3,18 @@
   "license": "MIT",
   "dependencies": {
     "Signed": {
-      "path": "/Users/alexanderhansen/code/qsharp/library/signed"
+      "github": {
+        "owner": "Microsoft",
+        "repo": "qsharp",
+        "ref": "3195043",
+        "path": "library/signed"
+      }
     },
     "Unstable": {
       "github": {
         "owner": "Microsoft",
         "repo": "qsharp",
-        "ref": "adcefe8",
+        "ref": "3195043",
         "path": "library/unstable"
       }
     }

--- a/library/signed/qsharp.json
+++ b/library/signed/qsharp.json
@@ -6,7 +6,7 @@
       "github": {
         "owner": "Microsoft",
         "repo": "qsharp",
-        "ref": "d1fb2a1",
+        "ref": "3195043",
         "path": "library/unstable"
       }
     }


### PR DESCRIPTION
I was just importing FixedPoint and noticed it doesn't work due to a local path dependency. This fixes that, but also updates the refs for other libraries to latest.

Aside:  I can't believe this got checked in with an absolute path on my PC. That's a big L on my part.