### PR TITLE
Minor lint fix for Rust 1.81

### DIFF
--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -247,7 +247,7 @@ fn get_indent(compilation: &Compilation, package_offset: u32) -> String {
         .try_into()
         .expect("offset can't be converted to uszie");
     let before_offset = &source.contents[..source_offset];
-    let mut indent = match before_offset.rfind(|c| c == '{' || c == '\n') {
+    let mut indent = match before_offset.rfind(['{', '\n']) {
         Some(begin) => {
             let indent = &before_offset[begin..];
             indent.strip_prefix('{').unwrap_or(indent)


### PR DESCRIPTION
I upgraded locally and clippy was mad about this line, so I applied the fix.