### PR TITLE
`DumpMachine` in playground should display message when no qubits are allocated

### DIFF
--- a/playground/src/results.tsx
+++ b/playground/src/results.tsx
@@ -245,6 +245,7 @@ export function ResultsTab(props: {
                   <StateTable
                     dump={evt.state}
                     latexDump={evt.stateLatex}
+                    count={evt.qubitCount}
                   ></StateTable>
                 </div>
               ) : (

--- a/playground/src/state.tsx
+++ b/playground/src/state.tsx
@@ -17,7 +17,34 @@ function formatComplex(real: number, imag: number) {
   return `${r}${i}`;
 }
 
-export function StateTable(props: { dump: Dump; latexDump: string | null }) {
+export function StateTable(props: {
+  dump: Dump;
+  latexDump: string | null;
+  count: number;
+}) {
+  if (props.count === 0) {
+    return (
+      <div>
+        <table class="state-table">
+          <thead>
+            <tr>
+              <th>Basis State</th>
+              <th>Amplitude</th>
+              <th>Measurement Probability</th>
+              <th colSpan={2}>Phase</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>No qubits allocated</td>
+            </tr>
+          </tbody>
+        </table>
+        <br></br>
+      </div>
+    );
+  }
+
   return (
     <div>
       <table class="state-table">


### PR DESCRIPTION
Fixes #1962

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/93ebc3aa-cbf7-4746-99b3-5d08d20bfbf6">
