### PR TITLE
Remove Unstable dependency; replace with stabilized stdlib version in library code

### DIFF
--- a/library/fixed_point/qsharp.json
+++ b/library/fixed_point/qsharp.json
@@ -9,14 +9,6 @@
         "ref": "3195043",
         "path": "library/signed"
       }
-    },
-    "Unstable": {
-      "github": {
-        "owner": "Microsoft",
-        "repo": "qsharp",
-        "ref": "3195043",
-        "path": "library/unstable"
-      }
     }
   },
   "files": [

--- a/library/fixed_point/src/Operations.qs
+++ b/library/fixed_point/src/Operations.qs
@@ -6,7 +6,7 @@ import Init.PrepareFxP;
 import Facts.AssertPointPositionsIdenticalFxP, Facts.AssertFormatsAreIdenticalFxP, Facts.AssertAllZeroFxP;
 import Signed.Operations.Invert2sSI, Signed.Operations.MultiplySI, Signed.Operations.SquareSI;
 import Std.Arrays.Zipped;
-import Unstable.Arithmetic.RippleCarryTTKIncByLE;
+import Std.Arithmetic.RippleCarryTTKIncByLE;
 
 /// # Summary
 /// Adds a classical constant to a quantum fixed-point number.

--- a/library/signed/qsharp.json
+++ b/library/signed/qsharp.json
@@ -2,14 +2,6 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
-    "Unstable": {
-      "github": {
-        "owner": "Microsoft",
-        "repo": "qsharp",
-        "ref": "3195043",
-        "path": "library/unstable"
-      }
-    },
     "Qtest": {
       "github": {
         "owner": "Microsoft",

--- a/library/signed/src/Comparison.qs
+++ b/library/signed/src/Comparison.qs
@@ -3,7 +3,7 @@
 
 import Std.Arrays.Tail, Std.Arrays.Zipped, Std.Arrays.Most, Std.Arrays.Rest;
 import Std.Diagnostics.Fact;
-import Unstable.Arithmetic.ApplyIfGreaterLE;
+import Std.Arithmetic.ApplyIfGreaterLE;
 
 /// # Summary
 /// Wrapper for signed integer comparison: `result = xs > ys`.

--- a/library/signed/src/Operations.qs
+++ b/library/signed/src/Operations.qs
@@ -3,9 +3,8 @@
 
 import Std.Arrays.Tail, Std.Arrays.Most, Std.Arrays.Enumerated;
 import Utils.AndLadder;
-import Unstable.Arithmetic.RippleCarryTTKIncByLE;
+import Std.Arithmetic.RippleCarryTTKIncByLE, Std.Arithmetic.ApplyIfGreaterLE;
 import Std.Diagnostics.Fact;
-import Unstable.Arithmetic.ApplyIfGreaterLE;
 
 /// # Summary
 /// Square signed integer `xs` and store


### PR DESCRIPTION
Now that the `Unstable` library has been deprecated and its contents ported to the standard library, we no longer need these external project dependencies.

Closes #2027
