### PR TITLE
Added Pauli noise support to sparse simulator

### DIFF
--- a/compiler/qsc_circuit/src/builder.rs
+++ b/compiler/qsc_circuit/src/builder.rs
@@ -174,8 +174,9 @@ impl Backend for Builder {
         self.remapper.qubit_allocate()
     }
 
-    fn qubit_release(&mut self, q: usize) {
+    fn qubit_release(&mut self, q: usize) -> bool {
         self.remapper.qubit_release(q);
+        true
     }
 
     fn qubit_swap_id(&mut self, q0: usize, q1: usize) {
@@ -187,8 +188,8 @@ impl Backend for Builder {
     }
 
     fn qubit_is_zero(&mut self, _q: usize) -> bool {
-        // Because `qubit_is_zero` is called on every qubit release, this must return
-        // true to avoid a panic.
+        // We don't simulate quantum execution here. So we don't know if the qubit
+        // is zero or not. Returning true avoids potential panics.
         true
     }
 

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -214,12 +214,13 @@ impl Backend for SparseSim {
         if res {
             self.sim.x(q);
         }
-        self.apply_noise(q); // Applying noise after reset
+        // After reset qubits start in ground state even with noise.
         res
     }
 
     fn reset(&mut self, q: usize) {
         self.mresetz(q);
+        // After reset qubits start in ground state even with noise.
     }
 
     fn rx(&mut self, theta: f64, q: usize) {
@@ -319,9 +320,8 @@ impl Backend for SparseSim {
     }
 
     fn qubit_allocate(&mut self) -> usize {
-        let q = self.sim.allocate();
-        self.apply_noise(q); // Noise is applied to fresh qubit.
-        q
+        // Fresh qubit start in ground state even with noise.
+        self.sim.allocate()
     }
 
     fn qubit_release(&mut self, q: usize) -> bool {

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -334,7 +334,7 @@ impl Backend for SparseSim {
     }
 
     fn qubit_swap_id(&mut self, q0: usize, q1: usize) {
-        // This is an service function rather than a gate so it doesn't incur noise.
+        // This is a service function rather than a gate so it doesn't incur noise.
         self.sim.swap_qubit_ids(q0, q1);
     }
 
@@ -359,7 +359,7 @@ impl Backend for SparseSim {
     }
 
     fn qubit_is_zero(&mut self, q: usize) -> bool {
-        // This is an service function rather than a measurement so it doesn't incur noise.
+        // This is a service function rather than a measurement so it doesn't incur noise.
         self.sim.qubit_is_zero(q)
     }
 

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::noise::PauliNoise;
+use crate::val::Value;
 use num_bigint::BigUint;
 use num_complex::Complex;
 use quantum_sparse_sim::QuantumSim;
-use rand::RngCore;
+use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
 
-use crate::val::Value;
+#[cfg(test)]
+mod noise_tests;
 
 /// The trait that must be implemented by a quantum backend, whose functions will be invoked when
 /// quantum intrinsics are called.
@@ -82,7 +85,11 @@ pub trait Backend {
     fn qubit_allocate(&mut self) -> usize {
         unimplemented!("qubit_allocate operation");
     }
-    fn qubit_release(&mut self, _q: usize) {
+    /// `false` indicates that the qubit was in a non-zero state before the release,
+    /// but should have been in the zero state.
+    /// `true` otherwise. This includes the case when the qubit was in
+    /// a non-zero state during a noisy simulation.
+    fn qubit_release(&mut self, _q: usize) -> bool {
         unimplemented!("qubit_release operation");
     }
     fn qubit_swap_id(&mut self, _q0: usize, _q1: usize) {
@@ -102,7 +109,14 @@ pub trait Backend {
 
 /// Default backend used when targeting sparse simulation.
 pub struct SparseSim {
+    /// Noiseless Sparse simulator to be used by this instance.
     pub sim: QuantumSim,
+    /// Pauli noise that is applied after a gate or before a measurement is executed.
+    /// Service functions aren't subject to noise.
+    pub noise: PauliNoise,
+    /// Random number generator to sample Pauli noise.
+    /// Noise is not applied when rng is None.
+    pub rng: Option<StdRng>,
 }
 
 impl Default for SparseSim {
@@ -116,7 +130,43 @@ impl SparseSim {
     pub fn new() -> Self {
         Self {
             sim: QuantumSim::new(None),
+            noise: PauliNoise::default(),
+            rng: None,
         }
+    }
+
+    #[must_use]
+    pub fn new_with_noise(noise: &PauliNoise) -> Self {
+        Self {
+            sim: QuantumSim::new(None),
+            noise: *noise,
+            rng: if noise.is_noiseless() {
+                None
+            } else {
+                Some(StdRng::from_entropy())
+            },
+        }
+    }
+
+    #[must_use]
+    fn is_noiseless(&self) -> bool {
+        self.rng.is_none()
+    }
+
+    fn apply_noise(&mut self, q: usize) {
+        if let Some(rng) = &mut self.rng {
+            let p = rng.gen_range(0.0..1.0);
+            if p >= self.noise.distribution[2] {
+                // In the most common case we don't apply noise
+            } else if p < self.noise.distribution[0] {
+                self.sim.x(q);
+            } else if p < self.noise.distribution[1] {
+                self.sim.y(q);
+            } else {
+                self.sim.z(q);
+            }
+        }
+        // No noise applied if rng is None.
     }
 }
 
@@ -125,29 +175,41 @@ impl Backend for SparseSim {
 
     fn ccx(&mut self, ctl0: usize, ctl1: usize, q: usize) {
         self.sim.mcx(&[ctl0, ctl1], q);
+        self.apply_noise(ctl0);
+        self.apply_noise(ctl1);
+        self.apply_noise(q);
     }
 
     fn cx(&mut self, ctl: usize, q: usize) {
         self.sim.mcx(&[ctl], q);
+        self.apply_noise(ctl);
+        self.apply_noise(q);
     }
 
     fn cy(&mut self, ctl: usize, q: usize) {
         self.sim.mcy(&[ctl], q);
+        self.apply_noise(ctl);
+        self.apply_noise(q);
     }
 
     fn cz(&mut self, ctl: usize, q: usize) {
         self.sim.mcz(&[ctl], q);
+        self.apply_noise(ctl);
+        self.apply_noise(q);
     }
 
     fn h(&mut self, q: usize) {
         self.sim.h(q);
+        self.apply_noise(q);
     }
 
     fn m(&mut self, q: usize) -> Self::ResultType {
+        self.apply_noise(q);
         self.sim.measure(q)
     }
 
     fn mresetz(&mut self, q: usize) -> Self::ResultType {
+        self.apply_noise(q);
         let res = self.sim.measure(q);
         if res {
             self.sim.x(q);
@@ -161,87 +223,118 @@ impl Backend for SparseSim {
 
     fn rx(&mut self, theta: f64, q: usize) {
         self.sim.rx(theta, q);
+        self.apply_noise(q);
     }
 
     fn rxx(&mut self, theta: f64, q0: usize, q1: usize) {
-        self.h(q0);
-        self.h(q1);
-        self.rzz(theta, q0, q1);
-        self.h(q1);
-        self.h(q0);
+        self.sim.h(q0);
+        self.sim.h(q1);
+        self.sim.mcx(&[q1], q0);
+        self.sim.rz(theta, q0);
+        self.sim.mcx(&[q1], q0);
+        self.sim.h(q1);
+        self.sim.h(q0);
+        self.apply_noise(q0);
+        self.apply_noise(q1);
     }
 
     fn ry(&mut self, theta: f64, q: usize) {
         self.sim.ry(theta, q);
+        self.apply_noise(q);
     }
 
     fn ryy(&mut self, theta: f64, q0: usize, q1: usize) {
-        self.h(q0);
-        self.s(q0);
-        self.h(q0);
-        self.h(q1);
-        self.s(q1);
-        self.h(q1);
-        self.rzz(theta, q0, q1);
-        self.h(q1);
-        self.sadj(q1);
-        self.h(q1);
-        self.h(q0);
-        self.sadj(q0);
-        self.h(q0);
+        self.sim.h(q0);
+        self.sim.s(q0);
+        self.sim.h(q0);
+        self.sim.h(q1);
+        self.sim.s(q1);
+        self.sim.h(q1);
+        self.sim.mcx(&[q1], q0);
+        self.sim.rz(theta, q0);
+        self.sim.mcx(&[q1], q0);
+        self.sim.h(q1);
+        self.sim.sadj(q1);
+        self.sim.h(q1);
+        self.sim.h(q0);
+        self.sim.sadj(q0);
+        self.sim.h(q0);
+        self.apply_noise(q0);
+        self.apply_noise(q1);
     }
 
     fn rz(&mut self, theta: f64, q: usize) {
         self.sim.rz(theta, q);
+        self.apply_noise(q);
     }
 
     fn rzz(&mut self, theta: f64, q0: usize, q1: usize) {
-        self.cx(q1, q0);
-        self.rz(theta, q0);
-        self.cx(q1, q0);
+        self.sim.mcx(&[q1], q0);
+        self.sim.rz(theta, q0);
+        self.sim.mcx(&[q1], q0);
+        self.apply_noise(q0);
+        self.apply_noise(q1);
     }
 
     fn sadj(&mut self, q: usize) {
         self.sim.sadj(q);
+        self.apply_noise(q);
     }
 
     fn s(&mut self, q: usize) {
         self.sim.s(q);
+        self.apply_noise(q);
     }
 
     fn swap(&mut self, q0: usize, q1: usize) {
         self.sim.swap_qubit_ids(q0, q1);
+        self.apply_noise(q0);
+        self.apply_noise(q1);
     }
 
     fn tadj(&mut self, q: usize) {
         self.sim.tadj(q);
+        self.apply_noise(q);
     }
 
     fn t(&mut self, q: usize) {
         self.sim.t(q);
+        self.apply_noise(q);
     }
 
     fn x(&mut self, q: usize) {
         self.sim.x(q);
+        self.apply_noise(q);
     }
 
     fn y(&mut self, q: usize) {
         self.sim.y(q);
+        self.apply_noise(q);
     }
 
     fn z(&mut self, q: usize) {
         self.sim.z(q);
+        self.apply_noise(q);
     }
 
     fn qubit_allocate(&mut self) -> usize {
         self.sim.allocate()
+        // No noise is applied on allocation
     }
 
-    fn qubit_release(&mut self, q: usize) {
-        self.sim.release(q);
+    fn qubit_release(&mut self, q: usize) -> bool {
+        if self.is_noiseless() {
+            let was_zero = self.sim.qubit_is_zero(q);
+            self.sim.release(q);
+            was_zero
+        } else {
+            self.sim.release(q);
+            true
+        }
     }
 
     fn qubit_swap_id(&mut self, q0: usize, q1: usize) {
+        // This is an service function rather than a gate so it doesn't incur noise.
         self.sim.swap_qubit_ids(q0, q1);
     }
 
@@ -266,10 +359,12 @@ impl Backend for SparseSim {
     }
 
     fn qubit_is_zero(&mut self, q: usize) -> bool {
+        // This is an service function rather than a measurement so it doesn't incur noise.
         self.sim.qubit_is_zero(q)
     }
 
     fn custom_intrinsic(&mut self, name: &str, arg: Value) -> Option<Result<Value, String>> {
+        // These intrinsics aren't subject to noise.
         match name {
             "GlobalPhase" => {
                 // Apply a global phase to the simulation by doing an Rz to a fresh qubit.
@@ -301,9 +396,16 @@ impl Backend for SparseSim {
     }
 
     fn set_seed(&mut self, seed: Option<u64>) {
-        match seed {
-            Some(seed) => self.sim.set_rng_seed(seed),
-            None => self.sim.set_rng_seed(rand::thread_rng().next_u64()),
+        if let Some(seed) = seed {
+            if !self.is_noiseless() {
+                self.rng = Some(StdRng::seed_from_u64(seed));
+            }
+            self.sim.set_rng_seed(seed);
+        } else {
+            if !self.is_noiseless() {
+                self.rng = Some(StdRng::from_entropy());
+            }
+            self.sim.set_rng_seed(rand::thread_rng().next_u64());
         }
     }
 }
@@ -458,9 +560,9 @@ where
         self.main.qubit_allocate()
     }
 
-    fn qubit_release(&mut self, q: usize) {
-        self.chained.qubit_release(q);
-        self.main.qubit_release(q);
+    fn qubit_release(&mut self, q: usize) -> bool {
+        let _ = self.chained.qubit_release(q);
+        self.main.qubit_release(q)
     }
 
     fn qubit_swap_id(&mut self, q0: usize, q1: usize) {

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -209,11 +209,12 @@ impl Backend for SparseSim {
     }
 
     fn mresetz(&mut self, q: usize) -> Self::ResultType {
-        self.apply_noise(q);
+        self.apply_noise(q); // Applying noise before measurement
         let res = self.sim.measure(q);
         if res {
             self.sim.x(q);
         }
+        self.apply_noise(q); // Applying noise after reset
         res
     }
 
@@ -318,8 +319,9 @@ impl Backend for SparseSim {
     }
 
     fn qubit_allocate(&mut self) -> usize {
-        self.sim.allocate()
-        // No noise is applied on allocation
+        let q = self.sim.allocate();
+        self.apply_noise(q); // Noise is applied to fresh qubit.
+        q
     }
 
     fn qubit_release(&mut self, q: usize) -> bool {

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -85,10 +85,8 @@ pub trait Backend {
     fn qubit_allocate(&mut self) -> usize {
         unimplemented!("qubit_allocate operation");
     }
-    /// `false` indicates that the qubit was in a non-zero state before the release,
-    /// but should have been in the zero state.
-    /// `true` otherwise. This includes the case when the qubit was in
-    /// a non-zero state during a noisy simulation.
+    /// `true` indicates that the qubit was in the zero state before the release,
+    /// `false` otherwise.
     fn qubit_release(&mut self, _q: usize) -> bool {
         unimplemented!("qubit_release operation");
     }
@@ -325,14 +323,9 @@ impl Backend for SparseSim {
     }
 
     fn qubit_release(&mut self, q: usize) -> bool {
-        if self.is_noiseless() {
-            let was_zero = self.sim.qubit_is_zero(q);
-            self.sim.release(q);
-            was_zero
-        } else {
-            self.sim.release(q);
-            true
-        }
+        let was_zero = self.sim.qubit_is_zero(q);
+        self.sim.release(q);
+        was_zero
     }
 
     fn qubit_swap_id(&mut self, q0: usize, q1: usize) {

--- a/compiler/qsc_eval/src/backend/noise_tests.rs
+++ b/compiler/qsc_eval/src/backend/noise_tests.rs
@@ -119,17 +119,17 @@ fn noisy_measurement() {
     let mut sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
     sim.set_seed(Some(0));
-    let q = sim.qubit_allocate(); // Allocation is noiseless even with noise.
     let mut true_count = 0;
-    for _ in 0..200 {
-        sim.reset(q);
-        // sim.m sometimes applies X before measuring
+    for _ in 0..1000 {
+        let q = sim.qubit_allocate(); // Allocation is noiseless even with noise.
+                                      // sim.m sometimes applies X before measuring
         if sim.m(q) {
             true_count += 1;
         };
+        sim.qubit_release(q);
     }
     assert!(
-        true_count > 40 && true_count < 80,
+        true_count > 200 && true_count < 400,
         "Expected about 30% bit flip noise."
     );
 }

--- a/compiler/qsc_eval/src/backend/noise_tests.rs
+++ b/compiler/qsc_eval/src/backend/noise_tests.rs
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::{
+    backend::{Backend, SparseSim},
+    noise::PauliNoise,
+    state::{fmt_complex, format_state_id},
+};
+use expect_test::expect;
+use num_bigint::BigUint;
+use num_complex::Complex;
+use std::fmt::Write;
+
+#[test]
+fn pauli_noise() {
+    let noise = PauliNoise::from_probabilities(0.0, 0.0, 0.0);
+    assert!(
+        noise
+            .expect("Expected construction of noiseless noise.")
+            .is_noiseless(),
+        "Expected noiseless noise."
+    );
+    let noise = PauliNoise::from_probabilities(1e-5, 0.0, 0.0);
+    assert!(
+        !noise
+            .expect("Expected construction of 1e-5 bit flip noise.")
+            .is_noiseless(),
+        "Expected noise to be noisy."
+    );
+    let noise = PauliNoise::from_probabilities(1.0, 0.0, 0.0);
+    assert!(
+        !noise
+            .expect("Expected construction of 1.0 bit flip noise.")
+            .is_noiseless(),
+        "Expected noise to be noisy."
+    );
+    let noise = PauliNoise::from_probabilities(0.01, 0.01, 0.01)
+        .expect("Expected construction of 0.01 depolarizing noise.");
+    assert!(!noise.is_noiseless(), "Expected noise to be noisy.");
+    assert!(
+        0.0 <= noise.distribution[0]
+            && noise.distribution[0] <= noise.distribution[1]
+            && noise.distribution[1] <= noise.distribution[2]
+            && noise.distribution[2] <= 1.1,
+        "Expected non-decreasing noise distribution."
+    );
+    let _ = PauliNoise::from_probabilities(-1e-10, 0.1, 0.1)
+        .expect_err("Expected error for probabilities -1e-10, 0.1, 0.1.");
+    let _ = PauliNoise::from_probabilities(1.0 + -1e-10, 0.1, 0.1)
+        .expect_err("Expected error for probabilities 1.0+1e-10, 0.1, 0.1.");
+    let _ = PauliNoise::from_probabilities(0.3, 0.4, 0.5)
+        .expect_err("Expected error for probabilities 0.3, 0.4, 0.5.");
+}
+
+#[test]
+fn noisy_simulator() {
+    let sim = SparseSim::new();
+    assert!(sim.is_noiseless(), "Expected noiseless simulator.");
+
+    let noise = PauliNoise::from_probabilities(0.0, 0.0, 0.0).expect("Cannot construct noise.");
+    let sim = SparseSim::new_with_noise(&noise);
+    assert!(sim.is_noiseless(), "Expected noiseless simulator.");
+
+    let noise = PauliNoise::from_probabilities(1e-10, 0.0, 0.0).expect("Cannot construct noise.");
+    let sim = SparseSim::new_with_noise(&noise);
+    assert!(!sim.is_noiseless(), "Expected noisy simulator.");
+
+    let noise = PauliNoise::from_probabilities(0.0, 0.0, 1e-10).expect("Cannot construct noise.");
+    let sim = SparseSim::new_with_noise(&noise);
+    assert!(!sim.is_noiseless(), "Expected noisy simulator.");
+}
+
+#[test]
+fn noiseless_gate() {
+    let noise = PauliNoise::from_probabilities(0.0, 0.0, 0.0).expect("Cannot construct noise.");
+    let mut sim = SparseSim::new_with_noise(&noise);
+    let q = sim.qubit_allocate();
+    for _ in 0..100 {
+        sim.x(q);
+        let res1 = sim.m(q);
+        assert!(res1, "Unexpected value. True expected without noise.");
+        sim.x(q);
+        let res2 = sim.m(q);
+        assert!(!res2, "Unexpected value. False expected without noise.");
+    }
+    assert!(sim.qubit_release(q), "Unexpected qubit state on release.");
+}
+
+#[test]
+fn bitflip_measurement() {
+    let noise = PauliNoise::from_probabilities(1.0, 0.0, 0.0).expect("Cannot construct noise.");
+    let mut sim = SparseSim::new_with_noise(&noise);
+    assert!(!sim.is_noiseless(), "Expected noisy simulator.");
+    let q = sim.qubit_allocate();
+    for _ in 0..100 {
+        let res1 = sim.m(q); // Always applies X before measuring
+        assert!(
+            res1,
+            "Unexpected value. True expected for 100% bitflip noise."
+        );
+        let res2 = sim.m(q); // Always applies X before measuring
+        assert!(
+            !res2,
+            "Unexpected value. False expected for 100% bitflip noise."
+        );
+    }
+    assert!(sim.qubit_release(q), "Unexpected qubit state on release.");
+}
+
+#[test]
+fn bitflip_gate() {
+    let noise = PauliNoise::from_probabilities(1.0, 0.0, 0.0).expect("Cannot construct noise.");
+    let mut sim = SparseSim::new_with_noise(&noise);
+    assert!(!sim.is_noiseless(), "Expected noisy simulator.");
+    let q = sim.qubit_allocate();
+    for _ in 0..100 {
+        sim.x(q); // This is a no-op under 100% bitflip noise.
+        let res1 = sim.m(q); // Always applies X before measuring
+        assert!(
+            res1,
+            "Unexpected value. True expected for 100% bitflip noise."
+        );
+        sim.x(q); // This is a no-op under 100% bitflip noise.
+        let res2 = sim.m(q);
+        assert!(
+            !res2,
+            "Unexpected value. False expected for 100% bitflip noise."
+        );
+    }
+    assert!(sim.qubit_release(q), "Unexpected qubit state on release.");
+}
+
+pub fn state_to_string(input: &(Vec<(BigUint, Complex<f64>)>, usize)) -> String {
+    input
+        .0
+        .iter()
+        .fold(String::new(), |mut output, (id, state)| {
+            let _ = write!(
+                output,
+                "{}: {} ",
+                format_state_id(id, input.1),
+                fmt_complex(state)
+            );
+            output
+        })
+        .to_string()
+}
+
+#[test]
+fn noisy_via_y() {
+    let noise = PauliNoise::from_probabilities(0.0, 1.0, 0.0).expect("Cannot construct noise.");
+    let mut sim = SparseSim::new_with_noise(&noise);
+    assert!(!sim.is_noiseless(), "Expected noisy simulator.");
+    let q = sim.qubit_allocate();
+    sim.x(q); // Followed by Y.
+    let state = sim.capture_quantum_state();
+    expect!["|0⟩: 0.0000−1.0000𝑖 "].assert_eq(&state_to_string(&state));
+    sim.y(q); // Followed by Y. So, no op.
+    let state = sim.capture_quantum_state();
+    expect!["|0⟩: 0.0000−1.0000𝑖 "].assert_eq(&state_to_string(&state));
+    sim.z(q); // Followed by Y.
+    let state = sim.capture_quantum_state();
+    expect!["|1⟩: 1.0000+0.0000𝑖 "].assert_eq(&state_to_string(&state));
+}
+
+#[test]
+fn noisy_via_z() {
+    let noise = PauliNoise::from_probabilities(0.0, 0.0, 1.0).expect("Cannot construct noise.");
+    let mut sim = SparseSim::new_with_noise(&noise);
+    assert!(!sim.is_noiseless(), "Expected noisy simulator.");
+    let q = sim.qubit_allocate();
+    sim.x(q); // Followed by Z.
+    let state = sim.capture_quantum_state();
+    expect!["|1⟩: −1.0000+0.0000𝑖 "].assert_eq(&state_to_string(&state));
+    sim.y(q); // Followed by Z.
+    let state = sim.capture_quantum_state();
+    expect!["|0⟩: 0.0000+1.0000𝑖 "].assert_eq(&state_to_string(&state));
+    sim.z(q); // Followed by Z. So, no op.
+    let state = sim.capture_quantum_state();
+    expect!["|0⟩: 0.0000+1.0000𝑖 "].assert_eq(&state_to_string(&state));
+}

--- a/compiler/qsc_eval/src/backend/noise_tests.rs
+++ b/compiler/qsc_eval/src/backend/noise_tests.rs
@@ -6,7 +6,7 @@ use crate::{
     noise::PauliNoise,
     state::{fmt_complex, format_state_id},
 };
-use expect_test::expect;
+use expect_test::{expect, Expect};
 use num_bigint::BigUint;
 use num_complex::Complex;
 use std::fmt::Write;
@@ -16,26 +16,26 @@ fn pauli_noise() {
     let noise = PauliNoise::from_probabilities(0.0, 0.0, 0.0);
     assert!(
         noise
-            .expect("Expected construction of noiseless noise.")
+            .expect("noiseless Pauli noise should be constructable.")
             .is_noiseless(),
         "Expected noiseless noise."
     );
     let noise = PauliNoise::from_probabilities(1e-5, 0.0, 0.0);
     assert!(
         !noise
-            .expect("Expected construction of 1e-5 bit flip noise.")
+            .expect("bit flip noise with probability 1e-5 should be constructable.")
             .is_noiseless(),
         "Expected noise to be noisy."
     );
     let noise = PauliNoise::from_probabilities(1.0, 0.0, 0.0);
     assert!(
         !noise
-            .expect("Expected construction of 1.0 bit flip noise.")
+            .expect("bit flip noise with probability 1 should be constructable.")
             .is_noiseless(),
         "Expected noise to be noisy."
     );
     let noise = PauliNoise::from_probabilities(0.01, 0.01, 0.01)
-        .expect("Expected construction of 0.01 depolarizing noise.");
+        .expect("depolarizing noise with probability 0.01 should be constructable..");
     assert!(!noise.is_noiseless(), "Expected noise to be noisy.");
     assert!(
         0.0 <= noise.distribution[0]
@@ -45,11 +45,11 @@ fn pauli_noise() {
         "Expected non-decreasing noise distribution."
     );
     let _ = PauliNoise::from_probabilities(-1e-10, 0.1, 0.1)
-        .expect_err("Expected error for probabilities -1e-10, 0.1, 0.1.");
+        .expect_err("pauli noise with probabilities -1e-10, 0.1, 0.1 should result in error.");
     let _ = PauliNoise::from_probabilities(1.0 + -1e-10, 0.1, 0.1)
-        .expect_err("Expected error for probabilities 1.0+1e-10, 0.1, 0.1.");
+        .expect_err("pauli noise with probabilities 1.0+1e-10, 0.1, 0.1 should result in error.");
     let _ = PauliNoise::from_probabilities(0.3, 0.4, 0.5)
-        .expect_err("Expected error for probabilities 0.3, 0.4, 0.5.");
+        .expect_err("pauli noise with probabilities 0.3, 0.4, 0.5 should result in error.");
 }
 
 #[test]
@@ -57,77 +57,59 @@ fn noisy_simulator() {
     let sim = SparseSim::new();
     assert!(sim.is_noiseless(), "Expected noiseless simulator.");
 
-    let noise = PauliNoise::from_probabilities(0.0, 0.0, 0.0).expect("Cannot construct noise.");
+    let noise = PauliNoise::from_probabilities(0.0, 0.0, 0.0)
+        .expect("noiseless Pauli noise should be constructable.");
     let sim = SparseSim::new_with_noise(&noise);
     assert!(sim.is_noiseless(), "Expected noiseless simulator.");
 
-    let noise = PauliNoise::from_probabilities(1e-10, 0.0, 0.0).expect("Cannot construct noise.");
+    let noise = PauliNoise::from_probabilities(1e-10, 0.0, 0.0)
+        .expect("1e-10, 0.0, 0.0 Pauli noise should be constructable.");
     let sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
 
-    let noise = PauliNoise::from_probabilities(0.0, 0.0, 1e-10).expect("Cannot construct noise.");
+    let noise = PauliNoise::from_probabilities(0.0, 0.0, 1e-10)
+        .expect("0.0, 0.0, 1e-10 Pauli noise should be constructable.");
     let sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
 }
 
 #[test]
 fn noiseless_gate() {
-    let noise = PauliNoise::from_probabilities(0.0, 0.0, 0.0).expect("Cannot construct noise.");
+    let noise = PauliNoise::from_probabilities(0.0, 0.0, 0.0)
+        .expect("noiseless Pauli noise should be constructable.");
     let mut sim = SparseSim::new_with_noise(&noise);
     let q = sim.qubit_allocate();
     for _ in 0..100 {
         sim.x(q);
         let res1 = sim.m(q);
-        assert!(res1, "Unexpected value. True expected without noise.");
+        assert!(res1, "Expected True without noise.");
         sim.x(q);
         let res2 = sim.m(q);
-        assert!(!res2, "Unexpected value. False expected without noise.");
+        assert!(!res2, "Expected False without noise.");
     }
-    assert!(sim.qubit_release(q), "Unexpected qubit state on release.");
+    assert!(
+        sim.qubit_release(q),
+        "Expected correct qubit state on release."
+    );
 }
 
 #[test]
 fn bitflip_measurement() {
-    let noise = PauliNoise::from_probabilities(1.0, 0.0, 0.0).expect("Cannot construct noise.");
+    let noise = PauliNoise::from_probabilities(1.0, 0.0, 0.0)
+        .expect("bit flip noise with probability 100% should be constructable.");
     let mut sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
-    let q = sim.qubit_allocate();
+    let q = sim.qubit_allocate(); // Allocation applies X
     for _ in 0..100 {
         let res1 = sim.m(q); // Always applies X before measuring
-        assert!(
-            res1,
-            "Unexpected value. True expected for 100% bitflip noise."
-        );
+        assert!(!res1, "Expected False for 100% bit flip noise.");
         let res2 = sim.m(q); // Always applies X before measuring
-        assert!(
-            !res2,
-            "Unexpected value. False expected for 100% bitflip noise."
-        );
+        assert!(res2, "Expected True for 100% bit flip noise.");
     }
-    assert!(sim.qubit_release(q), "Unexpected qubit state on release.");
-}
-
-#[test]
-fn bitflip_gate() {
-    let noise = PauliNoise::from_probabilities(1.0, 0.0, 0.0).expect("Cannot construct noise.");
-    let mut sim = SparseSim::new_with_noise(&noise);
-    assert!(!sim.is_noiseless(), "Expected noisy simulator.");
-    let q = sim.qubit_allocate();
-    for _ in 0..100 {
-        sim.x(q); // This is a no-op under 100% bitflip noise.
-        let res1 = sim.m(q); // Always applies X before measuring
-        assert!(
-            res1,
-            "Unexpected value. True expected for 100% bitflip noise."
-        );
-        sim.x(q); // This is a no-op under 100% bitflip noise.
-        let res2 = sim.m(q);
-        assert!(
-            !res2,
-            "Unexpected value. False expected for 100% bitflip noise."
-        );
-    }
-    assert!(sim.qubit_release(q), "Unexpected qubit state on release.");
+    assert!(
+        sim.qubit_release(q),
+        "Expected correct qubit state on release."
+    );
 }
 
 pub fn state_to_string(input: &(Vec<(BigUint, Complex<f64>)>, usize)) -> String {
@@ -146,36 +128,55 @@ pub fn state_to_string(input: &(Vec<(BigUint, Complex<f64>)>, usize)) -> String 
         .to_string()
 }
 
+fn check_state(sim: &mut SparseSim, expected: &Expect) {
+    let state = sim.capture_quantum_state();
+    expected.assert_eq(&state_to_string(&state));
+}
+
 #[test]
-fn noisy_via_y() {
-    let noise = PauliNoise::from_probabilities(0.0, 1.0, 0.0).expect("Cannot construct noise.");
+fn noisy_via_x() {
+    let noise = PauliNoise::from_probabilities(1.0, 0.0, 0.0)
+        .expect("bit flip noise with probability 100% should be constructable.");
     let mut sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
-    let q = sim.qubit_allocate();
+    let q = sim.qubit_allocate(); // Followed by X.
+    check_state(&mut sim, &expect!["|1⟩: 1.0000+0.0000𝑖 "]);
+    sim.x(q); // Followed by X. So, no op.
+    check_state(&mut sim, &expect!["|1⟩: 1.0000+0.0000𝑖 "]);
+    sim.y(q); // Followed by X.
+    check_state(&mut sim, &expect!["|1⟩: 0.0000−1.0000𝑖 "]);
+    sim.z(q); // Followed by X.
+    check_state(&mut sim, &expect!["|0⟩: 0.0000+1.0000𝑖 "]);
+}
+
+#[test]
+fn noisy_via_y() {
+    let noise = PauliNoise::from_probabilities(0.0, 1.0, 0.0)
+        .expect("0.0, 1.0, 0.0 Pauli noise should be constructable.");
+    let mut sim = SparseSim::new_with_noise(&noise);
+    assert!(!sim.is_noiseless(), "Expected noisy simulator.");
+    let q = sim.qubit_allocate(); // Followed by Y.
+    check_state(&mut sim, &expect!["|1⟩: 0.0000+1.0000𝑖 "]);
     sim.x(q); // Followed by Y.
-    let state = sim.capture_quantum_state();
-    expect!["|0⟩: 0.0000−1.0000𝑖 "].assert_eq(&state_to_string(&state));
+    check_state(&mut sim, &expect!["|1⟩: −1.0000+0.0000𝑖 "]);
     sim.y(q); // Followed by Y. So, no op.
-    let state = sim.capture_quantum_state();
-    expect!["|0⟩: 0.0000−1.0000𝑖 "].assert_eq(&state_to_string(&state));
+    check_state(&mut sim, &expect!["|1⟩: −1.0000+0.0000𝑖 "]);
     sim.z(q); // Followed by Y.
-    let state = sim.capture_quantum_state();
-    expect!["|1⟩: 1.0000+0.0000𝑖 "].assert_eq(&state_to_string(&state));
+    check_state(&mut sim, &expect!["|0⟩: 0.0000−1.0000𝑖 "]);
 }
 
 #[test]
 fn noisy_via_z() {
-    let noise = PauliNoise::from_probabilities(0.0, 0.0, 1.0).expect("Cannot construct noise.");
+    let noise = PauliNoise::from_probabilities(0.0, 0.0, 1.0)
+        .expect("phase flip noise with probability 100% should be constructable.");
     let mut sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
-    let q = sim.qubit_allocate();
+    let q = sim.qubit_allocate(); // Followed by Z.
+    check_state(&mut sim, &expect!["|0⟩: 1.0000+0.0000𝑖 "]);
     sim.x(q); // Followed by Z.
-    let state = sim.capture_quantum_state();
-    expect!["|1⟩: −1.0000+0.0000𝑖 "].assert_eq(&state_to_string(&state));
+    check_state(&mut sim, &expect!["|1⟩: −1.0000+0.0000𝑖 "]);
     sim.y(q); // Followed by Z.
-    let state = sim.capture_quantum_state();
-    expect!["|0⟩: 0.0000+1.0000𝑖 "].assert_eq(&state_to_string(&state));
+    check_state(&mut sim, &expect!["|0⟩: 0.0000+1.0000𝑖 "]);
     sim.z(q); // Followed by Z. So, no op.
-    let state = sim.capture_quantum_state();
-    expect!["|0⟩: 0.0000+1.0000𝑖 "].assert_eq(&state_to_string(&state));
+    check_state(&mut sim, &expect!["|0⟩: 0.0000+1.0000𝑖 "]);
 }

--- a/compiler/qsc_eval/src/backend/noise_tests.rs
+++ b/compiler/qsc_eval/src/backend/noise_tests.rs
@@ -99,16 +99,38 @@ fn bitflip_measurement() {
         .expect("bit flip noise with probability 100% should be constructable.");
     let mut sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
-    let q = sim.qubit_allocate(); // Allocation applies X
+    let q = sim.qubit_allocate(); // Allocation is noiseless even with noise.
     for _ in 0..100 {
         let res1 = sim.m(q); // Always applies X before measuring
-        assert!(!res1, "Expected False for 100% bit flip noise.");
+        assert!(res1, "Expected True for 100% bit flip noise.");
         let res2 = sim.m(q); // Always applies X before measuring
-        assert!(res2, "Expected True for 100% bit flip noise.");
+        assert!(!res2, "Expected False for 100% bit flip noise.");
     }
     assert!(
         sim.qubit_release(q),
         "Expected correct qubit state on release."
+    );
+}
+
+#[test]
+fn noisy_measurement() {
+    let noise = PauliNoise::from_probabilities(0.3, 0.0, 0.0)
+        .expect("bit flip noise with probability 100% should be constructable.");
+    let mut sim = SparseSim::new_with_noise(&noise);
+    assert!(!sim.is_noiseless(), "Expected noisy simulator.");
+    sim.set_seed(Some(0));
+    let q = sim.qubit_allocate(); // Allocation is noiseless even with noise.
+    let mut true_count = 0;
+    for _ in 0..200 {
+        sim.reset(q);
+        // sim.m sometimes applies X before measuring
+        if sim.m(q) {
+            true_count += 1;
+        };
+    }
+    assert!(
+        true_count > 40 && true_count < 80,
+        "Expected about 30% bit flip noise."
     );
 }
 
@@ -139,14 +161,14 @@ fn noisy_via_x() {
         .expect("bit flip noise with probability 100% should be constructable.");
     let mut sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
-    let q = sim.qubit_allocate(); // Followed by X.
-    check_state(&mut sim, &expect!["|1⟩: 1.0000+0.0000𝑖 "]);
+    let q = sim.qubit_allocate(); // Allocation is noiseless even with noise.
+    check_state(&mut sim, &expect!["|0⟩: 1.0000+0.0000𝑖 "]);
     sim.x(q); // Followed by X. So, no op.
-    check_state(&mut sim, &expect!["|1⟩: 1.0000+0.0000𝑖 "]);
+    check_state(&mut sim, &expect!["|0⟩: 1.0000+0.0000𝑖 "]);
     sim.y(q); // Followed by X.
-    check_state(&mut sim, &expect!["|1⟩: 0.0000−1.0000𝑖 "]);
-    sim.z(q); // Followed by X.
     check_state(&mut sim, &expect!["|0⟩: 0.0000+1.0000𝑖 "]);
+    sim.z(q); // Followed by X.
+    check_state(&mut sim, &expect!["|1⟩: 0.0000+1.0000𝑖 "]);
 }
 
 #[test]
@@ -155,14 +177,14 @@ fn noisy_via_y() {
         .expect("0.0, 1.0, 0.0 Pauli noise should be constructable.");
     let mut sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
-    let q = sim.qubit_allocate(); // Followed by Y.
-    check_state(&mut sim, &expect!["|1⟩: 0.0000+1.0000𝑖 "]);
+    let q = sim.qubit_allocate(); // Allocation is noiseless even with noise.
+    check_state(&mut sim, &expect!["|0⟩: 1.0000+0.0000𝑖 "]);
     sim.x(q); // Followed by Y.
-    check_state(&mut sim, &expect!["|1⟩: −1.0000+0.0000𝑖 "]);
-    sim.y(q); // Followed by Y. So, no op.
-    check_state(&mut sim, &expect!["|1⟩: −1.0000+0.0000𝑖 "]);
-    sim.z(q); // Followed by Y.
     check_state(&mut sim, &expect!["|0⟩: 0.0000−1.0000𝑖 "]);
+    sim.y(q); // Followed by Y. So, no op.
+    check_state(&mut sim, &expect!["|0⟩: 0.0000−1.0000𝑖 "]);
+    sim.z(q); // Followed by Y.
+    check_state(&mut sim, &expect!["|1⟩: 1.0000+0.0000𝑖 "]);
 }
 
 #[test]
@@ -171,7 +193,7 @@ fn noisy_via_z() {
         .expect("phase flip noise with probability 100% should be constructable.");
     let mut sim = SparseSim::new_with_noise(&noise);
     assert!(!sim.is_noiseless(), "Expected noisy simulator.");
-    let q = sim.qubit_allocate(); // Followed by Z.
+    let q = sim.qubit_allocate(); // Allocation is noiseless even with noise.
     check_state(&mut sim, &expect!["|0⟩: 1.0000+0.0000𝑖 "]);
     sim.x(q); // Followed by Z.
     check_state(&mut sim, &expect!["|1⟩: −1.0000+0.0000𝑖 "]);

--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -145,8 +145,7 @@ pub(crate) fn call(
         "__quantum__rt__qubit_allocate" => Ok(Value::Qubit(Qubit(sim.qubit_allocate()))),
         "__quantum__rt__qubit_release" => {
             let qubit = arg.unwrap_qubit().0;
-            if sim.qubit_is_zero(qubit) {
-                sim.qubit_release(qubit);
+            if sim.qubit_release(qubit) {
                 Ok(Value::unit())
             } else {
                 Err(Error::ReleasedQubitNotZero(qubit, arg_span))

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -121,8 +121,8 @@ impl Backend for CustomSim {
         self.sim.qubit_allocate()
     }
 
-    fn qubit_release(&mut self, q: usize) {
-        self.sim.qubit_release(q);
+    fn qubit_release(&mut self, q: usize) -> bool {
+        self.sim.qubit_release(q)
     }
 
     fn qubit_swap_id(&mut self, q0: usize, q1: usize) {

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -21,6 +21,7 @@ pub mod backend;
 pub mod debug;
 mod error;
 pub mod intrinsic;
+pub mod noise;
 pub mod output;
 pub mod state;
 pub mod val;

--- a/compiler/qsc_eval/src/noise.rs
+++ b/compiler/qsc_eval/src/noise.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[derive(Copy, Clone, Debug)]
+pub struct PauliNoise {
+    /// Pauli noise distribution for sampling.
+    /// When p is randomly distributed on [0.0, 1.0) the following error is applied:
+    /// X, when p is from [0.0, distribution[0])
+    /// Y, when p is from [distribution[0], distribution[1])
+    /// Z, when p is from [distribution[1], distribution[2])
+    /// I, when p is from [distribution[2], 1.0)
+    pub distribution: [f64; 3],
+}
+
+impl Default for PauliNoise {
+    fn default() -> Self {
+        Self {
+            distribution: [0.0; 3],
+        }
+    }
+}
+
+impl PauliNoise {
+    pub fn from_probabilities(px: f64, py: f64, pz: f64) -> Result<Self, String> {
+        let px_py = px + py;
+        let px_py_pz = px_py + pz;
+        if px < 0.0 || py < 0.0 || pz < 0.0 || px_py_pz > 1.0 {
+            Err("Incorrect Pauli noise probabilities.".to_string())
+        } else {
+            Ok(Self {
+                distribution: [px, px_py, px_py_pz],
+            })
+        }
+    }
+
+    #[must_use]
+    pub fn is_noiseless(&self) -> bool {
+        self.distribution[2] <= f64::EPSILON
+    }
+}

--- a/resource_estimator/src/counts.rs
+++ b/resource_estimator/src/counts.rs
@@ -502,8 +502,9 @@ impl Backend for LogicalCounter {
         }
     }
 
-    fn qubit_release(&mut self, q: usize) {
+    fn qubit_release(&mut self, q: usize) -> bool {
         self.free_list.push(q);
+        true
     }
 
     fn qubit_swap_id(&mut self, _q0: usize, _q1: usize) {


### PR DESCRIPTION
Added support for parametric Pauli noise to sparce simulator. (px, py, pz) can be provided. Sparse simulator will apply X, Y or Z gates after each gate and before each measurement with corresponding probability.
- This allows for simulation with parametric Pauli noise: bit flip, phase flip, depolarizing, etc.
- For two-qubit gates noise is applied to each qubit.
- Allocation and service functions do not apply noise. Idle (Identity) gate is also noiseless.
- Reset applies noise.
- Added tests.
- Released qubits are no longer checked to be in zero state by consumers of the backend via calling qubit_is_zero. Instead, qubit_release returns Boolean. True indicates, that the release was valid - the qubit was in a zero state in a noiseless simulation. It will always be true in noisy simulations when the release of a qubit is always valid.
- The functionality is not yet exposed outside Rust code. Will come in subsequent PRs.