### PR TITLE
Fix bug in Unselect operation when selecting a single bit string

### DIFF
--- a/library/src/tests/table_lookup.rs
+++ b/library/src/tests/table_lookup.rs
@@ -9,6 +9,15 @@ use qsc::interpret::Value;
 const SELECT_TEST_LIB: &str = include_str!("resources/src/select.qs");
 
 #[test]
+fn check_select_exhaustive_bitwidth_0() {
+    test_expression_with_lib(
+        "Test.TestSelect(0, 10)",
+        SELECT_TEST_LIB,
+        &Value::Tuple(vec![].into()),
+    );
+}
+
+#[test]
 fn check_select_exhaustive_bitwidth_1() {
     test_expression_with_lib(
         "Test.TestSelect(1, 10)",


### PR DESCRIPTION
When selecting a single bit string the number of address bits is 0, and we run into a problem splitting the address register in the optimized Unlookup implementation. This case is now handled without measurement based uncomputation.