### PR TITLE
Support code lenses on more callables

### DIFF
--- a/compiler/qsc_circuit/src/operations.rs
+++ b/compiler/qsc_circuit/src/operations.rs
@@ -47,6 +47,11 @@ pub enum Error {
 #[must_use]
 pub fn qubit_param_info(item: &Item) -> Option<(Vec<u32>, u32)> {
     if let ItemKind::Callable(decl) = &item.kind {
+        if decl.input.ty == Ty::UNIT {
+            // Support no parameters by allocating 0 qubits.
+            return Some((vec![], 0));
+        }
+
         let (qubit_param_dimensions, total_num_qubits) = get_qubit_param_info(&decl.input.ty);
 
         if !qubit_param_dimensions.is_empty() {

--- a/compiler/qsc_circuit/src/operations.rs
+++ b/compiler/qsc_circuit/src/operations.rs
@@ -33,7 +33,7 @@ pub enum Error {
 /// If the item is not a callable, returns `None`.
 /// If the callable takes any non-qubit parameters, returns `None`.
 ///
-/// If the callable only takes qubit parameters or no parameters, (including qubit arrays):
+/// If the callable only takes qubit parameters (including qubit arrays) or no parameters:
 ///
 /// The first element of the return tuple is a vector,
 /// where each element corresponds to a parameter, and the

--- a/compiler/qsc_circuit/src/operations.rs
+++ b/compiler/qsc_circuit/src/operations.rs
@@ -33,7 +33,7 @@ pub enum Error {
 /// If the item is not a callable, returns `None`.
 /// If the callable takes any non-qubit parameters, returns `None`.
 ///
-/// If the callable only takes qubit parameters, (including qubit arrays):
+/// If the callable only takes qubit parameters or no parameters, (including qubit arrays):
 ///
 /// The first element of the return tuple is a vector,
 /// where each element corresponds to a parameter, and the

--- a/compiler/qsc_circuit/src/operations/tests.rs
+++ b/compiler/qsc_circuit/src/operations/tests.rs
@@ -62,8 +62,8 @@ fn no_params() {
     );
     let expr = entry_expr_for_qubit_operation(&item, FunctorApp::default(), &operation);
     expect![[r#"
-        Err(
-            NoQubitParameters,
+        Ok(
+            "{\n            use qs = Qubit[0];\n            (Test.Test)();\n            let r: Result[] = [];\n            r\n        }",
         )
     "#]]
     .assert_debug_eq(&expr);

--- a/language_service/src/code_lens.rs
+++ b/language_service/src/code_lens.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use qsc::{
     circuit::qubit_param_info,
-    hir::{Expr, ExprKind, ItemId, ItemKind, LocalItemId, Package, Res},
+    hir::{ty::Ty, CallableKind, ItemKind},
     line_column::Encoding,
 };
 
@@ -29,95 +29,72 @@ pub(crate) fn get_code_lenses(
     let package = &user_unit.package;
     let source_span = compilation.package_span_of_source(source_name);
 
-    let entry_item_id = entry_callable(package);
+    package
+        .items
+        .iter()
+        .fold(Vec::new(), |mut accum, (_, item)| {
+            if source_span.contains(item.span.lo) {
+                if let ItemKind::Callable(decl) = &item.kind {
+                    if let Some(ItemKind::Namespace(ns, _)) = item
+                        .parent
+                        .and_then(|parent_id| package.items.get(parent_id))
+                        .map(|parent| &parent.kind)
+                    {
+                        let namespace = ns.name();
+                        let range = into_range(position_encoding, decl.span, &user_unit.sources);
+                        let name = decl.name.name.clone();
 
-    // Get callables in the current source file.
-    let callables = package.items.iter().filter_map(|(item_id, item)| {
-        if source_span.contains(item.span.lo) {
-            if let ItemKind::Callable(decl) = &item.kind {
-                if let Some(ItemKind::Namespace(ns, _)) = item
-                    .parent
-                    .and_then(|parent_id| package.items.get(parent_id))
-                    .map(|parent| &parent.kind)
-                {
-                    let namespace = ns.name();
-                    let range = into_range(position_encoding, decl.span, &user_unit.sources);
-                    let name = decl.name.name.clone();
+                        if decl.input.ty == Ty::UNIT {
+                            // For a callable that takes no input, always show all lenses except for circuit.
+                            let expr = format!("{namespace}.{name}()");
+                            accum = accum
+                                .into_iter()
+                                .chain([
+                                    CodeLens {
+                                        range,
+                                        command: CodeLensCommand::Run(expr.clone()),
+                                    },
+                                    CodeLens {
+                                        range,
+                                        command: CodeLensCommand::Histogram(expr.clone()),
+                                    },
+                                    CodeLens {
+                                        range,
+                                        command: CodeLensCommand::Estimate(expr.clone()),
+                                    },
+                                    CodeLens {
+                                        range,
+                                        command: CodeLensCommand::Debug(expr),
+                                    },
+                                ])
+                                .collect();
+                        }
+                        if decl.kind == CallableKind::Operation {
+                            // If this is either an operation that takes no arguments or one that takes only qubit arguments,
+                            // show the circuit lens.
+                            if decl.input.ty == Ty::UNIT {
+                                accum.push(CodeLens {
+                                    range,
+                                    command: CodeLensCommand::Circuit(OperationInfo {
+                                        operation: format!("{namespace}.{name}"),
+                                        total_num_qubits: 0,
+                                    }),
+                                });
+                            } else if let Some((_, total_num_qubits)) = qubit_param_info(item) {
+                                accum.push(CodeLens {
+                                    range,
+                                    command: CodeLensCommand::Circuit(OperationInfo {
+                                        operation: format!("{namespace}.{name}"),
+                                        total_num_qubits,
+                                    }),
+                                });
+                            }
+                        }
 
-                    return Some((item, range, namespace, name, Some(item_id) == entry_item_id));
+                        return accum;
+                    }
                 }
             }
-        }
-        None
-    });
-
-    callables
-        .flat_map(|(item, range, namespace, name, is_entry_point)| {
-            if is_entry_point {
-                vec![
-                    CodeLens {
-                        range,
-                        command: CodeLensCommand::Run,
-                    },
-                    CodeLens {
-                        range,
-                        command: CodeLensCommand::Histogram,
-                    },
-                    CodeLens {
-                        range,
-                        command: CodeLensCommand::Estimate,
-                    },
-                    CodeLens {
-                        range,
-                        command: CodeLensCommand::Debug,
-                    },
-                    CodeLens {
-                        range,
-                        command: CodeLensCommand::Circuit(None),
-                    },
-                ]
-            } else {
-                if let Some((_, total_num_qubits)) = qubit_param_info(item) {
-                    return vec![CodeLens {
-                        range,
-                        command: CodeLensCommand::Circuit(Some(OperationInfo {
-                            operation: format!("{namespace}.{name}"),
-                            total_num_qubits,
-                        })),
-                    }];
-                }
-                vec![]
-            }
+            accum
         })
-        .collect()
-}
-
-/// Uses the entry expression in the package to find the
-/// entrypoint callable item id. The entry expression has to
-/// be a call to a parameterless operation or function. This is the
-/// specific pattern generated by the "generate entry expression" pass.
-/// In practice, this callable will be the one tagged with the
-/// `@EntryPoint()` attribute or named "Main".
-fn entry_callable(package: &Package) -> Option<LocalItemId> {
-    if let Some(Expr {
-        kind: ExprKind::Call(callee, args),
-        ..
-    }) = &package.entry
-    {
-        if let ExprKind::Tuple(args) = &args.kind {
-            if args.is_empty() {
-                if let ExprKind::Var(
-                    Res::Item(ItemId {
-                        package: None,
-                        item,
-                    }),
-                    ..,
-                ) = callee.kind
-                {
-                    return Some(item);
-                }
-            }
-        }
-    }
-    None
 }

--- a/language_service/src/code_lens/tests.rs
+++ b/language_service/src/code_lens/tests.rs
@@ -58,12 +58,23 @@ fn one_entrypoint() {
                 (
                     0,
                     [
-                        Run,
-                        Histogram,
-                        Estimate,
-                        Debug,
+                        Run(
+                            "Test.Test()",
+                        ),
+                        Histogram(
+                            "Test.Test()",
+                        ),
+                        Estimate(
+                            "Test.Test()",
+                        ),
+                        Debug(
+                            "Test.Test()",
+                        ),
                         Circuit(
-                            None,
+                            OperationInfo {
+                                operation: "Test.Test",
+                                total_num_qubits: 0,
+                            },
                         ),
                     ],
                 ),
@@ -78,15 +89,62 @@ fn two_entrypoints() {
         r#"
         namespace Test {
             @EntryPoint()
-            operation Main() : Unit{
-            }
+            ◉operation Main() : Unit{
+            }◉
 
             @EntryPoint()
-            operation Foo() : Unit{
-            }
+            ◉operation Foo() : Unit{
+            }◉
         }"#,
         &expect![[r#"
-            []
+            [
+                (
+                    0,
+                    [
+                        Run(
+                            "Test.Main()",
+                        ),
+                        Histogram(
+                            "Test.Main()",
+                        ),
+                        Estimate(
+                            "Test.Main()",
+                        ),
+                        Debug(
+                            "Test.Main()",
+                        ),
+                        Circuit(
+                            OperationInfo {
+                                operation: "Test.Main",
+                                total_num_qubits: 0,
+                            },
+                        ),
+                    ],
+                ),
+                (
+                    1,
+                    [
+                        Run(
+                            "Test.Foo()",
+                        ),
+                        Histogram(
+                            "Test.Foo()",
+                        ),
+                        Estimate(
+                            "Test.Foo()",
+                        ),
+                        Debug(
+                            "Test.Foo()",
+                        ),
+                        Circuit(
+                            OperationInfo {
+                                operation: "Test.Foo",
+                                total_num_qubits: 0,
+                            },
+                        ),
+                    ],
+                ),
+            ]
         "#]],
     );
 }
@@ -99,20 +157,54 @@ fn main_function() {
             ◉operation Main() : Unit {
             }◉
 
-            operation Foo() : Unit{
-            }
+            ◉operation Foo() : Unit{
+            }◉
         }"#,
         &expect![[r#"
             [
                 (
                     0,
                     [
-                        Run,
-                        Histogram,
-                        Estimate,
-                        Debug,
+                        Run(
+                            "Test.Main()",
+                        ),
+                        Histogram(
+                            "Test.Main()",
+                        ),
+                        Estimate(
+                            "Test.Main()",
+                        ),
+                        Debug(
+                            "Test.Main()",
+                        ),
                         Circuit(
-                            None,
+                            OperationInfo {
+                                operation: "Test.Main",
+                                total_num_qubits: 0,
+                            },
+                        ),
+                    ],
+                ),
+                (
+                    1,
+                    [
+                        Run(
+                            "Test.Foo()",
+                        ),
+                        Histogram(
+                            "Test.Foo()",
+                        ),
+                        Estimate(
+                            "Test.Foo()",
+                        ),
+                        Debug(
+                            "Test.Foo()",
+                        ),
+                        Circuit(
+                            OperationInfo {
+                                operation: "Test.Foo",
+                                total_num_qubits: 0,
+                            },
                         ),
                     ],
                 ),
@@ -153,12 +245,10 @@ fn qubit_operation_circuit() {
                     0,
                     [
                         Circuit(
-                            Some(
-                                OperationInfo {
-                                    operation: "Test.Foo",
-                                    total_num_qubits: 1,
-                                },
-                            ),
+                            OperationInfo {
+                                operation: "Test.Foo",
+                                total_num_qubits: 1,
+                            },
                         ),
                     ],
                 ),
@@ -181,12 +271,10 @@ fn qubit_arrays_operation_circuit() {
                     0,
                     [
                         Circuit(
-                            Some(
-                                OperationInfo {
-                                    operation: "Test.Foo",
-                                    total_num_qubits: 7,
-                                },
-                            ),
+                            OperationInfo {
+                                operation: "Test.Foo",
+                                total_num_qubits: 7,
+                            },
                         ),
                     ],
                 ),

--- a/language_service/src/protocol.rs
+++ b/language_service/src/protocol.rs
@@ -198,11 +198,11 @@ pub struct CodeLens {
 
 #[derive(Debug)]
 pub enum CodeLensCommand {
-    Histogram,
-    Debug,
-    Run,
-    Estimate,
-    Circuit(Option<OperationInfo>),
+    Histogram(String),
+    Debug(String),
+    Run(String),
+    Estimate(String),
+    Circuit(OperationInfo),
 }
 
 #[derive(Debug)]

--- a/npm/qsharp/src/compiler/compiler.ts
+++ b/npm/qsharp/src/compiler/compiler.ts
@@ -64,7 +64,11 @@ export interface ICompiler {
 
   getQir(program: ProgramConfig): Promise<string>;
 
-  getEstimates(program: ProgramConfig, params: string): Promise<string>;
+  getEstimates(
+    program: ProgramConfig,
+    expr: string,
+    params: string,
+  ): Promise<string>;
 
   getCircuit(
     program: ProgramConfig,
@@ -204,9 +208,14 @@ export class Compiler implements ICompiler {
     return this.wasm.get_qir(toWasmProgramConfig(program, "base"));
   }
 
-  async getEstimates(program: ProgramConfig, params: string): Promise<string> {
+  async getEstimates(
+    program: ProgramConfig,
+    expr: string,
+    params: string,
+  ): Promise<string> {
     return this.wasm.get_estimates(
       toWasmProgramConfig(program, "unrestricted"),
+      expr,
       params,
     );
   }

--- a/vscode/src/debugger/activate.ts
+++ b/vscode/src/debugger/activate.ts
@@ -45,17 +45,21 @@ function registerCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       `${qsharpExtensionId}.runEditorContents`,
-      (resource: vscode.Uri) =>
+      (resource: vscode.Uri, expr?: string) =>
         startDebugging(
           resource,
-          { name: "Run Q# File", stopOnEntry: false },
+          { name: "Run Q# File", stopOnEntry: false, entry: expr },
           { noDebug: true },
         ),
     ),
     vscode.commands.registerCommand(
       `${qsharpExtensionId}.debugEditorContents`,
-      (resource: vscode.Uri) =>
-        startDebugging(resource, { name: "Debug Q# File", stopOnEntry: true }),
+      (resource: vscode.Uri, expr?: string) =>
+        startDebugging(resource, {
+          name: "Debug Q# File",
+          stopOnEntry: true,
+          entry: expr,
+        }),
     ),
     vscode.commands.registerCommand(
       `${qsharpExtensionId}.runEditorContentsWithCircuit`,
@@ -69,28 +73,6 @@ function registerCommands(context: vscode.ExtensionContext) {
           },
           { noDebug: true },
         ),
-    ),
-    vscode.commands.registerCommand(
-      `${qsharpExtensionId}.runExpression`,
-      (expr: string) =>
-        startDebugging(
-          undefined,
-          {
-            name: "Run Expression",
-            stopOnEntry: false,
-            entry: expr,
-          },
-          { noDebug: true },
-        ),
-    ),
-    vscode.commands.registerCommand(
-      `${qsharpExtensionId}.debugExpression`,
-      (expr: string) =>
-        startDebugging(undefined, {
-          name: "Debug Expression",
-          stopOnEntry: true,
-          entry: expr,
-        }),
     ),
   );
 

--- a/vscode/src/debugger/activate.ts
+++ b/vscode/src/debugger/activate.ts
@@ -70,10 +70,32 @@ function registerCommands(context: vscode.ExtensionContext) {
           { noDebug: true },
         ),
     ),
+    vscode.commands.registerCommand(
+      `${qsharpExtensionId}.runExpression`,
+      (expr: string) =>
+        startDebugging(
+          undefined,
+          {
+            name: "Run Expression",
+            stopOnEntry: false,
+            entry: expr,
+          },
+          { noDebug: true },
+        ),
+    ),
+    vscode.commands.registerCommand(
+      `${qsharpExtensionId}.debugExpression`,
+      (expr: string) =>
+        startDebugging(undefined, {
+          name: "Debug Expression",
+          stopOnEntry: true,
+          entry: expr,
+        }),
+    ),
   );
 
   function startDebugging(
-    resource: vscode.Uri,
+    resource: vscode.Uri | undefined,
     config: { name: string; [key: string]: any },
     options?: vscode.DebugSessionOptions,
   ) {
@@ -147,6 +169,7 @@ class QsDebugConfigProvider implements vscode.DebugConfigurationProvider {
         config.shots = 1;
         config.noDebug = "noDebug" in config ? config.noDebug : false;
         config.stopOnEntry = !config.noDebug;
+        config.entry = config.entry ?? "";
       }
     }
 

--- a/vscode/src/language-service/codeLens.ts
+++ b/vscode/src/language-service/codeLens.ts
@@ -52,12 +52,12 @@ function mapCodeLens(cl: ICodeLens): vscode.CodeLens {
       break;
     case "debug":
       title = "Debug";
-      command = "qsharp-vscode.debugExpression";
+      command = "qsharp-vscode.debugEditorContents";
       tooltip = "Debug callable";
       break;
     case "run":
       title = "Run";
-      command = "qsharp-vscode.runExpression";
+      command = "qsharp-vscode.runEditorContents";
       tooltip = "Run callable";
       break;
     case "circuit":
@@ -70,7 +70,7 @@ function mapCodeLens(cl: ICodeLens): vscode.CodeLens {
   return new vscode.CodeLens(toVsCodeRange(cl.range), {
     title,
     command,
-    arguments: [cl.args],
+    arguments: cl.args ?? [],
     tooltip,
   });
 }

--- a/vscode/src/language-service/codeLens.ts
+++ b/vscode/src/language-service/codeLens.ts
@@ -39,7 +39,6 @@ function mapCodeLens(cl: ICodeLens): vscode.CodeLens {
   let command;
   let title;
   let tooltip;
-  let args = undefined;
   switch (cl.command) {
     case "histogram":
       title = "Histogram";
@@ -53,28 +52,25 @@ function mapCodeLens(cl: ICodeLens): vscode.CodeLens {
       break;
     case "debug":
       title = "Debug";
-      command = "qsharp-vscode.debugEditorContents";
-      tooltip = "Debug program";
+      command = "qsharp-vscode.debugExpression";
+      tooltip = "Debug callable";
       break;
     case "run":
       title = "Run";
-      command = "qsharp-vscode.runEditorContents";
-      tooltip = "Run program";
+      command = "qsharp-vscode.runExpression";
+      tooltip = "Run callable";
       break;
     case "circuit":
       title = "Circuit";
       command = "qsharp-vscode.showCircuit";
       tooltip = "Show circuit";
-      if (cl.args) {
-        args = [cl.args];
-      }
       break;
   }
 
   return new vscode.CodeLens(toVsCodeRange(cl.range), {
     title,
     command,
-    arguments: args,
+    arguments: [cl.args],
     tooltip,
   });
 }

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -44,229 +44,233 @@ export function registerWebViewCommands(context: ExtensionContext) {
   ).toString();
 
   context.subscriptions.push(
-    commands.registerCommand(`${qsharpExtensionId}.showRe`, async () => {
-      clearCommandDiagnostics();
-      const associationId = getRandomGuid();
-      sendTelemetryEvent(
-        EventType.TriggerResourceEstimation,
-        { associationId },
-        {},
-      );
-      const program = await getActiveProgram();
-      if (!program.success) {
-        throw new Error(program.errorMsg);
-      }
-
-      const qubitType = await window.showQuickPick(
-        [
-          {
-            label: "qubit_gate_ns_e3",
-            detail: "Superconducting/spin qubit with 1e-3 error rate",
-            picked: true,
-            params: {
-              qubitParams: { name: "qubit_gate_ns_e3" },
-              qecScheme: { name: "surface_code" },
-            },
-          },
-          {
-            label: "qubit_gate_ns_e4",
-            detail: "Superconducting/spin qubit with 1e-4 error rate",
-            params: {
-              qubitParams: { name: "qubit_gate_ns_e4" },
-              qecScheme: { name: "surface_code" },
-            },
-          },
-          {
-            label: "qubit_gate_us_e3",
-            detail: "Trapped ion qubit with 1e-3 error rate",
-            params: {
-              qubitParams: { name: "qubit_gate_us_e3" },
-              qecScheme: { name: "surface_code" },
-            },
-          },
-          {
-            label: "qubit_gate_us_e4",
-            detail: "Trapped ion qubit with 1e-4 error rate",
-            params: {
-              qubitParams: { name: "qubit_gate_us_e4" },
-              qecScheme: { name: "surface_code" },
-            },
-          },
-          {
-            label: "qubit_maj_ns_e4 + surface_code",
-            detail: "Majorana qubit with 1e-4 error rate (surface code QEC)",
-            params: {
-              qubitParams: { name: "qubit_maj_ns_e4" },
-              qecScheme: { name: "surface_code" },
-            },
-          },
-          {
-            label: "qubit_maj_ns_e6 + surface_code",
-            detail: "Majorana qubit with 1e-6 error rate (surface code QEC)",
-            params: {
-              qubitParams: { name: "qubit_maj_ns_e6" },
-              qecScheme: { name: "surface_code" },
-            },
-          },
-          {
-            label: "qubit_maj_ns_e4 + floquet_code",
-            detail: "Majorana qubit with 1e-4 error rate (floquet code QEC)",
-            params: {
-              qubitParams: { name: "qubit_maj_ns_e4" },
-              qecScheme: { name: "floquet_code" },
-            },
-          },
-          {
-            label: "qubit_maj_ns_e6 + floquet_code",
-            detail: "Majorana qubit with 1e-6 error rate (floquet code QEC)",
-            params: {
-              qubitParams: { name: "qubit_maj_ns_e6" },
-              qecScheme: { name: "floquet_code" },
-            },
-          },
-        ],
-        {
-          canPickMany: true,
-          title: "Qubit types",
-          placeHolder: "Superconducting/spin qubit with 1e-3 error rate",
-          matchOnDetail: true,
-        },
-      );
-
-      if (!qubitType) {
-        return;
-      }
-
-      // Prompt for error budget (default to 0.001)
-      const validateErrorBudget = (input: string) => {
-        const result = parseFloat(input);
-        if (isNaN(result) || result <= 0.0 || result >= 1.0) {
-          return "Error budgets must be between 0 and 1";
-        }
-      };
-
-      const errorBudget = await window.showInputBox({
-        value: "0.001",
-        prompt: "Error budget",
-        validateInput: validateErrorBudget,
-      });
-
-      // abort if the user hits <Esc> during shots entry
-      if (errorBudget === undefined) {
-        return;
-      }
-
-      let runName = await window.showInputBox({
-        title: "Friendly name for run",
-        value: `${program.programConfig.projectName}`,
-      });
-      if (!runName) {
-        return;
-      }
-
-      const params = qubitType.map((item) => ({
-        ...item.params,
-        errorBudget: parseFloat(errorBudget),
-        estimateType: "frontier",
-      }));
-
-      log.info("RE params", params);
-
-      sendMessageToPanel({ panelType: "estimates" }, true, {
-        calculating: true,
-      });
-
-      const estimatePanel = getOrCreatePanel("estimates");
-      // Ensure the name is unique
-      if (estimatePanel.state[runName] !== undefined) {
-        let idx = 2;
-        for (;;) {
-          const newName = `${runName}-${idx}`;
-          if (estimatePanel.state[newName] === undefined) {
-            runName = newName;
-            break;
-          }
-          idx++;
-        }
-      }
-      estimatePanel.state[runName] = true;
-
-      // Start the worker, run the code, and send the results to the webview
-      log.debug("Starting resource estimates worker.");
-      let timedOut = false;
-
-      const worker = getCompilerWorker(compilerWorkerScriptPath);
-      const compilerTimeout = setTimeout(() => {
-        log.info("Compiler timeout. Terminating worker.");
-        timedOut = true;
-        worker.terminate();
-      }, compilerRunTimeoutMs);
-
-      try {
-        const start = performance.now();
+    commands.registerCommand(
+      `${qsharpExtensionId}.showRe`,
+      async (expr?: string) => {
+        clearCommandDiagnostics();
+        const associationId = getRandomGuid();
         sendTelemetryEvent(
-          EventType.ResourceEstimationStart,
+          EventType.TriggerResourceEstimation,
           { associationId },
           {},
         );
-        const estimatesStr = await worker.getEstimates(
-          program.programConfig,
-          JSON.stringify(params),
-        );
-        sendTelemetryEvent(
-          EventType.ResourceEstimationEnd,
-          { associationId },
-          { timeToCompleteMs: performance.now() - start },
-        );
-        log.debug("Estimates result", estimatesStr);
+        const program = await getActiveProgram();
+        if (!program.success) {
+          throw new Error(program.errorMsg);
+        }
 
-        // Should be an array of one ReData object returned
-        const estimates = JSON.parse(estimatesStr);
+        const qubitType = await window.showQuickPick(
+          [
+            {
+              label: "qubit_gate_ns_e3",
+              detail: "Superconducting/spin qubit with 1e-3 error rate",
+              picked: true,
+              params: {
+                qubitParams: { name: "qubit_gate_ns_e3" },
+                qecScheme: { name: "surface_code" },
+              },
+            },
+            {
+              label: "qubit_gate_ns_e4",
+              detail: "Superconducting/spin qubit with 1e-4 error rate",
+              params: {
+                qubitParams: { name: "qubit_gate_ns_e4" },
+                qecScheme: { name: "surface_code" },
+              },
+            },
+            {
+              label: "qubit_gate_us_e3",
+              detail: "Trapped ion qubit with 1e-3 error rate",
+              params: {
+                qubitParams: { name: "qubit_gate_us_e3" },
+                qecScheme: { name: "surface_code" },
+              },
+            },
+            {
+              label: "qubit_gate_us_e4",
+              detail: "Trapped ion qubit with 1e-4 error rate",
+              params: {
+                qubitParams: { name: "qubit_gate_us_e4" },
+                qecScheme: { name: "surface_code" },
+              },
+            },
+            {
+              label: "qubit_maj_ns_e4 + surface_code",
+              detail: "Majorana qubit with 1e-4 error rate (surface code QEC)",
+              params: {
+                qubitParams: { name: "qubit_maj_ns_e4" },
+                qecScheme: { name: "surface_code" },
+              },
+            },
+            {
+              label: "qubit_maj_ns_e6 + surface_code",
+              detail: "Majorana qubit with 1e-6 error rate (surface code QEC)",
+              params: {
+                qubitParams: { name: "qubit_maj_ns_e6" },
+                qecScheme: { name: "surface_code" },
+              },
+            },
+            {
+              label: "qubit_maj_ns_e4 + floquet_code",
+              detail: "Majorana qubit with 1e-4 error rate (floquet code QEC)",
+              params: {
+                qubitParams: { name: "qubit_maj_ns_e4" },
+                qecScheme: { name: "floquet_code" },
+              },
+            },
+            {
+              label: "qubit_maj_ns_e6 + floquet_code",
+              detail: "Majorana qubit with 1e-6 error rate (floquet code QEC)",
+              params: {
+                qubitParams: { name: "qubit_maj_ns_e6" },
+                qecScheme: { name: "floquet_code" },
+              },
+            },
+          ],
+          {
+            canPickMany: true,
+            title: "Qubit types",
+            placeHolder: "Superconducting/spin qubit with 1e-3 error rate",
+            matchOnDetail: true,
+          },
+        );
 
-        for (const item of estimates) {
-          // if item doesn't have a status property, it's an error
-          if (!("status" in item) || item.status !== "success") {
-            log.error("Estimates error code: ", item.code);
-            log.error("Estimates error message: ", item.message);
-            throw item.message;
+        if (!qubitType) {
+          return;
+        }
+
+        // Prompt for error budget (default to 0.001)
+        const validateErrorBudget = (input: string) => {
+          const result = parseFloat(input);
+          if (isNaN(result) || result <= 0.0 || result >= 1.0) {
+            return "Error budgets must be between 0 and 1";
+          }
+        };
+
+        const errorBudget = await window.showInputBox({
+          value: "0.001",
+          prompt: "Error budget",
+          validateInput: validateErrorBudget,
+        });
+
+        // abort if the user hits <Esc> during shots entry
+        if (errorBudget === undefined) {
+          return;
+        }
+
+        let runName = await window.showInputBox({
+          title: "Friendly name for run",
+          value: `${program.programConfig.projectName}`,
+        });
+        if (!runName) {
+          return;
+        }
+
+        const params = qubitType.map((item) => ({
+          ...item.params,
+          errorBudget: parseFloat(errorBudget),
+          estimateType: "frontier",
+        }));
+
+        log.info("RE params", params);
+
+        sendMessageToPanel({ panelType: "estimates" }, true, {
+          calculating: true,
+        });
+
+        const estimatePanel = getOrCreatePanel("estimates");
+        // Ensure the name is unique
+        if (estimatePanel.state[runName] !== undefined) {
+          let idx = 2;
+          for (;;) {
+            const newName = `${runName}-${idx}`;
+            if (estimatePanel.state[newName] === undefined) {
+              runName = newName;
+              break;
+            }
+            idx++;
           }
         }
+        estimatePanel.state[runName] = true;
 
-        (estimates as Array<any>).forEach(
-          (item) => (item.jobParams.sharedRunName = runName),
-        );
+        // Start the worker, run the code, and send the results to the webview
+        log.debug("Starting resource estimates worker.");
+        let timedOut = false;
 
-        clearTimeout(compilerTimeout);
-
-        const message = {
-          calculating: false,
-          estimates,
-        };
-        sendMessageToPanel({ panelType: "estimates" }, true, message);
-      } catch (e: any) {
-        // Stop the 'calculating' animation
-        const message = {
-          calculating: false,
-          estimates: [],
-        };
-        sendMessageToPanel({ panelType: "estimates" }, false, message);
-
-        if (timedOut) {
-          // Show a VS Code popup that a timeout occurred
-          window.showErrorMessage(
-            "The resource estimation timed out. Please try again.",
-          );
-        } else {
-          log.error("getEstimates error: ", e.toString());
-          throw new Error("Estimating failed with error: " + e.toString());
-        }
-      } finally {
-        if (!timedOut) {
-          log.debug("Terminating resource estimates worker.");
+        const worker = getCompilerWorker(compilerWorkerScriptPath);
+        const compilerTimeout = setTimeout(() => {
+          log.info("Compiler timeout. Terminating worker.");
+          timedOut = true;
           worker.terminate();
+        }, compilerRunTimeoutMs);
+
+        try {
+          const start = performance.now();
+          sendTelemetryEvent(
+            EventType.ResourceEstimationStart,
+            { associationId },
+            {},
+          );
+          const estimatesStr = await worker.getEstimates(
+            program.programConfig,
+            expr ?? "",
+            JSON.stringify(params),
+          );
+          sendTelemetryEvent(
+            EventType.ResourceEstimationEnd,
+            { associationId },
+            { timeToCompleteMs: performance.now() - start },
+          );
+          log.debug("Estimates result", estimatesStr);
+
+          // Should be an array of one ReData object returned
+          const estimates = JSON.parse(estimatesStr);
+
+          for (const item of estimates) {
+            // if item doesn't have a status property, it's an error
+            if (!("status" in item) || item.status !== "success") {
+              log.error("Estimates error code: ", item.code);
+              log.error("Estimates error message: ", item.message);
+              throw item.message;
+            }
+          }
+
+          (estimates as Array<any>).forEach(
+            (item) => (item.jobParams.sharedRunName = runName),
+          );
+
+          clearTimeout(compilerTimeout);
+
+          const message = {
+            calculating: false,
+            estimates,
+          };
+          sendMessageToPanel({ panelType: "estimates" }, true, message);
+        } catch (e: any) {
+          // Stop the 'calculating' animation
+          const message = {
+            calculating: false,
+            estimates: [],
+          };
+          sendMessageToPanel({ panelType: "estimates" }, false, message);
+
+          if (timedOut) {
+            // Show a VS Code popup that a timeout occurred
+            window.showErrorMessage(
+              "The resource estimation timed out. Please try again.",
+            );
+          } else {
+            log.error("getEstimates error: ", e.toString());
+            throw new Error("Estimating failed with error: " + e.toString());
+          }
+        } finally {
+          if (!timedOut) {
+            log.debug("Terminating resource estimates worker.");
+            worker.terminate();
+          }
         }
-      }
-    }),
+      },
+    ),
   );
 
   context.subscriptions.push(
@@ -277,103 +281,110 @@ export function registerWebViewCommands(context: ExtensionContext) {
   );
 
   context.subscriptions.push(
-    commands.registerCommand(`${qsharpExtensionId}.showHistogram`, async () => {
-      clearCommandDiagnostics();
+    commands.registerCommand(
+      `${qsharpExtensionId}.showHistogram`,
+      async (expr?: string) => {
+        clearCommandDiagnostics();
 
-      const associationId = getRandomGuid();
-      sendTelemetryEvent(EventType.TriggerHistogram, { associationId }, {});
-      function resultToLabel(result: string | VSDiagnostic): string {
-        if (typeof result !== "string") return "ERROR";
-        return result;
-      }
-
-      const program = await getActiveProgram();
-      if (!program.success) {
-        throw new Error(program.errorMsg);
-      }
-
-      const panelId = program.programConfig.projectName;
-
-      // Start the worker, run the code, and send the results to the webview
-      const worker = getCompilerWorker(compilerWorkerScriptPath);
-      const compilerTimeout = setTimeout(() => {
-        worker.terminate();
-      }, compilerRunTimeoutMs);
-
-      try {
-        const validateShotsInput = (input: string) => {
-          const result = parseFloat(input);
-          if (isNaN(result) || Math.floor(result) !== result || result <= 0) {
-            return "Number of shots must be a positive integer";
-          }
-        };
-
-        const numberOfShots =
-          (await window.showInputBox({
-            value: "100",
-            prompt: "Number of shots",
-            validateInput: validateShotsInput,
-          })) || "100";
-
-        // abort if the user hits <Esc> during shots entry
-        if (numberOfShots === undefined) {
-          return;
+        const associationId = getRandomGuid();
+        sendTelemetryEvent(EventType.TriggerHistogram, { associationId }, {});
+        function resultToLabel(result: string | VSDiagnostic): string {
+          if (typeof result !== "string") return "ERROR";
+          return result;
         }
 
-        sendMessageToPanel(
-          { panelType: "histogram", id: panelId },
-          true,
-          undefined,
-        );
+        const program = await getActiveProgram();
+        if (!program.success) {
+          throw new Error(program.errorMsg);
+        }
 
-        const evtTarget = new QscEventTarget(true);
-        evtTarget.addEventListener("uiResultsRefresh", () => {
-          const results = evtTarget.getResults();
-          const resultCount = evtTarget.resultCount();
-          const buckets = new Map();
-          for (let i = 0; i < resultCount; ++i) {
-            const key = results[i].result;
-            const strKey = resultToLabel(key);
-            const newValue = (buckets.get(strKey) || 0) + 1;
-            buckets.set(strKey, newValue);
-          }
-          const message = {
-            buckets: Array.from(buckets.entries()),
-            shotCount: resultCount,
+        const panelId = program.programConfig.projectName;
+
+        // Start the worker, run the code, and send the results to the webview
+        const worker = getCompilerWorker(compilerWorkerScriptPath);
+        const compilerTimeout = setTimeout(() => {
+          worker.terminate();
+        }, compilerRunTimeoutMs);
+
+        try {
+          const validateShotsInput = (input: string) => {
+            const result = parseFloat(input);
+            if (isNaN(result) || Math.floor(result) !== result || result <= 0) {
+              return "Number of shots must be a positive integer";
+            }
           };
+
+          const numberOfShots =
+            (await window.showInputBox({
+              value: "100",
+              prompt: "Number of shots",
+              validateInput: validateShotsInput,
+            })) || "100";
+
+          // abort if the user hits <Esc> during shots entry
+          if (numberOfShots === undefined) {
+            return;
+          }
+
           sendMessageToPanel(
             { panelType: "histogram", id: panelId },
-            false,
-            message,
+            true,
+            undefined,
           );
-        });
-        const start = performance.now();
-        sendTelemetryEvent(EventType.HistogramStart, { associationId }, {});
 
-        const noise = getPauliNoiseModel();
-        if (noise[0] != 0 || noise[1] != 0 || noise[2] != 0) {
-          sendTelemetryEvent(EventType.NoisySimulation, { associationId }, {});
+          const evtTarget = new QscEventTarget(true);
+          evtTarget.addEventListener("uiResultsRefresh", () => {
+            const results = evtTarget.getResults();
+            const resultCount = evtTarget.resultCount();
+            const buckets = new Map();
+            for (let i = 0; i < resultCount; ++i) {
+              const key = results[i].result;
+              const strKey = resultToLabel(key);
+              const newValue = (buckets.get(strKey) || 0) + 1;
+              buckets.set(strKey, newValue);
+            }
+            const message = {
+              buckets: Array.from(buckets.entries()),
+              shotCount: resultCount,
+            };
+            sendMessageToPanel(
+              { panelType: "histogram", id: panelId },
+              false,
+              message,
+            );
+          });
+          const start = performance.now();
+          sendTelemetryEvent(EventType.HistogramStart, { associationId }, {});
+
+          const noise = getPauliNoiseModel();
+          if (noise[0] != 0 || noise[1] != 0 || noise[2] != 0) {
+            sendTelemetryEvent(
+              EventType.NoisySimulation,
+              { associationId },
+              {},
+            );
+          }
+          await worker.runWithPauliNoise(
+            program.programConfig,
+            expr ?? "",
+            parseInt(numberOfShots),
+            noise,
+            evtTarget,
+          );
+          sendTelemetryEvent(
+            EventType.HistogramEnd,
+            { associationId },
+            { timeToCompleteMs: performance.now() - start },
+          );
+          clearTimeout(compilerTimeout);
+        } catch (e: any) {
+          log.error("Histogram error. ", e.toString());
+          throw new Error("Run failed. " + e.toString());
+        } finally {
+          worker.terminate();
         }
-        await worker.runWithPauliNoise(
-          program.programConfig,
-          "",
-          parseInt(numberOfShots),
-          noise,
-          evtTarget,
-        );
-        sendTelemetryEvent(
-          EventType.HistogramEnd,
-          { associationId },
-          { timeToCompleteMs: performance.now() - start },
-        );
-        clearTimeout(compilerTimeout);
-      } catch (e: any) {
-        log.error("Histogram error. ", e.toString());
-        throw new Error("Run failed. " + e.toString());
-      } finally {
-        worker.terminate();
-      }
-    }),
+      },
+    ),
   );
 
   context.subscriptions.push(

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import * as vscode from "vscode";
 import {
   IOperationInfo,
   QscEventTarget,
@@ -46,7 +47,7 @@ export function registerWebViewCommands(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand(
       `${qsharpExtensionId}.showRe`,
-      async (expr?: string) => {
+      async (resource?: vscode.Uri, expr?: string) => {
         clearCommandDiagnostics();
         const associationId = getRandomGuid();
         sendTelemetryEvent(
@@ -283,7 +284,7 @@ export function registerWebViewCommands(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand(
       `${qsharpExtensionId}.showHistogram`,
-      async (expr?: string) => {
+      async (resource?: vscode.Uri, expr?: string) => {
         clearCommandDiagnostics();
 
         const associationId = getRandomGuid();

--- a/vscode/test/suites/language-service/language-service.test.ts
+++ b/vscode/test/suites/language-service/language-service.test.ts
@@ -227,7 +227,7 @@ suite("Q# Language Service Tests", function suite() {
       doc.uri,
     )) as vscode.CodeLens[];
 
-    assert.lengthOf(actualCodeLenses, 5);
+    assert.lengthOf(actualCodeLenses, 4);
 
     for (const lens of actualCodeLenses) {
       assert.include(doc.getText(lens.range), "function Test()");

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -339,23 +339,26 @@ impl LanguageService {
                 let range = lens.range.into();
                 let (command, args) = match lens.command {
                     qsls::protocol::CodeLensCommand::Histogram(expr) => {
-                        ("histogram", Some(CodeLensArg::Expr(expr)))
+                        ("histogram", Some(CodeLensArg::Expr((None, expr))))
                     }
                     qsls::protocol::CodeLensCommand::Debug(expr) => {
-                        ("debug", Some(CodeLensArg::Expr(expr)))
+                        ("debug", Some(CodeLensArg::Expr((None, expr))))
                     }
                     qsls::protocol::CodeLensCommand::Run(expr) => {
-                        ("run", Some(CodeLensArg::Expr(expr)))
+                        ("run", Some(CodeLensArg::Expr((None, expr))))
                     }
                     qsls::protocol::CodeLensCommand::Estimate(expr) => {
-                        ("estimate", Some(CodeLensArg::Expr(expr)))
+                        ("estimate", Some(CodeLensArg::Expr((None, expr))))
                     }
                     qsls::protocol::CodeLensCommand::Circuit(op_info) => (
                         "circuit",
-                        Some(CodeLensArg::Operation(OperationInfo {
-                            operation: op_info.operation,
-                            total_num_qubits: op_info.total_num_qubits,
-                        })),
+                        Some(CodeLensArg::Operation((
+                            None,
+                            OperationInfo {
+                                operation: op_info.operation,
+                                total_num_qubits: op_info.total_num_qubits,
+                            },
+                        ))),
                     ),
                 };
                 CodeLens {
@@ -540,8 +543,8 @@ serializable_type! {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum CodeLensArg {
-    Expr(String),
-    Operation(OperationInfo),
+    Expr((Option<String>, String)),
+    Operation((Option<String>, OperationInfo)),
 }
 
 serializable_type! {
@@ -555,7 +558,7 @@ serializable_type! {
     r#"export type ICodeLens = {
         range: IRange;
         command: "histogram" | "estimate" | "debug" | "run" | "circuit";
-        args?: object;
+        args?: any[];
     }"#,
     ICodeLens
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -82,12 +82,12 @@ pub(crate) fn get_qir_(
 }
 
 #[wasm_bindgen]
-pub fn get_estimates(program: ProgramConfig, params: &str) -> Result<String, String> {
-    let (source_map, capabilities, language_features, store, deps) = into_qsc_args(program, None)
-        .map_err(|mut e| {
-        // Wrap in `interpret::Error` to match the error type from `Interpreter::new` below
-        qsc::interpret::Error::from(e.pop().expect("expected at least one error")).to_string()
-    })?;
+pub fn get_estimates(program: ProgramConfig, expr: &str, params: &str) -> Result<String, String> {
+    let (source_map, capabilities, language_features, store, deps) =
+        into_qsc_args(program, Some(expr.into())).map_err(|mut e| {
+            // Wrap in `interpret::Error` to match the error type from `Interpreter::new` below
+            qsc::interpret::Error::from(e.pop().expect("expected at least one error")).to_string()
+        })?;
 
     let mut interpreter = interpret::Interpreter::new(
         source_map,


### PR DESCRIPTION
This change adds support for code lenses on any callable that qualifies for them instead of just the entry point. In practice, this means any function or operation that doesn't take arguments can be used as the starting place for a run, debug, estimate, histogram, or (in the case of operations) circuit. This is paticularly helpful for unit tests identifed by the `@Test()` attribute, as it lets them be run or debug outside of the test infra with a single click.