### PR TITLE
Include samples in completions when the document is empty

### DIFF
--- a/vscode/src/completion.ts
+++ b/vscode/src/completion.ts
@@ -87,13 +87,14 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
     });
 
     // Include the samples in contexts that are syntactically appropriate.
-    // The presence of the "namespace" keyword in the completion list is a
-    // hint that the cursor is at the top level.
+    // The presence of the "operation" keyword in the completion list is a
+    // hint that the cursor is at a point we can insert the sample code.
+    
     const shouldIncludeSamples =
       results.findIndex(
         (i) =>
           i.kind === vscode.CompletionItemKind.Keyword &&
-          i.label === "namespace",
+          i.label === "operation",
       ) !== -1;
 
     return !shouldIncludeSamples ? results : results.concat(this.samples);

--- a/vscode/src/completion.ts
+++ b/vscode/src/completion.ts
@@ -86,7 +86,15 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
       return item;
     });
 
+    let isEmptyOrWhitespace = true;
+    for (let i = 0; i < document.lineCount; i++) {
+      if (!document.lineAt(i).isEmptyOrWhitespace) {
+        isEmptyOrWhitespace = false;
+        break;
+      }
+    }
+
     // Include the samples list for empty documents
-    return document.lineCount > 0 ? results : results.concat(this.samples);
+    return !isEmptyOrWhitespace ? results : results.concat(this.samples);
   }
 }

--- a/vscode/src/completion.ts
+++ b/vscode/src/completion.ts
@@ -86,15 +86,16 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
       return item;
     });
 
-    let isEmptyOrWhitespace = true;
-    for (let i = 0; i < document.lineCount; i++) {
-      if (!document.lineAt(i).isEmptyOrWhitespace) {
-        isEmptyOrWhitespace = false;
-        break;
-      }
-    }
+    // Include the samples in contexts that are syntactically appropriate.
+    // The presence of the "namespace" keyword in the completion list is a
+    // hint that the cursor is at the top level.
+    const shouldIncludeSamples =
+      results.findIndex(
+        (i) =>
+          i.kind === vscode.CompletionItemKind.Keyword &&
+          i.label === "namespace",
+      ) !== -1;
 
-    // Include the samples list for empty documents
-    return !isEmptyOrWhitespace ? results : results.concat(this.samples);
+    return !shouldIncludeSamples ? results : results.concat(this.samples);
   }
 }

--- a/vscode/src/completion.ts
+++ b/vscode/src/completion.ts
@@ -89,7 +89,7 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
     // Include the samples in contexts that are syntactically appropriate.
     // The presence of the "operation" keyword in the completion list is a
     // hint that the cursor is at a point we can insert the sample code.
-    
+
     const shouldIncludeSamples =
       results.findIndex(
         (i) =>

--- a/vscode/test/suites/language-service/language-service.test.ts
+++ b/vscode/test/suites/language-service/language-service.test.ts
@@ -16,6 +16,7 @@ suite("Q# Language Service Tests", function suite() {
 
   const testQs = joinPath(workspaceFolderUri, "test.qs");
   const noErrorsQs = joinPath(workspaceFolderUri, "no-errors.qs");
+  const emptyQs = joinPath(workspaceFolderUri, "empty.qs");
   const mainPackageMainQs = joinPath(packages, "MainPackage", "src", "Main.qs");
   const depPackageMainQs = joinPath(packages, "DepPackage", "src", "Main.qs");
   const missingDepMainQs = joinPath(packages, "MissingDep", "src", "Main.qs");
@@ -45,6 +46,7 @@ suite("Q# Language Service Tests", function suite() {
     // before we start testing.
     await vscode.workspace.openTextDocument(testQs);
     await vscode.workspace.openTextDocument(noErrorsQs);
+    await vscode.workspace.openTextDocument(emptyQs);
     await vscode.workspace.openTextDocument(mainPackageMainQs);
     await vscode.workspace.openTextDocument(depPackageMainQs);
     await vscode.workspace.openTextDocument(missingDepMainQs);
@@ -78,6 +80,24 @@ suite("Q# Language Service Tests", function suite() {
     assert.include(
       actualCompletionList.items.map((i) => i.label),
       "operation",
+    );
+
+    assert.notInclude(
+      actualCompletionList.items.map((i) => i.label),
+      "Shor sample",
+    );
+  });
+
+  test("Completions - include samples in empty document", async () => {
+    const actualCompletionList = (await vscode.commands.executeCommand(
+      "vscode.executeCompletionItemProvider",
+      emptyQs,
+      new vscode.Position(1, 0),
+    )) as vscode.CompletionList;
+
+    assert.include(
+      actualCompletionList.items.map((i) => i.label),
+      "Shor sample",
     );
   });
 

--- a/vscode/test/suites/language-service/language-service.test.ts
+++ b/vscode/test/suites/language-service/language-service.test.ts
@@ -16,7 +16,6 @@ suite("Q# Language Service Tests", function suite() {
 
   const testQs = joinPath(workspaceFolderUri, "test.qs");
   const noErrorsQs = joinPath(workspaceFolderUri, "no-errors.qs");
-  const emptyQs = joinPath(workspaceFolderUri, "empty.qs");
   const mainPackageMainQs = joinPath(packages, "MainPackage", "src", "Main.qs");
   const depPackageMainQs = joinPath(packages, "DepPackage", "src", "Main.qs");
   const missingDepMainQs = joinPath(packages, "MissingDep", "src", "Main.qs");
@@ -46,7 +45,6 @@ suite("Q# Language Service Tests", function suite() {
     // before we start testing.
     await vscode.workspace.openTextDocument(testQs);
     await vscode.workspace.openTextDocument(noErrorsQs);
-    await vscode.workspace.openTextDocument(emptyQs);
     await vscode.workspace.openTextDocument(mainPackageMainQs);
     await vscode.workspace.openTextDocument(depPackageMainQs);
     await vscode.workspace.openTextDocument(missingDepMainQs);
@@ -82,20 +80,20 @@ suite("Q# Language Service Tests", function suite() {
       "operation",
     );
 
-    assert.notInclude(
+    assert.include(
       actualCompletionList.items.map((i) => i.label),
       "Shor sample",
     );
   });
 
-  test("Completions - include samples in empty document", async () => {
+  test("Completions - don't include samples when syntactically inappropriate", async () => {
     const actualCompletionList = (await vscode.commands.executeCommand(
       "vscode.executeCompletionItemProvider",
-      emptyQs,
-      new vscode.Position(1, 0),
+      testQs,
+      new vscode.Position(12, 0), // put the cursor after the namespace declaration
     )) as vscode.CompletionList;
 
-    assert.include(
+    assert.notInclude(
       actualCompletionList.items.map((i) => i.label),
       "Shor sample",
     );


### PR DESCRIPTION
Fixing the behavior that regressed in #1947 when I was attempting to limit samples to empty documents only. 