### PR TITLE
npm/qsharp - Make `languageFeatures` an optional parameter again

### DIFF
--- a/npm/qsharp/src/compiler/compiler.ts
+++ b/npm/qsharp/src/compiler/compiler.ts
@@ -94,7 +94,7 @@ export type ProgramConfig = (
       /** An array of source objects, each containing a name and contents. */
       sources: [string, string][];
       /** An array of language features to be opted in to in this compilation. */
-      languageFeatures: string[];
+      languageFeatures?: string[];
     }
   | {
       /** Sources from all resolved dependencies, along with their languageFeatures configuration */


### PR DESCRIPTION
Revert breaking change for QCOM. I don't recall the specific reason we had to make this required - I think it was an accident that snuck in when we made the `languageFeatures` a required method in OTHER method signatures in this file (#2078)