### PR TITLE
Long gate in ASCII art circuits - lengthen column width when necessary

### DIFF
--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -148,8 +148,6 @@ fn rotation_gate() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    // The wire isn't visible here since the gate label is longer
-    // than the static column width, but we can live with it.
     expect![[r"
         q_0    ─ rx(1.5708) ──
     "]]
@@ -494,8 +492,7 @@ fn custom_intrinsic_mixed_args() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    // This is one gate that spans ten target wires, even though the
-    // text visualization doesn't convey that clearly.
+    // This is one gate that spans ten target wires.
     expect![[r"
         q_0    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
         q_1    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──

--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -454,8 +454,6 @@ fn custom_intrinsic_one_classical_arg() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    // A custom intrinsic that doesn't take qubits just doesn't
-    // show up on the circuit.
     expect![[r"
         q_0    ── X ─── foo(4) ──
     "]]
@@ -492,7 +490,8 @@ fn custom_intrinsic_mixed_args() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    // This is one gate that spans ten target wires.
+    // This is one gate that spans ten target wires, even though the
+    // text visualization doesn't convey that clearly.
     expect![[r"
         q_0    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
         q_1    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──

--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -151,7 +151,7 @@ fn rotation_gate() {
     // The wire isn't visible here since the gate label is longer
     // than the static column width, but we can live with it.
     expect![[r"
-        q_0     rx(1.5708)
+        q_0    ─ rx(1.5708) ──
     "]]
     .assert_eq(&circ.to_string());
 }
@@ -262,8 +262,8 @@ fn mresetz_unrestricted_profile() {
         .expect("circuit generation should succeed");
 
     expect![[r"
-        q_0    ── H ──── M ─── |0〉 ─
-                         ╘══════════
+        q_0    ── H ──── M ──── |0〉 ──
+                         ╘════════════
     "]]
     .assert_eq(&circ.to_string());
 }
@@ -349,10 +349,10 @@ fn unrestricted_profile_result_comparison() {
         .expect("circuit generation should succeed");
 
     expect![[r"
-        q_0    ── H ──── M ──── X ─── |0〉 ─
-                         ╘═════════════════
-        q_1    ── H ──── M ─── |0〉 ────────
-                         ╘═════════════════
+        q_0    ── H ──── M ───── X ───── |0〉 ──
+                         ╘═════════════════════
+        q_1    ── H ──── M ──── |0〉 ───────────
+                         ╘═════════════════════
     "]]
     .assert_eq(&circ.to_string());
 
@@ -366,10 +366,10 @@ fn unrestricted_profile_result_comparison() {
 
     let circuit = interpreter.get_circuit();
     expect![[r"
-        q_0    ── H ──── M ──── X ─── |0〉 ─
-                         ╘═════════════════
-        q_1    ── H ──── M ─── |0〉 ────────
-                         ╘═════════════════
+        q_0    ── H ──── M ───── X ───── |0〉 ──
+                         ╘═════════════════════
+        q_1    ── H ──── M ──── |0〉 ───────────
+                         ╘═════════════════════
     "]]
     .assert_eq(&circuit.to_string());
 }
@@ -459,7 +459,7 @@ fn custom_intrinsic_one_classical_arg() {
     // A custom intrinsic that doesn't take qubits just doesn't
     // show up on the circuit.
     expect![[r"
-        q_0    ── X ── foo(4)
+        q_0    ── X ─── foo(4) ──
     "]]
     .assert_eq(&circ.to_string());
 }
@@ -497,16 +497,16 @@ fn custom_intrinsic_mixed_args() {
     // This is one gate that spans ten target wires, even though the
     // text visualization doesn't convey that clearly.
     expect![[r"
-        q_0     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_1     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_2     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_3     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_4     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_5     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_6     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_7     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_8     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_9     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
+        q_0    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_1    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_2    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_3    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_4    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_5    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_6    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_7    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_8    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_9    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
     "]]
     .assert_eq(&circ.to_string());
 
@@ -535,9 +535,9 @@ fn custom_intrinsic_apply_idle_noise() {
 
     // ConfigurePauliNoise has no qubit arguments so it shouldn't show up.
     // ApplyIdleNoise is a quantum operation so it shows up.
-    expect![[r#"
-        q_0     ApplyIdleNoise
-    "#]]
+    expect![[r"
+        q_0    ─ ApplyIdleNoise ──
+    "]]
     .assert_eq(&circ.to_string());
 }
 
@@ -1005,24 +1005,24 @@ mod debugger_stepping {
         // Note the circuit still looks different than what would be
         // generated in Unrestricted Profile for the same code,
         // due to conditional compilation in the standard library.
-        expect![["
+        expect![[r"
             step:
             step:
             q_0
             step:
             q_0    ── H ──
             step:
-            q_0    ── H ──── Z ───────────────────────
-            q_1    ── H ──── ● ──── H ──── M ─── |0〉 ─
-                                           ╘══════════
+            q_0    ── H ──── Z ─────────────────────────
+            q_1    ── H ──── ● ──── H ──── M ──── |0〉 ──
+                                           ╘════════════
             step:
-            q_0    ── H ──── Z ─── |0〉 ───────────────
-            q_1    ── H ──── ● ──── H ──── M ─── |0〉 ─
-                                           ╘══════════
+            q_0    ── H ──── Z ──── |0〉 ──────────────────
+            q_1    ── H ──── ● ───── H ───── M ──── |0〉 ──
+                                             ╘════════════
             step:
-            q_0    ── H ──── Z ─── |0〉 ───────────────
-            q_1    ── H ──── ● ──── H ──── M ─── |0〉 ─
-                                           ╘══════════
+            q_0    ── H ──── Z ──── |0〉 ──────────────────
+            q_1    ── H ──── ● ───── H ───── M ──── |0〉 ──
+                                             ╘════════════
         "]]
         .assert_eq(&circs);
     }
@@ -1056,11 +1056,11 @@ mod debugger_stepping {
             q_0    ── H ──── M ──
                              ╘═══
             step:
-            q_0    ── H ──── M ─── |0〉 ─
-                             ╘══════════
+            q_0    ── H ──── M ──── |0〉 ──
+                             ╘════════════
             step:
-            q_0    ── H ──── M ─── |0〉 ─
-                             ╘══════════
+            q_0    ── H ──── M ──── |0〉 ──
+                             ╘════════════
         "]]
         .assert_eq(&circs);
     }

--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -535,9 +535,9 @@ fn custom_intrinsic_apply_idle_noise() {
 
     // ConfigurePauliNoise has no qubit arguments so it shouldn't show up.
     // ApplyIdleNoise is a quantum operation so it shows up.
-    expect![[r"
+    expect![[r#"
         q_0    ─ ApplyIdleNoise ──
-    "]]
+    "#]]
     .assert_eq(&circ.to_string());
 }
 
@@ -1005,7 +1005,7 @@ mod debugger_stepping {
         // Note the circuit still looks different than what would be
         // generated in Unrestricted Profile for the same code,
         // due to conditional compilation in the standard library.
-        expect![[r"
+        expect![["
             step:
             step:
             q_0

--- a/compiler/qsc_circuit/src/circuit.rs
+++ b/compiler/qsc_circuit/src/circuit.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use rustc_hash::FxHashMap;
 use serde::Serialize;
-use std::{cmp, fmt::Display, fmt::Write, ops::Not, vec};
+use std::{fmt::Display, fmt::Write, ops::Not, vec};
 
 /// Representation of a quantum circuit.
 /// Implementation of <https://github.com/microsoft/quantum-viz.js/wiki/API-schema-reference>
@@ -426,16 +426,12 @@ impl Display for Circuit {
                     rows.iter()
                         .filter_map(|row| row.objects.get(&column))
                         .filter_map(|object| match object {
-                            CircuitObject::Object(string) => {
-                                Some(cmp::max(
-                                    (string.len() + 4) | 1, // Column lengths need to be odd numbers
-                                    MIN_COLUMN_WIDTH,
-                                ))
-                            }
+                            CircuitObject::Object(string) => Some((string.len() + 4) | 1), // Column lengths need to be odd numbers
                             _ => None,
                         })
+                        .chain(std::iter::once(MIN_COLUMN_WIDTH))
                         .max()
-                        .unwrap_or(MIN_COLUMN_WIDTH),
+                        .unwrap(),
                 )
             })
             .collect::<ColumnWidthsByColumn>();

--- a/compiler/qsc_circuit/src/circuit.rs
+++ b/compiler/qsc_circuit/src/circuit.rs
@@ -118,7 +118,7 @@ impl Row {
             gate_label.push('\'');
         }
         if let Some(args) = args {
-            let _ = write!(&mut gate_label, "({args})"); // TODO
+            let _ = write!(&mut gate_label, "({args})");
         }
 
         self.add_object(column, gate_label.as_str());
@@ -297,7 +297,7 @@ fn fmt_classical_circuit_object(circuit_object: &CircuitObject, column_width: us
 fn fmt_qubit_circuit_object(circuit_object: &CircuitObject, column_width: usize) -> String {
     match circuit_object {
         CircuitObject::WireCross => get_qubit_wire_cross(column_width),
-        CircuitObject::WireStart => get_classical_wire_start(column_width), // TODO!
+        CircuitObject::WireStart => get_blank(column_width), // This would never happen
         CircuitObject::DashedCross => get_qubit_wire_dashed_cross(column_width),
         CircuitObject::Vertical => get_vertical(column_width),
         CircuitObject::VerticalDashed => get_vertical_dashed(column_width),
@@ -417,9 +417,8 @@ impl Display for Circuit {
             .max_by_key(|r| r.next_column)
             .map_or(1, |r| r.next_column);
 
-        // To be able to fit long-named operations, we pre-calculate the required width for each column.
-        // Currently, it's only gates that have long enough names for us to worry about.
-        // let column_widths = ColumnWidthsByColumn::default();
+        // To be able to fit long-named operations, we calculate the required width for each column,
+        // based on the maximum length needed for gates, where a gate X is printed as "- X -".
         let column_widths = (0..end_column)
             .map(|column| {
                 (
@@ -429,7 +428,7 @@ impl Display for Circuit {
                         .filter_map(|object| match object {
                             CircuitObject::Object(string) => {
                                 Some(cmp::max((string.len() + 4) | 1, MIN_COLUMN_WIDTH))
-                            } // Make odd!
+                            }
                             _ => None,
                         })
                         .max()

--- a/compiler/qsc_circuit/src/circuit.rs
+++ b/compiler/qsc_circuit/src/circuit.rs
@@ -297,7 +297,7 @@ fn fmt_classical_circuit_object(circuit_object: &CircuitObject, column_width: us
 fn fmt_qubit_circuit_object(circuit_object: &CircuitObject, column_width: usize) -> String {
     match circuit_object {
         CircuitObject::WireCross => get_qubit_wire_cross(column_width),
-        CircuitObject::WireStart => get_blank(column_width), // This would never happen
+        CircuitObject::WireStart => get_blank(column_width), // This should never happen
         CircuitObject::DashedCross => get_qubit_wire_dashed_cross(column_width),
         CircuitObject::Vertical => get_vertical(column_width),
         CircuitObject::VerticalDashed => get_vertical_dashed(column_width),
@@ -427,7 +427,10 @@ impl Display for Circuit {
                         .filter_map(|row| row.objects.get(&column))
                         .filter_map(|object| match object {
                             CircuitObject::Object(string) => {
-                                Some(cmp::max((string.len() + 4) | 1, MIN_COLUMN_WIDTH))
+                                Some(cmp::max(
+                                    (string.len() + 4) | 1, // Column lengths need to be odd numbers
+                                    MIN_COLUMN_WIDTH,
+                                ))
                             }
                             _ => None,
                         })

--- a/compiler/qsc_circuit/src/circuit/tests.rs
+++ b/compiler/qsc_circuit/src/circuit/tests.rs
@@ -224,7 +224,7 @@ fn with_args() {
     // This looks wonky because the gate label is longer
     // than the static column width, but we can live with it.
     expect![[r"
-        q_0     rx(1.5708)
+        q_0    ─ rx(1.5708) ──
     "]]
     .assert_eq(&c.to_string());
 }
@@ -261,9 +261,9 @@ fn two_targets() {
     // This looks wonky because the gate label is longer
     // than the static column width, but we can live with it.
     expect![[r"
-        q_0     rzz(1.0000)
-        q_1    ───┆───
-        q_2     rzz(1.0000)
+        q_0    ─ rzz(1.0000) ─
+        q_1    ───────┆───────
+        q_2    ─ rzz(1.0000) ─
     "]]
     .assert_eq(&c.to_string());
 }

--- a/compiler/qsc_circuit/src/circuit/tests.rs
+++ b/compiler/qsc_circuit/src/circuit/tests.rs
@@ -221,8 +221,6 @@ fn with_args() {
         }],
     };
 
-    // This looks wonky because the gate label is longer
-    // than the static column width, but we can live with it.
     expect![[r"
         q_0    ─ rx(1.5708) ──
     "]]
@@ -258,8 +256,6 @@ fn two_targets() {
         ],
     };
 
-    // This looks wonky because the gate label is longer
-    // than the static column width, but we can live with it.
     expect![[r"
         q_0    ─ rzz(1.0000) ─
         q_1    ───────┆───────


### PR DESCRIPTION
See issue https://github.com/microsoft/qsharp/issues/1476.

I tried to keep the logic as close as possible to the original, because I wanted to keep it easy to review it in relation to the old logic.

The main change here is that instead of having the `ObjectsByColumn` of every Row be a `FxHashMap<usize, String>` which contains the 7-width-wide strings, it's now a `FxHashMap<usize, CircuitObject>`, where `CircuitObject` is an enum that supports every circuit object except for than blanks and wires (because those are inserted later on, on-the-go).

Using this enum allows us to calculate the required `ColumnWidthsByColumn` (a `FxHashMap<usize, usize>`) right before calling `row.fmt` - so we know what width the `CircuitObjects` need to be when converted into strings.

In the example from the ticket, this means that this circuit:
```
use q3 = Qubit();

H(q3);
Rx(1.0, q3);
H(q3);
Rx(1.0, q3);
H(q3);
Rx(1.0, q3);
```

Which used to give:
```
q_0    ── H ─────────── ● ──── M ────────────────
                        │      ╘═════════════════
q_1    ── H ──── X ──── X ───────────────────────
q_2     rx(1.0000)  rx(1.0000) ────────────────────────────
q_3    ── H ── rx(1.0000) ── H ── rx(1.0000) ── H ── rx(1.0000)
```

Now gives
```
q_0    ────── H ─────────────────────── ● ──────── M ────────────────────────────
                                        │          ╘═════════════════════════════
q_1    ────── H ──────────── X ──────── X ───────────────────────────────────────
q_2    ─ rx(1.0000) ─── rx(1.0000) ──────────────────────────────────────────────
q_3    ────── H ─────── rx(1.0000) ──── H ─── rx(1.0000) ──── H ─── rx(1.0000) ──
```


Apart from this desired change for long gates, the only notable difference is that, where ket-zero (`|0〉`) used to show as a width-5 circuit object (`─ |0〉 ─`, it now shows as a width-7 circuit object (`── |0〉 ──`) - you can see the difference in every test that used it.