### PR TITLE
add UDT to list of terms when processing reexport

### DIFF
--- a/compiler/qsc_frontend/src/compile/tests/multiple_packages.rs
+++ b/compiler/qsc_frontend/src/compile/tests/multiple_packages.rs
@@ -602,3 +602,44 @@ fn callable_reexport() {
         ),
     ]);
 }
+
+#[test]
+fn old_syntax_udt_reexported() {
+    multiple_package_multiple_source_check(
+        vec![
+            (
+                "A",
+                vec![
+                    (
+                        "FileOne",
+                        "
+                     struct Foo { content: Bool, otherContent: Bool }
+                     newtype Bar = ( content: Bool, otherContent: Bool );
+                     ",
+                    ),
+                    ("FileTwo", "export FileOne.Foo as Bar, FileOne.Bar as Baz;"),
+                ],
+            ),
+            (
+                "B",
+                vec![(
+                    "FileThree",
+                    "export A.FileTwo.Bar as Baz, A.FileTwo.Baz as Quux;",
+                )],
+            ),
+            (
+                "C",
+                vec![(
+                    "FileFour",
+                    "@EntryPoint()
+            operation Main() : Unit {
+            // use old UDT syntax with both a struct and a newtype
+                let x = B.FileThree.Baz(true, true);
+                let x = B.FileThree.Quux(true, true);
+            }",
+                )],
+            ),
+        ],
+        Some(&expect!["[]"]),
+    );
+}

--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -1680,6 +1680,10 @@ impl GlobalTable {
                                 global.name.clone(),
                                 Res::Item(item_id, ItemStatus::Available),
                             );
+                            self.scope.terms.get_mut_or_default(namespace).insert(
+                                global.name.clone(),
+                                Res::Item(item_id, ItemStatus::Available),
+                            );
                         }
                         hir::ItemKind::Export(_, _) => {
                             unreachable!("find_item will never return an Export")


### PR DESCRIPTION
Closes #2146


I also found another unrelated bug while working on this, which I filed here: #2153
