### PR TITLE
Fix RCA panic on lambda with explicit return

### DIFF
--- a/compiler/qsc_frontend/src/lower/tests.rs
+++ b/compiler/qsc_frontend/src/lower/tests.rs
@@ -2381,6 +2381,90 @@ fn lambda_with_invalid_free_variable() {
 }
 
 #[test]
+fn lambda_with_explicit_return_should_have_non_unit_output_type() {
+    check_hir(
+        "function Foo(): Unit { let f = i -> return i + 1;}",
+        &expect![[r#"
+            Package:
+                Item 0 [0-50] (Public):
+                    Namespace (Ident 21 [0-50] "test"): Item 1
+                Item 1 [0-50] (Internal):
+                    Parent: 0
+                    Callable 0 [0-50] (function):
+                        name: Ident 1 [9-12] "Foo"
+                        input: Pat 2 [12-14] [Type Unit]: Unit
+                        output: Unit
+                        functors: empty set
+                        body: SpecDecl 3 [0-50]: Impl:
+                            Block 4 [21-50] [Type Unit]:
+                                Stmt 5 [23-49]: Local (Immutable):
+                                    Pat 6 [27-28] [Type (Int -> Int)]: Bind: Ident 7 [27-28] "f"
+                                    Expr 8 [31-48] [Type (Int -> Int)]: Closure([], 2)
+                        adj: <none>
+                        ctl: <none>
+                        ctl-adj: <none>
+                Item 2 [31-48] (Internal):
+                    Parent: 1
+                    Callable 16 [31-48] (function):
+                        name: Ident 17 [31-48] "<lambda>"
+                        input: Pat 15 [31-48] [Type (Int,)]: Tuple:
+                            Pat 9 [31-32] [Type Int]: Bind: Ident 10 [31-32] "i"
+                        output: Int
+                        functors: empty set
+                        body: SpecDecl 18 [36-48]: Impl:
+                            Block 19 [36-48] [Type Int]:
+                                Stmt 20 [36-48]: Expr: Expr 11 [36-48] [Type Int]: Return: Expr 12 [43-48] [Type Int]: BinOp (Add):
+                                    Expr 13 [43-44] [Type Int]: Var: Local 10
+                                    Expr 14 [47-48] [Type Int]: Lit: Int(1)
+                        adj: <none>
+                        ctl: <none>
+                        ctl-adj: <none>"#]],
+    );
+}
+
+#[test]
+fn lambda_with_implicit_return_should_have_non_unit_output_type() {
+    check_hir(
+        "function Foo(): Unit { let f = i -> i + 1}",
+        &expect![[r#"
+            Package:
+                Item 0 [0-42] (Public):
+                    Namespace (Ident 20 [0-42] "test"): Item 1
+                Item 1 [0-42] (Internal):
+                    Parent: 0
+                    Callable 0 [0-42] (function):
+                        name: Ident 1 [9-12] "Foo"
+                        input: Pat 2 [12-14] [Type Unit]: Unit
+                        output: Unit
+                        functors: empty set
+                        body: SpecDecl 3 [0-42]: Impl:
+                            Block 4 [21-42] [Type Unit]:
+                                Stmt 5 [23-41]: Local (Immutable):
+                                    Pat 6 [27-28] [Type (Int -> Int)]: Bind: Ident 7 [27-28] "f"
+                                    Expr 8 [31-41] [Type (Int -> Int)]: Closure([], 2)
+                        adj: <none>
+                        ctl: <none>
+                        ctl-adj: <none>
+                Item 2 [31-41] (Internal):
+                    Parent: 1
+                    Callable 15 [31-41] (function):
+                        name: Ident 16 [31-41] "<lambda>"
+                        input: Pat 14 [31-41] [Type (Int,)]: Tuple:
+                            Pat 9 [31-32] [Type Int]: Bind: Ident 10 [31-32] "i"
+                        output: Int
+                        functors: empty set
+                        body: SpecDecl 17 [36-41]: Impl:
+                            Block 18 [36-41] [Type Int]:
+                                Stmt 19 [36-41]: Expr: Expr 11 [36-41] [Type Int]: BinOp (Add):
+                                    Expr 12 [36-37] [Type Int]: Var: Local 10
+                                    Expr 13 [40-41] [Type Int]: Lit: Int(1)
+                        adj: <none>
+                        ctl: <none>
+                        ctl-adj: <none>"#]],
+    );
+}
+
+#[test]
 fn duplicate_commas_in_tydef() {
     check_hir(
         indoc! {r#"

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -399,12 +399,8 @@ impl<'a> Context<'a> {
                     .take()
                     .expect("return type should be present");
                 self.return_ty = prev_ret_ty;
-                if !body_partial.diverges {
-                    // Only when the type of the body converges do we need to unify with the inferred output type.
-                    // Otherwise we'd get spurious errors from lambdas that use explicit return-expr rather than implicit.
-                    self.inferrer
-                        .eq(body.span, output_ty.clone(), body_partial.ty);
-                }
+                self.inferrer
+                    .eq(body.span, output_ty.clone(), body_partial.ty);
                 converge(Ty::Arrow(Box::new(Arrow {
                     kind: convert::callable_kind_from_ast(*kind),
                     input: Box::new(input),

--- a/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/compiler/qsc_frontend/src/typeck/rules.rs
@@ -400,7 +400,7 @@ impl<'a> Context<'a> {
                     .expect("return type should be present");
                 self.return_ty = prev_ret_ty;
                 self.inferrer
-                    .eq(body.span, output_ty.clone(), body_partial.ty);
+                    .eq(body.span, body_partial.ty, output_ty.clone());
                 converge(Ty::Arrow(Box::new(Arrow {
                     kind: convert::callable_kind_from_ast(*kind),
                     input: Box::new(input),

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -3189,7 +3189,7 @@ fn lambda_inner_return_without_call_ambiguous() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 40-112 "{\n        let f = (a, b) -> {\n            return a + b;\n        };\n    }" : Unit
             #12 54-55 "f" : ((?2, ?2) -> ?2)
@@ -3204,7 +3204,7 @@ fn lambda_inner_return_without_call_ambiguous() {
             #25 89-90 "a" : ?2
             #28 93-94 "b" : ?2
             Error(Type(Error(AmbiguousTy(Span { lo: 62, hi: 63 }))))
-        "##]],
+        "#]],
     );
 }
 

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -3192,17 +3192,18 @@ fn lambda_inner_return_without_call_ambiguous() {
         &expect![[r##"
             #6 30-32 "()" : Unit
             #10 40-112 "{\n        let f = (a, b) -> {\n            return a + b;\n        };\n    }" : Unit
-            #12 54-55 "f" : ((Unit, Unit) -> Unit)
-            #14 58-105 "(a, b) -> {\n            return a + b;\n        }" : ((Unit, Unit) -> Unit)
-            #15 58-64 "(a, b)" : (Unit, Unit)
-            #16 59-60 "a" : Unit
-            #18 62-63 "b" : Unit
-            #20 68-105 "{\n            return a + b;\n        }" : Unit
-            #21 68-105 "{\n            return a + b;\n        }" : Unit
+            #12 54-55 "f" : ((?2, ?2) -> ?2)
+            #14 58-105 "(a, b) -> {\n            return a + b;\n        }" : ((?2, ?2) -> ?2)
+            #15 58-64 "(a, b)" : (?2, ?2)
+            #16 59-60 "a" : ?2
+            #18 62-63 "b" : ?2
+            #20 68-105 "{\n            return a + b;\n        }" : ?2
+            #21 68-105 "{\n            return a + b;\n        }" : ?2
             #23 82-94 "return a + b" : Unit
-            #24 89-94 "a + b" : Unit
-            #25 89-90 "a" : Unit
-            #28 93-94 "b" : Unit
+            #24 89-94 "a + b" : ?2
+            #25 89-90 "a" : ?2
+            #28 93-94 "b" : ?2
+            Error(Type(Error(AmbiguousTy(Span { lo: 62, hi: 63 }))))
         "##]],
     );
 }
@@ -3220,21 +3221,21 @@ fn lambda_implicit_return_without_call_ambiguous() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 30-32 "()" : Unit
             #10 40-104 "{\n        let f = (a, b) -> {\n            a + b\n        };\n    }" : Unit
-            #12 54-55 "f" : ((?2, ?2) -> ?2)
-            #14 58-97 "(a, b) -> {\n            a + b\n        }" : ((?2, ?2) -> ?2)
-            #15 58-64 "(a, b)" : (?2, ?2)
-            #16 59-60 "a" : ?2
-            #18 62-63 "b" : ?2
-            #20 68-97 "{\n            a + b\n        }" : ?2
-            #21 68-97 "{\n            a + b\n        }" : ?2
-            #23 82-87 "a + b" : ?2
-            #24 82-83 "a" : ?2
-            #27 86-87 "b" : ?2
-            Error(Type(Error(AmbiguousTy(Span { lo: 62, hi: 63 }))))
-        "#]],
+            #12 54-55 "f" : ((?3, ?3) -> ?3)
+            #14 58-97 "(a, b) -> {\n            a + b\n        }" : ((?3, ?3) -> ?3)
+            #15 58-64 "(a, b)" : (?3, ?3)
+            #16 59-60 "a" : ?3
+            #18 62-63 "b" : ?3
+            #20 68-97 "{\n            a + b\n        }" : ?3
+            #21 68-97 "{\n            a + b\n        }" : ?3
+            #23 82-87 "a + b" : ?3
+            #24 82-83 "a" : ?3
+            #27 86-87 "b" : ?3
+            Error(Type(Error(AmbiguousTy(Span { lo: 68, hi: 97 }))))
+        "##]],
     );
 }
 

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -3164,8 +3164,8 @@ fn lambda_inner_return() {
             #12 54-55 "f" : (Unit -> Int)
             #14 58-98 "() -> {\n            return 42;\n        }" : (Unit -> Int)
             #15 58-60 "()" : Unit
-            #16 64-98 "{\n            return 42;\n        }" : Unit
-            #17 64-98 "{\n            return 42;\n        }" : Unit
+            #16 64-98 "{\n            return 42;\n        }" : Int
+            #17 64-98 "{\n            return 42;\n        }" : Int
             #19 78-87 "return 42" : Unit
             #20 85-87 "42" : Int
             #22 112-113 "r" : Int
@@ -3189,22 +3189,21 @@ fn lambda_inner_return_without_call_ambiguous() {
             }
         "},
         "",
-        &expect![[r#"
+        &expect![[r##"
             #6 30-32 "()" : Unit
             #10 40-112 "{\n        let f = (a, b) -> {\n            return a + b;\n        };\n    }" : Unit
-            #12 54-55 "f" : ((?2, ?2) -> ?2)
-            #14 58-105 "(a, b) -> {\n            return a + b;\n        }" : ((?2, ?2) -> ?2)
-            #15 58-64 "(a, b)" : (?2, ?2)
-            #16 59-60 "a" : ?2
-            #18 62-63 "b" : ?2
+            #12 54-55 "f" : ((Unit, Unit) -> Unit)
+            #14 58-105 "(a, b) -> {\n            return a + b;\n        }" : ((Unit, Unit) -> Unit)
+            #15 58-64 "(a, b)" : (Unit, Unit)
+            #16 59-60 "a" : Unit
+            #18 62-63 "b" : Unit
             #20 68-105 "{\n            return a + b;\n        }" : Unit
             #21 68-105 "{\n            return a + b;\n        }" : Unit
             #23 82-94 "return a + b" : Unit
-            #24 89-94 "a + b" : ?2
-            #25 89-90 "a" : ?2
-            #28 93-94 "b" : ?2
-            Error(Type(Error(AmbiguousTy(Span { lo: 62, hi: 63 }))))
-        "#]],
+            #24 89-94 "a + b" : Unit
+            #25 89-90 "a" : Unit
+            #28 93-94 "b" : Unit
+        "##]],
     );
 }
 

--- a/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/compiler/qsc_frontend/src/typeck/tests.rs
@@ -3221,7 +3221,7 @@ fn lambda_implicit_return_without_call_ambiguous() {
             }
         "},
         "",
-        &expect![[r##"
+        &expect![[r#"
             #6 30-32 "()" : Unit
             #10 40-104 "{\n        let f = (a, b) -> {\n            a + b\n        };\n    }" : Unit
             #12 54-55 "f" : ((?3, ?3) -> ?3)
@@ -3235,7 +3235,7 @@ fn lambda_implicit_return_without_call_ambiguous() {
             #24 82-83 "a" : ?3
             #27 86-87 "b" : ?3
             Error(Type(Error(AmbiguousTy(Span { lo: 68, hi: 97 }))))
-        "##]],
+        "#]],
     );
 }
 

--- a/compiler/qsc_rca/src/tests/lambdas.rs
+++ b/compiler/qsc_rca/src/tests/lambdas.rs
@@ -217,3 +217,41 @@ fn check_rca_for_operation_lambda_two_parameters_with_controls() {
                 dynamic_param_applications: <empty>"#]],
     );
 }
+
+#[test]
+fn check_rca_for_function_lambda_using_array_slicing_with_explicit_return() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let lambda = (a, n) -> { return a[...n - 1] };
+        lambda([1, 2, 3], 2)
+        "#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}
+
+#[test]
+fn check_rca_for_function_lambda_using_array_slicing_with_implicit_return() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        let lambda = (a, n) -> { a[...n - 1] };
+        lambda([1, 2, 3], 2)
+        "#,
+    );
+    let package_store_compute_properties = compilation_context.get_compute_properties();
+    check_last_statement_compute_properties(
+        package_store_compute_properties,
+        &expect![[r#"
+            ApplicationsGeneratorSet:
+                inherent: Classical
+                dynamic_param_applications: <empty>"#]],
+    );
+}


### PR DESCRIPTION
This fixes a quirk leftover from the fixes in #649 and #793. Those introduced and then updated a conditional that avoided unifying certain types during type checking, but it turns out it was always safe to unconditionally unify the types once #649 introduced the explicit return type tracking. With this fix, the lifted lambda callables with explicit returns have the correct output type instead of always being `Unit` and RCA is able to use that type information as expected, avoiding the panic.

Fixes #2186