### PR TITLE
Disable completions in attribute arguments

### DIFF
--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -139,7 +139,6 @@ fn collect_hardcoded_words(expected: WordKinds) -> Vec<Completion> {
                 completions.extend([
                     Completion::new("EntryPoint".to_string(), CompletionItemKind::Interface),
                     Completion::new("Config".to_string(), CompletionItemKind::Interface),
-                    Completion::new("Unimplemented".to_string(), CompletionItemKind::Interface),
                     Completion::new(
                         "SimulatableIntrinsic".to_string(),
                         CompletionItemKind::Interface,

--- a/language_service/src/completion/fields.rs
+++ b/language_service/src/completion/fields.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::{path_context::PathOrFieldAccess, Completion};
+use super::{ast_context::AstContext, Completion};
 use crate::{compilation::Compilation, protocol::CompletionItemKind};
 use qsc::{
     display::Lookup,
@@ -15,19 +15,19 @@ use qsc::{
 /// provides the possible field names.
 pub(super) struct Fields<'a> {
     compilation: &'a Compilation,
-    path_context: &'a PathOrFieldAccess<'a>,
+    ast_context: &'a AstContext<'a>,
 }
 
 impl<'a> Fields<'a> {
-    pub(crate) fn new(compilation: &'a Compilation, path_context: &'a PathOrFieldAccess) -> Self {
+    pub(crate) fn new(compilation: &'a Compilation, ast_context: &'a AstContext) -> Self {
         Self {
             compilation,
-            path_context,
+            ast_context,
         }
     }
 
     pub(crate) fn fields(&self) -> Vec<Completion> {
-        let Some(id) = self.path_context.field_access_context() else {
+        let Some(id) = self.ast_context.field_access_context() else {
             return vec![];
         };
 

--- a/language_service/src/completion/tests.rs
+++ b/language_service/src/completion/tests.rs
@@ -3804,3 +3804,45 @@ fn field_access_local_shadows_global() {
         "#]],
     );
 }
+
+#[test]
+fn no_completion_inside_attr() {
+    check(
+        "namespace Test {
+
+        @Config(↘)
+        function Main() : Unit {
+            let FakeStdLib = new Foo { bar = 3 };
+            FakeStdLib.↘
+        }
+    }",
+        &["Fake", "not", "Test"],
+        &expect![[r#"
+            [
+                None,
+                None,
+                None,
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn no_path_segment_completion_inside_attr() {
+    check(
+        "namespace Test {
+
+        @Config(FakeStdLib.↘)
+        function Main() : Unit {
+        }
+    }",
+        &["Fake", "not", "Test"],
+        &expect![[r#"
+            [
+                None,
+                None,
+                None,
+            ]
+        "#]],
+    );
+}


### PR DESCRIPTION
Disable completions inside attribute arguments, despite what the parser says, since we support either hardcoded values or nothing at all.

examples:

```qsharp
@Config( | ) 
operation Foo() : Unit {}
```

```qsharp
@EntryPoint( | ) 
operation Foo() : Unit {}
```

no completions at this locations.