### PR TITLE
Fix Qiskit interop with v1.3

### DIFF
--- a/build.py
+++ b/build.py
@@ -514,7 +514,7 @@ if build_pip and build_widgets and args.integration_tests:
         "ipykernel",
         "nbconvert",
         "pandas",
-        "qiskit>=1.2.2,<2.0.0",
+        "qiskit>=1.3.0,<2.0.0",
     ]
     subprocess.run(pip_install_args, check=True, text=True, cwd=root_dir, env=pip_env)
 

--- a/build.py
+++ b/build.py
@@ -69,10 +69,10 @@ parser.add_argument(
 )
 
 parser.add_argument(
-        "--ci-bench",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Run the benchmarking script that is run in CI (default is --no-ci-bench)",
+    "--ci-bench",
+    action=argparse.BooleanOptionalAction,
+    default=False,
+    help="Run the benchmarking script that is run in CI (default is --no-ci-bench)",
 )
 
 args = parser.parse_args()
@@ -303,24 +303,45 @@ def run_python_integration_tests(cwd, interpreter):
 def run_ci_historic_benchmark():
     branch = "main"
     output = subprocess.check_output(
-        ["git", "rev-list", "--since=1 week ago", "--pretty=format:%ad__%h", "--date=short", branch]
+        [
+            "git",
+            "rev-list",
+            "--since=1 week ago",
+            "--pretty=format:%ad__%h",
+            "--date=short",
+            branch,
+        ]
     ).decode("utf-8")
-    print('\n'.join([line for i, line in enumerate(output.split('\n')) if i % 2 == 1]))
+    print("\n".join([line for i, line in enumerate(output.split("\n")) if i % 2 == 1]))
 
     output = subprocess.check_output(
-        ["git", "rev-list", "--since=1 week ago", "--pretty=format:%ad__%h", "--date=short", branch]
+        [
+            "git",
+            "rev-list",
+            "--since=1 week ago",
+            "--pretty=format:%ad__%h",
+            "--date=short",
+            branch,
+        ]
     ).decode("utf-8")
-    date_and_commits = [line for i, line in enumerate(output.split('\n')) if i % 2 == 1]
+    date_and_commits = [line for i, line in enumerate(output.split("\n")) if i % 2 == 1]
 
     for date_and_commit in date_and_commits:
         print("benching commit", date_and_commit)
         result = subprocess.run(
-            ["cargo", "criterion", "--message-format=json", "--history-id", date_and_commit],
+            [
+                "cargo",
+                "criterion",
+                "--message-format=json",
+                "--history-id",
+                date_and_commit,
+            ],
             capture_output=True,
-            text=True
+            text=True,
         )
         with open(f"{date_and_commit}.json", "w") as f:
             f.write(result.stdout)
+
 
 if build_pip:
     step_start("Building the pip package")
@@ -514,7 +535,7 @@ if build_pip and build_widgets and args.integration_tests:
         "ipykernel",
         "nbconvert",
         "pandas",
-        "qiskit>=1.2.2,<1.3.0",
+        "qiskit>=1.2.2,<2.0.0",
     ]
     subprocess.run(pip_install_args, check=True, text=True, cwd=root_dir, env=pip_env)
 

--- a/build.py
+++ b/build.py
@@ -69,10 +69,10 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    "--ci-bench",
-    action=argparse.BooleanOptionalAction,
-    default=False,
-    help="Run the benchmarking script that is run in CI (default is --no-ci-bench)",
+        "--ci-bench",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Run the benchmarking script that is run in CI (default is --no-ci-bench)",
 )
 
 args = parser.parse_args()
@@ -303,45 +303,24 @@ def run_python_integration_tests(cwd, interpreter):
 def run_ci_historic_benchmark():
     branch = "main"
     output = subprocess.check_output(
-        [
-            "git",
-            "rev-list",
-            "--since=1 week ago",
-            "--pretty=format:%ad__%h",
-            "--date=short",
-            branch,
-        ]
+        ["git", "rev-list", "--since=1 week ago", "--pretty=format:%ad__%h", "--date=short", branch]
     ).decode("utf-8")
-    print("\n".join([line for i, line in enumerate(output.split("\n")) if i % 2 == 1]))
+    print('\n'.join([line for i, line in enumerate(output.split('\n')) if i % 2 == 1]))
 
     output = subprocess.check_output(
-        [
-            "git",
-            "rev-list",
-            "--since=1 week ago",
-            "--pretty=format:%ad__%h",
-            "--date=short",
-            branch,
-        ]
+        ["git", "rev-list", "--since=1 week ago", "--pretty=format:%ad__%h", "--date=short", branch]
     ).decode("utf-8")
-    date_and_commits = [line for i, line in enumerate(output.split("\n")) if i % 2 == 1]
+    date_and_commits = [line for i, line in enumerate(output.split('\n')) if i % 2 == 1]
 
     for date_and_commit in date_and_commits:
         print("benching commit", date_and_commit)
         result = subprocess.run(
-            [
-                "cargo",
-                "criterion",
-                "--message-format=json",
-                "--history-id",
-                date_and_commit,
-            ],
+            ["cargo", "criterion", "--message-format=json", "--history-id", date_and_commit],
             capture_output=True,
-            text=True,
+            text=True
         )
         with open(f"{date_and_commit}.json", "w") as f:
             f.write(result.stdout)
-
 
 if build_pip:
     step_start("Building the pip package")

--- a/pip/qsharp/interop/qiskit/backends/qirtarget.py
+++ b/pip/qsharp/interop/qiskit/backends/qirtarget.py
@@ -61,6 +61,8 @@ class QirTarget(Target):
     ):
         super().__init__(num_qubits=num_qubits)
 
+        self._num_qubits = num_qubits
+
         if target_profile != TargetProfile.Base:
             self.add_instruction(ControlFlowOp, name="control_flow")
             self.add_instruction(IfElseOp, name="if_else")
@@ -121,3 +123,16 @@ class QirTarget(Target):
         self.add_instruction(IGate, name="id")
 
         self.add_instruction(CHGate, name="ch")
+
+    # NOTE: The follow property intentionally shadows the property on the parent class to allow it to return `None`
+    # when the value is not set, which allows bypassing transpilation checks for number of qubits. Without this,
+    # versions of Qiskit 1.3.0 and higher default to `0` which will fail later checks.
+    @property
+    def num_qubits(self):
+        return self._num_qubits
+
+    # NOTE: The follow property setter intentionally shadows the property on the parent class to allow it to be set, which
+    # maintains compatiblity with Qiskit versions before 1.3.0 where the property was settable.
+    @num_qubits.setter
+    def num_qubits(self, value):
+        self._num_qubits = value

--- a/pip/tests-integration/interop_qiskit/test_gate_correctness.py
+++ b/pip/tests-integration/interop_qiskit/test_gate_correctness.py
@@ -242,7 +242,13 @@ def _test_circuit(
 ):
     target_profile = TargetProfile.Base
     seed = 42
-    backend = QSharpBackend(target_profile=target_profile, seed=seed)
+    backend = QSharpBackend(
+        target_profile=target_profile,
+        seed=seed,
+        transpile_options={
+            "optimization_level": 0  # Use no optimization to get consistent results in simulations
+        },
+    )
     try:
         job = backend.run(circuit, shots=num_shots)
         result = job.result()

--- a/pip/tests-integration/interop_qiskit/test_gateset_qasm.py
+++ b/pip/tests-integration/interop_qiskit/test_gateset_qasm.py
@@ -16,6 +16,9 @@ def run_transpile_test(
 ) -> None:
     circuit = QuantumCircuit(3, 3)
     operation(circuit)
+    if "optimization_level" not in options:
+        # Use no optimization so gate transpilation is consistent
+        options["optimization_level"] = 0
     info = QSharpBackend()._qasm3(circuit, **options)
     lines = info.splitlines()
     # remove the first four lines, which are the header

--- a/pip/tests-integration/interop_qiskit/test_re.py
+++ b/pip/tests-integration/interop_qiskit/test_re.py
@@ -38,7 +38,7 @@ def test_qsharp_estimation_with_single_params() -> None:
     for index in range(10):
         circuit.t(index)
         circuit.measure(index, index)
-    sim = ResourceEstimatorBackend()
+    sim = ResourceEstimatorBackend(transpile_options={"optimization_level": 0})
     res = sim.run(circuit, params=params).result()
 
     assert res["status"] == "success"
@@ -69,8 +69,8 @@ def test_estimate_qiskit_rgqft_multiplier() -> None:
         {
             "numQubits": 16,
             "tCount": 90,
-            "rotationCount": 958,
-            "rotationDepth": 658,
+            "rotationCount": 1002,
+            "rotationDepth": 680,
             "cczCount": 0,
             "ccixCount": 0,
             "measurementCount": 0,
@@ -94,8 +94,8 @@ def test_estimate_qiskit_rgqft_multiplier_in_threadpool() -> None:
         {
             "numQubits": 16,
             "tCount": 90,
-            "rotationCount": 958,
-            "rotationDepth": 658,
+            "rotationCount": 1002,
+            "rotationDepth": 680,
             "cczCount": 0,
             "ccixCount": 0,
             "measurementCount": 0,

--- a/pip/tests-integration/test_requirements.txt
+++ b/pip/tests-integration/test_requirements.txt
@@ -1,5 +1,5 @@
 pytest==8.2.2
-qiskit>=1.2.2,<2.0.0
+qiskit>=1.3.0,<2.0.0
 qirrunner==0.7.1
 pyqir==0.10.2
 qiskit-aer==0.14.2

--- a/pip/tests-integration/test_requirements.txt
+++ b/pip/tests-integration/test_requirements.txt
@@ -1,5 +1,5 @@
 pytest==8.2.2
-qiskit>=1.2.2,<1.3.0
+qiskit>=1.2.2,<2.0.0
 qirrunner==0.7.1
 pyqir==0.10.2
 qiskit-aer==0.14.2


### PR DESCRIPTION
Qiskit v1.3 changed the behavior of `num_qubits` on the `Target` class in way that broke our `QirTarget` usage, since we expect to default to `None` but the new logic ignores the `num_qubits` parameter to `__init__` and always defaults to zero qubits, failing later calls to transpilation. By shadowing the parent class property in `QirTarget` we can continue returning `None` and trigger the right behavior in transpilation while preserving a setter for use with v1.2.

Note: I tested locally with both v1.2.4 and v1.3.0 integration tests to confirm the behavior is as expected.

Fixes #2047