### PR TITLE
Indentation fix in doc comment formatting

### DIFF
--- a/compiler/qsc_formatter/src/formatter.rs
+++ b/compiler/qsc_formatter/src/formatter.rs
@@ -277,10 +277,10 @@ impl<'a> Formatter<'a> {
                 effect_trim_comment(left, &mut edits, self.code);
                 effect_correct_indentation(left, whitespace, right, &mut edits, self.indent_level);
             }
-            (_, Comment) if matches!(left_delim_state, Delimiter::Open) => {
+            (_, Comment | Syntax(DocComment)) if matches!(left_delim_state, Delimiter::Open) => {
                 effect_correct_indentation(left, whitespace, right, &mut edits, self.indent_level);
             }
-            (_, Comment) => {
+            (_, Comment | Syntax(DocComment)) => {
                 if are_newlines_in_spaces {
                     effect_correct_indentation(
                         left,

--- a/library/signed/src/Operations.qs
+++ b/library/signed/src/Operations.qs
@@ -285,7 +285,7 @@ operation DivideI(xs : Qubit[], ys : Qubit[], result : Qubit[]) : Unit is Adj + 
             (Controlled Adjoint RippleCarryTTKIncByLE)([result[i]], (ys, xtrunc));
         }
     }
-}   
+}
 
 /// # Summary
 /// Computes the reciprocal 1/x for an unsigned integer x

--- a/library/std/src/Std/Canon.qs
+++ b/library/std/src/Std/Canon.qs
@@ -234,13 +234,13 @@ operation CZ(control : Qubit, target : Qubit) : Unit is Adj + Ctl {
     adjoint self;
 }
 
-    /// Given a pair, returns its first element.
+/// Given a pair, returns its first element.
 function Fst<'T, 'U>(pair : ('T, 'U)) : 'T {
     let (fst, _) = pair;
     return fst;
 }
 
-    /// Given a pair, returns its second element.
+/// Given a pair, returns its second element.
 function Snd<'T, 'U>(pair : ('T, 'U)) : 'U {
     let (_, snd) = pair;
     return snd;

--- a/library/std/src/Std/InternalHelpers.qs
+++ b/library/std/src/Std/InternalHelpers.qs
@@ -122,7 +122,7 @@ internal operation EntangleForJointMeasure(basis : Pauli, aux : Qubit, qubit : Q
     }
 }
 
-    /// Collects the given list of control qubits into one or two of the given auxiliary qubits, using
+/// Collects the given list of control qubits into one or two of the given auxiliary qubits, using
 /// all but the last qubits in the auxiliary list as scratch qubits. The auxiliary list must be
 /// big enough to accommodate the data, so it is usually smaller than controls list by number of
 /// qubits needed for the eventual controlled unitary application. The passed adjustment value is
@@ -143,7 +143,7 @@ internal operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : I
     }
 }
 
-    /// When collecting controls, if there is an uneven number of original control qubits then the
+/// When collecting controls, if there is an uneven number of original control qubits then the
 /// last control and the second to last auxiliary will be collected into the last auxiliary.
 internal operation AdjustForSingleControl(ctls : Qubit[], aux : Qubit[]) : Unit is Adj {
     if Length(ctls) % 2 != 0 {

--- a/library/unstable/src/TableLookup.qs
+++ b/library/unstable/src/TableLookup.qs
@@ -167,7 +167,7 @@ operation WriteMemoryContents(
     ApplyPauliFromBitString(PauliX, true, value, target);
 }
 
-    /// # References
+/// # References
 /// - [arXiv:1905.07682](https://arxiv.org/abs/1905.07682)
 ///   "Windowed arithmetic"
 operation Unlookup(


### PR DESCRIPTION
Noticed a minor issue in the formatter where we weren't treating doc comments as comments.