### PR TITLE
Fixes possible infinite loop in RE

### DIFF
--- a/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
+++ b/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
@@ -107,7 +107,10 @@ impl<
                 ));
             }
 
-            num_cycles = max_allowed_num_cycles_for_code_parameter + 1;
+            num_cycles = std::cmp::max(
+                max_allowed_num_cycles_for_code_parameter + 1,
+                num_cycles + 1,
+            );
         }
     }
 


### PR DESCRIPTION
In the rare case that a factory runs longer than the algorithm, we adjust the number of cycles. The heuristic we use is to take the maximum number of cycles for the current code parameter + 1. However, for some code definitions this may end in an infite loop, which we break by ensuring that the number of cycles is always increasing.