### PR TITLE
Telementry event for noisy simulation

### DIFF
--- a/vscode/src/telemetry.ts
+++ b/vscode/src/telemetry.ts
@@ -39,6 +39,7 @@ export enum EventType {
   ResourceEstimationEnd = "Qsharp.ResourceEstimationEnd",
   TriggerHistogram = "Qsharp.TriggerHistogram",
   HistogramStart = "Qsharp.HistogramStart",
+  NoisySimulation = "Qsharp.NoisySimulation",
   HistogramEnd = "Qsharp.HistogramEnd",
   FormatStart = "Qsharp.FormatStart",
   FormatEnd = "Qsharp.FormatEnd",
@@ -206,6 +207,10 @@ type EventTypes = {
     measurements: Empty;
   };
   [EventType.HistogramStart]: {
+    properties: { associationId: string };
+    measurements: Empty;
+  };
+  [EventType.NoisySimulation]: {
     properties: { associationId: string };
     measurements: Empty;
   };

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -345,6 +345,9 @@ export function registerWebViewCommands(context: ExtensionContext) {
         sendTelemetryEvent(EventType.HistogramStart, { associationId }, {});
 
         const noise = getPauliNoiseModel();
+        if (noise[0] != 0 || noise[1] != 0 || noise[2] != 0) {
+          sendTelemetryEvent(EventType.NoisySimulation, { associationId }, {});
+        }
         await worker.runWithPauliNoise(
           program.programConfig,
           "",


### PR DESCRIPTION
This adds telemetry even when noisy simulation is used in vscode plugin.