### PR TITLE
Added simple VQE sample

### DIFF
--- a/samples/algorithms/SimpleVQE.qs
+++ b/samples/algorithms/SimpleVQE.qs
@@ -34,26 +34,27 @@ operation Main() : Double {
         // Start from these angles for ansatz state preparation
         [1.0, 1.0],
         // Use initial step pi/8 to find minimum
-        PI()/8.0,
+        PI() / 8.0,
         // Stop optimization if step is 0
         0.0,
         // Stop optimization after 100 attempts to improve
-        100)
+        100
+    )
 }
 
 /// # Summary
 /// Find expectation value of a Hamiltonian given parameters for the
 /// ansatz state and number of shots to evaluate each term.
-operation FindHamiltonianExpectationValue(thetas: Double[], shots: Int): Double {
+operation FindHamiltonianExpectationValue(thetas : Double[], shots : Int) : Double {
     let terms = [
-        ([PauliZ,PauliI,PauliI,PauliI], 0.16),
-        ([PauliI,PauliI,PauliZ,PauliI], 0.25),
-        ([PauliZ,PauliZ,PauliI,PauliI], 0.17),
-        ([PauliI,PauliI,PauliZ,PauliZ], 0.45),
-        ([PauliX,PauliX,PauliX,PauliX], 0.2),
-        ([PauliY,PauliY,PauliY,PauliY], 0.1),
-        ([PauliY,PauliX,PauliX,PauliY], 0.02),
-        ([PauliX,PauliY,PauliY,PauliX], 0.22),
+        ([PauliZ, PauliI, PauliI, PauliI], 0.16),
+        ([PauliI, PauliI, PauliZ, PauliI], 0.25),
+        ([PauliZ, PauliZ, PauliI, PauliI], 0.17),
+        ([PauliI, PauliI, PauliZ, PauliZ], 0.45),
+        ([PauliX, PauliX, PauliX, PauliX], 0.2),
+        ([PauliY, PauliY, PauliY, PauliY], 0.1),
+        ([PauliY, PauliX, PauliX, PauliY], 0.02),
+        ([PauliX, PauliY, PauliY, PauliX], 0.22),
     ];
     mutable value = 0.0;
     for (basis, coefficient) in terms {
@@ -66,9 +67,10 @@ operation FindHamiltonianExpectationValue(thetas: Double[], shots: Int): Double 
 /// Find expectation value of a Hamiltonian term given parameters for the
 /// ansatz state, measurement basis and number of shots to evaluate each term.
 operation FindTermExpectationValue(
-    thetas: Double[],
-    pauliBasis: Pauli[],
-    shots: Int): Double {
+    thetas : Double[],
+    pauliBasis : Pauli[],
+    shots : Int
+) : Double {
 
     mutable zeroCount = 0;
     for _ in 1..shots {
@@ -84,7 +86,7 @@ operation FindTermExpectationValue(
 
 /// # Summary
 /// Prepare the ansatz state for given parameters on a qubit register
-operation PrepareAnsatzState(qs: Qubit[], thetas: Double[]): Unit {
+operation PrepareAnsatzState(qs : Qubit[], thetas : Double[]) : Unit {
     BosonicExitationTerm(thetas[0], qs[0], qs[2]);
     CNOT(qs[0], qs[1]);
     NonBosonicExitataionTerm(thetas[1], qs[0], qs[1], qs[2], qs[3]);
@@ -93,9 +95,10 @@ operation PrepareAnsatzState(qs: Qubit[], thetas: Double[]): Unit {
 /// # Summary
 /// Bosonic exitation circuit
 operation BosonicExitationTerm(
-    theta: Double,
-    moX: Qubit,
-    moY: Qubit): Unit {
+    theta : Double,
+    moX : Qubit,
+    moY : Qubit
+) : Unit {
 
     Adjoint S(moX);
     Rxx(theta, moX, moY);
@@ -108,11 +111,12 @@ operation BosonicExitationTerm(
 /// # Summary
 /// Non-bosonic exitation circuit
 operation NonBosonicExitataionTerm(
-    theta: Double,
+    theta : Double,
     moXsoX : Qubit,
     moXsoY : Qubit,
     moYsoX : Qubit,
-    moYsoY : Qubit) : Unit {
+    moYsoY : Qubit
+) : Unit {
 
     Adjoint S(moXsoX);
     within {
@@ -146,11 +150,12 @@ operation NonBosonicExitataionTerm(
 /// Tries to takes steps in all directions and proceeds if the new point is better.
 /// If no moves result in function value improvement the step size is halved.
 operation SimpleDescent(
-    f: Double[] => Double,
-    initialPoint: Double[],
-    initialStep: Double,
-    minimalStep: Double,
-    attemptLimit: Int) : Double {
+    f : Double[] => Double,
+    initialPoint : Double[],
+    initialStep : Double,
+    minimalStep : Double,
+    attemptLimit : Int
+) : Double {
     Fact(not IsEmpty(initialPoint), "Argument array must contain elements.");
     Fact(initialStep > 0.0, "Initial step must be positive.");
     Fact(minimalStep >= 0.0, "Minimal step must be non-negative.");

--- a/samples/algorithms/SimpleVQE.qs
+++ b/samples/algorithms/SimpleVQE.qs
@@ -30,7 +30,7 @@ operation Main() : Double {
     // by varying ansatz parameters to minimize its expectation value.
     SimpleDescent(
         // Use 1000 shots when estimating hamiltonian terms
-        FindHamiltonianExpectationValue(_, 1000),
+        FindHamiltonianExpectationValue(_, 100),
         // Start from these angles for ansatz state preparation
         [1.0, 1.0],
         // Use initial step pi/8 to find minimum

--- a/samples/algorithms/SimpleVQE.qs
+++ b/samples/algorithms/SimpleVQE.qs
@@ -5,11 +5,11 @@
 /// This is an example of a Variational Quantum Eigensolver (VQE).
 /// This example includes:
 ///   1. Simple classical optimization to find minimum of a multi-variable function
-///      in order to find an approximation to the minimum eigenvalue of a hamiltonian
+///      in order to find an approximation to the minimum eigenvalue of a Hamiltonian
 ///   2. Finding Hamiltonian expectation value as a weighted sum of terms.
 ///   3. Finding one term expectation value by performing multiple shots.
 ///   4. Ansatz state preparation similar to the circuit in the referenced paper.
-/// To keep this sample simple hamiltonian terms are generated randomly.
+/// To keep this sample simple Hamiltonian terms are generated randomly.
 ///
 /// # Reference
 /// Ground-state energy estimation of the water molecule on a trapped ion quantum
@@ -29,7 +29,7 @@ operation Main() : Double {
     // Find the approximation to the minimum eigenvalue of a Hamiltonian
     // by varying ansatz parameters to minimize its expectation value.
     SimpleDescent(
-        // Use a number of shots when estimating hamiltonian terms
+        // Use a number of shots when estimating Hamiltonian terms
         // Actual VQE implementations may require very large number of shots.
         FindHamiltonianExpectationValue(_, 100),
         // Start from these angles for ansatz state preparation

--- a/samples/algorithms/SimpleVQE.qs
+++ b/samples/algorithms/SimpleVQE.qs
@@ -1,0 +1,133 @@
+/// # Sample
+/// A part of ansatz circuit used in water molecule simulation
+/// This sample is suitable for adaptive profile.
+///
+/// # Description
+/// This is an example of the quantum part of a Variational Quantum Eigensolver (VQE) method.
+/// This example shows one variant of ansatz circuit used in a water molecule simulation
+/// in the referenced paper. To keep this sample suitable for adaptive profile,
+/// random angles are used and optimization part is omitted.
+///
+/// # Reference
+/// Ground-state energy estimation of the water molecule on a trapped ion quantum
+/// computer by Yunseong Nam et al., 2019. https://arxiv.org/abs/1902.10171
+
+import Std.Diagnostics.Fact;
+
+/// # Summary
+/// Bosonic exitation circuit
+operation BosonicExitationTerm(
+    theta: Double,
+    moX: Qubit,
+    moY: Qubit): Unit {
+
+    Adjoint S(moX);
+    Rxx(theta, moX, moY);
+    S(moX);
+    Adjoint S(moY);
+    Rxx(-theta, moX, moY);
+    S(moY);
+}
+
+/// # Summary
+/// Non-bosonic exitation circuit
+operation NonBosonicExitataionTerm(
+    theta: Double,
+    moXsoX : Qubit,
+    moXsoY : Qubit,
+    moYsoX : Qubit,
+    moYsoY : Qubit) : Unit {
+
+    Adjoint S(moXsoX);
+    within {
+        CNOT(moXsoX, moYsoY);
+        CNOT(moXsoX, moYsoX);
+        CNOT(moXsoX, moXsoY);
+        H(moXsoX);
+    } apply {
+        Rz(theta, moXsoX);
+        CNOT(moXsoY, moXsoX);
+        Rz(theta, moXsoX);
+        CNOT(moYsoY, moXsoX);
+        Rz(-theta, moXsoX);
+        CNOT(moXsoY, moXsoX);
+        Rz(-theta, moXsoX);
+        Adjoint S(moYsoX);
+        CNOT(moYsoX, moXsoX);
+        Rx(theta, moXsoX);
+        CNOT(moXsoY, moXsoX);
+        Rx(theta, moXsoX);
+        CNOT(moYsoY, moXsoX);
+        Rz(-theta, moXsoX);
+        CNOT(moXsoY, moXsoX);
+        Rz(-theta, moXsoX);
+    }
+    S(moYsoX);
+}
+
+/// # Summary
+/// Prepare state containing both bosonic and non-bosinic interactions
+/// And measure the result in PauliZ basis.
+operation PrepareAndMeasureAnsatzInZ(
+    thetasMo: Double[],
+    thetasSo: Double[]) : Result[] {
+
+    Fact(Length(thetasMo) == 4, "Length of thetasMo should be 4.");
+    Fact(Length(thetasSo) == 4, "Length of thetasSo should be 4.");
+
+    use mo = Qubit[4];
+
+    BosonicExitationTerm(thetasMo[0], mo[0], mo[1]);
+    BosonicExitationTerm(thetasMo[1], mo[2], mo[3]);
+    BosonicExitationTerm(thetasMo[2], mo[0], mo[3]);
+    BosonicExitationTerm(thetasMo[3], mo[1], mo[2]);
+
+    use so = Qubit[4];
+    CNOT(mo[0], so[0]);
+    CNOT(mo[1], so[1]);
+    CNOT(mo[2], so[2]);
+    CNOT(mo[3], so[3]);
+
+    NonBosonicExitataionTerm(thetasSo[0], mo[0], so[0], mo[1], so[1]);
+    NonBosonicExitataionTerm(thetasSo[1], mo[2], so[2], mo[3], so[3]);
+    NonBosonicExitataionTerm(thetasSo[2], mo[1], so[1], mo[2], so[2]);
+    NonBosonicExitataionTerm(thetasSo[3], mo[0], so[0], mo[3], so[3]);
+
+    MResetEachZ(mo+so)
+}
+
+/// # Summary
+/// Count number of zeroes when performing measurements
+/// on a state determined by some predefined angles.
+operation FindZeroFrequencies(shots: Int): Int[] {
+    let thetasMo = [0.5, 0.5, 0.5, 0.5];
+    let thetasSo = [0.3, 0.3, 0.3, 0.3];
+    mutable c0 = 0;
+    mutable c1 = 0;
+    mutable c2 = 0;
+    mutable c3 = 0;
+    mutable c4 = 0;
+    mutable c5 = 0;
+    mutable c6 = 0;
+    mutable c7 = 0;
+    for _ in 1..shots {
+        let results = PrepareAndMeasureAnsatzInZ(thetasMo, thetasSo);
+        set c0 = c0 + if results[0] == Zero {1} else {0};
+        set c1 = c1 + if results[1] == Zero {1} else {0};
+        set c2 = c2 + if results[2] == Zero {1} else {0};
+        set c3 = c3 + if results[3] == Zero {1} else {0};
+        set c4 = c4 + if results[4] == Zero {1} else {0};
+        set c5 = c4 + if results[5] == Zero {1} else {0};
+        set c6 = c4 + if results[6] == Zero {1} else {0};
+        set c7 = c4 + if results[7] == Zero {1} else {0};
+    }
+    [c0, c1, c2, c3, c4, c5, c6, c7]
+}
+
+/// # Summary
+/// Prepare one ansatz state and perform measurements multiple times
+/// In actual VQE state parameters will be varied based on measurement
+/// results.
+operation Main() : Int[] {
+    FindZeroFrequencies(1000)
+}

--- a/samples_test/src/tests/algorithms.rs
+++ b/samples_test/src/tests/algorithms.rs
@@ -258,6 +258,26 @@ pub const SIMPLEISING_EXPECT: Expect =
     expect!["[Zero, Zero, Zero, One, One, Zero, One, One, Zero]"];
 pub const SIMPLEISING_EXPECT_DEBUG: Expect =
     expect!["[Zero, Zero, Zero, One, One, Zero, One, One, Zero]"];
+pub const SIMPLEVQE_EXPECT: Expect = expect![[r#"
+    Beginning descent from value 0.9795.
+    Value improved to 0.9511000000000001.
+    Value improved to 0.8876000000000001.
+    Value improved to 0.8764000000000001.
+    Value improved to 0.8702000000000001.
+    Value improved to 0.8641000000000002.
+    Value improved to 0.8549000000000001.
+    Descent done. Attempts: 100, Step: 0.00000037450702829239286, Arguments: [1.5886651273511148, 1.3926990816987241], Value: 0.8549000000000001.
+    0.8549000000000001"#]];
+pub const SIMPLEVQE_EXPECT_DEBUG: Expect = expect![[r#"
+    Beginning descent from value 0.9795.
+    Value improved to 0.9511000000000001.
+    Value improved to 0.8876000000000001.
+    Value improved to 0.8764000000000001.
+    Value improved to 0.8702000000000001.
+    Value improved to 0.8641000000000002.
+    Value improved to 0.8549000000000001.
+    Descent done. Attempts: 100, Step: 0.00000037450702829239286, Arguments: [1.5886651273511148, 1.3926990816987241], Value: 0.8549000000000001.
+    0.8549000000000001"#]];
 pub const SUPERDENSECODING_EXPECT: Expect = expect!["((false, true), (false, true))"];
 pub const SUPERDENSECODING_EXPECT_DEBUG: Expect = expect!["((false, true), (false, true))"];
 pub const SUPERPOSITION_EXPECT: Expect = expect!["Zero"];

--- a/samples_test/src/tests/algorithms.rs
+++ b/samples_test/src/tests/algorithms.rs
@@ -259,25 +259,21 @@ pub const SIMPLEISING_EXPECT: Expect =
 pub const SIMPLEISING_EXPECT_DEBUG: Expect =
     expect!["[Zero, Zero, Zero, One, One, Zero, One, One, Zero]"];
 pub const SIMPLEVQE_EXPECT: Expect = expect![[r#"
-    Beginning descent from value 0.9795.
-    Value improved to 0.9511000000000001.
-    Value improved to 0.8876000000000001.
-    Value improved to 0.8764000000000001.
-    Value improved to 0.8702000000000001.
-    Value improved to 0.8641000000000002.
-    Value improved to 0.8549000000000001.
-    Descent done. Attempts: 100, Step: 0.00000037450702829239286, Arguments: [1.5886651273511148, 1.3926990816987241], Value: 0.8549000000000001.
-    0.8549000000000001"#]];
+   Beginning descent from value 0.43300000000000005.
+   Value improved to 0.35300000000000004.
+   Value improved to 0.3454.
+   Value improved to 0.3422.
+   Value improved to 0.3216.
+   Descent done. Attempts: 52, Step: 0.0009765625, Arguments: [1.5, 1.0625], Value: 0.3216.
+   0.3216"#]];
 pub const SIMPLEVQE_EXPECT_DEBUG: Expect = expect![[r#"
-    Beginning descent from value 0.9795.
-    Value improved to 0.9511000000000001.
-    Value improved to 0.8876000000000001.
-    Value improved to 0.8764000000000001.
-    Value improved to 0.8702000000000001.
-    Value improved to 0.8641000000000002.
-    Value improved to 0.8549000000000001.
-    Descent done. Attempts: 100, Step: 0.00000037450702829239286, Arguments: [1.5886651273511148, 1.3926990816987241], Value: 0.8549000000000001.
-    0.8549000000000001"#]];
+   Beginning descent from value 0.43300000000000005.
+   Value improved to 0.35300000000000004.
+   Value improved to 0.3454.
+   Value improved to 0.3422.
+   Value improved to 0.3216.
+   Descent done. Attempts: 52, Step: 0.0009765625, Arguments: [1.5, 1.0625], Value: 0.3216.
+   0.3216"#]];
 pub const SUPERDENSECODING_EXPECT: Expect = expect!["((false, true), (false, true))"];
 pub const SUPERDENSECODING_EXPECT_DEBUG: Expect = expect!["((false, true), (false, true))"];
 pub const SUPERPOSITION_EXPECT: Expect = expect!["Zero"];


### PR DESCRIPTION
This PR adds simple self-contained example of a Variational Quantum Eigensolver (VQE).

This example includes:

1. Simple classical optimization to find minimum of a multi-variable function in order to find the approximation to the minimum eigenvalue of a Hamiltonian.
2. Finding Hamiltonian expectation value as a weighted sum of terms.
3. Finding one term expectation value by performing multiple shots of preparing ansatz state and measuring it.
4. Ansatz state preparation similar to the circuit in the published paper "Ground-state energy estimation of the water molecule on a trapped ion quantum computer" (https://arxiv.org/abs/1902.10171)

To keep this sample simple and self-contained Hamiltonian is artificial (doesn't correspond to any actual chemistry problem). Also, this sample doesn't include any application of VQE, for example, finding a geometry of a molecule.
