### PR TITLE
Update devcontainer to Ubuntu noble base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "qsharp",
-	"image": "mcr.microsoft.com/devcontainers/cpp",
+	"image": "mcr.microsoft.com/devcontainers/base:noble",
 	"features": {
 		"ghcr.io/devcontainers/features/python:1": {},
 		"ghcr.io/devcontainers/features/node:1": {


### PR DESCRIPTION
This updates the repo's devcontainer to use a base image with a newer Ubuntu version making it more compatible out of the box with our build tooling requirements and installable published packages.