### PR TITLE
No completions in comments

### DIFF
--- a/language_service/src/completion.rs
+++ b/language_service/src/completion.rs
@@ -102,6 +102,16 @@ fn expected_word_kinds(
     source_contents: &str,
     cursor_offset: u32,
 ) -> WordKinds {
+    // We should not retun any completions in comments.
+    // This compensates for a bug in [`possible_words_at_offset_in_source`] .
+    // Ideally, that function would be aware of the comment context and not
+    // return any completions, however this is difficult to do today because
+    // of the parser's unawareness of comment tokens.
+    // So we do a simple check here where we have access to the full source contents.
+    if in_comment(source_contents, cursor_offset) {
+        return WordKinds::empty();
+    }
+
     match &compilation.kind {
         CompilationKind::OpenProject {
             package_graph_sources,
@@ -119,6 +129,16 @@ fn expected_word_kinds(
             cursor_offset,
         ),
     }
+}
+
+fn in_comment(source_contents: &str, cursor_offset: u32) -> bool {
+    // find the last newline before the cursor
+    let last_line_start = source_contents[..cursor_offset as usize]
+        .rfind('\n')
+        .unwrap_or(0);
+    // find the last comment start before the cursor
+    let last_comment_start = source_contents[last_line_start..cursor_offset as usize].rfind("//");
+    last_comment_start.is_some()
 }
 
 /// Collects hardcoded completions from the given set of parser predictions.


### PR DESCRIPTION
Suppress completions inside comments like

```qsharp
import Foo;
// Hello there |
import Bar;
```