### PR TITLE
Don't log errors from telemetry

### DIFF
--- a/pip/qsharp/telemetry.py
+++ b/pip/qsharp/telemetry.py
@@ -239,7 +239,7 @@ def _post_telemetry() -> bool:
             return True
 
     except Exception:
-        logger.exception(
+        logger.info(
             "Failed to post telemetry. Pending metrics will be retried at the next interval."
         )
         return False
@@ -271,7 +271,7 @@ def _telemetry_thread_start():
             if msg == "exit":
                 logger.debug("Exiting telemetry thread")
                 if not _post_telemetry():
-                    logger.error("Failed to post telemetry on exit")
+                    logger.info("Failed to post telemetry on exit")
                 return
             else:
                 on_metric(msg)

--- a/pip/qsharp/telemetry.py
+++ b/pip/qsharp/telemetry.py
@@ -239,7 +239,7 @@ def _post_telemetry() -> bool:
             return True
 
     except Exception:
-        logger.info(
+        logger.debug(
             "Failed to post telemetry. Pending metrics will be retried at the next interval."
         )
         return False
@@ -271,7 +271,7 @@ def _telemetry_thread_start():
             if msg == "exit":
                 logger.debug("Exiting telemetry thread")
                 if not _post_telemetry():
-                    logger.info("Failed to post telemetry on exit")
+                    logger.debug("Failed to post telemetry on exit")
                 return
             else:
                 on_metric(msg)


### PR DESCRIPTION
Failure to send telemetry should not be reported as an error. This changes those log messages to `info` level. (Only `warning` or higher logs by default if not explicitly configured).

Fixes #2081