### PR TITLE
Remove configuration in DF chemistry sample

### DIFF
--- a/samples/estimation/df-chemistry/chemistry.py
+++ b/samples/estimation/df-chemistry/chemistry.py
@@ -493,11 +493,7 @@ if args.paramsfile is None:
             "errorBudget": 0.01,
             "qubitParams": {"name": "qubit_maj_ns_e6"},
             "qecScheme": {"name": "floquet_code"},
-        },
-        {
-            "qubitParams": {"name": "qubit_gate_us_e3"},
-            "estimateType": "frontier",
-        },
+        }
     ]
 else:
     params = []


### PR DESCRIPTION
This configuration was added in #1700, but it has a wrong error budget that is not compatible with the other configuration and the sample. I removed it again for clarity.