### PR TITLE
Noise settings available in Q#

### DIFF
--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -514,6 +514,34 @@ fn custom_intrinsic_mixed_args() {
 }
 
 #[test]
+fn custom_intrinsic_apply_idle_noise() {
+    let mut interpreter = interpreter(
+        r"
+    namespace Test {
+        import Std.Diagnostics.*;
+        @EntryPoint()
+        operation Main() : Unit {
+            ConfigurePauliNoise(BitFlipNoise(1.0));
+            use q = Qubit();
+            ApplyIdleNoise(q);
+        }
+    }",
+        Profile::Unrestricted,
+    );
+
+    let circ = interpreter
+        .circuit(CircuitEntryPoint::EntryPoint, false)
+        .expect("circuit generation should succeed");
+
+    // ConfigurePauliNoise has no qubit qrguments so it shouldn't show up.
+    // ApplyIdleNoise is a quantum operation so it shows up.
+    expect![[r#"
+        q_0     ApplyIdleNoise
+    "#]]
+    .assert_eq(&circ.to_string());
+}
+
+#[test]
 fn operation_with_qubits() {
     let mut interpreter = interpreter(
         r"

--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -533,7 +533,7 @@ fn custom_intrinsic_apply_idle_noise() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    // ConfigurePauliNoise has no qubit qrguments so it shouldn't show up.
+    // ConfigurePauliNoise has no qubit arguments so it shouldn't show up.
     // ApplyIdleNoise is a quantum operation so it shows up.
     expect![[r#"
         q_0     ApplyIdleNoise

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -401,7 +401,7 @@ impl Backend for SparseSim {
             | "EndRepeatEstimatesInternal" => Some(Ok(Value::unit())),
             "ConfigurePauliNoise" => {
                 let [xv, yv, zv] = &*arg.unwrap_tuple() else {
-                    panic!("tuple arity for SetPauliNoise intrinsic should be 3");
+                    panic!("tuple arity for ConfigurePauliNoise intrinsic should be 3");
                 };
                 let px = xv.get_double();
                 let py = yv.get_double();

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -101,6 +101,9 @@ pub trait Backend {
     fn qubit_is_zero(&mut self, _q: usize) -> bool {
         unimplemented!("qubit_is_zero operation");
     }
+    /// Executes custom intrinsic specified by `_name`.
+    /// Returns None if this intrinsic is unknown.
+    /// Otherwise returns Some(Result), with the Result from intrinsic.
     fn custom_intrinsic(&mut self, _name: &str, _arg: Value) -> Option<Result<Value, String>> {
         None
     }

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -1603,9 +1603,9 @@ fn check_pauli_noise() {
         indoc! {"{
             import Std.Diagnostics.*;
             use q = Qubit();
-            ConfigurePauliNoise(1.0,0.0,0.0);
+            ConfigurePauliNoise(BitFlipNoise(1.0));
             ApplyIdleNoise(q);
-            ConfigurePauliNoise(0.0,0.0,0.0);
+            ConfigurePauliNoise(NoNoise());
             DumpMachine();
             Reset(q);
         }"},

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -143,7 +143,7 @@ impl Backend for CustomSim {
         match name {
             "Add1" => Some(Ok(Value::Int(arg.unwrap_int() + 1))),
             "Check" => Some(Err("cannot verify input".to_string())),
-            _ => None,
+            _ => self.sim.custom_intrinsic(name, arg),
         }
     }
 }
@@ -1593,5 +1593,25 @@ fn start_counting_qubits_called_twice_before_stop_fails() {
             Std.Diagnostics.StartCountingQubits();
         }"},
         &expect!["qubits already counted"],
+    );
+}
+
+#[test]
+fn check_pauli_noise() {
+    check_intrinsic_output(
+        "",
+        indoc! {"{
+            import Std.Diagnostics.*;
+            use q = Qubit();
+            ConfigurePauliNoise(1.0,0.0,0.0);
+            ApplyIdleNoise(q);
+            ConfigurePauliNoise(0.0,0.0,0.0);
+            DumpMachine();
+            Reset(q);
+        }"},
+        &expect![[r#"
+            STATE:
+            |1⟩: 1.0000+0.0000𝑖
+        "#]],
     );
 }

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -3722,7 +3722,7 @@ fn controlled_operation_with_duplicate_controls_fails() {
                                 1,
                             ),
                             item: LocalItemId(
-                                136,
+                                140,
                             ),
                         },
                         caller: PackageId(
@@ -3772,7 +3772,7 @@ fn controlled_operation_with_target_in_controls_fails() {
                                 1,
                             ),
                             item: LocalItemId(
-                                136,
+                                140,
                             ),
                         },
                         caller: PackageId(

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -3722,7 +3722,7 @@ fn controlled_operation_with_duplicate_controls_fails() {
                                 1,
                             ),
                             item: LocalItemId(
-                                134,
+                                136,
                             ),
                         },
                         caller: PackageId(
@@ -3772,7 +3772,7 @@ fn controlled_operation_with_target_in_controls_fails() {
                                 1,
                             ),
                             item: LocalItemId(
-                                134,
+                                136,
                             ),
                         },
                         caller: PackageId(

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -263,6 +263,14 @@ impl Value {
         v
     }
 
+    #[must_use]
+    pub fn get_double(&self) -> f64 {
+        let Value::Double(v) = self else {
+            panic!("value should be Double, got {}", self.type_name());
+        };
+        *v
+    }
+
     /// Convert the [Value] into a global tuple
     /// # Panics
     /// This will panic if the [Value] is not a [`Value::Global`].

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -1344,6 +1344,7 @@ impl<'a> PartialEvaluator<'a> {
             | "AccountForEstimatesInternal"
             | "BeginRepeatEstimatesInternal"
             | "EndRepeatEstimatesInternal"
+            | "ApplyIdleNoise"
             | "GlobalPhase" => Ok(Value::unit()),
             // The following intrinsic functions and operations should never make it past conditional compilation and
             // the capabilities check pass.

--- a/compiler/qsc_partial_eval/src/management.rs
+++ b/compiler/qsc_partial_eval/src/management.rs
@@ -133,7 +133,9 @@ impl Backend for QuantumIntrinsicsChecker {
     ) -> Option<std::result::Result<Value, String>> {
         match name {
             "BeginEstimateCaching" => Some(Ok(Value::Bool(true))),
-            "EndEstimateCaching" | "GlobalPhase" | "ConfigurePauliNoise" => Some(Ok(Value::unit())),
+            "EndEstimateCaching" | "GlobalPhase" | "ConfigurePauliNoise" | "ApplyIdleNoise" => {
+                Some(Ok(Value::unit()))
+            }
             _ => None,
         }
     }

--- a/compiler/qsc_partial_eval/src/management.rs
+++ b/compiler/qsc_partial_eval/src/management.rs
@@ -133,7 +133,7 @@ impl Backend for QuantumIntrinsicsChecker {
     ) -> Option<std::result::Result<Value, String>> {
         match name {
             "BeginEstimateCaching" => Some(Ok(Value::Bool(true))),
-            "EndEstimateCaching" | "GlobalPhase" => Some(Ok(Value::unit())),
+            "EndEstimateCaching" | "GlobalPhase" | "ConfigurePauliNoise" => Some(Ok(Value::unit())),
             _ => None,
         }
     }

--- a/compiler/qsc_partial_eval/src/tests/intrinsics.rs
+++ b/compiler/qsc_partial_eval/src/tests/intrinsics.rs
@@ -922,6 +922,31 @@ fn call_to_dump_register_does_not_generate_instructions() {
 }
 
 #[test]
+fn use_of_noise_does_not_generate_instructions() {
+    let program = get_rir_program(indoc! {
+        r#"
+        namespace Test {
+            import Std.Diagnostics.*;
+            @EntryPoint()
+            operation Main() : Unit {
+                use q = Qubit();
+                ConfigurePauliNoise(0.2, 0.2, 0.2);
+                ApplyIdleNoise(q);
+            }
+        }
+        "#,
+    });
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Call id(1), args( Integer(0), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
 #[should_panic(expected = "`CheckZero` is not a supported by partial evaluation")]
 fn call_to_check_zero_panics() {
     _ = get_rir_program(indoc! {

--- a/library/src/tests/diagnostics.rs
+++ b/library/src/tests/diagnostics.rs
@@ -424,3 +424,35 @@ fn check_dumpoperation_with_extra_qubits_relative_phase_not_reflected_in_matrix(
     "#]]
     .assert_eq(&output);
 }
+
+#[test]
+fn check_bit_flip_noise_values() {
+    test_expression(
+        "Std.Diagnostics.BitFlipNoise(0.3)",
+        &Value::Tuple([Value::Double(0.3), Value::Double(0.0), Value::Double(0.0)].into()),
+    );
+}
+
+#[test]
+fn check_phase_flip_noise_values() {
+    test_expression(
+        "Std.Diagnostics.PhaseFlipNoise(0.3)",
+        &Value::Tuple([Value::Double(0.0), Value::Double(0.0), Value::Double(0.3)].into()),
+    );
+}
+
+#[test]
+fn check_depolarizing_noise_values() {
+    test_expression(
+        "Std.Diagnostics.DepolarizingNoise(0.3)",
+        &Value::Tuple([Value::Double(0.1), Value::Double(0.1), Value::Double(0.1)].into()),
+    );
+}
+
+#[test]
+fn check_no_noise_values() {
+    test_expression(
+        "Std.Diagnostics.NoNoise()",
+        &Value::Tuple([Value::Double(0.0), Value::Double(0.0), Value::Double(0.0)].into()),
+    );
+}

--- a/library/std/src/Std/Diagnostics.qs
+++ b/library/std/src/Std/Diagnostics.qs
@@ -385,7 +385,6 @@ operation StopCountingQubits() : Int {
 /// Probability of applying Y gate.
 /// ## pz
 /// Probability of applying Z gate.
-@Config(Unrestricted)
 function ConfigurePauliNoise(px : Double, py : Double, pz : Double) : Unit {
     body intrinsic;
 }
@@ -403,9 +402,32 @@ function ConfigurePauliNoise(px : Double, py : Double, pz : Double) : Unit {
 /// # Input
 /// ## qubit
 /// The qubit to which noise is applied.
-@Config(Unrestricted)
 operation ApplyIdleNoise(qubit : Qubit) : Unit {
     body intrinsic;
+}
+
+/// # Summary
+///  The bit flip noise with probability `p`.
+function BitFlipNoise(p: Double) : (Double, Double, Double) {
+    (p, 0.0, 0.0)
+}
+
+/// # Summary
+///  The phase flip noise with probability `p`.
+function PhaseFlipNoise(p: Double) : (Double, Double, Double) {
+    (0.0, 0.0, p)
+}
+
+/// # Summary
+///  The depolarizing noise with probability `p`.
+function DepolarizingNoise(p: Double) : (Double, Double, Double) {
+    (p / 3.0, p / 3.0, p / 3.0)
+}
+
+/// # Summary
+///  No noise for noiseless operation.
+function NoNoise() : (Double, Double, Double) {
+    (0.0, 0.0, 0.0)
 }
 
 export
@@ -423,4 +445,8 @@ export
     StartCountingQubits,
     StopCountingQubits,
     ConfigurePauliNoise,
-    ApplyIdleNoise;
+    ApplyIdleNoise,
+    BitFlipNoise,
+    PhaseFlipNoise,
+    DepolarizingNoise,
+    NoNoise;

--- a/library/std/src/Std/Diagnostics.qs
+++ b/library/std/src/Std/Diagnostics.qs
@@ -408,19 +408,19 @@ operation ApplyIdleNoise(qubit : Qubit) : Unit {
 
 /// # Summary
 ///  The bit flip noise with probability `p`.
-function BitFlipNoise(p: Double) : (Double, Double, Double) {
+function BitFlipNoise(p : Double) : (Double, Double, Double) {
     (p, 0.0, 0.0)
 }
 
 /// # Summary
 ///  The phase flip noise with probability `p`.
-function PhaseFlipNoise(p: Double) : (Double, Double, Double) {
+function PhaseFlipNoise(p : Double) : (Double, Double, Double) {
     (0.0, 0.0, p)
 }
 
 /// # Summary
 ///  The depolarizing noise with probability `p`.
-function DepolarizingNoise(p: Double) : (Double, Double, Double) {
+function DepolarizingNoise(p : Double) : (Double, Double, Double) {
     (p / 3.0, p / 3.0, p / 3.0)
 }
 

--- a/library/std/src/Std/Diagnostics.qs
+++ b/library/std/src/Std/Diagnostics.qs
@@ -379,14 +379,14 @@ operation StopCountingQubits() : Int {
 /// Use 0.0 for all parameters to simulate without noise.
 ///
 /// # Input
-/// # px
+/// ## px
 /// Probability of applying X gate.
-/// # py
+/// ## py
 /// Probability of applying Y gate.
-/// # pz
+/// ## pz
 /// Probability of applying Z gate.
 @Config(Unrestricted)
-function ConfigurePauliNoise(px: Double, py: Double, pz: Double): Unit {
+function ConfigurePauliNoise(px : Double, py : Double, pz : Double) : Unit {
     body intrinsic;
 }
 
@@ -404,7 +404,7 @@ function ConfigurePauliNoise(px: Double, py: Double, pz: Double): Unit {
 /// ## qubit
 /// The qubit to which noise is applied.
 @Config(Unrestricted)
-operation ApplyIdleNoise(qubit: Qubit): Unit {
+operation ApplyIdleNoise(qubit : Qubit) : Unit {
     body intrinsic;
 }
 

--- a/library/std/src/Std/Diagnostics.qs
+++ b/library/std/src/Std/Diagnostics.qs
@@ -368,6 +368,46 @@ operation StopCountingQubits() : Int {
     body intrinsic;
 }
 
+/// # Summary
+/// Configures Pauli noise for simulation.
+///
+/// # Description
+/// This function configures Pauli noise for simulation. Parameters represent
+/// probabilities of applying X, Y, and Z gates and must add up to at most 1.0.
+/// Noise is applied after each gate and before each measurement in the simulator
+/// backend. Decompositions may affect the number of times noise is applied.
+/// Use 0.0 for all parameters to simulate without noise.
+///
+/// # Input
+/// # px
+/// Probability of applying X gate.
+/// # py
+/// Probability of applying Y gate.
+/// # pz
+/// Probability of applying Z gate.
+@Config(Unrestricted)
+function ConfigurePauliNoise(px: Double, py: Double, pz: Double): Unit {
+    body intrinsic;
+}
+
+/// # Summary
+/// Applies configured noise to a qubit.
+///
+/// # Description
+/// This operation applies configured noise to a qubit during simulation. For example,
+/// if configured noise is a bit-flip noise with 5% probability, the X gate will be applied
+/// with 5% probability. If no noise is configured, no noise is applied.
+/// This is useful to simulate noise during idle periods. It could also be used to
+/// apply noise immediately after qubit allocation.
+///
+/// # Input
+/// ## qubit
+/// The qubit to which noise is applied.
+@Config(Unrestricted)
+operation ApplyIdleNoise(qubit: Qubit): Unit {
+    body intrinsic;
+}
+
 export
     DumpMachine,
     DumpRegister,
@@ -381,4 +421,6 @@ export
     StartCountingFunction,
     StopCountingFunction,
     StartCountingQubits,
-    StopCountingQubits;
+    StopCountingQubits,
+    ConfigurePauliNoise,
+    ApplyIdleNoise;

--- a/resource_estimator/src/counts.rs
+++ b/resource_estimator/src/counts.rs
@@ -522,7 +522,6 @@ impl Backend for LogicalCounter {
 
     fn custom_intrinsic(&mut self, name: &str, arg: Value) -> Option<Result<Value, String>> {
         match name {
-            "GlobalPhase" => Some(Ok(Value::unit())),
             "BeginEstimateCaching" => {
                 let values = arg.unwrap_tuple();
                 let [cache_name, cache_variant] = array::from_fn(|i| values[i].clone());
@@ -565,6 +564,7 @@ impl Backend for LogicalCounter {
                         .map(|()| Value::unit()),
                 )
             }
+            "GlobalPhase" | "ConfigurePauliNoise" | "ApplyIdleNoise" => Some(Ok(Value::unit())),
             _ => None,
         }
     }


### PR DESCRIPTION
Added ConfigurePauliNoise and ApplyIdleNoise to Diagnostric namespace to control noise from Q# program.