### PR TITLE
Set the markdown renderer on load

### DIFF
--- a/widgets/js/index.tsx
+++ b/widgets/js/index.tsx
@@ -11,6 +11,7 @@ import {
   EstimatesPanel,
   ReData,
   Circuit,
+  setRenderer,
 } from "qsharp-lang/ux";
 import markdownIt from "markdown-it";
 
@@ -20,6 +21,7 @@ import mk from "@vscode/markdown-it-katex";
 
 const md = markdownIt();
 md.use(mk);
+setRenderer((input: string) => md.render(input));
 
 export function mdRenderer(input: string) {
   // Note: Need to ensure this 'fix' is still needed with the latest data JSON.


### PR DESCRIPTION
This resolves the issue where when displaying the EstimateDetails widget sometimes there would be an error about the markdown renderer not being set.