### PR TITLE
Fix doc comment on `DumpOperation`

### DIFF
--- a/library/std/src/Std/Diagnostics.qs
+++ b/library/std/src/Std/Diagnostics.qs
@@ -78,7 +78,7 @@ function DumpRegister(register : Qubit[]) : Unit {
 /// # Remarks
 /// When run on the sparse-state simulator, the following snippet
 /// will output the matrix
-/// $\left(\begin{matrix} 0.707 & 0.707 \\\\ 0.707 & 0.707\end{matrix}\right)$:
+/// $\left(\begin{matrix} 0.707 & 0.707 \\\\ 0.707 & -0.707\end{matrix}\right)$:
 ///
 /// ```qsharp
 /// operation DumpH() : Unit {

--- a/library/std/src/Std/Diagnostics.qs
+++ b/library/std/src/Std/Diagnostics.qs
@@ -78,7 +78,7 @@ function DumpRegister(register : Qubit[]) : Unit {
 /// # Remarks
 /// When run on the sparse-state simulator, the following snippet
 /// will output the matrix
-/// $\left(\begin{matrix} 0.0 & 0.707 \\\\ 0.707 & 0.0\end{matrix}\right)$:
+/// $\left(\begin{matrix} 0.707 & 0.707 \\\\ 0.707 & 0.707\end{matrix}\right)$:
 ///
 /// ```qsharp
 /// operation DumpH() : Unit {


### PR DESCRIPTION
The matrix was wrong in the doc comment, in that it was showing H as diagonal and shouldn't be.