### PR TITLE
More parser error recovery, unlocking completions in more locations

### DIFF
--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -4555,7 +4555,7 @@ fn expr_incomplete_field_access_no_semi() {
         &expect![[r##"
             #14 55-57 "()" : Unit
             #18 65-99 "{\n        (new B { C = 5 }).\n    }" : ?
-            #20 75-93 "(new B { C = 5 })." : ?
+            #20 75-98 "(new B { C = 5 }).\n    " : ?
             #21 75-92 "(new B { C = 5 })" : UDT<"B": Item 1>
             #22 76-91 "new B { C = 5 }" : UDT<"B": Item 1>
             #27 88-89 "5" : Int

--- a/compiler/qsc_parse/src/item/tests.rs
+++ b/compiler/qsc_parse/src/item/tests.rs
@@ -3,7 +3,7 @@
 
 use super::{
     parse, parse_attr, parse_implicit_namespace, parse_import_or_export, parse_open,
-    parse_spec_decl,
+    parse_spec_decl, parse_top_level_nodes,
 };
 use crate::{
     scan::ParserContext,
@@ -927,19 +927,28 @@ fn function_missing_output_ty() {
         parse,
         "function Foo() { body intrinsic; }",
         &expect![[r#"
-            Error(
-                Token(
-                    Colon,
-                    Open(
-                        Brace,
+            Item _id_ [0-34]:
+                Callable _id_ [0-34] (Function):
+                    name: Ident _id_ [9-12] "Foo"
+                    input: Pat _id_ [12-14]: Unit
+                    output: Type _id_ [15-15]: Err
+                    body: Specializations:
+                        SpecDecl _id_ [17-32] (Body): Gen: Intrinsic
+
+            [
+                Error(
+                    Token(
+                        Colon,
+                        Open(
+                            Brace,
+                        ),
+                        Span {
+                            lo: 15,
+                            hi: 16,
+                        },
                     ),
-                    Span {
-                        lo: 15,
-                        hi: 16,
-                    },
                 ),
-            )
-        "#]],
+            ]"#]],
     );
 }
 
@@ -1405,7 +1414,12 @@ fn recover_callable_item() {
                         body: Block: Block _id_ [47-52]:
                             Stmt _id_ [49-50]: Expr: Expr _id_ [49-50]: Lit: Int(5)
                 Item _id_ [65-86]:
-                    Err
+                    Callable _id_ [65-86] (Function):
+                        name: Ident _id_ [74-77] "Bar"
+                        input: Pat _id_ [77-79]: Unit
+                        output: Type _id_ [80-80]: Err
+                        body: Block: Block _id_ [80-86]:
+                            Stmt _id_ [82-84]: Expr: Expr _id_ [82-84]: Lit: Int(10)
                 Item _id_ [99-131]:
                     Callable _id_ [99-131] (Operation):
                         name: Ident _id_ [109-112] "Baz"
@@ -2246,6 +2260,118 @@ fn missing_semi_between_items() {
                         Span {
                             lo: 44,
                             hi: 45,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn callable_decl_no_return_type_or_body_recovery() {
+    check(
+        parse,
+        "operation Foo<'T>() : ",
+        &expect![[r#"
+            Item _id_ [0-22]:
+                Callable _id_ [0-22] (Operation):
+                    name: Ident _id_ [10-13] "Foo"
+                    generics:
+                        Ident _id_ [14-16] "'T"
+                    input: Pat _id_ [17-19]: Unit
+                    output: Type _id_ [22-22]: Err
+                    body: Block: Block _id_ [22-22]: <empty>
+
+            [
+                Error(
+                    Rule(
+                        "type",
+                        Eof,
+                        Span {
+                            lo: 22,
+                            hi: 22,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn callable_decl_broken_return_type_no_body_recovery() {
+    check(
+        parse,
+        "operation Foo<'T>() : () => ",
+        &expect![[r#"
+            Item _id_ [0-28]:
+                Callable _id_ [0-28] (Operation):
+                    name: Ident _id_ [10-13] "Foo"
+                    generics:
+                        Ident _id_ [14-16] "'T"
+                    input: Pat _id_ [17-19]: Unit
+                    output: Type _id_ [22-28]: Arrow (Operation):
+                        param: Type _id_ [22-24]: Unit
+                        return: Type _id_ [28-28]: Err
+                    body: Block: Block _id_ [28-28]: <empty>
+
+            [
+                Error(
+                    Rule(
+                        "type",
+                        Eof,
+                        Span {
+                            lo: 28,
+                            hi: 28,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn top_level_nodes() {
+    check_vec(
+        parse_top_level_nodes,
+        "function Foo() : Unit { body intrinsic; } let x = 5;",
+        &expect![[r#"
+            Stmt _id_ [0-41]: Item: Item _id_ [0-41]:
+                Callable _id_ [0-41] (Function):
+                    name: Ident _id_ [9-12] "Foo"
+                    input: Pat _id_ [12-14]: Unit
+                    output: Type _id_ [17-21]: Path: Path _id_ [17-21] (Ident _id_ [17-21] "Unit")
+                    body: Specializations:
+                        SpecDecl _id_ [24-39] (Body): Gen: Intrinsic,
+            Stmt _id_ [42-52]: Local (Immutable):
+                Pat _id_ [46-47]: Bind:
+                    Ident _id_ [46-47] "x"
+                Expr _id_ [50-51]: Lit: Int(5)"#]],
+    );
+}
+
+#[test]
+fn top_level_nodes_error_recovery() {
+    check_vec(
+        parse_top_level_nodes,
+        "function Foo() : Unit { body intrinsic; } 3 + ",
+        &expect![[r#"
+            Stmt _id_ [0-41]: Item: Item _id_ [0-41]:
+                Callable _id_ [0-41] (Function):
+                    name: Ident _id_ [9-12] "Foo"
+                    input: Pat _id_ [12-14]: Unit
+                    output: Type _id_ [17-21]: Path: Path _id_ [17-21] (Ident _id_ [17-21] "Unit")
+                    body: Specializations:
+                        SpecDecl _id_ [24-39] (Body): Gen: Intrinsic,
+            Stmt _id_ [42-45]: Err
+
+            [
+                Error(
+                    Rule(
+                        "expression",
+                        Eof,
+                        Span {
+                            lo: 46,
+                            hi: 46,
                         },
                     ),
                 ),

--- a/compiler/qsc_parse/src/prim/tests.rs
+++ b/compiler/qsc_parse/src/prim/tests.rs
@@ -287,17 +287,22 @@ fn pat_missing_ty() {
         pat,
         "foo :",
         &expect![[r#"
-            Error(
-                Rule(
-                    "type",
-                    Eof,
-                    Span {
-                        lo: 5,
-                        hi: 5,
-                    },
+            Pat _id_ [0-5]: Bind:
+                Ident _id_ [0-3] "foo"
+                Type _id_ [5-5]: Err
+
+            [
+                Error(
+                    Rule(
+                        "type",
+                        Eof,
+                        Span {
+                            lo: 5,
+                            hi: 5,
+                        },
+                    ),
                 ),
-            )
-        "#]],
+            ]"#]],
     );
 }
 

--- a/compiler/qsc_parse/src/stmt/tests.rs
+++ b/compiler/qsc_parse/src/stmt/tests.rs
@@ -714,7 +714,10 @@ fn recover_in_block() {
         "{ let x = 1 +; x }",
         &expect![[r#"
             Block _id_ [0-18]:
-                Stmt _id_ [2-14]: Err
+                Stmt _id_ [2-14]: Local (Immutable):
+                    Pat _id_ [6-7]: Bind:
+                        Ident _id_ [6-7] "x"
+                    Expr _id_ [10-13]: Err
                 Stmt _id_ [15-16]: Expr: Expr _id_ [15-16]: Path: Path _id_ [15-16] (Ident _id_ [15-16] "x")
 
             [
@@ -781,7 +784,10 @@ fn recover_statements_before_and_after() {
                     Expr _id_ [22-27]: BinOp (Add):
                         Expr _id_ [22-23]: Lit: Int(2)
                         Expr _id_ [26-27]: Lit: Int(2)
-                Stmt _id_ [41-81]: Err
+                Stmt _id_ [41-81]: Local (Immutable):
+                    Pat _id_ [45-46]: Bind:
+                        Ident _id_ [45-46] "y"
+                    Expr _id_ [49-80]: Err
                 Stmt _id_ [94-95]: Expr: Expr _id_ [94-95]: Path: Path _id_ [94-95] (Ident _id_ [94-95] "z")
 
             [

--- a/compiler/qsc_parse/src/ty.rs
+++ b/compiler/qsc_parse/src/ty.rs
@@ -14,7 +14,7 @@ use crate::{
     completion::WordKinds,
     item::throw_away_doc,
     lex::{ClosedBinOp, Delim, TokenKind},
-    prim::recovering_path,
+    prim::{parse_or_else, recovering_path},
     ErrorKind,
 };
 use qsc_ast::ast::{
@@ -28,6 +28,18 @@ pub(super) fn ty(s: &mut ParserContext) -> Result<Ty> {
     array_or_arrow(s, lhs, lo)
 }
 
+pub(super) fn recovering_ty(s: &mut ParserContext) -> Result<Ty> {
+    parse_or_else(
+        s,
+        |span| Ty {
+            id: NodeId::default(),
+            span,
+            kind: Box::new(TyKind::Err),
+        },
+        ty,
+    )
+}
+
 pub(super) fn array_or_arrow(s: &mut ParserContext<'_>, mut lhs: Ty, lo: u32) -> Result<Ty> {
     loop {
         if let Some(()) = opt(s, array)? {
@@ -37,7 +49,7 @@ pub(super) fn array_or_arrow(s: &mut ParserContext<'_>, mut lhs: Ty, lo: u32) ->
                 kind: Box::new(TyKind::Array(Box::new(lhs))),
             }
         } else if let Some(kind) = opt(s, arrow)? {
-            let output = ty(s)?;
+            let output = recovering_ty(s)?;
             let functors = if token(s, TokenKind::Keyword(Keyword::Is)).is_ok() {
                 Some(Box::new(functor_expr(s)?))
             } else {

--- a/language_service/src/completion/tests.rs
+++ b/language_service/src/completion/tests.rs
@@ -1473,6 +1473,67 @@ fn notebook_auto_open_start_of_cell() {
 }
 
 #[test]
+fn notebook_last_expr() {
+    check_notebook(
+        &[(
+            "cell1",
+            indoc! {"
+                    //qsharp
+                    function Foo() : Unit {}
+                    3 + ↘"
+            },
+        )],
+        &["Foo", "Fake"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "Foo",
+                        kind: Function,
+                        sort_text: Some(
+                            "0100Foo",
+                        ),
+                        detail: Some(
+                            "function Foo() : Unit",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+                Some(
+                    CompletionItem {
+                        label: "Fake",
+                        kind: Function,
+                        sort_text: Some(
+                            "0401Fake",
+                        ),
+                        detail: Some(
+                            "operation Fake() : Unit",
+                        ),
+                        additional_text_edits: Some(
+                            [
+                                TextEdit {
+                                    new_text: "import FakeStdLib.Fake;\n",
+                                    range: Range {
+                                        start: Position {
+                                            line: 1,
+                                            column: 0,
+                                        },
+                                        end: Position {
+                                            line: 1,
+                                            column: 0,
+                                        },
+                                    },
+                                },
+                            ],
+                        ),
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
 fn local_vars() {
     check(
         r#"
@@ -3797,6 +3858,213 @@ fn field_access_local_shadows_global() {
                         detail: Some(
                             "Int",
                         ),
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn ty_param_in_signature() {
+    check(
+        r"namespace Test {
+            operation Test<'T>(x: ↘) : Unit {}
+        }",
+        &["'T", "FakeStdLib"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "'T",
+                        kind: TypeParameter,
+                        sort_text: Some(
+                            "0100'T",
+                        ),
+                        detail: None,
+                        additional_text_edits: None,
+                    },
+                ),
+                Some(
+                    CompletionItem {
+                        label: "FakeStdLib",
+                        kind: Module,
+                        sort_text: Some(
+                            "0600FakeStdLib",
+                        ),
+                        detail: None,
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn ty_param_in_return_type() {
+    check(
+        r"namespace Test {
+            operation Test<'T>(x: 'T) : ↘ {}
+        }",
+        &["'T", "FakeStdLib"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "'T",
+                        kind: TypeParameter,
+                        sort_text: Some(
+                            "0100'T",
+                        ),
+                        detail: None,
+                        additional_text_edits: None,
+                    },
+                ),
+                Some(
+                    CompletionItem {
+                        label: "FakeStdLib",
+                        kind: Module,
+                        sort_text: Some(
+                            "0600FakeStdLib",
+                        ),
+                        detail: None,
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn path_segment_in_return_type() {
+    check(
+        r"namespace Test {
+            operation Test(x: 'T) : FakeStdLib.↘ {}
+        }",
+        &["Udt"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "Udt",
+                        kind: Interface,
+                        sort_text: Some(
+                            "0300Udt",
+                        ),
+                        detail: Some(
+                            "struct Udt { x : Int, y : Int }",
+                        ),
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn return_type_in_partial_callable_signature() {
+    check(
+        r"namespace Test {
+            operation Test<'T>() : ↘
+        }",
+        &["'T", "FakeStdLib"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "'T",
+                        kind: TypeParameter,
+                        sort_text: Some(
+                            "0100'T",
+                        ),
+                        detail: None,
+                        additional_text_edits: None,
+                    },
+                ),
+                Some(
+                    CompletionItem {
+                        label: "FakeStdLib",
+                        kind: Module,
+                        sort_text: Some(
+                            "0600FakeStdLib",
+                        ),
+                        detail: None,
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn arg_type_in_partial_callable_signature() {
+    check(
+        r"namespace Test {
+            operation Test<'T>(x: ↘)
+        }",
+        &["'T", "FakeStdLib"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "'T",
+                        kind: TypeParameter,
+                        sort_text: Some(
+                            "0100'T",
+                        ),
+                        detail: None,
+                        additional_text_edits: None,
+                    },
+                ),
+                Some(
+                    CompletionItem {
+                        label: "FakeStdLib",
+                        kind: Module,
+                        sort_text: Some(
+                            "0600FakeStdLib",
+                        ),
+                        detail: None,
+                        additional_text_edits: None,
+                    },
+                ),
+            ]
+        "#]],
+    );
+}
+
+#[test]
+fn incomplete_return_type_in_partial_callable_signature() {
+    check(
+        r"namespace Test {
+            operation Test<'T>() : () => ↘
+        }",
+        &["'T", "FakeStdLib"],
+        &expect![[r#"
+            [
+                Some(
+                    CompletionItem {
+                        label: "'T",
+                        kind: TypeParameter,
+                        sort_text: Some(
+                            "0100'T",
+                        ),
+                        detail: None,
+                        additional_text_edits: None,
+                    },
+                ),
+                Some(
+                    CompletionItem {
+                        label: "FakeStdLib",
+                        kind: Module,
+                        sort_text: Some(
+                            "0600FakeStdLib",
+                        ),
+                        detail: None,
                         additional_text_edits: None,
                     },
                 ),


### PR DESCRIPTION
1. Callable signatures tolerate a lot more broken syntax now. This allows us to complete type parameters correctly in broken syntax that we commonly see when the user is in the middle of typing:

```qsharp
operation Test<'T>() : () => |
```
```qsharp
operation Test<'T>(x: |)
```
```qsharp
operation Test<'T>() : |
```
```qsharp
operation Test<'T>(x: Std.|) : Unit {}
```

2. Error recovery in notebook cells if a statement can't be parsed. Fixes #1960 and allows completions to work in scenarios like this:
```qsharp
%%qsharp

function Foo() : Unit {}
let x = |  // expect Foo in the list
```