### PR TITLE
fix deprecation warning for `initSync()`

### DIFF
--- a/npm/qsharp/src/workers/browser.ts
+++ b/npm/qsharp/src/workers/browser.ts
@@ -41,7 +41,7 @@ export function createWorker<
     switch (data.type) {
       case "init":
         {
-          wasm.initSync(data.wasmModule);
+          wasm.initSync({ module: data.wasmModule });
 
           invokeService = initService<TService, TServiceEventMsg>(
             self.postMessage.bind(self),


### PR DESCRIPTION
This warning comes from [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen/blob/c35cc9369d5e0dc418986f7811a0dd702fb33ef9/crates/cli-support/src/js/mod.rs#L981) and shows up in the JS console every time we load the playground / VS Code . 

Just updating the code to use the signature they want us to use.