### PR TITLE
Add `Qtest` library that uses class constraints

### DIFF
--- a/library/qtest/qsharp.json
+++ b/library/qtest/qsharp.json
@@ -2,9 +2,10 @@
   "author": "Microsoft",
   "license": "MIT",
   "files": [
+    "src/Functions.qs",
     "src/Main.qs",
     "src/Operations.qs",
-    "src/Functions.qs",
-    "src/Tests.qs"
+    "src/Tests.qs",
+    "src/Util.qs"
   ]
 }

--- a/library/qtest/qsharp.json
+++ b/library/qtest/qsharp.json
@@ -1,0 +1,10 @@
+{
+  "author": "Microsoft",
+  "license": "MIT",
+  "files": [
+    "src/Main.qs",
+    "src/Operations.qs",
+    "src/Functions.qs",
+    "src/Tests.qs"
+  ]
+}

--- a/library/qtest/src/Functions.qs
+++ b/library/qtest/src/Functions.qs
@@ -1,112 +1,60 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import Util.TestCaseResult, Util.OutputMessage;
+import Std.Arrays.Mapped, Std.Arrays.All;
+
 /// # Summary
-/// Runs a series of named test functions with expected results.
+/// Runs a number of test cases and returns true if all tests passed, false otherwise.
+/// Prints a report of what passed and what failed as output.
 ///
-/// # Description
-/// Given an array of test names, test functions, and expected results (of the same type), returns `true`
-/// if all tests passed, and `false` if any one test failed.
-/// Prints the expected and received result for any failed tests.
+/// For a more flexible test running function, see `RunAllTestCases` which returns
+/// test results instead of printing out to output.
 ///
 /// # Input
-/// ## test_cases
-/// An array of three-arity tuples of the form `(test_name, callable_to_test, expected_result)`.
-/// `callable_to_test` will be called and its result will be compared to `expected_result`.
+/// Takes a list of test cases. A test case is a tuple of `(String, () -> T, 'T)`, where
+/// the first String is the name of the test, the function is the test case itself, and the
+/// final element of the tuple is the expected return value from the test case.
 ///
 /// # Example
 /// ```qsharp
-/// function Main() : Unit {
-///     TestCases([
-///         ("Should return 42", TestCaseOne, 42),
-///         ("Should add one", () -> AddOne(5), 6)
-///     ]);
-/// }
-///
-/// function TestCaseOne() : Int {
-///     42
-/// }
-///
-/// function AddOne(x: Int) : Int {
-///     x + 1
-/// }
+/// CheckAllTestCases([("Should return 42", () -> 42, 42)]);
 /// ```
-function TestCases<'Result : Eq + Show > (test_cases : (String, () -> 'Result, 'Result)[]) : Bool {
-    let failed_test_buf = TestCasesSilent(test_cases);
+function CheckAllTestCases<'T : Eq + Show>(test_cases : (String, () -> 'T, 'T)[]) : Bool {
+    let test_results = RunAllTestCases(test_cases);
 
-    if Length(failed_test_buf) == 0 {
-        Message($"{Length(test_cases)} test(s) passed.");
-        true
-    } else {
-        Message($"{Length(failed_test_buf)} tests failed.");
-        for item in failed_test_buf {
-            Message($"{item}")
-        }
-        false
-    }
+    OutputMessage(test_results);
+    All(test_case -> test_case.did_pass, test_results)
 }
 
 /// # Summary
-/// Similar to `Qtest.Functions.TestCases`, but returns test failure info in an array of strings instead of directly messaging to
-/// output. Useful if you want to handle your own messaging when writing tests, for CI or similar.
-
-/// See `Qtest.Functions.TestCases` for more details.
-///
-/// # Description
-/// Given an array of test names, test functions, and expected results (of the same type), returns an array
-/// of strings representing all failed test cases (if any). Strings are of the form "test_name: expected {}, got {}"
-///
+/// Runs all given test cases and returns a `TestCaseResult` for each test, representing whether or not it passed
+/// and what the failure message, if any.
+/// This is a good alternative to `CheckAllTestCases` when you want custom output based on the results of your tests,
+/// or more control over how test results are rendered.
 /// # Input
-/// ## test_cases
-/// An array of three-arity tuples of the form `(test_name, callable_to_test, expected_result)`.
-/// `callable_to_test` will be called and its result will be compared to `expected_result`.
+/// Takes a list of test cases. A test case is a tuple of `(String, () -> T, 'T)`, where
+/// the first String is the name of the test, the function is the test case itself, and the
+/// final element of the tuple is the expected return value from the test case.
 ///
 /// # Example
 /// ```qsharp
-/// function Main() : Unit {
-///     let failure_messages = TestCasesSilent([
-///         ("Should return 42", TestCaseOne, 42),
-///         ("Should add one", () -> AddOne(5), 6)
-///     ]);
-///     Std.Diagnostics.Fact(Length(failure_messages) == 0, "No tests should fail.")
-/// }
-///
-/// function TestCaseOne() : Int {
-///     42
-/// }
-///
-/// function AddOne(x: Int) : Int {
-///     x + 1
-/// }
+/// RunAllTestCases([("Should return 42", () -> 42, 42)]);
 /// ```
-function TestCasesSilent<'Result : Eq + Show > (test_cases : (String, () -> 'Result, 'Result)[]) : String[] {
+function RunAllTestCases<'T : Eq + Show>(test_cases : (String, () -> 'T, 'T)[]) : TestCaseResult[] {
     let num_tests = Length(test_cases);
-    mutable failed_test_buf = [];
 
-    for (name, case, result) in test_cases {
-        let (did_pass, message) = TestCase(case, result)!;
-        if not did_pass {
-            set failed_test_buf = failed_test_buf + [$"{name}: {message}"];
-        }
-    }
-
-    failed_test_buf
+    Mapped((name, case, result) -> TestCase(name, case, result), test_cases)
 }
 
-struct TestCaseResult {
-    did_pass : Bool,
-    message : String,
-}
-
-function TestCase<'Result : Eq + Show > (test_case : () -> 'Result, expected : 'Result) : TestCaseResult {
+/// Internal (non-exported) helper function. Runs a test case and produces a `TestCaseResult`
+function TestCase<'T : Eq + Show>(name : String, test_case : () -> 'T, expected : 'T) : TestCaseResult {
     let result = test_case();
     if result == expected {
         new TestCaseResult { did_pass = true, message = "" }
     } else {
-        new TestCaseResult { did_pass = false, message = $"expected: {expected}, got: {result}" }
+        new TestCaseResult { did_pass = false, message = $"{name}: expected: {expected}, got: {result}" }
     }
 }
 
-
-
-export TestCases; 
+export CheckAllTestCases, RunAllTestCases; 

--- a/library/qtest/src/Functions.qs
+++ b/library/qtest/src/Functions.qs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/// # Summary
+/// Runs a series of named test functions with expected results.
+///
+/// # Description
+/// Given an array of test names, test functions, and expected results (of the same type), returns `true`
+/// if all tests passed, and `false` if any one test failed.
+/// Prints the expected and received result for any failed tests.
+///
+/// # Input
+/// ## test_cases
+/// An array of three-arity tuples of the form `(test_name, callable_to_test, expected_result)`.
+/// `callable_to_test` will be called and its result will be compared to `expected_result`.
+///
+/// # Example
+/// ```qsharp
+/// function Main() : Unit {
+///     TestCases([
+///         ("Should return 42", TestCaseOne, 42),
+///         ("Should add one", () -> AddOne(5), 6)
+///     ]);
+/// }
+///
+/// function TestCaseOne() : Int {
+///     42
+/// }
+///
+/// function AddOne(x: Int) : Int {
+///     x + 1
+/// }
+/// ```
+function TestCases<'Result : Eq + Show > (test_cases : (String, () -> 'Result, 'Result)[]) : Bool {
+    let failed_test_buf = TestCasesSilent(test_cases);
+
+    if Length(failed_test_buf) == 0 {
+        Message($"{Length(test_cases)} test(s) passed.");
+        true
+    } else {
+        Message($"{Length(failed_test_buf)} tests failed.");
+        for item in failed_test_buf {
+            Message($"{item}")
+        }
+        false
+    }
+}
+
+/// # Summary
+/// Similar to `Qtest.Functions.TestCases`, but returns test failure info in an array of strings instead of directly messaging to
+/// output. Useful if you want to handle your own messaging when writing tests, for CI or similar.
+
+/// See `Qtest.Functions.TestCases` for more details.
+///
+/// # Description
+/// Given an array of test names, test functions, and expected results (of the same type), returns an array
+/// of strings representing all failed test cases (if any). Strings are of the form "test_name: expected {}, got {}"
+///
+/// # Input
+/// ## test_cases
+/// An array of three-arity tuples of the form `(test_name, callable_to_test, expected_result)`.
+/// `callable_to_test` will be called and its result will be compared to `expected_result`.
+///
+/// # Example
+/// ```qsharp
+/// function Main() : Unit {
+///     let failure_messages = TestCasesSilent([
+///         ("Should return 42", TestCaseOne, 42),
+///         ("Should add one", () -> AddOne(5), 6)
+///     ]);
+///     Std.Diagnostics.Fact(Length(failure_messages) == 0, "No tests should fail.")
+/// }
+///
+/// function TestCaseOne() : Int {
+///     42
+/// }
+///
+/// function AddOne(x: Int) : Int {
+///     x + 1
+/// }
+/// ```
+function TestCasesSilent<'Result : Eq + Show > (test_cases : (String, () -> 'Result, 'Result)[]) : String[] {
+    let num_tests = Length(test_cases);
+    mutable failed_test_buf = [];
+
+    for (name, case, result) in test_cases {
+        let (did_pass, message) = TestCase(case, result)!;
+        if not did_pass {
+            set failed_test_buf = failed_test_buf + [$"{name}: {message}"];
+        }
+    }
+
+    failed_test_buf
+}
+
+struct TestCaseResult {
+    did_pass : Bool,
+    message : String,
+}
+
+function TestCase<'Result : Eq + Show > (test_case : () -> 'Result, expected : 'Result) : TestCaseResult {
+    let result = test_case();
+    if result == expected {
+        new TestCaseResult { did_pass = true, message = "" }
+    } else {
+        new TestCaseResult { did_pass = false, message = $"expected: {expected}, got: {result}" }
+    }
+}
+
+
+
+export TestCases; 

--- a/library/qtest/src/Main.qs
+++ b/library/qtest/src/Main.qs
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export Functions, Operations;
+export Util.TestCaseResult;

--- a/library/qtest/src/Main.qs
+++ b/library/qtest/src/Main.qs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export Functions, Operations;

--- a/library/qtest/src/Operations.qs
+++ b/library/qtest/src/Operations.qs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/// # Summary
+/// Runs a series of named test operations with expected results.
+///
+/// # Description
+/// Given an array of test names, test operations, and expected results (of the same type), returns `true`
+/// if all tests passed, and `false` if any one test failed.
+/// Prints the expected and received result for any failed tests.
+///
+/// # Input
+/// ## test_cases
+/// An array of five-arity tuples of the form `(test_name, num_qubits, qubit_prep_callable, callable_to_test, expected_result)`.
+/// `num_qubits` will be allocated in a qubit array and passed to `qubit_prep_callable` to prepare the state before executing 
+/// `callable_to_test`. Afterwards, `callable_to_test` will be called and its result will be compared to `expected_result`.
+///
+/// # Example
+/// ```qsharp
+/// function Main() : Unit {
+///     TestCases([
+///         ("Should return 42", TestCaseOne, 42),
+///         ("Should add one", () => AddOne(5), 6)
+///     ]);
+/// }
+///
+/// function TestCaseOne() : Int {
+///     42
+/// }
+///
+/// function AddOne(x: Int) : Int {
+///     x + 1
+/// }
+/// ```
+operation TestCases<'Result : Eq + Show > (test_cases : (String, Int, (Qubit[]) => (), (Qubit[]) => 'Result, 'Result)[]) : Bool {
+    let failed_test_buf = TestCasesSilent(test_cases);
+    
+    if Length(failed_test_buf) == 0 {
+        Message($"{Length(test_cases)} test(s) passed.");
+        true
+    } else {
+        Message($"{Length(failed_test_buf)} tests failed.");
+        for item in failed_test_buf {
+            Message($"{item}")
+        }
+        false
+    }
+}
+
+/// # Summary
+/// Similar to `Qtest.Operations.TestCases`, but returns test failure info in an array of strings instead of directly messaging to
+/// output. Useful if you want to handle your own messaging when writing tests, for CI or similar.
+
+/// See `Qtest.Operations.TestCases` for more details.
+///
+/// # Description
+/// Given an array of test names, test functions, and expected results (of the same type), returns an array
+/// of strings representing all failed test cases (if any). Strings are of the form "test_name: expected {}, got {}"
+///
+/// # Input
+/// ## test_cases
+/// An array of five-arity tuples of the form `(test_name, num_qubits, qubit_prep_callable, callable_to_test, expected_result)`.
+/// `num_qubits` will be allocated in a qubit array and passed to `qubit_prep_callable` to prepare the state before executing 
+/// `callable_to_test`. Afterwards, `callable_to_test` will be called and its result will be compared to `expected_result`.
+///
+/// # Example
+/// ```qsharp
+/// function Main() : Unit {
+///     let failure_messages = TestCasesSilent([
+///         ("Should return 42", TestCaseOne, 42),
+///         ("Should add one", () => AddOne(5), 6)
+///     ]);
+///     Std.Diagnostics.Fact(Length(failure_messages) == 0, "No tests should fail.")
+/// }
+///
+/// function TestCaseOne() : Int {
+///     42
+/// }
+///
+/// function AddOne(x: Int) : Int {
+///     x + 1
+/// }
+/// ```
+operation TestCasesSilent<'Result : Eq + Show > (test_cases : (String, Int, (Qubit[]) => (), (Qubit[]) => 'Result, 'Result)[]) : String[] {
+    let num_tests = Length(test_cases);
+    mutable failed_test_buf = [];
+
+    for (name, num_qubits, prepare_state, case, result) in test_cases {
+        use qubits = Qubit[num_qubits];
+        prepare_state(qubits);
+        let (did_pass, message) = TestCase(qubits, case, result)!;
+        if not did_pass {
+            set failed_test_buf = failed_test_buf + [$"{name}: {message}"];
+        }
+        ResetAll(qubits);
+    }
+
+    failed_test_buf
+}
+struct TestCaseResult {
+    did_pass : Bool,
+    message : String,
+}
+
+operation TestCase<'Result : Eq + Show > (qubits: Qubit[], test_case : (Qubit[]) => 'Result, expected : 'Result) : TestCaseResult {
+    let result = test_case(qubits);
+    if result == expected {
+        new TestCaseResult { did_pass = true, message = "" }
+    } else {
+        new TestCaseResult { did_pass = false, message = $"expected: {expected}, got: {result}" }
+    }
+}
+
+
+
+export TestCases; 

--- a/library/qtest/src/Tests.qs
+++ b/library/qtest/src/Tests.qs
@@ -1,20 +1,35 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+import Std.Diagnostics.Fact;
+
 function Main() : Unit {
-    Std.Diagnostics.Fact(
-        Functions.TestCases([
-            ("Should return 42", TestCaseOne, 42),
-            ("Should add one", () -> AddOne(5), 6)
-        ]),
-        "Test harness failed to return true for all passing tests."
+    let sample_tests = [
+        ("Should return 42", TestCaseOne, 43),
+        ("Should add one", () -> AddOne(5), 42),
+        ("Should add one", () -> AddOne(5), 6)
+    ];
+
+    Fact(
+        not Functions.CheckAllTestCases(sample_tests),
+        "Test harness failed to return false for a failing tests."
     );
-    Std.Diagnostics.Fact(
-        Length(Functions.TestCasesSilent([
-            ("Should return 42", TestCaseOne, 43),
-            ("Should add one", () -> AddOne(5), 42)
-        ])) == 2,
-        "Test harness failed to return messages for failing tests."
+
+    Fact(
+        Functions.CheckAllTestCases([("always returns true", () -> true, true)]),
+        "Test harness failed to return true for a passing test"
     );
+
+    let run_all_result = Functions.RunAllTestCases(sample_tests);
+
+    Fact(
+        Length(run_all_result) == 3,
+        "Test harness did not return results for all test cases."
+    );
+
+    Fact(run_all_result[0].did_pass, "test one passed when it should have failed");
+    Fact(run_all_result[1].did_pass, "test two failed when it should have passed");
+    Fact(run_all_result[2].did_pass, "test three passed when it should have failed");
 }
 
 function TestCaseOne() : Int {

--- a/library/qtest/src/Tests.qs
+++ b/library/qtest/src/Tests.qs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+function Main() : Unit {
+    Std.Diagnostics.Fact(
+        Functions.TestCases([
+            ("Should return 42", TestCaseOne, 42),
+            ("Should add one", () -> AddOne(5), 6)
+        ]),
+        "Test harness failed to return true for all passing tests."
+    );
+    Std.Diagnostics.Fact(
+        Length(Functions.TestCasesSilent([
+            ("Should return 42", TestCaseOne, 43),
+            ("Should add one", () -> AddOne(5), 42)
+        ])) == 2,
+        "Test harness failed to return messages for failing tests."
+    );
+}
+
+function TestCaseOne() : Int {
+    42
+}
+
+function AddOne(x : Int) : Int {
+    x + 1
+}

--- a/library/qtest/src/Util.qs
+++ b/library/qtest/src/Util.qs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import Std.Arrays.Filtered;
+import Std.Diagnostics.Fact;
+
+struct TestCaseResult {
+    did_pass : Bool,
+    message : String,
+}
+
+
+function OutputMessage(test_results : TestCaseResult[]) : Unit {
+    let num_tests = Length(test_results);
+    let failed_tests = Filtered((item -> not item.did_pass), test_results);
+    let num_passed = Std.Arrays.Count((item -> item.did_pass), test_results);
+    let num_failed = Length(failed_tests);
+
+    Fact((num_passed + num_failed) == num_tests, "invariant failed in test harness: passed plus failed should equal total");
+
+    let test_word = if num_tests == 1 or num_tests == 0 { "test" } else { "tests" };
+    Message($"{num_passed} of {num_tests} {test_word} passed. ({num_failed} failed)");
+    for failed_test in failed_tests {
+        Message($"{failed_test.message}");
+    }
+}

--- a/library/signed/qsharp.json
+++ b/library/signed/qsharp.json
@@ -9,6 +9,14 @@
         "ref": "3195043",
         "path": "library/unstable"
       }
+    },
+    "Qtest": {
+      "github": {
+        "owner": "Microsoft",
+        "repo": "qsharp",
+        "ref": "b408eddb",
+        "path": "library/qtest"
+      }
     }
   },
   "files": [

--- a/library/signed/qsharp.json
+++ b/library/signed/qsharp.json
@@ -14,7 +14,7 @@
       "github": {
         "owner": "Microsoft",
         "repo": "qsharp",
-        "ref": "b408eddb",
+        "ref": "486616a4",
         "path": "library/qtest"
       }
     }

--- a/library/signed/src/Tests.qs
+++ b/library/signed/src/Tests.qs
@@ -8,7 +8,7 @@ import Measurement.MeasureSignedInteger;
 /// This entrypoint runs tests for the signed integer library.
 operation Main() : Unit {
     UnsignedOpTests();
-    Qtest.Operations.TestCases(MeasureSignedIntTests());
+    Fact(Qtest.Operations.CheckAllTestCases(MeasureSignedIntTests()), "SignedInt tests failed");
     SignedOpTests();
 
 }

--- a/library/signed/src/Tests.qs
+++ b/library/signed/src/Tests.qs
@@ -8,47 +8,24 @@ import Measurement.MeasureSignedInteger;
 /// This entrypoint runs tests for the signed integer library.
 operation Main() : Unit {
     UnsignedOpTests();
-    MeasureSignedIntTests();
+    Qtest.Operations.TestCases(MeasureSignedIntTests());
     SignedOpTests();
 
 }
 
-operation MeasureSignedIntTests() : Unit {
-    use a = Qubit[4];
-
-    // 0b0001 == 1
-    X(a[0]);
-    let res = MeasureSignedInteger(a, 4);
-    Fact(res == 1, $"Expected 1, received {res}");
-
-    // 0b1111 == -1
-    X(a[0]);
-    X(a[1]);
-    X(a[2]);
-    X(a[3]);
-    let res = MeasureSignedInteger(a, 4);
-    Fact(res == -1, $"Expected -1, received {res}");
-
-    // 0b01000 == 8
-    use a = Qubit[5];
-    X(a[3]);
-    let res = MeasureSignedInteger(a, 5);
-    Fact(res == 8, $"Expected 8, received {res}");
-
-    // 0b11110 == -2
-    X(a[1]);
-    X(a[2]);
-    X(a[3]);
-    X(a[4]);
-    let res = MeasureSignedInteger(a, 5);
-    Fact(res == -2, $"Expected -2, received {res}");
-
-    // 0b11000 == -8
-    X(a[3]);
-    X(a[4]);
-    let res = MeasureSignedInteger(a, 5);
-    Fact(res == -8, $"Expected -8, received {res}");
-
+function MeasureSignedIntTests() : (String, Int, (Qubit[]) => (), (Qubit[]) => Int, Int)[] {
+    [
+        ("0b0001 == 1", 4, (qs) => X(qs[0]), (qs) => MeasureSignedInteger(qs, 4), 1),
+        ("0b1111 == -1", 4, (qs) => { X(qs[0]); X(qs[1]); X(qs[2]); X(qs[3]); }, (qs) => MeasureSignedInteger(qs, 4), -1),
+        ("0b01000 == 8", 5, (qs) => X(qs[3]), (qs) => MeasureSignedInteger(qs, 5), 8),
+        ("0b11110 == -2", 5, (qs) => {
+            X(qs[1]);
+            X(qs[2]);
+            X(qs[3]);
+            X(qs[4]);
+        }, (qs) => MeasureSignedInteger(qs, 5), -2),
+        ("0b11000 == -8", 5, (qs) => { X(qs[3]); X(qs[4]); }, (qs) => MeasureSignedInteger(qs, 5), -8)
+    ]
 }
 
 operation SignedOpTests() : Unit {


### PR DESCRIPTION
This PR introduces Qtest, a library for running Q# unit tests. It includes two namespaces: `Functions` for testing functions and `Operations` for testing operations. `Operations` also allows for qubit state preparation before tests.

To demonstrate, I converted `MeasureSignedIntTests()` in `signed/src/Tests.qs` to use Qtest. [The result is fewer lines of code](https://github.com/microsoft/qsharp/pull/2013/files#diff-fa6f0fda29e55d52d8254ab813dcda39094b02928370e841ea741c526e3d5338L16) and clearer test intentions. Additionally, all tests run before reporting any failures, unlike the current behavior which stops at the first failure.

I haven't converted all existing Q# tests yet, as that's beyond this PR's scope. This PR aims to validate the API's utility before proceeding with further conversions.

