### PR TITLE
Mitigate VS Code language service integration tests flakiness

### DIFF
--- a/vscode/test/suites/language-service/language-service.test.ts
+++ b/vscode/test/suites/language-service/language-service.test.ts
@@ -53,7 +53,7 @@ suite("Q# Language Service Tests", function suite() {
     await vscode.workspace.openTextDocument(hasBadDepMainQs);
 
     // Give the language service a tiny bit of time to settle
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Bring up Problems view for when we want to visually inspect what's going on
     vscode.commands.executeCommand("workbench.action.problems.focus");


### PR DESCRIPTION
VS Code integration tests started failing intermittently on Windows. Other platforms have been passing fine.

In my local runs, I can see the tests failing about 1/4 times.

This seems to be due to an existing, known, timing issue in the tests.

Somehow some recent change made this delay worse, but I can't track down what exactly.

Increasing this delay from 50ms to 100ms made the tests pass on my local machine 20 times in a row... which I consider improvement enough.

Sad.