### PR TITLE
Fix Circuit codelens

### DIFF
--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -391,7 +391,7 @@ export function registerWebViewCommands(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand(
       `${qsharpExtensionId}.showCircuit`,
-      async (operation?: IOperationInfo) => {
+      async (resource?: vscode.Uri, operation?: IOperationInfo) => {
         await showCircuitCommand(context.extensionUri, operation);
       },
     ),


### PR DESCRIPTION
The feature in #2174 mistakenly broke Circuit codelenses (late refactoring caused it to always run the entry point instead of the associated operation).
Fixes #2189