### PR TITLE
Multiple Webview Tabs

### DIFF
--- a/vscode/src/circuit.ts
+++ b/vscode/src/circuit.ts
@@ -332,6 +332,7 @@ export function updateCircuitPanel(
     calculating?: boolean;
   },
 ) {
+  const panelId = params?.operation?.operation || projectName;
   const title = params?.operation
     ? `${params.operation.operation} with ${params.operation.totalNumQubits} input qubits`
     : projectName;
@@ -352,7 +353,7 @@ export function updateCircuitPanel(
     command: "circuit",
     props,
   };
-  sendMessageToPanel("circuit", reveal, message);
+  sendMessageToPanel({ panelType: "circuit", id: panelId }, reveal, message);
 }
 
 /**

--- a/vscode/src/circuit.ts
+++ b/vscode/src/circuit.ts
@@ -350,7 +350,6 @@ export function updateCircuitPanel(
   };
 
   const message = {
-    command: "circuit",
     props,
   };
   sendMessageToPanel({ panelType: "circuit", id: panelId }, reveal, message);

--- a/vscode/src/debugger/session.ts
+++ b/vscode/src/debugger/session.ts
@@ -953,7 +953,10 @@ export class QscDebugSession extends LoggingDebugSession {
 
   /* Updates the circuit panel if `showCircuit` is true or if panel is already open */
   private async updateCircuit(error?: any) {
-    if (this.config.showCircuit || isPanelOpen("circuit")) {
+    if (
+      this.config.showCircuit ||
+      isPanelOpen("circuit", this.program.projectName)
+    ) {
       // Error returned from the debugger has a message and a stack (which also includes the message).
       // We would ideally retrieve the original runtime error, and format it to be consistent
       // with the other runtime errors that can be shown in the circuit panel, but that will require

--- a/vscode/src/documentation.ts
+++ b/vscode/src/documentation.ts
@@ -14,7 +14,7 @@ export async function showDocumentationCommand(extensionUri: Uri) {
 
   // Reveal panel and show 'Loading...' for immediate feedback.
   sendMessageToPanel(
-    { panelType: "documentation", id: "" }, // This is needed to route the message to the proper panel
+    { panelType: "documentation" }, // This is needed to route the message to the proper panel
     true, // Reveal panel
     null, // With no message
   );
@@ -48,7 +48,7 @@ export async function showDocumentationCommand(extensionUri: Uri) {
   };
 
   sendMessageToPanel(
-    { panelType: "documentation", id: "" }, // This is needed to route the message to the proper panel
+    { panelType: "documentation" }, // This is needed to route the message to the proper panel
     true, // Reveal panel
     message, // And ask it to display documentation
   );

--- a/vscode/src/documentation.ts
+++ b/vscode/src/documentation.ts
@@ -14,7 +14,7 @@ export async function showDocumentationCommand(extensionUri: Uri) {
 
   // Reveal panel and show 'Loading...' for immediate feedback.
   sendMessageToPanel(
-    "documentation", // This is needed to route the message to the proper panel
+    { panelType: "documentation", id: "" }, // This is needed to route the message to the proper panel
     true, // Reveal panel
     null, // With no message
   );
@@ -48,7 +48,7 @@ export async function showDocumentationCommand(extensionUri: Uri) {
   };
 
   sendMessageToPanel(
-    "documentation", // This is needed to route the message to the proper panel
+    { panelType: "documentation", id: "" }, // This is needed to route the message to the proper panel
     true, // Reveal panel
     message, // And ask it to display documentation
   );

--- a/vscode/src/webview/webview.tsx
+++ b/vscode/src/webview/webview.tsx
@@ -40,7 +40,6 @@ type HistogramState = {
 
 type EstimatesState = {
   viewType: "estimates";
-  panelId: string;
   estimatesData: {
     calculating: boolean;
     estimates: ReData[];
@@ -55,20 +54,19 @@ type CircuitState = {
 
 type DocumentationState = {
   viewType: "documentation";
-  panelId: string;
   fragmentsToRender: IDocFile[];
   projectName: string;
 };
 
 type State =
   | { viewType: "loading"; panelId: string }
-  | { viewType: "help"; panelId: string }
+  | { viewType: "help" }
   | HistogramState
   | EstimatesState
   | CircuitState
   | DocumentationState;
 const loadingState: State = { viewType: "loading", panelId: "" };
-const helpState: State = { viewType: "help", panelId: "" };
+const helpState: State = { viewType: "help" };
 let state: State = loadingState;
 
 const themeAttribute = "data-vscode-theme-kind";
@@ -154,7 +152,6 @@ function onMessage(event: any) {
       {
         const newState: EstimatesState = {
           viewType: "estimates",
-          panelId: message.panelId,
           estimatesData: {
             calculating: !!message.calculating,
             estimates: [],
@@ -192,7 +189,6 @@ function onMessage(event: any) {
       {
         state = {
           viewType: "documentation",
-          panelId: message.panelId,
           fragmentsToRender: message.fragmentsToRender,
           projectName: message.projectName,
         };

--- a/vscode/src/webview/webview.tsx
+++ b/vscode/src/webview/webview.tsx
@@ -33,12 +33,14 @@ window.addEventListener("load", main);
 
 type HistogramState = {
   viewType: "histogram";
+  panelId: string;
   buckets: Array<[string, number]>;
   shotCount: number;
 };
 
 type EstimatesState = {
   viewType: "estimates";
+  panelId: string;
   estimatesData: {
     calculating: boolean;
     estimates: ReData[];
@@ -47,24 +49,26 @@ type EstimatesState = {
 
 type CircuitState = {
   viewType: "circuit";
+  panelId: string;
   props: CircuitProps;
 };
 
 type DocumentationState = {
   viewType: "documentation";
+  panelId: string;
   fragmentsToRender: IDocFile[];
   projectName: string;
 };
 
 type State =
-  | { viewType: "loading" }
-  | { viewType: "help" }
+  | { viewType: "loading"; panelId: string }
+  | { viewType: "help"; panelId: string }
   | HistogramState
   | EstimatesState
   | CircuitState
   | DocumentationState;
-const loadingState: State = { viewType: "loading" };
-const helpState: State = { viewType: "help" };
+const loadingState: State = { viewType: "loading", panelId: "" };
+const helpState: State = { viewType: "help", panelId: "" };
 let state: State = loadingState;
 
 const themeAttribute = "data-vscode-theme-kind";
@@ -140,6 +144,7 @@ function onMessage(event: any) {
       }
       state = {
         viewType: "histogram",
+        panelId: message.panelId,
         buckets: message.buckets as Array<[string, number]>,
         shotCount: message.shotCount,
       };
@@ -149,6 +154,7 @@ function onMessage(event: any) {
       {
         const newState: EstimatesState = {
           viewType: "estimates",
+          panelId: message.panelId,
           estimatesData: {
             calculating: !!message.calculating,
             estimates: [],
@@ -186,6 +192,7 @@ function onMessage(event: any) {
       {
         state = {
           viewType: "documentation",
+          panelId: message.panelId,
           fragmentsToRender: message.fragmentsToRender,
           projectName: message.projectName,
         };

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -597,7 +597,7 @@ export class QSharpViewViewPanelSerializer implements WebviewPanelSerializer {
     log.info("Deserializing webview panel", state);
 
     const panelType: PanelType = state?.viewType;
-    const id = state?.panelId; // ToDo: This doesn't work
+    const id = state?.panelId;
 
     if (
       panelType !== "estimates" &&

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -172,7 +172,6 @@ export function registerWebViewCommands(context: ExtensionContext) {
       log.info("RE params", params);
 
       sendMessageToPanel({ panelType: "estimates", id: runName }, true, {
-        command: "estimates",
         calculating: true,
       });
 
@@ -239,7 +238,6 @@ export function registerWebViewCommands(context: ExtensionContext) {
         clearTimeout(compilerTimeout);
 
         const message = {
-          command: "estimates",
           calculating: false,
           estimates,
         };
@@ -251,7 +249,6 @@ export function registerWebViewCommands(context: ExtensionContext) {
       } catch (e: any) {
         // Stop the 'calculating' animation
         const message = {
-          command: "estimates",
           calculating: false,
           estimates: [],
         };
@@ -281,9 +278,7 @@ export function registerWebViewCommands(context: ExtensionContext) {
 
   context.subscriptions.push(
     commands.registerCommand("qsharp-vscode.showHelp", async () => {
-      const message = {
-        command: "help",
-      };
+      const message = {};
       sendMessageToPanel({ panelType: "help", id: "" }, true, message);
     }),
   );
@@ -350,7 +345,6 @@ export function registerWebViewCommands(context: ExtensionContext) {
             buckets.set(strKey, newValue);
           }
           const message = {
-            command: "histogram",
             buckets: Array.from(buckets.entries()),
             shotCount: resultCount,
           };
@@ -560,6 +554,8 @@ export class QSharpWebViewPanel {
   }
 
   sendMessage(message: any) {
+    message.command = message.command || this.type;
+    message.panelId = message.panelId || this.id;
     if (this._ready) {
       log.debug("Sending message to webview", message);
       this.panel.webview.postMessage(message);

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -175,20 +175,6 @@ export function registerWebViewCommands(context: ExtensionContext) {
       sendMessageToPanel({ panelType: "estimates", id: runName }, true, {
         calculating: true,
       });
-
-      // ToDo: Check what effect this is supposed to have
-      // Ensure the name is unique
-      // if (panelTypeToPanel["estimates"].state[runName] !== undefined) {
-      //   let idx = 2;
-      //   for (;;) {
-      //     const newName = `${runName}-${idx}`;
-      //     if (panelTypeToPanel["estimates"].state[newName] === undefined) {
-      //       runName = newName;
-      //       break;
-      //     }
-      //     idx++;
-      //   }
-      // }
       getOrCreatePanel("estimates", runName).state[runName] = true;
 
       // Start the worker, run the code, and send the results to the webview

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -172,10 +172,25 @@ export function registerWebViewCommands(context: ExtensionContext) {
 
       log.info("RE params", params);
 
-      sendMessageToPanel({ panelType: "estimates", id: runName }, true, {
+      sendMessageToPanel({ panelType: "estimates", id: "" }, true, {
         calculating: true,
       });
-      getOrCreatePanel("estimates", runName).state[runName] = true;
+
+      let uniqueRunName = runName;
+      const estimatePanel = getOrCreatePanel("estimates", "");
+      // Ensure the name is unique
+      if (estimatePanel.state[uniqueRunName] !== undefined) {
+        let idx = 2;
+        for (;;) {
+          const newName = `${uniqueRunName}-${idx}`;
+          if (estimatePanel.state[newName] === undefined) {
+            uniqueRunName = newName;
+            break;
+          }
+          idx++;
+        }
+      }
+      estimatePanel.state[uniqueRunName] = true;
 
       // Start the worker, run the code, and send the results to the webview
       log.debug("Starting resource estimates worker.");
@@ -228,22 +243,14 @@ export function registerWebViewCommands(context: ExtensionContext) {
           calculating: false,
           estimates,
         };
-        sendMessageToPanel(
-          { panelType: "estimates", id: runName },
-          true,
-          message,
-        );
+        sendMessageToPanel({ panelType: "estimates", id: "" }, true, message);
       } catch (e: any) {
         // Stop the 'calculating' animation
         const message = {
           calculating: false,
           estimates: [],
         };
-        sendMessageToPanel(
-          { panelType: "estimates", id: runName },
-          false,
-          message,
-        );
+        sendMessageToPanel({ panelType: "estimates", id: "" }, false, message);
 
         if (timedOut) {
           // Show a VS Code popup that a timeout occurred

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -156,7 +156,7 @@ export function registerWebViewCommands(context: ExtensionContext) {
         return;
       }
 
-      const runName = await window.showInputBox({
+      let runName = await window.showInputBox({
         title: "Friendly name for run",
         value: `${program.programConfig.projectName}`,
       });
@@ -176,21 +176,20 @@ export function registerWebViewCommands(context: ExtensionContext) {
         calculating: true,
       });
 
-      let uniqueRunName = runName;
       const estimatePanel = getOrCreatePanel("estimates", "");
       // Ensure the name is unique
-      if (estimatePanel.state[uniqueRunName] !== undefined) {
+      if (estimatePanel.state[runName] !== undefined) {
         let idx = 2;
         for (;;) {
-          const newName = `${uniqueRunName}-${idx}`;
+          const newName = `${runName}-${idx}`;
           if (estimatePanel.state[newName] === undefined) {
-            uniqueRunName = newName;
+            runName = newName;
             break;
           }
           idx++;
         }
       }
-      estimatePanel.state[uniqueRunName] = true;
+      estimatePanel.state[runName] = true;
 
       // Start the worker, run the code, and send the results to the webview
       log.debug("Starting resource estimates worker.");
@@ -419,7 +418,7 @@ const panels: Record<PanelType, { [id: string]: PanelDesc }> = {
 
 const panelTypeToTitle: Record<PanelType, string> = {
   histogram: "Histogram",
-  estimates: "Estimates",
+  estimates: "Q# Estimates",
   circuit: "Circuit",
   help: "Q# Help",
   documentation: "Q# Documentation",
@@ -449,7 +448,9 @@ function createPanel(
         ? "Q# Help"
         : type == "documentation"
           ? "Q# Documentation"
-          : `${id} ${panelTypeToTitle[type]}`;
+          : type == "estimates"
+            ? "Q# Estimates"
+            : `${id} ${panelTypeToTitle[type]}`;
     const newPanel = window.createWebviewPanel(
       QSharpWebViewType,
       title,


### PR DESCRIPTION
Instead of always consuming the last Q# webview tab, open a new webview tab when activated with a new operation. Activation with the same operation will still consume/update the last webview for that operation. Works on circuit and histogram panels.