### PR TITLE
Track qubit live-ness during simulation

### DIFF
--- a/compiler/qsc_circuit/src/builder.rs
+++ b/compiler/qsc_circuit/src/builder.rs
@@ -303,7 +303,13 @@ impl Builder {
                 self.push_list::<'(', ')'>(vals, qubits, classical_args);
             }
             Value::Qubit(q) => {
-                qubits.push(self.map(q.0));
+                qubits.push(
+                    self.map(
+                        q.upgrade()
+                            .expect("qubit liveness should be checked by evaluator")
+                            .0,
+                    ),
+                );
             }
             v => {
                 let _ = write!(classical_args, "{v}");

--- a/compiler/qsc_circuit/src/builder.rs
+++ b/compiler/qsc_circuit/src/builder.rs
@@ -303,13 +303,7 @@ impl Builder {
                 self.push_list::<'(', ')'>(vals, qubits, classical_args);
             }
             Value::Qubit(q) => {
-                qubits.push(
-                    self.map(
-                        q.upgrade()
-                            .expect("qubit liveness should be checked by evaluator")
-                            .0,
-                    ),
-                );
+                qubits.push(self.map(q.deref().0));
             }
             v => {
                 let _ = write!(classical_args, "{v}");

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -384,7 +384,15 @@ impl Backend for SparseSim {
                     .clone()
                     .unwrap_array()
                     .iter()
-                    .map(|q| q.clone().unwrap_qubit().0)
+                    .map(|q| {
+                        q.clone()
+                            .unwrap_qubit()
+                            .upgrade()
+                            .expect(
+                                "qubits should be checked for liveness before call into backend",
+                            )
+                            .0
+                    })
                     .collect::<Vec<_>>();
                 let q = self.sim.allocate();
                 // The new qubit is by-definition in the |0⟩ state, so by reversing the sign of the
@@ -415,7 +423,11 @@ impl Backend for SparseSim {
                 }
             }
             "ApplyIdleNoise" => {
-                let q = arg.unwrap_qubit().0;
+                let q = arg
+                    .unwrap_qubit()
+                    .upgrade()
+                    .expect("qubit should be checked for liveness before call into backend")
+                    .0;
                 self.apply_noise(q);
                 Some(Ok(Value::unit()))
             }

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -384,15 +384,7 @@ impl Backend for SparseSim {
                     .clone()
                     .unwrap_array()
                     .iter()
-                    .map(|q| {
-                        q.clone()
-                            .unwrap_qubit()
-                            .upgrade()
-                            .expect(
-                                "qubits should be checked for liveness before call into backend",
-                            )
-                            .0
-                    })
+                    .map(|q| q.clone().unwrap_qubit().deref().0)
                     .collect::<Vec<_>>();
                 let q = self.sim.allocate();
                 // The new qubit is by-definition in the |0⟩ state, so by reversing the sign of the
@@ -423,11 +415,7 @@ impl Backend for SparseSim {
                 }
             }
             "ApplyIdleNoise" => {
-                let q = arg
-                    .unwrap_qubit()
-                    .upgrade()
-                    .expect("qubit should be checked for liveness before call into backend")
-                    .0;
+                let q = arg.unwrap_qubit().deref().0;
                 self.apply_noise(q);
                 Some(Ok(Value::unit()))
             }

--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -65,7 +65,7 @@ pub(crate) fn call(
             let qubits_len = qubits.len();
             let qubits = qubits
                 .iter()
-                .filter_map(|q| q.clone().unwrap_qubit().upgrade().map(|q| q.0))
+                .filter_map(|q| q.clone().unwrap_qubit().try_deref().map(|q| q.0))
                 .collect::<Vec<_>>();
             if qubits.len() != qubits_len {
                 return Err(Error::QubitUsedAfterRelease(arg_span));
@@ -86,7 +86,7 @@ pub(crate) fn call(
             let qubits_len = qubits.len();
             let qubits = qubits
                 .iter()
-                .filter_map(|q| q.clone().unwrap_qubit().upgrade().map(|q| q.0))
+                .filter_map(|q| q.clone().unwrap_qubit().try_deref().map(|q| q.0))
                 .collect::<Vec<_>>();
             if qubits.len() != qubits_len {
                 return Err(Error::QubitUsedAfterRelease(arg_span));
@@ -111,7 +111,7 @@ pub(crate) fn call(
         "CheckZero" => Ok(Value::Bool(
             sim.qubit_is_zero(
                 arg.unwrap_qubit()
-                    .upgrade()
+                    .try_deref()
                     .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                     .0,
             ),
@@ -194,7 +194,7 @@ pub(crate) fn call(
         "__quantum__qis__m__body" => Ok(Value::Result(
             sim.m(arg
                 .unwrap_qubit()
-                .upgrade()
+                .try_deref()
                 .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                 .0)
                 .into(),
@@ -202,7 +202,7 @@ pub(crate) fn call(
         "__quantum__qis__mresetz__body" => Ok(Value::Result(
             sim.mresetz(
                 arg.unwrap_qubit()
-                    .upgrade()
+                    .try_deref()
                     .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                     .0,
             )
@@ -213,7 +213,7 @@ pub(crate) fn call(
             let qubits_len = qubits.len();
             let qubits = qubits
                 .iter()
-                .filter_map(|q| q.upgrade().map(|q| q.0))
+                .filter_map(|q| q.try_deref().map(|q| q.0))
                 .collect::<Vec<_>>();
             if qubits.len() != qubits_len {
                 return Err(Error::QubitUsedAfterRelease(arg_span));
@@ -237,7 +237,7 @@ fn one_qubit_gate(
 ) -> Result<Value, Error> {
     gate(
         arg.unwrap_qubit()
-            .upgrade()
+            .try_deref()
             .ok_or(Error::QubitUsedAfterRelease(arg_span))?
             .0,
     );
@@ -255,11 +255,11 @@ fn two_qubit_gate(
     } else {
         gate(
             x.unwrap_qubit()
-                .upgrade()
+                .try_deref()
                 .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                 .0,
             y.unwrap_qubit()
-                .upgrade()
+                .try_deref()
                 .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                 .0,
         );
@@ -280,7 +280,7 @@ fn one_qubit_rotation(
         gate(
             angle,
             y.unwrap_qubit()
-                .upgrade()
+                .try_deref()
                 .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                 .0,
         );
@@ -299,15 +299,15 @@ fn three_qubit_gate(
     } else {
         gate(
             x.unwrap_qubit()
-                .upgrade()
+                .try_deref()
                 .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                 .0,
             y.unwrap_qubit()
-                .upgrade()
+                .try_deref()
                 .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                 .0,
             z.unwrap_qubit()
-                .upgrade()
+                .try_deref()
                 .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                 .0,
         );
@@ -330,11 +330,11 @@ fn two_qubit_rotation(
         gate(
             angle,
             y.unwrap_qubit()
-                .upgrade()
+                .try_deref()
                 .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                 .0,
             z.unwrap_qubit()
-                .upgrade()
+                .try_deref()
                 .ok_or(Error::QubitUsedAfterRelease(arg_span))?
                 .0,
         );
@@ -355,7 +355,7 @@ pub fn qubit_relabel(
     let left_len = left.len();
     let left = left
         .iter()
-        .filter_map(|q| q.clone().unwrap_qubit().upgrade().map(|q| q.0))
+        .filter_map(|q| q.clone().unwrap_qubit().try_deref().map(|q| q.0))
         .collect::<Vec<_>>();
     if left.len() != left_len {
         return Err(Error::QubitUsedAfterRelease(arg_span));
@@ -364,7 +364,7 @@ pub fn qubit_relabel(
     let right_len = right.len();
     let right = right
         .iter()
-        .filter_map(|q| q.clone().unwrap_qubit().upgrade().map(|q| q.0))
+        .filter_map(|q| q.clone().unwrap_qubit().try_deref().map(|q| q.0))
         .collect::<Vec<_>>();
     if right.len() != right_len {
         return Err(Error::QubitUsedAfterRelease(arg_span));

--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -213,7 +213,7 @@ pub(crate) fn call(
             let qubits_len = qubits.len();
             let qubits = qubits
                 .iter()
-                .filter_map(|q| q.clone().upgrade().map(|q| q.0))
+                .filter_map(|q| q.upgrade().map(|q| q.0))
                 .collect::<Vec<_>>();
             if qubits.len() != qubits_len {
                 return Err(Error::QubitUsedAfterRelease(arg_span));

--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -10,7 +10,7 @@ use crate::{
     backend::Backend,
     error::PackageSpan,
     output::Receiver,
-    val::{self, Qubit, Value},
+    val::{self, Value},
     Error, Rc,
 };
 use num_bigint::BigInt;
@@ -62,10 +62,14 @@ pub(crate) fn call(
         }
         "DumpRegister" => {
             let qubits = arg.unwrap_array();
+            let qubits_len = qubits.len();
             let qubits = qubits
                 .iter()
-                .map(|q| q.clone().unwrap_qubit().0)
+                .filter_map(|q| q.clone().unwrap_qubit().upgrade().map(|q| q.0))
                 .collect::<Vec<_>>();
+            if qubits.len() != qubits_len {
+                return Err(Error::QubitUsedAfterRelease(arg_span));
+            }
             if qubits.len() != qubits.iter().collect::<FxHashSet<_>>().len() {
                 return Err(Error::QubitUniqueness(arg_span));
             }
@@ -79,10 +83,14 @@ pub(crate) fn call(
         }
         "DumpMatrix" => {
             let qubits = arg.unwrap_array();
+            let qubits_len = qubits.len();
             let qubits = qubits
                 .iter()
-                .map(|q| q.clone().unwrap_qubit().0)
+                .filter_map(|q| q.clone().unwrap_qubit().upgrade().map(|q| q.0))
                 .collect::<Vec<_>>();
+            if qubits.len() != qubits_len {
+                return Err(Error::QubitUsedAfterRelease(arg_span));
+            }
             if qubits.len() != qubits.iter().collect::<FxHashSet<_>>().len() {
                 return Err(Error::QubitUniqueness(arg_span));
             }
@@ -100,7 +108,14 @@ pub(crate) fn call(
             Ok(()) => Ok(Value::unit()),
             Err(_) => Err(Error::OutputFail(name_span)),
         },
-        "CheckZero" => Ok(Value::Bool(sim.qubit_is_zero(arg.unwrap_qubit().0))),
+        "CheckZero" => Ok(Value::Bool(
+            sim.qubit_is_zero(
+                arg.unwrap_qubit()
+                    .upgrade()
+                    .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                    .0,
+            ),
+        )),
         "ArcCos" => Ok(Value::Double(arg.unwrap_double().acos())),
         "ArcSin" => Ok(Value::Double(arg.unwrap_double().asin())),
         "ArcTan" => Ok(Value::Double(arg.unwrap_double().atan())),
@@ -142,15 +157,6 @@ pub(crate) fn call(
         }
         #[allow(clippy::cast_possible_truncation)]
         "Truncate" => Ok(Value::Int(arg.unwrap_double() as i64)),
-        "__quantum__rt__qubit_allocate" => Ok(Value::Qubit(Qubit(sim.qubit_allocate()))),
-        "__quantum__rt__qubit_release" => {
-            let qubit = arg.unwrap_qubit().0;
-            if sim.qubit_release(qubit) {
-                Ok(Value::unit())
-            } else {
-                Err(Error::ReleasedQubitNotZero(qubit, arg_span))
-            }
-        }
         "__quantum__qis__ccx__body" => {
             three_qubit_gate(|ctl0, ctl1, q| sim.ccx(ctl0, ctl1, q), arg, arg_span)
         }
@@ -175,21 +181,43 @@ pub(crate) fn call(
         "__quantum__qis__rzz__body" => {
             two_qubit_rotation(|theta, q0, q1| sim.rzz(theta, q0, q1), arg, arg_span)
         }
-        "__quantum__qis__h__body" => Ok(one_qubit_gate(|q| sim.h(q), arg)),
-        "__quantum__qis__s__body" => Ok(one_qubit_gate(|q| sim.s(q), arg)),
-        "__quantum__qis__s__adj" => Ok(one_qubit_gate(|q| sim.sadj(q), arg)),
-        "__quantum__qis__t__body" => Ok(one_qubit_gate(|q| sim.t(q), arg)),
-        "__quantum__qis__t__adj" => Ok(one_qubit_gate(|q| sim.tadj(q), arg)),
-        "__quantum__qis__x__body" => Ok(one_qubit_gate(|q| sim.x(q), arg)),
-        "__quantum__qis__y__body" => Ok(one_qubit_gate(|q| sim.y(q), arg)),
-        "__quantum__qis__z__body" => Ok(one_qubit_gate(|q| sim.z(q), arg)),
+        "__quantum__qis__h__body" => one_qubit_gate(|q| sim.h(q), arg, arg_span),
+        "__quantum__qis__s__body" => one_qubit_gate(|q| sim.s(q), arg, arg_span),
+        "__quantum__qis__s__adj" => one_qubit_gate(|q| sim.sadj(q), arg, arg_span),
+        "__quantum__qis__t__body" => one_qubit_gate(|q| sim.t(q), arg, arg_span),
+        "__quantum__qis__t__adj" => one_qubit_gate(|q| sim.tadj(q), arg, arg_span),
+        "__quantum__qis__x__body" => one_qubit_gate(|q| sim.x(q), arg, arg_span),
+        "__quantum__qis__y__body" => one_qubit_gate(|q| sim.y(q), arg, arg_span),
+        "__quantum__qis__z__body" => one_qubit_gate(|q| sim.z(q), arg, arg_span),
         "__quantum__qis__swap__body" => two_qubit_gate(|q0, q1| sim.swap(q0, q1), arg, arg_span),
-        "__quantum__qis__reset__body" => Ok(one_qubit_gate(|q| sim.reset(q), arg)),
-        "__quantum__qis__m__body" => Ok(Value::Result(sim.m(arg.unwrap_qubit().0).into())),
-        "__quantum__qis__mresetz__body" => {
-            Ok(Value::Result(sim.mresetz(arg.unwrap_qubit().0).into()))
-        }
+        "__quantum__qis__reset__body" => one_qubit_gate(|q| sim.reset(q), arg, arg_span),
+        "__quantum__qis__m__body" => Ok(Value::Result(
+            sim.m(arg
+                .unwrap_qubit()
+                .upgrade()
+                .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                .0)
+                .into(),
+        )),
+        "__quantum__qis__mresetz__body" => Ok(Value::Result(
+            sim.mresetz(
+                arg.unwrap_qubit()
+                    .upgrade()
+                    .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                    .0,
+            )
+            .into(),
+        )),
         _ => {
+            let qubits = arg.qubits();
+            let qubits_len = qubits.len();
+            let qubits = qubits
+                .iter()
+                .filter_map(|q| q.clone().upgrade().map(|q| q.0))
+                .collect::<Vec<_>>();
+            if qubits.len() != qubits_len {
+                return Err(Error::QubitUsedAfterRelease(arg_span));
+            }
             if let Some(result) = sim.custom_intrinsic(name, arg) {
                 match result {
                     Ok(value) => Ok(value),
@@ -202,9 +230,18 @@ pub(crate) fn call(
     }
 }
 
-fn one_qubit_gate(mut gate: impl FnMut(usize), arg: Value) -> Value {
-    gate(arg.unwrap_qubit().0);
-    Value::unit()
+fn one_qubit_gate(
+    mut gate: impl FnMut(usize),
+    arg: Value,
+    arg_span: PackageSpan,
+) -> Result<Value, Error> {
+    gate(
+        arg.unwrap_qubit()
+            .upgrade()
+            .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+            .0,
+    );
+    Ok(Value::unit())
 }
 
 fn two_qubit_gate(
@@ -216,7 +253,16 @@ fn two_qubit_gate(
     if x == y {
         Err(Error::QubitUniqueness(arg_span))
     } else {
-        gate(x.unwrap_qubit().0, y.unwrap_qubit().0);
+        gate(
+            x.unwrap_qubit()
+                .upgrade()
+                .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                .0,
+            y.unwrap_qubit()
+                .upgrade()
+                .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                .0,
+        );
         Ok(Value::unit())
     }
 }
@@ -231,7 +277,13 @@ fn one_qubit_rotation(
     if angle.is_nan() || angle.is_infinite() {
         Err(Error::InvalidRotationAngle(angle, arg_span))
     } else {
-        gate(angle, y.unwrap_qubit().0);
+        gate(
+            angle,
+            y.unwrap_qubit()
+                .upgrade()
+                .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                .0,
+        );
         Ok(Value::unit())
     }
 }
@@ -245,7 +297,20 @@ fn three_qubit_gate(
     if x == y || y == z || x == z {
         Err(Error::QubitUniqueness(arg_span))
     } else {
-        gate(x.unwrap_qubit().0, y.unwrap_qubit().0, z.unwrap_qubit().0);
+        gate(
+            x.unwrap_qubit()
+                .upgrade()
+                .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                .0,
+            y.unwrap_qubit()
+                .upgrade()
+                .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                .0,
+            z.unwrap_qubit()
+                .upgrade()
+                .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                .0,
+        );
         Ok(Value::unit())
     }
 }
@@ -262,7 +327,17 @@ fn two_qubit_rotation(
     } else if angle.is_nan() || angle.is_infinite() {
         Err(Error::InvalidRotationAngle(angle, arg_span))
     } else {
-        gate(angle, y.unwrap_qubit().0, z.unwrap_qubit().0);
+        gate(
+            angle,
+            y.unwrap_qubit()
+                .upgrade()
+                .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                .0,
+            z.unwrap_qubit()
+                .upgrade()
+                .ok_or(Error::QubitUsedAfterRelease(arg_span))?
+                .0,
+        );
         Ok(Value::unit())
     }
 }
@@ -276,16 +351,24 @@ pub fn qubit_relabel(
     mut swap: impl FnMut(usize, usize),
 ) -> Result<Value, Error> {
     let [left, right] = unwrap_tuple(arg);
+    let left = left.unwrap_array();
+    let left_len = left.len();
     let left = left
-        .unwrap_array()
         .iter()
-        .map(|q| q.clone().unwrap_qubit().0)
+        .filter_map(|q| q.clone().unwrap_qubit().upgrade().map(|q| q.0))
         .collect::<Vec<_>>();
+    if left.len() != left_len {
+        return Err(Error::QubitUsedAfterRelease(arg_span));
+    }
+    let right = right.unwrap_array();
+    let right_len = right.len();
     let right = right
-        .unwrap_array()
         .iter()
-        .map(|q| q.clone().unwrap_qubit().0)
+        .filter_map(|q| q.clone().unwrap_qubit().upgrade().map(|q| q.0))
         .collect::<Vec<_>>();
+    if right.len() != right_len {
+        return Err(Error::QubitUsedAfterRelease(arg_span));
+    }
     let left_set = left.iter().collect::<FxHashSet<_>>();
     let right_set = right.iter().collect::<FxHashSet<_>>();
     if left.len() != left_set.len() || right.len() != right_set.len() {

--- a/compiler/qsc_eval/src/intrinsic/tests.rs
+++ b/compiler/qsc_eval/src/intrinsic/tests.rs
@@ -522,6 +522,18 @@ fn dump_register_qubits_not_unique_fails() {
 }
 
 #[test]
+fn dump_register_qubits_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+        let q = { use q = Qubit(); q };
+        Microsoft.Quantum.Diagnostics.DumpRegister([q]);
+    }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn dump_register_target_in_minus_with_other_in_zero() {
     check_intrinsic_output(
         "",
@@ -632,6 +644,18 @@ fn check_zero_false() {
             isZero
         }"},
         &expect!["false"],
+    );
+}
+
+#[test]
+fn check_zero_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            Microsoft.Quantum.Diagnostics.CheckZero(q)
+        }"},
+        &expect!["qubit used after release"],
     );
 }
 
@@ -917,6 +941,18 @@ fn rx() {
 }
 
 #[test]
+fn rx_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__rx__body(3.14, q)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn rxx() {
     check_intrinsic_result(
         "",
@@ -939,6 +975,19 @@ fn rxx() {
 }
 
 #[test]
+fn rxx_qubits_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q1 = { use q = Qubit(); q };
+            let q2 = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__rxx__body(3.14, q1, q2)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn ry() {
     check_intrinsic_result(
         "",
@@ -953,6 +1002,18 @@ fn ry() {
             Microsoft.Quantum.Diagnostics.CheckZero(q1)
         }"#},
         &expect!["true"],
+    );
+}
+
+#[test]
+fn ry_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__ry__body(3.14, q)
+        }"},
+        &expect!["qubit used after release"],
     );
 }
 
@@ -979,6 +1040,19 @@ fn ryy() {
 }
 
 #[test]
+fn ryy_qubits_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q1 = { use q = Qubit(); q };
+            let q2 = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__ryy__body(3.14, q1, q2)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn rz() {
     check_intrinsic_result(
         "",
@@ -997,6 +1071,18 @@ fn rz() {
             Microsoft.Quantum.Diagnostics.CheckZero(q1)
         }"#},
         &expect!["true"],
+    );
+}
+
+#[test]
+fn rz_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__rz__body(3.14, q)
+        }"},
+        &expect!["qubit used after release"],
     );
 }
 
@@ -1031,6 +1117,19 @@ fn rzz() {
 }
 
 #[test]
+fn rzz_qubits_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q1 = { use q = Qubit(); q };
+            let q2 = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__rzz__body(3.14, q1, q2)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn h() {
     check_intrinsic_result(
         "",
@@ -1044,6 +1143,18 @@ fn h() {
             Microsoft.Quantum.Diagnostics.CheckZero(q1)
         }"#},
         &expect!["true"],
+    );
+}
+
+#[test]
+fn h_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__h__body(q)
+        }"},
+        &expect!["qubit used after release"],
     );
 }
 
@@ -1071,6 +1182,18 @@ fn s() {
 }
 
 #[test]
+fn s_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__s__body(q)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn sadj() {
     check_intrinsic_result(
         "",
@@ -1090,6 +1213,18 @@ fn sadj() {
             Microsoft.Quantum.Diagnostics.CheckZero(q1)
         }"#},
         &expect!["true"],
+    );
+}
+
+#[test]
+fn sadj_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__s__adj(q)
+        }"},
+        &expect!["qubit used after release"],
     );
 }
 
@@ -1121,6 +1256,18 @@ fn t() {
 }
 
 #[test]
+fn t_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__t__body(q)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn tadj() {
     check_intrinsic_result(
         "",
@@ -1148,6 +1295,18 @@ fn tadj() {
 }
 
 #[test]
+fn tadj_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__t__adj(q)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn x() {
     check_intrinsic_result(
         "",
@@ -1165,6 +1324,18 @@ fn x() {
 }
 
 #[test]
+fn x_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__x__body(q)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn y() {
     check_intrinsic_result(
         "",
@@ -1178,6 +1349,18 @@ fn y() {
             Microsoft.Quantum.Diagnostics.CheckZero(q1)
         }"#},
         &expect!["true"],
+    );
+}
+
+#[test]
+fn y_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__y__body(q)
+        }"},
+        &expect!["qubit used after release"],
     );
 }
 
@@ -1203,6 +1386,18 @@ fn z() {
 }
 
 #[test]
+fn z_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__z__body(q)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn swap() {
     check_intrinsic_result(
         "",
@@ -1224,6 +1419,19 @@ fn swap() {
 }
 
 #[test]
+fn swap_qubits_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q1 = { use q = Qubit(); q };
+            let q2 = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__swap__body(q1, q2)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn reset() {
     check_intrinsic_result(
         "",
@@ -1238,6 +1446,18 @@ fn reset() {
             Microsoft.Quantum.Diagnostics.CheckZero(q1)
         }"#},
         &expect!["true"],
+    );
+}
+
+#[test]
+fn reset_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__reset__body(q)
+        }"},
+        &expect!["qubit used after release"],
     );
 }
 
@@ -1289,6 +1509,18 @@ fn m() {
 }
 
 #[test]
+fn m_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__m__body(q)
+        }"},
+        &expect!["qubit used after release"],
+    );
+}
+
+#[test]
 fn mresetz() {
     check_intrinsic_result(
         "",
@@ -1309,6 +1541,18 @@ fn mresetz() {
             (res2, Microsoft.Quantum.Diagnostics.CheckZero(q1))
         }"#},
         &expect!["(One, true)"],
+    );
+}
+
+#[test]
+fn mresetz_qubit_already_released_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            QIR.Intrinsic.__quantum__qis__mresetz__body(q)
+        }"},
+        &expect!["qubit used after release"],
     );
 }
 
@@ -1387,6 +1631,19 @@ fn qubit_release_non_zero_failure() {
             X(q);
         }"},
         &expect!["Qubit0 released while not in |0⟩ state"],
+    );
+}
+
+#[test]
+fn qubit_double_release_fails() {
+    check_intrinsic_result(
+        "",
+        indoc! {"{
+                let q = QIR.Runtime.__quantum__rt__qubit_allocate();
+                QIR.Runtime.__quantum__rt__qubit_release(q);
+                QIR.Runtime.__quantum__rt__qubit_release(q);
+            }"},
+        &expect!["qubit double release"],
     );
 }
 
@@ -1613,5 +1870,17 @@ fn check_pauli_noise() {
             STATE:
             |1⟩: 1.0000+0.0000𝑖
         "#]],
+    );
+}
+
+#[test]
+fn applyidlenoise_qubit_already_released_fails() {
+    check_intrinsic_output(
+        "",
+        indoc! {"{
+            let q = { use q = Qubit(); q };
+            Std.Diagnostics.ApplyIdleNoise(q);
+        }"},
+        &expect!["qubit used after release"],
     );
 }

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -1116,12 +1116,12 @@ impl State {
                 if let Some(counter) = &mut self.qubit_counter {
                     counter.allocated(q.0);
                 }
-                Value::Qubit(Rc::downgrade(&q))
+                Value::Qubit(q.into())
             }
             "__quantum__rt__qubit_release" => {
                 let qubit = arg
                     .unwrap_qubit()
-                    .upgrade()
+                    .try_deref()
                     .ok_or(Error::QubitDoubleRelease(arg_span))?;
                 env.release_qubit(&qubit);
                 if sim.qubit_release(qubit.0) {
@@ -1620,14 +1620,14 @@ impl State {
 pub fn are_ctls_unique(ctls: &[Value], tup: &Value) -> bool {
     let mut qubits = FxHashSet::default();
     for ctl in ctls.iter().flat_map(Value::qubits) {
-        if let Some(ctl) = ctl.upgrade() {
+        if let Some(ctl) = ctl.try_deref() {
             if !qubits.insert(ctl) {
                 return false;
             }
         }
     }
     for qubit in tup.qubits() {
-        if let Some(qubit) = qubit.upgrade() {
+        if let Some(qubit) = qubit.try_deref() {
             if qubits.contains(&qubit) {
                 return false;
             }

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -363,7 +363,6 @@ impl Range {
     }
 }
 
-// TODO: move qubit tracker here...
 pub struct Env {
     scopes: Vec<Scope>,
     qubits: FxHashSet<Rc<Qubit>>,

--- a/compiler/qsc_eval/src/lib.rs
+++ b/compiler/qsc_eval/src/lib.rs
@@ -54,7 +54,7 @@ use std::{
     rc::Rc,
 };
 use thiserror::Error;
-use val::update_functor_app;
+use val::{update_functor_app, Qubit};
 
 #[derive(Clone, Debug, Diagnostic, Error)]
 pub enum Error {
@@ -117,6 +117,15 @@ pub enum Error {
     #[error("qubits in invocation are not unique")]
     #[diagnostic(code("Qsc.Eval.QubitUniqueness"))]
     QubitUniqueness(#[label] PackageSpan),
+
+    #[error("qubit used after release")]
+    #[diagnostic(help("qubits should not be used after being released, which typically occurs when a qubit is used after it has gone out of scope"))]
+    #[diagnostic(code("Qsc.Eval.QubitUsedAfterRelease"))]
+    QubitUsedAfterRelease(#[label] PackageSpan),
+
+    #[error("qubit double release")]
+    #[diagnostic(code("Qsc.Eval.QubitDoubleRelease"))]
+    QubitDoubleRelease(#[label("qubit has already been released")] PackageSpan),
 
     #[error("qubits already counted")]
     #[diagnostic(help("counting for qubits must be stopped before it can be started again"))]
@@ -190,6 +199,8 @@ impl Error {
             | Error::InvalidNegativeInt(_, span)
             | Error::OutputFail(span)
             | Error::QubitUniqueness(span)
+            | Error::QubitUsedAfterRelease(span)
+            | Error::QubitDoubleRelease(span)
             | Error::QubitsAlreadyCounted(span)
             | Error::QubitsNotCounted(span)
             | Error::QubitsNotSeparable(span)
@@ -352,24 +363,34 @@ impl Range {
     }
 }
 
-pub struct Env(Vec<Scope>);
+// TODO: move qubit tracker here...
+pub struct Env {
+    scopes: Vec<Scope>,
+    qubits: FxHashSet<Rc<Qubit>>,
+}
 
 impl Default for Env {
     #[must_use]
     fn default() -> Self {
         // Always create a global scope for top-level statements.
-        Self(vec![Scope::default()])
+        Self {
+            scopes: vec![Scope::default()],
+            qubits: FxHashSet::default(),
+        }
     }
 }
 
 impl Env {
     #[must_use]
     pub fn get(&self, id: LocalVarId) -> Option<&Variable> {
-        self.0.iter().rev().find_map(|scope| scope.bindings.get(id))
+        self.scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.bindings.get(id))
     }
 
     fn get_mut(&mut self, id: LocalVarId) -> Option<&mut Variable> {
-        self.0
+        self.scopes
             .iter_mut()
             .rev()
             .find_map(|scope| scope.bindings.get_mut(id))
@@ -380,14 +401,14 @@ impl Env {
             frame_id,
             ..Default::default()
         };
-        self.0.push(scope);
+        self.scopes.push(scope);
     }
 
     pub fn leave_scope(&mut self) {
         // Only pop the scope if there is more than one scope in the stack,
         // because the global/top-level scope cannot be exited.
-        if self.0.len() > 1 {
-            self.0
+        if self.scopes.len() > 1 {
+            self.scopes
                 .pop()
                 .expect("scope should have more than one entry.");
         }
@@ -395,7 +416,7 @@ impl Env {
 
     pub fn leave_current_frame(&mut self) {
         let current_frame_id = self
-            .0
+            .scopes
             .last()
             .expect("should be at least one scope")
             .frame_id;
@@ -403,11 +424,12 @@ impl Env {
             // Do not remove the global scope.
             return;
         }
-        self.0.retain(|scope| scope.frame_id != current_frame_id);
+        self.scopes
+            .retain(|scope| scope.frame_id != current_frame_id);
     }
 
     pub fn bind_variable_in_top_frame(&mut self, local_var_id: LocalVarId, var: Variable) {
-        let Some(scope) = self.0.last_mut() else {
+        let Some(scope) = self.scopes.last_mut() else {
             panic!("no frames in scope");
         };
 
@@ -416,7 +438,7 @@ impl Env {
 
     #[must_use]
     pub fn get_variables_in_top_frame(&self) -> Vec<VariableInfo> {
-        if let Some(scope) = self.0.last() {
+        if let Some(scope) = self.scopes.last() {
             self.get_variables_in_frame(scope.frame_id)
         } else {
             vec![]
@@ -426,7 +448,7 @@ impl Env {
     #[must_use]
     pub fn get_variables_in_frame(&self, frame_id: usize) -> Vec<VariableInfo> {
         let candidate_scopes: Vec<_> = self
-            .0
+            .scopes
             .iter()
             .filter(|scope| scope.frame_id == frame_id)
             .map(|scope| scope.bindings.iter())
@@ -451,7 +473,7 @@ impl Env {
     #[allow(clippy::len_without_is_empty)]
     #[must_use]
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.scopes.len()
     }
 
     pub fn update_variable_in_top_frame(&mut self, local_var_id: LocalVarId, value: Value) {
@@ -459,6 +481,14 @@ impl Env {
             .get_mut(local_var_id)
             .expect("local variable is not present");
         variable.value = value;
+    }
+
+    pub fn track_qubit(&mut self, qubit: Rc<Qubit>) {
+        self.qubits.insert(qubit);
+    }
+
+    pub fn release_qubit(&mut self, qubit: &Rc<Qubit>) {
+        self.qubits.remove(qubit);
     }
 }
 
@@ -1010,39 +1040,17 @@ impl State {
                 self.leave_frame();
                 Ok(())
             }
-            CallableImpl::Intrinsic => {
-                self.push_frame(Vec::new().into(), callee_id, functor);
-
-                self.increment_call_count(callee_id, functor);
-
-                let name = &callee.name.name;
-                let val = intrinsic::call(
-                    name,
-                    callee_span,
-                    arg,
-                    arg_span,
-                    sim,
-                    &mut self.rng.borrow_mut(),
-                    out,
-                )?;
-                if val == Value::unit() && callee.output != Ty::UNIT {
-                    return Err(Error::UnsupportedIntrinsicType(
-                        callee.name.name.to_string(),
-                        callee_span,
-                    ));
-                }
-
-                // If qubit counting is enabled, update the qubit counter when the intrinsic for allocation is called.
-                if let (Some(counter), "__quantum__rt__qubit_allocate", Value::Qubit(q)) =
-                    (&mut self.qubit_counter, name.as_ref(), &val)
-                {
-                    counter.allocated(q.0);
-                }
-
-                self.set_val_register(val);
-                self.leave_frame();
-                Ok(())
-            }
+            CallableImpl::Intrinsic => self.eval_intrinsic(
+                env,
+                callee_id,
+                functor,
+                callee,
+                sim,
+                callee_span,
+                arg,
+                arg_span,
+                out,
+            ),
             CallableImpl::Spec(specialized_implementation) => {
                 let spec_decl = match spec {
                     Spec::Body => Some(&specialized_implementation.body),
@@ -1084,6 +1092,67 @@ impl State {
                 Ok(())
             }
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn eval_intrinsic(
+        &mut self,
+        env: &mut Env,
+        callee_id: StoreItemId,
+        functor: FunctorApp,
+        callee: &fir::CallableDecl,
+        sim: &mut impl Backend<ResultType = impl Into<val::Result>>,
+        callee_span: PackageSpan,
+        arg: Value,
+        arg_span: PackageSpan,
+        out: &mut impl Receiver,
+    ) -> Result<(), Error> {
+        self.push_frame(Vec::new().into(), callee_id, functor);
+        self.increment_call_count(callee_id, functor);
+        let name = &callee.name.name;
+        let val = match name.as_ref() {
+            "__quantum__rt__qubit_allocate" => {
+                let q = Rc::new(Qubit(sim.qubit_allocate()));
+                env.track_qubit(Rc::clone(&q));
+                if let Some(counter) = &mut self.qubit_counter {
+                    counter.allocated(q.0);
+                }
+                Value::Qubit(Rc::downgrade(&q))
+            }
+            "__quantum__rt__qubit_release" => {
+                let qubit = arg
+                    .unwrap_qubit()
+                    .upgrade()
+                    .ok_or(Error::QubitDoubleRelease(arg_span))?;
+                env.release_qubit(&qubit);
+                if sim.qubit_release(qubit.0) {
+                    Value::unit()
+                } else {
+                    return Err(Error::ReleasedQubitNotZero(qubit.0, arg_span));
+                }
+            }
+            _ => {
+                let val = intrinsic::call(
+                    name,
+                    callee_span,
+                    arg,
+                    arg_span,
+                    sim,
+                    &mut self.rng.borrow_mut(),
+                    out,
+                )?;
+                if val == Value::unit() && callee.output != Ty::UNIT {
+                    return Err(Error::UnsupportedIntrinsicType(
+                        callee.name.name.to_string(),
+                        callee_span,
+                    ));
+                }
+                val
+            }
+        };
+        self.set_val_register(val);
+        self.leave_frame();
+        Ok(())
     }
 
     fn eval_field(&mut self, field: Field) {
@@ -1330,7 +1399,7 @@ impl State {
         let pat = globals.get_pat((self.package, pat).into());
         match &pat.kind {
             PatKind::Bind(variable) => {
-                let scope = env.0.last_mut().expect("binding should have a scope");
+                let scope = env.scopes.last_mut().expect("binding should have a scope");
                 scope.bindings.insert(
                     variable.id,
                     Variable {
@@ -1552,13 +1621,17 @@ impl State {
 pub fn are_ctls_unique(ctls: &[Value], tup: &Value) -> bool {
     let mut qubits = FxHashSet::default();
     for ctl in ctls.iter().flat_map(Value::qubits) {
-        if !qubits.insert(ctl) {
-            return false;
+        if let Some(ctl) = ctl.upgrade() {
+            if !qubits.insert(ctl) {
+                return false;
+            }
         }
     }
     for qubit in tup.qubits() {
-        if qubits.contains(&qubit) {
-            return false;
+        if let Some(qubit) = qubit.upgrade() {
+            if qubits.contains(&qubit) {
+                return false;
+            }
         }
     }
     true

--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -337,10 +337,10 @@ fn block_mutable_nested_scopes_shadowing_expr() {
 fn block_qubit_use_expr() {
     check_expr(
         "",
-        indoc! {"{
+        indoc! {r#"{
             use q = Qubit();
-            q
-        }"},
+            $"{q}"
+        }"#},
         &expect!["Qubit0"],
     );
 }
@@ -349,11 +349,11 @@ fn block_qubit_use_expr() {
 fn block_qubit_use_use_expr() {
     check_expr(
         "",
-        indoc! {"{
+        indoc! {r#"{
             use q = Qubit();
             use q1 = Qubit();
-            q1
-        }"},
+            $"{q1}"
+        }"#},
         &expect!["Qubit1"],
     );
 }
@@ -362,13 +362,13 @@ fn block_qubit_use_use_expr() {
 fn block_qubit_use_reuse_expr() {
     check_expr(
         "",
-        indoc! {"{
+        indoc! {r#"{
             {
                 use q = Qubit();
             }
             use q = Qubit();
-            q
-        }"},
+            $"{q}"
+        }"#},
         &expect!["Qubit0"],
     );
 }
@@ -377,12 +377,12 @@ fn block_qubit_use_reuse_expr() {
 fn block_qubit_use_scope_reuse_expr() {
     check_expr(
         "",
-        indoc! {"{
+        indoc! {r#"{
             use q = Qubit() {
             }
             use q = Qubit();
-            q
-        }"},
+            $"{q}"
+        }"#},
         &expect!["Qubit0"],
     );
 }
@@ -391,10 +391,10 @@ fn block_qubit_use_scope_reuse_expr() {
 fn block_qubit_use_array_expr() {
     check_expr(
         "",
-        indoc! {"{
+        indoc! {r#"{
             use q = Qubit[3];
-            q
-        }"},
+            $"{q}"
+        }"#},
         &expect!["[Qubit0, Qubit1, Qubit2]"],
     );
 }
@@ -428,10 +428,10 @@ fn block_qubit_use_array_invalid_count_expr() {
 fn block_qubit_use_tuple_expr() {
     check_expr(
         "",
-        indoc! {"{
+        indoc! {r#"{
             use q = (Qubit[3], Qubit(), Qubit());
-            q
-        }"},
+            $"{q}"
+        }"#},
         &expect!["([Qubit0, Qubit1, Qubit2], Qubit3, Qubit4)"],
     );
 }
@@ -440,10 +440,10 @@ fn block_qubit_use_tuple_expr() {
 fn block_qubit_use_nested_tuple_expr() {
     check_expr(
         "",
-        indoc! {"{
+        indoc! {r#"{
             use q = (Qubit[3], (Qubit(), Qubit()));
-            q
-        }"},
+            $"{q}"
+        }"#},
         &expect!["([Qubit0, Qubit1, Qubit2], (Qubit3, Qubit4))"],
     );
 }

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -427,7 +427,7 @@ impl Value {
         match self {
             Value::Array(arr) => arr.iter().flat_map(Value::qubits).collect(),
             Value::Closure(closure) => closure.fixed_args.iter().flat_map(Value::qubits).collect(),
-            Value::Qubit(q) => vec![q.clone()],
+            Value::Qubit(q) => vec![Weak::clone(q)],
             Value::Tuple(tup) => tup.iter().flat_map(Value::qubits).collect(),
 
             Value::BigInt(_)

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -13,7 +13,7 @@ use crate::{error::PackageSpan, AsIndex, Error, Range as EvalRange};
 
 pub(super) const DEFAULT_RANGE_STEP: i64 = 1;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Value {
     Array(Rc<Vec<Value>>),
     BigInt(BigInt),
@@ -23,7 +23,7 @@ pub enum Value {
     Global(StoreItemId, FunctorApp),
     Int(i64),
     Pauli(Pauli),
-    Qubit(Weak<Qubit>),
+    Qubit(QubitRef),
     Range(Box<Range>),
     Result(Result),
     String(Rc<str>),
@@ -87,6 +87,58 @@ impl From<usize> for Result {
     }
 }
 
+/// Tracks a reference to a qubit. This reference may be invalid if the qubit has been released.
+/// A `QubitRef` can only be created by converting a `Rc<Qubit>` to a `QubitRef`, which will maintain
+/// a weak reference to the `Rc<Qubit>`. This allows the `QubitRef` to be cloned and passed around
+/// separately from tracking the qubit's lifetime, and requires the caller to call `try_deref` or `deref`
+/// to access the qubit, only getting the underlying `Rc<Qubit>` if it is still alive.
+#[derive(Clone, Debug)]
+pub struct QubitRef {
+    inner: Weak<Qubit>,
+}
+
+impl PartialEq for QubitRef {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.try_deref(), other.try_deref()) {
+            (Some(a), Some(b)) => *a == *b,
+            _ => false,
+        }
+    }
+}
+
+impl From<&Rc<Qubit>> for QubitRef {
+    fn from(qubit: &Rc<Qubit>) -> Self {
+        Self {
+            inner: Rc::downgrade(qubit),
+        }
+    }
+}
+
+impl From<Rc<Qubit>> for QubitRef {
+    fn from(qubit: Rc<Qubit>) -> Self {
+        (&qubit).into()
+    }
+}
+
+impl QubitRef {
+    /// Attempts to dereference the `QubitRef` to get the underlying `Rc<Qubit>`. If the qubit has been
+    /// released, this will return `None`. Callers should check the result of this method and handle the
+    /// case where the qubit is no longer alive.
+    #[must_use]
+    pub fn try_deref(&self) -> Option<Rc<Qubit>> {
+        Weak::upgrade(&self.inner)
+    }
+
+    /// Dereferences the `QubitRef` to get the underlying `Rc<Qubit>`. If the qubit has been released, this
+    /// will panic. Callers should only use this method if they are certain the qubit is still alive.
+    /// # Panics
+    /// This will panic if the qubit has been released.
+    #[must_use]
+    pub fn deref(&self) -> Rc<Qubit> {
+        self.try_deref().expect("qubit should still be alive")
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Qubit(pub usize);
 
@@ -128,7 +180,7 @@ impl Display for Value {
             Value::Qubit(v) => write!(
                 f,
                 "Qubit{}",
-                (v.upgrade()
+                (v.try_deref()
                     .map_or_else(|| "<released>".to_string(), |v| v.0.to_string()))
             ),
             Value::Range(inner) => match (inner.start, inner.step, inner.end) {
@@ -184,31 +236,6 @@ impl Display for VarTy {
 
 thread_local! {
     static UNIT: Rc<[Value; 0]> = Rc::new([]);
-}
-
-impl PartialEq for Value {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Value::Array(a), Value::Array(b)) => a == b,
-            (Value::BigInt(a), Value::BigInt(b)) => a == b,
-            (Value::Bool(a), Value::Bool(b)) => a == b,
-            (Value::Closure(a), Value::Closure(b)) => a == b,
-            (Value::Double(a), Value::Double(b)) => a == b,
-            (Value::Global(a, b), Value::Global(c, d)) => a == c && b == d,
-            (Value::Int(a), Value::Int(b)) => a == b,
-            (Value::Pauli(a), Value::Pauli(b)) => a == b,
-            (Value::Qubit(a), Value::Qubit(b)) => match (a.upgrade(), b.upgrade()) {
-                (Some(a), Some(b)) => a == b,
-                _ => false,
-            },
-            (Value::Range(a), Value::Range(b)) => a == b,
-            (Value::Result(a), Value::Result(b)) => a == b,
-            (Value::String(a), Value::String(b)) => a == b,
-            (Value::Tuple(a), Value::Tuple(b)) => a == b,
-            (Value::Var(a), Value::Var(b)) => a == b,
-            _ => false,
-        }
-    }
 }
 
 impl Value {
@@ -338,7 +365,7 @@ impl Value {
     /// # Panics
     /// This will panic if the [Value] is not a [`Value::Qubit`].
     #[must_use]
-    pub fn unwrap_qubit(self) -> Weak<Qubit> {
+    pub fn unwrap_qubit(self) -> QubitRef {
         let Value::Qubit(v) = self else {
             panic!("value should be Qubit, got {}", self.type_name());
         };
@@ -423,11 +450,11 @@ impl Value {
     /// Returns any qubits contained in the value as a vector. This does not
     /// consume the value, and will recursively search through any nested values.
     #[must_use]
-    pub fn qubits(&self) -> Vec<Weak<Qubit>> {
+    pub fn qubits(&self) -> Vec<QubitRef> {
         match self {
             Value::Array(arr) => arr.iter().flat_map(Value::qubits).collect(),
             Value::Closure(closure) => closure.fixed_args.iter().flat_map(Value::qubits).collect(),
-            Value::Qubit(q) => vec![Weak::clone(q)],
+            Value::Qubit(q) => vec![q.clone()],
             Value::Tuple(tup) => tup.iter().flat_map(Value::qubits).collect(),
 
             Value::BigInt(_)

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -1309,9 +1309,9 @@ impl<'a> PartialEvaluator<'a> {
         callable_decl: &CallableDecl,
         args_value: Value,
         args_span: PackageSpan,        // For diagnostic purposes only.
-        callee_expr_span: PackageSpan, // For diagnostic puprposes only.
+        callee_expr_span: PackageSpan, // For diagnostic purposes only.
     ) -> Result<Value, Error> {
-        // check qubits here!
+        // Check if any qubits passed as arguments have been released.
         let qubits = args_value.qubits();
         let qubits_len = qubits.len();
         if qubits_len > 0 {

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -55,11 +55,7 @@ use qsc_rir::{
     },
 };
 use rustc_hash::FxHashMap;
-use std::{
-    collections::hash_map::Entry,
-    rc::{Rc, Weak},
-    result::Result,
-};
+use std::{collections::hash_map::Entry, rc::Rc, result::Result};
 use thiserror::Error;
 
 /// Partially evaluates a program with the specified entry expression.
@@ -1321,7 +1317,7 @@ impl<'a> PartialEvaluator<'a> {
         if qubits_len > 0 {
             let qubits = qubits
                 .iter()
-                .filter_map(|q| q.upgrade().map(|q| q.0))
+                .filter_map(|q| q.try_deref().map(|q| q.0))
                 .collect::<Vec<_>>();
             if qubits.len() != qubits_len {
                 return if callable_decl.name.name.as_ref() == "__quantum__rt__qubit_release" {
@@ -2310,9 +2306,7 @@ impl<'a> PartialEvaluator<'a> {
                         panic!("by this point a qsc_pass should have checked that all arguments are Qubits")
                     };
                     input_type.push(qsc_rir::rir::Ty::Qubit);
-                    operands.push(
-                        self.map_eval_value_to_rir_operand(&Value::Qubit(Weak::clone(qubit))),
-                    );
+                    operands.push(self.map_eval_value_to_rir_operand(&Value::Qubit(qubit.clone())));
                 }
             }
             _ => {

--- a/compiler/qsc_partial_eval/src/lib.rs
+++ b/compiler/qsc_partial_eval/src/lib.rs
@@ -55,7 +55,11 @@ use qsc_rir::{
     },
 };
 use rustc_hash::FxHashMap;
-use std::{collections::hash_map::Entry, rc::Rc, result::Result};
+use std::{
+    collections::hash_map::Entry,
+    rc::{Rc, Weak},
+    result::Result,
+};
 use thiserror::Error;
 
 /// Partially evaluates a program with the specified entry expression.
@@ -2306,7 +2310,9 @@ impl<'a> PartialEvaluator<'a> {
                         panic!("by this point a qsc_pass should have checked that all arguments are Qubits")
                     };
                     input_type.push(qsc_rir::rir::Ty::Qubit);
-                    operands.push(self.map_eval_value_to_rir_operand(&Value::Qubit(qubit.clone())));
+                    operands.push(
+                        self.map_eval_value_to_rir_operand(&Value::Qubit(Weak::clone(qubit))),
+                    );
                 }
             }
             _ => {

--- a/compiler/qsc_partial_eval/src/management.rs
+++ b/compiler/qsc_partial_eval/src/management.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::rc::{Rc, Weak};
+
 use num_bigint::BigUint;
 use num_complex::Complex;
 use qsc_data_structures::index_map::IndexMap;
@@ -9,12 +11,14 @@ use qsc_eval::{
     val::{Qubit, Result, Value},
 };
 use qsc_rir::rir::{BlockId, CallableId, VariableId};
+use rustc_hash::FxHashSet;
 
 /// Manages IDs for resources needed while performing partial evaluation.
 #[derive(Default)]
 pub struct ResourceManager {
     qubits_in_use: Vec<bool>,
     qubit_id_map: IndexMap<usize, usize>,
+    qubit_tracker: FxHashSet<Rc<Qubit>>,
     next_callable: CallableId,
     next_block: BlockId,
     next_result_register: usize,
@@ -22,7 +26,8 @@ pub struct ResourceManager {
 }
 
 impl ResourceManager {
-    pub fn map_qubit(&self, q: Qubit) -> usize {
+    pub fn map_qubit(&self, q: &Weak<Qubit>) -> usize {
+        let q = q.upgrade().expect("qubit should still be alive");
         *self
             .qubit_id_map
             .get(q.0)
@@ -40,7 +45,7 @@ impl ResourceManager {
     }
 
     /// Allocates a qubit by favoring available qubit IDs before using new ones.
-    pub fn allocate_qubit(&mut self) -> Qubit {
+    pub fn allocate_qubit(&mut self) -> Weak<Qubit> {
         let qubit = if let Some(qubit) = self.qubits_in_use.iter().position(|in_use| !in_use) {
             self.qubits_in_use[qubit] = true;
             qubit
@@ -58,14 +63,19 @@ impl ResourceManager {
             }
             next_id += 1;
         }
-        Qubit(next_id)
+        let q = Rc::new(Qubit(next_id));
+        self.qubit_tracker.insert(Rc::clone(&q));
+        Rc::downgrade(&q)
     }
 
     /// Releases a qubit ID for future use.
-    pub fn release_qubit(&mut self, q: Qubit) {
+    pub fn release_qubit(&mut self, q: &Weak<Qubit>) {
         let qubit = self.map_qubit(q);
-        self.qubit_id_map.remove(q.0);
         self.qubits_in_use[qubit] = false;
+
+        let q = q.upgrade().expect("qubit should still be alive");
+        self.qubit_id_map.remove(q.0);
+        self.qubit_tracker.remove(&q);
     }
 
     /// Gets the next block ID.
@@ -96,11 +106,17 @@ impl ResourceManager {
         var_id.into()
     }
 
-    pub fn swap_qubit_ids(&mut self, q0: Qubit, q1: Qubit) {
-        let id0 = self.map_qubit(q0);
-        let id1 = self.map_qubit(q1);
-        self.qubit_id_map.insert(q0.0, id1);
-        self.qubit_id_map.insert(q1.0, id0);
+    pub fn swap_qubit_ids(&mut self, q0: usize, q1: usize) {
+        let id0 = *self
+            .qubit_id_map
+            .get(q0)
+            .expect("qubit id should be in map");
+        let id1 = *self
+            .qubit_id_map
+            .get(q1)
+            .expect("qubit id should be in map");
+        self.qubit_id_map.insert(q0, id1);
+        self.qubit_id_map.insert(q1, id0);
     }
 }
 

--- a/compiler/qsc_partial_eval/src/tests/operators.rs
+++ b/compiler/qsc_partial_eval/src/tests/operators.rs
@@ -2091,7 +2091,7 @@ fn integer_exponentiation_with_lhs_classical_integer_and_rhs_classical_negative_
     assert_error(
         &error,
         &expect![[
-            r#"EvaluationFailed("exponent must be non-negative", PackageSpan { package: PackageId(2), span: Span { lo: 142, hi: 148 } })"#
+            r#"EvaluationFailed("negative integers cannot be used here: -1", PackageSpan { package: PackageId(2), span: Span { lo: 142, hi: 148 } })"#
         ]],
     );
 }

--- a/compiler/qsc_partial_eval/src/tests/qubits.rs
+++ b/compiler/qsc_partial_eval/src/tests/qubits.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::{assert_block_instructions, assert_callable, get_rir_program};
+use super::{
+    assert_block_instructions, assert_callable, assert_error, get_partial_evaluation_error,
+    get_rir_program,
+};
 use expect_test::expect;
 use indoc::indoc;
 use qsc_rir::rir::{BlockId, CallableId};
@@ -309,4 +312,51 @@ fn qubit_array_allocation_and_access() {
     );
     assert_eq!(program.num_qubits, 3);
     assert_eq!(program.num_results, 0);
+}
+
+#[test]
+fn qubit_escaping_scope_triggers_runtime_error() {
+    let error = get_partial_evaluation_error(indoc! {
+        r#"
+        namespace Test {
+            operation Op(q : Qubit) : Unit { body intrinsic; }
+            @EntryPoint()
+            operation Main() : Unit {
+                let q = {
+                    use q = Qubit();
+                    q
+                };
+                Op(q);
+            }
+        }
+        "#,
+    });
+    assert_error(
+        &error,
+        &expect![[
+            r#"EvaluationFailed("qubit used after release", PackageSpan { package: PackageId(2), span: Span { lo: 204, hi: 205 } })"#
+        ]],
+    );
+}
+
+#[test]
+fn qubit_double_release_triggers_runtime_error() {
+    let error = get_partial_evaluation_error(indoc! {
+        r#"
+        namespace Test {
+            @EntryPoint()
+            operation Main() : Unit {
+                let q = QIR.Runtime.__quantum__rt__qubit_allocate();
+                QIR.Runtime.__quantum__rt__qubit_release(q);
+                QIR.Runtime.__quantum__rt__qubit_release(q);
+            }
+        }
+        "#,
+    });
+    assert_error(
+        &error,
+        &expect![[
+            r#"EvaluationFailed("qubit double release", PackageSpan { package: PackageId(2), span: Span { lo: 229, hi: 230 } })"#
+        ]],
+    );
 }

--- a/resource_estimator/src/counts.rs
+++ b/resource_estimator/src/counts.rs
@@ -557,15 +557,7 @@ impl Backend for LogicalCounter {
                 let qubits = qubits
                     .unwrap_array()
                     .iter()
-                    .map(|v| {
-                        v.clone()
-                            .unwrap_qubit()
-                            .upgrade()
-                            .expect(
-                                "qubits should be checked for liveness before call into backend",
-                            )
-                            .0
-                    })
+                    .map(|v| v.clone().unwrap_qubit().deref().0)
                     .collect::<Vec<_>>();
                 Some(
                     self.add_estimate(&estimates, layout, &qubits)

--- a/resource_estimator/src/counts.rs
+++ b/resource_estimator/src/counts.rs
@@ -557,7 +557,15 @@ impl Backend for LogicalCounter {
                 let qubits = qubits
                     .unwrap_array()
                     .iter()
-                    .map(|v| v.clone().unwrap_qubit().0)
+                    .map(|v| {
+                        v.clone()
+                            .unwrap_qubit()
+                            .upgrade()
+                            .expect(
+                                "qubits should be checked for liveness before call into backend",
+                            )
+                            .0
+                    })
                     .collect::<Vec<_>>();
                 Some(
                     self.add_estimate(&estimates, layout, &qubits)


### PR DESCRIPTION
This change adds some basic qubit live-ness tracking to the simulator, achieved by changing the `Value::Qubit` variant to a weak pointer to the qubit and having the execution environment own and track the `Rc` that owns the qubit. This provides a few benefits:

- Fixes a panic when a qubit is passed to the simulator after it has been released.
- Adds graceful error handling to treat use-after-release as a runtime error.
- Adds a specific error for "double release" of a qubit if it is being manually managed.
- Updates the display of the qubit type to show the qubit ID when it is live and `Qubit<released>` when it is not, enabling easier debugging of qubit lifetimes.

Of note, local perf testing showing no impact on performance (thanks, Rust zero-cost abstractions!), though it stands to reason this change could theoretically have some impact on programs that use many thousands of qubits.