### PR TITLE
Add three qubit repetition sample to playground

### DIFF
--- a/samples/samples.mjs
+++ b/samples/samples.mjs
@@ -23,6 +23,7 @@ export default [
     { title: "Hidden Shift", file: "./algorithms/HiddenShiftNISQ.qs", shots: 1 },
     { title: "Hidden Shift (Advanced)", file: "./algorithms/HiddenShift.qs", shots: 1 },
     { title: "Shor", file: "./algorithms/Shor.qs", shots: 1 },
+    { title: "Three Qubit Repetition Code", file: "./algorithms/ThreeQubitRepetitionCode.qs", shots: 1 },
     { title: "Dynamics (Resource Estimation)", file: "./estimation/Dynamics.qs", shots: 1, omitFromTests: true },
     { title: "Precalculated (Resource Estimation)", file: "./estimation/Precalculated.qs", shots: 1, omitFromTests: true  },
     { title: "Shor (Resource Estimation)", file: "./estimation/ShorRE.qs", shots: 1, omitFromTests: true },


### PR DESCRIPTION
This just adds the existing Three Qubit Repetition Code sample to the playground (both the VS Code playground and the developer playground).