### PR TITLE
Switch QIR Target checking from allow list to deny list

### DIFF
--- a/vscode/src/azure/providerProperties.ts
+++ b/vscode/src/azure/providerProperties.ts
@@ -13,9 +13,8 @@ export function targetSupportQir(target: string) {
   // Note: Most of these should be dynamic at some point, with configuration coming
   // from the service, and able to be overridden by settings.
   return (
-    target.startsWith("ionq") ||
-    target.startsWith("quantinuum") ||
-    target.startsWith("rigetti")
+    !(target == "microsoft.estimator") &&
+    !(target.startsWith("microsoft") && target.endsWith("cpu"))
   );
 }
 
@@ -28,5 +27,5 @@ export function shouldExcludeProvider(provider: string) {
 }
 
 export function supportsAdaptive(target: string) {
-  return target.startsWith("quantinuum");
+  return !target.startsWith("ionq") && !target.startsWith("rigetti");
 }


### PR DESCRIPTION
This change updates the logic we use to decide if a target supports QIR submission in the extension. Previously it was an allow list which required any new targets or providers to be explicitly added. Instead, this uses a deny list style so that new providers and targets are allowed to submit either base or adaptive without requiring updates to the QDK. Then we can coordinate with new partners on what targets should be lit up for which purposes.