### PR TITLE
Fix to partial evaluation generating branch instructions on constant conditions

### DIFF
--- a/compiler/qsc_partial_eval/src/tests/branching.rs
+++ b/compiler/qsc_partial_eval/src/tests/branching.rs
@@ -1313,17 +1313,17 @@ fn if_else_expression_with_result_literal_fails() {
 }
 
 #[test]
-fn if_comparison_with_mixed_static_dynamic_array() {
+fn if_expression_with_classical_operand_from_hybrid_results_array_comparing_to_literal_zero() {
     let program = get_rir_program(indoc! {r#"
         @EntryPoint()
         operation Main() : Result[] {
-            mutable measurements = Repeated(Zero, 2);
-            use qs = Qubit[2];
-            set measurements w/= 0 <- MResetZ(qs[0]);
-            if measurements[1] == One {
-                X(qs[1]);
+            mutable measurements = [Zero, Zero];
+            use (a, b) = (Qubit(), Qubit());
+            set measurements w/= 0 <- MResetZ(a);
+            if measurements[1] == Zero {
+                X(b);
             }
-            set measurements w/= 1 <- MResetZ(qs[1]);
+            set measurements w/= 1 <- MResetZ(b);
             measurements
         }
         "#
@@ -1331,10 +1331,159 @@ fn if_comparison_with_mixed_static_dynamic_array() {
 
     // Verify the callables added to the program.
     let mresetz_callable_id = CallableId(1);
-    assert_callable(&program, mresetz_callable_id, &expect![]);
-    let read_result_callable_id = CallableId(2);
-    assert_callable(&program, read_result_callable_id, &expect![]);
-    let x_callable_id = CallableId(1);
-    assert_callable(&program, x_callable_id, &expect![]);
-    assert_blocks(&program, &expect![]);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let x_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        x_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__x__body
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let record_array_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        record_array_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_result_callable_id = CallableId(4);
+    assert_callable(
+        &program,
+        record_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+        Blocks:
+        Block 0:Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(2), args( Qubit(1), )
+            Call id(1), args( Qubit(1), Result(1), )
+            Call id(3), args( Integer(2), Pointer, )
+            Call id(4), args( Result(0), Pointer, )
+            Call id(4), args( Result(1), Pointer, )
+            Return"#]],
+    );
+}
+
+#[test]
+fn if_expression_with_classical_operand_from_hybrid_results_array_comparing_to_literal_one() {
+    let program = get_rir_program(indoc! {r#"
+        @EntryPoint()
+        operation Main() : Result[] {
+            mutable measurements = [Zero, Zero];
+            use (a, b) = (Qubit(), Qubit());
+            set measurements w/= 0 <- MResetZ(a);
+            if measurements[1] != One {
+                X(b);
+            }
+            set measurements w/= 1 <- MResetZ(b);
+            measurements
+        }
+        "#
+    });
+
+    // Verify the callables added to the program.
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let x_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        x_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__x__body
+            call_type: Regular
+            input_type:
+                [0]: Qubit
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let record_array_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        record_array_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_result_callable_id = CallableId(4);
+    assert_callable(
+        &program,
+        record_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+        Blocks:
+        Block 0:Block:
+            Call id(1), args( Qubit(0), Result(0), )
+            Call id(2), args( Qubit(1), )
+            Call id(1), args( Qubit(1), Result(1), )
+            Call id(3), args( Integer(2), Pointer, )
+            Call id(4), args( Result(0), Pointer, )
+            Call id(4), args( Result(1), Pointer, )
+            Return"#]],
+    );
 }

--- a/compiler/qsc_partial_eval/src/tests/branching.rs
+++ b/compiler/qsc_partial_eval/src/tests/branching.rs
@@ -1311,3 +1311,60 @@ fn if_else_expression_with_result_literal_fails() {
         ]],
     );
 }
+
+#[test]
+fn if_comparison_with_mixed_static_dynamic_array() {
+    let program = get_rir_program(indoc!{r#"
+        @EntryPoint()
+        operation circuit_160() : Result[] {
+            mutable c = Repeated(Zero, 3);
+            use qs = Qubit[3];
+            H(qs[0]);
+            CNOT(qs[0], qs[1]);
+            set c w/= 0 <- M(qs[0]);
+            if Std.Convert.ResultArrayAsInt(c) == 4 {
+                Rz(0.5, qs[1]);
+            }
+            set c w/= 1 <- M(qs[1]);
+            set c w/= 2 <- M(qs[2]);
+            c
+        }
+    "#});
+
+    // Verify the callables added to the program.
+    let h_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        h_callable_id,
+        &expect![],
+    );
+    let cnot_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        cnot_callable_id,
+        &expect![],
+    );
+    let m_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        m_callable_id,
+        &expect![],
+    );
+    let read_result_callable_id = CallableId(4);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![],
+    );
+    let rz_callable_id = CallableId(5);
+    assert_callable(
+        &program,
+        rz_callable_id,
+        &expect![],
+    );
+
+    assert_blocks(
+        &program,
+        &expect![],
+    );
+}

--- a/compiler/qsc_partial_eval/src/tests/branching.rs
+++ b/compiler/qsc_partial_eval/src/tests/branching.rs
@@ -1320,6 +1320,7 @@ fn if_expression_with_classical_operand_from_hybrid_results_array_comparing_to_l
             mutable measurements = [Zero, Zero];
             use (a, b) = (Qubit(), Qubit());
             set measurements w/= 0 <- MResetZ(a);
+            // Use a static result in the condition.
             if measurements[1] == Zero {
                 X(b);
             }
@@ -1408,6 +1409,7 @@ fn if_expression_with_classical_operand_from_hybrid_results_array_comparing_to_l
             mutable measurements = [Zero, Zero];
             use (a, b) = (Qubit(), Qubit());
             set measurements w/= 0 <- MResetZ(a);
+            // Use a static result in the condition.
             if measurements[1] != One {
                 X(b);
             }
@@ -1485,5 +1487,578 @@ fn if_expression_with_classical_operand_from_hybrid_results_array_comparing_to_l
             Call id(4), args( Result(0), Pointer, )
             Call id(4), args( Result(1), Pointer, )
             Return"#]],
+    );
+}
+
+#[test]
+fn if_expression_with_dynamic_operand_from_hybrid_results_array() {
+    let program = get_rir_program(indoc! {r#"
+        @EntryPoint()
+        operation Main() : Result[] {
+            mutable measurements = [Zero, Zero];
+            use (a, b) = (Qubit(), Qubit());
+            set measurements w/= 0 <- MResetZ(a);
+            // Use a dynamic result in the condition.
+            if measurements[0] == Zero {
+                X(b);
+            }
+            set measurements w/= 1 <- MResetZ(b);
+            measurements
+        }
+        "#
+    });
+
+    // Verify the callables added to the program.
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let read_result_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let x_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        x_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__x__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_array_callable_id = CallableId(4);
+    assert_callable(
+        &program,
+        record_array_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_result_callable_id = CallableId(5);
+    assert_callable(
+        &program,
+        record_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__result_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Result
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                Branch Variable(1, Boolean), 2, 1
+            Block 1:Block:
+                Call id(1), args( Qubit(1), Result(1), )
+                Call id(4), args( Integer(2), Pointer, )
+                Call id(5), args( Result(0), Pointer, )
+                Call id(5), args( Result(1), Pointer, )
+                Return
+            Block 2:Block:
+                Call id(3), args( Qubit(1), )
+                Jump(1)"#]],
+    );
+}
+
+#[test]
+fn if_expression_with_classical_operand_from_hybrid_booleans_array() {
+    let program = get_rir_program(indoc! {r#"
+        @EntryPoint()
+        operation Main() : Bool[] {
+            mutable flags = [false, false];
+            use (a, b) = (Qubit(), Qubit());
+            set flags w/= 0 <- MResetZ(a) == One;
+            // Use a static Boolean in the condition.
+            if flags[1] == false {
+                X(b);
+            }
+            set flags w/= 1 <- MResetZ(b) == One;
+            flags
+        }
+        "#
+    });
+
+    // Verify the callables added to the program.
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let read_result_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let x_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        x_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__x__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_array_callable_id = CallableId(4);
+    assert_callable(
+        &program,
+        record_array_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_bool_callable_id = CallableId(5);
+    assert_callable(
+        &program,
+        record_bool_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__bool_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Boolean
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Store Variable(0, Boolean)
+                Call id(3), args( Qubit(1), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Variable(2, Boolean) = Call id(2), args( Result(1), )
+                Variable(3, Boolean) = Store Variable(2, Boolean)
+                Call id(4), args( Integer(2), Pointer, )
+                Call id(5), args( Variable(1, Boolean), Pointer, )
+                Call id(5), args( Variable(3, Boolean), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn if_expression_with_dynamic_operand_from_hybrid_booleans_array() {
+    let program = get_rir_program(indoc! {r#"
+        @EntryPoint()
+        operation Main() : Bool[] {
+            mutable flags = [false, false];
+            use (a, b) = (Qubit(), Qubit());
+            set flags w/= 0 <- MResetZ(a) == One;
+            // Use a dynamic Boolean in the condition.
+            if flags[0] {
+                X(b);
+            }
+            set flags w/= 1 <- MResetZ(b) == One;
+            flags
+        }
+        "#
+    });
+
+    // Verify the callables added to the program.
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let read_result_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let x_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        x_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__x__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_array_callable_id = CallableId(4);
+    assert_callable(
+        &program,
+        record_array_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_bool_callable_id = CallableId(5);
+    assert_callable(
+        &program,
+        record_bool_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__bool_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Boolean
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Store Variable(0, Boolean)
+                Branch Variable(1, Boolean), 2, 1
+            Block 1:Block:
+                Call id(1), args( Qubit(1), Result(1), )
+                Variable(2, Boolean) = Call id(2), args( Result(1), )
+                Variable(3, Boolean) = Store Variable(2, Boolean)
+                Call id(4), args( Integer(2), Pointer, )
+                Call id(5), args( Variable(1, Boolean), Pointer, )
+                Call id(5), args( Variable(3, Boolean), Pointer, )
+                Return
+            Block 2:Block:
+                Call id(3), args( Qubit(1), )
+                Jump(1)"#]],
+    );
+}
+
+#[test]
+fn if_expression_with_classical_operand_from_hybrid_integers_array() {
+    let program = get_rir_program(indoc! {r#"
+        @EntryPoint()
+        operation Main() : Int[] {
+            mutable integers = [0, 0];
+            use (a, b) = (Qubit(), Qubit());
+            set integers w/= 0 <- MResetZ(a) == Zero ? 0 | 1;
+            // Use a static integer in the condition.
+            if integers[1] == 0 {
+                X(b);
+            }
+            set integers w/= 1 <- MResetZ(b) == Zero ? 0 | 1;
+            integers
+        }
+        "#
+    });
+
+    // Verify the callables added to the program.
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let read_result_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let x_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        x_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__x__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_array_callable_id = CallableId(4);
+    assert_callable(
+        &program,
+        record_array_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_int_callable_id = CallableId(5);
+    assert_callable(
+        &program,
+        record_int_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__int_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                Branch Variable(1, Boolean), 2, 3
+            Block 1:Block:
+                Call id(3), args( Qubit(1), )
+                Call id(1), args( Qubit(1), Result(1), )
+                Variable(3, Boolean) = Call id(2), args( Result(1), )
+                Variable(4, Boolean) = Icmp Eq, Variable(3, Boolean), Bool(false)
+                Branch Variable(4, Boolean), 5, 6
+            Block 2:Block:
+                Variable(2, Integer) = Store Integer(0)
+                Jump(1)
+            Block 3:Block:
+                Variable(2, Integer) = Store Integer(1)
+                Jump(1)
+            Block 4:Block:
+                Call id(4), args( Integer(2), Pointer, )
+                Call id(5), args( Variable(2, Integer), Pointer, )
+                Call id(5), args( Variable(5, Integer), Pointer, )
+                Return
+            Block 5:Block:
+                Variable(5, Integer) = Store Integer(0)
+                Jump(4)
+            Block 6:Block:
+                Variable(5, Integer) = Store Integer(1)
+                Jump(4)"#]],
+    );
+}
+
+#[test]
+fn if_expression_with_dynamic_operand_from_hybrid_integers_array() {
+    let program = get_rir_program(indoc! {r#"
+        @EntryPoint()
+        operation Main() : Int[] {
+            mutable integers = [0, 0];
+            use (a, b) = (Qubit(), Qubit());
+            set integers w/= 0 <- MResetZ(a) == Zero ? 0 | 1;
+            // Use a dynamic integer in the condition.
+            if integers[0] == 0 {
+                X(b);
+            }
+            set integers w/= 1 <- MResetZ(b) == Zero ? 0 | 1;
+            integers
+        }
+        "#
+    });
+
+    // Verify the callables added to the program.
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        mresetz_callable_id,
+        &expect![[r#"
+        Callable:
+            name: __quantum__qis__mresetz__body
+            call_type: Measurement
+            input_type:
+                [0]: Qubit
+                [1]: Result
+            output_type: <VOID>
+            body: <NONE>"#]],
+    );
+    let read_result_callable_id = CallableId(2);
+    assert_callable(
+        &program,
+        read_result_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__read_result__body
+                call_type: Readout
+                input_type:
+                    [0]: Result
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    let x_callable_id = CallableId(3);
+    assert_callable(
+        &program,
+        x_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__qis__x__body
+                call_type: Regular
+                input_type:
+                    [0]: Qubit
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_array_callable_id = CallableId(4);
+    assert_callable(
+        &program,
+        record_array_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__array_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    let record_int_callable_id = CallableId(5);
+    assert_callable(
+        &program,
+        record_int_callable_id,
+        &expect![[r#"
+            Callable:
+                name: __quantum__rt__int_record_output
+                call_type: OutputRecording
+                input_type:
+                    [0]: Integer
+                    [1]: Pointer
+                output_type: <VOID>
+                body: <NONE>"#]],
+    );
+    assert_blocks(
+        &program,
+        &expect![[r#"
+            Blocks:
+            Block 0:Block:
+                Call id(1), args( Qubit(0), Result(0), )
+                Variable(0, Boolean) = Call id(2), args( Result(0), )
+                Variable(1, Boolean) = Icmp Eq, Variable(0, Boolean), Bool(false)
+                Branch Variable(1, Boolean), 2, 3
+            Block 1:Block:
+                Variable(3, Boolean) = Icmp Eq, Variable(2, Integer), Integer(0)
+                Branch Variable(3, Boolean), 5, 4
+            Block 2:Block:
+                Variable(2, Integer) = Store Integer(0)
+                Jump(1)
+            Block 3:Block:
+                Variable(2, Integer) = Store Integer(1)
+                Jump(1)
+            Block 4:Block:
+                Call id(1), args( Qubit(1), Result(1), )
+                Variable(4, Boolean) = Call id(2), args( Result(1), )
+                Variable(5, Boolean) = Icmp Eq, Variable(4, Boolean), Bool(false)
+                Branch Variable(5, Boolean), 7, 8
+            Block 5:Block:
+                Call id(3), args( Qubit(1), )
+                Jump(4)
+            Block 6:Block:
+                Call id(4), args( Integer(2), Pointer, )
+                Call id(5), args( Variable(2, Integer), Pointer, )
+                Call id(5), args( Variable(6, Integer), Pointer, )
+                Return
+            Block 7:Block:
+                Variable(6, Integer) = Store Integer(0)
+                Jump(6)
+            Block 8:Block:
+                Variable(6, Integer) = Store Integer(1)
+                Jump(6)"#]],
     );
 }

--- a/compiler/qsc_partial_eval/src/tests/branching.rs
+++ b/compiler/qsc_partial_eval/src/tests/branching.rs
@@ -1314,57 +1314,27 @@ fn if_else_expression_with_result_literal_fails() {
 
 #[test]
 fn if_comparison_with_mixed_static_dynamic_array() {
-    let program = get_rir_program(indoc!{r#"
+    let program = get_rir_program(indoc! {r#"
         @EntryPoint()
-        operation circuit_160() : Result[] {
-            mutable c = Repeated(Zero, 3);
-            use qs = Qubit[3];
-            H(qs[0]);
-            CNOT(qs[0], qs[1]);
-            set c w/= 0 <- M(qs[0]);
-            if Std.Convert.ResultArrayAsInt(c) == 4 {
-                Rz(0.5, qs[1]);
+        operation Main() : Result[] {
+            mutable measurements = Repeated(Zero, 2);
+            use qs = Qubit[2];
+            set measurements w/= 0 <- MResetZ(qs[0]);
+            if measurements[1] == One {
+                X(qs[1]);
             }
-            set c w/= 1 <- M(qs[1]);
-            set c w/= 2 <- M(qs[2]);
-            c
+            set measurements w/= 1 <- MResetZ(qs[1]);
+            measurements
         }
-    "#});
+        "#
+    });
 
     // Verify the callables added to the program.
-    let h_callable_id = CallableId(1);
-    assert_callable(
-        &program,
-        h_callable_id,
-        &expect![],
-    );
-    let cnot_callable_id = CallableId(2);
-    assert_callable(
-        &program,
-        cnot_callable_id,
-        &expect![],
-    );
-    let m_callable_id = CallableId(3);
-    assert_callable(
-        &program,
-        m_callable_id,
-        &expect![],
-    );
-    let read_result_callable_id = CallableId(4);
-    assert_callable(
-        &program,
-        read_result_callable_id,
-        &expect![],
-    );
-    let rz_callable_id = CallableId(5);
-    assert_callable(
-        &program,
-        rz_callable_id,
-        &expect![],
-    );
-
-    assert_blocks(
-        &program,
-        &expect![],
-    );
+    let mresetz_callable_id = CallableId(1);
+    assert_callable(&program, mresetz_callable_id, &expect![]);
+    let read_result_callable_id = CallableId(2);
+    assert_callable(&program, read_result_callable_id, &expect![]);
+    let x_callable_id = CallableId(1);
+    assert_callable(&program, x_callable_id, &expect![]);
+    assert_blocks(&program, &expect![]);
 }


### PR DESCRIPTION
RCA can categorize an expression as dynamic even if it is in fact purely classical. This can happen in cases where a data structure such an array, tuple or UDT contains a mix of static and dynamic values. In such instances, RCA identifies all the contents of the data structure as dynamic even if some values are static. This causes partial evaluation to generate branch instructions on constant conditions under certain circumstances. This change fixes this issue.