### PR TITLE
Add support for custom resets using the `@Reset()` attribute

### DIFF
--- a/compiler/qsc/src/codegen/tests.rs
+++ b/compiler/qsc/src/codegen/tests.rs
@@ -1080,7 +1080,7 @@ mod adaptive_ri_profile {
 
             declare void @__quantum__qis__x__body(%Qubit*)
 
-            declare void @__quantum__qis__reset__body(%Qubit*)
+            declare void @__quantum__qis__reset__body(%Qubit*) #1
 
             declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
 

--- a/compiler/qsc/src/codegen/tests.rs
+++ b/compiler/qsc/src/codegen/tests.rs
@@ -1263,4 +1263,73 @@ mod adaptive_ri_profile {
             !10 = !{i32 1, !"multiple_target_branching", i1 false}
         "#]].assert_eq(&qir);
     }
+
+    #[test]
+    fn custom_reset_generates_correct_qir() {
+        let source = "namespace Test {
+            operation Main() : Result {
+                use q = Qubit();
+                __quantum__qis__custom_reset__body(q);
+                M(q)
+            }
+
+            @Reset()
+            operation __quantum__qis__custom_reset__body(target: Qubit) : Unit {
+                body intrinsic;
+            }
+        }";
+        let sources = SourceMap::new([("test.qs".into(), source.into())], None);
+        let language_features = LanguageFeatures::default();
+        let capabilities = TargetCapabilityFlags::Adaptive
+            | TargetCapabilityFlags::QubitReset
+            | TargetCapabilityFlags::IntegerComputations;
+
+        let (std_id, store) = crate::compile::package_store_with_stdlib(capabilities);
+        let qir = get_qir(
+            sources,
+            language_features,
+            capabilities,
+            store,
+            &[(std_id, None)],
+        )
+        .expect("the input program set in the `source` variable should be valid Q#");
+        expect![[r#"
+            %Result = type opaque
+            %Qubit = type opaque
+
+            define void @ENTRYPOINT__main() #0 {
+            block_0:
+              call void @__quantum__qis__custom_reset__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+              ret void
+            }
+
+            declare void @__quantum__qis__custom_reset__body(%Qubit*) #1
+
+            declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+            attributes #1 = { "irreversible" }
+
+            ; module flags
+
+            !llvm.module.flags = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10}
+
+            !0 = !{i32 1, !"qir_major_version", i32 1}
+            !1 = !{i32 7, !"qir_minor_version", i32 0}
+            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+            !3 = !{i32 1, !"dynamic_result_management", i1 false}
+            !4 = !{i32 1, !"classical_ints", i1 true}
+            !5 = !{i32 1, !"qubit_resetting", i1 true}
+            !6 = !{i32 1, !"classical_floats", i1 false}
+            !7 = !{i32 1, !"backwards_branching", i1 false}
+            !8 = !{i32 1, !"classical_fixed_points", i1 false}
+            !9 = !{i32 1, !"user_functions", i1 false}
+            !10 = !{i32 1, !"multiple_target_branching", i1 false}
+        "#]]
+        .assert_eq(&qir);
+    }
 }

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -508,7 +508,7 @@ impl ToQir<String> for rir::Callable {
                     self.call_type,
                     rir::CallableType::Measurement | rir::CallableType::Reset
                 ) {
-                    // Measurement callables are a special case that needs the irreversable attribute.
+                    // These callables are a special case that need the irreversable attribute.
                     " #1"
                 } else {
                     ""

--- a/compiler/qsc_codegen/src/qir.rs
+++ b/compiler/qsc_codegen/src/qir.rs
@@ -504,7 +504,10 @@ impl ToQir<String> for rir::Callable {
             return format!(
                 "declare {output_type} @{}({input_type}){}",
                 self.name,
-                if self.call_type == rir::CallableType::Measurement {
+                if matches!(
+                    self.call_type,
+                    rir::CallableType::Measurement | rir::CallableType::Reset
+                ) {
                     // Measurement callables are a special case that needs the irreversable attribute.
                     " #1"
                 } else {

--- a/compiler/qsc_fir/src/fir.rs
+++ b/compiler/qsc_fir/src/fir.rs
@@ -756,6 +756,8 @@ pub struct CallableDecl {
     pub functors: FunctorSetValue,
     /// The callable implementation.
     pub implementation: CallableImpl,
+    /// The attributes of the callable, (e.g.: Measurement or Reset).
+    pub attrs: Vec<Attr>,
 }
 
 impl CallableDecl {
@@ -1521,6 +1523,8 @@ pub enum Attr {
     EntryPoint,
     /// Indicates that a callable is a measurement.
     Measurement,
+    /// Indicates that a callable is a reset.
+    Reset,
 }
 
 /// A field.

--- a/compiler/qsc_frontend/src/closure.rs
+++ b/compiler/qsc_frontend/src/closure.rs
@@ -151,6 +151,7 @@ pub(super) fn lift(
         adj: None,
         ctl: None,
         ctl_adj: None,
+        attrs: Vec::default(),
     };
 
     (free_vars, callable)

--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -2221,10 +2221,36 @@ fn test_measurement_attr_on_function_issues_error() {
         "#},
         &expect![[r#"
             [
-                InvalidMeasurementAttrOnFunction(
+                InvalidAttrOnFunction(
+                    "Measurement",
                     Span {
                         lo: 49,
                         hi: 52,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn test_reset_attr_on_function_issues_error() {
+    check_errors(
+        indoc! {r#"
+            namespace Test {
+                @Reset()
+                function Foo(q: Qubit) : Unit {
+                    body intrinsic;
+                }
+            }
+        "#},
+        &expect![[r#"
+            [
+                InvalidAttrOnFunction(
+                    "Reset",
+                    Span {
+                        lo: 43,
+                        hi: 46,
                     },
                 ),
             ]

--- a/compiler/qsc_hir/src/hir.rs
+++ b/compiler/qsc_hir/src/hir.rs
@@ -391,6 +391,8 @@ pub struct CallableDecl {
     pub ctl: Option<SpecDecl>,
     /// The controlled adjoint specialization.
     pub ctl_adj: Option<SpecDecl>,
+    /// The attributes of the callable, (e.g.: Measurement or Reset).
+    pub attrs: Vec<Attr>,
 }
 
 impl CallableDecl {
@@ -1352,8 +1354,11 @@ pub enum Attr {
     /// and any implementation should be ignored.
     SimulatableIntrinsic,
     /// Indicates that a callable is a measurement. This means that the operation will be marked as
-    /// "irreversible" in the generated QIR.
+    /// "irreversible" in the generated QIR, and output Result types will be moved to the arguments.
     Measurement,
+    /// Indicates that a callable is a reset. This means that the operation will be marked as
+    /// "irreversible" in the generated QIR.
+    Reset,
 }
 
 impl FromStr for Attr {
@@ -1366,6 +1371,7 @@ impl FromStr for Attr {
             "Unimplemented" => Ok(Self::Unimplemented),
             "SimulatableIntrinsic" => Ok(Self::SimulatableIntrinsic),
             "Measurement" => Ok(Self::Measurement),
+            "Reset" => Ok(Self::Reset),
             _ => Err(()),
         }
     }

--- a/compiler/qsc_lowerer/src/lib.rs
+++ b/compiler/qsc_lowerer/src/lib.rs
@@ -282,6 +282,7 @@ impl Lowerer {
             };
             CallableImpl::Spec(specialized_implementation)
         };
+        let attrs = lower_attrs(&decl.attrs);
 
         self.assigner.reset_local();
         self.locals.clear();
@@ -299,6 +300,7 @@ impl Lowerer {
             output,
             functors,
             implementation,
+            attrs,
         }
     }
 
@@ -888,6 +890,7 @@ fn lower_attrs(attrs: &[hir::Attr]) -> Vec<fir::Attr> {
         .filter_map(|attr| match attr {
             hir::Attr::EntryPoint => Some(fir::Attr::EntryPoint),
             hir::Attr::Measurement => Some(fir::Attr::Measurement),
+            hir::Attr::Reset => Some(fir::Attr::Reset),
             hir::Attr::SimulatableIntrinsic | hir::Attr::Unimplemented | hir::Attr::Config => None,
         })
         .collect()

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -2401,7 +2401,7 @@ impl<'a> PartialEvaluator<'a> {
             call_type: CallableType::Reset,
         };
 
-        // Resove the call arguments, create the call instruction and insert it to the current block.
+        // Resolve the call arguments, create the call instruction and insert it to the current block.
         let (args, ctls_arg) = self
             .resolve_args(
                 (store_item_id.package, callable_decl.input).into(),

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -6,7 +6,8 @@ use super::tests_common::{
     CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION, CUSTOM_MEASUREMENT,
-    CUSTOM_MEASUREMENT_WITH_SIMULATABLE_INTRINSIC_ATTR, LOOP_WITH_DYNAMIC_CONDITION,
+    CUSTOM_MEASUREMENT_WITH_SIMULATABLE_INTRINSIC_ATTR, CUSTOM_RESET,
+    CUSTOM_RESET_WITH_SIMULATABLE_INTRINSIC_ATTR, LOOP_WITH_DYNAMIC_CONDITION,
     MEASUREMENT_WITHIN_DYNAMIC_SCOPE, MINIMAL, RETURN_WITHIN_DYNAMIC_SCOPE, USE_CLOSURE_FUNCTION,
     USE_DYNAMICALLY_SIZED_ARRAY, USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE,
     USE_DYNAMIC_FUNCTION, USE_DYNAMIC_INDEX, USE_DYNAMIC_INT, USE_DYNAMIC_LHS_EXP_BINOP,
@@ -460,6 +461,26 @@ fn custom_measurement_yields_no_errors() {
 fn custom_measurement_with_simulatable_intrinsic_yields_no_errors() {
     check_profile(
         CUSTOM_MEASUREMENT_WITH_SIMULATABLE_INTRINSIC_ATTR,
+        &expect![[r#"
+            []
+        "#]],
+    );
+}
+
+#[test]
+fn custom_reset_yields_no_errors() {
+    check_profile(
+        CUSTOM_RESET,
+        &expect![[r#"
+            []
+        "#]],
+    );
+}
+
+#[test]
+fn custom_reset_with_simulatable_intrinsic_yields_no_errors() {
+    check_profile(
+        CUSTOM_RESET_WITH_SIMULATABLE_INTRINSIC_ATTR,
         &expect![[r#"
             []
         "#]],

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -467,9 +467,8 @@ fn custom_measurement_yields_no_errors() {
 
 #[test]
 fn custom_measurement_with_simulatable_intrinsic_yields_no_errors() {
-    check_profile_extended(
+    check_profile(
         CUSTOM_MEASUREMENT_WITH_SIMULATABLE_INTRINSIC_ATTR,
-        TargetCapabilityFlags::QubitReset,
         &expect![[r#"
             []
         "#]],
@@ -489,8 +488,9 @@ fn custom_reset_yields_no_errors() {
 
 #[test]
 fn custom_reset_with_simulatable_intrinsic_yields_no_errors() {
-    check_profile(
+    check_profile_extended(
         CUSTOM_RESET_WITH_SIMULATABLE_INTRINSIC_ATTR,
+        TargetCapabilityFlags::QubitReset,
         &expect![[r#"
             []
         "#]],

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -25,6 +25,14 @@ fn check_profile(source: &str, expect: &Expect) {
     check(source, expect, TargetCapabilityFlags::Adaptive);
 }
 
+fn check_profile_extended(source: &str, capabilities: TargetCapabilityFlags, expect: &Expect) {
+    check(
+        source,
+        expect,
+        TargetCapabilityFlags::Adaptive | capabilities,
+    );
+}
+
 fn check_profile_for_exe(source: &str, expect: &Expect) {
     check_for_exe(source, expect, TargetCapabilityFlags::Adaptive);
 }
@@ -459,8 +467,9 @@ fn custom_measurement_yields_no_errors() {
 
 #[test]
 fn custom_measurement_with_simulatable_intrinsic_yields_no_errors() {
-    check_profile(
+    check_profile_extended(
         CUSTOM_MEASUREMENT_WITH_SIMULATABLE_INTRINSIC_ATTR,
+        TargetCapabilityFlags::QubitReset,
         &expect![[r#"
             []
         "#]],
@@ -469,8 +478,9 @@ fn custom_measurement_with_simulatable_intrinsic_yields_no_errors() {
 
 #[test]
 fn custom_reset_yields_no_errors() {
-    check_profile(
+    check_profile_extended(
         CUSTOM_RESET,
+        TargetCapabilityFlags::QubitReset,
         &expect![[r#"
             []
         "#]],

--- a/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_base.rs
@@ -6,7 +6,8 @@ use super::tests_common::{
     CALL_TO_CYCLIC_FUNCTION_WITH_CLASSICAL_ARGUMENT, CALL_TO_CYCLIC_FUNCTION_WITH_DYNAMIC_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_CLASSICAL_ARGUMENT,
     CALL_TO_CYCLIC_OPERATION_WITH_DYNAMIC_ARGUMENT, CALL_UNRESOLVED_FUNCTION, CUSTOM_MEASUREMENT,
-    CUSTOM_MEASUREMENT_WITH_SIMULATABLE_INTRINSIC_ATTR, LOOP_WITH_DYNAMIC_CONDITION,
+    CUSTOM_MEASUREMENT_WITH_SIMULATABLE_INTRINSIC_ATTR, CUSTOM_RESET,
+    CUSTOM_RESET_WITH_SIMULATABLE_INTRINSIC_ATTR, LOOP_WITH_DYNAMIC_CONDITION,
     MEASUREMENT_WITHIN_DYNAMIC_SCOPE, MINIMAL, RETURN_WITHIN_DYNAMIC_SCOPE, USE_CLOSURE_FUNCTION,
     USE_DYNAMICALLY_SIZED_ARRAY, USE_DYNAMIC_BIG_INT, USE_DYNAMIC_BOOLEAN, USE_DYNAMIC_DOUBLE,
     USE_DYNAMIC_FUNCTION, USE_DYNAMIC_INDEX, USE_DYNAMIC_INT, USE_DYNAMIC_LHS_EXP_BINOP,
@@ -574,6 +575,40 @@ fn custom_measurement_with_simulatable_intrinsic_yields_errors() {
                     Span {
                         lo: 99,
                         hi: 105,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn custom_reset_yields_errors() {
+    check_profile(
+        CUSTOM_RESET,
+        &expect![[r#"
+            [
+                CallToCustomReset(
+                    Span {
+                        lo: 145,
+                        hi: 151,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn custom_reset_with_simulatable_intrinsic_yields_errors() {
+    check_profile(
+        CUSTOM_RESET_WITH_SIMULATABLE_INTRINSIC_ATTR,
+        &expect![[r#"
+            [
+                CallToCustomReset(
+                    Span {
+                        lo: 145,
+                        hi: 151,
                     },
                 ),
             ]

--- a/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_common.rs
@@ -353,6 +353,39 @@ pub const CUSTOM_MEASUREMENT_WITH_SIMULATABLE_INTRINSIC_ATTR: &str = r#"
         }
     }"#;
 
+pub const CUSTOM_RESET: &str = r#"
+    namespace Test {
+        operation Main() : Result {
+            use q = Qubit();
+            H(q);
+            let res = M(q);
+            Foo(q);
+            res
+        }
+
+        @Reset()
+        operation Foo(q: Qubit) : Unit {
+            body intrinsic;
+        }
+    }"#;
+
+pub const CUSTOM_RESET_WITH_SIMULATABLE_INTRINSIC_ATTR: &str = r#"
+    namespace Test {
+        operation Main() : Result {
+            use q = Qubit();
+            H(q);
+            let res = M(q);
+            Foo(q);
+            res
+        }
+
+        @Reset()
+        @SimulatableIntrinsic()
+        operation Foo(q: Qubit) : Unit {
+            Reset(q);
+        }
+    }"#;
+
 pub const USE_DYNAMIC_INDEX: &str = r#"
     namespace Test {
         import Std.Convert.*;

--- a/compiler/qsc_passes/src/lib.rs
+++ b/compiler/qsc_passes/src/lib.rs
@@ -13,6 +13,7 @@ mod logic_sep;
 mod loop_unification;
 mod measurement;
 mod replace_qubit_allocation;
+mod reset;
 mod spec_gen;
 
 use callable_limits::CallableLimits;
@@ -49,6 +50,7 @@ pub enum Error {
     ConjInvert(conjugate_invert::Error),
     EntryPoint(entry_point::Error),
     Measurement(measurement::Error),
+    Reset(reset::Error),
     SpecGen(spec_gen::Error),
 }
 
@@ -108,6 +110,7 @@ impl PassContext {
         Validator::default().visit_package(package);
 
         let measurement_decl_errors = measurement::validate_measurement_declarations(package);
+        let reset_decl_errors = reset::validate_reset_declarations(package);
 
         let entry_point_errors = generate_entry_expr(package, assigner, package_type);
         Validator::default().visit_package(package);
@@ -126,6 +129,7 @@ impl PassContext {
             .chain(conjugate_errors.into_iter().map(Error::ConjInvert))
             .chain(entry_point_errors)
             .chain(measurement_decl_errors.into_iter().map(Error::Measurement))
+            .chain(reset_decl_errors.into_iter().map(Error::Reset))
             .collect()
     }
 

--- a/compiler/qsc_passes/src/reset.rs
+++ b/compiler/qsc_passes/src/reset.rs
@@ -23,7 +23,7 @@ pub enum Error {
     #[diagnostic(code("Qsc.Reset.NonQubitArgument"))]
     NonQubitArgument(#[label] Span),
 
-    #[error("a callable with the reset attribute should only have outputs of type Result")]
+    #[error("a callable with the reset attribute should have output of type Unit")]
     #[diagnostic(code("Qsc.Reset.NonResultOutput"))]
     NonUnitOutput(#[label] Span),
 

--- a/compiler/qsc_passes/src/reset/tests.rs
+++ b/compiler/qsc_passes/src/reset/tests.rs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(clippy::needless_raw_string_hashes)]
+
+use crate::reset::validate_reset_declarations;
+use expect_test::{expect, Expect};
+use indoc::indoc;
+use qsc_data_structures::{language_features::LanguageFeatures, target::TargetCapabilityFlags};
+use qsc_frontend::compile::{self, compile, PackageStore, SourceMap};
+
+fn check(file: &str, expr: &str, expect: &Expect) {
+    let sources = SourceMap::new([("test".into(), file.into())], Some(expr.into()));
+    let unit = compile(
+        &PackageStore::new(compile::core()),
+        &[],
+        sources,
+        TargetCapabilityFlags::all(),
+        LanguageFeatures::default(),
+    );
+
+    let errors = validate_reset_declarations(&unit.package);
+    expect.assert_debug_eq(&errors);
+}
+
+#[test]
+fn test_custom_reset_declaration_with_simulatable_intrinsic_attr() {
+    check(
+        indoc! {"
+            namespace Test {
+                @Reset()
+                @SimulatableIntrinsic()
+                operation CustomReset(target: Qubit) : Unit {
+                    Reset(target);
+                }
+            }"},
+        "",
+        &expect![[r#"
+            []
+        "#]],
+    );
+}
+
+#[test]
+fn test_custom_reset_declaration() {
+    check(
+        indoc! {"
+            namespace Test {
+                @Reset()
+                operation CustomReset(target: Qubit) : Unit { body intrinsic; }
+            }"},
+        "",
+        &expect![[r#"
+            []
+        "#]],
+    );
+}
+
+#[test]
+fn test_reset_with_no_arguments_error() {
+    check(
+        indoc! {"
+            namespace Test {
+                @Reset()
+                operation CustomReset() : Unit { body intrinsic; }
+            }"},
+        "",
+        &expect![[r#"
+            [
+                NoArguments(
+                    Span {
+                        lo: 56,
+                        hi: 58,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn test_non_intrinsic_reset_error() {
+    check(
+        indoc! {"
+            namespace Test {
+                @Reset()
+                operation CustomReset(target: Qubit) : Unit { Reset(target); }
+            }"},
+        "",
+        &expect![[r#"
+            [
+                NotIntrinsic(
+                    Span {
+                        lo: 45,
+                        hi: 56,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn test_non_qubit_arguments_error() {
+    check(
+        indoc! {"
+            namespace Test {
+                @Reset()
+                operation CustomReset(target: Qubit, n: Int) : Unit { body intrinsic; }
+            }"},
+        "",
+        &expect![[r#"
+            [
+                NonQubitArgument(
+                    Span {
+                        lo: 56,
+                        hi: 79,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn test_non_unit_output_error() {
+    check(
+        indoc! {"
+            namespace Test {
+                @Reset()
+                operation CustomReset(target: Qubit) : Reset { body intrinsic; }
+            }"},
+        "",
+        &expect![[r#"
+            [
+                NonUnitOutput(
+                    Span {
+                        lo: 35,
+                        hi: 99,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}

--- a/compiler/qsc_qasm3/src/tests/statement/reset.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/reset.rs
@@ -139,7 +139,7 @@ fn reset_with_adaptive_ri_profile_generates_reset_qir() -> miette::Result<(), Ve
           ret void
         }
 
-        declare void @__quantum__qis__reset__body(%Qubit*)
+        declare void @__quantum__qis__reset__body(%Qubit*) #1
 
         declare void @__quantum__qis__h__body(%Qubit*)
 

--- a/compiler/qsc_rca/src/core.rs
+++ b/compiler/qsc_rca/src/core.rs
@@ -15,10 +15,11 @@ use qsc_data_structures::{functors::FunctorApp, index_map::IndexMap};
 use qsc_fir::{
     extensions::InputParam,
     fir::{
-        BinOp, Block, BlockId, CallableDecl, CallableImpl, CallableKind, Expr, ExprId, ExprKind,
-        FieldAssign, Global, Ident, Item, ItemKind, LocalVarId, Mutability, Package, PackageId,
-        PackageLookup, PackageStore, PackageStoreLookup, Pat, PatId, PatKind, Res, SpecDecl,
-        SpecImpl, Stmt, StmtId, StmtKind, StoreExprId, StoreItemId, StorePatId, StringComponent,
+        Attr, BinOp, Block, BlockId, CallableDecl, CallableImpl, CallableKind, Expr, ExprId,
+        ExprKind, FieldAssign, Global, Ident, Item, ItemKind, LocalVarId, Mutability, Package,
+        PackageId, PackageLookup, PackageStore, PackageStoreLookup, Pat, PatId, PatKind, Res,
+        SpecDecl, SpecImpl, Stmt, StmtId, StmtKind, StoreExprId, StoreItemId, StorePatId,
+        StringComponent,
     },
     ty::{Arrow, FunctorSetValue, Prim, Ty},
     visit::{walk_stmt, Visitor},
@@ -1239,6 +1240,7 @@ impl<'a> Analyzer<'a> {
             callable_decl.kind,
             input_params,
             callable_decl.output.clone(),
+            &callable_decl.attrs,
         );
 
         // Continue with the analysis differently depending on whether the callable is an intrinsic or not.
@@ -1788,7 +1790,12 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
         let package = self.package_store.get(package_id);
         let input_params = package.derive_callable_input_params(decl);
         let current_callable_context = self.get_current_item_context_mut();
-        current_callable_context.set_callable_context(decl.kind, input_params, decl.output.clone());
+        current_callable_context.set_callable_context(
+            decl.kind,
+            input_params,
+            decl.output.clone(),
+            &decl.attrs,
+        );
         self.visit_callable_impl(&decl.implementation);
     }
 
@@ -2129,12 +2136,14 @@ impl ItemContext {
         kind: CallableKind,
         input_params: Vec<InputParam>,
         output_type: Ty,
+        attrs: &[Attr],
     ) {
         assert!(self.callable_context.is_none());
         self.callable_context = Some(CallableContext {
             kind,
             input_params,
             output_type,
+            attrs: attrs.to_vec(),
         });
     }
 
@@ -2148,6 +2157,7 @@ struct CallableContext {
     pub kind: CallableKind,
     pub input_params: Vec<InputParam>,
     pub output_type: Ty,
+    pub attrs: Vec<Attr>,
 }
 
 struct SpecContext {
@@ -2252,13 +2262,17 @@ fn derive_instrinsic_operation_application_generator_set(
         ValueKind::new_dynamic_from_type(&callable_context.output_type)
     };
 
+    let mut inherent_runtime_features = RuntimeFeatureFlags::empty();
+    if callable_context.attrs.contains(&Attr::Measurement) {
+        inherent_runtime_features |= RuntimeFeatureFlags::CallToCustomMeasurement;
+    }
+    if callable_context.attrs.contains(&Attr::Reset) {
+        inherent_runtime_features |= RuntimeFeatureFlags::CallToCustomReset;
+    }
+
     // The compute kind of intrinsic operations is always quantum.
     let inherent_compute_kind = ComputeKind::Quantum(QuantumProperties {
-        runtime_features: if matches!(callable_context.kind, CallableKind::Operation) {
-            RuntimeFeatureFlags::empty()
-        } else {
-            RuntimeFeatureFlags::CustomMeasurement
-        },
+        runtime_features: inherent_runtime_features,
         value_kind,
     });
 

--- a/compiler/qsc_rca/src/errors.rs
+++ b/compiler/qsc_rca/src/errors.rs
@@ -167,6 +167,12 @@ pub enum Error {
     #[diagnostic(code("Qsc.CapabilitiesCk.CallToCustomMeasurement"))]
     CallToCustomMeasurement(#[label] Span),
 
+    #[error("cannot call a custom reset")]
+    #[diagnostic(help("cannot call a custom reset in the configured target profile"))]
+    #[diagnostic(url("https://aka.ms/qdk.qir#call-to-custom-reset"))]
+    #[diagnostic(code("Qsc.CapabilitiesCk.CallToCustomReset"))]
+    CallToCustomReset(#[label] Span),
+
     #[error("cannot access an array using a dynamic index")]
     #[diagnostic(help("accessing an array using an index that depends on a measurement result is not supported by the configured target profile"))]
     #[diagnostic(url("https://aka.ms/qdk.qir#use-of-dynamic-array-index"))]
@@ -308,8 +314,11 @@ pub fn generate_errors_from_runtime_features(
     if runtime_features.contains(RuntimeFeatureFlags::UseOfAdvancedOutput) {
         errors.push(Error::UseOfAdvancedOutput(span));
     }
-    if runtime_features.contains(RuntimeFeatureFlags::CustomMeasurement) {
+    if runtime_features.contains(RuntimeFeatureFlags::CallToCustomMeasurement) {
         errors.push(Error::CallToCustomMeasurement(span));
+    }
+    if runtime_features.contains(RuntimeFeatureFlags::CallToCustomReset) {
+        errors.push(Error::CallToCustomReset(span));
     }
     errors
 }

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -810,8 +810,10 @@ bitflags! {
         const UseOfDynamicResult = 1 << 26;
         /// Use of a dynamic tuple variable.
         const UseOfDynamicTuple = 1 << 27;
-        /// A custom measurement was declared using the @Measurement attribute.
-        const CustomMeasurement = 1 << 28;
+        /// A callee expression to a measurement.
+        const CallToCustomMeasurement = 1 << 28;
+        /// A callee expression to a reset.
+        const CallToCustomReset = 1 << 29;
     }
 }
 
@@ -914,8 +916,12 @@ impl RuntimeFeatureFlags {
         if self.contains(RuntimeFeatureFlags::UseOfDynamicTuple) {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
-        if self.contains(RuntimeFeatureFlags::CustomMeasurement) {
+        if self.contains(RuntimeFeatureFlags::CallToCustomMeasurement) {
             capabilities |= TargetCapabilityFlags::Adaptive;
+        }
+        if self.contains(RuntimeFeatureFlags::CallToCustomReset) {
+            capabilities |= TargetCapabilityFlags::Adaptive;
+            capabilities |= TargetCapabilityFlags::QubitReset;
         }
         capabilities
     }

--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -132,6 +132,7 @@ fn collect_hardcoded_words(expected: WordKinds) -> Vec<Completion> {
                     Completion::new("EntryPoint".to_string(), CompletionItemKind::Interface),
                     Completion::new("Config".to_string(), CompletionItemKind::Interface),
                     Completion::new("Measurement".to_string(), CompletionItemKind::Interface),
+                    Completion::new("Reset".to_string(), CompletionItemKind::Interface),
                 ]);
             }
             HardcodedIdentKind::Size => {

--- a/pip/tests-integration/resources/output/Adaptive_RI/ArithmeticOps.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/ArithmeticOps.ll
@@ -93,7 +93,7 @@ declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
 declare i1 @__quantum__qis__read_result__body(%Result*)
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/BernsteinVaziraniNISQ.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/BernsteinVaziraniNISQ.ll
@@ -41,7 +41,7 @@ declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
 declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__array_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/ConstantFolding.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/ConstantFolding.ll
@@ -47,7 +47,7 @@ declare void @__quantum__qis__rx__body(double, %Qubit*)
 
 declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__array_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/DeutschJozsaNISQ.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/DeutschJozsaNISQ.ll
@@ -65,7 +65,7 @@ declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
 declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/Functors.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/Functors.ll
@@ -95,7 +95,7 @@ declare void @__quantum__qis__s__adj(%Qubit*)
 
 declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/IntegerComparison.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/IntegerComparison.ll
@@ -119,7 +119,7 @@ declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
 declare i1 @__quantum__qis__read_result__body(%Result*)
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/IntrinsicCCNOT.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/IntrinsicCCNOT.ll
@@ -47,7 +47,7 @@ declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
 
 declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__qis__x__body(%Qubit*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/IntrinsicCNOT.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/IntrinsicCNOT.ll
@@ -28,7 +28,7 @@ declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
 declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__qis__x__body(%Qubit*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/IntrinsicM.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/IntrinsicM.ll
@@ -18,7 +18,7 @@ declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/MeasurementComparison.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/MeasurementComparison.ll
@@ -38,7 +38,7 @@ declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
 declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare i1 @__quantum__qis__read_result__body(%Result*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/NestedBranching.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/NestedBranching.ll
@@ -305,7 +305,7 @@ declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
 declare i1 @__quantum__qis__read_result__body(%Result*)
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__qis__y__body(%Qubit*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/RandomBit.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/RandomBit.ll
@@ -14,7 +14,7 @@ declare void @__quantum__qis__h__body(%Qubit*)
 
 declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__result_record_output(%Result*, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/SampleTeleport.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/SampleTeleport.ll
@@ -46,7 +46,7 @@ declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
 
 declare void @__quantum__qis__z__body(%Qubit*)
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__result_record_output(%Result*, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/ShortcuttingMeasurement.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/ShortcuttingMeasurement.ll
@@ -38,7 +38,7 @@ declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
 declare i1 @__quantum__qis__read_result__body(%Result*)
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/Slicing.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/Slicing.ll
@@ -36,7 +36,7 @@ declare void @__quantum__qis__x__body(%Qubit*)
 
 declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__array_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/SuperdenseCoding.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/SuperdenseCoding.ll
@@ -59,7 +59,7 @@ declare void @__quantum__qis__x__body(%Qubit*)
 
 declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/SwitchHandling.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/SwitchHandling.ll
@@ -58,7 +58,7 @@ declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
 declare i1 @__quantum__qis__read_result__body(%Result*)
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__qis__ry__body(double, %Qubit*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/ThreeQubitRepetitionCode.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/ThreeQubitRepetitionCode.ll
@@ -283,7 +283,7 @@ declare i1 @__quantum__qis__read_result__body(%Result*)
 
 declare void @__quantum__qis__x__body(%Qubit*)
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__tuple_record_output(i64, i8*)
 

--- a/pip/tests-integration/resources/output/Adaptive_RI/WithinApply.ll
+++ b/pip/tests-integration/resources/output/Adaptive_RI/WithinApply.ll
@@ -27,7 +27,7 @@ declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
 
 declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-declare void @__quantum__qis__reset__body(%Qubit*)
+declare void @__quantum__qis__reset__body(%Qubit*) #1
 
 declare void @__quantum__rt__array_record_output(i64, i8*)
 


### PR DESCRIPTION
This PR adds support for custom resets using the `@Reset` attribute. It consists of the following changes:
 - Adding a `@Reset` attribute to the language.
 - Piping it down to FIR.
 - Using the attribute to generate the correct QIR, including the `"irreversible"` attribute.
 - Semantic validation passes in `qsc_passes` based on the `@Reset` attribute.
 - The right handling of reset operations during partial evaluation.
 - Unit tests.
 - Update previous tests to include the `#1` irreversible attribute in QIR when calling the Reset operation.