### PR TITLE
Use `deploy-pages@v4`

### DIFF
--- a/.github/workflows/publish-playground.yml
+++ b/.github/workflows/publish-playground.yml
@@ -67,4 +67,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Since we are using `upload-pages-artifact@v3` we must use v4 of the deploy task (see https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0)