### PR TITLE
`Relabel` in adaptive conditional block should be disallowed

### DIFF
--- a/compiler/qsc_partial_eval/src/evaluation_context.rs
+++ b/compiler/qsc_partial_eval/src/evaluation_context.rs
@@ -76,6 +76,13 @@ impl EvaluationContext {
     pub fn push_scope(&mut self, s: Scope) {
         self.scopes.push(s);
     }
+
+    /// Determines whether we are currently in a dynamic branch context for any scope.
+    pub fn is_currently_evaluating_any_branch(&self) -> bool {
+        self.scopes
+            .iter()
+            .any(Scope::is_currently_evaluating_branch)
+    }
 }
 
 /// Struct that represents a block node when we intepret an RIR program as a graph.

--- a/compiler/qsc_partial_eval/src/tests/qubits.rs
+++ b/compiler/qsc_partial_eval/src/tests/qubits.rs
@@ -360,3 +360,23 @@ fn qubit_double_release_triggers_runtime_error() {
         ]],
     );
 }
+
+#[test]
+fn qubit_relabel_in_dynamic_block_triggers_capability_error() {
+    let error = get_partial_evaluation_error(indoc! {
+        r#"
+        operation Main() : Result {
+            use qs = Qubit[2];
+            if M(qs[0]) == One {
+                Relabel(qs, Std.Arrays.Reversed(qs));
+            }
+            MResetZ(qs[1])
+        }
+        "#,
+    });
+
+    assert_error(
+        &error,
+        &expect!["CapabilityError(UseOfDynamicQubit(Span { lo: 59760, hi: 59773 }))"],
+    );
+}


### PR DESCRIPTION
This adds a check at codegen time if a qubit relabel is occurring in an adaptive conditional. This will ensure we don't generate QIR with incorrect qubit IDs. The change ties the error to the dynamic qubit capability because if/when we support dynamic qubits we'll need to update relabel to become an intrinsic that is supported by backends to do a runtime relabel of qubit identifiers.

Fixes #2152