### PR TITLE
Multi-target gate circuit art improvement

### DIFF
--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -148,10 +148,8 @@ fn rotation_gate() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    // The wire isn't visible here since the gate label is longer
-    // than the static column width, but we can live with it.
     expect![[r"
-        q_0     rx(1.5708)
+        q_0    ─ rx(1.5708) ──
     "]]
     .assert_eq(&circ.to_string());
 }
@@ -262,8 +260,8 @@ fn mresetz_unrestricted_profile() {
         .expect("circuit generation should succeed");
 
     expect![[r"
-        q_0    ── H ──── M ─── |0〉 ─
-                         ╘══════════
+        q_0    ── H ──── M ──── |0〉 ──
+                         ╘════════════
     "]]
     .assert_eq(&circ.to_string());
 }
@@ -349,10 +347,10 @@ fn unrestricted_profile_result_comparison() {
         .expect("circuit generation should succeed");
 
     expect![[r"
-        q_0    ── H ──── M ──── X ─── |0〉 ─
-                         ╘═════════════════
-        q_1    ── H ──── M ─── |0〉 ────────
-                         ╘═════════════════
+        q_0    ── H ──── M ───── X ───── |0〉 ──
+                         ╘═════════════════════
+        q_1    ── H ──── M ──── |0〉 ───────────
+                         ╘═════════════════════
     "]]
     .assert_eq(&circ.to_string());
 
@@ -366,10 +364,10 @@ fn unrestricted_profile_result_comparison() {
 
     let circuit = interpreter.get_circuit();
     expect![[r"
-        q_0    ── H ──── M ──── X ─── |0〉 ─
-                         ╘═════════════════
-        q_1    ── H ──── M ─── |0〉 ────────
-                         ╘═════════════════
+        q_0    ── H ──── M ───── X ───── |0〉 ──
+                         ╘═════════════════════
+        q_1    ── H ──── M ──── |0〉 ───────────
+                         ╘═════════════════════
     "]]
     .assert_eq(&circuit.to_string());
 }
@@ -456,10 +454,8 @@ fn custom_intrinsic_one_classical_arg() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    // A custom intrinsic that doesn't take qubits just doesn't
-    // show up on the circuit.
     expect![[r"
-        q_0    ── X ── foo(4)
+        q_0    ── X ─── foo(4) ──
     "]]
     .assert_eq(&circ.to_string());
 }
@@ -497,16 +493,16 @@ fn custom_intrinsic_mixed_args() {
     // This is one gate that spans ten target wires, even though the
     // text visualization doesn't convey that clearly.
     expect![[r"
-        q_0     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_1     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_2     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_3     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_4     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_5     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_6     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_7     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_8     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
-        q_9     AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1)
+        q_0    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_1    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_2    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_3    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_4    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_5    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_6    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_7    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_8    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
+        q_9    ─ AccountForEstimatesInternal([(0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)], 1) ──
     "]]
     .assert_eq(&circ.to_string());
 
@@ -536,7 +532,7 @@ fn custom_intrinsic_apply_idle_noise() {
     // ConfigurePauliNoise has no qubit arguments so it shouldn't show up.
     // ApplyIdleNoise is a quantum operation so it shows up.
     expect![[r#"
-        q_0     ApplyIdleNoise
+        q_0    ─ ApplyIdleNoise ──
     "#]]
     .assert_eq(&circ.to_string());
 }
@@ -834,6 +830,63 @@ fn operation_with_non_qubit_args() {
     .assert_debug_eq(&circ_err);
 }
 
+#[test]
+fn operation_with_long_gates_properly_aligned() {
+    let mut interpreter = interpreter(
+        r"
+            namespace Test {
+                import Std.Measurement.*;
+
+                @EntryPoint()
+                operation Main() : Result[] {
+                    use q0 = Qubit();
+                    use q1 = Qubit();
+
+                    H(q0);
+                    H(q1);
+                    X(q1);
+                    Ry(1.0, q1);
+                    CNOT(q0, q1);
+                    M(q0);
+
+                    use q2 = Qubit();
+
+                    H(q2);
+                    Rx(1.0, q2);
+                    H(q2);
+                    Rx(1.0, q2);
+                    H(q2);
+                    Rx(1.0, q2);
+
+                    use q3 = Qubit();
+
+                    Rxx(1.0, q1, q3);
+
+                    CNOT(q0, q3);
+
+                    [M(q1), M(q3)]
+                }
+            }
+        ",
+        Profile::Unrestricted,
+    );
+
+    let circ = interpreter
+        .circuit(CircuitEntryPoint::EntryPoint, false)
+        .expect("circuit generation should succeed");
+
+    expect![[r#"
+        q_0    ── H ────────────────────────────────────── ● ──────── M ────────────────────────────────── ● ─────────
+                                                           │          ╘════════════════════════════════════╪══════════
+        q_1    ── H ──────── X ─────── ry(1.0000) ──────── X ───────────────────────────── rxx(1.0000) ────┼───── M ──
+                                                                                                ┆          │      ╘═══
+        q_2    ── H ─── rx(1.0000) ──────── H ─────── rx(1.0000) ──── H ─── rx(1.0000) ─────────┆──────────┼──────────
+        q_3    ─────────────────────────────────────────────────────────────────────────── rxx(1.0000) ─── X ──── M ──
+                                                                                                                  ╘═══
+    "#]]
+    .assert_eq(&circ.to_string());
+}
+
 /// Tests that invoke circuit generation throught the debugger.
 mod debugger_stepping {
     use super::Debugger;
@@ -915,17 +968,17 @@ mod debugger_stepping {
             step:
             q_0    ── H ──
             step:
-            q_0    ── H ──── Z ───────────────────────
-            q_1    ── H ──── ● ──── H ──── M ─── |0〉 ─
-                                           ╘══════════
+            q_0    ── H ──── Z ─────────────────────────
+            q_1    ── H ──── ● ──── H ──── M ──── |0〉 ──
+                                           ╘════════════
             step:
-            q_0    ── H ──── Z ─── |0〉 ───────────────
-            q_1    ── H ──── ● ──── H ──── M ─── |0〉 ─
-                                           ╘══════════
+            q_0    ── H ──── Z ──── |0〉 ──────────────────
+            q_1    ── H ──── ● ───── H ───── M ──── |0〉 ──
+                                             ╘════════════
             step:
-            q_0    ── H ──── Z ─── |0〉 ───────────────
-            q_1    ── H ──── ● ──── H ──── M ─── |0〉 ─
-                                           ╘══════════
+            q_0    ── H ──── Z ──── |0〉 ──────────────────
+            q_1    ── H ──── ● ───── H ───── M ──── |0〉 ──
+                                             ╘════════════
         "]]
         .assert_eq(&circs);
     }
@@ -959,11 +1012,11 @@ mod debugger_stepping {
             q_0    ── H ──── M ──
                              ╘═══
             step:
-            q_0    ── H ──── M ─── |0〉 ─
-                             ╘══════════
+            q_0    ── H ──── M ──── |0〉 ──
+                             ╘════════════
             step:
-            q_0    ── H ──── M ─── |0〉 ─
-                             ╘══════════
+            q_0    ── H ──── M ──── |0〉 ──
+                             ╘════════════
         "]]
         .assert_eq(&circs);
     }

--- a/compiler/qsc_circuit/src/circuit/tests.rs
+++ b/compiler/qsc_circuit/src/circuit/tests.rs
@@ -221,10 +221,8 @@ fn with_args() {
         }],
     };
 
-    // This looks wonky because the gate label is longer
-    // than the static column width, but we can live with it.
     expect![[r"
-        q_0     rx(1.5708)
+        q_0    ─ rx(1.5708) ──
     "]]
     .assert_eq(&c.to_string());
 }
@@ -258,12 +256,10 @@ fn two_targets() {
         ],
     };
 
-    // This looks wonky because the gate label is longer
-    // than the static column width, but we can live with it.
     expect![[r"
-        q_0     rzz(1.0000)
-        q_1    ───┆───
-        q_2     rzz(1.0000)
+        q_0    ─ rzz(1.0000) ─
+        q_1    ───────┆───────
+        q_2    ─ rzz(1.0000) ─
     "]]
     .assert_eq(&c.to_string());
 }


### PR DESCRIPTION
This PR has a proposed fix for issue https://github.com/microsoft/qsharp/issues/2184, but it mainly includes refactoring of the circuit-art code based on comments from PR https://github.com/microsoft/qsharp/pull/2126.

The only real functionality change in this code is that multi-target gates get extra lines that behave in the same way as measurement lines, in order to better convey the qubits involved.

For example, a circuit like this one:
```
use q0 = Qubit();
use q1 = Qubit();
Rxx(1.0, q0, q1);

use q2 = Qubit();
use q3 = Qubit();
Rxx(1.0, q2, q3);
```
instead of rendering as
```
q_0    ─ rxx(1.0000) ─
q_1    ─ rxx(1.0000) ─
q_2    ─ rxx(1.0000) ─
q_3    ─ rxx(1.0000) ─
```
will instead render as 
```
q_0    ─ rxx(1.0000) ─
              ┆
q_1    ─ rxx(1.0000) ─
q_2    ─ rxx(1.0000) ─
              ┆
q_3    ─ rxx(1.0000) ─
```

This is very similar to what we get if we measure the first qubit of each of these two-qubit gate, i.e.
```
q_0    ─ rxx(1.0000) ─── M ──
              ┆          ╘═══
q_1    ─ rxx(1.0000) ────────
q_2    ─ rxx(1.0000) ─── M ──
              ┆          ╘═══
q_3    ─ rxx(1.0000) ────────
```

On top of this change in rendering, the first few commits in this PR are actually just code refactoring. As such, it's probably best to review this PR commit by commit, for two reason - a. it's going to be much easier to follow, and b. any of these commits can be reverted if you think they make the code more complicated instead of making it easier to read.

The commits are as follows:
1. [a400655](https://github.com/microsoft/qsharp/pull/2185/commits/a4006557b4b0fcd0bacd14c5c1142eeecefbaa76) A rework of PR https://github.com/microsoft/qsharp/pull/2126, which, to be honest, is how I think I should have implemented it in the first place.
2. [c141799](https://github.com/microsoft/qsharp/pull/2185/commits/c14179907ed45ebd02e07199db85a401edaf61b1) A cleanup based on [this comment](https://github.com/microsoft/qsharp/pull/2126#pullrequestreview-2579485021). It makes the code significantly better, in my opinion.
3. [4012ee8](https://github.com/microsoft/qsharp/pull/2185/commits/4012ee8378f0080cf79b2220dead041ccc964edf) A small simplification to have the ColumnRenderer have a `new` method which is in charge of making sure that the column width is an odd number, and also a `Default` trait implementation for the case where we don't need a specific width.
4. [cfa7382](https://github.com/microsoft/qsharp/pull/2185/commits/cfa7382630b83ee0aefd64ee414ca6b5b600f2d2) This is the actual enhancement - it makes sure there is a classical line (same as what you get from a measurement) if there are two consecutive qubits for the same operation. If you think there is a better solution to make the rendering clearer, let me know. But of the ones I could think of, I found this one to be the least disruptive one (to both the existing code, and the existing circuits).