### PR TITLE
Work around reexport issue in libraries

### DIFF
--- a/library/fixed_point/src/Main.qs
+++ b/library/fixed_point/src/Main.qs
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export Init.PrepareFxP, Measurement.MeasureFxP, Reciprocal.ComputeReciprocalFxP, Types.FixedPoint;
+export Init.PrepareFxP as PrepareFxP, Measurement.MeasureFxP as MeasureFxP, Reciprocal.ComputeReciprocalFxP as ComputeReciprocalFxP, Types.FixedPoint as FixedPoint;

--- a/library/rotations/src/Main.qs
+++ b/library/rotations/src/Main.qs
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export HammingWeightPhasing.HammingWeightPhasing;
+export HammingWeightPhasing.HammingWeightPhasing as HammingWeightPhasing;


### PR DESCRIPTION
Works around #1955 in the libraries we publish by reexporting the items under an alias. This change should make no difference to the intended public API of the library.