### PR TITLE
LookAheadDKRSAddLE now accepts carry-in

### DIFF
--- a/library/src/tests/resources/src/add_le.qs
+++ b/library/src/tests/resources/src/add_le.qs
@@ -15,33 +15,36 @@ namespace Test {
         use y = Qubit[yLen];
         use z = Qubit[zLen];
 
-        for xValue in 0..(1 <<< xLen) - 1 {
-            for yValue in 0..(1 <<< yLen) - 1 {
-                ApplyXorInPlace(xValue, x);
-                ApplyXorInPlace(yValue, y);
-                adder(x, y, z);
+        for carryIn in 0..1 {
+            for xValue in 0..(1 <<< xLen) - 1 {
+                for yValue in 0..(1 <<< yLen) - 1 {
+                    ApplyXorInPlace(xValue, x);
+                    ApplyXorInPlace(yValue, y);
+                    ApplyXorInPlace(carryIn, z);
+                    adder(x, y, z);
 
-                let xActual = MeasureInteger(x);
-                let yActual = MeasureInteger(y);
-                let zActual = MeasureInteger(z);
-                let zExpected = (xValue + yValue) % (1 <<< zLen);
+                    let xActual = MeasureInteger(x);
+                    let yActual = MeasureInteger(y);
+                    let zActual = MeasureInteger(z);
+                    let zExpected = (xValue + yValue + carryIn) % (1 <<< zLen);
 
-                Fact(
-                    xActual == xValue,
-                    $"{name}: Incorrect x={xActual}, expected={xValue}. |x|={xLen}, |y|={yLen}, |z|={zLen}, x={xValue}, y={yValue}."
-                );
-                Fact(
-                    yActual == yValue,
-                    $"{name}: Incorrect y={yActual}, expected={yValue}. |x|={xLen}, |y|={yLen}, |z|={zLen}, x={xValue}, y={yValue}."
-                );
-                Fact(
-                    zActual == zExpected,
-                    $"{name}: Incorrect z={zActual}, expected={zExpected}. |x|={xLen}, |y|={yLen}, |z|={zLen}, x={xValue}, y={yValue}."
-                );
+                    Fact(
+                        xActual == xValue,
+                        $"{name}: Incorrect x={xActual}, expected={xValue}. |x|={xLen}, |y|={yLen}, |z|={zLen}, x={xValue}, y={yValue}, z={carryIn}."
+                    );
+                    Fact(
+                        yActual == yValue,
+                        $"{name}: Incorrect y={yActual}, expected={yValue}. |x|={xLen}, |y|={yLen}, |z|={zLen}, x={xValue}, y={yValue}, z={carryIn}."
+                    );
+                    Fact(
+                        zActual == zExpected,
+                        $"{name}: Incorrect z={zActual}, expected={zExpected}. |x|={xLen}, |y|={yLen}, |z|={zLen}, x={xValue}, y={yValue}, z={carryIn}."
+                    );
 
-                ResetAll(x);
-                ResetAll(y);
-                ResetAll(z);
+                    ResetAll(x);
+                    ResetAll(y);
+                    ResetAll(z);
+                }
             }
         }
     }

--- a/library/std/src/Std/Arithmetic.qs
+++ b/library/std/src/Std/Arithmetic.qs
@@ -316,9 +316,7 @@ operation LookAheadDKRSAddLE(xs : Qubit[], ys : Qubit[], zs : Qubit[]) : Unit is
                 CNOT(xs[i], ys[i]);
             }
         } apply {
-            if xsLen > 1 {
-                ComputeCarries(ys, zs[0..xsLen]);
-            }
+            ComputeCarries(ys, zs[0..xsLen]);
 
             // compute sum into carries
             for k in 0..xsLen - 1 {

--- a/library/std/src/Std/Arithmetic.qs
+++ b/library/std/src/Std/Arithmetic.qs
@@ -317,7 +317,7 @@ operation LookAheadDKRSAddLE(xs : Qubit[], ys : Qubit[], zs : Qubit[]) : Unit is
             }
         } apply {
             if xsLen > 1 {
-                ComputeCarries(Rest(ys), zs[1..xsLen]);
+                ComputeCarries(ys, zs[0..xsLen]);
             }
 
             // compute sum into carries

--- a/library/std/src/Std/ArithmeticUtils.qs
+++ b/library/std/src/Std/ArithmeticUtils.qs
@@ -310,7 +310,7 @@ operation ApplyAndAssuming0Target(control1 : Qubit, control2 : Qubit, target : Q
 /// Computes carries for the look-ahead adder
 operation ComputeCarries(ps : Qubit[], gs : Qubit[]) : Unit is Adj {
     let n = Length(gs);
-    Fact(Length(ps) + 1 == n, "Register gs must be one qubit longer than register gs.");
+    Fact(Length(ps) + 1 == n, "Register gs must be one qubit longer than register ps.");
 
     let T = Floor(Lg(IntAsDouble(n)));
     use qs = Qubit[n - HammingWeightI(n) - T];
@@ -318,6 +318,8 @@ operation ComputeCarries(ps : Qubit[], gs : Qubit[]) : Unit is Adj {
     let registerPartition = MappedOverRange(t -> Floor(IntAsDouble(n) / IntAsDouble(2^t)) - 1, 1..T - 1);
     let pWorkspace = [ps] + Partitioned(registerPartition, qs);
 
+    // Note that we cannot use gs[0] as a target for ApplyAndAssuming0Target
+    // as it may not be in the 0 state. We use regular CCNOT in GRounds and CRounds.
     within {
         PRounds(pWorkspace);
     } apply {

--- a/library/std/src/Std/ArithmeticUtils.qs
+++ b/library/std/src/Std/ArithmeticUtils.qs
@@ -318,7 +318,7 @@ operation ComputeCarries(ps : Qubit[], gs : Qubit[]) : Unit is Adj {
     let registerPartition = MappedOverRange(t -> Floor(IntAsDouble(n) / IntAsDouble(2^t)) - 1, 1..T - 1);
     let pWorkspace = [ps] + Partitioned(registerPartition, qs);
 
-    // Note that we cannot use gs[0] as a target for ApplyAndAssuming0Target
+    // Note that we cannot use ApplyAndAssuming0Target targeting gs[0]
     // as it may not be in the 0 state. We use regular CCNOT in GRounds and CRounds.
     within {
         PRounds(pWorkspace);


### PR DESCRIPTION
Updated LookAheadDKRSAddLE to accept carry-in.
Updated tests.
Resolves https://github.com/microsoft/qsharp/issues/2101
