### PR TITLE
(clippy) Allow enum variant imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ module_name_repetitions = "allow"
 needless_raw_string_hashes = "allow"
 unnecessary_wraps = "allow"
 default_trait_access = "allow"
+enum_glob_use = "allow"
 
 [profile.release]
 debug = "limited"


### PR DESCRIPTION
# The "For" Case

This PR allows another lint that is on in the *pedantic* profile but not in the default profile.

One pattern I've always used, and enjoyed, is matching across enum variants. This is excessively verbose, typically:

```rust

match my_enum {
  ClassConstraint::Exp { .. } => (),
  ClassConstraint::Num => (),
  ClassConstraint::Eq => ()
}
```

I find that this is too noisy, so I typically would write:

```rust

use ClassConstraint::*;
match my_enum {
  Exp { .. } => (), 
  Num => (),
  Eq => ()
}

```

As this lint is not on by default, this is not a problem in most Rust codebases, only those that enable the `pedantic` clippy profile.


# The "Against" Case

This lint provides a code action to expand the `*` import into an import of all of the variants. I don't like this as much, as it means you still end up stuttering all of the enum names (mentioning them twice) just to save some characters (thusly, not actually saving many characters or making the code more clear). The presence of the code action quick fix, however, does make this a tolerable compromise if others feel strongly that this lint should be on.
