### PR TITLE
Allow `Default::default()` pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ missing_panics_doc = "allow"
 module_name_repetitions = "allow"
 needless_raw_string_hashes = "allow"
 unnecessary_wraps = "allow"
+default_trait_access = "allow"
 
 [profile.release]
 debug = "limited"


### PR DESCRIPTION
One pattern I use a lot in Rust is `Default::default()` to construct a default instance of a type. However, pedantic clippy settings state that this is unclear. I personally dislike this setting, and actually find `Default::default()` more usable and consistent.

Consistency wise, there's no reason (IMO) for clippy to single out the `Default` trait. We access other trait methods in this way, and clippy has no such rule against other traits. For example, `Into::into()`, or `Display::to_string()`. 

Style wise -- the point of using a language with type inference is that you only have to specify the type _once_, and then subsequent lines of code do not need to redeclare (or "stutter") the type. I will frequently update an underlying data structure, e.g. switching from `HashMap` to `BTreeMap`, or `Vec` to `HashSet`. If I've used `Default::default()` everywhere, I do not need to go update those invocations. However, if I've followed clippy's advice, I have a lot more refactoring to do -- I have to go call `HashMap::default()` or whatever everywhere.

These are just some examples to prove a point -- in my opinion, this pattern is clear, idiomatic, and consistent.