### PR TITLE
Increase integration test timeout to 30m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
 
   integration-tests:
     name: Integration tests
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-14]


### PR DESCRIPTION
Current runtime is ~13min under normal circumstances. Extending timeout to 30min which should be generous enough.

(At the time that this current 15min timeout was added, integration tests took 5 minutes to run).