### PR TITLE
Added comments to sample tests

### DIFF
--- a/samples_test/src/tests.rs
+++ b/samples_test/src/tests.rs
@@ -20,6 +20,10 @@ use qsc::{
 };
 use qsc_project::{FileSystem, StdFs};
 
+// Two tests are needed to check interpreter working in debug and non-debug mode.
+// This results in two exepected stings defined. Although two strings are typically the same,
+// there may be a difference. Also, having two separate strings helps with
+// automatic updates of expected value by Rust analyzer.
 fn compile_and_run(sources: SourceMap) -> String {
     compile_and_run_internal(sources, false)
 }

--- a/samples_test/src/tests.rs
+++ b/samples_test/src/tests.rs
@@ -21,7 +21,7 @@ use qsc::{
 use qsc_project::{FileSystem, StdFs};
 
 // Two tests are needed to check interpreter working in debug and non-debug mode.
-// This results in two exepected stings defined. Although two strings are typically the same,
+// This results in two expected strings defined. Although two strings are typically the same,
 // there may be a difference. Also, having two separate strings helps with
 // automatic updates of expected value by Rust analyzer.
 fn compile_and_run(sources: SourceMap) -> String {

--- a/samples_test/src/tests/algorithms.rs
+++ b/samples_test/src/tests/algorithms.rs
@@ -3,9 +3,9 @@
 
 use expect_test::{expect, Expect};
 
-/// Each file in the samples/algorithms folder is compiled and run as two tests and should
-/// have matching expect strings in this file. If new samples are added, this file will
-/// fail to compile until the new expect strings are added.
+// Each file in the samples/algorithms folder is compiled and run as two tests and should
+// have matching expect strings in this file. If new samples are added, this file will
+// fail to compile until the new expect strings are added.
 pub const BELLSTATE_EXPECT: Expect = expect![[r#"
     Bell state |Φ+〉:
     STATE:

--- a/samples_test/src/tests/language.rs
+++ b/samples_test/src/tests/language.rs
@@ -3,9 +3,9 @@
 
 use expect_test::{expect, Expect};
 
-/// Each file in the samples/language folder is compiled and run as two tests and should
-/// have matching expect strings in this file. If new samples are added, this file will
-/// fail to compile until the new expect strings are added.
+// Each file in the samples/language folder is compiled and run as two tests and should
+// have matching expect strings in this file. If new samples are added, this file will
+// fail to compile until the new expect strings are added.
 pub const ARITHMETICOPERATORS_EXPECT: Expect = expect!["()"];
 pub const ARITHMETICOPERATORS_EXPECT_DEBUG: Expect = expect!["()"];
 pub const ARRAY_EXPECT: Expect = expect![[r#"


### PR DESCRIPTION
1. Added clarification comment why we need two expected strings in sample testing.
2. Made general comment a normal comment rather than doc comment - otherwise it was bound to the first constant in the file.