### PR TITLE
fix `qsharp.init(project_root='.')`

### DIFF
--- a/pip/qsharp/_qsharp.py
+++ b/pip/qsharp/_qsharp.py
@@ -182,6 +182,8 @@ def init(
 
     manifest_contents = None
     if project_root is not None:
+        # Normalize the project path (i.e. fix file separators and remove unnecessary '.' and '..')
+        project_root = resolve(".", project_root)
         qsharp_json = join(project_root, "qsharp.json")
         if not exists(qsharp_json):
             raise QSharpError(


### PR DESCRIPTION
Fixing regression described in https://github.com/microsoft/qsharp/pull/2109#issuecomment-2629169244