### PR TITLE
DocGen Tool: Don't escape pipe character in metadata

### DIFF
--- a/compiler/qsc_doc_gen/src/generate_docs.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs.rs
@@ -522,7 +522,7 @@ fn generate_index_file(files: &mut FilesWithMetadata, ns: &Rc<str>, items: &mut 
                 "| [{}](xref:Qdk.{}) | {} |",
                 item.name,
                 item.fully_qualified_name(),
-                item.summary
+                item.summary.replace('|', "\\|")
             )
         })
         .collect::<Vec<_>>()
@@ -698,8 +698,7 @@ fn get_metadata(
 
     let summary = parse_doc_for_summary(&item.doc)
         .replace("\r\n", " ")
-        .replace('\n', " ")
-        .replace('|', "\\|");
+        .replace('\n', " ");
 
     Some(Metadata {
         uid: format!("Qdk.{ns}.{name}"),

--- a/compiler/qsc_doc_gen/src/generate_docs/tests.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs/tests.rs
@@ -66,14 +66,14 @@ fn generates_unrestricted_item() {
         ---
         uid: Qdk.Std.Diagnostics.CheckZero
         title: CheckZero operation
-        description: "Q# CheckZero operation: Checks whether a qubit is in the \|0⟩ state, returning true if it is."
+        description: "Q# CheckZero operation: Checks whether a qubit is in the |0⟩ state, returning true if it is."
         ms.date: {TIMESTAMP}
         ms.topic: managed-reference
         qsharp.kind: operation
         qsharp.package: __Std__
         qsharp.namespace: Std.Diagnostics
         qsharp.name: CheckZero
-        qsharp.summary: "Checks whether a qubit is in the \|0⟩ state, returning true if it is."
+        qsharp.summary: "Checks whether a qubit is in the |0⟩ state, returning true if it is."
         ---
 
         # CheckZero operation

--- a/library/std/src/Std/Math.qs
+++ b/library/std/src/Std/Math.qs
@@ -11,7 +11,7 @@ import Std.Diagnostics.*;
 
 /// # Summary
 /// Returns a double-precision approximation of the
-/// matematical constant 𝝅 ≈ 3.14159265358979323846
+/// mathematical constant 𝝅 ≈ 3.14159265358979323846
 ///
 /// # Remarks
 /// Mathematical constant 𝝅 represents the ratio of the circumference

--- a/library/std/src/Std/Measurement.qs
+++ b/library/std/src/Std/Measurement.qs
@@ -34,7 +34,7 @@ operation MeasureAllZ(register : Qubit[]) : Result {
 ///
 /// # Description
 /// Measures each qubit in a register in the `Z` basis
-/// and retuns the result of each measurement.
+/// and returns the result of each measurement.
 /// This operation does not reset the measured qubits to the |0⟩ state,
 /// leaving them in the state that corresponds to the measurement results.
 ///
@@ -46,9 +46,9 @@ operation MeasureAllZ(register : Qubit[]) : Result {
 ///
 /// # Remarks
 /// Please note the following differences:
-/// - Operation `MeasureEachZ` performs one measurement for each qubit and retuns
+/// - Operation `MeasureEachZ` performs one measurement for each qubit and returns
 ///   an array of results. The operation does not reset the qubits.
-/// - Operation `MResetEachZ` performs one measurement for each qubit and retuns
+/// - Operation `MResetEachZ` performs one measurement for each qubit and returns
 ///   an array of results. The operation resets all qubits to |0⟩ state.
 /// - Operation `MeasureAllZ` performs a joint measurement on all qubits
 ///   and returns one result. The operation does not reset the qubits.


### PR DESCRIPTION
We no longer want to escape the pipe character in the metadata fields, but still want to escape it when composing the index.md files.