### PR TITLE
Updated doc comments on measurement operations

### DIFF
--- a/library/std/src/Std/Measurement.qs
+++ b/library/std/src/Std/Measurement.qs
@@ -87,7 +87,7 @@ operation MResetEachZ(register : Qubit[]) : Result[] {
 
 /// # Summary
 /// Performs a single-qubit measurement in the Pauli X basis,
-/// and resets qubit to |0⟩ state after the measurement.
+/// and resets `target` to the |0⟩ state after the measurement.
 ///
 /// # Input
 /// ## target
@@ -104,7 +104,7 @@ operation MResetX(target : Qubit) : Result {
 
 /// # Summary
 /// Performs a single-qubit measurement in the Pauli Y basis,
-/// and resets qubit to |0⟩ state after the measurement.
+/// and resets `target` to the |0⟩ state after the measurement.
 ///
 /// # Input
 /// ## target
@@ -123,7 +123,7 @@ operation MResetY(target : Qubit) : Result {
 
 /// # Summary
 /// Performs a single-qubit measurement in the Pauli Z basis,
-/// and resets qubit to |0⟩ state after the measurement.
+/// and resets `target` to the |0⟩ state after the measurement.
 ///
 /// # Input
 /// ## target

--- a/library/std/src/Std/Measurement.qs
+++ b/library/std/src/Std/Measurement.qs
@@ -138,8 +138,8 @@ operation MResetZ(target : Qubit) : Result {
 /// # Summary
 /// Measures the content of a quantum register and converts it to an integer.
 /// The measurement is performed with respect to the standard computational basis,
-/// i.e., the eigenbasis of `PauliZ`. Input register is reset to |00...0⟩ state
-/// suitable for releasing back to a target machine.
+/// i.e., the eigenbasis of `PauliZ`. Input register is reset to the |00...0⟩ state,
+/// which is suitable for releasing the register back to a target machine.
 ///
 /// # Input
 /// ## target

--- a/library/std/src/Std/Measurement.qs
+++ b/library/std/src/Std/Measurement.qs
@@ -30,7 +30,7 @@ operation MeasureAllZ(register : Qubit[]) : Result {
 }
 
 /// # Summary
-/// Measures each qubit in a given array in the standard basis.
+/// Measures each qubit in a given array in the Pauli Z basis.
 ///
 /// # Description
 /// Measures each qubit in a register in the `Z` basis
@@ -65,8 +65,8 @@ operation MeasureEachZ(register : Qubit[]) : Result[] {
 }
 
 /// # Summary
-/// Measures each qubit in a given array in the Z basis
-/// and resets them to a fixed initial state.
+/// Measures each qubit in a given array in the Pauli Z basis
+/// and resets them to |0⟩ state.
 ///
 /// # Input
 /// ## targets
@@ -86,14 +86,8 @@ operation MResetEachZ(register : Qubit[]) : Result[] {
 }
 
 /// # Summary
-/// Measures a single qubit in the X basis,
-/// and resets it to a fixed initial state
-/// following the measurement.
-///
-/// # Description
-/// Performs a single-qubit measurement in the X-basis,
-/// and ensures that the qubit is returned to |0⟩
-/// following the measurement.
+/// Performs a single-qubit measurement in the Pauli X basis,
+/// and resets qubit to |0⟩ state after the measurement.
 ///
 /// # Input
 /// ## target
@@ -109,14 +103,8 @@ operation MResetX(target : Qubit) : Result {
 }
 
 /// # Summary
-/// Measures a single qubit in the Y basis,
-/// and resets it to a fixed initial state
-/// following the measurement.
-///
-/// # Description
-/// Performs a single-qubit measurement in the Y-basis,
-/// and ensures that the qubit is returned to |0⟩
-/// following the measurement.
+/// Performs a single-qubit measurement in the Pauli Y basis,
+/// and resets qubit to |0⟩ state after the measurement.
 ///
 /// # Input
 /// ## target
@@ -134,14 +122,8 @@ operation MResetY(target : Qubit) : Result {
 }
 
 /// # Summary
-/// Measures a single qubit in the Z basis,
-/// and resets it to a fixed initial state
-/// following the measurement.
-///
-/// # Description
-/// Performs a single-qubit measurement in the Z-basis,
-/// and ensures that the qubit is returned to |0⟩
-/// following the measurement.
+/// Performs a single-qubit measurement in the Pauli Z basis,
+/// and resets qubit to |0⟩ state after the measurement.
 ///
 /// # Input
 /// ## target
@@ -154,9 +136,10 @@ operation MResetZ(target : Qubit) : Result {
 }
 
 /// # Summary
-/// Measures the content of a quantum register and converts
-/// it to an integer. The measurement is performed with respect
-/// to the standard computational basis, i.e., the eigenbasis of `PauliZ`.
+/// Measures the content of a quantum register and converts it to an integer.
+/// The measurement is performed with respect to the standard computational basis,
+/// i.e., the eigenbasis of `PauliZ`. Input register is reset to |00...0⟩ state
+/// suitable for releasing back to a target machine.
 ///
 /// # Input
 /// ## target
@@ -164,10 +147,6 @@ operation MResetZ(target : Qubit) : Result {
 ///
 /// # Output
 /// An unsigned integer that contains the measured value of `target`.
-///
-/// # Remarks
-/// This operation resets its input register to the |00...0> state,
-/// suitable for releasing back to a target machine.
 operation MeasureInteger(target : Qubit[]) : Int {
     let nBits = Length(target);
     Fact(nBits < 64, $"`Length(target)` must be less than 64, but was {nBits}.");


### PR DESCRIPTION
Moved important remarks into summary as only summary is visible in most cases. Removed description when it was a simple rewording of the summary.
For example, MeasureInteger resets its arguments, but it was not clear from the name or summary.