### PR TITLE
Remove scipy

### DIFF
--- a/samples/estimation/df-chemistry/chemistry.py
+++ b/samples/estimation/df-chemistry/chemistry.py
@@ -3,11 +3,11 @@
 import json
 import math
 import numpy as np
+import numpy.linalg as LA
 import numpy.typing as npt
 import qsharp
 from argparse import ArgumentParser
 from dataclasses import dataclass
-from scipy import linalg as LA
 from urllib.parse import urlparse
 from urllib.request import urlretrieve
 
@@ -294,7 +294,7 @@ class DoubleFactorization:
         matrix[np.tril_indices(dimension, 0)] = vector
 
         # Compute the eigen decomposition of the lower triangular matrix
-        evals, evecs = LA.eigh(matrix, lower=True)
+        evals, evecs = LA.eigh(matrix, UPLO="L")
         norm1 = np.linalg.norm(evals, 1)
         norm2 = np.linalg.norm(evals)
 

--- a/samples/estimation/df-chemistry/chemistry.py
+++ b/samples/estimation/df-chemistry/chemistry.py
@@ -295,8 +295,8 @@ class DoubleFactorization:
 
         # Compute the eigen decomposition of the lower triangular matrix
         evals, evecs = LA.eigh(matrix, UPLO="L")
-        norm1 = np.linalg.norm(evals, 1)
-        norm2 = np.linalg.norm(evals)
+        norm1 = LA.norm(evals, 1)
+        norm2 = LA.norm(evals)
 
         (rows, cols) = np.shape(evecs)
         evecs_1D = np.reshape(np.transpose(evecs), cols * rows)


### PR DESCRIPTION
Scipy does not work on Windows ARM64 currently (see https://github.com/scipy/scipy/issues/21562) which is a platform we support.

This is the only sample that uses scipy, so removing that usage for the equivalent numpy usage.

CC @msoeken and @aarthims 