### PR TITLE
allow needless raw string hashes and unnecessary wraps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ unwrap_used = "warn"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"
+needless_raw_string_hashes = "allow"
+unnecessary_wraps = "allow"
 
 [profile.release]
 debug = "limited"

--- a/compiler/qsc/src/interpret/debug/tests.rs
+++ b/compiler/qsc/src/interpret/debug/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use indoc::indoc;
 use miette::Result;
 use qsc_data_structures::{language_features::LanguageFeatures, target::TargetCapabilityFlags};

--- a/compiler/qsc/src/interpret/debugger_tests.rs
+++ b/compiler/qsc/src/interpret/debugger_tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::interpret::Debugger;
 use crate::line_column::Encoding;
 use qsc_data_structures::language_features::LanguageFeatures;

--- a/compiler/qsc/src/interpret/package_tests.rs
+++ b/compiler/qsc/src/interpret/package_tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::{interpret::Interpreter, packages::BuildableProgram};
 use indoc::indoc;
 use qsc_data_structures::{language_features::LanguageFeatures, target::TargetCapabilityFlags};

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 mod given_interpreter {
     use crate::interpret::{InterpretResult, Interpreter};
     use expect_test::Expect;

--- a/compiler/qsc_codegen/src/qsharp/spec_decls.rs
+++ b/compiler/qsc_codegen/src/qsharp/spec_decls.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::expect;
 use indoc::indoc;

--- a/compiler/qsc_codegen/src/qsharp/test_utils.rs
+++ b/compiler/qsc_codegen/src/qsharp/test_utils.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_raw_string_hashes)]
 
 use std::sync::Arc;
 

--- a/compiler/qsc_codegen/src/qsharp/tests.rs
+++ b/compiler/qsc_codegen/src/qsharp/tests.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::expect;
 use indoc::indoc;

--- a/compiler/qsc_data_structures/src/namespaces/tests.rs
+++ b/compiler/qsc_data_structures/src/namespaces/tests.rs
@@ -4,8 +4,6 @@
 // allowing needless raw hashes here because we auto-update these expected outputs
 // and don't want to risk weird breakages
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 
 use super::*;

--- a/compiler/qsc_doc_gen/src/generate_docs/tests.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::generate_docs;
 use expect_test::expect;
 

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use std::f64::consts;
 
 use crate::backend::{Backend, SparseSim};

--- a/compiler/qsc_eval/src/state/tests.rs
+++ b/compiler/qsc_eval/src/state/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{
     get_matrix_latex, get_state_latex, write_latex_for_algebraic_number,
     write_latex_for_cartesian_form, write_latex_for_complex_number, write_latex_for_decimal_number,

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::{
     backend::{Backend, SparseSim},
     debug::Frame,

--- a/compiler/qsc_frontend/src/compile/tests.rs
+++ b/compiler/qsc_frontend/src/compile/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 mod multiple_packages;
 
 use std::sync::Arc;

--- a/compiler/qsc_frontend/src/error/tests.rs
+++ b/compiler/qsc_frontend/src/error/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::WithSource;
 use crate::compile::SourceMap;
 use expect_test::expect;

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::compile::{self, compile, PackageStore, SourceMap};
 use expect_test::{expect, Expect};
 use indoc::indoc;

--- a/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/compiler/qsc_frontend/src/resolve/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{Error, Locals, Names, Res};
 use crate::{
     compile,

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::{
     compile::{self, Offsetter},
     resolve::{self, Resolver},

--- a/compiler/qsc_parse/src/expr/tests.rs
+++ b/compiler/qsc_parse/src/expr/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::expr;
 use crate::tests::check;
 use expect_test::expect;

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{
     parse, parse_attr, parse_implicit_namespace, parse_import_or_export, parse_open,
     parse_spec_decl,

--- a/compiler/qsc_parse/src/lex/cooked/tests.rs
+++ b/compiler/qsc_parse/src/lex/cooked/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{Lexer, Token, TokenKind};
 use crate::lex::Delim;
 use expect_test::{expect, Expect};

--- a/compiler/qsc_parse/src/lex/raw/tests.rs
+++ b/compiler/qsc_parse/src/lex/raw/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::Lexer;
 use crate::lex::raw::{Single, Token, TokenKind};
 use expect_test::{expect, Expect};

--- a/compiler/qsc_parse/src/stmt/tests.rs
+++ b/compiler/qsc_parse/src/stmt/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{parse, parse_block};
 use crate::tests::check;
 use expect_test::expect;

--- a/compiler/qsc_partial_eval/src/tests/classical_args.rs
+++ b/compiler/qsc_partial_eval/src/tests/classical_args.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{assert_block_instructions, assert_callable, get_rir_program};
 use expect_test::expect;
 use indoc::indoc;

--- a/compiler/qsc_partial_eval/src/tests/intrinsics.rs
+++ b/compiler/qsc_partial_eval/src/tests/intrinsics.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{assert_block_instructions, assert_blocks, assert_callable, get_rir_program};
 use expect_test::{expect, Expect};
 use indoc::{formatdoc, indoc};

--- a/compiler/qsc_partial_eval/src/tests/loops.rs
+++ b/compiler/qsc_partial_eval/src/tests/loops.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{assert_block_instructions, assert_callable, get_rir_program};
 use expect_test::expect;
 use indoc::indoc;

--- a/compiler/qsc_partial_eval/src/tests/operators.rs
+++ b/compiler/qsc_partial_eval/src/tests/operators.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{
     assert_block_instructions, assert_blocks, assert_callable, assert_error,
     get_partial_evaluation_error, get_rir_program,

--- a/compiler/qsc_partial_eval/src/tests/output_recording.rs
+++ b/compiler/qsc_partial_eval/src/tests/output_recording.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{assert_error, get_partial_evaluation_error, get_rir_program};
 use expect_test::expect;
 use indoc::indoc;

--- a/compiler/qsc_partial_eval/src/tests/qubits.rs
+++ b/compiler/qsc_partial_eval/src/tests/qubits.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{assert_block_instructions, assert_callable, get_rir_program};
 use expect_test::expect;
 use indoc::indoc;

--- a/compiler/qsc_partial_eval/src/tests/results.rs
+++ b/compiler/qsc_partial_eval/src/tests/results.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{assert_block_instructions, assert_callable, get_rir_program};
 use expect_test::expect;
 use indoc::indoc;

--- a/compiler/qsc_passes/src/baseprofck/tests.rs
+++ b/compiler/qsc_passes/src/baseprofck/tests.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::{expect, Expect};
 use indoc::indoc;

--- a/compiler/qsc_passes/src/borrowck/tests.rs
+++ b/compiler/qsc_passes/src/borrowck/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::{language_features::LanguageFeatures, target::TargetCapabilityFlags};

--- a/compiler/qsc_passes/src/callable_limits/tests.rs
+++ b/compiler/qsc_passes/src/callable_limits/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::{expect, Expect};
 use indoc::indoc;
 use qsc_data_structures::{language_features::LanguageFeatures, target::TargetCapabilityFlags};

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::tests_common::{
     check, check_for_exe, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
     CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::capabilitiesck::tests_common::USE_DYNAMIC_RANGE;
 
 use super::tests_common::{

--- a/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::tests_common::{
     check, check_for_exe, CALL_DYNAMIC_FUNCTION, CALL_DYNAMIC_OPERATION,
     CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,

--- a/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::Expect;
 
 use crate::capabilitiesck::check_supported_capabilities;

--- a/compiler/qsc_passes/src/conjugate_invert/tests.rs
+++ b/compiler/qsc_passes/src/conjugate_invert/tests.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::{expect, Expect};
 use indoc::indoc;

--- a/compiler/qsc_passes/src/entry_point/tests.rs
+++ b/compiler/qsc_passes/src/entry_point/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::{entry_point::generate_entry_expr, PackageType};
 use expect_test::{expect, Expect};
 use indoc::indoc;

--- a/compiler/qsc_passes/src/logic_sep/tests.rs
+++ b/compiler/qsc_passes/src/logic_sep/tests.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::{expect, Expect};
 use qsc_data_structures::{

--- a/compiler/qsc_passes/src/spec_gen/tests.rs
+++ b/compiler/qsc_passes/src/spec_gen/tests.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![allow(clippy::too_many_lines)]
-#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::{expect, Expect};
 use indoc::indoc;

--- a/compiler/qsc_qasm3/src/tests/declaration.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 mod array;
 mod bit;
 mod bool;

--- a/compiler/qsc_qasm3/src/tests/declaration/bit.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/bit.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_stmt_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/declaration/bool.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/bool.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_stmt_to_qsharp;
 
 use expect_test::expect;

--- a/compiler/qsc_qasm3/src/tests/declaration/complex.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/complex.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_stmt_to_qsharp;
 
 use expect_test::expect;

--- a/compiler/qsc_qasm3/src/tests/declaration/float.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/float.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_stmt_to_qsharp;
 
 use expect_test::expect;

--- a/compiler/qsc_qasm3/src/tests/declaration/gate.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/gate.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_stmt_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/declaration/integer.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/integer.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_stmt_to_qsharp;
 
 use expect_test::expect;

--- a/compiler/qsc_qasm3/src/tests/declaration/io/explicit_input.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/io/explicit_input.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp_operation;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/declaration/io/explicit_output.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/io/explicit_output.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp_operation;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/declaration/io/implicit_output.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/io/implicit_output.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp_operation;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/declaration/qubit.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/qubit.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/declaration/unsigned_integer.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/unsigned_integer.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_stmt_to_qsharp;
 
 use expect_test::expect;

--- a/compiler/qsc_qasm3/src/tests/expression/binary.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/binary.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 
 use crate::tests::compile_qasm_to_qsharp;

--- a/compiler/qsc_qasm3/src/tests/expression/binary/arithmetic_conversions.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/binary/arithmetic_conversions.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/expression/binary/comparison.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/binary/comparison.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-#![allow(clippy::needless_raw_string_hashes)]
 
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/expression/binary/complex.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/binary/complex.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_stmt_to_qsharp;
 
 use expect_test::expect;

--- a/compiler/qsc_qasm3/src/tests/expression/binary/ident.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/binary/ident.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/expression/binary/literal/multiplication.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/binary/literal/multiplication.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/expression/bits.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/bits.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::{compile_qasm_to_qsharp, compile_qasm_to_qsharp_file};
 
 use expect_test::expect;

--- a/compiler/qsc_qasm3/src/tests/expression/ident.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/ident.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::{compile_qasm_stmt_to_qsharp, compile_qasm_to_qsharp};
 
 use expect_test::expect;

--- a/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bit.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bit.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bitarray.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bitarray.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bool.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bool.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_float.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_float.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_int.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_int.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/expression/indexed.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/indexed.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::{compile_qasm_stmt_to_qsharp, compile_qasm_to_qsharp};
 
 use expect_test::expect;

--- a/compiler/qsc_qasm3/src/tests/expression/unary.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/unary.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::expect;
 use miette::Report;
 

--- a/compiler/qsc_qasm3/src/tests/output.rs
+++ b/compiler/qsc_qasm3/src/tests/output.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::{
     qasm_to_program,
     tests::{fail_on_compilation_errors, gen_qsharp, parse},

--- a/compiler/qsc_qasm3/src/tests/scopes.rs
+++ b/compiler/qsc_qasm3/src/tests/scopes.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/annotation.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/annotation.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/end.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/end.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/for_loop.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/for_loop.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::{compile_qasm_to_qir, compile_qasm_to_qsharp};
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/if_stmt.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/if_stmt.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/implicit_modified_gate_call.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/implicit_modified_gate_call.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/include.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/include.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::{
     qasm_to_program,
     tests::{parse_all, qsharp_from_qasm_compilation},

--- a/compiler/qsc_qasm3/src/tests/statement/measure.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/measure.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/modified_gate_call.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/modified_gate_call.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/reset.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/reset.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::{
     qasm_to_program,
     tests::{fail_on_compilation_errors, gen_qsharp, parse},

--- a/compiler/qsc_qasm3/src/tests/statement/switch.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/switch.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::{compile_qasm_to_qsharp, compile_qasm_to_qsharp_file};
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_qasm3/src/tests/statement/while_loop.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/while_loop.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/compiler/qsc_rca/src/tests/arrays.rs
+++ b/compiler/qsc_rca/src/tests/arrays.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/assigns.rs
+++ b/compiler/qsc_rca/src/tests/assigns.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/bindings.rs
+++ b/compiler/qsc_rca/src/tests/bindings.rs
@@ -3,8 +3,6 @@
 
 //! These tests use bindings to check that RCA for the use of different static and dynamic types is correct.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/binops.rs
+++ b/compiler/qsc_rca/src/tests/binops.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/callables.rs
+++ b/compiler/qsc_rca/src/tests/callables.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{
     check_callable_compute_properties, check_last_statement_compute_properties, CompilationContext,
 };

--- a/compiler/qsc_rca/src/tests/calls.rs
+++ b/compiler/qsc_rca/src/tests/calls.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/cycles.rs
+++ b/compiler/qsc_rca/src/tests/cycles.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_callable_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/ifs.rs
+++ b/compiler/qsc_rca/src/tests/ifs.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{
     check_callable_compute_properties, check_last_statement_compute_properties, CompilationContext,
 };

--- a/compiler/qsc_rca/src/tests/intrinsics.rs
+++ b/compiler/qsc_rca/src/tests/intrinsics.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_callable_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/loops.rs
+++ b/compiler/qsc_rca/src/tests/loops.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/measurements.rs
+++ b/compiler/qsc_rca/src/tests/measurements.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/overrides.rs
+++ b/compiler/qsc_rca/src/tests/overrides.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/qubits.rs
+++ b/compiler/qsc_rca/src/tests/qubits.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{
     check_callable_compute_properties, check_last_statement_compute_properties, CompilationContext,
 };

--- a/compiler/qsc_rca/src/tests/strings.rs
+++ b/compiler/qsc_rca/src/tests/strings.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/structs.rs
+++ b/compiler/qsc_rca/src/tests/structs.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/types.rs
+++ b/compiler/qsc_rca/src/tests/types.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/udts.rs
+++ b/compiler/qsc_rca/src/tests/udts.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/compiler/qsc_rca/src/tests/vars.rs
+++ b/compiler/qsc_rca/src/tests/vars.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{check_last_statement_compute_properties, CompilationContext};
 use expect_test::expect;
 

--- a/language_service/src/code_lens/tests.rs
+++ b/language_service/src/code_lens/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::get_code_lenses;
 use crate::{
     test_utils::{

--- a/language_service/src/completion/tests.rs
+++ b/language_service/src/completion/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{get_completions, CompletionItem};
 use crate::{
     protocol::CompletionList,

--- a/language_service/src/definition/tests.rs
+++ b/language_service/src/definition/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::{expect, Expect};
 use qsc::location::Location;
 

--- a/language_service/src/hover/tests.rs
+++ b/language_service/src/hover/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::get_hover;
 use crate::test_utils::{compile_notebook_with_markers, compile_with_markers};
 use expect_test::{expect, Expect};

--- a/language_service/src/references/tests.rs
+++ b/language_service/src/references/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::get_references;
 use crate::{
     test_utils::{compile_notebook_with_markers, compile_with_markers},

--- a/language_service/src/rename/tests.rs
+++ b/language_service/src/rename/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{get_rename, prepare_rename};
 use crate::{
     test_utils::{compile_notebook_with_markers, compile_with_markers},

--- a/language_service/src/signature_help/tests.rs
+++ b/language_service/src/signature_help/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::get_signature_help;
 use crate::{test_utils::compile_with_markers, Encoding};
 use expect_test::{expect, Expect};

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use crate::{
     protocol::{DiagnosticUpdate, ErrorKind},
     Encoding, LanguageService, UpdateWorker,

--- a/library/src/tests.rs
+++ b/library/src/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 mod arithmetic;
 mod arrays;
 mod canon;

--- a/library/src/tests/canon.rs
+++ b/library/src/tests/canon.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::{test_expression, test_expression_with_lib};
 use indoc::indoc;
 use qsc::interpret::Value;

--- a/library/src/tests/measurement.rs
+++ b/library/src/tests/measurement.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use super::test_expression;
 use indoc::indoc;
 use qsc::interpret::Value;

--- a/resource_estimator/src/counts/tests.rs
+++ b/resource_estimator/src/counts/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use std::convert::Into;
 
 use expect_test::{expect, Expect};

--- a/resource_estimator/src/system/data/report.rs
+++ b/resource_estimator/src/system/data/report.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 #[cfg(test)]
 mod tests;
 

--- a/samples_test/src/tests.rs
+++ b/samples_test/src/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 mod algorithms;
 #[rustfmt::skip]
 mod algorithms_generated;

--- a/samples_test/src/tests/algorithms.rs
+++ b/samples_test/src/tests/algorithms.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::{expect, Expect};
 
 /// Each file in the samples/algorithms folder is compiled and run as two tests and should

--- a/samples_test/src/tests/language.rs
+++ b/samples_test/src/tests/language.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(clippy::needless_raw_string_hashes)]
-
 use expect_test::{expect, Expect};
 
 /// Each file in the samples/language folder is compiled and run as two tests and should


### PR DESCRIPTION
This change updates our root clippy config and removes the individual overrides for `needless_raw_string_hashes`. It also preemptively allows `unnecessary_wraps` in anticipation of #1954 