### PR TITLE
Chemistry lib: readablility, lints, syntax, tests

### DIFF
--- a/library/chemistry/qsharp.json
+++ b/library/chemistry/qsharp.json
@@ -23,6 +23,22 @@
     {
       "lint": "needlessParens",
       "level": "error"
+    },
+    {
+      "lint": "doubleEquality",
+      "level": "error"
+    },
+    {
+      "lint": "redundantSemicolons",
+      "level": "error"
+    },
+    {
+      "lint": "discourageChainAssignment",
+      "level": "error"
+    },
+    {
+      "lint": "needlessOperation",
+      "level": "error"
     }
   ],
   "files": [

--- a/library/chemistry/src/JordanWigner/Convenience.qs
+++ b/library/chemistry/src/JordanWigner/Convenience.qs
@@ -50,10 +50,9 @@ function TrotterStepOracle(jwHamiltonian : JordanWignerEncodingData, trotterStep
 
 function QubitizationOracleSeperatedRegisters(jwHamiltonian : JordanWignerEncodingData) : ((Int, Int), (Double, ((Qubit[], Qubit[]) => Unit is Adj + Ctl))) {
     let generatorSystem = JordanWignerBlockEncodingGeneratorSystem(jwHamiltonian.Terms);
-    let (nTerms, genIdxFunction) = generatorSystem!;
     let (oneNorm, blockEncodingReflection) = PauliBlockEncoding(generatorSystem);
     let nTargetRegisterQubits = jwHamiltonian.NumQubits;
-    let nCtrlRegisterQubits = Ceiling(Lg(IntAsDouble(nTerms)));
+    let nCtrlRegisterQubits = Ceiling(Lg(IntAsDouble(generatorSystem.NumEntries)));
     return ((nCtrlRegisterQubits, nTargetRegisterQubits), (oneNorm, QuantumWalkByQubitization(blockEncodingReflection)));
 }
 

--- a/library/chemistry/src/JordanWigner/Convenience.qs
+++ b/library/chemistry/src/JordanWigner/Convenience.qs
@@ -6,6 +6,10 @@ export
     QubitizationOracle,
     OptimizedQubitizationOracle;
 
+import Std.Convert.IntAsDouble;
+import Std.Math.Ceiling;
+import Std.Math.Lg;
+
 import JordanWigner.JordanWignerBlockEncoding.JordanWignerBlockEncodingGeneratorSystem;
 import JordanWigner.JordanWignerEvolutionSet.JordanWignerFermionEvolutionSet;
 import JordanWigner.JordanWignerEvolutionSet.JordanWignerGeneratorSystem;
@@ -13,11 +17,7 @@ import JordanWigner.JordanWignerOptimizedBlockEncoding.JordanWignerOptimizedBloc
 import JordanWigner.JordanWignerOptimizedBlockEncoding.PauliBlockEncoding;
 import JordanWigner.JordanWignerOptimizedBlockEncoding.QuantumWalkByQubitization;
 import JordanWigner.Utils.JordanWignerEncodingData;
-import JordanWigner.Utils.MultiplexOperationsFromGenerator;
 import JordanWigner.Utils.TrotterSimulationAlgorithm;
-import Std.Convert.IntAsDouble;
-import Std.Math.Ceiling;
-import Std.Math.Lg;
 import Utils.EvolutionGenerator;
 
 // Convenience functions for performing simulation.

--- a/library/chemistry/src/JordanWigner/ConvenienceVQE.qs
+++ b/library/chemistry/src/JordanWigner/ConvenienceVQE.qs
@@ -5,6 +5,8 @@ export
     EstimateEnergyWrapper,
     EstimateEnergy;
 
+import Std.Math.Complex;
+
 import JordanWigner.JordanWignerEvolutionSet.JordanWignerGeneratorSystem;
 import JordanWigner.JordanWignerVQE.EstimateTermExpectation;
 import JordanWigner.JordanWignerVQE.ExpandedCoefficients;
@@ -36,8 +38,8 @@ operation EstimateEnergyWrapper(jwHamiltonian : (Int, ((Int[], Double[])[], (Int
     let (inputState1, inputState2) = inputState;
     mutable jwInputState = [];
     for entry in inputState2 {
-        let (amp, idicies) = entry;
-        jwInputState += [new JordanWignerInputState { Amplitude = amp, FermionIndices = idicies }];
+        let ((r, i), idicies) = entry;
+        jwInputState += [new JordanWignerInputState { Amplitude = new Complex { Real = r, Imag = i }, FermionIndices = idicies }];
     }
     let inputState = (inputState1, jwInputState);
     let jwHamiltonian = new JordanWignerEncodingData {

--- a/library/chemistry/src/JordanWigner/ConvenienceVQE.qs
+++ b/library/chemistry/src/JordanWigner/ConvenienceVQE.qs
@@ -67,26 +67,26 @@ operation EstimateEnergy(jwHamiltonian : JordanWignerEncodingData, nSamples : In
     // Initialize return value
     mutable energy = 0.;
 
-    // Unpack information and qubit Hamiltonian terms
-    let (nQubits, jwTerms, inputState, energyOffset) = jwHamiltonian!;
+    let nQubits = jwHamiltonian.NumQubits;
 
     // Loop over all qubit Hamiltonian terms
-    let (nTerms, indexFunction) = (JordanWignerGeneratorSystem(jwTerms))!;
+    let generatorSystem = JordanWignerGeneratorSystem(jwHamiltonian.Terms);
 
-    for idxTerm in 0..nTerms - 1 {
-        let term = indexFunction(idxTerm);
-        let ((idxTermType, coeff), idxFermions) = term!;
+    for idxTerm in 0..generatorSystem.NumEntries - 1 {
+        let term = generatorSystem.EntryAt(idxTerm);
+        let (idxTermType, coeff) = term.Term;
+        let idxFermions = term.Subsystem;
         let termType = idxTermType[0];
 
         let ops = MeasurementOperators(nQubits, idxFermions, termType);
         let coeffs = ExpandedCoefficients(coeff, termType);
 
         // The private wrapper enables fast emulation during expectation estimation
-        let inputStateUnitary = PrepareTrialState(inputState, _);
+        let inputStateUnitary = PrepareTrialState(jwHamiltonian.InputState, _);
 
         let jwTermEnergy = EstimateTermExpectation(inputStateUnitary, ops, coeffs, nQubits, nSamples);
         energy += jwTermEnergy;
     }
 
-    return energy + energyOffset;
+    return energy + jwHamiltonian.EnergyOffset;
 }

--- a/library/chemistry/src/JordanWigner/JordanWignerBlockEncoding.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerBlockEncoding.qs
@@ -3,9 +3,10 @@
 
 export JordanWignerBlockEncodingGeneratorSystem;
 
+import Std.Arrays.IndexRange;
+
 import JordanWigner.Utils.JWOptimizedHTerms;
 import JordanWigner.Utils.RangeAsIntArray;
-import Std.Arrays.IndexRange;
 import Utils.GeneratorIndex;
 import Utils.GeneratorSystem;
 import Utils.HTermToGenIdx;

--- a/library/chemistry/src/JordanWigner/JordanWignerBlockEncoding.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerBlockEncoding.qs
@@ -164,7 +164,10 @@ function V0123TermToPauliGenIdx(term : GeneratorIndex) : GeneratorIndex[] {
 /// # Output
 /// Representation of Hamiltonian as `GeneratorSystem`.
 function JordanWignerBlockEncodingGeneratorSystem(data : JWOptimizedHTerms) : GeneratorSystem {
-    let (ZData, ZZData, PQandPQQRData, h0123Data) = data!;
+    let ZData = data.HTerm0;
+    let ZZData = data.HTerm1;
+    let PQandPQQRData = data.HTerm2;
+    let h0123Data = data.HTerm3;
     mutable genIdxes = Repeated(
         new GeneratorIndex { Term = ([0], [0.0]), Subsystem = [0] },
         ((Length(ZData) + Length(ZZData)) + 2 * Length(PQandPQQRData)) + 8 * Length(h0123Data)

--- a/library/chemistry/src/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
@@ -90,7 +90,8 @@ function ComputeJordanWignerPauliString(nFermions : Int, idxFermions : Int[], pa
 /// ## qubits
 /// Qubits of Hamiltonian.
 operation ApplyJordanWignerClusterOperatorPQTerm(term : GeneratorIndex, stepSize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
-    let ((idxTermType, coeff), idxFermions) = term!;
+    let (_, coeff) = term.Term;
+    let idxFermions = term.Subsystem;
     let p = idxFermions[0];
     let q = idxFermions[1];
     if p == q {
@@ -118,7 +119,8 @@ operation ApplyJordanWignerClusterOperatorPQTerm(term : GeneratorIndex, stepSize
 /// ## qubits
 /// Qubits of Hamiltonian.
 operation ApplyJordanWignerClusterOperatorPQRSTerm(term : GeneratorIndex, stepSize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
-    let ((idxTermType, coeff), idxFermions) = term!;
+    let (_, coeff) = term.Term;
+    let idxFermions = term.Subsystem;
     let p = idxFermions[0];
     let q = idxFermions[1];
     let r = idxFermions[2];
@@ -204,7 +206,8 @@ function JordanWignerClusterOperatorGeneratorSystem(data : JordanWignerInputStat
 }
 
 function JordanWignerStateAsGeneratorIndex(data : JordanWignerInputState[], idx : Int) : GeneratorIndex {
-    let ((real, imaginary), idxFermions) = data[idx]!;
+    let (real, imaginary) = data[idx].Amplitude;
+    let idxFermions = data[idx].FermionIndices;
 
     if Length(idxFermions) == 2 {
         // PQ term
@@ -230,7 +233,7 @@ function JordanWignerStateAsGeneratorIndex(data : JordanWignerInputState[], idx 
 /// ## qubits
 /// Register acted upon by time-evolution operator.
 operation JordanWignerClusterOperatorImpl(generatorIndex : GeneratorIndex, stepSize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
-    let ((idxTermType, idxDoubles), idxFermions) = generatorIndex!;
+    let (idxTermType, _) = generatorIndex.Term;
     let termType = idxTermType[0];
 
     if termType == 0 {

--- a/library/chemistry/src/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
@@ -72,7 +72,8 @@ function ComputeJordanWignerPauliZString(nFermions : Int, idxFermions : Int[]) :
 function ComputeJordanWignerPauliString(
     nFermions : Int,
     idxFermions : Int[],
-    pauliReplacements : Pauli[]) : Pauli[] {
+    pauliReplacements : Pauli[]
+) : Pauli[] {
 
     mutable pauliString = ComputeJordanWignerPauliZString(nFermions, idxFermions);
 
@@ -98,7 +99,8 @@ function ComputeJordanWignerPauliString(
 operation ApplyJordanWignerClusterOperatorPQTerm(
     term : GeneratorIndex,
     stepSize : Double,
-    qubits : Qubit[]) : Unit is Adj + Ctl {
+    qubits : Qubit[]
+) : Unit is Adj + Ctl {
 
     let (_, coeff) = term.Term;
     let idxFermions = term.Subsystem;
@@ -131,7 +133,8 @@ operation ApplyJordanWignerClusterOperatorPQTerm(
 operation ApplyJordanWignerClusterOperatorPQRSTerm(
     term : GeneratorIndex,
     stepSize : Double,
-    qubits : Qubit[]) : Unit is Adj + Ctl {
+    qubits : Qubit[]
+) : Unit is Adj + Ctl {
 
     let (_, coeff) = term.Term;
     let idxFermions = term.Subsystem;
@@ -162,8 +165,8 @@ function JordanWignerClusterOperatorPQRSTermSigns(indices : Int[]) : (Int[], Dou
     let q = indices[1];
     let r = indices[2];
     let s = indices[3];
-    mutable sorted = [0,0,0,0];
-    mutable signs = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0];
+    mutable sorted = [0, 0, 0, 0];
+    mutable signs = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
     mutable sign = 1.0;
 
     if (p > q) {
@@ -216,7 +219,8 @@ function JordanWignerClusterOperatorPQRSTermSigns(indices : Int[]) : (Int[], Dou
 /// # Output
 /// Representation of Hamiltonian as `GeneratorSystem`.
 function JordanWignerClusterOperatorGeneratorSystem(
-    data : JordanWignerInputState[]) : GeneratorSystem {
+    data : JordanWignerInputState[]
+) : GeneratorSystem {
     new GeneratorSystem {
         NumEntries = Length(data),
         EntryAt = JordanWignerStateAsGeneratorIndex(data, _)
@@ -253,7 +257,8 @@ function JordanWignerStateAsGeneratorIndex(data : JordanWignerInputState[], idx 
 operation JordanWignerClusterOperatorImpl(
     generatorIndex : GeneratorIndex,
     stepSize : Double,
-    qubits : Qubit[]) : Unit is Adj + Ctl {
+    qubits : Qubit[]
+) : Unit is Adj + Ctl {
 
     let (idxTermType, _) = generatorIndex.Term;
     let termType = idxTermType[0];

--- a/library/chemistry/src/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
@@ -5,10 +5,11 @@ export
     JordanWignerClusterOperatorEvolutionSet,
     JordanWignerClusterOperatorGeneratorSystem;
 
-import JordanWigner.Utils.JordanWignerInputState;
 import Std.Arrays.IndexRange;
 import Std.Math.Max;
 import Std.Math.Min;
+
+import JordanWigner.Utils.JordanWignerInputState;
 import Utils.GeneratorIndex;
 import Utils.GeneratorSystem;
 
@@ -28,19 +29,20 @@ import Utils.GeneratorSystem;
 ///
 /// # Example
 /// ```qsharp
-/// let bitString = ComputeJordanWignerBitString(6, [0,1,2,6]) ;
-/// // bitString is [false, false, false ,true, true, true, false].
+/// let bitString = ComputeJordanWignerBitString(5, [0, 3]) ;
+/// // bitString is [false, true, true, false, false].
 /// ```
 function ComputeJordanWignerBitString(nFermions : Int, idxFermions : Int[]) : Bool[] {
     if Length(idxFermions) % 2 != 0 {
         fail $"ComputeJordanWignerString failed. `idxFermions` must contain an even number of terms.";
     }
 
-    mutable zString = [false, size = nFermions];
+    mutable zString = Repeated(false, nFermions);
     for fermionIdx in idxFermions {
         if fermionIdx >= nFermions {
             fail $"ComputeJordanWignerString failed. fermionIdx {fermionIdx} out of range.";
         }
+        // NOTE: This could be optimized
         for idx in 0..fermionIdx {
             zString w/= idx <- not zString[idx];
         }
@@ -67,7 +69,11 @@ function ComputeJordanWignerPauliZString(nFermions : Int, idxFermions : Int[]) :
 
 // Identical to `ComputeJordanWignerPauliZString`, except that some
 // specified elements are substituted.
-function ComputeJordanWignerPauliString(nFermions : Int, idxFermions : Int[], pauliReplacements : Pauli[]) : Pauli[] {
+function ComputeJordanWignerPauliString(
+    nFermions : Int,
+    idxFermions : Int[],
+    pauliReplacements : Pauli[]) : Pauli[] {
+
     mutable pauliString = ComputeJordanWignerPauliZString(nFermions, idxFermions);
 
     for idx in IndexRange(idxFermions) {
@@ -89,7 +95,11 @@ function ComputeJordanWignerPauliString(nFermions : Int, idxFermions : Int[], pa
 /// Duration of time-evolution.
 /// ## qubits
 /// Qubits of Hamiltonian.
-operation ApplyJordanWignerClusterOperatorPQTerm(term : GeneratorIndex, stepSize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
+operation ApplyJordanWignerClusterOperatorPQTerm(
+    term : GeneratorIndex,
+    stepSize : Double,
+    qubits : Qubit[]) : Unit is Adj + Ctl {
+
     let (_, coeff) = term.Term;
     let idxFermions = term.Subsystem;
     let p = idxFermions[0];
@@ -118,7 +128,11 @@ operation ApplyJordanWignerClusterOperatorPQTerm(term : GeneratorIndex, stepSize
 /// Duration of time-evolution.
 /// ## qubits
 /// Qubits of Hamiltonian.
-operation ApplyJordanWignerClusterOperatorPQRSTerm(term : GeneratorIndex, stepSize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
+operation ApplyJordanWignerClusterOperatorPQRSTerm(
+    term : GeneratorIndex,
+    stepSize : Double,
+    qubits : Qubit[]) : Unit is Adj + Ctl {
+
     let (_, coeff) = term.Term;
     let idxFermions = term.Subsystem;
     let p = idxFermions[0];
@@ -148,8 +162,8 @@ function JordanWignerClusterOperatorPQRSTermSigns(indices : Int[]) : (Int[], Dou
     let q = indices[1];
     let r = indices[2];
     let s = indices[3];
-    mutable sorted = [0, size = 4];
-    mutable signs = [0.0, size = 8];
+    mutable sorted = [0,0,0,0];
+    mutable signs = [0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0];
     mutable sign = 1.0;
 
     if (p > q) {
@@ -201,12 +215,16 @@ function JordanWignerClusterOperatorPQRSTermSigns(indices : Int[]) : (Int[], Dou
 ///
 /// # Output
 /// Representation of Hamiltonian as `GeneratorSystem`.
-function JordanWignerClusterOperatorGeneratorSystem(data : JordanWignerInputState[]) : GeneratorSystem {
-    new GeneratorSystem { NumEntries = Length(data), EntryAt = JordanWignerStateAsGeneratorIndex(data, _) }
+function JordanWignerClusterOperatorGeneratorSystem(
+    data : JordanWignerInputState[]) : GeneratorSystem {
+    new GeneratorSystem {
+        NumEntries = Length(data),
+        EntryAt = JordanWignerStateAsGeneratorIndex(data, _)
+    }
 }
 
 function JordanWignerStateAsGeneratorIndex(data : JordanWignerInputState[], idx : Int) : GeneratorIndex {
-    let (real, imaginary) = data[idx].Amplitude;
+    let real = data[idx].Amplitude.Real;
     let idxFermions = data[idx].FermionIndices;
 
     if Length(idxFermions) == 2 {
@@ -232,7 +250,11 @@ function JordanWignerStateAsGeneratorIndex(data : JordanWignerInputState[], idx 
 /// Dummy variable to match signature of simulation algorithms.
 /// ## qubits
 /// Register acted upon by time-evolution operator.
-operation JordanWignerClusterOperatorImpl(generatorIndex : GeneratorIndex, stepSize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
+operation JordanWignerClusterOperatorImpl(
+    generatorIndex : GeneratorIndex,
+    stepSize : Double,
+    qubits : Qubit[]) : Unit is Adj + Ctl {
+
     let (idxTermType, _) = generatorIndex.Term;
     let termType = idxTermType[0];
 

--- a/library/chemistry/src/JordanWigner/JordanWignerEvolutionSet.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerEvolutionSet.qs
@@ -77,7 +77,8 @@ operation ApplyJordanWignerZZTerm(term : GeneratorIndex, stepSize : Double, qubi
 /// ## qubits
 /// Qubits of Hamiltonian.
 operation ApplyJordanWignerPQTerm(term : GeneratorIndex, stepSize : Double, extraParityQubits : Qubit[], qubits : Qubit[]) : Unit is Adj + Ctl {
-    let ((idxTermType, coeff), idxFermions) = term!;
+    let (_, coeff) = term.Term;
+    let idxFermions = term.Subsystem;
     let angle = (1.0 * coeff[0]) * stepSize;
     let qubitsPQ = Subarray(idxFermions[0..1], qubits);
     let qubitsJW = qubits[idxFermions[0] + 1..idxFermions[1] - 1];
@@ -101,7 +102,8 @@ operation ApplyJordanWignerPQTerm(term : GeneratorIndex, stepSize : Double, extr
 /// ## qubits
 /// Qubits of Hamiltonian.
 operation ApplyJordanWignerPQandPQQRTerm(term : GeneratorIndex, stepSize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
-    let ((idxTermType, coeff), idxFermions) = term!;
+    let (idxTermType, coeff) = term.Term;
+    let idxFermions = term.Subsystem;
     let angle = (1.0 * coeff[0]) * stepSize;
     let qubitQidx = idxFermions[1];
 
@@ -138,7 +140,8 @@ operation ApplyJordanWignerPQandPQQRTerm(term : GeneratorIndex, stepSize : Doubl
 /// ## qubits
 /// Qubits to apply the given term to.
 operation ApplyJordanWigner0123Term(term : GeneratorIndex, stepSize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
-    let ((idxTermType, v0123), idxFermions) = term!;
+    let (idxTermType, v0123) = term.Term;
+    let idxFermions = term.Subsystem;
     let angle = stepSize;
     let qubitsPQ = Subarray(idxFermions[0..1], qubits);
     let qubitsRS = Subarray(idxFermions[2..3], qubits);
@@ -166,7 +169,10 @@ operation ApplyJordanWigner0123Term(term : GeneratorIndex, stepSize : Double, qu
 /// # Output
 /// Representation of Hamiltonian as `GeneratorSystem`.
 function JordanWignerGeneratorSystem(data : JWOptimizedHTerms) : GeneratorSystem {
-    let (ZData, ZZData, PQandPQQRData, h0123Data) = data!;
+    let ZData = data.HTerm0;
+    let ZZData = data.HTerm1;
+    let PQandPQQRData = data.HTerm2;
+    let h0123Data = data.HTerm3;
     let ZGenSys = HTermsToGenSys(ZData, [0]);
     let ZZGenSys = HTermsToGenSys(ZZData, [1]);
     let PQandPQQRGenSys = HTermsToGenSys(PQandPQQRData, [2]);
@@ -214,7 +220,7 @@ function AddGeneratorSystems(generatorSystemA : GeneratorSystem, generatorSystem
 /// ## qubits
 /// Register acted upon by time-evolution operator.
 operation JordanWignerFermionImpl(generatorIndex : GeneratorIndex, stepSize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
-    let ((idxTermType, idxDoubles), idxFermions) = generatorIndex!;
+    let (idxTermType, idxDoubles) = generatorIndex.Term;
     let termType = idxTermType[0];
 
     if (termType == 0) {

--- a/library/chemistry/src/JordanWigner/JordanWignerEvolutionSet.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerEvolutionSet.qs
@@ -5,9 +5,10 @@ export
     JordanWignerGeneratorSystem,
     JordanWignerFermionEvolutionSet;
 
-import JordanWigner.Utils.JWOptimizedHTerms;
 import Std.Arrays.IndexRange;
 import Std.Arrays.Subarray;
+
+import JordanWigner.Utils.JWOptimizedHTerms;
 import Utils.GeneratorIndex;
 import Utils.GeneratorSystem;
 import Utils.HTermsToGenSys;

--- a/library/chemistry/src/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
@@ -53,17 +53,12 @@ struct OptimizedBEGeneratorSystem {
     SelectTerm : (Int -> OptimizedBETermIndex)
 }
 
-// Get OptimizedBETermIndex coefficients
-function GetOptimizedBETermIndexCoeff(term : OptimizedBETermIndex) : Double {
-    term.Coefficient
-}
-
 
 // Get OptimizedBEGeneratorSystem coefficients
 function OptimizedBEGeneratorSystemCoeff(optimizedBEGeneratorSystem : OptimizedBEGeneratorSystem) : Double[] {
     mutable coefficients = [];
     for idx in 0..optimizedBEGeneratorSystem.NumTerms - 1 {
-        coefficients += [GetOptimizedBETermIndexCoeff(optimizedBEGeneratorSystem.SelectTerm(idx))];
+        coefficients += [optimizedBEGeneratorSystem.SelectTerm(idx).Coefficient];
     }
     return coefficients;
 }
@@ -312,7 +307,7 @@ function OptimizedBlockEncodingGeneratorSystem(data : JWOptimizedHTerms) : Optim
     mutable oneNorm = 0.0;
 
     for idx in 0..finalIdx - 1 {
-        oneNorm = oneNorm + AbsD(GetOptimizedBETermIndexCoeff(majIdxes[idx]));
+        oneNorm = oneNorm + AbsD(majIdxes[idx].Coefficient);
     }
 
     let majIdxes = majIdxes[0..finalIdx - 1];

--- a/library/chemistry/src/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
@@ -54,20 +54,16 @@ struct OptimizedBEGeneratorSystem {
 
 // Get OptimizedBETermIndex coefficients
 function GetOptimizedBETermIndexCoeff(term : OptimizedBETermIndex) : Double {
-    let (a, b, c, d, e, f) = term!;
-    return a;
+    term.Coefficient
 }
 
 
 // Get OptimizedBEGeneratorSystem coefficients
 function OptimizedBEGeneratorSystemCoeff(optimizedBEGeneratorSystem : OptimizedBEGeneratorSystem) : Double[] {
-    let (nTerms, oneNorm, intToGenIdx) = optimizedBEGeneratorSystem!;
-    mutable coefficients = [0.0, size = nTerms];
-
-    for idx in 0..nTerms - 1 {
-        coefficients w/= idx <- GetOptimizedBETermIndexCoeff(intToGenIdx(idx));
+    mutable coefficients = [];
+    for idx in 0..optimizedBEGeneratorSystem.NumTerms - 1 {
+        coefficients += [GetOptimizedBETermIndexCoeff(optimizedBEGeneratorSystem.SelectTerm(idx))];
     }
-
     return coefficients;
 }
 
@@ -83,7 +79,8 @@ function OptimizedBEGeneratorSystemCoeff(optimizedBEGeneratorSystem : OptimizedB
 /// # Output
 /// `GeneratorIndex[]` expressing Z term as Pauli terms.
 function ZTermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermIndex {
-    let ((idxTermType, coeff), idxFermions) = term!;
+    let (_, coeff) = term.Term;
+    let idxFermions = term.Subsystem;
     let signQubit = coeff[0] < 0.0;
     let selectZControlRegisters = [true];
     let optimizedBEControlRegisters = [];
@@ -111,7 +108,8 @@ function ZTermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermIndex {
 /// # Output
 /// `GeneratorIndex[]` expressing ZZ term as Pauli terms.
 function ZZTermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermIndex {
-    let ((idxTermType, coeff), idxFermions) = term!;
+    let (_, coeff) = term.Term;
+    let idxFermions = term.Subsystem;
     let signQubit = coeff[0] < 0.0;
     let selectZControlRegisters = [true, true];
     let optimizedBEControlRegisters = [];
@@ -139,7 +137,8 @@ function ZZTermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermIndex {
 /// # Output
 /// `GeneratorIndex[]` expressing PQ term as Pauli terms.
 function PQTermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermIndex {
-    let ((idxTermType, coeff), idxFermions) = term!;
+    let (_, coeff) = term.Term;
+    let idxFermions = term.Subsystem;
     let sign = coeff[0] < 0.0;
     let selectZControlRegisters = [];
     let optimizedBEControlRegisters = [true, true];
@@ -167,7 +166,8 @@ function PQTermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermIndex {
 /// # Output
 /// `GeneratorIndex[]` expressing PQ or PQQR term as Pauli terms.
 function PQandPQQRTermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermIndex {
-    let ((idxTermType, coeff), idxFermions) = term!;
+    let (_, coeff) = term.Term;
+    let idxFermions = term.Subsystem;
     let sign = coeff[0] < 0.0;
 
     if Length(idxFermions) == 2 {
@@ -203,7 +203,8 @@ function PQandPQQRTermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermInde
 /// # Output
 /// `GeneratorIndex[]` expressing PQRS term as Pauli terms.
 function V0123TermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermIndex[] {
-    let ((idxTermType, v0123), idxFermions) = term!;
+    let (_, v0123) = term.Term;
+    let idxFermions = term.Subsystem;
     let qubitsPQ = idxFermions[0..1];
     let qubitsRS = idxFermions[2..3];
     let qubitsPQJW = RangeAsIntArray(qubitsPQ[0] + 1..qubitsPQ[1] - 1);
@@ -256,7 +257,10 @@ function V0123TermToPauliMajIdx(term : GeneratorIndex) : OptimizedBETermIndex[] 
 /// # Output
 /// Representation of Hamiltonian as `GeneratorSystem`.
 function OptimizedBlockEncodingGeneratorSystem(data : JWOptimizedHTerms) : OptimizedBEGeneratorSystem {
-    let (ZData, ZZData, PQandPQQRData, h0123Data) = data!;
+    let ZData = data.HTerm0;
+    let ZZData = data.HTerm1;
+    let PQandPQQRData = data.HTerm2;
+    let h0123Data = data.HTerm3;
     mutable majIdxes = Repeated(
         new OptimizedBETermIndex {
             Coefficient = 0.0,
@@ -324,15 +328,15 @@ operation ToJordanWignerSelectInput(
     pauliBasesIdx : Qubit[],
     indexRegisters : Qubit[][]
 ) : Unit is Adj + Ctl {
-    let (nTerms, oneNorm, intToGenIdx) = optimizedBEGeneratorSystem!;
-    let (coeff, signQubitSet, selectZControlRegistersSet, OptimizedBEControlRegistersSet, pauliBasesSet, indexRegistersSet) = (intToGenIdx(idx))!;
+    let optimizedBETermIndex = optimizedBEGeneratorSystem.SelectTerm(idx);
 
     // Write bit to apply - signQubit
-    if (signQubitSet == true) {
+    if optimizedBETermIndex.UseSignQubit {
         X(signQubit);
     }
 
     // Write bit to activate selectZ operator
+    let selectZControlRegistersSet = optimizedBETermIndex.ZControlRegisterMask;
     for i in IndexRange(selectZControlRegistersSet) {
         if selectZControlRegistersSet[i] {
             X(selectZControlRegisters[i]);
@@ -340,18 +344,21 @@ operation ToJordanWignerSelectInput(
     }
 
     // Write bit to activate OptimizedBEXY operator
-    for i in IndexRange(OptimizedBEControlRegistersSet) {
-        if OptimizedBEControlRegistersSet[i] {
+    let optimizedBEControlRegistersSet = optimizedBETermIndex.OptimizedControlRegisterMask;
+    for i in IndexRange(optimizedBEControlRegistersSet) {
+        if optimizedBEControlRegistersSet[i] {
             X(optimizedBEControlRegisters[i]);
         }
     }
 
     // Write bitstring to apply desired XZ... or YZ... Pauli string
+    let indexRegistersSet = optimizedBETermIndex.RegisterIndices;
     for i in IndexRange(indexRegistersSet) {
         ApplyXorInPlace(indexRegistersSet[i], indexRegisters[i]);
     }
 
     // Crete state to select uniform superposition of X and Y operators.
+    let pauliBasesSet = optimizedBETermIndex.PauliBases;
     if Length(pauliBasesSet) == 2 {
         // for PQ or PQQR terms, create |00> + |11>
         ApplyXorInPlace(0, pauliBasesIdx);
@@ -385,66 +392,163 @@ operation ToPauliBases(idx : Int, pauliBases : Qubit[]) : Unit is Adj + Ctl {
 }
 
 // This prepares the state that selects _JordanWignerSelect_;
-operation JordanWignerOptimizedBlockEncodingStatePrep(targetError : Double, optimizedBEGeneratorSystem : OptimizedBEGeneratorSystem, qROMIdxRegister : Qubit[], qROMGarbage : Qubit[], signQubit : Qubit, selectZControlRegisters : Qubit[], optimizedBEControlRegisters : Qubit[], pauliBases : Qubit[], pauliBasesIdx : Qubit[], indexRegisters : Qubit[][]) : Unit is Adj + Ctl {
-    let (nTerms, _, _) = optimizedBEGeneratorSystem!;
+operation JordanWignerOptimizedBlockEncodingStatePrep(
+    targetError : Double,
+    optimizedBEGeneratorSystem : OptimizedBEGeneratorSystem,
+    qROMIdxRegister : Qubit[],
+    qROMGarbage : Qubit[],
+    signQubit : Qubit,
+    selectZControlRegisters : Qubit[],
+    optimizedBEControlRegisters : Qubit[],
+    pauliBases : Qubit[],
+    pauliBasesIdx : Qubit[],
+    indexRegisters : Qubit[][]
+) : Unit is Adj + Ctl {
+
     let coefficients = OptimizedBEGeneratorSystemCoeff(optimizedBEGeneratorSystem);
     let purifiedState = PurifiedMixedState(targetError, coefficients);
-    let unitaryGenerator = (nTerms, idx -> ToJordanWignerSelectInput(idx, optimizedBEGeneratorSystem, _, _, _, _, _));
+    let unitaryGenerator = (
+        optimizedBEGeneratorSystem.NumTerms,
+        idx -> ToJordanWignerSelectInput(idx, optimizedBEGeneratorSystem, _, _, _, _, _)
+    );
     let pauliBasesUnitaryGenerator = (5, idx -> (qs => ToPauliBases(idx, qs)));
 
     purifiedState.Prepare(qROMIdxRegister, [], qROMGarbage);
-    MultiplexOperationsFromGenerator(unitaryGenerator, qROMIdxRegister, (signQubit, selectZControlRegisters, optimizedBEControlRegisters, pauliBasesIdx, indexRegisters));
+    MultiplexOperationsFromGenerator(
+        unitaryGenerator,
+        qROMIdxRegister,
+        (signQubit, selectZControlRegisters, optimizedBEControlRegisters, pauliBasesIdx, indexRegisters)
+    );
     MultiplexOperationsFromGenerator(pauliBasesUnitaryGenerator, pauliBasesIdx, pauliBases);
 }
 
-function JordanWignerOptimizedBlockEncodingQubitManager(targetError : Double, nCoeffs : Int, nZ : Int, nMaj : Int, nIdxRegQubits : Int, ctrlRegister : Qubit[]) : ((Qubit[], Qubit[], Qubit, Qubit[], Qubit[], Qubit[], Qubit[], Qubit[][]), (Qubit, Qubit[], Qubit[], Qubit[], Qubit[][]), Qubit[]) {
+function JordanWignerOptimizedBlockEncodingQubitManager(
+    targetError : Double,
+    nCoeffs : Int,
+    nZ : Int,
+    nMaj : Int,
+    nIdxRegQubits : Int,
+    ctrlRegister : Qubit[]
+) : (
+    (Qubit[], Qubit[], Qubit, Qubit[], Qubit[], Qubit[], Qubit[], Qubit[][]),
+    (Qubit, Qubit[], Qubit[], Qubit[], Qubit[][]),
+    Qubit[]
+) {
+
     let requirements = PurifiedMixedStateRequirements(targetError, nCoeffs);
     let parts = Partitioned([requirements.NumIndexQubits, requirements.NumGarbageQubits], ctrlRegister);
     let ((qROMIdx, qROMGarbage), rest0) = ((parts[0], parts[1]), parts[2]);
     let ((signQubit, selectZControlRegisters, optimizedBEControlRegisters, pauliBases, indexRegisters, tmp), rest1) = JordanWignerSelectQubitManager(nZ, nMaj, nIdxRegQubits, rest0, []);
     let registers = Partitioned([3], rest1);
     let pauliBasesIdx = registers[0];
-    return ((qROMIdx, qROMGarbage, signQubit, selectZControlRegisters, optimizedBEControlRegisters, pauliBases, pauliBasesIdx, indexRegisters), (signQubit, selectZControlRegisters, optimizedBEControlRegisters, pauliBases, indexRegisters), registers[1]);
+    return (
+        (qROMIdx, qROMGarbage, signQubit, selectZControlRegisters, optimizedBEControlRegisters, pauliBases, pauliBasesIdx, indexRegisters),
+        (signQubit, selectZControlRegisters, optimizedBEControlRegisters, pauliBases, indexRegisters),
+        registers[1]
+    );
 }
 
-function JordanWignerOptimizedBlockEncodingQubitCount(targetError : Double, nCoeffs : Int, nZ : Int, nMaj : Int, nIdxRegQubits : Int, nTarget : Int) : ((Int, Int), (Int, Int, Int, Int, Int, Int, Int, Int[], Int)) {
+function JordanWignerOptimizedBlockEncodingQubitCount(
+    targetError : Double,
+    nCoeffs : Int,
+    nZ : Int,
+    nMaj : Int,
+    nIdxRegQubits : Int,
+    nTarget : Int
+) : (
+    (Int, Int),
+    (Int, Int, Int, Int, Int, Int, Int, Int[], Int)
+) {
+
     let (nSelectTotal, (a0, a1, a2, a3, a4)) = JordanWignerSelectQubitCount(nZ, nMaj, nIdxRegQubits);
-    let (nQROMTotal, b0, b1) = PurifiedMixedStateRequirements(targetError, nCoeffs)!;
+    let requirements = PurifiedMixedStateRequirements(targetError, nCoeffs);
     let pauliBasesIdx = 3;
-    return (((nSelectTotal + nQROMTotal) + pauliBasesIdx, nTarget), (b0, b1, a0, a1, a2, a3, pauliBasesIdx, a4, nTarget));
+    return (
+        ((nSelectTotal + requirements.NumTotalQubits) + pauliBasesIdx, nTarget),
+        (requirements.NumIndexQubits, requirements.NumGarbageQubits, a0, a1, a2, a3, pauliBasesIdx, a4, nTarget)
+    );
 }
 
 
-operation JordanWignerOptimizedBlockEncodingStatePrepWrapper(targetError : Double, nCoeffs : Int, optimizedBEGeneratorSystem : OptimizedBEGeneratorSystem, nZ : Int, nMaj : Int, nIdxRegQubits : Int, ctrlRegister : Qubit[]) : Unit is Adj + Ctl {
+operation JordanWignerOptimizedBlockEncodingStatePrepWrapper(
+    targetError : Double,
+    nCoeffs : Int,
+    optimizedBEGeneratorSystem : OptimizedBEGeneratorSystem,
+    nZ : Int,
+    nMaj : Int,
+    nIdxRegQubits : Int,
+    ctrlRegister : Qubit[]
+) : Unit is Adj + Ctl {
+
     let (statePrepRegister, selectRegister, rest) = JordanWignerOptimizedBlockEncodingQubitManager(targetError, nCoeffs, nZ, nMaj, nIdxRegQubits, ctrlRegister);
     let statePrepOp = JordanWignerOptimizedBlockEncodingStatePrep(targetError, optimizedBEGeneratorSystem, _, _, _, _, _, _, _, _);
     statePrepOp(statePrepRegister);
 }
 
 
-operation JordanWignerOptimizedBlockEncodingSelect(targetError : Double, nCoeffs : Int, optimizedBEGeneratorSystem : OptimizedBEGeneratorSystem, nZ : Int, nMaj : Int, nIdxRegQubits : Int, ctrlRegister : Qubit[], targetRegister : Qubit[]) : Unit is Adj + Ctl {
+operation JordanWignerOptimizedBlockEncodingSelect(
+    targetError : Double,
+    nCoeffs : Int,
+    optimizedBEGeneratorSystem : OptimizedBEGeneratorSystem,
+    nZ : Int,
+    nMaj : Int,
+    nIdxRegQubits : Int,
+    ctrlRegister : Qubit[],
+    targetRegister : Qubit[]
+) : Unit is Adj + Ctl {
+
     let (statePrepRegister, selectRegister, rest) = JordanWignerOptimizedBlockEncodingQubitManager(targetError, nCoeffs, nZ, nMaj, nIdxRegQubits, ctrlRegister);
     let selectOp = JordanWignerSelect(_, _, _, _, _, targetRegister);
     selectOp(selectRegister);
 }
 
 
-function JordanWignerOptimizedBlockEncoding(targetError : Double, data : JWOptimizedHTerms, nSpinOrbitals : Int) : ((Int, Int), (Double, (Qubit[], Qubit[]) => Unit is Adj + Ctl)) {
+function JordanWignerOptimizedBlockEncoding(
+    targetError : Double,
+    data : JWOptimizedHTerms,
+    nSpinOrbitals : Int
+) : ((Int, Int), (Double, (Qubit[], Qubit[]) => Unit is Adj + Ctl)) {
+
     let nZ = 2;
     let nMaj = 4;
     let optimizedBEGeneratorSystem = OptimizedBlockEncodingGeneratorSystem(data);
-    let (nCoeffs, oneNorm, tmp) = optimizedBEGeneratorSystem!;
+    let nCoeffs = optimizedBEGeneratorSystem.NumTerms;
     let nIdxRegQubits = Ceiling(Lg(IntAsDouble(nSpinOrbitals)));
     let ((nCtrlRegisterQubits, nTargetRegisterQubits), rest) = JordanWignerOptimizedBlockEncodingQubitCount(targetError, nCoeffs, nZ, nMaj, nIdxRegQubits, nSpinOrbitals);
-    let statePrepOp = JordanWignerOptimizedBlockEncodingStatePrepWrapper(targetError, nCoeffs, optimizedBEGeneratorSystem, nZ, nMaj, nIdxRegQubits, _);
-    let selectOp = JordanWignerOptimizedBlockEncodingSelect(targetError, nCoeffs, optimizedBEGeneratorSystem, nZ, nMaj, nIdxRegQubits, _, _);
+    let statePrepOp = JordanWignerOptimizedBlockEncodingStatePrepWrapper(
+        targetError,
+        nCoeffs,
+        optimizedBEGeneratorSystem,
+        nZ,
+        nMaj,
+        nIdxRegQubits,
+        _
+    );
+    let selectOp = JordanWignerOptimizedBlockEncodingSelect(
+        targetError,
+        nCoeffs,
+        optimizedBEGeneratorSystem,
+        nZ,
+        nMaj,
+        nIdxRegQubits,
+        _,
+        _
+    );
     let blockEncodingReflection = BlockEncodingByLCU(statePrepOp, selectOp);
-    return ((nCtrlRegisterQubits, nTargetRegisterQubits), (oneNorm, blockEncodingReflection));
+    return ((nCtrlRegisterQubits, nTargetRegisterQubits), (optimizedBEGeneratorSystem.Norm, blockEncodingReflection));
 }
 
-function JordanWignerOptimizedQuantumWalkByQubitization(targetError : Double, data : JWOptimizedHTerms, nSpinOrbitals : Int) : ((Int, Int), (Double, ((Qubit[], Qubit[]) => Unit is Adj + Ctl))) {
+function JordanWignerOptimizedQuantumWalkByQubitization(
+    targetError : Double,
+    data : JWOptimizedHTerms,
+    nSpinOrbitals : Int
+) : ((Int, Int), (Double, ((Qubit[], Qubit[]) => Unit is Adj + Ctl))) {
+
     let ((nCtrlRegisterQubits, nTargetRegisterQubits), (oneNorm, blockEncodingReflection)) = JordanWignerOptimizedBlockEncoding(targetError, data, nSpinOrbitals);
-    return ((nCtrlRegisterQubits, nTargetRegisterQubits), (oneNorm, QuantumWalkByQubitization(blockEncodingReflection)));
+    return (
+        (nCtrlRegisterQubits, nTargetRegisterQubits),
+        (oneNorm, QuantumWalkByQubitization(blockEncodingReflection))
+    );
 }
 
 /// # Summary
@@ -879,14 +983,14 @@ function PauliBlockEncodingInner(
     statePrepUnitary : (Double[] -> (Qubit[] => Unit is Adj + Ctl)),
     multiplexer : ((Int, (Int -> (Qubit[] => Unit is Adj + Ctl))) -> ((Qubit[], Qubit[]) => Unit is Adj + Ctl))
 ) : (Double, (Qubit[], Qubit[]) => Unit is Adj + Ctl) {
-    let (nTerms, intToGenIdx) = generatorSystem!;
-    let op = idx -> Sqrt(AbsD({
-        let ((idxPaulis, coeff), idxQubits) = intToGenIdx(idx)!;
-        coeff[0]
-    }));
+    let nTerms = generatorSystem.NumEntries;
+    let op = idx -> {
+        let (_, coeff) = generatorSystem.EntryAt(idx).Term;
+        Sqrt(AbsD(coeff[0]))
+    };
     let coefficients = Mapped(op, RangeAsIntArray(0..nTerms-1));
     let oneNorm = PNorm(2.0, coefficients)^2.0;
-    let unitaryGenerator = (nTerms, idx -> PauliLCUUnitary(intToGenIdx(idx)));
+    let unitaryGenerator = (nTerms, idx -> PauliLCUUnitary(generatorSystem.EntryAt(idx)));
     let statePreparation = statePrepUnitary(coefficients);
     let selector = multiplexer(unitaryGenerator);
     let blockEncoding = (qs0, qs1) => BlockEncodingByLCU(statePreparation, selector)(qs0, qs1);
@@ -902,7 +1006,8 @@ function PauliLCUUnitary(generatorIndex : GeneratorIndex) : (Qubit[] => Unit is 
 /// # Summary
 /// Used in implementation of `PauliBlockEncoding`
 operation ApplyPauliLCUUnitary(generatorIndex : GeneratorIndex, qubits : Qubit[]) : Unit is Adj + Ctl {
-    let ((idxPaulis, coeff), idxQubits) = generatorIndex!;
+    let (idxPaulis, coeff) = generatorIndex.Term;
+    let idxQubits = generatorIndex.Subsystem;
     let paulis = [PauliI, PauliX, PauliY, PauliZ];
     let pauliString = IntArrayAsPauliArray(idxPaulis);
     let pauliQubits = Subarray(idxQubits, qubits);

--- a/library/chemistry/src/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
@@ -13,12 +13,6 @@ export
     QuantumWalkByQubitization,
     PauliBlockEncoding;
 
-import JordanWigner.OptimizedBEOperator.JordanWignerSelect;
-import JordanWigner.OptimizedBEOperator.JordanWignerSelectQubitCount;
-import JordanWigner.OptimizedBEOperator.JordanWignerSelectQubitManager;
-import JordanWigner.Utils.JWOptimizedHTerms;
-import JordanWigner.Utils.MultiplexOperationsFromGenerator;
-import JordanWigner.Utils.RangeAsIntArray;
 import Std.Arrays.*;
 import Std.Math.*;
 import Std.Convert.IntAsDouble;
@@ -26,6 +20,13 @@ import Std.Arithmetic.ApplyIfGreaterLE;
 import Std.StatePreparation.PreparePureStateD;
 import Std.StatePreparation.PrepareUniformSuperposition;
 import Std.Diagnostics.Fact;
+
+import JordanWigner.OptimizedBEOperator.JordanWignerSelect;
+import JordanWigner.OptimizedBEOperator.JordanWignerSelectQubitCount;
+import JordanWigner.OptimizedBEOperator.JordanWignerSelectQubitManager;
+import JordanWigner.Utils.JWOptimizedHTerms;
+import JordanWigner.Utils.MultiplexOperationsFromGenerator;
+import JordanWigner.Utils.RangeAsIntArray;
 import Utils.GeneratorIndex;
 import Utils.GeneratorSystem;
 import Utils.HTermToGenIdx;

--- a/library/chemistry/src/JordanWigner/JordanWignerVQE.qs
+++ b/library/chemistry/src/JordanWigner/JordanWignerVQE.qs
@@ -33,7 +33,14 @@ import Std.Math.AbsD;
 ///
 /// # Output
 /// The energy associated to the Jordan-Wigner term.
-operation EstimateTermExpectation(inputStateUnitary : (Qubit[] => Unit), ops : Pauli[][], coeffs : Double[], nQubits : Int, nSamples : Int) : Double {
+operation EstimateTermExpectation(
+    inputStateUnitary : (Qubit[] => Unit),
+    ops : Pauli[][],
+    coeffs : Double[],
+    nQubits : Int,
+    nSamples : Int
+) : Double {
+
     mutable jwTermEnergy = 0.;
 
     for i in IndexRange(coeffs) {
@@ -75,7 +82,13 @@ operation EstimateTermExpectation(inputStateUnitary : (Qubit[] => Unit), ops : P
 ///
 /// This is particularly important on target machines which respect
 /// physical limitations, such that probabilities cannot be measured.
-operation EstimateFrequency(preparation : (Qubit[] => Unit), measurement : (Qubit[] => Result), nQubits : Int, nMeasurements : Int) : Double {
+operation EstimateFrequency(
+    preparation : (Qubit[] => Unit),
+    measurement : (Qubit[] => Result),
+    nQubits : Int,
+    nMeasurements : Int
+) : Double {
+
     mutable nUp = 0;
 
     for idxMeasurement in 0..nMeasurements - 1 {
@@ -113,7 +126,12 @@ operation EstimateFrequency(preparation : (Qubit[] => Unit), measurement : (Qubi
 ///
 /// # Output
 /// An array of measurement operators (each being an array of Pauli).
-function MeasurementOperators(nQubits : Int, indices : Int[], termType : Int) : Pauli[][] {
+function MeasurementOperators(
+    nQubits : Int,
+    indices : Int[],
+    termType : Int
+) : Pauli[][] {
+
     // Compute the size and initialize the array of operators to be returned
     mutable nOps = 0;
     if (termType == 2) {
@@ -124,7 +142,7 @@ function MeasurementOperators(nQubits : Int, indices : Int[], termType : Int) : 
         nOps = 1;
     }
 
-    mutable ops = [[], size = nOps];
+    mutable ops = Repeated([], nOps);
 
     // Z and ZZ terms
     if termType == 0 or termType == 1 {
@@ -137,7 +155,16 @@ function MeasurementOperators(nQubits : Int, indices : Int[], termType : Int) : 
 
     // PQRS terms set operators between indices P and Q (resp R and S) to PauliZ
     elif termType == 3 {
-        let compactOps = [[PauliX, PauliX, PauliX, PauliX], [PauliY, PauliY, PauliY, PauliY], [PauliX, PauliX, PauliY, PauliY], [PauliY, PauliY, PauliX, PauliX], [PauliX, PauliY, PauliX, PauliY], [PauliY, PauliX, PauliY, PauliX], [PauliY, PauliX, PauliX, PauliY], [PauliX, PauliY, PauliY, PauliX]];
+        let compactOps = [
+            [PauliX, PauliX, PauliX, PauliX],
+            [PauliY, PauliY, PauliY, PauliY],
+            [PauliX, PauliX, PauliY, PauliY],
+            [PauliY, PauliY, PauliX, PauliX],
+            [PauliX, PauliY, PauliX, PauliY],
+            [PauliY, PauliX, PauliY, PauliX],
+            [PauliY, PauliX, PauliX, PauliY],
+            [PauliX, PauliY, PauliY, PauliX]
+        ];
 
         for iOp in 0..7 {
             mutable compactOp = compactOps[iOp];
@@ -207,7 +234,7 @@ function ExpandedCoefficients(coeff : Double[], termType : Int) : Double[] {
         nCoeffs = 1;
     }
 
-    mutable coeffs = [0.0, size = nCoeffs];
+    mutable coeffs = Repeated(0.0, nCoeffs);
 
     // Return the expanded array of coefficients
     if termType == 0 or termType == 1 {

--- a/library/chemistry/src/JordanWigner/OptimizedBEOperator.qs
+++ b/library/chemistry/src/JordanWigner/OptimizedBEOperator.qs
@@ -3,10 +3,11 @@
 
 export OptimizedBEXY;
 
-import JordanWigner.Utils.MultiplexOperationsFromGenerator;
 import Std.Arrays.IndexRange;
 import Std.Arrays.Partitioned;
 import Std.Math.Max;
+
+import JordanWigner.Utils.MultiplexOperationsFromGenerator;
 
 /// # Summary
 /// Applies a sequence of Z operations and either an X or Y operation to

--- a/library/chemistry/src/JordanWigner/StatePreparation.qs
+++ b/library/chemistry/src/JordanWigner/StatePreparation.qs
@@ -6,15 +6,16 @@ export
     PrepareSparseMultiConfigurationalState,
     PrepareUnitaryCoupledClusterState;
 
-import JordanWigner.JordanWignerClusterOperatorEvolutionSet.JordanWignerClusterOperatorEvolutionSet;
-import JordanWigner.JordanWignerClusterOperatorEvolutionSet.JordanWignerClusterOperatorGeneratorSystem;
-import JordanWigner.Utils.JordanWignerInputState;
-import JordanWigner.Utils.TrotterSimulationAlgorithm;
 import Std.Arrays.*;
 import Std.Convert.ComplexAsComplexPolar;
 import Std.Convert.IntAsDouble;
 import Std.StatePreparation.PreparePureStateD;
 import Std.Math.*;
+
+import JordanWigner.JordanWignerClusterOperatorEvolutionSet.JordanWignerClusterOperatorEvolutionSet;
+import JordanWigner.JordanWignerClusterOperatorEvolutionSet.JordanWignerClusterOperatorGeneratorSystem;
+import JordanWigner.Utils.JordanWignerInputState;
+import JordanWigner.Utils.TrotterSimulationAlgorithm;
 import Utils.EvolutionGenerator;
 
 operation PrepareTrialState(stateData : (Int, JordanWignerInputState[]), qubits : Qubit[]) : Unit {
@@ -86,22 +87,20 @@ operation PrepareSparseMultiConfigurationalState(
 ) : Unit {
     let nExcitations = Length(excitations);
 
-    mutable coefficientsSqrtAbs = [0.0, size = nExcitations];
-    mutable coefficientsNewComplexPolar = Repeated(new ComplexPolar { Magnitude = 0.0, Argument = 0.0 }, nExcitations);
-    mutable applyFlips = [[], size = nExcitations];
+    mutable coefficientsSqrtAbs = [];
+    mutable coefficientsNewComplexPolar = [];
+    mutable applyFlips = [];
 
     for idx in 0..nExcitations - 1 {
-        let (r, i) = excitations[idx].Amplitude;
-        let amplitude = new Complex {Real = r, Imag = i};
-        let amplitudePolar = ComplexAsComplexPolar(amplitude);
+        let amplitudePolar = ComplexAsComplexPolar(excitations[idx].Amplitude);
+        let sqrAbsAmplitude = Sqrt(AbsComplexPolar(amplitudePolar));
 
-        coefficientsSqrtAbs w/= idx <- Sqrt(AbsComplexPolar(amplitudePolar));
-        coefficientsNewComplexPolar w/= idx <- new ComplexPolar {
-            Magnitude = coefficientsSqrtAbs[idx],
+        coefficientsSqrtAbs += [sqrAbsAmplitude];
+        coefficientsNewComplexPolar += [new ComplexPolar {
+            Magnitude = sqrAbsAmplitude,
             Argument = ArgComplexPolar(amplitudePolar)
-        };
-        let excitation = excitations[idx].FermionIndices;
-        applyFlips w/= idx <- excitation;
+        }];
+        applyFlips += [excitations[idx].FermionIndices];
     }
 
     let nBitsIndices = Ceiling(Lg(IntAsDouble(nExcitations)));

--- a/library/chemistry/src/JordanWigner/StatePreparation.qs
+++ b/library/chemistry/src/JordanWigner/StatePreparation.qs
@@ -31,8 +31,7 @@ operation PrepareTrialState(stateData : (Int, JordanWignerInputState[]), qubits 
         if IsEmpty(terms) {
             // Do nothing, as there are no terms to prepare.
         } elif Length(terms) == 1 {
-            let (_, qubitIndices) = terms[0]!;
-            PrepareSingleConfigurationalStateSingleSiteOccupation(qubitIndices, qubits);
+            PrepareSingleConfigurationalStateSingleSiteOccupation(terms[0].FermionIndices, qubits);
         } else {
             PrepareSparseMultiConfigurationalState(qs => I(qs[0]), terms, qubits);
         }
@@ -92,12 +91,16 @@ operation PrepareSparseMultiConfigurationalState(
     mutable applyFlips = [[], size = nExcitations];
 
     for idx in 0..nExcitations - 1 {
-        let ((r, i), excitation) = excitations[idx]!;
-        coefficientsSqrtAbs w/= idx <- Sqrt(AbsComplexPolar(ComplexAsComplexPolar(new Complex { Real = r, Imag = i })));
+        let (r, i) = excitations[idx].Amplitude;
+        let amplitude = new Complex {Real = r, Imag = i};
+        let amplitudePolar = ComplexAsComplexPolar(amplitude);
+
+        coefficientsSqrtAbs w/= idx <- Sqrt(AbsComplexPolar(amplitudePolar));
         coefficientsNewComplexPolar w/= idx <- new ComplexPolar {
             Magnitude = coefficientsSqrtAbs[idx],
-            Argument = ArgComplexPolar(ComplexAsComplexPolar(new Complex { Real = r, Imag = i }))
+            Argument = ArgComplexPolar(amplitudePolar)
         };
+        let excitation = excitations[idx].FermionIndices;
         applyFlips w/= idx <- excitation;
     }
 

--- a/library/chemistry/src/JordanWigner/Utils.qs
+++ b/library/chemistry/src/JordanWigner/Utils.qs
@@ -13,6 +13,7 @@ export
 import Std.Arrays.*;
 import Std.Convert.IntAsDouble;
 import Std.Math.*;
+
 import Utils.EvolutionGenerator;
 
 /// # Summary
@@ -29,7 +30,7 @@ struct JWOptimizedHTerms {
 /// Represents preparation of the initial state
 /// The meaning of the data represented is determined by the algorithm that receives it.
 struct JordanWignerInputState {
-    Amplitude : (Double, Double), // TODO: This is a complex number
+    Amplitude : Complex,
     FermionIndices : Int[],
 }
 
@@ -263,7 +264,8 @@ operation TrotterStepImpl(
     evolutionGenerator : EvolutionGenerator,
     idx : Int,
     stepsize : Double,
-    qubits : Qubit[]) : Unit is Adj + Ctl {
+    qubits : Qubit[]
+) : Unit is Adj + Ctl {
 
     let generatorIndex = evolutionGenerator.System.EntryAt(idx);
     (evolutionGenerator.EvolutionSet(generatorIndex))(stepsize, qubits);
@@ -288,13 +290,15 @@ operation TrotterStepImpl(
 function TrotterStep(
     evolutionGenerator : EvolutionGenerator,
     trotterOrder : Int,
-    trotterStepSize : Double) : (Qubit[] => Unit is Adj + Ctl) {
+    trotterStepSize : Double
+) : (Qubit[] => Unit is Adj + Ctl) {
 
     // The input to DecomposeIntoTimeStepsCA has signature
     // (Int, ((Int, Double, Qubit[]) => () is Adj + Ctl))
     let trotterForm = (
         evolutionGenerator.System.NumEntries,
-        TrotterStepImpl(evolutionGenerator, _, _, _));
+        TrotterStepImpl(evolutionGenerator, _, _, _)
+    );
     return (DecomposedIntoTimeStepsCA(trotterForm, trotterOrder))(trotterStepSize, _);
 }
 

--- a/library/chemistry/src/Tests.qs
+++ b/library/chemistry/src/Tests.qs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-
 import Std.Arrays.IndexRange;
 import Std.Arrays.Mapped;
 import Std.Arrays.Reversed;
@@ -24,6 +23,8 @@ import JordanWigner.OptimizedBEOperator.SelectZ;
 import JordanWigner.StatePreparation.PrepareSparseMultiConfigurationalState;
 import JordanWigner.StatePreparation.PrepareUnitaryCoupledClusterState;
 import JordanWigner.Utils.JordanWignerInputState;
+import JordanWigner.JordanWignerClusterOperatorEvolutionSet.ComputeJordanWignerBitString;
+import JordanWigner.JordanWignerClusterOperatorEvolutionSet.ComputeJordanWignerPauliZString;
 
 @Config(Unrestricted)
 @Test()
@@ -31,10 +32,7 @@ operation PrepareSparseMultiConfigurationalState0Test() : Unit {
     let nQubits = 6;
     let expectedResult = 39;
     let excitations = [
-        new JordanWignerInputState {
-            Amplitude = NewComplex(0.1, 0.0),
-            FermionIndices = [0, 1, 2, 5]
-        }
+        NewJordanWignerInputState(0.1, 0.0, [0, 1, 2, 5])
     ];
 
     use qubits = Qubit[nQubits];
@@ -286,9 +284,8 @@ function JordanWignerClusterOperatorPQRSTermSignsTest() : Unit {
 
 @Config(Unrestricted)
 function DoublesToComplexPolar(input : Double[]) : ComplexPolar[] {
-    Std.Arrays.Mapped(re -> ComplexAsComplexPolar(NewComplex(re, 0.0)), input)
+    Std.Arrays.Mapped(re -> ComplexAsComplexPolar(new Complex{ Real=re, Imag=0.0}), input)
 }
-
 
 @Config(Unrestricted)
 operation JordanWignerUCCTermTestHelper(nQubits : Int, excitations : Int[], term : JordanWignerInputState[], result : Double[]) : Unit {
@@ -307,12 +304,12 @@ operation JordanWignerUCCTermTestHelper(nQubits : Int, excitations : Int[], term
 @Test()
 operation JordanWignerUCCSTermTest() : Unit {
     // test using Exp(2.0 (a^\dag_1 a_3 - h.c.))
-    let term0 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [1, 3] }];
+    let term0 = [NewJordanWignerInputState(2.0, 0.0, [1, 3])];
     let state0 = [0., 0.,-0.416147, 0., 0., 0., 0., 0.,-0.909297, 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(4, [1], term0, state0);
 
     // test using Exp(2.0 (a^\dag_3 a_1 - h.c.))
-    let term1 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [3, 1] }];
+    let term1 = [NewJordanWignerInputState(2.0, 0.0, [3, 1])];
     let state1 = [0., 0.,-0.416147, 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(4, [1], term1, state1);
 }
@@ -321,22 +318,22 @@ operation JordanWignerUCCSTermTest() : Unit {
 @Test()
 operation JordanWignerUCCDTermPQRSTest() : Unit {
     // test using Exp(2.0 (a^\dag_0 a^\dag_1 a_3 a_4 - h.c.))
-    let term0 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [0, 1, 2, 4] }];
+    let term0 = [NewJordanWignerInputState(2.0, 0.0, [0, 1, 2, 4])];
     let state0 = [0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1], term0, state0);
 
     // test using Exp(2.0 (a^\dag_0 a^\dag_1 a_3 a_4 - h.c.))
-    let term1 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [0, 1, 2, 4] }];
+    let term1 = [NewJordanWignerInputState (2.0, 0.0, [0, 1, 2, 4])];
     let state1 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.909297, 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1, 3], term1, state1);
 
     // test using Exp(2.0 (a^\dag_1 a^\dag_0 a_2 a_4 - h.c.))
-    let term2 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [1, 0, 2, 4] }];
+    let term2 = [NewJordanWignerInputState (2.0, 0.0, [1, 0, 2, 4])];
     let state2 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1, 3], term2, state2);
 
     // test using Exp(2.0 (a^\dag_1 a^\dag_0 a_2 a_4 - h.c.))
-    let term3 = [new JordanWignerInputState { Amplitude = NewComplex(-2.0, 0.0), FermionIndices = [4, 2, 1, 0] }];
+    let term3 = [NewJordanWignerInputState (-2.0, 0.0, [4, 2, 1, 0])];
     let state3 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1, 3], term2, state2);
 }
@@ -344,11 +341,11 @@ operation JordanWignerUCCDTermPQRSTest() : Unit {
 @Config(Unrestricted)
 // @Test()
 operation JordanWignerUCCDTermPRQSTest() : Unit {
-    let term0 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [2, 0, 4, 1] }];
+    let term0 = [NewJordanWignerInputState (2.0, 0.0, [2, 0, 4, 1])];
     let state0 = [0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 2], term0, state0);
 
-    let term1 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [2, 0, 4, 1] }];
+    let term1 = [NewJordanWignerInputState (2.0, 0.0, [2, 0, 4, 1])];
     let state1 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.909297, 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 2, 3], term1, state1);
 }
@@ -356,12 +353,10 @@ operation JordanWignerUCCDTermPRQSTest() : Unit {
 @Config(Unrestricted)
 @Test()
 operation JordanWignerUCCDTermPRSQTest() : Unit {
-    let term3 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [0, 4, 2, 3] }];
+    let term3 = [NewJordanWignerInputState (2.0, 0.0, [0, 4, 2, 3])];
     let state3 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 4], term3, state3);
 }
-
-import JordanWigner.JordanWignerClusterOperatorEvolutionSet.ComputeJordanWignerBitString;
 
 @Config(Unrestricted)
 @Test()
@@ -383,8 +378,6 @@ function ComputeJordanWignerBitString_1Test() : Unit {
     Fact(bitString == expectedBitString, "Bit strings not equal");
 }
 
-import JordanWigner.JordanWignerClusterOperatorEvolutionSet.ComputeJordanWignerPauliZString;
-
 @Config(Unrestricted)
 @Test()
 function ComputeJordanWignerPauliZString_0Test() : Unit {
@@ -405,7 +398,9 @@ function NearEqualityFactD(actual : Double, expected : Double) : Unit {
     }
 }
 
-// For convenience of constructing complex constants
-function NewComplex(r : Double, i : Double) : Complex {
-    return new Complex { Real = r, Imag = i };
+function NewJordanWignerInputState(re: Double, im: Double, indices: Int[]) : JordanWignerInputState {
+    new JordanWignerInputState {
+        Amplitude = new Complex { Real = re, Imag = im },
+        FermionIndices = indices
+    }
 }

--- a/library/chemistry/src/Tests.qs
+++ b/library/chemistry/src/Tests.qs
@@ -284,7 +284,7 @@ function JordanWignerClusterOperatorPQRSTermSignsTest() : Unit {
 
 @Config(Unrestricted)
 function DoublesToComplexPolar(input : Double[]) : ComplexPolar[] {
-    Std.Arrays.Mapped(re -> ComplexAsComplexPolar(new Complex{ Real=re, Imag=0.0}), input)
+    Std.Arrays.Mapped(re -> ComplexAsComplexPolar(new Complex { Real = re, Imag = 0.0 }), input)
 }
 
 @Config(Unrestricted)
@@ -323,17 +323,17 @@ operation JordanWignerUCCDTermPQRSTest() : Unit {
     JordanWignerUCCTermTestHelper(5, [0, 1], term0, state0);
 
     // test using Exp(2.0 (a^\dag_0 a^\dag_1 a_3 a_4 - h.c.))
-    let term1 = [NewJordanWignerInputState (2.0, 0.0, [0, 1, 2, 4])];
+    let term1 = [NewJordanWignerInputState(2.0, 0.0, [0, 1, 2, 4])];
     let state1 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.909297, 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1, 3], term1, state1);
 
     // test using Exp(2.0 (a^\dag_1 a^\dag_0 a_2 a_4 - h.c.))
-    let term2 = [NewJordanWignerInputState (2.0, 0.0, [1, 0, 2, 4])];
+    let term2 = [NewJordanWignerInputState(2.0, 0.0, [1, 0, 2, 4])];
     let state2 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1, 3], term2, state2);
 
     // test using Exp(2.0 (a^\dag_1 a^\dag_0 a_2 a_4 - h.c.))
-    let term3 = [NewJordanWignerInputState (-2.0, 0.0, [4, 2, 1, 0])];
+    let term3 = [NewJordanWignerInputState(-2.0, 0.0, [4, 2, 1, 0])];
     let state3 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1, 3], term2, state2);
 }
@@ -341,11 +341,11 @@ operation JordanWignerUCCDTermPQRSTest() : Unit {
 @Config(Unrestricted)
 // @Test()
 operation JordanWignerUCCDTermPRQSTest() : Unit {
-    let term0 = [NewJordanWignerInputState (2.0, 0.0, [2, 0, 4, 1])];
+    let term0 = [NewJordanWignerInputState(2.0, 0.0, [2, 0, 4, 1])];
     let state0 = [0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 2], term0, state0);
 
-    let term1 = [NewJordanWignerInputState (2.0, 0.0, [2, 0, 4, 1])];
+    let term1 = [NewJordanWignerInputState(2.0, 0.0, [2, 0, 4, 1])];
     let state1 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.909297, 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 2, 3], term1, state1);
 }
@@ -353,7 +353,7 @@ operation JordanWignerUCCDTermPRQSTest() : Unit {
 @Config(Unrestricted)
 @Test()
 operation JordanWignerUCCDTermPRSQTest() : Unit {
-    let term3 = [NewJordanWignerInputState (2.0, 0.0, [0, 4, 2, 3])];
+    let term3 = [NewJordanWignerInputState(2.0, 0.0, [0, 4, 2, 3])];
     let state3 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 4], term3, state3);
 }
@@ -398,7 +398,7 @@ function NearEqualityFactD(actual : Double, expected : Double) : Unit {
     }
 }
 
-function NewJordanWignerInputState(re: Double, im: Double, indices: Int[]) : JordanWignerInputState {
+function NewJordanWignerInputState(re : Double, im : Double, indices : Int[]) : JordanWignerInputState {
     new JordanWignerInputState {
         Amplitude = new Complex { Real = re, Imag = im },
         FermionIndices = indices

--- a/library/chemistry/src/Tests.qs
+++ b/library/chemistry/src/Tests.qs
@@ -1,14 +1,10 @@
-import Std.StatePreparation.ApproximatelyPreparePureStateCP;
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import JordanWigner.JordanWignerClusterOperatorEvolutionSet.JordanWignerClusterOperatorPQRSTermSigns;
-import JordanWigner.OptimizedBEOperator.OptimizedBEXY;
-import JordanWigner.OptimizedBEOperator.SelectZ;
-import JordanWigner.StatePreparation.PrepareSparseMultiConfigurationalState;
-import JordanWigner.StatePreparation.PrepareUnitaryCoupledClusterState;
-import JordanWigner.Utils.JordanWignerInputState;
+
 import Std.Arrays.IndexRange;
+import Std.Arrays.Mapped;
+import Std.Arrays.Reversed;
 import Std.Convert.ComplexAsComplexPolar;
 import Std.Convert.IntAsDouble;
 import Std.Diagnostics.CheckAllZero;
@@ -19,8 +15,15 @@ import Std.Math.Ceiling;
 import Std.Math.Complex;
 import Std.Math.ComplexPolar;
 import Std.Math.Lg;
-import Std.Arrays.Reversed;
 import Std.Math.Sqrt;
+import Std.StatePreparation.ApproximatelyPreparePureStateCP;
+
+import JordanWigner.JordanWignerClusterOperatorEvolutionSet.JordanWignerClusterOperatorPQRSTermSigns;
+import JordanWigner.OptimizedBEOperator.OptimizedBEXY;
+import JordanWigner.OptimizedBEOperator.SelectZ;
+import JordanWigner.StatePreparation.PrepareSparseMultiConfigurationalState;
+import JordanWigner.StatePreparation.PrepareUnitaryCoupledClusterState;
+import JordanWigner.Utils.JordanWignerInputState;
 
 @Config(Unrestricted)
 @Test()
@@ -29,7 +32,7 @@ operation PrepareSparseMultiConfigurationalState0Test() : Unit {
     let expectedResult = 39;
     let excitations = [
         new JordanWignerInputState {
-            Amplitude = (0.1, 0.0),
+            Amplitude = NewComplex(0.1, 0.0),
             FermionIndices = [0, 1, 2, 5]
         }
     ];
@@ -283,12 +286,9 @@ function JordanWignerClusterOperatorPQRSTermSignsTest() : Unit {
 
 @Config(Unrestricted)
 function DoublesToComplexPolar(input : Double[]) : ComplexPolar[] {
-    mutable arr = [new ComplexPolar { Magnitude = 0.0, Argument = 0.0 }, size = Length(input)];
-    for idx in 0..Length(input)-1 {
-        arr w/= idx <- ComplexAsComplexPolar(new Complex { Real = input[idx], Imag = 0. });
-    }
-    return arr;
+    Std.Arrays.Mapped(re -> ComplexAsComplexPolar(NewComplex(re, 0.0)), input)
 }
+
 
 @Config(Unrestricted)
 operation JordanWignerUCCTermTestHelper(nQubits : Int, excitations : Int[], term : JordanWignerInputState[], result : Double[]) : Unit {
@@ -307,12 +307,12 @@ operation JordanWignerUCCTermTestHelper(nQubits : Int, excitations : Int[], term
 @Test()
 operation JordanWignerUCCSTermTest() : Unit {
     // test using Exp(2.0 (a^\dag_1 a_3 - h.c.))
-    let term0 = [new JordanWignerInputState { Amplitude = (2.0, 0.0), FermionIndices = [1, 3] }];
+    let term0 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [1, 3] }];
     let state0 = [0., 0.,-0.416147, 0., 0., 0., 0., 0.,-0.909297, 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(4, [1], term0, state0);
 
     // test using Exp(2.0 (a^\dag_3 a_1 - h.c.))
-    let term1 = [new JordanWignerInputState { Amplitude = (2.0, 0.0), FermionIndices = [3, 1] }];
+    let term1 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [3, 1] }];
     let state1 = [0., 0.,-0.416147, 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(4, [1], term1, state1);
 }
@@ -321,22 +321,22 @@ operation JordanWignerUCCSTermTest() : Unit {
 @Test()
 operation JordanWignerUCCDTermPQRSTest() : Unit {
     // test using Exp(2.0 (a^\dag_0 a^\dag_1 a_3 a_4 - h.c.))
-    let term0 = [new JordanWignerInputState { Amplitude = (2.0, 0.0), FermionIndices = [0, 1, 2, 4] }];
+    let term0 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [0, 1, 2, 4] }];
     let state0 = [0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1], term0, state0);
 
     // test using Exp(2.0 (a^\dag_0 a^\dag_1 a_3 a_4 - h.c.))
-    let term1 = [new JordanWignerInputState { Amplitude = (2.0, 0.0), FermionIndices = [0, 1, 2, 4] }];
+    let term1 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [0, 1, 2, 4] }];
     let state1 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.909297, 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1, 3], term1, state1);
 
     // test using Exp(2.0 (a^\dag_1 a^\dag_0 a_2 a_4 - h.c.))
-    let term2 = [new JordanWignerInputState { Amplitude = (2.0, 0.0), FermionIndices = [1, 0, 2, 4] }];
+    let term2 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [1, 0, 2, 4] }];
     let state2 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1, 3], term2, state2);
 
     // test using Exp(2.0 (a^\dag_1 a^\dag_0 a_2 a_4 - h.c.))
-    let term3 = [new JordanWignerInputState { Amplitude = (-2.0, 0.0), FermionIndices = [4, 2, 1, 0] }];
+    let term3 = [new JordanWignerInputState { Amplitude = NewComplex(-2.0, 0.0), FermionIndices = [4, 2, 1, 0] }];
     let state3 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 1, 3], term2, state2);
 }
@@ -344,11 +344,11 @@ operation JordanWignerUCCDTermPQRSTest() : Unit {
 @Config(Unrestricted)
 // @Test()
 operation JordanWignerUCCDTermPRQSTest() : Unit {
-    let term0 = [new JordanWignerInputState { Amplitude = (2.0, 0.0), FermionIndices = [2, 0, 4, 1] }];
+    let term0 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [2, 0, 4, 1] }];
     let state0 = [0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 2], term0, state0);
 
-    let term1 = [new JordanWignerInputState { Amplitude = (2.0, 0.0), FermionIndices = [2, 0, 4, 1] }];
+    let term1 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [2, 0, 4, 1] }];
     let state1 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,-0.909297, 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 2, 3], term1, state1);
 }
@@ -356,9 +356,43 @@ operation JordanWignerUCCDTermPRQSTest() : Unit {
 @Config(Unrestricted)
 @Test()
 operation JordanWignerUCCDTermPRSQTest() : Unit {
-    let term3 = [new JordanWignerInputState { Amplitude = (2.0, 0.0), FermionIndices = [0, 4, 2, 3] }];
+    let term3 = [new JordanWignerInputState { Amplitude = NewComplex(2.0, 0.0), FermionIndices = [0, 4, 2, 3] }];
     let state3 = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.909297, 0., 0., 0., 0.,-0.416147, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.];
     JordanWignerUCCTermTestHelper(5, [0, 4], term3, state3);
+}
+
+import JordanWigner.JordanWignerClusterOperatorEvolutionSet.ComputeJordanWignerBitString;
+
+@Config(Unrestricted)
+@Test()
+function ComputeJordanWignerBitString_0Test() : Unit {
+    let nFermions = 5;
+    let fermionIndices = [0, 3];
+    let expectedBitString = [false, true, true, false, false];
+    let bitString = ComputeJordanWignerBitString(nFermions, fermionIndices);
+    Fact(bitString == expectedBitString, "Bit strings not equal");
+}
+
+@Config(Unrestricted)
+@Test()
+function ComputeJordanWignerBitString_1Test() : Unit {
+    let nFermions = 7;
+    let fermionIndices = [0, 4, 2, 6];
+    let expectedBitString = [false, true, false, false, false, true, false];
+    let bitString = ComputeJordanWignerBitString(nFermions, fermionIndices);
+    Fact(bitString == expectedBitString, "Bit strings not equal");
+}
+
+import JordanWigner.JordanWignerClusterOperatorEvolutionSet.ComputeJordanWignerPauliZString;
+
+@Config(Unrestricted)
+@Test()
+function ComputeJordanWignerPauliZString_0Test() : Unit {
+    let nFermions = 7;
+    let fermionIndices = [0, 4, 2, 6];
+    let expectedBitString = [PauliI, PauliZ, PauliI, PauliI, PauliI, PauliZ, PauliI];
+    let bitString = ComputeJordanWignerPauliZString(nFermions, fermionIndices);
+    Fact(bitString == expectedBitString, "Bit strings not equal");
 }
 
 
@@ -369,4 +403,9 @@ function NearEqualityFactD(actual : Double, expected : Double) : Unit {
     if (delta > tolerance or delta < -tolerance) {
         fail $"Values were not equal within tolerance\nActual: {actual}, Expected: {expected}, Tolerance: {tolerance}";
     }
+}
+
+// For convenience of constructing complex constants
+function NewComplex(r : Double, i : Double) : Complex {
+    return new Complex { Real = r, Imag = i };
 }

--- a/library/chemistry/src/Tests.qs
+++ b/library/chemistry/src/Tests.qs
@@ -27,7 +27,12 @@ import Std.Math.Sqrt;
 operation PrepareSparseMultiConfigurationalState0Test() : Unit {
     let nQubits = 6;
     let expectedResult = 39;
-    let excitations = [new JordanWignerInputState { Amplitude = (0.1, 0.0), FermionIndices = [0, 1, 2, 5] }];
+    let excitations = [
+        new JordanWignerInputState {
+            Amplitude = (0.1, 0.0),
+            FermionIndices = [0, 1, 2, 5]
+        }
+    ];
 
     use qubits = Qubit[nQubits];
     PrepareSparseMultiConfigurationalState(qs => I(qs[0]), excitations, qubits);

--- a/library/chemistry/src/Utils.qs
+++ b/library/chemistry/src/Utils.qs
@@ -48,14 +48,20 @@ struct GeneratorIndex {
 /// We iterate over this
 /// collection using a single-index integer, and the size of the
 /// collection is assumed to be known.
-struct GeneratorSystem { NumEntries : Int, EntryAt : (Int -> GeneratorIndex) }
+struct GeneratorSystem {
+    NumEntries : Int,
+    EntryAt : (Int -> GeneratorIndex)
+}
 
 /// # Summary
 /// Represents a dynamical generator as a set of simulatable gates and
 /// an expansion in terms of that basis.
 ///
 /// Last parameter for number of terms.
-struct EvolutionGenerator { EvolutionSet : GeneratorIndex -> (Double, Qubit[]) => Unit is Adj + Ctl, System : GeneratorSystem }
+struct EvolutionGenerator {
+    EvolutionSet : GeneratorIndex -> (Double, Qubit[]) => Unit is Adj + Ctl,
+    System : GeneratorSystem
+}
 
 /// # Summary
 /// Converts a Hamiltonian term to a GeneratorIndex.


### PR DESCRIPTION
This change updates chemistry library:
- Removes old sysntax such as a! and [x, size=5]
- Reduced use of w/= where possible
- Makes long argument lists more readable
- Fixes error in comments
- Updates pairs of double representing a complex number to use complex type
- Adds a few unit tests

No renames yet.