### PR TITLE
Fix Run and Debug buttons

### DIFF
--- a/vscode/src/debugger/activate.ts
+++ b/vscode/src/debugger/activate.ts
@@ -45,21 +45,33 @@ function registerCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       `${qsharpExtensionId}.runEditorContents`,
-      (resource: vscode.Uri, expr?: string) =>
+      (resource: vscode.Uri, expr?: string) => {
+        // if expr is not a string, ignore it. VS Code can sometimes
+        // pass other types when this command is invoked via UI buttons.
+        if (typeof expr !== "string") {
+          expr = undefined;
+        }
         startDebugging(
           resource,
           { name: "Run Q# File", stopOnEntry: false, entry: expr },
           { noDebug: true },
-        ),
+        );
+      },
     ),
     vscode.commands.registerCommand(
       `${qsharpExtensionId}.debugEditorContents`,
-      (resource: vscode.Uri, expr?: string) =>
+      (resource: vscode.Uri, expr?: string) => {
+        // if expr is not a string, ignore it. VS Code can sometimes
+        // pass other types when this command is invoked via UI buttons.
+        if (typeof expr !== "string") {
+          expr = undefined;
+        }
         startDebugging(resource, {
           name: "Debug Q# File",
           stopOnEntry: true,
           entry: expr,
-        }),
+        });
+      },
     ),
     vscode.commands.registerCommand(
       `${qsharpExtensionId}.runEditorContentsWithCircuit`,


### PR DESCRIPTION
The change in #2174 broke the Run/Debug UI buttons, as it turns out they pass extra parameters that the code used to ignore and were now being treated as string input. This adds some runtime type checking to protect against that.

When invoked via code lens, the command receives the entry expression as expected with the updates:
<img width="321" alt="image" src="https://github.com/user-attachments/assets/1a7f653d-305b-4f2b-8f7d-98e55333de95" />

When invoked via the command palette, the entry expression is undefined, which makes sense because it is a new paramter that was never meant to be passed in that scenario:
<img width="321" alt="image" src="https://github.com/user-attachments/assets/13315a2f-97ab-4783-81f9-a0853e4ce9d9" />

But when invoked via the UI "Run" button, the new paramter receives an object that presumably describes the UI element:
<img width="321" alt="image" src="https://github.com/user-attachments/assets/f8a63816-2c9e-4ad0-abd8-52d35366bf23" />

This unexpected input was later treated as a string, passed over the FFI into Rust, and then triggered an out-of-bounds memory read.