### PR TITLE
Support `ApplyUnitary` in simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ dependencies = [
 [[package]]
 name = "quantum-sparse-sim"
 version = "0.7.5"
-source = "git+https://github.com/qir-alliance/qir-runner?rev=fa912185954c1866eb8592f0a2f49424360d0aad#fa912185954c1866eb8592f0a2f49424360d0aad"
+source = "git+https://github.com/qir-alliance/qir-runner?rev=562e2c11ad685dd01bfc1ae975e00d4133615995#562e2c11ad685dd01bfc1ae975e00d4133615995"
 dependencies = [
  "ndarray",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "expect-test",
  "indoc",
  "miette",
+ "ndarray",
  "num-bigint",
  "num-complex",
  "num-traits",
@@ -1625,8 +1626,8 @@ dependencies = [
 
 [[package]]
 name = "quantum-sparse-sim"
-version = "0.7.4"
-source = "git+https://github.com/qir-alliance/qir-runner?tag=v0.7.4#7b41f9313609f8309317ce91afccf0a2c7fe5a6f"
+version = "0.7.5"
+source = "git+https://github.com/qir-alliance/qir-runner?rev=fa912185954c1866eb8592f0a2f49424360d0aad#fa912185954c1866eb8592f0a2f49424360d0aad"
 dependencies = [
  "ndarray",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ log = "0.4"
 miette = { version = "7.2", features = ["fancy-no-syscall"] }
 thiserror = "1.0"
 nalgebra = { version = "0.33" }
+ndarray = "0.15.4"
 num-bigint = "0.4"
 num-complex = "0.4"
 num-traits = "0.2"
@@ -77,7 +78,7 @@ wasm-bindgen-futures = "0.4"
 rand = "0.8"
 serde_json = "1.0"
 pyo3 = "0.22"
-quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", tag = "v0.7.4" }
+quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", rev = "fa912185954c1866eb8592f0a2f49424360d0aad" }
 async-trait = "0.1"
 tokio = { version = "1.35", features = ["macros", "rt"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ wasm-bindgen-futures = "0.4"
 rand = "0.8"
 serde_json = "1.0"
 pyo3 = "0.22"
-quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", rev = "fa912185954c1866eb8592f0a2f49424360d0aad" }
+quantum-sparse-sim = { git = "https://github.com/qir-alliance/qir-runner", rev = "562e2c11ad685dd01bfc1ae975e00d4133615995" }
 async-trait = "0.1"
 tokio = { version = "1.35", features = ["macros", "rt"] }
 

--- a/compiler/qsc_eval/Cargo.toml
+++ b/compiler/qsc_eval/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 
 [dependencies]
 miette = { workspace = true }
+ndarray = { workspace = true }
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
 num-traits = { workspace = true }

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -429,6 +429,11 @@ impl Backend for SparseSim {
                     .collect::<Vec<_>>();
                 let matrix = unwrap_matrix_as_array2(matrix, &qubits);
 
+                let adj = matrix.t().map(Complex::<f64>::conj);
+                if matrix.dot(&adj) != Array2::eye(1 << qubits.len()) {
+                    return Some(Err("matrix is not unitary".to_string()));
+                }
+
                 self.sim.apply(&matrix, &qubits, None);
 
                 Some(Ok(Value::unit()))

--- a/compiler/qsc_eval/src/backend.rs
+++ b/compiler/qsc_eval/src/backend.rs
@@ -429,8 +429,13 @@ impl Backend for SparseSim {
                     .collect::<Vec<_>>();
                 let matrix = unwrap_matrix_as_array2(matrix, &qubits);
 
+                // Confirm the matrix is unitary by checking if multiplying it by its adjoint gives the identity matrix (up to numerical precision).
                 let adj = matrix.t().map(Complex::<f64>::conj);
-                if matrix.dot(&adj) != Array2::eye(1 << qubits.len()) {
+                if (matrix.dot(&adj) - Array2::<Complex<f64>>::eye(1 << qubits.len()))
+                    .map(|x| x.norm())
+                    .sum()
+                    > 1e-9
+                {
                     return Some(Err("matrix is not unitary".to_string()));
                 }
 

--- a/compiler/qsc_eval/src/intrinsic.rs
+++ b/compiler/qsc_eval/src/intrinsic.rs
@@ -10,13 +10,12 @@ use crate::{
     backend::Backend,
     error::PackageSpan,
     output::Receiver,
-    val::{self, Value},
+    val::{self, unwrap_tuple, Value},
     Error, Rc,
 };
 use num_bigint::BigInt;
 use rand::{rngs::StdRng, Rng};
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::array;
 use std::convert::TryFrom;
 
 #[allow(clippy::too_many_lines)]
@@ -425,9 +424,4 @@ pub fn qubit_relabel(
     }
 
     Ok(Value::unit())
-}
-
-fn unwrap_tuple<const N: usize>(value: Value) -> [Value; N] {
-    let values = value.unwrap_tuple();
-    array::from_fn(|i| values[i].clone())
 }

--- a/compiler/qsc_eval/src/val.rs
+++ b/compiler/qsc_eval/src/val.rs
@@ -5,6 +5,7 @@ use num_bigint::BigInt;
 use qsc_data_structures::{display::join, functors::FunctorApp};
 use qsc_fir::fir::{Functor, Pauli, StoreItemId};
 use std::{
+    array,
     fmt::{self, Display, Formatter},
     rc::{Rc, Weak},
 };
@@ -577,4 +578,10 @@ pub fn update_functor_app(functor: Functor, app: FunctorApp) -> FunctorApp {
             controlled: app.controlled + 1,
         },
     }
+}
+
+#[must_use]
+pub fn unwrap_tuple<const N: usize>(value: Value) -> [Value; N] {
+    let values = value.unwrap_tuple();
+    array::from_fn(|i| values[i].clone())
 }

--- a/library/src/tests/intrinsic.rs
+++ b/library/src/tests/intrinsic.rs
@@ -7,7 +7,7 @@ use expect_test::expect;
 use indoc::indoc;
 use qsc::{interpret::Value, target::Profile, SparseSim};
 
-use super::{test_expression, test_expression_with_lib_and_profile_and_sim};
+use super::{test_expression, test_expression_fails, test_expression_with_lib_and_profile_and_sim};
 
 // These tests verify multi-controlled decomposition logic for gate operations. Each test
 // manually allocates 2N qubits, performs the decomposed operation from the library on the first N,
@@ -3007,4 +3007,120 @@ fn test_exp() {
         |1111⟩: 0.2252+0.1085𝑖
     "#]]
     .assert_eq(&dump);
+}
+
+#[test]
+fn test_apply_unitary_with_h_matrix() {
+    let dump = test_expression(
+        indoc! {"
+        {
+            open Std.Math;
+            open Std.Diagnostics;
+            use q = Qubit();
+            let one_sqrt_2 = new Complex { Real = 1.0 / Sqrt(2.0), Imag = 0.0 };
+            ApplyUnitary(
+                [
+                    [one_sqrt_2, one_sqrt_2],
+                    [one_sqrt_2, NegationC(one_sqrt_2)]
+                ],
+                [q]
+            );
+            DumpMachine();
+            Reset(q);
+        }
+        "},
+        &Value::unit(),
+    );
+
+    expect![[r#"
+        STATE:
+        |0⟩: 0.7071+0.0000𝑖
+        |1⟩: 0.7071+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+}
+
+#[test]
+fn test_apply_unitary_with_swap_matrix() {
+    let dump = test_expression(
+        indoc! {"
+        {
+            open Std.Math;
+            open Std.Diagnostics;
+            use qs = Qubit[2];
+            H(qs[0]);
+            DumpMachine();
+            let one = new Complex { Real = 1.0, Imag = 0.0 };
+            let zero = new Complex { Real = 0.0, Imag = 0.0 };
+            ApplyUnitary(
+                [
+                    [one, zero, zero, zero],
+                    [zero, zero, one, zero],
+                    [zero, one, zero, zero],
+                    [zero, zero, zero, one]
+                ],
+                qs
+            );
+            DumpMachine();
+            ResetAll(qs);
+        }
+        "},
+        &Value::unit(),
+    );
+
+    expect![[r#"
+        STATE:
+        |00⟩: 0.7071+0.0000𝑖
+        |10⟩: 0.7071+0.0000𝑖
+        STATE:
+        |00⟩: 0.7071+0.0000𝑖
+        |01⟩: 0.7071+0.0000𝑖
+    "#]]
+    .assert_eq(&dump);
+}
+
+#[test]
+fn test_apply_unitary_fails_when_matrix_not_square() {
+    let err = test_expression_fails(indoc! {"
+        {
+            open Std.Math;
+            open Std.Diagnostics;
+            use q = Qubit();
+            ApplyUnitary(
+                [
+                    [new Complex { Real = 1.0, Imag = 0.0 }],
+                    [new Complex { Real = 0.0, Imag = 0.0 }]
+                ],
+                [q]
+            );
+            DumpMachine();
+            Reset(q);
+        }
+        "});
+
+    expect!["program failed: matrix passed to ApplyUnitary must be square."].assert_eq(&err);
+}
+
+#[test]
+fn test_apply_unitary_fails_when_matrix_wrong_size() {
+    let err = test_expression_fails(indoc! {"
+        {
+            open Std.Math;
+            open Std.Diagnostics;
+            use qs = Qubit[2];
+            let one_sqrt_2 = new Complex { Real = 1.0 / Sqrt(2.0), Imag = 0.0 };
+            ApplyUnitary(
+                [
+                    [one_sqrt_2, one_sqrt_2],
+                    [one_sqrt_2, NegationC(one_sqrt_2)]
+                ],
+                qs
+            );
+            DumpMachine();
+            ResetAll(qs);
+        }
+        "});
+
+    expect!["program failed: matrix passed to ApplyUnitary must have dimensions 2^Length(qubits)."]
+        .assert_eq(&err);
 }

--- a/library/src/tests/intrinsic.rs
+++ b/library/src/tests/intrinsic.rs
@@ -3124,3 +3124,26 @@ fn test_apply_unitary_fails_when_matrix_wrong_size() {
     expect!["program failed: matrix passed to ApplyUnitary must have dimensions 2^Length(qubits)."]
         .assert_eq(&err);
 }
+
+#[test]
+fn test_apply_unitary_fails_when_matrix_not_unitary() {
+    let err = test_expression_fails(indoc! {"
+        {
+            open Std.Math;
+            open Std.Diagnostics;
+            use q = Qubit();
+            let zero = new Complex { Real = 0.0, Imag = 0.0 };
+            ApplyUnitary(
+                [
+                    [zero, zero],
+                    [zero, zero]
+                ],
+                [q]
+            );
+            DumpMachine();
+            Reset(q);
+        }
+        "});
+
+    expect!["intrinsic callable `Apply` failed: matrix is not unitary"].assert_eq(&err);
+}

--- a/library/std/src/Std/Intrinsic.qs
+++ b/library/std/src/Std/Intrinsic.qs
@@ -1141,7 +1141,7 @@ operation Z(qubit : Qubit) : Unit is Adj + Ctl {
 }
 
 /// # Summary
-/// Applies the given unitary matrix to the given qubits. The matrix must be square, with dimensions dictated by the number of qubits.
+/// Applies the given unitary matrix to the given qubits. The matrix is checked at runtime to ensure it's shape is square and that the matrix dimensions are `2 ^ Length(qubits)`.
 /// This operation is simulator-only and is not supported on hardware.
 ///
 /// # Input
@@ -1149,9 +1149,6 @@ operation Z(qubit : Qubit) : Unit is Adj + Ctl {
 /// The unitary matrix to apply.
 /// ## qubits
 /// The qubits to which the unitary matrix should be applied.
-///
-/// # Remarks
-/// The matrix is checked at runtime to ensure it's shape is square and that the matrix dimensions are `2 ^ Length(qubits)`.
 ///
 /// # Example
 /// This performs a two qubit CNOT using the unitary matrix representation:

--- a/library/std/src/Std/Intrinsic.qs
+++ b/library/std/src/Std/Intrinsic.qs
@@ -1141,6 +1141,40 @@ operation Z(qubit : Qubit) : Unit is Adj + Ctl {
 }
 
 /// # Summary
+/// Applies the given unitary matrix to the given qubits. The matrix must be square, with dimensions dictated by the number of qubits.
+/// This operation is simulator-only and is not supported on hardware.
+///
+/// # Input
+/// ## matrix
+/// The unitary matrix to apply.
+/// ## qubits
+/// The qubits to which the unitary matrix should be applied.
+///
+/// # Remarks
+/// The matrix is checked at runtime to ensure it's shape is square and that the matrix dimensions are `2 ^ Length(qubits)`.
+@Config(Unrestricted)
+operation ApplyUnitary(matrix : Complex[][], qubits : Qubit[]) : Unit {
+    let num_rows = Length(matrix);
+    for col in matrix {
+        if Length(col) != num_rows {
+            fail "matrix passed to ApplyUnitary must be square.";
+        }
+    }
+
+    let num_qubits = Length(qubits);
+    if num_rows != 1 <<< num_qubits {
+        fail "matrix passed to ApplyUnitary must have dimensions 2^Length(qubits).";
+    }
+
+    Apply(matrix, qubits);
+}
+
+@Config(Unrestricted)
+operation Apply(matrix : Complex[][], qubits : Qubit[]) : Unit {
+    body intrinsic;
+}
+
+/// # Summary
 /// Logs a message.
 ///
 /// # Input
@@ -1155,4 +1189,4 @@ function Message(msg : String) : Unit {
     body intrinsic;
 }
 
-export AND, CCNOT, CNOT, Exp, H, I, M, Measure, R, R1, R1Frac, Reset, ResetAll, RFrac, Rx, Rxx, Ry, Ryy, Rz, Rzz, S, SWAP, T, X, Y, Z, Message;
+export AND, CCNOT, CNOT, Exp, H, I, M, Measure, R, R1, R1Frac, Reset, ResetAll, RFrac, Rx, Rxx, Ry, Ryy, Rz, Rzz, S, SWAP, T, X, Y, Z, ApplyUnitary, Message;

--- a/library/std/src/Std/Intrinsic.qs
+++ b/library/std/src/Std/Intrinsic.qs
@@ -1152,6 +1152,24 @@ operation Z(qubit : Qubit) : Unit is Adj + Ctl {
 ///
 /// # Remarks
 /// The matrix is checked at runtime to ensure it's shape is square and that the matrix dimensions are `2 ^ Length(qubits)`.
+///
+/// # Example
+/// This performs a two qubit CNOT using the unitary matrix representation:
+/// ```qsharp
+/// import Std.Math.Complex;
+/// use qs = Qubit[2];
+/// let one = new Complex { Real = 1.0, Imag = 0.0 };
+/// let zero = new Complex { Real = 0.0, Imag = 0.0 };
+/// ApplyUnitary(
+///     [
+///         [one, zero, zero, zero],
+///         [zero, one, zero, zero],
+///         [zero, zero, zero, one],
+///         [zero, zero, one, zero]
+///     ],
+///     qs
+/// );
+/// ```
 @Config(Unrestricted)
 operation ApplyUnitary(matrix : Complex[][], qubits : Qubit[]) : Unit {
     let num_rows = Length(matrix);


### PR DESCRIPTION
This adds a new library function `ApplyUnitary` that given a matrix of complex numbers will apply that matrix to the given qubits. This requires a new version of the simulator that exposes the functionality publicly.

Starting as draft to wait for https://github.com/qir-alliance/qir-runner/pull/208