### PR TITLE
Deduplicate lints to avoid having repeated lints in operations that have multiple specializations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
  "qsc_hir",
  "qsc_parse",
  "qsc_passes",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",

--- a/compiler/qsc_linter/Cargo.toml
+++ b/compiler/qsc_linter/Cargo.toml
@@ -15,6 +15,7 @@ qsc_hir = { path = "../qsc_hir" }
 qsc_data_structures = { path = "../qsc_data_structures" }
 qsc_frontend = { path = "../qsc_frontend" }
 qsc_doc_gen = { path = "../qsc_doc_gen" }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/compiler/qsc_linter/src/linter.rs
+++ b/compiler/qsc_linter/src/linter.rs
@@ -21,6 +21,20 @@ pub fn run_lints(
     compile_unit: &CompileUnit,
     config: Option<&[LintConfig]>,
 ) -> Vec<Lint> {
+    let mut lints = run_lints_without_deduplication(package_store, compile_unit, config);
+    remove_duplicates(&mut lints);
+    lints
+}
+
+/// This function is used by our unit tests, to make sure lints aren't duplicated under
+/// normal circunstances. The `run_lints` functions deduplicates the lints to take care
+/// of a few special cases where the same expression (referring to the same span in the
+/// source code) appears referenced in multiple places in the HIR.
+pub(crate) fn run_lints_without_deduplication(
+    package_store: &PackageStore,
+    compile_unit: &CompileUnit,
+    config: Option<&[LintConfig]>,
+) -> Vec<Lint> {
     let compilation = Compilation {
         package_store,
         compile_unit,
@@ -32,7 +46,6 @@ pub fn run_lints(
     let mut lints = Vec::new();
     lints.append(&mut ast_lints);
     lints.append(&mut hir_lints);
-    remove_duplicates(&mut lints);
     lints
 }
 

--- a/compiler/qsc_linter/src/linter/ast.rs
+++ b/compiler/qsc_linter/src/linter/ast.rs
@@ -185,7 +185,7 @@ macro_rules! declare_ast_lints {
         use serde::{Deserialize, Serialize};
 
         /// An enum listing all existing AST lints.
-        #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+        #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash)]
         #[serde(rename_all = "camelCase")]
         pub enum AstLint {
             $(

--- a/compiler/qsc_linter/src/linter/hir.rs
+++ b/compiler/qsc_linter/src/linter/hir.rs
@@ -149,7 +149,7 @@ macro_rules! declare_hir_lints {
         use serde::{Deserialize, Serialize};
 
         /// An enum listing all existing HIR lints.
-        #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+        #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash)]
         #[serde(rename_all = "camelCase")]
         pub enum HirLint {
             $(

--- a/compiler/qsc_linter/src/tests.rs
+++ b/compiler/qsc_linter/src/tests.rs
@@ -760,7 +760,6 @@ fn check_that_hir_lints_are_deduplicated_in_operations_with_multiple_specializat
 }
 
 fn compile_and_collect_lints(source: &str) -> Vec<Lint> {
-    let source = wrap_in_namespace(source);
     let mut store = PackageStore::new(compile::core());
     let std = store.insert(compile::std(&store, TargetCapabilityFlags::all()));
     let sources = SourceMap::new([("source.qs".into(), source.clone().into())], None);
@@ -780,19 +779,21 @@ fn compile_and_collect_lints(source: &str) -> Vec<Lint> {
 }
 
 fn check(source: &str, expected: &Expect) {
-    let actual: Vec<_> = compile_and_collect_lints(source)
+    let source = wrap_in_namespace(source);
+    let actual: Vec<_> = compile_and_collect_lints(&source)
         .into_iter()
-        .map(|lint| SrcLint::from(&lint, source))
+        .map(|lint| SrcLint::from(&lint, &source))
         .collect();
     expected.assert_debug_eq(&actual);
 }
 
 fn check_with_deduplication(source: &str, expected: &Expect) {
-    let mut lints = compile_and_collect_lints(source);
+    let source = wrap_in_namespace(source);
+    let mut lints = compile_and_collect_lints(&source);
     remove_duplicates(&mut lints);
     let actual: Vec<_> = lints
         .into_iter()
-        .map(|lint| SrcLint::from(&lint, source))
+        .map(|lint| SrcLint::from(&lint, &source))
         .collect();
     expected.assert_debug_eq(&actual);
 }

--- a/compiler/qsc_linter/src/tests.rs
+++ b/compiler/qsc_linter/src/tests.rs
@@ -762,7 +762,7 @@ fn check_that_hir_lints_are_deduplicated_in_operations_with_multiple_specializat
 fn compile_and_collect_lints(source: &str) -> Vec<Lint> {
     let mut store = PackageStore::new(compile::core());
     let std = store.insert(compile::std(&store, TargetCapabilityFlags::all()));
-    let sources = SourceMap::new([("source.qs".into(), source.clone().into())], None);
+    let sources = SourceMap::new([("source.qs".into(), source.into())], None);
     let (unit, _) = qsc::compile::compile(
         &store,
         &[(std, None)],


### PR DESCRIPTION
This PR deduplicates lints in the `run_lints` function, which is the entry point to the linter, to avoid having repeated lints in operations that have multiple specializations. 