### PR TITLE
Avoid qiskit-1.3

### DIFF
--- a/build.py
+++ b/build.py
@@ -514,7 +514,7 @@ if build_pip and build_widgets and args.integration_tests:
         "ipykernel",
         "nbconvert",
         "pandas",
-        "qiskit>=1.2.2,<2.0.0",
+        "qiskit>=1.2.2,<1.3.0",
     ]
     subprocess.run(pip_install_args, check=True, text=True, cwd=root_dir, env=pip_env)
 

--- a/pip/tests-integration/test_requirements.txt
+++ b/pip/tests-integration/test_requirements.txt
@@ -1,5 +1,5 @@
 pytest==8.2.2
-qiskit>=1.2.2,<2.0.0
+qiskit>=1.2.2,<1.3.0
 qirrunner==0.7.1
 pyqir==0.10.2
 qiskit-aer==0.14.2


### PR DESCRIPTION
Looks like something changed in Qiskit v1.3 that breaks our interop. Pinning to 1.2 while we investigate.