### PR TITLE
Fix RCA panic when compiling lambda

### DIFF
--- a/compiler/qsc_rca/src/tests.rs
+++ b/compiler/qsc_rca/src/tests.rs
@@ -10,6 +10,7 @@ mod calls;
 mod cycles;
 mod ifs;
 mod intrinsics;
+mod lambdas;
 mod loops;
 mod measurements;
 mod overrides;

--- a/compiler/qsc_rca/src/tests/lambdas.rs
+++ b/compiler/qsc_rca/src/tests/lambdas.rs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::{check_last_statement_compute_properties, CompilationContext};
+use expect_test::expect;
+
+#[test]
+fn check_rca_for_classical_lambda_one_parameter() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let myOp = a -> {};
+        myOp(1)"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_classical_lambda_two_parameters() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let myOp = (a, b) -> {};
+        myOp(1, 2)"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_classical_lambda_one_parameter_one_capture() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let x = 0.0;
+        let myOp = a -> {x};
+        myOp(1)"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_classical_lambda_one_parameter_two_captures() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let x = 0.0;
+        let y = 0.0;
+        let myOp = a -> {x+y};
+        myOp(1)"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_classical_lambda_two_parameters_one_capture() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let x = 0.0;
+        let myOp = (a, b) -> {x};
+        myOp(1, 2)"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_classical_lambda_two_parameters_two_captures() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let x = 0.0;
+        let y = 0.0;
+        let myOp = (a, b) -> {x+y};
+        myOp(1, 2)"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_dynamic_lambda_two_classical_parameters_one_dynamic_capture() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let x = {
+            use q = Qubit();
+            if MResetZ(q) == One {
+                1.0
+            } else {
+                0.0
+            }
+        };
+        let myOp = (a, b) -> {x};
+        myOp(1, 2)"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
+                    value_kind: Element(Dynamic)
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_dynamic_lambda_two_dynamic_parameters_one_classical_capture() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let x = 0.0;
+        let myOp = (a, b) -> {a + x};
+        let a = {
+            use q = Qubit();
+            if MResetZ(q) == One {
+                1.0
+            } else {
+                0.0
+            }
+        };
+        myOp(a, 2)"#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Quantum: QuantumProperties:
+                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                    value_kind: Element(Dynamic)
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+


### PR DESCRIPTION
Compiling a lambda that has more than one parameter can trigger a panic in RCA due to processing the fixed arguments for captures. This adds new tests for the lambda cases and confirms the dynamic runtime features for paramters and captures are detected as expected.