### PR TITLE
Remove unnecessary EntryPoint attributes in the samples

### DIFF
--- a/samples/algorithms/BernsteinVazirani.qs
+++ b/samples/algorithms/BernsteinVazirani.qs
@@ -13,7 +13,6 @@ namespace Sample {
     import Std.Math.*;
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : Int[] {
         // Consider a function 𝑓(𝑥⃗) on bitstrings 𝑥⃗ = (𝑥₀, …, 𝑥ₙ₋₁) of the form
         //     𝑓(𝑥⃗) ≔ Σᵢ 𝑥ᵢ 𝑟ᵢ

--- a/samples/algorithms/BernsteinVaziraniNISQ.qs
+++ b/samples/algorithms/BernsteinVaziraniNISQ.qs
@@ -13,7 +13,6 @@ namespace Sample {
     import Std.Math.*;
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : Result[] {
         // Consider a function 𝑓(𝑥⃗) on bitstrings 𝑥⃗ = (𝑥₀, …, 𝑥ₙ₋₁) of the form
         //     𝑓(𝑥⃗) ≔ Σᵢ 𝑥ᵢ 𝑟ᵢ

--- a/samples/algorithms/BitFlipCode.qs
+++ b/samples/algorithms/BitFlipCode.qs
@@ -25,7 +25,6 @@ namespace Sample {
     import Std.Diagnostics.*;
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : Result {
         use logicalQubit = Qubit[3];
 

--- a/samples/algorithms/CatState.qs
+++ b/samples/algorithms/CatState.qs
@@ -9,7 +9,6 @@
 namespace Sample {
     import Std.Diagnostics.*;
 
-    @EntryPoint()
     operation Main() : Result[] {
         use register = Qubit[5];
 

--- a/samples/algorithms/DeutschJozsa.qs
+++ b/samples/algorithms/DeutschJozsa.qs
@@ -12,7 +12,6 @@ namespace Sample {
     import Std.Math.*;
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : (String, Bool)[] {
         // A Boolean function is a function that maps bitstrings to a bit:
         //     𝑓 : {0, 1}^n → {0, 1}.

--- a/samples/algorithms/DeutschJozsaNISQ.qs
+++ b/samples/algorithms/DeutschJozsaNISQ.qs
@@ -10,7 +10,6 @@
 namespace Sample {
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : (Result[], Result[]) {
         // A Boolean function is a function that maps bitstrings to a bit:
         //     𝑓 : {0, 1}^n → {0, 1}.

--- a/samples/algorithms/DotProductViaPhaseEstimation.qs
+++ b/samples/algorithms/DotProductViaPhaseEstimation.qs
@@ -24,7 +24,6 @@ namespace IterativePhaseEstimation {
     import Std.Math.*;
     import Std.Convert.*;
 
-    @EntryPoint()
     operation Main() : (Int, Int) {
         // The angles for inner product. Inner product is meeasured for vectors
         // (cos(Θ₁/2), sin(Θ₁/2)) and (cos(Θ₂/2), sin(Θ₂/2)).

--- a/samples/algorithms/GHZ.qs
+++ b/samples/algorithms/GHZ.qs
@@ -18,7 +18,6 @@
 namespace Sample {
     import Std.Diagnostics.*;
 
-    @EntryPoint()
     operation Main() : Result[] {
         use qs = Qubit[3];
 

--- a/samples/algorithms/Grover.qs
+++ b/samples/algorithms/Grover.qs
@@ -14,7 +14,6 @@ namespace Sample {
     import Std.Measurement.*;
     import Std.Diagnostics.*;
 
-    @EntryPoint()
     operation Main() : Result[] {
         let nQubits = 5;
 

--- a/samples/algorithms/HiddenShift.qs
+++ b/samples/algorithms/HiddenShift.qs
@@ -14,7 +14,6 @@ namespace Sample {
     import Std.Diagnostics.*;
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : Int[] {
         let nQubits = 10;
 

--- a/samples/algorithms/HiddenShiftNISQ.qs
+++ b/samples/algorithms/HiddenShiftNISQ.qs
@@ -14,7 +14,6 @@ namespace Sample {
     import Std.Diagnostics.*;
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : Result[] {
         // Consider the case of finding a hidden shift 𝑠 between two Boolean
         // functions 𝑓(𝑥) and 𝑔(𝑥) = 𝑓(𝑥 ⊕ 𝑠).

--- a/samples/algorithms/JointMeasurement.qs
+++ b/samples/algorithms/JointMeasurement.qs
@@ -7,7 +7,6 @@
 namespace Sample {
     import Std.Diagnostics.*;
 
-    @EntryPoint()
     operation Main() : (Result, Result[]) {
         // Prepare an entangled state.
         use qs = Qubit[2];  // |00〉

--- a/samples/algorithms/Measurement.qs
+++ b/samples/algorithms/Measurement.qs
@@ -13,7 +13,6 @@
 namespace Sample {
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : (Result, Result[]) {
         // The `M` operation performs a measurement of a single qubit in the
         // computational basis, also known as the Pauli Z basis.

--- a/samples/algorithms/PhaseFlipCode.qs
+++ b/samples/algorithms/PhaseFlipCode.qs
@@ -25,7 +25,6 @@ namespace Sample {
     import Std.Diagnostics.*;
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : Result {
         use logicalQubit = Qubit[3];
 

--- a/samples/algorithms/QRNG.qs
+++ b/samples/algorithms/QRNG.qs
@@ -9,7 +9,6 @@ namespace Sample {
     import Std.Intrinsic.*;
     import Std.Math.*;
 
-    @EntryPoint()
     operation Main() : Int {
         let max = 100;
         Message($"Sampling a random number between 0 and {max}:");

--- a/samples/algorithms/QRNGNISQ.qs
+++ b/samples/algorithms/QRNGNISQ.qs
@@ -8,7 +8,6 @@ namespace Sample {
     import Std.Measurement.*;
     import Std.Intrinsic.*;
 
-    @EntryPoint()
     operation Main() : Result[] {
         // Generate 5-bit random number.
         let nBits = 5;

--- a/samples/algorithms/Shor.qs
+++ b/samples/algorithms/Shor.qs
@@ -14,7 +14,6 @@ namespace Sample {
     import Microsoft.Quantum.Unstable.Arithmetic.*;
     import Std.Arrays.*;
 
-    @EntryPoint()
     operation Main() : (Int, Int) {
         let n = 143; // 11*13;
         // You can try these other examples for a lengthier computation.

--- a/samples/algorithms/SuperdenseCoding.qs
+++ b/samples/algorithms/SuperdenseCoding.qs
@@ -9,7 +9,7 @@
 /// This Q# program implements superdense coding to send two classical bits of
 /// information.
 namespace Sample {
-    @EntryPoint()
+
     operation Main() : ((Bool, Bool), (Bool, Bool)) {
         use (aliceQubit, bobQubit) = (Qubit(), Qubit());
 

--- a/samples/algorithms/Teleportation.qs
+++ b/samples/algorithms/Teleportation.qs
@@ -14,7 +14,6 @@ namespace Sample {
     import Std.Intrinsic.*;
     import Std.Measurement.*;
 
-    @EntryPoint()
     operation Main() : Result[] {
         // Use the `Teleport` operation to send different quantum states.
         let stateInitializerBasisTuples = [

--- a/samples/estimation/Dynamics.qs
+++ b/samples/estimation/Dynamics.qs
@@ -15,8 +15,6 @@ namespace QuantumDynamics {
     import Std.Math.*;
     import Std.Arrays.*;
 
-
-    @EntryPoint()
     operation Main() : Unit {
         // n : Int, m : Int, t: Double, u : Double, tstep : Double
 

--- a/samples/language/Specializations.qs
+++ b/samples/language/Specializations.qs
@@ -42,7 +42,6 @@ operation SWAP(q1 : Qubit, q2 : Qubit) : Unit is Adj + Ctl {
 }
 
 /// The main function cannot be Adj or Ctl.
-@EntryPoint()
 operation Main() : Unit {
 
     // We invoke specializations using functors at the call site.


### PR DESCRIPTION
Removes unnecessary `@EntryPoint()` attributes in the Q# samples.

Addresses #1688