### PR TITLE
Tidy up Display functions in QASM3 parser

### DIFF
--- a/compiler/qsc_qasm3/src/ast.rs
+++ b/compiler/qsc_qasm3/src/ast.rs
@@ -172,9 +172,11 @@ pub struct MeasureExpr {
 
 impl Display for MeasureExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "MeasureExpr {}: {}", self.span, self.operand)
+        writeln_header(f, "MeasureExpr", self.span)?;
+        write_field(f, "operand", &self.operand)
     }
 }
+
 /// A binary operator.
 #[derive(Clone, Copy, Debug)]
 pub enum BinOp {
@@ -1121,6 +1123,7 @@ pub struct MeasureStmt {
 impl Display for MeasureStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "MeasureStmt", self.span)?;
+        writeln_field(f, "measurement", &self.measurement)?;
         write_opt_field(f, "target", self.target.as_ref())
     }
 }

--- a/compiler/qsc_qasm3/src/ast.rs
+++ b/compiler/qsc_qasm3/src/ast.rs
@@ -312,7 +312,7 @@ pub struct AliasDeclStmt {
 
 impl Display for AliasDeclStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln_header(f, "Alias", self.span)?;
+        writeln_header(f, "AliasDeclStmt", self.span)?;
         writeln_field(f, "ident", &self.ident)?;
         write_list_field(f, "exprs", &self.exprs)
     }
@@ -481,7 +481,7 @@ pub struct BarrierStmt {
 
 impl Display for BarrierStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln_header(f, "Barrier", self.span)?;
+        writeln_header(f, "BarrierStmt", self.span)?;
         write_list_field(f, "operands", &self.qubits)
     }
 }
@@ -929,6 +929,7 @@ pub struct ArrayReferenceType {
 impl Display for ArrayReferenceType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "ArrayReferenceType", self.span)?;
+        writeln_field(f, "mutability", &self.mutability)?;
         writeln_field(f, "base_type", &self.base_type)?;
         writeln_list_field(f, "dimensions", &self.dimensions)
     }
@@ -1092,7 +1093,7 @@ pub struct DelayStmt {
 
 impl Display for DelayStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln_header(f, "DelayInstruction", self.span)?;
+        writeln_header(f, "DelayStmt", self.span)?;
         writeln_field(f, "duration", &self.duration)?;
         write_list_field(f, "qubits", &self.qubits)
     }
@@ -1154,8 +1155,8 @@ pub enum ValueExpression {
 impl Display for ValueExpression {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ValueExpression::Expr(expr) => write!(f, "ValueExpression {expr}"),
-            ValueExpression::Measurement(measure) => write!(f, "ValueExpression {measure}"),
+            ValueExpression::Expr(expr) => write!(f, "{expr}"),
+            ValueExpression::Measurement(measure) => write!(f, "{measure}"),
         }
     }
 }
@@ -1608,9 +1609,9 @@ pub enum IndexElement {
 impl Display for IndexElement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            IndexElement::DiscreteSet(set) => write!(f, "IndexElement {set}"),
+            IndexElement::DiscreteSet(set) => write!(f, "{set}"),
             IndexElement::IndexSet(items) => {
-                write!(f, "IndexElement:")?;
+                write!(f, "IndexSet:")?;
                 write_indented_list(f, items)
             }
         }
@@ -1635,8 +1636,8 @@ impl WithSpan for IndexSetItem {
 impl Display for IndexSetItem {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            IndexSetItem::RangeDefinition(range) => write!(f, "IndexSetItem {range}"),
-            IndexSetItem::Expr(expr) => write!(f, "IndexSetItem {expr}"),
+            IndexSetItem::RangeDefinition(range) => write!(f, "{range}"),
+            IndexSetItem::Expr(expr) => write!(f, "{expr}"),
             IndexSetItem::Err => write!(f, "Err"),
         }
     }
@@ -1689,7 +1690,7 @@ pub struct BreakStmt {
 
 impl Display for BreakStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Break {}", self.span)
+        write!(f, "BreakStmt {}", self.span)
     }
 }
 
@@ -1700,7 +1701,7 @@ pub struct ContinueStmt {
 
 impl Display for ContinueStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Continue {}", self.span)
+        write!(f, "ContinueStmt {}", self.span)
     }
 }
 
@@ -1711,6 +1712,6 @@ pub struct EndStmt {
 
 impl Display for EndStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "End {}", self.span)
+        write!(f, "EndStmt {}", self.span)
     }
 }

--- a/compiler/qsc_qasm3/src/ast.rs
+++ b/compiler/qsc_qasm3/src/ast.rs
@@ -969,9 +969,11 @@ pub struct Pragma {
 
 impl Display for Pragma {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let identifier = format!("\"{}\"", self.identifier);
+        let value = self.value.as_ref().map(|val| format!("\"{val}\""));
         writeln_header(f, "Pragma", self.span)?;
-        writeln_field(f, "identifier", &self.identifier)?;
-        write_opt_field(f, "value", self.value.as_ref())
+        writeln_field(f, "identifier", &identifier)?;
+        write_opt_field(f, "value", value.as_ref())
     }
 }
 
@@ -1605,7 +1607,7 @@ impl Display for IndexElement {
         match self {
             IndexElement::DiscreteSet(set) => write!(f, "IndexElement {set}"),
             IndexElement::IndexSet(items) => {
-                write!(f, "IndexElement: ")?;
+                write!(f, "IndexElement:")?;
                 write_indented_list(f, items)
             }
         }

--- a/compiler/qsc_qasm3/src/ast.rs
+++ b/compiler/qsc_qasm3/src/ast.rs
@@ -68,15 +68,11 @@ pub struct Annotation {
 }
 impl Display for Annotation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if let Some(value) = &self.value {
-            write!(
-                f,
-                "Annotation {}: ({}, {})",
-                self.span, self.identifier, value
-            )
-        } else {
-            write!(f, "Annotation {}: ({})", self.span, self.identifier)
-        }
+        let identifier = format!("\"{}\"", self.identifier);
+        let value = self.value.as_ref().map(|val| format!("\"{val}\""));
+        writeln_header(f, "Annotation", self.span)?;
+        writeln_field(f, "identifier", &identifier)?;
+        write_opt_field(f, "value", value.as_ref())
     }
 }
 

--- a/compiler/qsc_qasm3/src/ast/display_utils.rs
+++ b/compiler/qsc_qasm3/src/ast/display_utils.rs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::fmt::{self, Display, Write};
+
+fn with_indentation<T>(f: &mut T) -> indenter::Indented<'_, T>
+where
+    T: fmt::Write,
+{
+    let indent = indenter::indented(f);
+    set_indentation(indent, 1)
+}
+
+fn set_indentation<T>(indent: indenter::Indented<'_, T>, level: usize) -> indenter::Indented<'_, T>
+where
+    T: fmt::Write,
+{
+    match level {
+        0 => indent.with_str(""),
+        1 => indent.with_str("    "),
+        2 => indent.with_str("        "),
+        3 => indent.with_str("            "),
+        _ => unimplemented!("indentation level not supported"),
+    }
+}
+
+fn write_list<'write, 'itemref, 'item, T, I>(f: &'write mut impl Write, vals: I) -> fmt::Result
+where
+    'item: 'itemref,
+    T: Display + 'item,
+    I: IntoIterator<Item = &'itemref T>,
+{
+    let mut iter = vals.into_iter().peekable();
+    if iter.peek().is_none() {
+        write!(f, "<empty>")
+    } else {
+        for elt in iter {
+            write!(f, "\n{elt}")?;
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn write_indented_list<'write, 'itemref, 'item, T, I>(
+    f: &'write mut impl Write,
+    vals: I,
+) -> fmt::Result
+where
+    'item: 'itemref,
+    T: Display + 'item,
+    I: IntoIterator<Item = &'itemref T>,
+{
+    let mut iter = vals.into_iter().peekable();
+    if iter.peek().is_none() {
+        write!(f, "<empty>")
+    } else {
+        let mut indent = with_indentation(f);
+        for elt in iter {
+            write!(indent, "\n{elt}")?;
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn write_header(f: &mut impl Write, name: &str, span: super::Span) -> fmt::Result {
+    write!(f, "{name} {span}: ")
+}
+
+pub(super) fn writeln_header(f: &mut impl Write, name: &str, span: super::Span) -> fmt::Result {
+    writeln!(f, "{name} {span}:")
+}
+
+pub(super) fn write_field<T: Display>(
+    f: &mut impl Write,
+    field_name: &str,
+    val: &T,
+) -> fmt::Result {
+    let mut indent = with_indentation(f);
+    write!(indent, "{field_name}: ")?;
+    write!(indent, "{val}")
+}
+
+pub(super) fn writeln_field<T: Display>(
+    f: &mut impl Write,
+    field_name: &str,
+    val: &T,
+) -> fmt::Result {
+    write_field(f, field_name, val)?;
+    writeln!(f)
+}
+
+pub(super) fn write_opt_field<T: Display>(
+    f: &mut impl Write,
+    field_name: &str,
+    opt_val: Option<&T>,
+) -> fmt::Result {
+    if let Some(val) = opt_val {
+        write_field(f, field_name, val)
+    } else {
+        write_field(f, field_name, &"<none>")
+    }
+}
+
+pub(super) fn writeln_opt_field<T: Display>(
+    f: &mut impl Write,
+    field_name: &str,
+    opt_val: Option<&T>,
+) -> fmt::Result {
+    write_opt_field(f, field_name, opt_val)?;
+    writeln!(f)
+}
+
+pub(super) fn write_list_field<'write, 'itemref, 'item, T, I>(
+    f: &mut impl Write,
+    field_name: &str,
+    vals: I,
+) -> fmt::Result
+where
+    'item: 'itemref,
+    T: Display + 'item,
+    I: IntoIterator<Item = &'itemref T>,
+{
+    let mut indent = with_indentation(f);
+    write!(indent, "{field_name}: ")?;
+    let mut indent = set_indentation(indent, 2);
+    write_list(&mut indent, vals)
+}
+
+pub(super) fn writeln_list_field<'write, 'itemref, 'item, T, I>(
+    f: &mut impl Write,
+    field_name: &str,
+    vals: I,
+) -> fmt::Result
+where
+    'item: 'itemref,
+    T: Display + 'item,
+    I: IntoIterator<Item = &'itemref T>,
+{
+    write_list_field(f, field_name, vals)?;
+    writeln!(f)
+}
+
+pub(super) fn write_opt_list_field<'write, 'itemref, 'item, T, I>(
+    f: &mut impl Write,
+    field_name: &str,
+    opt_vals: Option<I>,
+) -> fmt::Result
+where
+    'item: 'itemref,
+    T: Display + 'item,
+    I: IntoIterator<Item = &'itemref T>,
+{
+    if let Some(vals) = opt_vals {
+        write_list_field(f, field_name, vals)
+    } else {
+        let mut indent = with_indentation(f);
+        write!(indent, "{field_name}: <none>")
+    }
+}
+
+pub(super) fn writeln_opt_list_field<'write, 'itemref, 'item, T, I>(
+    f: &mut impl Write,
+    field_name: &str,
+    opt_vals: Option<I>,
+) -> fmt::Result
+where
+    'item: 'itemref,
+    T: Display + 'item,
+    I: IntoIterator<Item = &'itemref T>,
+{
+    write_opt_list_field(f, field_name, opt_vals)?;
+    writeln!(f)
+}

--- a/compiler/qsc_qasm3/src/ast/display_utils.rs
+++ b/compiler/qsc_qasm3/src/ast/display_utils.rs
@@ -3,6 +3,9 @@
 
 use std::fmt::{self, Display, Write};
 
+/// Takes a unicode buffer or stream and wraps it with
+/// `indenter::Idented`. Which applies an indentation of 1
+/// each time you insert a new line.
 fn with_indentation<T>(f: &mut T) -> indenter::Indented<'_, T>
 where
     T: fmt::Write,
@@ -11,6 +14,7 @@ where
     set_indentation(indent, 1)
 }
 
+/// Takes an `indenter::Idented` and changes its indentation level.
 fn set_indentation<T>(indent: indenter::Indented<'_, T>, level: usize) -> indenter::Indented<'_, T>
 where
     T: fmt::Write,
@@ -24,6 +28,7 @@ where
     }
 }
 
+/// Writes a list of elements to the given buffer or stream.
 fn write_list<'write, 'itemref, 'item, T, I>(f: &'write mut impl Write, vals: I) -> fmt::Result
 where
     'item: 'itemref,
@@ -41,6 +46,8 @@ where
     }
 }
 
+/// Writes a list of elements to the given buffer or stream
+/// with an additional indentation level.
 pub(super) fn write_indented_list<'write, 'itemref, 'item, T, I>(
     f: &'write mut impl Write,
     vals: I,
@@ -62,14 +69,19 @@ where
     }
 }
 
+/// Writes the name and span of a structure to the given buffer or stream.
 pub(super) fn write_header(f: &mut impl Write, name: &str, span: super::Span) -> fmt::Result {
     write!(f, "{name} {span}:")
 }
 
+/// Writes the name and span of a structure to the given buffer or stream.
+/// Inserts a newline afterwards.
 pub(super) fn writeln_header(f: &mut impl Write, name: &str, span: super::Span) -> fmt::Result {
     writeln!(f, "{name} {span}:")
 }
 
+/// Writes a field of a structure to the given buffer
+/// or stream with an additional indententation level.
 pub(super) fn write_field<T: Display>(
     f: &mut impl Write,
     field_name: &str,
@@ -79,6 +91,9 @@ pub(super) fn write_field<T: Display>(
     write!(indent, "{field_name}: {val}")
 }
 
+/// Writes a field of a structure to the given buffer
+/// or stream with an additional indententation level.
+/// Inserts a newline afterwards.
 pub(super) fn writeln_field<T: Display>(
     f: &mut impl Write,
     field_name: &str,
@@ -88,6 +103,8 @@ pub(super) fn writeln_field<T: Display>(
     writeln!(f)
 }
 
+/// Writes an optional field of a structure to the given buffer
+/// or stream with an additional indententation level.
 pub(super) fn write_opt_field<T: Display>(
     f: &mut impl Write,
     field_name: &str,
@@ -100,6 +117,9 @@ pub(super) fn write_opt_field<T: Display>(
     }
 }
 
+/// Writes an optional field of a structure to the given buffer
+/// or stream with an additional indententation level.
+/// Inserts a newline afterwards.
 pub(super) fn writeln_opt_field<T: Display>(
     f: &mut impl Write,
     field_name: &str,
@@ -109,6 +129,9 @@ pub(super) fn writeln_opt_field<T: Display>(
     writeln!(f)
 }
 
+/// Writes an field of a structure to the given buffer
+/// or stream with an additional indententation level.
+/// The field must be an iterable.
 pub(super) fn write_list_field<'write, 'itemref, 'item, T, I>(
     f: &mut impl Write,
     field_name: &str,
@@ -125,6 +148,10 @@ where
     write_list(&mut indent, vals)
 }
 
+/// Writes an field of a structure to the given buffer
+/// or stream with an additional indententation level.
+/// The field must be an iterable.
+/// Inserts a newline afterwards.
 pub(super) fn writeln_list_field<'write, 'itemref, 'item, T, I>(
     f: &mut impl Write,
     field_name: &str,
@@ -139,6 +166,9 @@ where
     writeln!(f)
 }
 
+/// Writes an optional field of a structure to the given buffer
+/// or stream with an additional indententation level.
+/// The field must be an iterable.
 pub(super) fn write_opt_list_field<'write, 'itemref, 'item, T, I>(
     f: &mut impl Write,
     field_name: &str,
@@ -157,6 +187,10 @@ where
     }
 }
 
+/// Writes an optional field of a structure to the given buffer
+/// or stream with an additional indententation level.
+/// The field must be an iterable.
+/// Inserts a newline afterwards.
 pub(super) fn writeln_opt_list_field<'write, 'itemref, 'item, T, I>(
     f: &mut impl Write,
     field_name: &str,

--- a/compiler/qsc_qasm3/src/ast/display_utils.rs
+++ b/compiler/qsc_qasm3/src/ast/display_utils.rs
@@ -32,7 +32,7 @@ where
 {
     let mut iter = vals.into_iter().peekable();
     if iter.peek().is_none() {
-        write!(f, "<empty>")
+        write!(f, " <empty>")
     } else {
         for elt in iter {
             write!(f, "\n{elt}")?;
@@ -52,7 +52,7 @@ where
 {
     let mut iter = vals.into_iter().peekable();
     if iter.peek().is_none() {
-        write!(f, "<empty>")
+        write!(f, " <empty>")
     } else {
         let mut indent = with_indentation(f);
         for elt in iter {
@@ -63,7 +63,7 @@ where
 }
 
 pub(super) fn write_header(f: &mut impl Write, name: &str, span: super::Span) -> fmt::Result {
-    write!(f, "{name} {span}: ")
+    write!(f, "{name} {span}:")
 }
 
 pub(super) fn writeln_header(f: &mut impl Write, name: &str, span: super::Span) -> fmt::Result {
@@ -76,8 +76,7 @@ pub(super) fn write_field<T: Display>(
     val: &T,
 ) -> fmt::Result {
     let mut indent = with_indentation(f);
-    write!(indent, "{field_name}: ")?;
-    write!(indent, "{val}")
+    write!(indent, "{field_name}: {val}")
 }
 
 pub(super) fn writeln_field<T: Display>(
@@ -121,7 +120,7 @@ where
     I: IntoIterator<Item = &'itemref T>,
 {
     let mut indent = with_indentation(f);
-    write!(indent, "{field_name}: ")?;
+    write!(indent, "{field_name}:")?;
     let mut indent = set_indentation(indent, 2);
     write_list(&mut indent, vals)
 }

--- a/compiler/qsc_qasm3/src/parser/expr.rs
+++ b/compiler/qsc_qasm3/src/parser/expr.rs
@@ -291,7 +291,7 @@ fn lit_token(lexeme: &str, token: Token) -> Result<Option<Lit>> {
 
                 Ok(Some(Lit {
                     span: token.span,
-                    kind: LiteralKind::Bitstring(value, width),
+                    kind: LiteralKind::Bitstring { value, width },
                 }))
             }
             Literal::Imaginary => {
@@ -556,7 +556,7 @@ pub(crate) fn set_expr(s: &mut ParserContext) -> Result<DiscreteSet> {
     recovering_token(s, TokenKind::Close(Delim::Brace));
     Ok(DiscreteSet {
         span: s.span(lo),
-        values: exprs.into_boxed_slice(),
+        values: list_from_iter(exprs),
     })
 }
 

--- a/compiler/qsc_qasm3/src/parser/expr.rs
+++ b/compiler/qsc_qasm3/src/parser/expr.rs
@@ -18,8 +18,8 @@ use crate::{
     ast::{
         self, list_from_iter, AssignExpr, AssignOpExpr, BinOp, BinaryOpExpr, Cast, DiscreteSet,
         Expr, ExprKind, FunctionCall, GateOperand, HardwareQubit, Ident, IndexElement, IndexExpr,
-        IndexSetItem, IndexedIdent, List, Lit, LiteralKind, MeasureExpr, RangeDefinition, TimeUnit,
-        TypeDef, UnaryOp, ValueExpression, Version,
+        IndexSet, IndexSetItem, IndexedIdent, List, Lit, LiteralKind, MeasureExpr, RangeDefinition,
+        TimeUnit, TypeDef, UnaryOp, ValueExpression, Version,
     },
     keyword::Keyword,
     lex::{
@@ -492,13 +492,13 @@ fn index_element(s: &mut ParserContext) -> Result<IndexElement> {
         Ok(Some(v)) => IndexElement::DiscreteSet(v),
         Err(err) => return Err(err),
         Ok(None) => {
+            let lo = s.peek().span.lo;
             let (exprs, _) = seq(s, index_set_item)?;
-            let exprs = exprs
-                .into_iter()
-                .map(Box::new)
-                .collect::<Vec<_>>()
-                .into_boxed_slice();
-            IndexElement::IndexSet(exprs)
+            let exprs = list_from_iter(exprs);
+            IndexElement::IndexSet(IndexSet {
+                span: s.span(lo),
+                values: exprs,
+            })
         }
     };
     Ok(index)

--- a/compiler/qsc_qasm3/src/parser/expr/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/expr/tests.rs
@@ -955,8 +955,8 @@ fn index_expr() {
         &expect![[r#"
             Expr [0-6]: IndexExpr [3-6]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement:
-                    IndexSetItem Expr [4-5]: Lit: Int(1)"#]],
+                index: IndexSet:
+                    Expr [4-5]: Lit: Int(1)"#]],
     );
 }
 
@@ -967,7 +967,7 @@ fn index_set() {
         &expect![[r#"
             Expr [0-14]: IndexExpr [3-14]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement DiscreteSet [4-13]:
+                index: DiscreteSet [4-13]:
                     values:
                         Expr [5-6]: Lit: Int(1)
                         Expr [8-9]: Lit: Int(4)
@@ -982,16 +982,16 @@ fn index_multiple_ranges() {
         &expect![[r#"
             Expr [0-18]: IndexExpr [3-18]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement:
-                    IndexSetItem RangeDefinition [4-7]:
+                index: IndexSet:
+                    RangeDefinition [4-7]:
                         start: Expr [4-5]: Lit: Int(1)
                         step: <none>
                         end: Expr [6-7]: Lit: Int(5)
-                    IndexSetItem RangeDefinition [9-12]:
+                    RangeDefinition [9-12]:
                         start: Expr [9-10]: Lit: Int(3)
                         step: <none>
                         end: Expr [11-12]: Lit: Int(7)
-                    IndexSetItem RangeDefinition [14-17]:
+                    RangeDefinition [14-17]:
                         start: Expr [14-15]: Lit: Int(4)
                         step: <none>
                         end: Expr [16-17]: Lit: Int(8)"#]],
@@ -1005,8 +1005,8 @@ fn index_range() {
         &expect![[r#"
             Expr [0-10]: IndexExpr [3-10]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement:
-                    IndexSetItem RangeDefinition [4-9]:
+                index: IndexSet:
+                    RangeDefinition [4-9]:
                         start: Expr [4-5]: Lit: Int(1)
                         step: Expr [6-7]: Lit: Int(5)
                         end: Expr [8-9]: Lit: Int(2)"#]],
@@ -1020,8 +1020,8 @@ fn index_full_range() {
         &expect![[r#"
             Expr [0-6]: IndexExpr [3-6]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement:
-                    IndexSetItem RangeDefinition [4-5]:
+                index: IndexSet:
+                    RangeDefinition [4-5]:
                         start: <none>
                         step: <none>
                         end: <none>"#]],
@@ -1035,8 +1035,8 @@ fn index_range_start() {
         &expect![[r#"
             Expr [0-7]: IndexExpr [3-7]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement:
-                    IndexSetItem RangeDefinition [4-6]:
+                index: IndexSet:
+                    RangeDefinition [4-6]:
                         start: Expr [4-5]: Lit: Int(1)
                         step: <none>
                         end: <none>"#]],
@@ -1050,8 +1050,8 @@ fn index_range_end() {
         &expect![[r#"
             Expr [0-7]: IndexExpr [3-7]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement:
-                    IndexSetItem RangeDefinition [4-6]:
+                index: IndexSet:
+                    RangeDefinition [4-6]:
                         start: <none>
                         step: <none>
                         end: Expr [5-6]: Lit: Int(5)"#]],
@@ -1065,8 +1065,8 @@ fn index_range_step() {
         &expect![[r#"
             Expr [0-8]: IndexExpr [3-8]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement:
-                    IndexSetItem RangeDefinition [4-7]:
+                index: IndexSet:
+                    RangeDefinition [4-7]:
                         start: <none>
                         step: Expr [5-6]: Lit: Int(2)
                         end: <none>"#]],
@@ -1155,10 +1155,10 @@ fn indexed_identifier() {
             IndexedIdent [0-9]:
                 name: Ident [0-3] "arr"
                 indices:
-                    IndexElement:
-                        IndexSetItem Expr [4-5]: Lit: Int(1)
-                    IndexElement:
-                        IndexSetItem Expr [7-8]: Lit: Int(2)"#]],
+                    IndexSet:
+                        Expr [4-5]: Lit: Int(1)
+                    IndexSet:
+                        Expr [7-8]: Lit: Int(2)"#]],
     );
 }
 
@@ -1183,10 +1183,10 @@ fn measure_indexed_identifier() {
                 operand: GateOperand IndexedIdent [8-20]:
                     name: Ident [8-14] "qubits"
                     indices:
-                        IndexElement:
-                            IndexSetItem Expr [15-16]: Lit: Int(1)
-                        IndexElement:
-                            IndexSetItem Expr [18-19]: Lit: Int(2)"#]],
+                        IndexSet:
+                            Expr [15-16]: Lit: Int(1)
+                        IndexSet:
+                            Expr [18-19]: Lit: Int(2)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/expr/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/expr/tests.rs
@@ -616,7 +616,7 @@ fn prat_parsing_exp_funcall() {
                 lhs: Expr [0-1]: Lit: Int(2)
                 rhs: Expr [5-14]: FunctionCall [5-14]:
                     name: Ident [5-11] "square"
-                    args: 
+                    args:
                         Expr [12-13]: Lit: Int(3)"#]],
     );
 }
@@ -630,7 +630,7 @@ fn prat_parsing_funcall_exp() {
                 op: Exp
                 lhs: Expr [0-9]: FunctionCall [0-9]:
                     name: Ident [0-6] "square"
-                    args: 
+                    args:
                         Expr [7-8]: Lit: Int(2)
                 rhs: Expr [13-14]: Lit: Int(3)"#]],
     );
@@ -643,7 +643,7 @@ fn prat_parsing_funcall_exp_arg() {
         &expect![[r#"
             Expr [0-14]: FunctionCall [0-14]:
                 name: Ident [0-6] "square"
-                args: 
+                args:
                     Expr [7-13]: BinaryOpExpr:
                         op: Exp
                         lhs: Expr [7-8]: Lit: Int(2)
@@ -658,7 +658,7 @@ fn funcall() {
         &expect![[r#"
             Expr [0-9]: FunctionCall [0-9]:
                 name: Ident [0-6] "square"
-                args: 
+                args:
                     Expr [7-8]: Lit: Int(2)"#]],
     );
 }
@@ -670,7 +670,7 @@ fn funcall_multiple_args() {
         &expect![[r#"
             Expr [0-12]: FunctionCall [0-12]:
                 name: Ident [0-6] "square"
-                args: 
+                args:
                     Expr [7-8]: Lit: Int(2)
                     Expr [10-11]: Lit: Int(3)"#]],
     );
@@ -683,7 +683,7 @@ fn funcall_multiple_args_trailing_comma() {
         &expect![[r#"
             Expr [0-13]: FunctionCall [0-13]:
                 name: Ident [0-6] "square"
-                args: 
+                args:
                     Expr [7-8]: Lit: Int(2)
                     Expr [10-11]: Lit: Int(3)"#]],
     );
@@ -853,7 +853,7 @@ fn cast_to_int_array() {
                 type: ArrayType [0-17]:
                     base_type: ArrayBaseTypeKind IntType [6-13]:
                         size: Expr [10-12]: Lit: Int(64)
-                    dimensions: 
+                    dimensions:
                         Expr [15-16]: Lit: Int(4)
                 arg: Expr [18-19]: Lit: Int(0)"#]],
     );
@@ -868,7 +868,7 @@ fn cast_to_uint_array() {
                 type: ArrayType [0-18]:
                     base_type: ArrayBaseTypeKind UIntType [6-14]:
                         size: Expr [11-13]: Lit: Int(64)
-                    dimensions: 
+                    dimensions:
                         Expr [16-17]: Lit: Int(4)
                 arg: Expr [19-20]: Lit: Int(0)"#]],
     );
@@ -883,7 +883,7 @@ fn cast_to_float_array() {
                 type: ArrayType [0-19]:
                     base_type: ArrayBaseTypeKind FloatType [6-15]:
                         size: Expr [12-14]: Lit: Int(64)
-                    dimensions: 
+                    dimensions:
                         Expr [17-18]: Lit: Int(4)
                 arg: Expr [20-21]: Lit: Int(0)"#]],
     );
@@ -898,7 +898,7 @@ fn cast_to_angle_array() {
                 type: ArrayType [0-19]:
                     base_type: ArrayBaseTypeKind AngleType [6-15]:
                         size: Expr [12-14]: Lit: Int(64)
-                    dimensions: 
+                    dimensions:
                         Expr [17-18]: Lit: Int(4)
                 arg: Expr [20-21]: Lit: Int(0)"#]],
     );
@@ -912,7 +912,7 @@ fn cast_to_bool_array() {
             Expr [0-17]: Cast [0-17]:
                 type: ArrayType [0-14]:
                     base_type: ArrayBaseTypeKind BoolType
-                    dimensions: 
+                    dimensions:
                         Expr [12-13]: Lit: Int(4)
                 arg: Expr [15-16]: Lit: Int(0)"#]],
     );
@@ -926,7 +926,7 @@ fn cast_to_duration_array() {
             Expr [0-21]: Cast [0-21]:
                 type: ArrayType [0-18]:
                     base_type: ArrayBaseTypeKind DurationType
-                    dimensions: 
+                    dimensions:
                         Expr [16-17]: Lit: Int(4)
                 arg: Expr [19-20]: Lit: Int(0)"#]],
     );
@@ -942,7 +942,7 @@ fn cast_to_complex_array() {
                     base_type: ArrayBaseTypeKind ComplexType [6-24]:
                         base_size: FloatType [14-23]:
                             size: Expr [20-22]: Lit: Int(32)
-                    dimensions: 
+                    dimensions:
                         Expr [26-27]: Lit: Int(4)
                 arg: Expr [29-30]: Lit: Int(0)"#]],
     );
@@ -955,7 +955,7 @@ fn index_expr() {
         &expect![[r#"
             Expr [0-6]: IndexExpr [3-6]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement: 
+                index: IndexElement:
                     IndexSetItem Expr [4-5]: Lit: Int(1)"#]],
     );
 }
@@ -968,7 +968,7 @@ fn index_set() {
             Expr [0-14]: IndexExpr [3-14]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
                 index: IndexElement DiscreteSet [4-13]:
-                    values: 
+                    values:
                         Expr [5-6]: Lit: Int(1)
                         Expr [8-9]: Lit: Int(4)
                         Expr [11-12]: Lit: Int(5)"#]],
@@ -982,7 +982,7 @@ fn index_multiple_ranges() {
         &expect![[r#"
             Expr [0-18]: IndexExpr [3-18]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement: 
+                index: IndexElement:
                     IndexSetItem RangeDefinition [4-7]:
                         start: Expr [4-5]: Lit: Int(1)
                         step: <none>
@@ -1005,7 +1005,7 @@ fn index_range() {
         &expect![[r#"
             Expr [0-10]: IndexExpr [3-10]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement: 
+                index: IndexElement:
                     IndexSetItem RangeDefinition [4-9]:
                         start: Expr [4-5]: Lit: Int(1)
                         step: Expr [6-7]: Lit: Int(5)
@@ -1020,7 +1020,7 @@ fn index_full_range() {
         &expect![[r#"
             Expr [0-6]: IndexExpr [3-6]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement: 
+                index: IndexElement:
                     IndexSetItem RangeDefinition [4-5]:
                         start: <none>
                         step: <none>
@@ -1035,7 +1035,7 @@ fn index_range_start() {
         &expect![[r#"
             Expr [0-7]: IndexExpr [3-7]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement: 
+                index: IndexElement:
                     IndexSetItem RangeDefinition [4-6]:
                         start: Expr [4-5]: Lit: Int(1)
                         step: <none>
@@ -1050,7 +1050,7 @@ fn index_range_end() {
         &expect![[r#"
             Expr [0-7]: IndexExpr [3-7]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement: 
+                index: IndexElement:
                     IndexSetItem RangeDefinition [4-6]:
                         start: <none>
                         step: <none>
@@ -1065,7 +1065,7 @@ fn index_range_step() {
         &expect![[r#"
             Expr [0-8]: IndexExpr [3-8]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexElement: 
+                index: IndexElement:
                     IndexSetItem RangeDefinition [4-7]:
                         start: <none>
                         step: Expr [5-6]: Lit: Int(2)
@@ -1080,7 +1080,7 @@ fn set_expr() {
         "{2, 3, 4}",
         &expect![[r#"
             DiscreteSet [0-9]:
-                values: 
+                values:
                     Expr [1-2]: Lit: Int(2)
                     Expr [4-5]: Lit: Int(3)
                     Expr [7-8]: Lit: Int(4)"#]],
@@ -1093,10 +1093,10 @@ fn lit_array() {
         super::lit_array,
         "{{2, {5}}, 1 + z}",
         &expect![[r#"
-            Expr [0-17]: Lit:     Array: 
-                    Expr [1-9]: Lit:     Array: 
+            Expr [0-17]: Lit:     Array:
+                    Expr [1-9]: Lit:     Array:
                             Expr [2-3]: Lit: Int(2)
-                            Expr [5-8]: Lit:     Array: 
+                            Expr [5-8]: Lit:     Array:
                                     Expr [6-7]: Lit: Int(5)
                     Expr [11-16]: BinaryOpExpr:
                         op: Add
@@ -1154,10 +1154,10 @@ fn indexed_identifier() {
         &expect![[r#"
             IndexedIdent [0-9]:
                 name: Ident [0-3] "arr"
-                indices: 
-                    IndexElement: 
+                indices:
+                    IndexElement:
                         IndexSetItem Expr [4-5]: Lit: Int(1)
-                    IndexElement: 
+                    IndexElement:
                         IndexSetItem Expr [7-8]: Lit: Int(2)"#]],
     );
 }
@@ -1179,10 +1179,10 @@ fn measure_indexed_identifier() {
         &expect![[r#"
             MeasureExpr [0-7]: GateOperand IndexedIdent [8-20]:
                 name: Ident [8-14] "qubits"
-                indices: 
-                    IndexElement: 
+                indices:
+                    IndexElement:
                         IndexSetItem Expr [15-16]: Lit: Int(1)
-                    IndexElement: 
+                    IndexElement:
                         IndexSetItem Expr [18-19]: Lit: Int(2)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/expr/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/expr/tests.rs
@@ -955,8 +955,9 @@ fn index_expr() {
         &expect![[r#"
             Expr [0-6]: IndexExpr [3-6]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexSet:
-                    Expr [4-5]: Lit: Int(1)"#]],
+                index: IndexSet [4-5]:
+                    values:
+                        Expr [4-5]: Lit: Int(1)"#]],
     );
 }
 
@@ -982,19 +983,20 @@ fn index_multiple_ranges() {
         &expect![[r#"
             Expr [0-18]: IndexExpr [3-18]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexSet:
-                    RangeDefinition [4-7]:
-                        start: Expr [4-5]: Lit: Int(1)
-                        step: <none>
-                        end: Expr [6-7]: Lit: Int(5)
-                    RangeDefinition [9-12]:
-                        start: Expr [9-10]: Lit: Int(3)
-                        step: <none>
-                        end: Expr [11-12]: Lit: Int(7)
-                    RangeDefinition [14-17]:
-                        start: Expr [14-15]: Lit: Int(4)
-                        step: <none>
-                        end: Expr [16-17]: Lit: Int(8)"#]],
+                index: IndexSet [4-17]:
+                    values:
+                        RangeDefinition [4-7]:
+                            start: Expr [4-5]: Lit: Int(1)
+                            step: <none>
+                            end: Expr [6-7]: Lit: Int(5)
+                        RangeDefinition [9-12]:
+                            start: Expr [9-10]: Lit: Int(3)
+                            step: <none>
+                            end: Expr [11-12]: Lit: Int(7)
+                        RangeDefinition [14-17]:
+                            start: Expr [14-15]: Lit: Int(4)
+                            step: <none>
+                            end: Expr [16-17]: Lit: Int(8)"#]],
     );
 }
 
@@ -1005,11 +1007,12 @@ fn index_range() {
         &expect![[r#"
             Expr [0-10]: IndexExpr [3-10]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexSet:
-                    RangeDefinition [4-9]:
-                        start: Expr [4-5]: Lit: Int(1)
-                        step: Expr [6-7]: Lit: Int(5)
-                        end: Expr [8-9]: Lit: Int(2)"#]],
+                index: IndexSet [4-9]:
+                    values:
+                        RangeDefinition [4-9]:
+                            start: Expr [4-5]: Lit: Int(1)
+                            step: Expr [6-7]: Lit: Int(5)
+                            end: Expr [8-9]: Lit: Int(2)"#]],
     );
 }
 
@@ -1020,11 +1023,12 @@ fn index_full_range() {
         &expect![[r#"
             Expr [0-6]: IndexExpr [3-6]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexSet:
-                    RangeDefinition [4-5]:
-                        start: <none>
-                        step: <none>
-                        end: <none>"#]],
+                index: IndexSet [4-5]:
+                    values:
+                        RangeDefinition [4-5]:
+                            start: <none>
+                            step: <none>
+                            end: <none>"#]],
     );
 }
 
@@ -1035,11 +1039,12 @@ fn index_range_start() {
         &expect![[r#"
             Expr [0-7]: IndexExpr [3-7]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexSet:
-                    RangeDefinition [4-6]:
-                        start: Expr [4-5]: Lit: Int(1)
-                        step: <none>
-                        end: <none>"#]],
+                index: IndexSet [4-6]:
+                    values:
+                        RangeDefinition [4-6]:
+                            start: Expr [4-5]: Lit: Int(1)
+                            step: <none>
+                            end: <none>"#]],
     );
 }
 
@@ -1050,11 +1055,12 @@ fn index_range_end() {
         &expect![[r#"
             Expr [0-7]: IndexExpr [3-7]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexSet:
-                    RangeDefinition [4-6]:
-                        start: <none>
-                        step: <none>
-                        end: Expr [5-6]: Lit: Int(5)"#]],
+                index: IndexSet [4-6]:
+                    values:
+                        RangeDefinition [4-6]:
+                            start: <none>
+                            step: <none>
+                            end: Expr [5-6]: Lit: Int(5)"#]],
     );
 }
 
@@ -1065,11 +1071,12 @@ fn index_range_step() {
         &expect![[r#"
             Expr [0-8]: IndexExpr [3-8]:
                 collection: Expr [0-3]: Ident [0-3] "foo"
-                index: IndexSet:
-                    RangeDefinition [4-7]:
-                        start: <none>
-                        step: Expr [5-6]: Lit: Int(2)
-                        end: <none>"#]],
+                index: IndexSet [4-7]:
+                    values:
+                        RangeDefinition [4-7]:
+                            start: <none>
+                            step: Expr [5-6]: Lit: Int(2)
+                            end: <none>"#]],
     );
 }
 
@@ -1155,10 +1162,12 @@ fn indexed_identifier() {
             IndexedIdent [0-9]:
                 name: Ident [0-3] "arr"
                 indices:
-                    IndexSet:
-                        Expr [4-5]: Lit: Int(1)
-                    IndexSet:
-                        Expr [7-8]: Lit: Int(2)"#]],
+                    IndexSet [4-5]:
+                        values:
+                            Expr [4-5]: Lit: Int(1)
+                    IndexSet [7-8]:
+                        values:
+                            Expr [7-8]: Lit: Int(2)"#]],
     );
 }
 
@@ -1169,7 +1178,7 @@ fn measure_hardware_qubit() {
         "measure $12",
         &expect![[r#"
             MeasureExpr [0-7]:
-                operand: GateOperand HardwareQubit [8-11]: 12"#]],
+                operand: HardwareQubit [8-11]: 12"#]],
     );
 }
 
@@ -1180,13 +1189,15 @@ fn measure_indexed_identifier() {
         "measure qubits[1][2]",
         &expect![[r#"
             MeasureExpr [0-7]:
-                operand: GateOperand IndexedIdent [8-20]:
+                operand: IndexedIdent [8-20]:
                     name: Ident [8-14] "qubits"
                     indices:
-                        IndexSet:
-                            Expr [15-16]: Lit: Int(1)
-                        IndexSet:
-                            Expr [18-19]: Lit: Int(2)"#]],
+                        IndexSet [15-16]:
+                            values:
+                                Expr [15-16]: Lit: Int(1)
+                        IndexSet [18-19]:
+                            values:
+                                Expr [18-19]: Lit: Int(2)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/expr/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/expr/tests.rs
@@ -117,8 +117,9 @@ fn lit_int_min() {
     check_expr(
         "-9_223_372_036_854_775_808",
         &expect![[r#"
-            Expr [0-26]: UnOp (Neg):
-                Expr [1-26]: Lit: Int(-9223372036854775808)"#]],
+            Expr [0-26]: UnaryOpExpr:
+                op: Neg
+                expr: Expr [1-26]: Lit: Int(-9223372036854775808)"#]],
     );
 }
 
@@ -540,9 +541,10 @@ fn pratt_parsing_binary_expr() {
     check_expr(
         "1 + 2",
         &expect![[r#"
-            Expr [0-5]: BinOp (Add):
-                Expr [0-1]: Lit: Int(1)
-                Expr [4-5]: Lit: Int(2)"#]],
+            Expr [0-5]: BinaryOpExpr:
+                op: Add
+                lhs: Expr [0-1]: Lit: Int(1)
+                rhs: Expr [4-5]: Lit: Int(2)"#]],
     );
 }
 
@@ -551,11 +553,13 @@ fn pratt_parsing_mul_add() {
     check_expr(
         "1 + 2 * 3",
         &expect![[r#"
-            Expr [0-9]: BinOp (Add):
-                Expr [0-1]: Lit: Int(1)
-                Expr [4-9]: BinOp (Mul):
-                    Expr [4-5]: Lit: Int(2)
-                    Expr [8-9]: Lit: Int(3)"#]],
+            Expr [0-9]: BinaryOpExpr:
+                op: Add
+                lhs: Expr [0-1]: Lit: Int(1)
+                rhs: Expr [4-9]: BinaryOpExpr:
+                    op: Mul
+                    lhs: Expr [4-5]: Lit: Int(2)
+                    rhs: Expr [8-9]: Lit: Int(3)"#]],
     );
 }
 
@@ -564,12 +568,13 @@ fn pratt_parsing_parens() {
     check_expr(
         "(1 + 2) * 3",
         &expect![[r#"
-            Expr [0-11]: BinOp (Mul):
-                Expr [0-7]: Paren:
-                    Expr [1-6]: BinOp (Add):
-                        Expr [1-2]: Lit: Int(1)
-                        Expr [5-6]: Lit: Int(2)
-                Expr [10-11]: Lit: Int(3)"#]],
+            Expr [0-11]: BinaryOpExpr:
+                op: Mul
+                lhs: Expr [0-7]: Paren Expr [1-6]: BinaryOpExpr:
+                    op: Add
+                    lhs: Expr [1-2]: Lit: Int(1)
+                    rhs: Expr [5-6]: Lit: Int(2)
+                rhs: Expr [10-11]: Lit: Int(3)"#]],
     );
 }
 
@@ -578,10 +583,12 @@ fn prat_parsing_mul_unary() {
     check_expr(
         "2 * -3",
         &expect![[r#"
-            Expr [0-6]: BinOp (Mul):
-                Expr [0-1]: Lit: Int(2)
-                Expr [4-6]: UnOp (Neg):
-                    Expr [5-6]: Lit: Int(3)"#]],
+            Expr [0-6]: BinaryOpExpr:
+                op: Mul
+                lhs: Expr [0-1]: Lit: Int(2)
+                rhs: Expr [4-6]: UnaryOpExpr:
+                    op: Neg
+                    expr: Expr [5-6]: Lit: Int(3)"#]],
     );
 }
 
@@ -590,10 +597,12 @@ fn prat_parsing_unary_mul() {
     check_expr(
         "-2 * 3",
         &expect![[r#"
-            Expr [0-6]: BinOp (Mul):
-                Expr [0-2]: UnOp (Neg):
-                    Expr [1-2]: Lit: Int(2)
-                Expr [5-6]: Lit: Int(3)"#]],
+            Expr [0-6]: BinaryOpExpr:
+                op: Mul
+                lhs: Expr [0-2]: UnaryOpExpr:
+                    op: Neg
+                    expr: Expr [1-2]: Lit: Int(2)
+                rhs: Expr [5-6]: Lit: Int(3)"#]],
     );
 }
 
@@ -602,10 +611,13 @@ fn prat_parsing_exp_funcall() {
     check_expr(
         "2 ** square(3)",
         &expect![[r#"
-            Expr [0-14]: BinOp (Exp):
-                Expr [0-1]: Lit: Int(2)
-                Expr [5-14]: FunctionCall [5-14]: Ident [5-11] "square"
-                    Expr [12-13]: Lit: Int(3)"#]],
+            Expr [0-14]: BinaryOpExpr:
+                op: Exp
+                lhs: Expr [0-1]: Lit: Int(2)
+                rhs: Expr [5-14]: FunctionCall [5-14]:
+                    name: Ident [5-11] "square"
+                    args: 
+                        Expr [12-13]: Lit: Int(3)"#]],
     );
 }
 
@@ -614,10 +626,13 @@ fn prat_parsing_funcall_exp() {
     check_expr(
         "square(2) ** 3",
         &expect![[r#"
-            Expr [0-14]: BinOp (Exp):
-                Expr [0-9]: FunctionCall [0-9]: Ident [0-6] "square"
-                    Expr [7-8]: Lit: Int(2)
-                Expr [13-14]: Lit: Int(3)"#]],
+            Expr [0-14]: BinaryOpExpr:
+                op: Exp
+                lhs: Expr [0-9]: FunctionCall [0-9]:
+                    name: Ident [0-6] "square"
+                    args: 
+                        Expr [7-8]: Lit: Int(2)
+                rhs: Expr [13-14]: Lit: Int(3)"#]],
     );
 }
 
@@ -626,10 +641,13 @@ fn prat_parsing_funcall_exp_arg() {
     check_expr(
         "square(2 ** 3)",
         &expect![[r#"
-            Expr [0-14]: FunctionCall [0-14]: Ident [0-6] "square"
-                Expr [7-13]: BinOp (Exp):
-                    Expr [7-8]: Lit: Int(2)
-                    Expr [12-13]: Lit: Int(3)"#]],
+            Expr [0-14]: FunctionCall [0-14]:
+                name: Ident [0-6] "square"
+                args: 
+                    Expr [7-13]: BinaryOpExpr:
+                        op: Exp
+                        lhs: Expr [7-8]: Lit: Int(2)
+                        rhs: Expr [12-13]: Lit: Int(3)"#]],
     );
 }
 
@@ -638,8 +656,10 @@ fn funcall() {
     check_expr(
         "square(2)",
         &expect![[r#"
-            Expr [0-9]: FunctionCall [0-9]: Ident [0-6] "square"
-                Expr [7-8]: Lit: Int(2)"#]],
+            Expr [0-9]: FunctionCall [0-9]:
+                name: Ident [0-6] "square"
+                args: 
+                    Expr [7-8]: Lit: Int(2)"#]],
     );
 }
 
@@ -648,9 +668,11 @@ fn funcall_multiple_args() {
     check_expr(
         "square(2, 3)",
         &expect![[r#"
-            Expr [0-12]: FunctionCall [0-12]: Ident [0-6] "square"
-                Expr [7-8]: Lit: Int(2)
-                Expr [10-11]: Lit: Int(3)"#]],
+            Expr [0-12]: FunctionCall [0-12]:
+                name: Ident [0-6] "square"
+                args: 
+                    Expr [7-8]: Lit: Int(2)
+                    Expr [10-11]: Lit: Int(3)"#]],
     );
 }
 
@@ -659,9 +681,11 @@ fn funcall_multiple_args_trailing_comma() {
     check_expr(
         "square(2, 3,)",
         &expect![[r#"
-            Expr [0-13]: FunctionCall [0-13]: Ident [0-6] "square"
-                Expr [7-8]: Lit: Int(2)
-                Expr [10-11]: Lit: Int(3)"#]],
+            Expr [0-13]: FunctionCall [0-13]:
+                name: Ident [0-6] "square"
+                args: 
+                    Expr [7-8]: Lit: Int(2)
+                    Expr [10-11]: Lit: Int(3)"#]],
     );
 }
 
@@ -671,8 +695,9 @@ fn cast_to_bit() {
         "bit(0)",
         &expect![[r#"
             Expr [0-6]: Cast [0-6]:
-                ClassicalType [0-3]: BitType
-                Expr [4-5]: Lit: Int(0)"#]],
+                type: ScalarType [0-3]: BitType [0-3]:
+                    size: <none>
+                arg: Expr [4-5]: Lit: Int(0)"#]],
     );
 }
 
@@ -682,8 +707,9 @@ fn cast_to_bit_with_designator() {
         "bit[4](0)",
         &expect![[r#"
             Expr [0-9]: Cast [0-9]:
-                ClassicalType [0-6]: BitType [0-6]: Expr [4-5]: Lit: Int(4)
-                Expr [7-8]: Lit: Int(0)"#]],
+                type: ScalarType [0-6]: BitType [0-6]:
+                    size: Expr [4-5]: Lit: Int(4)
+                arg: Expr [7-8]: Lit: Int(0)"#]],
     );
 }
 
@@ -693,8 +719,9 @@ fn cast_to_int() {
         "int(0)",
         &expect![[r#"
             Expr [0-6]: Cast [0-6]:
-                ClassicalType [0-3]: IntType [0-3]
-                Expr [4-5]: Lit: Int(0)"#]],
+                type: ScalarType [0-3]: IntType [0-3]:
+                    size: <none>
+                arg: Expr [4-5]: Lit: Int(0)"#]],
     );
 }
 
@@ -704,8 +731,9 @@ fn cast_to_int_with_designator() {
         "int[64](0)",
         &expect![[r#"
             Expr [0-10]: Cast [0-10]:
-                ClassicalType [0-7]: IntType[Expr [4-6]: Lit: Int(64)]: [0-7]
-                Expr [8-9]: Lit: Int(0)"#]],
+                type: ScalarType [0-7]: IntType [0-7]:
+                    size: Expr [4-6]: Lit: Int(64)
+                arg: Expr [8-9]: Lit: Int(0)"#]],
     );
 }
 
@@ -715,8 +743,9 @@ fn cast_to_uint() {
         "uint(0)",
         &expect![[r#"
             Expr [0-7]: Cast [0-7]:
-                ClassicalType [0-4]: UIntType [0-4]
-                Expr [5-6]: Lit: Int(0)"#]],
+                type: ScalarType [0-4]: UIntType [0-4]:
+                    size: <none>
+                arg: Expr [5-6]: Lit: Int(0)"#]],
     );
 }
 
@@ -726,8 +755,9 @@ fn cast_to_uint_with_designator() {
         "uint[64](0)",
         &expect![[r#"
             Expr [0-11]: Cast [0-11]:
-                ClassicalType [0-8]: UIntType[Expr [5-7]: Lit: Int(64)]: [0-8]
-                Expr [9-10]: Lit: Int(0)"#]],
+                type: ScalarType [0-8]: UIntType [0-8]:
+                    size: Expr [5-7]: Lit: Int(64)
+                arg: Expr [9-10]: Lit: Int(0)"#]],
     );
 }
 
@@ -737,8 +767,9 @@ fn cast_to_float() {
         "float(0)",
         &expect![[r#"
             Expr [0-8]: Cast [0-8]:
-                ClassicalType [0-5]: FloatType [0-5]
-                Expr [6-7]: Lit: Int(0)"#]],
+                type: ScalarType [0-5]: FloatType [0-5]:
+                    size: <none>
+                arg: Expr [6-7]: Lit: Int(0)"#]],
     );
 }
 
@@ -748,8 +779,9 @@ fn cast_to_float_with_designator() {
         "float[64](0)",
         &expect![[r#"
             Expr [0-12]: Cast [0-12]:
-                ClassicalType [0-9]: FloatType[Expr [6-8]: Lit: Int(64)]: [0-9]
-                Expr [10-11]: Lit: Int(0)"#]],
+                type: ScalarType [0-9]: FloatType [0-9]:
+                    size: Expr [6-8]: Lit: Int(64)
+                arg: Expr [10-11]: Lit: Int(0)"#]],
     );
 }
 
@@ -759,8 +791,10 @@ fn cast_to_complex() {
         "complex[float](0)",
         &expect![[r#"
             Expr [0-17]: Cast [0-17]:
-                ClassicalType [0-14]: ComplexType[float[FloatType [8-13]]]: [0-14]
-                Expr [15-16]: Lit: Int(0)"#]],
+                type: ScalarType [0-14]: ComplexType [0-14]:
+                    base_size: FloatType [8-13]:
+                        size: <none>
+                arg: Expr [15-16]: Lit: Int(0)"#]],
     );
 }
 
@@ -770,8 +804,10 @@ fn cast_to_complex_with_designator() {
         "complex[float[64]](0)",
         &expect![[r#"
             Expr [0-21]: Cast [0-21]:
-                ClassicalType [0-18]: ComplexType[float[FloatType[Expr [14-16]: Lit: Int(64)]: [8-17]]]: [0-18]
-                Expr [19-20]: Lit: Int(0)"#]],
+                type: ScalarType [0-18]: ComplexType [0-18]:
+                    base_size: FloatType [8-17]:
+                        size: Expr [14-16]: Lit: Int(64)
+                arg: Expr [19-20]: Lit: Int(0)"#]],
     );
 }
 
@@ -781,8 +817,8 @@ fn cast_to_bool() {
         "bool(0)",
         &expect![[r#"
             Expr [0-7]: Cast [0-7]:
-                ClassicalType [0-4]: BoolType
-                Expr [5-6]: Lit: Int(0)"#]],
+                type: ScalarType [0-4]: BoolType
+                arg: Expr [5-6]: Lit: Int(0)"#]],
     );
 }
 
@@ -792,8 +828,8 @@ fn cast_to_duration() {
         "duration(0)",
         &expect![[r#"
             Expr [0-11]: Cast [0-11]:
-                ClassicalType [0-8]: Duration
-                Expr [9-10]: Lit: Int(0)"#]],
+                type: ScalarType [0-8]: Duration
+                arg: Expr [9-10]: Lit: Int(0)"#]],
     );
 }
 
@@ -803,8 +839,8 @@ fn cast_to_stretch() {
         "stretch(0)",
         &expect![[r#"
             Expr [0-10]: Cast [0-10]:
-                ClassicalType [0-7]: Stretch
-                Expr [8-9]: Lit: Int(0)"#]],
+                type: ScalarType [0-7]: Stretch
+                arg: Expr [8-9]: Lit: Int(0)"#]],
     );
 }
 
@@ -814,9 +850,12 @@ fn cast_to_int_array() {
         "array[int[64], 4](0)",
         &expect![[r#"
             Expr [0-20]: Cast [0-20]:
-                ArrayType [0-17]: ArrayBaseTypeKind IntType[Expr [10-12]: Lit: Int(64)]: [6-13]
-                Expr [15-16]: Lit: Int(4)
-                Expr [18-19]: Lit: Int(0)"#]],
+                type: ArrayType [0-17]:
+                    base_type: ArrayBaseTypeKind IntType [6-13]:
+                        size: Expr [10-12]: Lit: Int(64)
+                    dimensions: 
+                        Expr [15-16]: Lit: Int(4)
+                arg: Expr [18-19]: Lit: Int(0)"#]],
     );
 }
 
@@ -826,9 +865,12 @@ fn cast_to_uint_array() {
         "array[uint[64], 4](0)",
         &expect![[r#"
             Expr [0-21]: Cast [0-21]:
-                ArrayType [0-18]: ArrayBaseTypeKind UIntType[Expr [11-13]: Lit: Int(64)]: [6-14]
-                Expr [16-17]: Lit: Int(4)
-                Expr [19-20]: Lit: Int(0)"#]],
+                type: ArrayType [0-18]:
+                    base_type: ArrayBaseTypeKind UIntType [6-14]:
+                        size: Expr [11-13]: Lit: Int(64)
+                    dimensions: 
+                        Expr [16-17]: Lit: Int(4)
+                arg: Expr [19-20]: Lit: Int(0)"#]],
     );
 }
 
@@ -838,9 +880,12 @@ fn cast_to_float_array() {
         "array[float[64], 4](0)",
         &expect![[r#"
             Expr [0-22]: Cast [0-22]:
-                ArrayType [0-19]: ArrayBaseTypeKind FloatType[Expr [12-14]: Lit: Int(64)]: [6-15]
-                Expr [17-18]: Lit: Int(4)
-                Expr [20-21]: Lit: Int(0)"#]],
+                type: ArrayType [0-19]:
+                    base_type: ArrayBaseTypeKind FloatType [6-15]:
+                        size: Expr [12-14]: Lit: Int(64)
+                    dimensions: 
+                        Expr [17-18]: Lit: Int(4)
+                arg: Expr [20-21]: Lit: Int(0)"#]],
     );
 }
 
@@ -850,9 +895,12 @@ fn cast_to_angle_array() {
         "array[angle[64], 4](0)",
         &expect![[r#"
             Expr [0-22]: Cast [0-22]:
-                ArrayType [0-19]: ArrayBaseTypeKind AngleType [6-15]: Expr [12-14]: Lit: Int(64)
-                Expr [17-18]: Lit: Int(4)
-                Expr [20-21]: Lit: Int(0)"#]],
+                type: ArrayType [0-19]:
+                    base_type: ArrayBaseTypeKind AngleType [6-15]:
+                        size: Expr [12-14]: Lit: Int(64)
+                    dimensions: 
+                        Expr [17-18]: Lit: Int(4)
+                arg: Expr [20-21]: Lit: Int(0)"#]],
     );
 }
 
@@ -862,9 +910,11 @@ fn cast_to_bool_array() {
         "array[bool, 4](0)",
         &expect![[r#"
             Expr [0-17]: Cast [0-17]:
-                ArrayType [0-14]: ArrayBaseTypeKind BoolType
-                Expr [12-13]: Lit: Int(4)
-                Expr [15-16]: Lit: Int(0)"#]],
+                type: ArrayType [0-14]:
+                    base_type: ArrayBaseTypeKind BoolType
+                    dimensions: 
+                        Expr [12-13]: Lit: Int(4)
+                arg: Expr [15-16]: Lit: Int(0)"#]],
     );
 }
 
@@ -874,9 +924,11 @@ fn cast_to_duration_array() {
         "array[duration, 4](0)",
         &expect![[r#"
             Expr [0-21]: Cast [0-21]:
-                ArrayType [0-18]: ArrayBaseTypeKind DurationType
-                Expr [16-17]: Lit: Int(4)
-                Expr [19-20]: Lit: Int(0)"#]],
+                type: ArrayType [0-18]:
+                    base_type: ArrayBaseTypeKind DurationType
+                    dimensions: 
+                        Expr [16-17]: Lit: Int(4)
+                arg: Expr [19-20]: Lit: Int(0)"#]],
     );
 }
 
@@ -886,9 +938,13 @@ fn cast_to_complex_array() {
         "array[complex[float[32]], 4](0)",
         &expect![[r#"
             Expr [0-31]: Cast [0-31]:
-                ArrayType [0-28]: ArrayBaseTypeKind ComplexType[float[FloatType[Expr [20-22]: Lit: Int(32)]: [14-23]]]: [6-24]
-                Expr [26-27]: Lit: Int(4)
-                Expr [29-30]: Lit: Int(0)"#]],
+                type: ArrayType [0-28]:
+                    base_type: ArrayBaseTypeKind ComplexType [6-24]:
+                        base_size: FloatType [14-23]:
+                            size: Expr [20-22]: Lit: Int(32)
+                    dimensions: 
+                        Expr [26-27]: Lit: Int(4)
+                arg: Expr [29-30]: Lit: Int(0)"#]],
     );
 }
 
@@ -897,8 +953,10 @@ fn index_expr() {
     check_expr(
         "foo[1]",
         &expect![[r#"
-            Expr [0-6]: IndexExpr [3-6]: Expr [0-3]: Ident [0-3] "foo", IndexElement:
-                IndexSetItem Expr [4-5]: Lit: Int(1)"#]],
+            Expr [0-6]: IndexExpr [3-6]:
+                collection: Expr [0-3]: Ident [0-3] "foo"
+                index: IndexElement: 
+                    IndexSetItem Expr [4-5]: Lit: Int(1)"#]],
     );
 }
 
@@ -907,10 +965,13 @@ fn index_set() {
     check_expr(
         "foo[{1, 4, 5}]",
         &expect![[r#"
-            Expr [0-14]: IndexExpr [3-14]: Expr [0-3]: Ident [0-3] "foo", IndexElement DiscreteSet [4-13]:
-                Expr [5-6]: Lit: Int(1)
-                Expr [8-9]: Lit: Int(4)
-                Expr [11-12]: Lit: Int(5)"#]],
+            Expr [0-14]: IndexExpr [3-14]:
+                collection: Expr [0-3]: Ident [0-3] "foo"
+                index: IndexElement DiscreteSet [4-13]:
+                    values: 
+                        Expr [5-6]: Lit: Int(1)
+                        Expr [8-9]: Lit: Int(4)
+                        Expr [11-12]: Lit: Int(5)"#]],
     );
 }
 
@@ -919,19 +980,21 @@ fn index_multiple_ranges() {
     check_expr(
         "foo[1:5, 3:7, 4:8]",
         &expect![[r#"
-            Expr [0-18]: IndexExpr [3-18]: Expr [0-3]: Ident [0-3] "foo", IndexElement:
-                Range: [4-7]
-                    start: Expr [4-5]: Lit: Int(1)
-                    <no step>
-                    end: Expr [6-7]: Lit: Int(5)
-                Range: [9-12]
-                    start: Expr [9-10]: Lit: Int(3)
-                    <no step>
-                    end: Expr [11-12]: Lit: Int(7)
-                Range: [14-17]
-                    start: Expr [14-15]: Lit: Int(4)
-                    <no step>
-                    end: Expr [16-17]: Lit: Int(8)"#]],
+            Expr [0-18]: IndexExpr [3-18]:
+                collection: Expr [0-3]: Ident [0-3] "foo"
+                index: IndexElement: 
+                    IndexSetItem RangeDefinition [4-7]:
+                        start: Expr [4-5]: Lit: Int(1)
+                        step: <none>
+                        end: Expr [6-7]: Lit: Int(5)
+                    IndexSetItem RangeDefinition [9-12]:
+                        start: Expr [9-10]: Lit: Int(3)
+                        step: <none>
+                        end: Expr [11-12]: Lit: Int(7)
+                    IndexSetItem RangeDefinition [14-17]:
+                        start: Expr [14-15]: Lit: Int(4)
+                        step: <none>
+                        end: Expr [16-17]: Lit: Int(8)"#]],
     );
 }
 
@@ -940,11 +1003,13 @@ fn index_range() {
     check_expr(
         "foo[1:5:2]",
         &expect![[r#"
-            Expr [0-10]: IndexExpr [3-10]: Expr [0-3]: Ident [0-3] "foo", IndexElement:
-                Range: [4-9]
-                    start: Expr [4-5]: Lit: Int(1)
-                    step: Expr [6-7]: Lit: Int(5)
-                    end: Expr [8-9]: Lit: Int(2)"#]],
+            Expr [0-10]: IndexExpr [3-10]:
+                collection: Expr [0-3]: Ident [0-3] "foo"
+                index: IndexElement: 
+                    IndexSetItem RangeDefinition [4-9]:
+                        start: Expr [4-5]: Lit: Int(1)
+                        step: Expr [6-7]: Lit: Int(5)
+                        end: Expr [8-9]: Lit: Int(2)"#]],
     );
 }
 
@@ -953,11 +1018,13 @@ fn index_full_range() {
     check_expr(
         "foo[:]",
         &expect![[r#"
-            Expr [0-6]: IndexExpr [3-6]: Expr [0-3]: Ident [0-3] "foo", IndexElement:
-                Range: [4-5]
-                    <no start>
-                    <no step>
-                    <no end>"#]],
+            Expr [0-6]: IndexExpr [3-6]:
+                collection: Expr [0-3]: Ident [0-3] "foo"
+                index: IndexElement: 
+                    IndexSetItem RangeDefinition [4-5]:
+                        start: <none>
+                        step: <none>
+                        end: <none>"#]],
     );
 }
 
@@ -966,11 +1033,13 @@ fn index_range_start() {
     check_expr(
         "foo[1:]",
         &expect![[r#"
-            Expr [0-7]: IndexExpr [3-7]: Expr [0-3]: Ident [0-3] "foo", IndexElement:
-                Range: [4-6]
-                    start: Expr [4-5]: Lit: Int(1)
-                    <no step>
-                    <no end>"#]],
+            Expr [0-7]: IndexExpr [3-7]:
+                collection: Expr [0-3]: Ident [0-3] "foo"
+                index: IndexElement: 
+                    IndexSetItem RangeDefinition [4-6]:
+                        start: Expr [4-5]: Lit: Int(1)
+                        step: <none>
+                        end: <none>"#]],
     );
 }
 
@@ -979,11 +1048,13 @@ fn index_range_end() {
     check_expr(
         "foo[:5]",
         &expect![[r#"
-            Expr [0-7]: IndexExpr [3-7]: Expr [0-3]: Ident [0-3] "foo", IndexElement:
-                Range: [4-6]
-                    <no start>
-                    <no step>
-                    end: Expr [5-6]: Lit: Int(5)"#]],
+            Expr [0-7]: IndexExpr [3-7]:
+                collection: Expr [0-3]: Ident [0-3] "foo"
+                index: IndexElement: 
+                    IndexSetItem RangeDefinition [4-6]:
+                        start: <none>
+                        step: <none>
+                        end: Expr [5-6]: Lit: Int(5)"#]],
     );
 }
 
@@ -992,11 +1063,13 @@ fn index_range_step() {
     check_expr(
         "foo[:2:]",
         &expect![[r#"
-            Expr [0-8]: IndexExpr [3-8]: Expr [0-3]: Ident [0-3] "foo", IndexElement:
-                Range: [4-7]
-                    <no start>
-                    step: Expr [5-6]: Lit: Int(2)
-                    <no end>"#]],
+            Expr [0-8]: IndexExpr [3-8]:
+                collection: Expr [0-3]: Ident [0-3] "foo"
+                index: IndexElement: 
+                    IndexSetItem RangeDefinition [4-7]:
+                        start: <none>
+                        step: Expr [5-6]: Lit: Int(2)
+                        end: <none>"#]],
     );
 }
 
@@ -1006,10 +1079,11 @@ fn set_expr() {
         super::set_expr,
         "{2, 3, 4}",
         &expect![[r#"
-        DiscreteSet [0-9]:
-            Expr [1-2]: Lit: Int(2)
-            Expr [4-5]: Lit: Int(3)
-            Expr [7-8]: Lit: Int(4)"#]],
+            DiscreteSet [0-9]:
+                values: 
+                    Expr [1-2]: Lit: Int(2)
+                    Expr [4-5]: Lit: Int(3)
+                    Expr [7-8]: Lit: Int(4)"#]],
     );
 }
 
@@ -1019,9 +1093,15 @@ fn lit_array() {
         super::lit_array,
         "{{2, {5}}, 1 + z}",
         &expect![[r#"
-            Expr [0-17]: Lit: Array:
-                Expr { span: Span { lo: 1, hi: 9 }, kind: Lit(Lit { span: Span { lo: 1, hi: 9 }, kind: Array([Expr { span: Span { lo: 2, hi: 3 }, kind: Lit(Lit { span: Span { lo: 2, hi: 3 }, kind: Int(2) }) }, Expr { span: Span { lo: 5, hi: 8 }, kind: Lit(Lit { span: Span { lo: 5, hi: 8 }, kind: Array([Expr { span: Span { lo: 6, hi: 7 }, kind: Lit(Lit { span: Span { lo: 6, hi: 7 }, kind: Int(5) }) }]) }) }]) }) }
-                Expr { span: Span { lo: 11, hi: 16 }, kind: BinaryOp(BinaryOpExpr { op: Add, lhs: Expr { span: Span { lo: 11, hi: 12 }, kind: Lit(Lit { span: Span { lo: 11, hi: 12 }, kind: Int(1) }) }, rhs: Expr { span: Span { lo: 15, hi: 16 }, kind: Ident(Ident { span: Span { lo: 15, hi: 16 }, name: "z" }) } }) }"#]],
+            Expr [0-17]: Lit:     Array: 
+                    Expr [1-9]: Lit:     Array: 
+                            Expr [2-3]: Lit: Int(2)
+                            Expr [5-8]: Lit:     Array: 
+                                    Expr [6-7]: Lit: Int(5)
+                    Expr [11-16]: BinaryOpExpr:
+                        op: Add
+                        lhs: Expr [11-12]: Lit: Int(1)
+                        rhs: Expr [15-16]: Ident [15-16] "z""#]],
     );
 }
 
@@ -1030,12 +1110,14 @@ fn assignment_and_unop() {
     check_expr(
         "c = a && !b",
         &expect![[r#"
-            Expr [0-11]: Assign:
-                Expr [0-1]: Ident [0-1] "c"
-                Expr [4-11]: BinOp (AndL):
-                    Expr [4-5]: Ident [4-5] "a"
-                    Expr [9-11]: UnOp (NotL):
-                        Expr [10-11]: Ident [10-11] "b""#]],
+            Expr [0-11]: AssignExpr:
+                lhs: Expr [0-1]: Ident [0-1] "c"
+                rhs: Expr [4-11]: BinaryOpExpr:
+                    op: AndL
+                    lhs: Expr [4-5]: Ident [4-5] "a"
+                    rhs: Expr [9-11]: UnaryOpExpr:
+                        op: NotL
+                        expr: Expr [10-11]: Ident [10-11] "b""#]],
     );
 }
 
@@ -1044,12 +1126,14 @@ fn assignment_unop_and() {
     check_expr(
         "d = !a && b",
         &expect![[r#"
-            Expr [0-11]: Assign:
-                Expr [0-1]: Ident [0-1] "d"
-                Expr [4-11]: BinOp (AndL):
-                    Expr [4-6]: UnOp (NotL):
-                        Expr [5-6]: Ident [5-6] "a"
-                    Expr [10-11]: Ident [10-11] "b""#]],
+            Expr [0-11]: AssignExpr:
+                lhs: Expr [0-1]: Ident [0-1] "d"
+                rhs: Expr [4-11]: BinaryOpExpr:
+                    op: AndL
+                    lhs: Expr [4-6]: UnaryOpExpr:
+                        op: NotL
+                        expr: Expr [5-6]: Ident [5-6] "a"
+                    rhs: Expr [10-11]: Ident [10-11] "b""#]],
     );
 }
 
@@ -1068,11 +1152,13 @@ fn indexed_identifier() {
         super::indexed_identifier,
         "arr[1][2]",
         &expect![[r#"
-        IndexedIdent [0-9]: Ident [0-3] "arr"[
-        IndexElement:
-            IndexSetItem Expr [4-5]: Lit: Int(1)
-        IndexElement:
-            IndexSetItem Expr [7-8]: Lit: Int(2)]"#]],
+            IndexedIdent [0-9]:
+                name: Ident [0-3] "arr"
+                indices: 
+                    IndexElement: 
+                        IndexSetItem Expr [4-5]: Lit: Int(1)
+                    IndexElement: 
+                        IndexSetItem Expr [7-8]: Lit: Int(2)"#]],
     );
 }
 
@@ -1091,11 +1177,13 @@ fn measure_indexed_identifier() {
         super::measure_expr,
         "measure qubits[1][2]",
         &expect![[r#"
-        MeasureExpr [0-7]: GateOperand IndexedIdent [8-20]: Ident [8-14] "qubits"[
-        IndexElement:
-            IndexSetItem Expr [15-16]: Lit: Int(1)
-        IndexElement:
-            IndexSetItem Expr [18-19]: Lit: Int(2)]"#]],
+            MeasureExpr [0-7]: GateOperand IndexedIdent [8-20]:
+                name: Ident [8-14] "qubits"
+                indices: 
+                    IndexElement: 
+                        IndexSetItem Expr [15-16]: Lit: Int(1)
+                    IndexElement: 
+                        IndexSetItem Expr [18-19]: Lit: Int(2)"#]],
     );
 }
 
@@ -1104,12 +1192,15 @@ fn addition_of_casts() {
     check_expr(
         "bit(0) + bit(1)",
         &expect![[r#"
-        Expr [0-15]: BinOp (Add):
-            Expr [0-6]: Cast [0-6]:
-                ClassicalType [0-3]: BitType
-                Expr [4-5]: Lit: Int(0)
-            Expr [9-15]: Cast [9-15]:
-                ClassicalType [9-12]: BitType
-                Expr [13-14]: Lit: Int(1)"#]],
+            Expr [0-15]: BinaryOpExpr:
+                op: Add
+                lhs: Expr [0-6]: Cast [0-6]:
+                    type: ScalarType [0-3]: BitType [0-3]:
+                        size: <none>
+                    arg: Expr [4-5]: Lit: Int(0)
+                rhs: Expr [9-15]: Cast [9-15]:
+                    type: ScalarType [9-12]: BitType [9-12]:
+                        size: <none>
+                    arg: Expr [13-14]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/expr/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/expr/tests.rs
@@ -1167,7 +1167,9 @@ fn measure_hardware_qubit() {
     check(
         super::measure_expr,
         "measure $12",
-        &expect!["MeasureExpr [0-7]: GateOperand HardwareQubit [8-11]: 12"],
+        &expect![[r#"
+            MeasureExpr [0-7]:
+                operand: GateOperand HardwareQubit [8-11]: 12"#]],
     );
 }
 
@@ -1177,13 +1179,14 @@ fn measure_indexed_identifier() {
         super::measure_expr,
         "measure qubits[1][2]",
         &expect![[r#"
-            MeasureExpr [0-7]: GateOperand IndexedIdent [8-20]:
-                name: Ident [8-14] "qubits"
-                indices:
-                    IndexElement:
-                        IndexSetItem Expr [15-16]: Lit: Int(1)
-                    IndexElement:
-                        IndexSetItem Expr [18-19]: Lit: Int(2)"#]],
+            MeasureExpr [0-7]:
+                operand: GateOperand IndexedIdent [8-20]:
+                    name: Ident [8-14] "qubits"
+                    indices:
+                        IndexElement:
+                            IndexSetItem Expr [15-16]: Lit: Int(1)
+                        IndexElement:
+                            IndexSetItem Expr [18-19]: Lit: Int(2)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/prim/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/prim/tests.rs
@@ -87,10 +87,14 @@ fn ident_keyword() {
 
 #[test]
 fn path_single() {
-    check(path, "Foo", &expect![[r#"
+    check(
+        path,
+        "Foo",
+        &expect![[r#"
         Path [0-3]:
             name: Ident [0-3] "Foo"
-            segments: <none>"#]]);
+            segments: <none>"#]],
+    );
 }
 
 #[test]
@@ -101,7 +105,7 @@ fn path_double() {
         &expect![[r#"
             Path [0-7]:
                 name: Ident [4-7] "Bar"
-                segments: 
+                segments:
                     Ident [0-3] "Foo""#]],
     );
 }
@@ -114,7 +118,7 @@ fn path_triple() {
         &expect![[r#"
             Path [0-11]:
                 name: Ident [8-11] "Baz"
-                segments: 
+                segments:
                     Ident [0-3] "Foo"
                     Ident [4-7] "Bar""#]],
     );
@@ -126,7 +130,7 @@ fn path_trailing_dot() {
         path,
         "Foo.Bar.",
         &expect![[r#"
-            Err IncompletePath [0-8]:    segments: 
+            Err IncompletePath [0-8]:    segments:
                     Ident [0-3] "Foo"
                     Ident [4-7] "Bar"
 
@@ -151,7 +155,7 @@ fn path_followed_by_keyword() {
         path,
         "Foo.Bar.in",
         &expect![[r#"
-            Err IncompletePath [0-10]:    segments: 
+            Err IncompletePath [0-10]:    segments:
                     Ident [0-3] "Foo"
                     Ident [4-7] "Bar"
 
@@ -180,7 +184,7 @@ fn opt_succeed() {
         &expect![[r#"
             Path [0-7]:
                 name: Ident [4-7] "Bar"
-                segments: 
+                segments:
                     Ident [0-3] "Foo""#]],
     );
 }
@@ -196,7 +200,7 @@ fn opt_fail_consume() {
         |s| opt(s, path),
         "Foo.$",
         &expect![[r#"
-            Err IncompletePath [0-5]:    segments: 
+            Err IncompletePath [0-5]:    segments:
                     Ident [0-3] "Foo"
 
             [

--- a/compiler/qsc_qasm3/src/parser/prim/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/prim/tests.rs
@@ -87,7 +87,10 @@ fn ident_keyword() {
 
 #[test]
 fn path_single() {
-    check(path, "Foo", &expect![[r#"Path [0-3] (Ident [0-3] "Foo")"#]]);
+    check(path, "Foo", &expect![[r#"
+        Path [0-3]:
+            name: Ident [0-3] "Foo"
+            segments: <none>"#]]);
 }
 
 #[test]
@@ -97,8 +100,9 @@ fn path_double() {
         "Foo.Bar",
         &expect![[r#"
             Path [0-7]:
-                Ident [0-3] "Foo"
-                Ident [4-7] "Bar""#]],
+                name: Ident [4-7] "Bar"
+                segments: 
+                    Ident [0-3] "Foo""#]],
     );
 }
 
@@ -109,9 +113,10 @@ fn path_triple() {
         "Foo.Bar.Baz",
         &expect![[r#"
             Path [0-11]:
-                Ident [0-3] "Foo"
-                Ident [4-7] "Bar"
-                Ident [8-11] "Baz""#]],
+                name: Ident [8-11] "Baz"
+                segments: 
+                    Ident [0-3] "Foo"
+                    Ident [4-7] "Bar""#]],
     );
 }
 
@@ -121,9 +126,9 @@ fn path_trailing_dot() {
         path,
         "Foo.Bar.",
         &expect![[r#"
-            Err IncompletePath [0-8]:
-                Ident [0-3] "Foo"
-                Ident [4-7] "Bar"
+            Err IncompletePath [0-8]:    segments: 
+                    Ident [0-3] "Foo"
+                    Ident [4-7] "Bar"
 
             [
                 Error(
@@ -146,9 +151,9 @@ fn path_followed_by_keyword() {
         path,
         "Foo.Bar.in",
         &expect![[r#"
-            Err IncompletePath [0-10]:
-                Ident [0-3] "Foo"
-                Ident [4-7] "Bar"
+            Err IncompletePath [0-10]:    segments: 
+                    Ident [0-3] "Foo"
+                    Ident [4-7] "Bar"
 
             [
                 Error(
@@ -174,8 +179,9 @@ fn opt_succeed() {
         "Foo.Bar",
         &expect![[r#"
             Path [0-7]:
-                Ident [0-3] "Foo"
-                Ident [4-7] "Bar""#]],
+                name: Ident [4-7] "Bar"
+                segments: 
+                    Ident [0-3] "Foo""#]],
     );
 }
 
@@ -190,8 +196,8 @@ fn opt_fail_consume() {
         |s| opt(s, path),
         "Foo.$",
         &expect![[r#"
-            Err IncompletePath [0-5]:
-                Ident [0-3] "Foo"
+            Err IncompletePath [0-5]:    segments: 
+                    Ident [0-3] "Foo"
 
             [
                 Error(

--- a/compiler/qsc_qasm3/src/parser/stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt.rs
@@ -25,7 +25,7 @@ use crate::{
         Identifier, IfStmt, IncludeStmt, IndexElement, IndexExpr, IndexSetItem, IntType, List,
         LiteralKind, MeasureStmt, Pragma, QuantumGateDefinition, QuantumGateModifier,
         QubitDeclaration, RangeDefinition, ResetStmt, ReturnStmt, ScalarType, ScalarTypeKind, Stmt,
-        StmtKind, SwitchStmt, TypeDef, TypedParameter, UIntType, WhileLoop,
+        StmtKind, SwitchCase, SwitchStmt, TypeDef, TypedParameter, UIntType, WhileLoop,
     },
     keyword::Keyword,
     lex::{cooked::Type, Delim, TokenKind},
@@ -911,7 +911,7 @@ pub fn parse_switch_stmt(s: &mut ParserContext) -> Result<SwitchStmt> {
     })
 }
 
-fn case_stmt(s: &mut ParserContext) -> Result<(List<Expr>, Block)> {
+fn case_stmt(s: &mut ParserContext) -> Result<SwitchCase> {
     let lo = s.peek().span.lo;
     token(s, TokenKind::Keyword(Keyword::Case))?;
 
@@ -921,7 +921,12 @@ fn case_stmt(s: &mut ParserContext) -> Result<(List<Expr>, Block)> {
     }
 
     let block = parse_block(s).map(|block| *block)?;
-    Ok((list_from_iter(controlling_label), block))
+
+    Ok(SwitchCase {
+        span: s.span(lo),
+        labels: list_from_iter(controlling_label),
+        block,
+    })
 }
 
 fn default_case_stmt(s: &mut ParserContext) -> Result<Block> {

--- a/compiler/qsc_qasm3/src/parser/stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt.rs
@@ -17,15 +17,16 @@ use super::{
 use crate::{
     ast::{
         list_from_iter, AccessControl, AliasDeclStmt, AngleType, Annotation, ArrayBaseTypeKind,
-        ArrayReferenceType, ArrayType, BarrierStmt, BitType, Block, BoxStmt, BreakStmt,
-        CalibrationGrammarStmt, CalibrationStmt, Cast, ClassicalDeclarationStmt, ComplexType,
-        ConstantDeclStmt, ContinueStmt, DefCalStmt, DefStmt, DelayStmt, EndStmt, EnumerableSet,
-        Expr, ExprKind, ExprStmt, ExternDecl, ExternParameter, FloatType, ForStmt, FunctionCall,
-        GPhase, GateCall, GateModifierKind, GateOperand, IODeclaration, IOKeyword, Ident,
-        Identifier, IfStmt, IncludeStmt, IndexElement, IndexExpr, IndexSetItem, IntType, List,
-        LiteralKind, MeasureStmt, Pragma, QuantumGateDefinition, QuantumGateModifier,
-        QubitDeclaration, RangeDefinition, ResetStmt, ReturnStmt, ScalarType, ScalarTypeKind, Stmt,
-        StmtKind, SwitchCase, SwitchStmt, TypeDef, TypedParameter, UIntType, WhileLoop,
+        ArrayReferenceType, ArrayType, ArrayTypedParameter, BarrierStmt, BitType, Block, BoxStmt,
+        BreakStmt, CalibrationGrammarStmt, CalibrationStmt, Cast, ClassicalDeclarationStmt,
+        ComplexType, ConstantDeclStmt, ContinueStmt, DefCalStmt, DefStmt, DelayStmt, EndStmt,
+        EnumerableSet, Expr, ExprKind, ExprStmt, ExternDecl, ExternParameter, FloatType, ForStmt,
+        FunctionCall, GPhase, GateCall, GateModifierKind, GateOperand, IODeclaration, IOKeyword,
+        Ident, Identifier, IfStmt, IncludeStmt, IndexElement, IndexExpr, IndexSetItem, IntType,
+        List, LiteralKind, MeasureStmt, Pragma, QuantumGateDefinition, QuantumGateModifier,
+        QuantumTypedParameter, QubitDeclaration, RangeDefinition, ResetStmt, ReturnStmt,
+        ScalarType, ScalarTypeKind, ScalarTypedParameter, Stmt, StmtKind, SwitchCase, SwitchStmt,
+        TypeDef, TypedParameter, UIntType, WhileLoop,
     },
     keyword::Keyword,
     lex::{cooked::Type, Delim, TokenKind},
@@ -359,10 +360,18 @@ fn arg_def(s: &mut ParserContext) -> Result<TypedParameter> {
 
     let kind = if let Ok(ty) = scalar_type(s) {
         let ident = prim::ident(s)?;
-        TypedParameter::Scalar(ty, Box::new(ident), s.span(lo))
+        TypedParameter::Scalar(ScalarTypedParameter {
+            span: s.span(lo),
+            r#type: Box::new(ty),
+            ident,
+        })
     } else if let Ok(size) = qubit_type(s) {
         let ident = prim::ident(s)?;
-        TypedParameter::Quantum(size, Box::new(ident), s.span(lo))
+        TypedParameter::Quantum(QuantumTypedParameter {
+            span: s.span(lo),
+            size,
+            ident,
+        })
     } else if let Ok((ident, size)) = creg_type(s) {
         let ty = ScalarType {
             span: s.span(lo),
@@ -371,12 +380,24 @@ fn arg_def(s: &mut ParserContext) -> Result<TypedParameter> {
                 span: s.span(lo),
             }),
         };
-        TypedParameter::Scalar(ty, ident, s.span(lo))
+        TypedParameter::Scalar(ScalarTypedParameter {
+            span: s.span(lo),
+            r#type: Box::new(ty),
+            ident,
+        })
     } else if let Ok((ident, size)) = qreg_type(s) {
-        TypedParameter::Quantum(size, ident, s.span(lo))
+        TypedParameter::Quantum(QuantumTypedParameter {
+            span: s.span(lo),
+            size,
+            ident,
+        })
     } else if let Ok(ty) = array_reference_ty(s) {
         let ident = prim::ident(s)?;
-        TypedParameter::ArrayReference(ty, Box::new(ident), s.span(lo))
+        TypedParameter::ArrayReference(ArrayTypedParameter {
+            span: s.span(lo),
+            r#type: Box::new(ty),
+            ident,
+        })
     } else {
         return Err(Error::new(ErrorKind::Rule(
             "argument definition",
@@ -472,7 +493,7 @@ fn parse_quantum_decl(s: &mut ParserContext) -> Result<StmtKind> {
     recovering_semi(s);
     Ok(StmtKind::QuantumDecl(QubitDeclaration {
         span: s.span(lo),
-        qubit: Box::new(ident),
+        qubit: ident,
         size,
     }))
 }
@@ -531,7 +552,7 @@ fn parse_non_constant_classical_decl(
     ty: TypeDef,
     lo: u32,
 ) -> Result<StmtKind> {
-    let identifier = Box::new(prim::ident(s)?);
+    let identifier = prim::ident(s)?;
     let init_expr = if s.peek().kind == TokenKind::Eq {
         s.advance();
         Some(expr::value_expr(s)?)
@@ -541,7 +562,7 @@ fn parse_non_constant_classical_decl(
     recovering_semi(s);
     let decl = ClassicalDeclarationStmt {
         span: s.span(lo),
-        r#type: ty,
+        r#type: Box::new(ty),
         identifier,
         init_expr,
     };
@@ -654,13 +675,13 @@ fn creg_decl(s: &mut ParserContext) -> Result<StmtKind> {
     recovering_semi(s);
     Ok(StmtKind::ClassicalDecl(ClassicalDeclarationStmt {
         span: s.span(lo),
-        r#type: TypeDef::Scalar(ScalarType {
+        r#type: Box::new(TypeDef::Scalar(ScalarType {
             span: s.span(lo),
             kind: ScalarTypeKind::Bit(BitType {
                 size,
                 span: s.span(lo),
             }),
-        }),
+        })),
         identifier,
         init_expr: None,
     }))
@@ -683,16 +704,16 @@ fn extern_creg_type(s: &mut ParserContext) -> Result<Option<Expr>> {
     Ok(size)
 }
 
-fn creg_type(s: &mut ParserContext) -> Result<(Box<Ident>, Option<Expr>)> {
+fn creg_type(s: &mut ParserContext) -> Result<(Ident, Option<Expr>)> {
     token(s, TokenKind::Keyword(crate::keyword::Keyword::CReg))?;
-    let name = Box::new(prim::ident(s)?);
+    let name = prim::ident(s)?;
     let size = opt(s, designator)?;
     Ok((name, size))
 }
 
-fn qreg_type(s: &mut ParserContext) -> Result<(Box<Ident>, Option<Expr>)> {
+fn qreg_type(s: &mut ParserContext) -> Result<(Ident, Option<Expr>)> {
     token(s, TokenKind::Keyword(crate::keyword::Keyword::QReg))?;
-    let name = Box::new(prim::ident(s)?);
+    let name = prim::ident(s)?;
     let size = opt(s, designator)?;
     Ok((name, size))
 }
@@ -1271,8 +1292,8 @@ fn reinterpret_index_expr(
     } = index_expr;
 
     if let IndexElement::IndexSet(set) = index {
-        if set.len() == 1 {
-            let first_elt: IndexSetItem = (*set[0]).clone();
+        if set.values.len() == 1 {
+            let first_elt: IndexSetItem = (*set.values[0]).clone();
             if let IndexSetItem::Expr(expr) = first_elt {
                 if duration.is_none() {
                     match *collection.kind {

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/alias.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/alias.rs
@@ -6,23 +6,45 @@ use crate::parser::tests::check;
 use expect_test::expect;
 
 #[test]
-fn alias_decl_stmt() {
+fn simple_alias() {
+    check(
+        parse,
+        "let x = a;",
+        &expect![[r#"
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: Alias [0-10]:
+                    ident: Ident [4-5] "x"
+                    exprs: 
+                        Expr [8-9]: Ident [8-9] "a""#]],
+    );
+}
+
+#[test]
+fn concatenation_alias() {
     check(
         parse,
         "let x = a[1:2] ++ b ++ c[1:2:3];",
         &expect![[r#"
-            Stmt [0-32]
-                StmtKind: Alias [0-32]: Ident [4-5] "x"
-                    Expr [8-14]: IndexExpr [9-14]: Expr [8-9]: Ident [8-9] "a", IndexElement:
-                        Range: [10-13]
-                            start: Expr [10-11]: Lit: Int(1)
-                            <no step>
-                            end: Expr [12-13]: Lit: Int(2)
-                    Expr [18-19]: Ident [18-19] "b"
-                    Expr [23-31]: IndexExpr [24-31]: Expr [23-24]: Ident [23-24] "c", IndexElement:
-                        Range: [25-30]
-                            start: Expr [25-26]: Lit: Int(1)
-                            step: Expr [27-28]: Lit: Int(2)
-                            end: Expr [29-30]: Lit: Int(3)"#]],
+            Stmt [0-32]:
+                annotations: <empty>
+                kind: Alias [0-32]:
+                    ident: Ident [4-5] "x"
+                    exprs: 
+                        Expr [8-14]: IndexExpr [9-14]:
+                            collection: Expr [8-9]: Ident [8-9] "a"
+                            index: IndexElement: 
+                                IndexSetItem RangeDefinition [10-13]:
+                                    start: Expr [10-11]: Lit: Int(1)
+                                    step: <none>
+                                    end: Expr [12-13]: Lit: Int(2)
+                        Expr [18-19]: Ident [18-19] "b"
+                        Expr [23-31]: IndexExpr [24-31]:
+                            collection: Expr [23-24]: Ident [23-24] "c"
+                            index: IndexElement: 
+                                IndexSetItem RangeDefinition [25-30]:
+                                    start: Expr [25-26]: Lit: Int(1)
+                                    step: Expr [27-28]: Lit: Int(2)
+                                    end: Expr [29-30]: Lit: Int(3)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/alias.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/alias.rs
@@ -13,7 +13,7 @@ fn simple_alias() {
         &expect![[r#"
             Stmt [0-10]:
                 annotations: <empty>
-                kind: Alias [0-10]:
+                kind: AliasDeclStmt [0-10]:
                     ident: Ident [4-5] "x"
                     exprs:
                         Expr [8-9]: Ident [8-9] "a""#]],
@@ -28,21 +28,21 @@ fn concatenation_alias() {
         &expect![[r#"
             Stmt [0-32]:
                 annotations: <empty>
-                kind: Alias [0-32]:
+                kind: AliasDeclStmt [0-32]:
                     ident: Ident [4-5] "x"
                     exprs:
                         Expr [8-14]: IndexExpr [9-14]:
                             collection: Expr [8-9]: Ident [8-9] "a"
-                            index: IndexElement:
-                                IndexSetItem RangeDefinition [10-13]:
+                            index: IndexSet:
+                                RangeDefinition [10-13]:
                                     start: Expr [10-11]: Lit: Int(1)
                                     step: <none>
                                     end: Expr [12-13]: Lit: Int(2)
                         Expr [18-19]: Ident [18-19] "b"
                         Expr [23-31]: IndexExpr [24-31]:
                             collection: Expr [23-24]: Ident [23-24] "c"
-                            index: IndexElement:
-                                IndexSetItem RangeDefinition [25-30]:
+                            index: IndexSet:
+                                RangeDefinition [25-30]:
                                     start: Expr [25-26]: Lit: Int(1)
                                     step: Expr [27-28]: Lit: Int(2)
                                     end: Expr [29-30]: Lit: Int(3)"#]],

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/alias.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/alias.rs
@@ -33,18 +33,20 @@ fn concatenation_alias() {
                     exprs:
                         Expr [8-14]: IndexExpr [9-14]:
                             collection: Expr [8-9]: Ident [8-9] "a"
-                            index: IndexSet:
-                                RangeDefinition [10-13]:
-                                    start: Expr [10-11]: Lit: Int(1)
-                                    step: <none>
-                                    end: Expr [12-13]: Lit: Int(2)
+                            index: IndexSet [10-13]:
+                                values:
+                                    RangeDefinition [10-13]:
+                                        start: Expr [10-11]: Lit: Int(1)
+                                        step: <none>
+                                        end: Expr [12-13]: Lit: Int(2)
                         Expr [18-19]: Ident [18-19] "b"
                         Expr [23-31]: IndexExpr [24-31]:
                             collection: Expr [23-24]: Ident [23-24] "c"
-                            index: IndexSet:
-                                RangeDefinition [25-30]:
-                                    start: Expr [25-26]: Lit: Int(1)
-                                    step: Expr [27-28]: Lit: Int(2)
-                                    end: Expr [29-30]: Lit: Int(3)"#]],
+                            index: IndexSet [25-30]:
+                                values:
+                                    RangeDefinition [25-30]:
+                                        start: Expr [25-26]: Lit: Int(1)
+                                        step: Expr [27-28]: Lit: Int(2)
+                                        end: Expr [29-30]: Lit: Int(3)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/alias.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/alias.rs
@@ -15,7 +15,7 @@ fn simple_alias() {
                 annotations: <empty>
                 kind: Alias [0-10]:
                     ident: Ident [4-5] "x"
-                    exprs: 
+                    exprs:
                         Expr [8-9]: Ident [8-9] "a""#]],
     );
 }
@@ -30,10 +30,10 @@ fn concatenation_alias() {
                 annotations: <empty>
                 kind: Alias [0-32]:
                     ident: Ident [4-5] "x"
-                    exprs: 
+                    exprs:
                         Expr [8-14]: IndexExpr [9-14]:
                             collection: Expr [8-9]: Ident [8-9] "a"
-                            index: IndexElement: 
+                            index: IndexElement:
                                 IndexSetItem RangeDefinition [10-13]:
                                     start: Expr [10-11]: Lit: Int(1)
                                     step: <none>
@@ -41,7 +41,7 @@ fn concatenation_alias() {
                         Expr [18-19]: Ident [18-19] "b"
                         Expr [23-31]: IndexExpr [24-31]:
                             collection: Expr [23-24]: Ident [23-24] "c"
-                            index: IndexElement: 
+                            index: IndexElement:
                                 IndexSetItem RangeDefinition [25-30]:
                                     start: Expr [25-26]: Lit: Int(1)
                                     step: Expr [27-28]: Lit: Int(2)

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/annotation.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/annotation.rs
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use expect_test::expect;
-
-use crate::parser::tests::check;
-
 use crate::parser::stmt::parse_annotation;
+use crate::parser::tests::check;
+use expect_test::expect;
 
 #[test]
 fn annotation() {
     check(
         parse_annotation,
         "@a.b.d 23",
-        &expect!["Annotation [0-9]: (a.b.d, 23)"],
+        &expect![[r#"
+            Annotation [0-9]:
+                identifier: "a.b.d"
+                value: "23""#]],
     );
 }
 
@@ -21,7 +22,10 @@ fn annotation_ident_only() {
     check(
         parse_annotation,
         "@a.b.d",
-        &expect!["Annotation [0-6]: (a.b.d)"],
+        &expect![[r#"
+            Annotation [0-6]:
+                identifier: "a.b.d"
+                value: <none>"#]],
     );
 }
 
@@ -31,7 +35,9 @@ fn annotation_missing_ident() {
         parse_annotation,
         "@",
         &expect![[r#"
-            Annotation [0-1]: ()
+            Annotation [0-1]:
+                identifier: ""
+                value: <none>
 
             [
                 Error(

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
@@ -11,13 +11,19 @@ fn barrier() {
         parse,
         "barrier r, q[0], $2;",
         &expect![[r#"
-        Stmt [0-20]
-            StmtKind: Barrier [0-20]: [
-            GateOperand IndexedIdent [8-9]: Ident [8-9] "r"[]
-            GateOperand IndexedIdent [11-15]: Ident [11-12] "q"[
-            IndexElement:
-                IndexSetItem Expr [13-14]: Lit: Int(0)]
-            GateOperand HardwareQubit [17-19]: 2]"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: Barrier [0-20]:
+                    operands: 
+                        GateOperand IndexedIdent [8-9]:
+                            name: Ident [8-9] "r"
+                            indices: <empty>
+                        GateOperand IndexedIdent [11-15]:
+                            name: Ident [11-12] "q"
+                            indices: 
+                                IndexElement: 
+                                    IndexSetItem Expr [13-14]: Lit: Int(0)
+                        GateOperand HardwareQubit [17-19]: 2"#]],
     );
 }
 
@@ -27,7 +33,9 @@ fn barrier_no_args() {
         parse,
         "barrier;",
         &expect![[r#"
-        Stmt [0-8]
-            StmtKind: Barrier [0-8]: []"#]],
+            Stmt [0-8]:
+                annotations: <empty>
+                kind: Barrier [0-8]:
+                    operands: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
@@ -14,14 +14,14 @@ fn barrier() {
             Stmt [0-20]:
                 annotations: <empty>
                 kind: Barrier [0-20]:
-                    operands: 
+                    operands:
                         GateOperand IndexedIdent [8-9]:
                             name: Ident [8-9] "r"
                             indices: <empty>
                         GateOperand IndexedIdent [11-15]:
                             name: Ident [11-12] "q"
-                            indices: 
-                                IndexElement: 
+                            indices:
+                                IndexElement:
                                     IndexSetItem Expr [13-14]: Lit: Int(0)
                         GateOperand HardwareQubit [17-19]: 2"#]],
     );

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
@@ -15,15 +15,16 @@ fn barrier() {
                 annotations: <empty>
                 kind: BarrierStmt [0-20]:
                     operands:
-                        GateOperand IndexedIdent [8-9]:
+                        IndexedIdent [8-9]:
                             name: Ident [8-9] "r"
                             indices: <empty>
-                        GateOperand IndexedIdent [11-15]:
+                        IndexedIdent [11-15]:
                             name: Ident [11-12] "q"
                             indices:
-                                IndexSet:
-                                    Expr [13-14]: Lit: Int(0)
-                        GateOperand HardwareQubit [17-19]: 2"#]],
+                                IndexSet [13-14]:
+                                    values:
+                                        Expr [13-14]: Lit: Int(0)
+                        HardwareQubit [17-19]: 2"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
@@ -13,7 +13,7 @@ fn barrier() {
         &expect![[r#"
             Stmt [0-20]:
                 annotations: <empty>
-                kind: Barrier [0-20]:
+                kind: BarrierStmt [0-20]:
                     operands:
                         GateOperand IndexedIdent [8-9]:
                             name: Ident [8-9] "r"
@@ -21,8 +21,8 @@ fn barrier() {
                         GateOperand IndexedIdent [11-15]:
                             name: Ident [11-12] "q"
                             indices:
-                                IndexElement:
-                                    IndexSetItem Expr [13-14]: Lit: Int(0)
+                                IndexSet:
+                                    Expr [13-14]: Lit: Int(0)
                         GateOperand HardwareQubit [17-19]: 2"#]],
     );
 }
@@ -35,7 +35,7 @@ fn barrier_no_args() {
         &expect![[r#"
             Stmt [0-8]:
                 annotations: <empty>
-                kind: Barrier [0-8]:
+                kind: BarrierStmt [0-8]:
                     operands: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/box_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/box_stmt.rs
@@ -28,7 +28,7 @@ fn box_stmt() {
                                 args: <empty>
                                 duration: <none>
                                 qubits:
-                                    GateOperand IndexedIdent [21-23]:
+                                    IndexedIdent [21-23]:
                                         name: Ident [21-23] "q0"
                                         indices: <empty>
                         Stmt [33-44]:
@@ -40,7 +40,7 @@ fn box_stmt() {
                                     Expr [36-39]: Lit: Float(2.4)
                                 duration: <none>
                                 qubits:
-                                    GateOperand IndexedIdent [41-43]:
+                                    IndexedIdent [41-43]:
                                         name: Ident [41-43] "q1"
                                         indices: <empty>"#]],
     );
@@ -69,7 +69,7 @@ fn box_stmt_with_designator() {
                                 args: <empty>
                                 duration: <none>
                                 qubits:
-                                    GateOperand IndexedIdent [26-28]:
+                                    IndexedIdent [26-28]:
                                         name: Ident [26-28] "q0"
                                         indices: <empty>
                         Stmt [38-49]:
@@ -81,7 +81,7 @@ fn box_stmt_with_designator() {
                                     Expr [41-44]: Lit: Float(2.4)
                                 duration: <none>
                                 qubits:
-                                    GateOperand IndexedIdent [46-48]:
+                                    IndexedIdent [46-48]:
                                         name: Ident [46-48] "q1"
                                         indices: <empty>"#]],
     );
@@ -110,7 +110,7 @@ fn box_stmt_with_invalid_instruction() {
                                 args: <empty>
                                 duration: <none>
                                 qubits:
-                                    GateOperand IndexedIdent [16-18]:
+                                    IndexedIdent [16-18]:
                                         name: Ident [16-18] "q0"
                                         indices: <empty>
                         Stmt [28-34]:
@@ -124,7 +124,7 @@ fn box_stmt_with_invalid_instruction() {
                                 args: <empty>
                                 duration: <none>
                                 qubits:
-                                    GateOperand IndexedIdent [45-47]:
+                                    IndexedIdent [45-47]:
                                         name: Ident [45-47] "q1"
                                         indices: <empty>
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/box_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/box_stmt.rs
@@ -15,15 +15,34 @@ fn box_stmt() {
         Rx(2.4) q1;
     }",
         &expect![[r#"
-            Stmt [5-50]
-                StmtKind: BoxStmt [5-50]: <no duration>
-                Stmt [19-24]
-                    StmtKind: GateCall [19-24]: Ident [19-20] "H"
-                    GateOperand IndexedIdent [21-23]: Ident [21-23] "q0"[]
-                Stmt [33-44]
-                    StmtKind: GateCall [33-44]: Ident [33-35] "Rx"
-                    Expr [36-39]: Lit: Float(2.4)
-                    GateOperand IndexedIdent [41-43]: Ident [41-43] "q1"[]"#]],
+            Stmt [5-50]:
+                annotations: <empty>
+                kind: BoxStmt [5-50]:
+                    duration: <none>
+                    body: 
+                        Stmt [19-24]:
+                            annotations: <empty>
+                            kind: GateCall [19-24]:
+                                modifiers: <empty>
+                                name: Ident [19-20] "H"
+                                args: <empty>
+                                duration: <none>
+                                qubits: 
+                                    GateOperand IndexedIdent [21-23]:
+                                        name: Ident [21-23] "q0"
+                                        indices: <empty>
+                        Stmt [33-44]:
+                            annotations: <empty>
+                            kind: GateCall [33-44]:
+                                modifiers: <empty>
+                                name: Ident [33-35] "Rx"
+                                args: 
+                                    Expr [36-39]: Lit: Float(2.4)
+                                duration: <none>
+                                qubits: 
+                                    GateOperand IndexedIdent [41-43]:
+                                        name: Ident [41-43] "q1"
+                                        indices: <empty>"#]],
     );
 }
 
@@ -37,15 +56,34 @@ fn box_stmt_with_designator() {
         Rx(2.4) q1;
     }",
         &expect![[r#"
-            Stmt [5-55]
-                StmtKind: BoxStmt [5-55]: Expr [9-12]: Lit: Duration(4.0, Us)
-                Stmt [24-29]
-                    StmtKind: GateCall [24-29]: Ident [24-25] "H"
-                    GateOperand IndexedIdent [26-28]: Ident [26-28] "q0"[]
-                Stmt [38-49]
-                    StmtKind: GateCall [38-49]: Ident [38-40] "Rx"
-                    Expr [41-44]: Lit: Float(2.4)
-                    GateOperand IndexedIdent [46-48]: Ident [46-48] "q1"[]"#]],
+            Stmt [5-55]:
+                annotations: <empty>
+                kind: BoxStmt [5-55]:
+                    duration: Expr [9-12]: Lit: Duration(4.0, Us)
+                    body: 
+                        Stmt [24-29]:
+                            annotations: <empty>
+                            kind: GateCall [24-29]:
+                                modifiers: <empty>
+                                name: Ident [24-25] "H"
+                                args: <empty>
+                                duration: <none>
+                                qubits: 
+                                    GateOperand IndexedIdent [26-28]:
+                                        name: Ident [26-28] "q0"
+                                        indices: <empty>
+                        Stmt [38-49]:
+                            annotations: <empty>
+                            kind: GateCall [38-49]:
+                                modifiers: <empty>
+                                name: Ident [38-40] "Rx"
+                                args: 
+                                    Expr [41-44]: Lit: Float(2.4)
+                                duration: <none>
+                                qubits: 
+                                    GateOperand IndexedIdent [46-48]:
+                                        name: Ident [46-48] "q1"
+                                        indices: <empty>"#]],
     );
 }
 
@@ -59,16 +97,36 @@ fn box_stmt_with_invalid_instruction() {
         X q1;
     }",
         &expect![[r#"
-            Stmt [0-54]
-                StmtKind: BoxStmt [0-54]: <no duration>
-                Stmt [14-19]
-                    StmtKind: GateCall [14-19]: Ident [14-15] "H"
-                    GateOperand IndexedIdent [16-18]: Ident [16-18] "q0"[]
-                Stmt [28-34]
-                    StmtKind: Err
-                Stmt [43-48]
-                    StmtKind: GateCall [43-48]: Ident [43-44] "X"
-                    GateOperand IndexedIdent [45-47]: Ident [45-47] "q1"[]
+            Stmt [0-54]:
+                annotations: <empty>
+                kind: BoxStmt [0-54]:
+                    duration: <none>
+                    body: 
+                        Stmt [14-19]:
+                            annotations: <empty>
+                            kind: GateCall [14-19]:
+                                modifiers: <empty>
+                                name: Ident [14-15] "H"
+                                args: <empty>
+                                duration: <none>
+                                qubits: 
+                                    GateOperand IndexedIdent [16-18]:
+                                        name: Ident [16-18] "q0"
+                                        indices: <empty>
+                        Stmt [28-34]:
+                            annotations: <empty>
+                            kind: Err
+                        Stmt [43-48]:
+                            annotations: <empty>
+                            kind: GateCall [43-48]:
+                                modifiers: <empty>
+                                name: Ident [43-44] "X"
+                                args: <empty>
+                                duration: <none>
+                                qubits: 
+                                    GateOperand IndexedIdent [45-47]:
+                                        name: Ident [45-47] "q1"
+                                        indices: <empty>
 
             [
                 Error(

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/box_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/box_stmt.rs
@@ -19,7 +19,7 @@ fn box_stmt() {
                 annotations: <empty>
                 kind: BoxStmt [5-50]:
                     duration: <none>
-                    body: 
+                    body:
                         Stmt [19-24]:
                             annotations: <empty>
                             kind: GateCall [19-24]:
@@ -27,7 +27,7 @@ fn box_stmt() {
                                 name: Ident [19-20] "H"
                                 args: <empty>
                                 duration: <none>
-                                qubits: 
+                                qubits:
                                     GateOperand IndexedIdent [21-23]:
                                         name: Ident [21-23] "q0"
                                         indices: <empty>
@@ -36,10 +36,10 @@ fn box_stmt() {
                             kind: GateCall [33-44]:
                                 modifiers: <empty>
                                 name: Ident [33-35] "Rx"
-                                args: 
+                                args:
                                     Expr [36-39]: Lit: Float(2.4)
                                 duration: <none>
-                                qubits: 
+                                qubits:
                                     GateOperand IndexedIdent [41-43]:
                                         name: Ident [41-43] "q1"
                                         indices: <empty>"#]],
@@ -60,7 +60,7 @@ fn box_stmt_with_designator() {
                 annotations: <empty>
                 kind: BoxStmt [5-55]:
                     duration: Expr [9-12]: Lit: Duration(4.0, Us)
-                    body: 
+                    body:
                         Stmt [24-29]:
                             annotations: <empty>
                             kind: GateCall [24-29]:
@@ -68,7 +68,7 @@ fn box_stmt_with_designator() {
                                 name: Ident [24-25] "H"
                                 args: <empty>
                                 duration: <none>
-                                qubits: 
+                                qubits:
                                     GateOperand IndexedIdent [26-28]:
                                         name: Ident [26-28] "q0"
                                         indices: <empty>
@@ -77,10 +77,10 @@ fn box_stmt_with_designator() {
                             kind: GateCall [38-49]:
                                 modifiers: <empty>
                                 name: Ident [38-40] "Rx"
-                                args: 
+                                args:
                                     Expr [41-44]: Lit: Float(2.4)
                                 duration: <none>
-                                qubits: 
+                                qubits:
                                     GateOperand IndexedIdent [46-48]:
                                         name: Ident [46-48] "q1"
                                         indices: <empty>"#]],
@@ -101,7 +101,7 @@ fn box_stmt_with_invalid_instruction() {
                 annotations: <empty>
                 kind: BoxStmt [0-54]:
                     duration: <none>
-                    body: 
+                    body:
                         Stmt [14-19]:
                             annotations: <empty>
                             kind: GateCall [14-19]:
@@ -109,7 +109,7 @@ fn box_stmt_with_invalid_instruction() {
                                 name: Ident [14-15] "H"
                                 args: <empty>
                                 duration: <none>
-                                qubits: 
+                                qubits:
                                     GateOperand IndexedIdent [16-18]:
                                         name: Ident [16-18] "q0"
                                         indices: <empty>
@@ -123,7 +123,7 @@ fn box_stmt_with_invalid_instruction() {
                                 name: Ident [43-44] "X"
                                 args: <empty>
                                 duration: <none>
-                                qubits: 
+                                qubits:
                                     GateOperand IndexedIdent [45-47]:
                                         name: Ident [45-47] "q1"
                                         indices: <empty>

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/cal.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/cal.rs
@@ -38,7 +38,8 @@ fn cal_block_accept_any_tokens_inside() {
         .314
     }",
         &expect![[r#"
-            Stmt [5-69]
-                StmtKind: CalibrationStmt [5-69]"#]],
+            Stmt [5-69]:
+                annotations: <empty>
+                kind: CalibrationStmt [5-69]"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/cal_grammar.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/cal_grammar.rs
@@ -11,8 +11,10 @@ fn defcalgrammar() {
         parse,
         r#"defcalgrammar "openpulse";"#,
         &expect![[r#"
-        Stmt [0-26]
-            StmtKind: CalibrationGrammarStmt [0-26]: openpulse"#]],
+            Stmt [0-26]:
+                annotations: <empty>
+                kind: CalibrationGrammarStmt [0-26]:
+                    name: openpulse"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
@@ -13,8 +13,13 @@ fn bit_decl() {
         parse,
         "bit b;",
         &expect![[r#"
-            Stmt [0-6]
-                StmtKind: ClassicalDeclarationStmt [0-6]: ClassicalType [0-3]: BitType, Ident [4-5] "b""#]],
+            Stmt [0-6]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-6]:
+                    type: ScalarType [0-3]: BitType [0-3]:
+                        size: <none>
+                    ident: Ident [4-5] "b"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -24,8 +29,13 @@ fn bit_decl_bit_lit() {
         parse,
         "bit b = 1;",
         &expect![[r#"
-            Stmt [0-10]
-                StmtKind: ClassicalDeclarationStmt [0-10]: ClassicalType [0-3]: BitType, Ident [4-5] "b", ValueExpression Expr [8-9]: Lit: Int(1)"#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-10]:
+                    type: ScalarType [0-3]: BitType [0-3]:
+                        size: <none>
+                    ident: Ident [4-5] "b"
+                    init_expr: ValueExpression Expr [8-9]: Lit: Int(1)"#]],
     );
 }
 
@@ -35,8 +45,13 @@ fn const_bit_decl_bit_lit() {
         parse,
         "const bit b = 1;",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: ConstantDeclaration [0-16]: ClassicalType [6-9]: BitType, Ident [10-11] "b", Expr [14-15]: Lit: Int(1)"#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-16]:
+                    type: ScalarType [6-9]: BitType [6-9]:
+                        size: <none>
+                    ident: Ident [10-11] "b"
+                    init_expr: Expr [14-15]: Lit: Int(1)"#]],
     );
 }
 
@@ -46,8 +61,13 @@ fn bit_array_decl() {
         parse,
         "bit[2] b;",
         &expect![[r#"
-            Stmt [0-9]
-                StmtKind: ClassicalDeclarationStmt [0-9]: ClassicalType [0-6]: BitType [0-6]: Expr [4-5]: Lit: Int(2), Ident [7-8] "b""#]],
+            Stmt [0-9]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-9]:
+                    type: ScalarType [0-6]: BitType [0-6]:
+                        size: Expr [4-5]: Lit: Int(2)
+                    ident: Ident [7-8] "b"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -57,8 +77,13 @@ fn bit_array_decl_bit_lit() {
         parse,
         "bit[2] b = \"11\";",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: ClassicalDeclarationStmt [0-16]: ClassicalType [0-6]: BitType [0-6]: Expr [4-5]: Lit: Int(2), Ident [7-8] "b", ValueExpression Expr [11-15]: Lit: Bitstring("11")"#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-16]:
+                    type: ScalarType [0-6]: BitType [0-6]:
+                        size: Expr [4-5]: Lit: Int(2)
+                    ident: Ident [7-8] "b"
+                    init_expr: ValueExpression Expr [11-15]: Lit: Bitstring("11")"#]],
     );
 }
 
@@ -68,8 +93,13 @@ fn const_bit_array_decl_bit_lit() {
         parse,
         "const bit[2] b = \"11\";",
         &expect![[r#"
-            Stmt [0-22]
-                StmtKind: ConstantDeclaration [0-22]: ClassicalType [6-12]: BitType [6-12]: Expr [10-11]: Lit: Int(2), Ident [13-14] "b", Expr [17-21]: Lit: Bitstring("11")"#]],
+            Stmt [0-22]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-22]:
+                    type: ScalarType [6-12]: BitType [6-12]:
+                        size: Expr [10-11]: Lit: Int(2)
+                    ident: Ident [13-14] "b"
+                    init_expr: Expr [17-21]: Lit: Bitstring("11")"#]],
     );
 }
 
@@ -79,8 +109,12 @@ fn bool_decl() {
         parse,
         "bool b;",
         &expect![[r#"
-            Stmt [0-7]
-                StmtKind: ClassicalDeclarationStmt [0-7]: ClassicalType [0-4]: BoolType, Ident [5-6] "b""#]],
+            Stmt [0-7]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-7]:
+                    type: ScalarType [0-4]: BoolType
+                    ident: Ident [5-6] "b"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -90,8 +124,12 @@ fn bool_decl_int_lit() {
         parse,
         "bool b = 1;",
         &expect![[r#"
-            Stmt [0-11]
-                StmtKind: ClassicalDeclarationStmt [0-11]: ClassicalType [0-4]: BoolType, Ident [5-6] "b", ValueExpression Expr [9-10]: Lit: Int(1)"#]],
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-11]:
+                    type: ScalarType [0-4]: BoolType
+                    ident: Ident [5-6] "b"
+                    init_expr: ValueExpression Expr [9-10]: Lit: Int(1)"#]],
     );
 }
 
@@ -101,8 +139,12 @@ fn const_bool_decl_bool_lit() {
         parse,
         "const bool b = true;",
         &expect![[r#"
-            Stmt [0-20]
-                StmtKind: ConstantDeclaration [0-20]: ClassicalType [6-10]: BoolType, Ident [11-12] "b", Expr [15-19]: Lit: Bool(true)"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-20]:
+                    type: ScalarType [6-10]: BoolType
+                    ident: Ident [11-12] "b"
+                    init_expr: Expr [15-19]: Lit: Bool(true)"#]],
     );
 }
 
@@ -112,8 +154,13 @@ fn complex_decl() {
         parse,
         "complex c;",
         &expect![[r#"
-            Stmt [0-10]
-                StmtKind: ClassicalDeclarationStmt [0-10]: ClassicalType [0-7]: ComplexType [0-7], Ident [8-9] "c""#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-10]:
+                    type: ScalarType [0-7]: ComplexType [0-7]:
+                        base_size: <none>
+                    ident: Ident [8-9] "c"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -123,8 +170,13 @@ fn complex_decl_complex_lit() {
         parse,
         "complex c = 1im;",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: ClassicalDeclarationStmt [0-16]: ClassicalType [0-7]: ComplexType [0-7], Ident [8-9] "c", ValueExpression Expr [12-15]: Lit: Imaginary(1.0)"#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-16]:
+                    type: ScalarType [0-7]: ComplexType [0-7]:
+                        base_size: <none>
+                    ident: Ident [8-9] "c"
+                    init_expr: ValueExpression Expr [12-15]: Lit: Imaginary(1.0)"#]],
     );
 }
 
@@ -134,8 +186,13 @@ fn const_complex_decl_complex_lit() {
         parse,
         "const complex c = 1im;",
         &expect![[r#"
-            Stmt [0-22]
-                StmtKind: ConstantDeclaration [0-22]: ClassicalType [6-13]: ComplexType [6-13], Ident [14-15] "c", Expr [18-21]: Lit: Imaginary(1.0)"#]],
+            Stmt [0-22]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-22]:
+                    type: ScalarType [6-13]: ComplexType [6-13]:
+                        base_size: <none>
+                    ident: Ident [14-15] "c"
+                    init_expr: Expr [18-21]: Lit: Imaginary(1.0)"#]],
     );
 }
 
@@ -145,10 +202,16 @@ fn const_complex_decl_complex_binary_lit() {
         parse,
         "const complex c = 23.5 + 1.7im;",
         &expect![[r#"
-            Stmt [0-31]
-                StmtKind: ConstantDeclaration [0-31]: ClassicalType [6-13]: ComplexType [6-13], Ident [14-15] "c", Expr [18-30]: BinOp (Add):
-                    Expr [18-22]: Lit: Float(23.5)
-                    Expr [25-30]: Lit: Imaginary(1.7)"#]],
+            Stmt [0-31]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-31]:
+                    type: ScalarType [6-13]: ComplexType [6-13]:
+                        base_size: <none>
+                    ident: Ident [14-15] "c"
+                    init_expr: Expr [18-30]: BinaryOpExpr:
+                        op: Add
+                        lhs: Expr [18-22]: Lit: Float(23.5)
+                        rhs: Expr [25-30]: Lit: Imaginary(1.7)"#]],
     );
 }
 
@@ -158,8 +221,14 @@ fn complex_sized_decl() {
         parse,
         "complex[float[32]] c;",
         &expect![[r#"
-            Stmt [0-21]
-                StmtKind: ClassicalDeclarationStmt [0-21]: ClassicalType [0-18]: ComplexType[float[FloatType[Expr [14-16]: Lit: Int(32)]: [8-17]]]: [0-18], Ident [19-20] "c""#]],
+            Stmt [0-21]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-21]:
+                    type: ScalarType [0-18]: ComplexType [0-18]:
+                        base_size: FloatType [8-17]:
+                            size: Expr [14-16]: Lit: Int(32)
+                    ident: Ident [19-20] "c"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -191,8 +260,14 @@ fn complex_sized_decl_complex_lit() {
         parse,
         "complex[float[32]] c = 1im;",
         &expect![[r#"
-            Stmt [0-27]
-                StmtKind: ClassicalDeclarationStmt [0-27]: ClassicalType [0-18]: ComplexType[float[FloatType[Expr [14-16]: Lit: Int(32)]: [8-17]]]: [0-18], Ident [19-20] "c", ValueExpression Expr [23-26]: Lit: Imaginary(1.0)"#]],
+            Stmt [0-27]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-27]:
+                    type: ScalarType [0-18]: ComplexType [0-18]:
+                        base_size: FloatType [8-17]:
+                            size: Expr [14-16]: Lit: Int(32)
+                    ident: Ident [19-20] "c"
+                    init_expr: ValueExpression Expr [23-26]: Lit: Imaginary(1.0)"#]],
     );
 }
 
@@ -202,8 +277,14 @@ fn const_complex_sized_decl_complex_lit() {
         parse,
         "const complex[float[32]] c = 1im;",
         &expect![[r#"
-            Stmt [0-33]
-                StmtKind: ConstantDeclaration [0-33]: ClassicalType [6-24]: ComplexType[float[FloatType[Expr [20-22]: Lit: Int(32)]: [14-23]]]: [6-24], Ident [25-26] "c", Expr [29-32]: Lit: Imaginary(1.0)"#]],
+            Stmt [0-33]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-33]:
+                    type: ScalarType [6-24]: ComplexType [6-24]:
+                        base_size: FloatType [14-23]:
+                            size: Expr [20-22]: Lit: Int(32)
+                    ident: Ident [25-26] "c"
+                    init_expr: Expr [29-32]: Lit: Imaginary(1.0)"#]],
     );
 }
 
@@ -213,8 +294,13 @@ fn int_decl() {
         parse,
         "int i;",
         &expect![[r#"
-            Stmt [0-6]
-                StmtKind: ClassicalDeclarationStmt [0-6]: ClassicalType [0-3]: IntType [0-3], Ident [4-5] "i""#]],
+            Stmt [0-6]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-6]:
+                    type: ScalarType [0-3]: IntType [0-3]:
+                        size: <none>
+                    ident: Ident [4-5] "i"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -224,8 +310,13 @@ fn int_decl_int_lit() {
         parse,
         "int i = 1;",
         &expect![[r#"
-            Stmt [0-10]
-                StmtKind: ClassicalDeclarationStmt [0-10]: ClassicalType [0-3]: IntType [0-3], Ident [4-5] "i", ValueExpression Expr [8-9]: Lit: Int(1)"#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-10]:
+                    type: ScalarType [0-3]: IntType [0-3]:
+                        size: <none>
+                    ident: Ident [4-5] "i"
+                    init_expr: ValueExpression Expr [8-9]: Lit: Int(1)"#]],
     );
 }
 
@@ -235,8 +326,13 @@ fn const_int_decl_int_lit() {
         parse,
         "const int i = 1;",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: ConstantDeclaration [0-16]: ClassicalType [6-9]: IntType [6-9], Ident [10-11] "i", Expr [14-15]: Lit: Int(1)"#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-16]:
+                    type: ScalarType [6-9]: IntType [6-9]:
+                        size: <none>
+                    ident: Ident [10-11] "i"
+                    init_expr: Expr [14-15]: Lit: Int(1)"#]],
     );
 }
 
@@ -246,8 +342,13 @@ fn int_sized_decl() {
         parse,
         "int[32] i;",
         &expect![[r#"
-            Stmt [0-10]
-                StmtKind: ClassicalDeclarationStmt [0-10]: ClassicalType [0-7]: IntType[Expr [4-6]: Lit: Int(32)]: [0-7], Ident [8-9] "i""#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-10]:
+                    type: ScalarType [0-7]: IntType [0-7]:
+                        size: Expr [4-6]: Lit: Int(32)
+                    ident: Ident [8-9] "i"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -257,8 +358,13 @@ fn int_sized_decl_int_lit() {
         parse,
         "int[32] i = 1;",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: ClassicalDeclarationStmt [0-14]: ClassicalType [0-7]: IntType[Expr [4-6]: Lit: Int(32)]: [0-7], Ident [8-9] "i", ValueExpression Expr [12-13]: Lit: Int(1)"#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-14]:
+                    type: ScalarType [0-7]: IntType [0-7]:
+                        size: Expr [4-6]: Lit: Int(32)
+                    ident: Ident [8-9] "i"
+                    init_expr: ValueExpression Expr [12-13]: Lit: Int(1)"#]],
     );
 }
 
@@ -268,8 +374,13 @@ fn const_int_sized_decl_int_lit() {
         parse,
         "const int[32] i = 1;",
         &expect![[r#"
-            Stmt [0-20]
-                StmtKind: ConstantDeclaration [0-20]: ClassicalType [6-13]: IntType[Expr [10-12]: Lit: Int(32)]: [6-13], Ident [14-15] "i", Expr [18-19]: Lit: Int(1)"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-20]:
+                    type: ScalarType [6-13]: IntType [6-13]:
+                        size: Expr [10-12]: Lit: Int(32)
+                    ident: Ident [14-15] "i"
+                    init_expr: Expr [18-19]: Lit: Int(1)"#]],
     );
 }
 
@@ -279,8 +390,13 @@ fn uint_decl() {
         parse,
         "uint i;",
         &expect![[r#"
-            Stmt [0-7]
-                StmtKind: ClassicalDeclarationStmt [0-7]: ClassicalType [0-4]: UIntType [0-4], Ident [5-6] "i""#]],
+            Stmt [0-7]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-7]:
+                    type: ScalarType [0-4]: UIntType [0-4]:
+                        size: <none>
+                    ident: Ident [5-6] "i"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -290,8 +406,13 @@ fn uint_decl_uint_lit() {
         parse,
         "uint i = 1;",
         &expect![[r#"
-            Stmt [0-11]
-                StmtKind: ClassicalDeclarationStmt [0-11]: ClassicalType [0-4]: UIntType [0-4], Ident [5-6] "i", ValueExpression Expr [9-10]: Lit: Int(1)"#]],
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-11]:
+                    type: ScalarType [0-4]: UIntType [0-4]:
+                        size: <none>
+                    ident: Ident [5-6] "i"
+                    init_expr: ValueExpression Expr [9-10]: Lit: Int(1)"#]],
     );
 }
 
@@ -301,8 +422,13 @@ fn const_uint_decl_uint_lit() {
         parse,
         "const uint i = 1;",
         &expect![[r#"
-            Stmt [0-17]
-                StmtKind: ConstantDeclaration [0-17]: ClassicalType [6-10]: UIntType [6-10], Ident [11-12] "i", Expr [15-16]: Lit: Int(1)"#]],
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-17]:
+                    type: ScalarType [6-10]: UIntType [6-10]:
+                        size: <none>
+                    ident: Ident [11-12] "i"
+                    init_expr: Expr [15-16]: Lit: Int(1)"#]],
     );
 }
 
@@ -312,8 +438,13 @@ fn uint_sized_decl() {
         parse,
         "uint[32] i;",
         &expect![[r#"
-            Stmt [0-11]
-                StmtKind: ClassicalDeclarationStmt [0-11]: ClassicalType [0-8]: UIntType[Expr [5-7]: Lit: Int(32)]: [0-8], Ident [9-10] "i""#]],
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-11]:
+                    type: ScalarType [0-8]: UIntType [0-8]:
+                        size: Expr [5-7]: Lit: Int(32)
+                    ident: Ident [9-10] "i"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -323,8 +454,13 @@ fn uint_sized_decl_uint_lit() {
         parse,
         "uint[32] i = 1;",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: ClassicalDeclarationStmt [0-15]: ClassicalType [0-8]: UIntType[Expr [5-7]: Lit: Int(32)]: [0-8], Ident [9-10] "i", ValueExpression Expr [13-14]: Lit: Int(1)"#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-15]:
+                    type: ScalarType [0-8]: UIntType [0-8]:
+                        size: Expr [5-7]: Lit: Int(32)
+                    ident: Ident [9-10] "i"
+                    init_expr: ValueExpression Expr [13-14]: Lit: Int(1)"#]],
     );
 }
 
@@ -334,8 +470,13 @@ fn const_uint_sized_decl_uint_lit() {
         parse,
         "const uint[32] i = 1;",
         &expect![[r#"
-            Stmt [0-21]
-                StmtKind: ConstantDeclaration [0-21]: ClassicalType [6-14]: UIntType[Expr [11-13]: Lit: Int(32)]: [6-14], Ident [15-16] "i", Expr [19-20]: Lit: Int(1)"#]],
+            Stmt [0-21]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-21]:
+                    type: ScalarType [6-14]: UIntType [6-14]:
+                        size: Expr [11-13]: Lit: Int(32)
+                    ident: Ident [15-16] "i"
+                    init_expr: Expr [19-20]: Lit: Int(1)"#]],
     );
 }
 
@@ -345,8 +486,13 @@ fn float_decl() {
         parse,
         "float f;",
         &expect![[r#"
-            Stmt [0-8]
-                StmtKind: ClassicalDeclarationStmt [0-8]: ClassicalType [0-5]: FloatType [0-5], Ident [6-7] "f""#]],
+            Stmt [0-8]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-8]:
+                    type: ScalarType [0-5]: FloatType [0-5]:
+                        size: <none>
+                    ident: Ident [6-7] "f"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -356,8 +502,13 @@ fn float_decl_float_lit() {
         parse,
         "float f = 1;",
         &expect![[r#"
-            Stmt [0-12]
-                StmtKind: ClassicalDeclarationStmt [0-12]: ClassicalType [0-5]: FloatType [0-5], Ident [6-7] "f", ValueExpression Expr [10-11]: Lit: Int(1)"#]],
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-12]:
+                    type: ScalarType [0-5]: FloatType [0-5]:
+                        size: <none>
+                    ident: Ident [6-7] "f"
+                    init_expr: ValueExpression Expr [10-11]: Lit: Int(1)"#]],
     );
 }
 
@@ -367,8 +518,13 @@ fn const_float_decl_float_lit() {
         parse,
         "const float f = 1.0;",
         &expect![[r#"
-            Stmt [0-20]
-                StmtKind: ConstantDeclaration [0-20]: ClassicalType [6-11]: FloatType [6-11], Ident [12-13] "f", Expr [16-19]: Lit: Float(1.0)"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-20]:
+                    type: ScalarType [6-11]: FloatType [6-11]:
+                        size: <none>
+                    ident: Ident [12-13] "f"
+                    init_expr: Expr [16-19]: Lit: Float(1.0)"#]],
     );
 }
 
@@ -378,8 +534,13 @@ fn float_sized_decl() {
         parse,
         "float[32] f;",
         &expect![[r#"
-            Stmt [0-12]
-                StmtKind: ClassicalDeclarationStmt [0-12]: ClassicalType [0-9]: FloatType[Expr [6-8]: Lit: Int(32)]: [0-9], Ident [10-11] "f""#]],
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-12]:
+                    type: ScalarType [0-9]: FloatType [0-9]:
+                        size: Expr [6-8]: Lit: Int(32)
+                    ident: Ident [10-11] "f"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -389,8 +550,13 @@ fn float_sized_decl_float_lit() {
         parse,
         "float[32] f = 1.0;",
         &expect![[r#"
-            Stmt [0-18]
-                StmtKind: ClassicalDeclarationStmt [0-18]: ClassicalType [0-9]: FloatType[Expr [6-8]: Lit: Int(32)]: [0-9], Ident [10-11] "f", ValueExpression Expr [14-17]: Lit: Float(1.0)"#]],
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-18]:
+                    type: ScalarType [0-9]: FloatType [0-9]:
+                        size: Expr [6-8]: Lit: Int(32)
+                    ident: Ident [10-11] "f"
+                    init_expr: ValueExpression Expr [14-17]: Lit: Float(1.0)"#]],
     );
 }
 
@@ -400,8 +566,13 @@ fn const_float_sized_decl_float_lit() {
         parse,
         "const float[32] f = 1;",
         &expect![[r#"
-            Stmt [0-22]
-                StmtKind: ConstantDeclaration [0-22]: ClassicalType [6-15]: FloatType[Expr [12-14]: Lit: Int(32)]: [6-15], Ident [16-17] "f", Expr [20-21]: Lit: Int(1)"#]],
+            Stmt [0-22]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-22]:
+                    type: ScalarType [6-15]: FloatType [6-15]:
+                        size: Expr [12-14]: Lit: Int(32)
+                    ident: Ident [16-17] "f"
+                    init_expr: Expr [20-21]: Lit: Int(1)"#]],
     );
 }
 
@@ -411,8 +582,13 @@ fn angle_decl() {
         parse,
         "angle a;",
         &expect![[r#"
-            Stmt [0-8]
-                StmtKind: ClassicalDeclarationStmt [0-8]: ClassicalType [0-5]: AngleType [0-5], Ident [6-7] "a""#]],
+            Stmt [0-8]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-8]:
+                    type: ScalarType [0-5]: AngleType [0-5]:
+                        size: <none>
+                    ident: Ident [6-7] "a"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -422,8 +598,13 @@ fn angle_decl_angle_lit() {
         parse,
         "angle a = 1.0;",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: ClassicalDeclarationStmt [0-14]: ClassicalType [0-5]: AngleType [0-5], Ident [6-7] "a", ValueExpression Expr [10-13]: Lit: Float(1.0)"#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-14]:
+                    type: ScalarType [0-5]: AngleType [0-5]:
+                        size: <none>
+                    ident: Ident [6-7] "a"
+                    init_expr: ValueExpression Expr [10-13]: Lit: Float(1.0)"#]],
     );
 }
 
@@ -453,8 +634,13 @@ fn const_angle_decl_angle_lit() {
         parse,
         "const angle a = 1.0;",
         &expect![[r#"
-            Stmt [0-20]
-                StmtKind: ConstantDeclaration [0-20]: ClassicalType [6-11]: AngleType [6-11], Ident [12-13] "a", Expr [16-19]: Lit: Float(1.0)"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-20]:
+                    type: ScalarType [6-11]: AngleType [6-11]:
+                        size: <none>
+                    ident: Ident [12-13] "a"
+                    init_expr: Expr [16-19]: Lit: Float(1.0)"#]],
     );
 }
 
@@ -464,8 +650,13 @@ fn angle_sized_decl() {
         parse,
         "angle[32] a;",
         &expect![[r#"
-            Stmt [0-12]
-                StmtKind: ClassicalDeclarationStmt [0-12]: ClassicalType [0-9]: AngleType [0-9]: Expr [6-8]: Lit: Int(32), Ident [10-11] "a""#]],
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-12]:
+                    type: ScalarType [0-9]: AngleType [0-9]:
+                        size: Expr [6-8]: Lit: Int(32)
+                    ident: Ident [10-11] "a"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -475,8 +666,13 @@ fn angle_sized_decl_angle_lit() {
         parse,
         "angle[32] a = 1.0;",
         &expect![[r#"
-            Stmt [0-18]
-                StmtKind: ClassicalDeclarationStmt [0-18]: ClassicalType [0-9]: AngleType [0-9]: Expr [6-8]: Lit: Int(32), Ident [10-11] "a", ValueExpression Expr [14-17]: Lit: Float(1.0)"#]],
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-18]:
+                    type: ScalarType [0-9]: AngleType [0-9]:
+                        size: Expr [6-8]: Lit: Int(32)
+                    ident: Ident [10-11] "a"
+                    init_expr: ValueExpression Expr [14-17]: Lit: Float(1.0)"#]],
     );
 }
 
@@ -486,8 +682,13 @@ fn const_angle_sized_decl_angle_lit() {
         parse,
         "const angle[32] a = 1.0;",
         &expect![[r#"
-            Stmt [0-24]
-                StmtKind: ConstantDeclaration [0-24]: ClassicalType [6-15]: AngleType [6-15]: Expr [12-14]: Lit: Int(32), Ident [16-17] "a", Expr [20-23]: Lit: Float(1.0)"#]],
+            Stmt [0-24]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-24]:
+                    type: ScalarType [6-15]: AngleType [6-15]:
+                        size: Expr [12-14]: Lit: Int(32)
+                    ident: Ident [16-17] "a"
+                    init_expr: Expr [20-23]: Lit: Float(1.0)"#]],
     );
 }
 
@@ -497,8 +698,12 @@ fn duration_decl() {
         parse,
         "duration d;",
         &expect![[r#"
-            Stmt [0-11]
-                StmtKind: ClassicalDeclarationStmt [0-11]: ClassicalType [0-8]: Duration, Ident [9-10] "d""#]],
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-11]:
+                    type: ScalarType [0-8]: Duration
+                    ident: Ident [9-10] "d"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -508,8 +713,12 @@ fn duration_decl_ns_lit() {
         parse,
         "duration d = 1000ns;",
         &expect![[r#"
-            Stmt [0-20]
-                StmtKind: ClassicalDeclarationStmt [0-20]: ClassicalType [0-8]: Duration, Ident [9-10] "d", ValueExpression Expr [13-19]: Lit: Duration(1000.0, Ns)"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-20]:
+                    type: ScalarType [0-8]: Duration
+                    ident: Ident [9-10] "d"
+                    init_expr: ValueExpression Expr [13-19]: Lit: Duration(1000.0, Ns)"#]],
     );
 }
 
@@ -519,8 +728,12 @@ fn duration_decl_us_lit() {
         parse,
         "duration d = 1000us;",
         &expect![[r#"
-            Stmt [0-20]
-                StmtKind: ClassicalDeclarationStmt [0-20]: ClassicalType [0-8]: Duration, Ident [9-10] "d", ValueExpression Expr [13-19]: Lit: Duration(1000.0, Us)"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-20]:
+                    type: ScalarType [0-8]: Duration
+                    ident: Ident [9-10] "d"
+                    init_expr: ValueExpression Expr [13-19]: Lit: Duration(1000.0, Us)"#]],
     );
 }
 
@@ -532,8 +745,12 @@ fn duration_decl_uus_lit() {
         parse,
         "duration d = 1000µs;",
         &expect![[r#"
-            Stmt [0-21]
-                StmtKind: ClassicalDeclarationStmt [0-21]: ClassicalType [0-8]: Duration, Ident [9-10] "d", ValueExpression Expr [13-20]: Lit: Duration(1000.0, Us)"#]],
+            Stmt [0-21]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-21]:
+                    type: ScalarType [0-8]: Duration
+                    ident: Ident [9-10] "d"
+                    init_expr: ValueExpression Expr [13-20]: Lit: Duration(1000.0, Us)"#]],
     );
 }
 
@@ -543,8 +760,12 @@ fn duration_decl_ms_lit() {
         parse,
         "duration d = 1000ms;",
         &expect![[r#"
-            Stmt [0-20]
-                StmtKind: ClassicalDeclarationStmt [0-20]: ClassicalType [0-8]: Duration, Ident [9-10] "d", ValueExpression Expr [13-19]: Lit: Duration(1000.0, Ms)"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-20]:
+                    type: ScalarType [0-8]: Duration
+                    ident: Ident [9-10] "d"
+                    init_expr: ValueExpression Expr [13-19]: Lit: Duration(1000.0, Ms)"#]],
     );
 }
 
@@ -554,8 +775,12 @@ fn duration_decl_s_lit() {
         parse,
         "duration d = 1000s;",
         &expect![[r#"
-            Stmt [0-19]
-                StmtKind: ClassicalDeclarationStmt [0-19]: ClassicalType [0-8]: Duration, Ident [9-10] "d", ValueExpression Expr [13-18]: Lit: Duration(1000.0, S)"#]],
+            Stmt [0-19]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-19]:
+                    type: ScalarType [0-8]: Duration
+                    ident: Ident [9-10] "d"
+                    init_expr: ValueExpression Expr [13-18]: Lit: Duration(1000.0, S)"#]],
     );
 }
 
@@ -565,8 +790,12 @@ fn duration_decl_dt_lit() {
         parse,
         "duration d = 1000dt;",
         &expect![[r#"
-            Stmt [0-20]
-                StmtKind: ClassicalDeclarationStmt [0-20]: ClassicalType [0-8]: Duration, Ident [9-10] "d", ValueExpression Expr [13-19]: Lit: Duration(1000.0, Dt)"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-20]:
+                    type: ScalarType [0-8]: Duration
+                    ident: Ident [9-10] "d"
+                    init_expr: ValueExpression Expr [13-19]: Lit: Duration(1000.0, Dt)"#]],
     );
 }
 
@@ -576,8 +805,12 @@ fn const_duration_decl_dt_lit() {
         parse,
         "const duration d = 10dt;",
         &expect![[r#"
-            Stmt [0-24]
-                StmtKind: ConstantDeclaration [0-24]: ClassicalType [6-14]: Duration, Ident [15-16] "d", Expr [19-23]: Lit: Duration(10.0, Dt)"#]],
+            Stmt [0-24]:
+                annotations: <empty>
+                kind: ConstantDeclStmt [0-24]:
+                    type: ScalarType [6-14]: Duration
+                    ident: Ident [15-16] "d"
+                    init_expr: Expr [19-23]: Lit: Duration(10.0, Dt)"#]],
     );
 }
 
@@ -587,8 +820,12 @@ fn stretch_decl() {
         parse,
         "stretch s;",
         &expect![[r#"
-            Stmt [0-10]
-                StmtKind: ClassicalDeclarationStmt [0-10]: ClassicalType [0-7]: Stretch, Ident [8-9] "s""#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-10]:
+                    type: ScalarType [0-7]: Stretch
+                    ident: Ident [8-9] "s"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -598,9 +835,16 @@ fn empty_array_decl() {
         parse,
         "array[int, 0] arr = {};",
         &expect![[r#"
-            Stmt [0-23]
-                StmtKind: ClassicalDeclarationStmt [0-23]: ArrayType [0-13]: ArrayBaseTypeKind IntType [6-9]
-                Expr [11-12]: Lit: Int(0), Ident [14-17] "arr", ValueExpression Expr [20-22]: Lit: Array:"#]],
+            Stmt [0-23]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-23]:
+                    type: ArrayType [0-13]:
+                        base_type: ArrayBaseTypeKind IntType [6-9]:
+                            size: <none>
+                        dimensions: 
+                            Expr [11-12]: Lit: Int(0)
+                    ident: Ident [14-17] "arr"
+                    init_expr: ValueExpression Expr [20-22]: Lit:     Array: <empty>"#]],
     );
 }
 
@@ -610,12 +854,19 @@ fn simple_array_decl() {
         parse,
         "array[int[32], 3] arr = {1, 2, 3};",
         &expect![[r#"
-            Stmt [0-34]
-                StmtKind: ClassicalDeclarationStmt [0-34]: ArrayType [0-17]: ArrayBaseTypeKind IntType[Expr [10-12]: Lit: Int(32)]: [6-13]
-                Expr [15-16]: Lit: Int(3), Ident [18-21] "arr", ValueExpression Expr [24-33]: Lit: Array:
-                    Expr { span: Span { lo: 25, hi: 26 }, kind: Lit(Lit { span: Span { lo: 25, hi: 26 }, kind: Int(1) }) }
-                    Expr { span: Span { lo: 28, hi: 29 }, kind: Lit(Lit { span: Span { lo: 28, hi: 29 }, kind: Int(2) }) }
-                    Expr { span: Span { lo: 31, hi: 32 }, kind: Lit(Lit { span: Span { lo: 31, hi: 32 }, kind: Int(3) }) }"#]],
+            Stmt [0-34]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-34]:
+                    type: ArrayType [0-17]:
+                        base_type: ArrayBaseTypeKind IntType [6-13]:
+                            size: Expr [10-12]: Lit: Int(32)
+                        dimensions: 
+                            Expr [15-16]: Lit: Int(3)
+                    ident: Ident [18-21] "arr"
+                    init_expr: ValueExpression Expr [24-33]: Lit:     Array: 
+                            Expr [25-26]: Lit: Int(1)
+                            Expr [28-29]: Lit: Int(2)
+                            Expr [31-32]: Lit: Int(3)"#]],
     );
 }
 
@@ -625,13 +876,26 @@ fn nested_array_decl() {
         parse,
         "array[int[32], 3, 2] arr = {{1, 2}, {3, 4}, {5, 6}};",
         &expect![[r#"
-            Stmt [0-52]
-                StmtKind: ClassicalDeclarationStmt [0-52]: ArrayType [0-20]: ArrayBaseTypeKind IntType[Expr [10-12]: Lit: Int(32)]: [6-13]
-                Expr [15-16]: Lit: Int(3)
-                Expr [18-19]: Lit: Int(2), Ident [21-24] "arr", ValueExpression Expr [27-51]: Lit: Array:
-                    Expr { span: Span { lo: 28, hi: 34 }, kind: Lit(Lit { span: Span { lo: 28, hi: 34 }, kind: Array([Expr { span: Span { lo: 29, hi: 30 }, kind: Lit(Lit { span: Span { lo: 29, hi: 30 }, kind: Int(1) }) }, Expr { span: Span { lo: 32, hi: 33 }, kind: Lit(Lit { span: Span { lo: 32, hi: 33 }, kind: Int(2) }) }]) }) }
-                    Expr { span: Span { lo: 36, hi: 42 }, kind: Lit(Lit { span: Span { lo: 36, hi: 42 }, kind: Array([Expr { span: Span { lo: 37, hi: 38 }, kind: Lit(Lit { span: Span { lo: 37, hi: 38 }, kind: Int(3) }) }, Expr { span: Span { lo: 40, hi: 41 }, kind: Lit(Lit { span: Span { lo: 40, hi: 41 }, kind: Int(4) }) }]) }) }
-                    Expr { span: Span { lo: 44, hi: 50 }, kind: Lit(Lit { span: Span { lo: 44, hi: 50 }, kind: Array([Expr { span: Span { lo: 45, hi: 46 }, kind: Lit(Lit { span: Span { lo: 45, hi: 46 }, kind: Int(5) }) }, Expr { span: Span { lo: 48, hi: 49 }, kind: Lit(Lit { span: Span { lo: 48, hi: 49 }, kind: Int(6) }) }]) }) }"#]],
+            Stmt [0-52]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-52]:
+                    type: ArrayType [0-20]:
+                        base_type: ArrayBaseTypeKind IntType [6-13]:
+                            size: Expr [10-12]: Lit: Int(32)
+                        dimensions: 
+                            Expr [15-16]: Lit: Int(3)
+                            Expr [18-19]: Lit: Int(2)
+                    ident: Ident [21-24] "arr"
+                    init_expr: ValueExpression Expr [27-51]: Lit:     Array: 
+                            Expr [28-34]: Lit:     Array: 
+                                    Expr [29-30]: Lit: Int(1)
+                                    Expr [32-33]: Lit: Int(2)
+                            Expr [36-42]: Lit:     Array: 
+                                    Expr [37-38]: Lit: Int(3)
+                                    Expr [40-41]: Lit: Int(4)
+                            Expr [44-50]: Lit:     Array: 
+                                    Expr [45-46]: Lit: Int(5)
+                                    Expr [48-49]: Lit: Int(6)"#]],
     );
 }
 
@@ -641,8 +905,13 @@ fn measure_hardware_qubit_decl() {
         parse,
         "bit res = measure $12;",
         &expect![[r#"
-            Stmt [0-22]
-                StmtKind: ClassicalDeclarationStmt [0-22]: ClassicalType [0-3]: BitType, Ident [4-7] "res", ValueExpression MeasureExpr [10-17]: GateOperand HardwareQubit [18-21]: 12"#]],
+            Stmt [0-22]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-22]:
+                    type: ScalarType [0-3]: BitType [0-3]:
+                        size: <none>
+                    ident: Ident [4-7] "res"
+                    init_expr: ValueExpression MeasureExpr [10-17]: GateOperand HardwareQubit [18-21]: 12"#]],
     );
 }
 
@@ -652,11 +921,18 @@ fn measure_register_decl() {
         parse,
         "bit res = measure qubits[2][3];",
         &expect![[r#"
-            Stmt [0-31]
-                StmtKind: ClassicalDeclarationStmt [0-31]: ClassicalType [0-3]: BitType, Ident [4-7] "res", ValueExpression MeasureExpr [10-17]: GateOperand IndexedIdent [18-30]: Ident [18-24] "qubits"[
-                IndexElement:
-                    IndexSetItem Expr [25-26]: Lit: Int(2)
-                IndexElement:
-                    IndexSetItem Expr [28-29]: Lit: Int(3)]"#]],
+            Stmt [0-31]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-31]:
+                    type: ScalarType [0-3]: BitType [0-3]:
+                        size: <none>
+                    ident: Ident [4-7] "res"
+                    init_expr: ValueExpression MeasureExpr [10-17]: GateOperand IndexedIdent [18-30]:
+                        name: Ident [18-24] "qubits"
+                        indices: 
+                            IndexElement: 
+                                IndexSetItem Expr [25-26]: Lit: Int(2)
+                            IndexElement: 
+                                IndexSetItem Expr [28-29]: Lit: Int(3)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
@@ -911,7 +911,8 @@ fn measure_hardware_qubit_decl() {
                     type: ScalarType [0-3]: BitType [0-3]:
                         size: <none>
                     ident: Ident [4-7] "res"
-                    init_expr: ValueExpression MeasureExpr [10-17]: GateOperand HardwareQubit [18-21]: 12"#]],
+                    init_expr: ValueExpression MeasureExpr [10-17]:
+                        operand: GateOperand HardwareQubit [18-21]: 12"#]],
     );
 }
 
@@ -927,12 +928,13 @@ fn measure_register_decl() {
                     type: ScalarType [0-3]: BitType [0-3]:
                         size: <none>
                     ident: Ident [4-7] "res"
-                    init_expr: ValueExpression MeasureExpr [10-17]: GateOperand IndexedIdent [18-30]:
-                        name: Ident [18-24] "qubits"
-                        indices:
-                            IndexElement:
-                                IndexSetItem Expr [25-26]: Lit: Int(2)
-                            IndexElement:
-                                IndexSetItem Expr [28-29]: Lit: Int(3)"#]],
+                    init_expr: ValueExpression MeasureExpr [10-17]:
+                        operand: GateOperand IndexedIdent [18-30]:
+                            name: Ident [18-24] "qubits"
+                            indices:
+                                IndexElement:
+                                    IndexSetItem Expr [25-26]: Lit: Int(2)
+                                IndexElement:
+                                    IndexSetItem Expr [28-29]: Lit: Int(3)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
@@ -35,7 +35,7 @@ fn bit_decl_bit_lit() {
                     type: ScalarType [0-3]: BitType [0-3]:
                         size: <none>
                     ident: Ident [4-5] "b"
-                    init_expr: ValueExpression Expr [8-9]: Lit: Int(1)"#]],
+                    init_expr: Expr [8-9]: Lit: Int(1)"#]],
     );
 }
 
@@ -83,7 +83,7 @@ fn bit_array_decl_bit_lit() {
                     type: ScalarType [0-6]: BitType [0-6]:
                         size: Expr [4-5]: Lit: Int(2)
                     ident: Ident [7-8] "b"
-                    init_expr: ValueExpression Expr [11-15]: Lit: Bitstring("11")"#]],
+                    init_expr: Expr [11-15]: Lit: Bitstring("11")"#]],
     );
 }
 
@@ -129,7 +129,7 @@ fn bool_decl_int_lit() {
                 kind: ClassicalDeclarationStmt [0-11]:
                     type: ScalarType [0-4]: BoolType
                     ident: Ident [5-6] "b"
-                    init_expr: ValueExpression Expr [9-10]: Lit: Int(1)"#]],
+                    init_expr: Expr [9-10]: Lit: Int(1)"#]],
     );
 }
 
@@ -176,7 +176,7 @@ fn complex_decl_complex_lit() {
                     type: ScalarType [0-7]: ComplexType [0-7]:
                         base_size: <none>
                     ident: Ident [8-9] "c"
-                    init_expr: ValueExpression Expr [12-15]: Lit: Imaginary(1.0)"#]],
+                    init_expr: Expr [12-15]: Lit: Imaginary(1.0)"#]],
     );
 }
 
@@ -267,7 +267,7 @@ fn complex_sized_decl_complex_lit() {
                         base_size: FloatType [8-17]:
                             size: Expr [14-16]: Lit: Int(32)
                     ident: Ident [19-20] "c"
-                    init_expr: ValueExpression Expr [23-26]: Lit: Imaginary(1.0)"#]],
+                    init_expr: Expr [23-26]: Lit: Imaginary(1.0)"#]],
     );
 }
 
@@ -316,7 +316,7 @@ fn int_decl_int_lit() {
                     type: ScalarType [0-3]: IntType [0-3]:
                         size: <none>
                     ident: Ident [4-5] "i"
-                    init_expr: ValueExpression Expr [8-9]: Lit: Int(1)"#]],
+                    init_expr: Expr [8-9]: Lit: Int(1)"#]],
     );
 }
 
@@ -364,7 +364,7 @@ fn int_sized_decl_int_lit() {
                     type: ScalarType [0-7]: IntType [0-7]:
                         size: Expr [4-6]: Lit: Int(32)
                     ident: Ident [8-9] "i"
-                    init_expr: ValueExpression Expr [12-13]: Lit: Int(1)"#]],
+                    init_expr: Expr [12-13]: Lit: Int(1)"#]],
     );
 }
 
@@ -412,7 +412,7 @@ fn uint_decl_uint_lit() {
                     type: ScalarType [0-4]: UIntType [0-4]:
                         size: <none>
                     ident: Ident [5-6] "i"
-                    init_expr: ValueExpression Expr [9-10]: Lit: Int(1)"#]],
+                    init_expr: Expr [9-10]: Lit: Int(1)"#]],
     );
 }
 
@@ -460,7 +460,7 @@ fn uint_sized_decl_uint_lit() {
                     type: ScalarType [0-8]: UIntType [0-8]:
                         size: Expr [5-7]: Lit: Int(32)
                     ident: Ident [9-10] "i"
-                    init_expr: ValueExpression Expr [13-14]: Lit: Int(1)"#]],
+                    init_expr: Expr [13-14]: Lit: Int(1)"#]],
     );
 }
 
@@ -508,7 +508,7 @@ fn float_decl_float_lit() {
                     type: ScalarType [0-5]: FloatType [0-5]:
                         size: <none>
                     ident: Ident [6-7] "f"
-                    init_expr: ValueExpression Expr [10-11]: Lit: Int(1)"#]],
+                    init_expr: Expr [10-11]: Lit: Int(1)"#]],
     );
 }
 
@@ -556,7 +556,7 @@ fn float_sized_decl_float_lit() {
                     type: ScalarType [0-9]: FloatType [0-9]:
                         size: Expr [6-8]: Lit: Int(32)
                     ident: Ident [10-11] "f"
-                    init_expr: ValueExpression Expr [14-17]: Lit: Float(1.0)"#]],
+                    init_expr: Expr [14-17]: Lit: Float(1.0)"#]],
     );
 }
 
@@ -604,7 +604,7 @@ fn angle_decl_angle_lit() {
                     type: ScalarType [0-5]: AngleType [0-5]:
                         size: <none>
                     ident: Ident [6-7] "a"
-                    init_expr: ValueExpression Expr [10-13]: Lit: Float(1.0)"#]],
+                    init_expr: Expr [10-13]: Lit: Float(1.0)"#]],
     );
 }
 
@@ -672,7 +672,7 @@ fn angle_sized_decl_angle_lit() {
                     type: ScalarType [0-9]: AngleType [0-9]:
                         size: Expr [6-8]: Lit: Int(32)
                     ident: Ident [10-11] "a"
-                    init_expr: ValueExpression Expr [14-17]: Lit: Float(1.0)"#]],
+                    init_expr: Expr [14-17]: Lit: Float(1.0)"#]],
     );
 }
 
@@ -718,7 +718,7 @@ fn duration_decl_ns_lit() {
                 kind: ClassicalDeclarationStmt [0-20]:
                     type: ScalarType [0-8]: Duration
                     ident: Ident [9-10] "d"
-                    init_expr: ValueExpression Expr [13-19]: Lit: Duration(1000.0, Ns)"#]],
+                    init_expr: Expr [13-19]: Lit: Duration(1000.0, Ns)"#]],
     );
 }
 
@@ -733,7 +733,7 @@ fn duration_decl_us_lit() {
                 kind: ClassicalDeclarationStmt [0-20]:
                     type: ScalarType [0-8]: Duration
                     ident: Ident [9-10] "d"
-                    init_expr: ValueExpression Expr [13-19]: Lit: Duration(1000.0, Us)"#]],
+                    init_expr: Expr [13-19]: Lit: Duration(1000.0, Us)"#]],
     );
 }
 
@@ -750,7 +750,7 @@ fn duration_decl_uus_lit() {
                 kind: ClassicalDeclarationStmt [0-21]:
                     type: ScalarType [0-8]: Duration
                     ident: Ident [9-10] "d"
-                    init_expr: ValueExpression Expr [13-20]: Lit: Duration(1000.0, Us)"#]],
+                    init_expr: Expr [13-20]: Lit: Duration(1000.0, Us)"#]],
     );
 }
 
@@ -765,7 +765,7 @@ fn duration_decl_ms_lit() {
                 kind: ClassicalDeclarationStmt [0-20]:
                     type: ScalarType [0-8]: Duration
                     ident: Ident [9-10] "d"
-                    init_expr: ValueExpression Expr [13-19]: Lit: Duration(1000.0, Ms)"#]],
+                    init_expr: Expr [13-19]: Lit: Duration(1000.0, Ms)"#]],
     );
 }
 
@@ -780,7 +780,7 @@ fn duration_decl_s_lit() {
                 kind: ClassicalDeclarationStmt [0-19]:
                     type: ScalarType [0-8]: Duration
                     ident: Ident [9-10] "d"
-                    init_expr: ValueExpression Expr [13-18]: Lit: Duration(1000.0, S)"#]],
+                    init_expr: Expr [13-18]: Lit: Duration(1000.0, S)"#]],
     );
 }
 
@@ -795,7 +795,7 @@ fn duration_decl_dt_lit() {
                 kind: ClassicalDeclarationStmt [0-20]:
                     type: ScalarType [0-8]: Duration
                     ident: Ident [9-10] "d"
-                    init_expr: ValueExpression Expr [13-19]: Lit: Duration(1000.0, Dt)"#]],
+                    init_expr: Expr [13-19]: Lit: Duration(1000.0, Dt)"#]],
     );
 }
 
@@ -844,7 +844,7 @@ fn empty_array_decl() {
                         dimensions:
                             Expr [11-12]: Lit: Int(0)
                     ident: Ident [14-17] "arr"
-                    init_expr: ValueExpression Expr [20-22]: Lit:     Array: <empty>"#]],
+                    init_expr: Expr [20-22]: Lit:     Array: <empty>"#]],
     );
 }
 
@@ -863,7 +863,7 @@ fn simple_array_decl() {
                         dimensions:
                             Expr [15-16]: Lit: Int(3)
                     ident: Ident [18-21] "arr"
-                    init_expr: ValueExpression Expr [24-33]: Lit:     Array:
+                    init_expr: Expr [24-33]: Lit:     Array:
                             Expr [25-26]: Lit: Int(1)
                             Expr [28-29]: Lit: Int(2)
                             Expr [31-32]: Lit: Int(3)"#]],
@@ -886,7 +886,7 @@ fn nested_array_decl() {
                             Expr [15-16]: Lit: Int(3)
                             Expr [18-19]: Lit: Int(2)
                     ident: Ident [21-24] "arr"
-                    init_expr: ValueExpression Expr [27-51]: Lit:     Array:
+                    init_expr: Expr [27-51]: Lit:     Array:
                             Expr [28-34]: Lit:     Array:
                                     Expr [29-30]: Lit: Int(1)
                                     Expr [32-33]: Lit: Int(2)
@@ -911,7 +911,7 @@ fn measure_hardware_qubit_decl() {
                     type: ScalarType [0-3]: BitType [0-3]:
                         size: <none>
                     ident: Ident [4-7] "res"
-                    init_expr: ValueExpression MeasureExpr [10-17]:
+                    init_expr: MeasureExpr [10-17]:
                         operand: GateOperand HardwareQubit [18-21]: 12"#]],
     );
 }
@@ -928,13 +928,13 @@ fn measure_register_decl() {
                     type: ScalarType [0-3]: BitType [0-3]:
                         size: <none>
                     ident: Ident [4-7] "res"
-                    init_expr: ValueExpression MeasureExpr [10-17]:
+                    init_expr: MeasureExpr [10-17]:
                         operand: GateOperand IndexedIdent [18-30]:
                             name: Ident [18-24] "qubits"
                             indices:
-                                IndexElement:
-                                    IndexSetItem Expr [25-26]: Lit: Int(2)
-                                IndexElement:
-                                    IndexSetItem Expr [28-29]: Lit: Int(3)"#]],
+                                IndexSet:
+                                    Expr [25-26]: Lit: Int(2)
+                                IndexSet:
+                                    Expr [28-29]: Lit: Int(3)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
@@ -841,7 +841,7 @@ fn empty_array_decl() {
                     type: ArrayType [0-13]:
                         base_type: ArrayBaseTypeKind IntType [6-9]:
                             size: <none>
-                        dimensions: 
+                        dimensions:
                             Expr [11-12]: Lit: Int(0)
                     ident: Ident [14-17] "arr"
                     init_expr: ValueExpression Expr [20-22]: Lit:     Array: <empty>"#]],
@@ -860,10 +860,10 @@ fn simple_array_decl() {
                     type: ArrayType [0-17]:
                         base_type: ArrayBaseTypeKind IntType [6-13]:
                             size: Expr [10-12]: Lit: Int(32)
-                        dimensions: 
+                        dimensions:
                             Expr [15-16]: Lit: Int(3)
                     ident: Ident [18-21] "arr"
-                    init_expr: ValueExpression Expr [24-33]: Lit:     Array: 
+                    init_expr: ValueExpression Expr [24-33]: Lit:     Array:
                             Expr [25-26]: Lit: Int(1)
                             Expr [28-29]: Lit: Int(2)
                             Expr [31-32]: Lit: Int(3)"#]],
@@ -882,18 +882,18 @@ fn nested_array_decl() {
                     type: ArrayType [0-20]:
                         base_type: ArrayBaseTypeKind IntType [6-13]:
                             size: Expr [10-12]: Lit: Int(32)
-                        dimensions: 
+                        dimensions:
                             Expr [15-16]: Lit: Int(3)
                             Expr [18-19]: Lit: Int(2)
                     ident: Ident [21-24] "arr"
-                    init_expr: ValueExpression Expr [27-51]: Lit:     Array: 
-                            Expr [28-34]: Lit:     Array: 
+                    init_expr: ValueExpression Expr [27-51]: Lit:     Array:
+                            Expr [28-34]: Lit:     Array:
                                     Expr [29-30]: Lit: Int(1)
                                     Expr [32-33]: Lit: Int(2)
-                            Expr [36-42]: Lit:     Array: 
+                            Expr [36-42]: Lit:     Array:
                                     Expr [37-38]: Lit: Int(3)
                                     Expr [40-41]: Lit: Int(4)
-                            Expr [44-50]: Lit:     Array: 
+                            Expr [44-50]: Lit:     Array:
                                     Expr [45-46]: Lit: Int(5)
                                     Expr [48-49]: Lit: Int(6)"#]],
     );
@@ -929,10 +929,10 @@ fn measure_register_decl() {
                     ident: Ident [4-7] "res"
                     init_expr: ValueExpression MeasureExpr [10-17]: GateOperand IndexedIdent [18-30]:
                         name: Ident [18-24] "qubits"
-                        indices: 
-                            IndexElement: 
+                        indices:
+                            IndexElement:
                                 IndexSetItem Expr [25-26]: Lit: Int(2)
-                            IndexElement: 
+                            IndexElement:
                                 IndexSetItem Expr [28-29]: Lit: Int(3)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
@@ -912,7 +912,7 @@ fn measure_hardware_qubit_decl() {
                         size: <none>
                     ident: Ident [4-7] "res"
                     init_expr: MeasureExpr [10-17]:
-                        operand: GateOperand HardwareQubit [18-21]: 12"#]],
+                        operand: HardwareQubit [18-21]: 12"#]],
     );
 }
 
@@ -929,12 +929,14 @@ fn measure_register_decl() {
                         size: <none>
                     ident: Ident [4-7] "res"
                     init_expr: MeasureExpr [10-17]:
-                        operand: GateOperand IndexedIdent [18-30]:
+                        operand: IndexedIdent [18-30]:
                             name: Ident [18-24] "qubits"
                             indices:
-                                IndexSet:
-                                    Expr [25-26]: Lit: Int(2)
-                                IndexSet:
-                                    Expr [28-29]: Lit: Int(3)"#]],
+                                IndexSet [25-26]:
+                                    values:
+                                        Expr [25-26]: Lit: Int(2)
+                                IndexSet [28-29]:
+                                    values:
+                                        Expr [28-29]: Lit: Int(3)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/def.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/def.rs
@@ -134,7 +134,7 @@ fn classical_subroutine() {
                         Stmt [31-45]:
                             annotations: <empty>
                             kind: ReturnStmt [31-45]:
-                                expr: ValueExpression Expr [38-44]: BinaryOpExpr:
+                                expr: Expr [38-44]: BinaryOpExpr:
                                     op: Exp
                                     lhs: Expr [38-39]: Ident [38-39] "x"
                                     rhs: Expr [43-44]: Lit: Int(2)"#]],
@@ -194,7 +194,7 @@ fn old_style_args() {
                         Stmt [58-72]:
                             annotations: <empty>
                             kind: ReturnStmt [58-72]:
-                                expr: ValueExpression Expr [65-71]: BinaryOpExpr:
+                                expr: Expr [65-71]: BinaryOpExpr:
                                     op: Exp
                                     lhs: Expr [65-66]: Ident [65-66] "x"
                                     rhs: Expr [70-71]: Lit: Int(2)"#]],
@@ -214,6 +214,7 @@ fn readonly_array_arg_with_int_dims() {
                     parameters:
                         TypedParameter::ArrayReference [18-55]:
                             type: ArrayReferenceType [18-47]:
+                                mutability: ReadOnly
                                 base_type: ArrayBaseTypeKind IntType [33-39]:
                                     size: Expr [37-38]: Lit: Int(8)
                                 dimensions:
@@ -239,6 +240,7 @@ fn readonly_array_arg_with_dim() {
                     parameters:
                         TypedParameter::ArrayReference [19-59]:
                             type: ArrayReferenceType [19-51]:
+                                mutability: ReadOnly
                                 base_type: ArrayBaseTypeKind IntType [34-40]:
                                     size: Expr [38-39]: Lit: Int(8)
                                 dimensions:
@@ -263,6 +265,7 @@ fn mutable_array_arg() {
                     parameters:
                         TypedParameter::ArrayReference [19-58]:
                             type: ArrayReferenceType [19-50]:
+                                mutability: Mutable
                                 base_type: ArrayBaseTypeKind IntType [33-39]:
                                     size: Expr [37-38]: Lit: Int(8)
                                 dimensions:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/def.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/def.rs
@@ -56,7 +56,7 @@ fn missing_args_with_delim_error() {
                 kind: DefStmt [0-12]:
                     ident: Ident [4-5] "x"
                     parameters:
-                        TypedParameter::Scalar [6-6]:
+                        ScalarTypedParameter [6-6]:
                             type: ScalarType [0-0]: Err
                             ident: Ident [0-0] ""
                     return_type: <none>
@@ -86,14 +86,14 @@ fn args_with_extra_delim_err_ty() {
                 kind: DefStmt [0-23]:
                     ident: Ident [4-5] "x"
                     parameters:
-                        TypedParameter::Scalar [6-11]:
+                        ScalarTypedParameter [6-11]:
                             type: ScalarType [6-9]: IntType [6-9]:
                                 size: <none>
                             ident: Ident [10-11] "a"
-                        TypedParameter::Scalar [12-12]:
+                        ScalarTypedParameter [12-12]:
                             type: ScalarType [0-0]: Err
                             ident: Ident [0-0] ""
-                        TypedParameter::Scalar [13-18]:
+                        ScalarTypedParameter [13-18]:
                             type: ScalarType [13-16]: IntType [13-16]:
                                 size: <none>
                             ident: Ident [17-18] "b"
@@ -124,7 +124,7 @@ fn classical_subroutine() {
                 kind: DefStmt [0-47]:
                     ident: Ident [4-10] "square"
                     parameters:
-                        TypedParameter::Scalar [11-20]:
+                        ScalarTypedParameter [11-20]:
                             type: ScalarType [11-18]: IntType [11-18]:
                                 size: Expr [15-17]: Lit: Int(32)
                             ident: Ident [19-20] "x"
@@ -152,10 +152,10 @@ fn quantum_args() {
                 kind: DefStmt [0-35]:
                     ident: Ident [4-5] "x"
                     parameters:
-                        TypedParameter::Quantum [6-13]:
+                        QuantumTypedParameter [6-13]:
                             size: <none>
                             ident: Ident [12-13] "q"
-                        TypedParameter::Quantum [15-30]:
+                        QuantumTypedParameter [15-30]:
                             size: Expr [21-22]: Ident [21-22] "n"
                             ident: Ident [24-30] "qubits"
                     return_type: <none>
@@ -174,18 +174,18 @@ fn old_style_args() {
                 kind: DefStmt [0-74]:
                     ident: Ident [4-8] "test"
                     parameters:
-                        TypedParameter::Scalar [9-15]:
+                        ScalarTypedParameter [9-15]:
                             type: ScalarType [9-15]: BitType [9-15]:
                                 size: <none>
                             ident: Ident [14-15] "c"
-                        TypedParameter::Quantum [17-23]:
+                        QuantumTypedParameter [17-23]:
                             size: <none>
                             ident: Ident [22-23] "q"
-                        TypedParameter::Scalar [25-35]:
+                        ScalarTypedParameter [25-35]:
                             type: ScalarType [25-35]: BitType [25-35]:
                                 size: Expr [33-34]: Lit: Int(2)
                             ident: Ident [30-32] "c2"
-                        TypedParameter::Quantum [37-47]:
+                        QuantumTypedParameter [37-47]:
                             size: Expr [45-46]: Lit: Int(4)
                             ident: Ident [42-44] "q4"
                     return_type: ScalarType [52-55]: IntType [52-55]:
@@ -212,7 +212,7 @@ fn readonly_array_arg_with_int_dims() {
                 kind: DefStmt [0-59]:
                     ident: Ident [4-17] "specified_sub"
                     parameters:
-                        TypedParameter::ArrayReference [18-55]:
+                        ArrayTypedParameter [18-55]:
                             type: ArrayReferenceType [18-47]:
                                 mutability: ReadOnly
                                 base_type: ArrayBaseTypeKind IntType [33-39]:
@@ -238,7 +238,7 @@ fn readonly_array_arg_with_dim() {
                 kind: DefStmt [0-63]:
                     ident: Ident [4-18] "arr_subroutine"
                     parameters:
-                        TypedParameter::ArrayReference [19-59]:
+                        ArrayTypedParameter [19-59]:
                             type: ArrayReferenceType [19-51]:
                                 mutability: ReadOnly
                                 base_type: ArrayBaseTypeKind IntType [34-40]:
@@ -263,7 +263,7 @@ fn mutable_array_arg() {
                 kind: DefStmt [0-62]:
                     ident: Ident [4-18] "mut_subroutine"
                     parameters:
-                        TypedParameter::ArrayReference [19-58]:
+                        ArrayTypedParameter [19-58]:
                             type: ArrayReferenceType [19-50]:
                                 mutability: Mutable
                                 base_type: ArrayBaseTypeKind IntType [33-39]:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/def.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/def.rs
@@ -13,8 +13,13 @@ fn minimal() {
         parse,
         "def x() { }",
         &expect![[r#"
-            Stmt [0-11]
-                StmtKind: DefStmt [0-11]: Ident [4-5] "x"(<no params>) "#]],
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: DefStmt [0-11]:
+                    ident: Ident [4-5] "x"
+                    parameters: <empty>
+                    return_type: <none>
+                    body: Block [8-11]: <empty>"#]],
     );
 }
 
@@ -46,8 +51,16 @@ fn missing_args_with_delim_error() {
         parse,
         "def x(,) { }",
         &expect![[r#"
-            Stmt [0-12]
-                StmtKind: DefStmt [0-12]: Ident [4-5] "x"([6-6] Ident [0-0] "": ClassicalType [0-0]: Err) 
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: DefStmt [0-12]:
+                    ident: Ident [4-5] "x"
+                    parameters: 
+                        TypedParameter::Scalar [6-6]:
+                            type: ScalarType [0-0]: Err
+                            ident: Ident [0-0] ""
+                    return_type: <none>
+                    body: Block [9-12]: <empty>
 
             [
                 Error(
@@ -68,8 +81,24 @@ fn args_with_extra_delim_err_ty() {
         parse,
         "def x(int a,,int b) { }",
         &expect![[r#"
-            Stmt [0-23]
-                StmtKind: DefStmt [0-23]: Ident [4-5] "x"([6-11] Ident [10-11] "a": ClassicalType [6-9]: IntType [6-9], [12-12] Ident [0-0] "": ClassicalType [0-0]: Err, [13-18] Ident [17-18] "b": ClassicalType [13-16]: IntType [13-16]) 
+            Stmt [0-23]:
+                annotations: <empty>
+                kind: DefStmt [0-23]:
+                    ident: Ident [4-5] "x"
+                    parameters: 
+                        TypedParameter::Scalar [6-11]:
+                            type: ScalarType [6-9]: IntType [6-9]:
+                                size: <none>
+                            ident: Ident [10-11] "a"
+                        TypedParameter::Scalar [12-12]:
+                            type: ScalarType [0-0]: Err
+                            ident: Ident [0-0] ""
+                        TypedParameter::Scalar [13-18]:
+                            type: ScalarType [13-16]: IntType [13-16]:
+                                size: <none>
+                            ident: Ident [17-18] "b"
+                    return_type: <none>
+                    body: Block [20-23]: <empty>
 
             [
                 Error(
@@ -90,13 +119,25 @@ fn classical_subroutine() {
         parse,
         "def square(int[32] x) -> int { return x ** 2; }",
         &expect![[r#"
-            Stmt [0-47]
-                StmtKind: DefStmt [0-47]: Ident [4-10] "square"([11-20] Ident [19-20] "x": ClassicalType [11-18]: IntType[Expr [15-17]: Lit: Int(32)]: [11-18]) 
-                Stmt [31-45]
-                    StmtKind: ReturnStmt [31-45]: ValueExpression Expr [38-44]: BinOp (Exp):
-                        Expr [38-39]: Ident [38-39] "x"
-                        Expr [43-44]: Lit: Int(2)
-                ClassicalType [25-28]: IntType [25-28]"#]],
+            Stmt [0-47]:
+                annotations: <empty>
+                kind: DefStmt [0-47]:
+                    ident: Ident [4-10] "square"
+                    parameters: 
+                        TypedParameter::Scalar [11-20]:
+                            type: ScalarType [11-18]: IntType [11-18]:
+                                size: Expr [15-17]: Lit: Int(32)
+                            ident: Ident [19-20] "x"
+                    return_type: ScalarType [25-28]: IntType [25-28]:
+                        size: <none>
+                    body: Block [29-47]: 
+                        Stmt [31-45]:
+                            annotations: <empty>
+                            kind: ReturnStmt [31-45]:
+                                expr: ValueExpression Expr [38-44]: BinaryOpExpr:
+                                    op: Exp
+                                    lhs: Expr [38-39]: Ident [38-39] "x"
+                                    rhs: Expr [43-44]: Lit: Int(2)"#]],
     );
 }
 
@@ -106,8 +147,19 @@ fn quantum_args() {
         parse,
         "def x(qubit q, qubit[n] qubits) { }",
         &expect![[r#"
-            Stmt [0-35]
-                StmtKind: DefStmt [0-35]: Ident [4-5] "x"([6-13] Ident [12-13] "q": qubit, [15-30] Ident [24-30] "qubits": qubit[Expr [21-22]: Ident [21-22] "n"]) "#]],
+            Stmt [0-35]:
+                annotations: <empty>
+                kind: DefStmt [0-35]:
+                    ident: Ident [4-5] "x"
+                    parameters: 
+                        TypedParameter::Quantum [6-13]:
+                            size: <none>
+                            ident: Ident [12-13] "q"
+                        TypedParameter::Quantum [15-30]:
+                            size: Expr [21-22]: Ident [21-22] "n"
+                            ident: Ident [24-30] "qubits"
+                    return_type: <none>
+                    body: Block [32-35]: <empty>"#]],
     );
 }
 
@@ -117,13 +169,35 @@ fn old_style_args() {
         parse,
         "def test(creg c, qreg q, creg c2[2], qreg q4[4]) -> int { return x ** 2; }",
         &expect![[r#"
-            Stmt [0-74]
-                StmtKind: DefStmt [0-74]: Ident [4-8] "test"([9-15] Ident [14-15] "c": ClassicalType [9-15]: BitType, [17-23] Ident [22-23] "q": qubit, [25-35] Ident [30-32] "c2": ClassicalType [25-35]: BitType [25-35]: Expr [33-34]: Lit: Int(2), [37-47] Ident [42-44] "q4": qubit[Expr [45-46]: Lit: Int(4)]) 
-                Stmt [58-72]
-                    StmtKind: ReturnStmt [58-72]: ValueExpression Expr [65-71]: BinOp (Exp):
-                        Expr [65-66]: Ident [65-66] "x"
-                        Expr [70-71]: Lit: Int(2)
-                ClassicalType [52-55]: IntType [52-55]"#]],
+            Stmt [0-74]:
+                annotations: <empty>
+                kind: DefStmt [0-74]:
+                    ident: Ident [4-8] "test"
+                    parameters: 
+                        TypedParameter::Scalar [9-15]:
+                            type: ScalarType [9-15]: BitType [9-15]:
+                                size: <none>
+                            ident: Ident [14-15] "c"
+                        TypedParameter::Quantum [17-23]:
+                            size: <none>
+                            ident: Ident [22-23] "q"
+                        TypedParameter::Scalar [25-35]:
+                            type: ScalarType [25-35]: BitType [25-35]:
+                                size: Expr [33-34]: Lit: Int(2)
+                            ident: Ident [30-32] "c2"
+                        TypedParameter::Quantum [37-47]:
+                            size: Expr [45-46]: Lit: Int(4)
+                            ident: Ident [42-44] "q4"
+                    return_type: ScalarType [52-55]: IntType [52-55]:
+                        size: <none>
+                    body: Block [56-74]: 
+                        Stmt [58-72]:
+                            annotations: <empty>
+                            kind: ReturnStmt [58-72]:
+                                expr: ValueExpression Expr [65-71]: BinaryOpExpr:
+                                    op: Exp
+                                    lhs: Expr [65-66]: Ident [65-66] "x"
+                                    rhs: Expr [70-71]: Lit: Int(2)"#]],
     );
 }
 
@@ -133,10 +207,22 @@ fn readonly_array_arg_with_int_dims() {
         parse,
         "def specified_sub(readonly array[int[8], 2, 10] arr_arg) {}",
         &expect![[r#"
-            Stmt [0-59]
-                StmtKind: DefStmt [0-59]: Ident [4-17] "specified_sub"([18-55] Ident [48-55] "arr_arg": ArrayReferenceType [18-47]: ArrayBaseTypeKind IntType[Expr [37-38]: Lit: Int(8)]: [33-39]
-                Expr [41-42]: Lit: Int(2)
-                Expr [44-46]: Lit: Int(10)) "#]],
+            Stmt [0-59]:
+                annotations: <empty>
+                kind: DefStmt [0-59]:
+                    ident: Ident [4-17] "specified_sub"
+                    parameters: 
+                        TypedParameter::ArrayReference [18-55]:
+                            type: ArrayReferenceType [18-47]:
+                                base_type: ArrayBaseTypeKind IntType [33-39]:
+                                    size: Expr [37-38]: Lit: Int(8)
+                                dimensions: 
+                                    Expr [41-42]: Lit: Int(2)
+                                    Expr [44-46]: Lit: Int(10)
+
+                            ident: Ident [48-55] "arr_arg"
+                    return_type: <none>
+                    body: Block [57-59]: <empty>"#]],
     );
 }
 
@@ -146,9 +232,21 @@ fn readonly_array_arg_with_dim() {
         parse,
         "def arr_subroutine(readonly array[int[8], #dim = 1] arr_arg) {}",
         &expect![[r#"
-            Stmt [0-63]
-                StmtKind: DefStmt [0-63]: Ident [4-18] "arr_subroutine"([19-59] Ident [52-59] "arr_arg": ArrayReferenceType [19-51]: ArrayBaseTypeKind IntType[Expr [38-39]: Lit: Int(8)]: [34-40]
-                Expr [49-50]: Lit: Int(1)) "#]],
+            Stmt [0-63]:
+                annotations: <empty>
+                kind: DefStmt [0-63]:
+                    ident: Ident [4-18] "arr_subroutine"
+                    parameters: 
+                        TypedParameter::ArrayReference [19-59]:
+                            type: ArrayReferenceType [19-51]:
+                                base_type: ArrayBaseTypeKind IntType [34-40]:
+                                    size: Expr [38-39]: Lit: Int(8)
+                                dimensions: 
+                                    Expr [49-50]: Lit: Int(1)
+
+                            ident: Ident [52-59] "arr_arg"
+                    return_type: <none>
+                    body: Block [61-63]: <empty>"#]],
     );
 }
 
@@ -158,8 +256,20 @@ fn mutable_array_arg() {
         parse,
         "def mut_subroutine(mutable array[int[8], #dim = 1] arr_arg) {}",
         &expect![[r#"
-            Stmt [0-62]
-                StmtKind: DefStmt [0-62]: Ident [4-18] "mut_subroutine"([19-58] Ident [51-58] "arr_arg": ArrayReferenceType [19-50]: ArrayBaseTypeKind IntType[Expr [37-38]: Lit: Int(8)]: [33-39]
-                Expr [48-49]: Lit: Int(1)) "#]],
+            Stmt [0-62]:
+                annotations: <empty>
+                kind: DefStmt [0-62]:
+                    ident: Ident [4-18] "mut_subroutine"
+                    parameters: 
+                        TypedParameter::ArrayReference [19-58]:
+                            type: ArrayReferenceType [19-50]:
+                                base_type: ArrayBaseTypeKind IntType [33-39]:
+                                    size: Expr [37-38]: Lit: Int(8)
+                                dimensions: 
+                                    Expr [48-49]: Lit: Int(1)
+
+                            ident: Ident [51-58] "arr_arg"
+                    return_type: <none>
+                    body: Block [60-62]: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/def.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/def.rs
@@ -55,7 +55,7 @@ fn missing_args_with_delim_error() {
                 annotations: <empty>
                 kind: DefStmt [0-12]:
                     ident: Ident [4-5] "x"
-                    parameters: 
+                    parameters:
                         TypedParameter::Scalar [6-6]:
                             type: ScalarType [0-0]: Err
                             ident: Ident [0-0] ""
@@ -85,7 +85,7 @@ fn args_with_extra_delim_err_ty() {
                 annotations: <empty>
                 kind: DefStmt [0-23]:
                     ident: Ident [4-5] "x"
-                    parameters: 
+                    parameters:
                         TypedParameter::Scalar [6-11]:
                             type: ScalarType [6-9]: IntType [6-9]:
                                 size: <none>
@@ -123,14 +123,14 @@ fn classical_subroutine() {
                 annotations: <empty>
                 kind: DefStmt [0-47]:
                     ident: Ident [4-10] "square"
-                    parameters: 
+                    parameters:
                         TypedParameter::Scalar [11-20]:
                             type: ScalarType [11-18]: IntType [11-18]:
                                 size: Expr [15-17]: Lit: Int(32)
                             ident: Ident [19-20] "x"
                     return_type: ScalarType [25-28]: IntType [25-28]:
                         size: <none>
-                    body: Block [29-47]: 
+                    body: Block [29-47]:
                         Stmt [31-45]:
                             annotations: <empty>
                             kind: ReturnStmt [31-45]:
@@ -151,7 +151,7 @@ fn quantum_args() {
                 annotations: <empty>
                 kind: DefStmt [0-35]:
                     ident: Ident [4-5] "x"
-                    parameters: 
+                    parameters:
                         TypedParameter::Quantum [6-13]:
                             size: <none>
                             ident: Ident [12-13] "q"
@@ -173,7 +173,7 @@ fn old_style_args() {
                 annotations: <empty>
                 kind: DefStmt [0-74]:
                     ident: Ident [4-8] "test"
-                    parameters: 
+                    parameters:
                         TypedParameter::Scalar [9-15]:
                             type: ScalarType [9-15]: BitType [9-15]:
                                 size: <none>
@@ -190,7 +190,7 @@ fn old_style_args() {
                             ident: Ident [42-44] "q4"
                     return_type: ScalarType [52-55]: IntType [52-55]:
                         size: <none>
-                    body: Block [56-74]: 
+                    body: Block [56-74]:
                         Stmt [58-72]:
                             annotations: <empty>
                             kind: ReturnStmt [58-72]:
@@ -211,12 +211,12 @@ fn readonly_array_arg_with_int_dims() {
                 annotations: <empty>
                 kind: DefStmt [0-59]:
                     ident: Ident [4-17] "specified_sub"
-                    parameters: 
+                    parameters:
                         TypedParameter::ArrayReference [18-55]:
                             type: ArrayReferenceType [18-47]:
                                 base_type: ArrayBaseTypeKind IntType [33-39]:
                                     size: Expr [37-38]: Lit: Int(8)
-                                dimensions: 
+                                dimensions:
                                     Expr [41-42]: Lit: Int(2)
                                     Expr [44-46]: Lit: Int(10)
 
@@ -236,12 +236,12 @@ fn readonly_array_arg_with_dim() {
                 annotations: <empty>
                 kind: DefStmt [0-63]:
                     ident: Ident [4-18] "arr_subroutine"
-                    parameters: 
+                    parameters:
                         TypedParameter::ArrayReference [19-59]:
                             type: ArrayReferenceType [19-51]:
                                 base_type: ArrayBaseTypeKind IntType [34-40]:
                                     size: Expr [38-39]: Lit: Int(8)
-                                dimensions: 
+                                dimensions:
                                     Expr [49-50]: Lit: Int(1)
 
                             ident: Ident [52-59] "arr_arg"
@@ -260,12 +260,12 @@ fn mutable_array_arg() {
                 annotations: <empty>
                 kind: DefStmt [0-62]:
                     ident: Ident [4-18] "mut_subroutine"
-                    parameters: 
+                    parameters:
                         TypedParameter::ArrayReference [19-58]:
                             type: ArrayReferenceType [19-50]:
                                 base_type: ArrayBaseTypeKind IntType [33-39]:
                                     size: Expr [37-38]: Lit: Int(8)
-                                dimensions: 
+                                dimensions:
                                     Expr [48-49]: Lit: Int(1)
 
                             ident: Ident [51-58] "arr_arg"

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/defcal.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/defcal.rs
@@ -38,7 +38,8 @@ fn cal_block_accept_any_tokens_inside() {
         .314
     }",
         &expect![[r#"
-            Stmt [5-88]
-                StmtKind: DefCalStmt [5-88]"#]],
+            Stmt [5-88]:
+                annotations: <empty>
+                kind: DefCalStmt [5-88]"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
@@ -16,15 +16,17 @@ fn delay() {
                 kind: DelayStmt [0-20]:
                     duration: Expr [6-7]: Ident [6-7] "a"
                     qubits:
-                        GateOperand IndexedIdent [9-13]:
+                        IndexedIdent [9-13]:
                             name: Ident [9-10] "q"
                             indices:
-                                IndexSet:
-                                    Expr [11-12]: Lit: Int(0)
-                        GateOperand IndexedIdent [15-19]:
+                                IndexSet [11-12]:
+                                    values:
+                                        Expr [11-12]: Lit: Int(0)
+                        IndexedIdent [15-19]:
                             name: Ident [15-16] "q"
                             indices:
-                                IndexSet:
-                                    Expr [17-18]: Lit: Int(1)"#]],
+                                IndexSet [17-18]:
+                                    values:
+                                        Expr [17-18]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
@@ -15,16 +15,16 @@ fn delay() {
                 annotations: <empty>
                 kind: DelayInstruction [0-20]:
                     duration: Expr [6-7]: Ident [6-7] "a"
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [9-13]:
                             name: Ident [9-10] "q"
-                            indices: 
-                                IndexElement: 
+                            indices:
+                                IndexElement:
                                     IndexSetItem Expr [11-12]: Lit: Int(0)
                         GateOperand IndexedIdent [15-19]:
                             name: Ident [15-16] "q"
-                            indices: 
-                                IndexElement: 
+                            indices:
+                                IndexElement:
                                     IndexSetItem Expr [17-18]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
@@ -13,18 +13,18 @@ fn delay() {
         &expect![[r#"
             Stmt [0-20]:
                 annotations: <empty>
-                kind: DelayInstruction [0-20]:
+                kind: DelayStmt [0-20]:
                     duration: Expr [6-7]: Ident [6-7] "a"
                     qubits:
                         GateOperand IndexedIdent [9-13]:
                             name: Ident [9-10] "q"
                             indices:
-                                IndexElement:
-                                    IndexSetItem Expr [11-12]: Lit: Int(0)
+                                IndexSet:
+                                    Expr [11-12]: Lit: Int(0)
                         GateOperand IndexedIdent [15-19]:
                             name: Ident [15-16] "q"
                             indices:
-                                IndexElement:
-                                    IndexSetItem Expr [17-18]: Lit: Int(1)"#]],
+                                IndexSet:
+                                    Expr [17-18]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
@@ -11,13 +11,20 @@ fn delay() {
         parse,
         "delay[a] q[0], q[1];",
         &expect![[r#"
-        Stmt [0-20]
-            StmtKind: DelayInstruction [0-20]: Expr [6-7]: Ident [6-7] "a"
-            GateOperand IndexedIdent [9-13]: Ident [9-10] "q"[
-            IndexElement:
-                IndexSetItem Expr [11-12]: Lit: Int(0)]
-            GateOperand IndexedIdent [15-19]: Ident [15-16] "q"[
-            IndexElement:
-                IndexSetItem Expr [17-18]: Lit: Int(1)]"#]],
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: DelayInstruction [0-20]:
+                    duration: Expr [6-7]: Ident [6-7] "a"
+                    qubits: 
+                        GateOperand IndexedIdent [9-13]:
+                            name: Ident [9-10] "q"
+                            indices: 
+                                IndexElement: 
+                                    IndexSetItem Expr [11-12]: Lit: Int(0)
+                        GateOperand IndexedIdent [15-19]:
+                            name: Ident [15-16] "q"
+                            indices: 
+                                IndexElement: 
+                                    IndexSetItem Expr [17-18]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
@@ -88,8 +88,8 @@ fn indexed_function_call() {
                             args:
                                 Expr [5-6]: Lit: Int(2)
                                 Expr [8-9]: Lit: Int(3)
-                        index: IndexElement:
-                            IndexSetItem Expr [11-12]: Lit: Int(1)"#]],
+                        index: IndexSet:
+                            Expr [11-12]: Lit: Int(1)"#]],
     );
 }
 
@@ -108,9 +108,9 @@ fn multi_indexed_function_call() {
                             args:
                                 Expr [5-6]: Lit: Int(2)
                                 Expr [8-9]: Lit: Int(3)
-                        index: IndexElement:
-                            IndexSetItem Expr [11-12]: Lit: Int(1)
-                            IndexSetItem Expr [14-15]: Lit: Int(0)"#]],
+                        index: IndexSet:
+                            Expr [11-12]: Lit: Int(1)
+                            Expr [14-15]: Lit: Int(0)"#]],
     );
 }
 
@@ -138,8 +138,8 @@ fn index_expr() {
                 kind: ExprStmt [0-8]:
                     expr: Expr [0-7]: IndexExpr [4-7]:
                         collection: Expr [0-4]: Ident [0-4] "Name"
-                        index: IndexElement:
-                            IndexSetItem Expr [5-6]: Lit: Int(1)"#]],
+                        index: IndexSet:
+                            Expr [5-6]: Lit: Int(1)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
@@ -11,8 +11,10 @@ fn identifier() {
         parse,
         "H;",
         &expect![[r#"
-            Stmt [0-2]
-                StmtKind: ExprStmt [0-2]: Expr [0-1]: Ident [0-1] "H""#]],
+            Stmt [0-2]:
+                annotations: <empty>
+                kind: ExprStmt [0-2]:
+                    expr: Expr [0-1]: Ident [0-1] "H""#]],
     );
 }
 
@@ -22,10 +24,13 @@ fn identifier_plus_number() {
         parse,
         "H + 2;",
         &expect![[r#"
-            Stmt [0-6]
-                StmtKind: ExprStmt [0-6]: Expr [0-5]: BinOp (Add):
-                    Expr [0-1]: Ident [0-1] "H"
-                    Expr [4-5]: Lit: Int(2)"#]],
+            Stmt [0-6]:
+                annotations: <empty>
+                kind: ExprStmt [0-6]:
+                    expr: Expr [0-5]: BinaryOpExpr:
+                        op: Add
+                        lhs: Expr [0-1]: Ident [0-1] "H"
+                        rhs: Expr [4-5]: Lit: Int(2)"#]],
     );
 }
 
@@ -37,12 +42,17 @@ fn function_call_plus_ident() {
         parse,
         "Name(2, 3) + a;",
         &expect![[r#"
-        Stmt [0-15]
-            StmtKind: ExprStmt [0-15]: Expr [0-14]: BinOp (Add):
-                Expr [0-10]: FunctionCall [0-10]: Ident [0-4] "Name"
-                    Expr [5-6]: Lit: Int(2)
-                    Expr [8-9]: Lit: Int(3)
-                Expr [13-14]: Ident [13-14] "a""#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: ExprStmt [0-15]:
+                    expr: Expr [0-14]: BinaryOpExpr:
+                        op: Add
+                        lhs: Expr [0-10]: FunctionCall [0-10]:
+                            name: Ident [0-4] "Name"
+                            args: 
+                                Expr [5-6]: Lit: Int(2)
+                                Expr [8-9]: Lit: Int(3)
+                        rhs: Expr [13-14]: Ident [13-14] "a""#]],
     );
 }
 
@@ -52,10 +62,14 @@ fn function_call() {
         parse,
         "Name(2, 3);",
         &expect![[r#"
-        Stmt [0-11]
-            StmtKind: ExprStmt [0-11]: Expr [0-10]: FunctionCall [0-10]: Ident [0-4] "Name"
-                Expr [5-6]: Lit: Int(2)
-                Expr [8-9]: Lit: Int(3)"#]],
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: ExprStmt [0-11]:
+                    expr: Expr [0-10]: FunctionCall [0-10]:
+                        name: Ident [0-4] "Name"
+                        args: 
+                            Expr [5-6]: Lit: Int(2)
+                            Expr [8-9]: Lit: Int(3)"#]],
     );
 }
 
@@ -65,11 +79,17 @@ fn indexed_function_call() {
         parse,
         "Name(2, 3)[1];",
         &expect![[r#"
-        Stmt [0-14]
-            StmtKind: ExprStmt [0-14]: Expr [0-13]: IndexExpr [10-13]: Expr [0-10]: FunctionCall [0-10]: Ident [0-4] "Name"
-                Expr [5-6]: Lit: Int(2)
-                Expr [8-9]: Lit: Int(3), IndexElement:
-                IndexSetItem Expr [11-12]: Lit: Int(1)"#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: ExprStmt [0-14]:
+                    expr: Expr [0-13]: IndexExpr [10-13]:
+                        collection: Expr [0-10]: FunctionCall [0-10]:
+                            name: Ident [0-4] "Name"
+                            args: 
+                                Expr [5-6]: Lit: Int(2)
+                                Expr [8-9]: Lit: Int(3)
+                        index: IndexElement: 
+                            IndexSetItem Expr [11-12]: Lit: Int(1)"#]],
     );
 }
 
@@ -79,12 +99,18 @@ fn multi_indexed_function_call() {
         parse,
         "Name(2, 3)[1, 0];",
         &expect![[r#"
-        Stmt [0-17]
-            StmtKind: ExprStmt [0-17]: Expr [0-16]: IndexExpr [10-16]: Expr [0-10]: FunctionCall [0-10]: Ident [0-4] "Name"
-                Expr [5-6]: Lit: Int(2)
-                Expr [8-9]: Lit: Int(3), IndexElement:
-                IndexSetItem Expr [11-12]: Lit: Int(1)
-                IndexSetItem Expr [14-15]: Lit: Int(0)"#]],
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: ExprStmt [0-17]:
+                    expr: Expr [0-16]: IndexExpr [10-16]:
+                        collection: Expr [0-10]: FunctionCall [0-10]:
+                            name: Ident [0-4] "Name"
+                            args: 
+                                Expr [5-6]: Lit: Int(2)
+                                Expr [8-9]: Lit: Int(3)
+                        index: IndexElement: 
+                            IndexSetItem Expr [11-12]: Lit: Int(1)
+                            IndexSetItem Expr [14-15]: Lit: Int(0)"#]],
     );
 }
 
@@ -94,8 +120,10 @@ fn ident() {
         parse,
         "Name;",
         &expect![[r#"
-        Stmt [0-5]
-            StmtKind: ExprStmt [0-5]: Expr [0-4]: Ident [0-4] "Name""#]],
+            Stmt [0-5]:
+                annotations: <empty>
+                kind: ExprStmt [0-5]:
+                    expr: Expr [0-4]: Ident [0-4] "Name""#]],
     );
 }
 
@@ -105,9 +133,13 @@ fn index_expr() {
         parse,
         "Name[1];",
         &expect![[r#"
-        Stmt [0-8]
-            StmtKind: ExprStmt [0-8]: Expr [0-7]: IndexExpr [4-7]: Expr [0-4]: Ident [0-4] "Name", IndexElement:
-                IndexSetItem Expr [5-6]: Lit: Int(1)"#]],
+            Stmt [0-8]:
+                annotations: <empty>
+                kind: ExprStmt [0-8]:
+                    expr: Expr [0-7]: IndexExpr [4-7]:
+                        collection: Expr [0-4]: Ident [0-4] "Name"
+                        index: IndexElement: 
+                            IndexSetItem Expr [5-6]: Lit: Int(1)"#]],
     );
 }
 
@@ -117,10 +149,13 @@ fn cast_expr() {
         parse,
         "bit(0);",
         &expect![[r#"
-            Stmt [0-7]
-                StmtKind: ExprStmt [0-7]: Expr [0-6]: Cast [0-6]:
-                    ClassicalType [0-3]: BitType
-                    Expr [4-5]: Lit: Int(0)"#]],
+            Stmt [0-7]:
+                annotations: <empty>
+                kind: ExprStmt [0-7]:
+                    expr: Expr [0-6]: Cast [0-6]:
+                        type: ScalarType [0-3]: BitType [0-3]:
+                            size: <none>
+                        arg: Expr [4-5]: Lit: Int(0)"#]],
     );
 }
 
@@ -130,9 +165,12 @@ fn cast_expr_with_designator() {
         parse,
         "bit[45](0);",
         &expect![[r#"
-            Stmt [0-11]
-                StmtKind: ExprStmt [0-11]: Expr [0-10]: Cast [0-10]:
-                    ClassicalType [0-7]: BitType [0-7]: Expr [4-6]: Lit: Int(45)
-                    Expr [8-9]: Lit: Int(0)"#]],
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: ExprStmt [0-11]:
+                    expr: Expr [0-10]: Cast [0-10]:
+                        type: ScalarType [0-7]: BitType [0-7]:
+                            size: Expr [4-6]: Lit: Int(45)
+                        arg: Expr [8-9]: Lit: Int(0)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
@@ -88,8 +88,9 @@ fn indexed_function_call() {
                             args:
                                 Expr [5-6]: Lit: Int(2)
                                 Expr [8-9]: Lit: Int(3)
-                        index: IndexSet:
-                            Expr [11-12]: Lit: Int(1)"#]],
+                        index: IndexSet [11-12]:
+                            values:
+                                Expr [11-12]: Lit: Int(1)"#]],
     );
 }
 
@@ -108,9 +109,10 @@ fn multi_indexed_function_call() {
                             args:
                                 Expr [5-6]: Lit: Int(2)
                                 Expr [8-9]: Lit: Int(3)
-                        index: IndexSet:
-                            Expr [11-12]: Lit: Int(1)
-                            Expr [14-15]: Lit: Int(0)"#]],
+                        index: IndexSet [11-15]:
+                            values:
+                                Expr [11-12]: Lit: Int(1)
+                                Expr [14-15]: Lit: Int(0)"#]],
     );
 }
 
@@ -138,8 +140,9 @@ fn index_expr() {
                 kind: ExprStmt [0-8]:
                     expr: Expr [0-7]: IndexExpr [4-7]:
                         collection: Expr [0-4]: Ident [0-4] "Name"
-                        index: IndexSet:
-                            Expr [5-6]: Lit: Int(1)"#]],
+                        index: IndexSet [5-6]:
+                            values:
+                                Expr [5-6]: Lit: Int(1)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
@@ -49,7 +49,7 @@ fn function_call_plus_ident() {
                         op: Add
                         lhs: Expr [0-10]: FunctionCall [0-10]:
                             name: Ident [0-4] "Name"
-                            args: 
+                            args:
                                 Expr [5-6]: Lit: Int(2)
                                 Expr [8-9]: Lit: Int(3)
                         rhs: Expr [13-14]: Ident [13-14] "a""#]],
@@ -67,7 +67,7 @@ fn function_call() {
                 kind: ExprStmt [0-11]:
                     expr: Expr [0-10]: FunctionCall [0-10]:
                         name: Ident [0-4] "Name"
-                        args: 
+                        args:
                             Expr [5-6]: Lit: Int(2)
                             Expr [8-9]: Lit: Int(3)"#]],
     );
@@ -85,10 +85,10 @@ fn indexed_function_call() {
                     expr: Expr [0-13]: IndexExpr [10-13]:
                         collection: Expr [0-10]: FunctionCall [0-10]:
                             name: Ident [0-4] "Name"
-                            args: 
+                            args:
                                 Expr [5-6]: Lit: Int(2)
                                 Expr [8-9]: Lit: Int(3)
-                        index: IndexElement: 
+                        index: IndexElement:
                             IndexSetItem Expr [11-12]: Lit: Int(1)"#]],
     );
 }
@@ -105,10 +105,10 @@ fn multi_indexed_function_call() {
                     expr: Expr [0-16]: IndexExpr [10-16]:
                         collection: Expr [0-10]: FunctionCall [0-10]:
                             name: Ident [0-4] "Name"
-                            args: 
+                            args:
                                 Expr [5-6]: Lit: Int(2)
                                 Expr [8-9]: Lit: Int(3)
-                        index: IndexElement: 
+                        index: IndexElement:
                             IndexSetItem Expr [11-12]: Lit: Int(1)
                             IndexSetItem Expr [14-15]: Lit: Int(0)"#]],
     );
@@ -138,7 +138,7 @@ fn index_expr() {
                 kind: ExprStmt [0-8]:
                     expr: Expr [0-7]: IndexExpr [4-7]:
                         collection: Expr [0-4]: Ident [0-4] "Name"
-                        index: IndexElement: 
+                        index: IndexElement:
                             IndexSetItem Expr [5-6]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/extern_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/extern_decl.rs
@@ -119,6 +119,7 @@ fn readonly_array_arg_with_int_dims() {
                     ident: Ident [7-8] "x"
                     parameters:
                         [9-38]: ArrayReferenceType [9-38]:
+                            mutability: ReadOnly
                             base_type: ArrayBaseTypeKind IntType [24-30]:
                                 size: Expr [28-29]: Lit: Int(8)
                             dimensions:
@@ -141,6 +142,7 @@ fn readonly_array_arg_with_dim() {
                     ident: Ident [7-8] "x"
                     parameters:
                         [9-41]: ArrayReferenceType [9-41]:
+                            mutability: ReadOnly
                             base_type: ArrayBaseTypeKind IntType [24-30]:
                                 size: Expr [28-29]: Lit: Int(8)
                             dimensions:
@@ -162,6 +164,7 @@ fn mutable_array_arg() {
                     ident: Ident [7-8] "x"
                     parameters:
                         [9-40]: ArrayReferenceType [9-40]:
+                            mutability: Mutable
                             base_type: ArrayBaseTypeKind IntType [23-29]:
                                 size: Expr [27-28]: Lit: Int(8)
                             dimensions:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/extern_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/extern_decl.rs
@@ -205,7 +205,9 @@ fn annotation() {
         &expect![[r#"
             Stmt [0-47]:
                 annotations:
-                    Annotation [0-16]: (test.annotation)
+                    Annotation [0-16]:
+                        identifier: "test.annotation"
+                        value: <none>
                 kind: ExternDecl [25-47]:
                     ident: Ident [32-33] "x"
                     parameters:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/extern_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/extern_decl.rs
@@ -13,8 +13,12 @@ fn missing_semicolon_err() {
         parse,
         "extern x()",
         &expect![[r#"
-            Stmt [0-10]
-                StmtKind: ExternDecl [0-10]: Ident [7-8] "x"
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: ExternDecl [0-10]:
+                    ident: Ident [7-8] "x"
+                    parameters: <empty>
+                    return_type: <none>
 
             [
                 Error(
@@ -37,10 +41,15 @@ fn bit_param_bit_ret_decl() {
         parse,
         "extern x(bit) -> bit;",
         &expect![[r#"
-            Stmt [0-21]
-                StmtKind: ExternDecl [0-21]: Ident [7-8] "x"
-                [9-12]: ClassicalType [9-12]: BitType
-                ClassicalType [17-20]: BitType"#]],
+            Stmt [0-21]:
+                annotations: <empty>
+                kind: ExternDecl [0-21]:
+                    ident: Ident [7-8] "x"
+                    parameters: 
+                        [9-12]: ScalarType [9-12]: BitType [9-12]:
+                            size: <none>
+                    return_type: ScalarType [17-20]: BitType [17-20]:
+                        size: <none>"#]],
     );
 }
 
@@ -50,10 +59,15 @@ fn sized_bit_param_bit_ret_decl() {
         parse,
         "extern x(bit[n]) -> bit;",
         &expect![[r#"
-            Stmt [0-24]
-                StmtKind: ExternDecl [0-24]: Ident [7-8] "x"
-                [9-15]: ClassicalType [9-15]: BitType [9-15]: Expr [13-14]: Ident [13-14] "n"
-                ClassicalType [20-23]: BitType"#]],
+            Stmt [0-24]:
+                annotations: <empty>
+                kind: ExternDecl [0-24]:
+                    ident: Ident [7-8] "x"
+                    parameters: 
+                        [9-15]: ScalarType [9-15]: BitType [9-15]:
+                            size: Expr [13-14]: Ident [13-14] "n"
+                    return_type: ScalarType [20-23]: BitType [20-23]:
+                        size: <none>"#]],
     );
 }
 
@@ -63,10 +77,15 @@ fn sized_creg_param_bit_ret_decl() {
         parse,
         "extern x(creg[n]) -> bit;",
         &expect![[r#"
-            Stmt [0-25]
-                StmtKind: ExternDecl [0-25]: Ident [7-8] "x"
-                [9-16]: ClassicalType [9-16]: BitType [9-16]: Expr [14-15]: Ident [14-15] "n"
-                ClassicalType [21-24]: BitType"#]],
+            Stmt [0-25]:
+                annotations: <empty>
+                kind: ExternDecl [0-25]:
+                    ident: Ident [7-8] "x"
+                    parameters: 
+                        [9-16]: ScalarType [9-16]: BitType [9-16]:
+                            size: Expr [14-15]: Ident [14-15] "n"
+                    return_type: ScalarType [21-24]: BitType [21-24]:
+                        size: <none>"#]],
     );
 }
 
@@ -76,10 +95,15 @@ fn creg_param_bit_ret_decl() {
         parse,
         "extern x(creg) -> bit;",
         &expect![[r#"
-            Stmt [0-22]
-                StmtKind: ExternDecl [0-22]: Ident [7-8] "x"
-                [9-13]: ClassicalType [9-13]: BitType
-                ClassicalType [18-21]: BitType"#]],
+            Stmt [0-22]:
+                annotations: <empty>
+                kind: ExternDecl [0-22]:
+                    ident: Ident [7-8] "x"
+                    parameters: 
+                        [9-13]: ScalarType [9-13]: BitType [9-13]:
+                            size: <none>
+                    return_type: ScalarType [18-21]: BitType [18-21]:
+                        size: <none>"#]],
     );
 }
 
@@ -89,11 +113,19 @@ fn readonly_array_arg_with_int_dims() {
         parse,
         "extern x(readonly array[int[8], 2, 10]);",
         &expect![[r#"
-            Stmt [0-40]
-                StmtKind: ExternDecl [0-40]: Ident [7-8] "x"
-                [9-38]: ArrayReferenceType [9-38]: ArrayBaseTypeKind IntType[Expr [28-29]: Lit: Int(8)]: [24-30]
-                Expr [32-33]: Lit: Int(2)
-                Expr [35-37]: Lit: Int(10)"#]],
+            Stmt [0-40]:
+                annotations: <empty>
+                kind: ExternDecl [0-40]:
+                    ident: Ident [7-8] "x"
+                    parameters: 
+                        [9-38]: ArrayReferenceType [9-38]:
+                            base_type: ArrayBaseTypeKind IntType [24-30]:
+                                size: Expr [28-29]: Lit: Int(8)
+                            dimensions: 
+                                Expr [32-33]: Lit: Int(2)
+                                Expr [35-37]: Lit: Int(10)
+
+                    return_type: <none>"#]],
     );
 }
 
@@ -103,10 +135,18 @@ fn readonly_array_arg_with_dim() {
         parse,
         "extern x(readonly array[int[8], #dim = 1]);",
         &expect![[r#"
-            Stmt [0-43]
-                StmtKind: ExternDecl [0-43]: Ident [7-8] "x"
-                [9-41]: ArrayReferenceType [9-41]: ArrayBaseTypeKind IntType[Expr [28-29]: Lit: Int(8)]: [24-30]
-                Expr [39-40]: Lit: Int(1)"#]],
+            Stmt [0-43]:
+                annotations: <empty>
+                kind: ExternDecl [0-43]:
+                    ident: Ident [7-8] "x"
+                    parameters: 
+                        [9-41]: ArrayReferenceType [9-41]:
+                            base_type: ArrayBaseTypeKind IntType [24-30]:
+                                size: Expr [28-29]: Lit: Int(8)
+                            dimensions: 
+                                Expr [39-40]: Lit: Int(1)
+
+                    return_type: <none>"#]],
     );
 }
 
@@ -116,10 +156,18 @@ fn mutable_array_arg() {
         parse,
         "extern x(mutable array[int[8], #dim = 1]);",
         &expect![[r#"
-            Stmt [0-42]
-                StmtKind: ExternDecl [0-42]: Ident [7-8] "x"
-                [9-40]: ArrayReferenceType [9-40]: ArrayBaseTypeKind IntType[Expr [27-28]: Lit: Int(8)]: [23-29]
-                Expr [38-39]: Lit: Int(1)"#]],
+            Stmt [0-42]:
+                annotations: <empty>
+                kind: ExternDecl [0-42]:
+                    ident: Ident [7-8] "x"
+                    parameters: 
+                        [9-40]: ArrayReferenceType [9-40]:
+                            base_type: ArrayBaseTypeKind IntType [23-29]:
+                                size: Expr [27-28]: Lit: Int(8)
+                            dimensions: 
+                                Expr [38-39]: Lit: Int(1)
+
+                    return_type: <none>"#]],
     );
 }
 
@@ -152,11 +200,16 @@ fn annotation() {
         r#"@test.annotation
         extern x(creg) -> bit;"#,
         &expect![[r#"
-            Stmt [0-47]
-                Annotation [0-16]: (test.annotation)
-                StmtKind: ExternDecl [25-47]: Ident [32-33] "x"
-                [34-38]: ClassicalType [34-38]: BitType
-                ClassicalType [43-46]: BitType"#]],
+            Stmt [0-47]:
+                annotations: 
+                    Annotation [0-16]: (test.annotation)
+                kind: ExternDecl [25-47]:
+                    ident: Ident [32-33] "x"
+                    parameters: 
+                        [34-38]: ScalarType [34-38]: BitType [34-38]:
+                            size: <none>
+                    return_type: ScalarType [43-46]: BitType [43-46]:
+                        size: <none>"#]],
     );
 }
 
@@ -186,9 +239,13 @@ fn missing_args_with_delim_error() {
         parse,
         "extern x(,);",
         &expect![[r#"
-            Stmt [0-12]
-                StmtKind: ExternDecl [0-12]: Ident [7-8] "x"
-                [9-9]: ClassicalType [0-0]: Err
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: ExternDecl [0-12]:
+                    ident: Ident [7-8] "x"
+                    parameters: 
+                        [9-9]: ScalarType [0-0]: Err
+                    return_type: <none>
 
             [
                 Error(
@@ -209,11 +266,17 @@ fn args_with_extra_delim_err_ty() {
         parse,
         "extern x(int,,int);",
         &expect![[r#"
-            Stmt [0-19]
-                StmtKind: ExternDecl [0-19]: Ident [7-8] "x"
-                [9-12]: ClassicalType [9-12]: IntType [9-12]
-                [13-13]: ClassicalType [0-0]: Err
-                [14-17]: ClassicalType [14-17]: IntType [14-17]
+            Stmt [0-19]:
+                annotations: <empty>
+                kind: ExternDecl [0-19]:
+                    ident: Ident [7-8] "x"
+                    parameters: 
+                        [9-12]: ScalarType [9-12]: IntType [9-12]:
+                            size: <none>
+                        [13-13]: ScalarType [0-0]: Err
+                        [14-17]: ScalarType [14-17]: IntType [14-17]:
+                            size: <none>
+                    return_type: <none>
 
             [
                 Error(

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/extern_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/extern_decl.rs
@@ -45,7 +45,7 @@ fn bit_param_bit_ret_decl() {
                 annotations: <empty>
                 kind: ExternDecl [0-21]:
                     ident: Ident [7-8] "x"
-                    parameters: 
+                    parameters:
                         [9-12]: ScalarType [9-12]: BitType [9-12]:
                             size: <none>
                     return_type: ScalarType [17-20]: BitType [17-20]:
@@ -63,7 +63,7 @@ fn sized_bit_param_bit_ret_decl() {
                 annotations: <empty>
                 kind: ExternDecl [0-24]:
                     ident: Ident [7-8] "x"
-                    parameters: 
+                    parameters:
                         [9-15]: ScalarType [9-15]: BitType [9-15]:
                             size: Expr [13-14]: Ident [13-14] "n"
                     return_type: ScalarType [20-23]: BitType [20-23]:
@@ -81,7 +81,7 @@ fn sized_creg_param_bit_ret_decl() {
                 annotations: <empty>
                 kind: ExternDecl [0-25]:
                     ident: Ident [7-8] "x"
-                    parameters: 
+                    parameters:
                         [9-16]: ScalarType [9-16]: BitType [9-16]:
                             size: Expr [14-15]: Ident [14-15] "n"
                     return_type: ScalarType [21-24]: BitType [21-24]:
@@ -99,7 +99,7 @@ fn creg_param_bit_ret_decl() {
                 annotations: <empty>
                 kind: ExternDecl [0-22]:
                     ident: Ident [7-8] "x"
-                    parameters: 
+                    parameters:
                         [9-13]: ScalarType [9-13]: BitType [9-13]:
                             size: <none>
                     return_type: ScalarType [18-21]: BitType [18-21]:
@@ -117,11 +117,11 @@ fn readonly_array_arg_with_int_dims() {
                 annotations: <empty>
                 kind: ExternDecl [0-40]:
                     ident: Ident [7-8] "x"
-                    parameters: 
+                    parameters:
                         [9-38]: ArrayReferenceType [9-38]:
                             base_type: ArrayBaseTypeKind IntType [24-30]:
                                 size: Expr [28-29]: Lit: Int(8)
-                            dimensions: 
+                            dimensions:
                                 Expr [32-33]: Lit: Int(2)
                                 Expr [35-37]: Lit: Int(10)
 
@@ -139,11 +139,11 @@ fn readonly_array_arg_with_dim() {
                 annotations: <empty>
                 kind: ExternDecl [0-43]:
                     ident: Ident [7-8] "x"
-                    parameters: 
+                    parameters:
                         [9-41]: ArrayReferenceType [9-41]:
                             base_type: ArrayBaseTypeKind IntType [24-30]:
                                 size: Expr [28-29]: Lit: Int(8)
-                            dimensions: 
+                            dimensions:
                                 Expr [39-40]: Lit: Int(1)
 
                     return_type: <none>"#]],
@@ -160,11 +160,11 @@ fn mutable_array_arg() {
                 annotations: <empty>
                 kind: ExternDecl [0-42]:
                     ident: Ident [7-8] "x"
-                    parameters: 
+                    parameters:
                         [9-40]: ArrayReferenceType [9-40]:
                             base_type: ArrayBaseTypeKind IntType [23-29]:
                                 size: Expr [27-28]: Lit: Int(8)
-                            dimensions: 
+                            dimensions:
                                 Expr [38-39]: Lit: Int(1)
 
                     return_type: <none>"#]],
@@ -201,11 +201,11 @@ fn annotation() {
         extern x(creg) -> bit;"#,
         &expect![[r#"
             Stmt [0-47]:
-                annotations: 
+                annotations:
                     Annotation [0-16]: (test.annotation)
                 kind: ExternDecl [25-47]:
                     ident: Ident [32-33] "x"
-                    parameters: 
+                    parameters:
                         [34-38]: ScalarType [34-38]: BitType [34-38]:
                             size: <none>
                     return_type: ScalarType [43-46]: BitType [43-46]:
@@ -243,7 +243,7 @@ fn missing_args_with_delim_error() {
                 annotations: <empty>
                 kind: ExternDecl [0-12]:
                     ident: Ident [7-8] "x"
-                    parameters: 
+                    parameters:
                         [9-9]: ScalarType [0-0]: Err
                     return_type: <none>
 
@@ -270,7 +270,7 @@ fn args_with_extra_delim_err_ty() {
                 annotations: <empty>
                 kind: ExternDecl [0-19]:
                     ident: Ident [7-8] "x"
-                    parameters: 
+                    parameters:
                         [9-12]: ScalarType [9-12]: IntType [9-12]:
                             size: <none>
                         [13-13]: ScalarType [0-0]: Err

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
@@ -196,7 +196,7 @@ fn for_loop_with_continue_stmt() {
                                     rhs: Expr [42-43]: Lit: Int(0)
                         Stmt [53-62]:
                             annotations: <empty>
-                            kind: Continue [53-62]"#]],
+                            kind: ContinueStmt [53-62]"#]],
     );
 }
 
@@ -230,6 +230,6 @@ fn for_loop_with_break_stmt() {
                                     rhs: Expr [42-43]: Lit: Int(0)
                         Stmt [53-59]:
                             annotations: <empty>
-                            kind: Break [53-59]"#]],
+                            kind: BreakStmt [53-59]"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
@@ -13,15 +13,42 @@ fn simple_for_loop() {
         a = 0;
     }",
         &expect![[r#"
-            Stmt [5-50]
-                StmtKind: ForStmt [5-50]: ClassicalType [9-12]: IntType [9-12], Ident [13-14] "x", DiscreteSet [18-27]:
-                    Expr [19-20]: Lit: Int(1)
-                    Expr [22-23]: Lit: Int(2)
-                    Expr [25-26]: Lit: Int(3)
-                Stmt [38-44]
-                    StmtKind: ExprStmt [38-44]: Expr [38-43]: Assign:
-                        Expr [38-39]: Ident [38-39] "a"
-                        Expr [42-43]: Lit: Int(0)"#]],
+            Stmt [5-50]:
+                annotations: <empty>
+                kind: ForStmt [5-50]:
+                    variable_type: ScalarType [9-12]: IntType [9-12]:
+                        size: <none>
+                    variable_name: Ident [13-14] "x"
+                    iterable: DiscreteSet [18-27]:
+                        values: 
+                            Expr [19-20]: Lit: Int(1)
+                            Expr [22-23]: Lit: Int(2)
+                            Expr [25-26]: Lit: Int(3)
+                    block: 
+                        Stmt [38-44]:
+                            annotations: <empty>
+                            kind: ExprStmt [38-44]:
+                                expr: Expr [38-43]: AssignExpr:
+                                    lhs: Expr [38-39]: Ident [38-39] "a"
+                                    rhs: Expr [42-43]: Lit: Int(0)"#]],
+    );
+}
+
+#[test]
+fn empty_for_loop() {
+    check(
+        parse,
+        "for int x in {} {}",
+        &expect![[r#"
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: ForStmt [0-18]:
+                    variable_type: ScalarType [4-7]: IntType [4-7]:
+                        size: <none>
+                    variable_name: Ident [8-9] "x"
+                    iterable: DiscreteSet [13-15]:
+                        values: <empty>
+                    block: <empty>"#]],
     );
 }
 
@@ -34,15 +61,24 @@ fn simple_for_loop_stmt_body() {
         a = 0;
     ",
         &expect![[r#"
-            Stmt [5-42]
-                StmtKind: ForStmt [5-42]: ClassicalType [9-12]: IntType [9-12], Ident [13-14] "x", DiscreteSet [18-27]:
-                    Expr [19-20]: Lit: Int(1)
-                    Expr [22-23]: Lit: Int(2)
-                    Expr [25-26]: Lit: Int(3)
-                Stmt [36-42]
-                    StmtKind: ExprStmt [36-42]: Expr [36-41]: Assign:
-                        Expr [36-37]: Ident [36-37] "a"
-                        Expr [40-41]: Lit: Int(0)"#]],
+            Stmt [5-42]:
+                annotations: <empty>
+                kind: ForStmt [5-42]:
+                    variable_type: ScalarType [9-12]: IntType [9-12]:
+                        size: <none>
+                    variable_name: Ident [13-14] "x"
+                    iterable: DiscreteSet [18-27]:
+                        values: 
+                            Expr [19-20]: Lit: Int(1)
+                            Expr [22-23]: Lit: Int(2)
+                            Expr [25-26]: Lit: Int(3)
+                    block: 
+                        Stmt [36-42]:
+                            annotations: <empty>
+                            kind: ExprStmt [36-42]:
+                                expr: Expr [36-41]: AssignExpr:
+                                    lhs: Expr [36-37]: Ident [36-37] "a"
+                                    rhs: Expr [40-41]: Lit: Int(0)"#]],
     );
 }
 
@@ -55,15 +91,23 @@ fn for_loop_range() {
         a = 0;
     }",
         &expect![[r#"
-            Stmt [5-48]
-                StmtKind: ForStmt [5-48]: ClassicalType [9-12]: IntType [9-12], Ident [13-14] "x", Range: [18-25]
-                    start: Expr [19-20]: Lit: Int(0)
-                    step: Expr [21-22]: Lit: Int(2)
-                    end: Expr [23-24]: Lit: Int(7)
-                Stmt [36-42]
-                    StmtKind: ExprStmt [36-42]: Expr [36-41]: Assign:
-                        Expr [36-37]: Ident [36-37] "a"
-                        Expr [40-41]: Lit: Int(0)"#]],
+            Stmt [5-48]:
+                annotations: <empty>
+                kind: ForStmt [5-48]:
+                    variable_type: ScalarType [9-12]: IntType [9-12]:
+                        size: <none>
+                    variable_name: Ident [13-14] "x"
+                    iterable: RangeDefinition [18-25]:
+                        start: Expr [19-20]: Lit: Int(0)
+                        step: Expr [21-22]: Lit: Int(2)
+                        end: Expr [23-24]: Lit: Int(7)
+                    block: 
+                        Stmt [36-42]:
+                            annotations: <empty>
+                            kind: ExprStmt [36-42]:
+                                expr: Expr [36-41]: AssignExpr:
+                                    lhs: Expr [36-37]: Ident [36-37] "a"
+                                    rhs: Expr [40-41]: Lit: Int(0)"#]],
     );
 }
 
@@ -76,15 +120,23 @@ fn for_loop_range_no_step() {
         a = 0;
     }",
         &expect![[r#"
-            Stmt [5-46]
-                StmtKind: ForStmt [5-46]: ClassicalType [9-12]: IntType [9-12], Ident [13-14] "x", Range: [18-23]
-                    start: Expr [19-20]: Lit: Int(0)
-                    <no step>
-                    end: Expr [21-22]: Lit: Int(7)
-                Stmt [34-40]
-                    StmtKind: ExprStmt [34-40]: Expr [34-39]: Assign:
-                        Expr [34-35]: Ident [34-35] "a"
-                        Expr [38-39]: Lit: Int(0)"#]],
+            Stmt [5-46]:
+                annotations: <empty>
+                kind: ForStmt [5-46]:
+                    variable_type: ScalarType [9-12]: IntType [9-12]:
+                        size: <none>
+                    variable_name: Ident [13-14] "x"
+                    iterable: RangeDefinition [18-23]:
+                        start: Expr [19-20]: Lit: Int(0)
+                        step: <none>
+                        end: Expr [21-22]: Lit: Int(7)
+                    block: 
+                        Stmt [34-40]:
+                            annotations: <empty>
+                            kind: ExprStmt [34-40]:
+                                expr: Expr [34-39]: AssignExpr:
+                                    lhs: Expr [34-35]: Ident [34-35] "a"
+                                    rhs: Expr [38-39]: Lit: Int(0)"#]],
     );
 }
 
@@ -97,12 +149,20 @@ fn for_loop_expr() {
         a = 0;
     }",
         &expect![[r#"
-            Stmt [5-43]
-                StmtKind: ForStmt [5-43]: ClassicalType [9-12]: IntType [9-12], Ident [13-14] "x", Expr [18-20]: Ident [18-20] "xs"
-                Stmt [31-37]
-                    StmtKind: ExprStmt [31-37]: Expr [31-36]: Assign:
-                        Expr [31-32]: Ident [31-32] "a"
-                        Expr [35-36]: Lit: Int(0)"#]],
+            Stmt [5-43]:
+                annotations: <empty>
+                kind: ForStmt [5-43]:
+                    variable_type: ScalarType [9-12]: IntType [9-12]:
+                        size: <none>
+                    variable_name: Ident [13-14] "x"
+                    iterable: Expr [18-20]: Ident [18-20] "xs"
+                    block: 
+                        Stmt [31-37]:
+                            annotations: <empty>
+                            kind: ExprStmt [31-37]:
+                                expr: Expr [31-36]: AssignExpr:
+                                    lhs: Expr [31-32]: Ident [31-32] "a"
+                                    rhs: Expr [35-36]: Lit: Int(0)"#]],
     );
 }
 
@@ -116,17 +176,27 @@ fn for_loop_with_continue_stmt() {
         continue;
     }",
         &expect![[r#"
-            Stmt [5-68]
-                StmtKind: ForStmt [5-68]: ClassicalType [9-12]: IntType [9-12], Ident [13-14] "x", DiscreteSet [18-27]:
-                    Expr [19-20]: Lit: Int(1)
-                    Expr [22-23]: Lit: Int(2)
-                    Expr [25-26]: Lit: Int(3)
-                Stmt [38-44]
-                    StmtKind: ExprStmt [38-44]: Expr [38-43]: Assign:
-                        Expr [38-39]: Ident [38-39] "a"
-                        Expr [42-43]: Lit: Int(0)
-                Stmt [53-62]
-                    StmtKind: Continue [53-62]"#]],
+            Stmt [5-68]:
+                annotations: <empty>
+                kind: ForStmt [5-68]:
+                    variable_type: ScalarType [9-12]: IntType [9-12]:
+                        size: <none>
+                    variable_name: Ident [13-14] "x"
+                    iterable: DiscreteSet [18-27]:
+                        values: 
+                            Expr [19-20]: Lit: Int(1)
+                            Expr [22-23]: Lit: Int(2)
+                            Expr [25-26]: Lit: Int(3)
+                    block: 
+                        Stmt [38-44]:
+                            annotations: <empty>
+                            kind: ExprStmt [38-44]:
+                                expr: Expr [38-43]: AssignExpr:
+                                    lhs: Expr [38-39]: Ident [38-39] "a"
+                                    rhs: Expr [42-43]: Lit: Int(0)
+                        Stmt [53-62]:
+                            annotations: <empty>
+                            kind: Continue [53-62]"#]],
     );
 }
 
@@ -140,16 +210,26 @@ fn for_loop_with_break_stmt() {
         break;
     }",
         &expect![[r#"
-            Stmt [5-65]
-                StmtKind: ForStmt [5-65]: ClassicalType [9-12]: IntType [9-12], Ident [13-14] "x", DiscreteSet [18-27]:
-                    Expr [19-20]: Lit: Int(1)
-                    Expr [22-23]: Lit: Int(2)
-                    Expr [25-26]: Lit: Int(3)
-                Stmt [38-44]
-                    StmtKind: ExprStmt [38-44]: Expr [38-43]: Assign:
-                        Expr [38-39]: Ident [38-39] "a"
-                        Expr [42-43]: Lit: Int(0)
-                Stmt [53-59]
-                    StmtKind: Break [53-59]"#]],
+            Stmt [5-65]:
+                annotations: <empty>
+                kind: ForStmt [5-65]:
+                    variable_type: ScalarType [9-12]: IntType [9-12]:
+                        size: <none>
+                    variable_name: Ident [13-14] "x"
+                    iterable: DiscreteSet [18-27]:
+                        values: 
+                            Expr [19-20]: Lit: Int(1)
+                            Expr [22-23]: Lit: Int(2)
+                            Expr [25-26]: Lit: Int(3)
+                    block: 
+                        Stmt [38-44]:
+                            annotations: <empty>
+                            kind: ExprStmt [38-44]:
+                                expr: Expr [38-43]: AssignExpr:
+                                    lhs: Expr [38-39]: Ident [38-39] "a"
+                                    rhs: Expr [42-43]: Lit: Int(0)
+                        Stmt [53-59]:
+                            annotations: <empty>
+                            kind: Break [53-59]"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
@@ -20,11 +20,11 @@ fn simple_for_loop() {
                         size: <none>
                     variable_name: Ident [13-14] "x"
                     iterable: DiscreteSet [18-27]:
-                        values: 
+                        values:
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block: 
+                    block:
                         Stmt [38-44]:
                             annotations: <empty>
                             kind: ExprStmt [38-44]:
@@ -68,11 +68,11 @@ fn simple_for_loop_stmt_body() {
                         size: <none>
                     variable_name: Ident [13-14] "x"
                     iterable: DiscreteSet [18-27]:
-                        values: 
+                        values:
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block: 
+                    block:
                         Stmt [36-42]:
                             annotations: <empty>
                             kind: ExprStmt [36-42]:
@@ -101,7 +101,7 @@ fn for_loop_range() {
                         start: Expr [19-20]: Lit: Int(0)
                         step: Expr [21-22]: Lit: Int(2)
                         end: Expr [23-24]: Lit: Int(7)
-                    block: 
+                    block:
                         Stmt [36-42]:
                             annotations: <empty>
                             kind: ExprStmt [36-42]:
@@ -130,7 +130,7 @@ fn for_loop_range_no_step() {
                         start: Expr [19-20]: Lit: Int(0)
                         step: <none>
                         end: Expr [21-22]: Lit: Int(7)
-                    block: 
+                    block:
                         Stmt [34-40]:
                             annotations: <empty>
                             kind: ExprStmt [34-40]:
@@ -156,7 +156,7 @@ fn for_loop_expr() {
                         size: <none>
                     variable_name: Ident [13-14] "x"
                     iterable: Expr [18-20]: Ident [18-20] "xs"
-                    block: 
+                    block:
                         Stmt [31-37]:
                             annotations: <empty>
                             kind: ExprStmt [31-37]:
@@ -183,11 +183,11 @@ fn for_loop_with_continue_stmt() {
                         size: <none>
                     variable_name: Ident [13-14] "x"
                     iterable: DiscreteSet [18-27]:
-                        values: 
+                        values:
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block: 
+                    block:
                         Stmt [38-44]:
                             annotations: <empty>
                             kind: ExprStmt [38-44]:
@@ -217,11 +217,11 @@ fn for_loop_with_break_stmt() {
                         size: <none>
                     variable_name: Ident [13-14] "x"
                     iterable: DiscreteSet [18-27]:
-                        values: 
+                        values:
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block: 
+                    block:
                         Stmt [38-44]:
                             annotations: <empty>
                             kind: ExprStmt [38-44]:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
@@ -19,7 +19,7 @@ fn gate_call() {
                     args: <empty>
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [2-4]:
+                        IndexedIdent [2-4]:
                             name: Ident [2-4] "q0"
                             indices: <empty>"#]],
     );
@@ -39,11 +39,12 @@ fn gate_call_qubit_register() {
                     args: <empty>
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [2-6]:
+                        IndexedIdent [2-6]:
                             name: Ident [2-3] "q"
                             indices:
-                                IndexSet:
-                                    Expr [4-5]: Lit: Int(2)"#]],
+                                IndexSet [4-5]:
+                                    values:
+                                        Expr [4-5]: Lit: Int(2)"#]],
     );
 }
 
@@ -61,14 +62,15 @@ fn gate_multiple_qubits() {
                     args: <empty>
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [5-7]:
+                        IndexedIdent [5-7]:
                             name: Ident [5-7] "q0"
                             indices: <empty>
-                        GateOperand IndexedIdent [9-13]:
+                        IndexedIdent [9-13]:
                             name: Ident [9-10] "q"
                             indices:
-                                IndexSet:
-                                    Expr [11-12]: Lit: Int(4)"#]],
+                                IndexSet [11-12]:
+                                    values:
+                                        Expr [11-12]: Lit: Int(4)"#]],
     );
 }
 
@@ -119,7 +121,7 @@ fn gate_call_with_parameters() {
                             rhs: Expr [8-9]: Lit: Int(2)
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [11-13]:
+                        IndexedIdent [11-13]:
                             name: Ident [11-13] "q0"
                             indices: <empty>"#]],
     );
@@ -140,7 +142,7 @@ fn gate_call_inv_modifier() {
                     args: <empty>
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [8-10]:
+                        IndexedIdent [8-10]:
                             name: Ident [8-10] "q0"
                             indices: <empty>"#]],
     );
@@ -166,13 +168,13 @@ fn gate_call_ctrl_inv_modifiers() {
                             rhs: Expr [24-25]: Lit: Int(2)
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [27-29]:
+                        IndexedIdent [27-29]:
                             name: Ident [27-29] "c1"
                             indices: <empty>
-                        GateOperand IndexedIdent [31-33]:
+                        IndexedIdent [31-33]:
                             name: Ident [31-33] "c2"
                             indices: <empty>
-                        GateOperand IndexedIdent [35-37]:
+                        IndexedIdent [35-37]:
                             name: Ident [35-37] "q0"
                             indices: <empty>"#]],
     );
@@ -213,7 +215,7 @@ fn parametrized_gate_call() {
                         Expr [8-9]: Lit: Int(3)
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [11-12]:
+                        IndexedIdent [11-12]:
                             name: Ident [11-12] "q"
                             indices: <empty>"#]],
     );
@@ -235,7 +237,7 @@ fn parametrized_gate_call_with_designator() {
                         Expr [8-9]: Lit: Int(3)
                     duration: Expr [11-12]: Lit: Int(1)
                     qubits:
-                        GateOperand IndexedIdent [14-15]:
+                        IndexedIdent [14-15]:
                             name: Ident [14-15] "q"
                             indices: <empty>"#]],
     );
@@ -273,7 +275,7 @@ fn gate_call_with_designator() {
                     args: <empty>
                     duration: Expr [2-5]: Lit: Duration(2.0, Us)
                     qubits:
-                        GateOperand IndexedIdent [7-8]:
+                        IndexedIdent [7-8]:
                             name: Ident [7-8] "q"
                             indices: <empty>"#]],
     );

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
@@ -42,8 +42,8 @@ fn gate_call_qubit_register() {
                         GateOperand IndexedIdent [2-6]:
                             name: Ident [2-3] "q"
                             indices:
-                                IndexElement:
-                                    IndexSetItem Expr [4-5]: Lit: Int(2)"#]],
+                                IndexSet:
+                                    Expr [4-5]: Lit: Int(2)"#]],
     );
 }
 
@@ -67,8 +67,8 @@ fn gate_multiple_qubits() {
                         GateOperand IndexedIdent [9-13]:
                             name: Ident [9-10] "q"
                             indices:
-                                IndexElement:
-                                    IndexSetItem Expr [11-12]: Lit: Int(4)"#]],
+                                IndexSet:
+                                    Expr [11-12]: Lit: Int(4)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
@@ -11,9 +11,17 @@ fn gate_call() {
         parse,
         "H q0;",
         &expect![[r#"
-            Stmt [0-5]
-                StmtKind: GateCall [0-5]: Ident [0-1] "H"
-                GateOperand IndexedIdent [2-4]: Ident [2-4] "q0"[]"#]],
+            Stmt [0-5]:
+                annotations: <empty>
+                kind: GateCall [0-5]:
+                    modifiers: <empty>
+                    name: Ident [0-1] "H"
+                    args: <empty>
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [2-4]:
+                            name: Ident [2-4] "q0"
+                            indices: <empty>"#]],
     );
 }
 
@@ -23,11 +31,19 @@ fn gate_call_qubit_register() {
         parse,
         "H q[2];",
         &expect![[r#"
-            Stmt [0-7]
-                StmtKind: GateCall [0-7]: Ident [0-1] "H"
-                GateOperand IndexedIdent [2-6]: Ident [2-3] "q"[
-                IndexElement:
-                    IndexSetItem Expr [4-5]: Lit: Int(2)]"#]],
+            Stmt [0-7]:
+                annotations: <empty>
+                kind: GateCall [0-7]:
+                    modifiers: <empty>
+                    name: Ident [0-1] "H"
+                    args: <empty>
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [2-6]:
+                            name: Ident [2-3] "q"
+                            indices: 
+                                IndexElement: 
+                                    IndexSetItem Expr [4-5]: Lit: Int(2)"#]],
     );
 }
 
@@ -37,12 +53,22 @@ fn gate_multiple_qubits() {
         parse,
         "CNOT q0, q[4];",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: GateCall [0-14]: Ident [0-4] "CNOT"
-                GateOperand IndexedIdent [5-7]: Ident [5-7] "q0"[]
-                GateOperand IndexedIdent [9-13]: Ident [9-10] "q"[
-                IndexElement:
-                    IndexSetItem Expr [11-12]: Lit: Int(4)]"#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: GateCall [0-14]:
+                    modifiers: <empty>
+                    name: Ident [0-4] "CNOT"
+                    args: <empty>
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [5-7]:
+                            name: Ident [5-7] "q0"
+                            indices: <empty>
+                        GateOperand IndexedIdent [9-13]:
+                            name: Ident [9-10] "q"
+                            indices: 
+                                IndexElement: 
+                                    IndexSetItem Expr [11-12]: Lit: Int(4)"#]],
     );
 }
 
@@ -52,8 +78,15 @@ fn gate_with_no_qubits() {
         parse,
         "inv @ H;",
         &expect![[r#"
-            Stmt [0-8]
-                StmtKind: GateCall [0-8]: Ident [6-7] "H"
+            Stmt [0-8]:
+                annotations: <empty>
+                kind: GateCall [0-8]:
+                    modifiers: 
+                        QuantumGateModifier [0-5]: Inv
+                    name: Ident [6-7] "H"
+                    args: <empty>
+                    duration: <none>
+                    qubits: <empty>
 
             [
                 Error(
@@ -74,12 +107,21 @@ fn gate_call_with_parameters() {
         parse,
         "Rx(pi / 2) q0;",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: GateCall [0-14]: Ident [0-2] "Rx"
-                Expr [3-9]: BinOp (Div):
-                    Expr [3-5]: Ident [3-5] "pi"
-                    Expr [8-9]: Lit: Int(2)
-                GateOperand IndexedIdent [11-13]: Ident [11-13] "q0"[]"#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: GateCall [0-14]:
+                    modifiers: <empty>
+                    name: Ident [0-2] "Rx"
+                    args: 
+                        Expr [3-9]: BinaryOpExpr:
+                            op: Div
+                            lhs: Expr [3-5]: Ident [3-5] "pi"
+                            rhs: Expr [8-9]: Lit: Int(2)
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [11-13]:
+                            name: Ident [11-13] "q0"
+                            indices: <empty>"#]],
     );
 }
 
@@ -89,9 +131,18 @@ fn gate_call_inv_modifier() {
         parse,
         "inv @ H q0;",
         &expect![[r#"
-            Stmt [0-11]
-                StmtKind: GateCall [0-11]: Ident [6-7] "H"
-                GateOperand IndexedIdent [8-10]: Ident [8-10] "q0"[]"#]],
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: GateCall [0-11]:
+                    modifiers: 
+                        QuantumGateModifier [0-5]: Inv
+                    name: Ident [6-7] "H"
+                    args: <empty>
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [8-10]:
+                            name: Ident [8-10] "q0"
+                            indices: <empty>"#]],
     );
 }
 
@@ -101,14 +152,29 @@ fn gate_call_ctrl_inv_modifiers() {
         parse,
         "ctrl(2) @ inv @ Rx(pi / 2) c1, c2, q0;",
         &expect![[r#"
-            Stmt [0-38]
-                StmtKind: GateCall [0-38]: Ident [16-18] "Rx"
-                Expr [19-25]: BinOp (Div):
-                    Expr [19-21]: Ident [19-21] "pi"
-                    Expr [24-25]: Lit: Int(2)
-                GateOperand IndexedIdent [27-29]: Ident [27-29] "c1"[]
-                GateOperand IndexedIdent [31-33]: Ident [31-33] "c2"[]
-                GateOperand IndexedIdent [35-37]: Ident [35-37] "q0"[]"#]],
+            Stmt [0-38]:
+                annotations: <empty>
+                kind: GateCall [0-38]:
+                    modifiers: 
+                        QuantumGateModifier [0-9]: Ctrl Some(Expr { span: Span { lo: 5, hi: 6 }, kind: Lit(Lit { span: Span { lo: 5, hi: 6 }, kind: Int(2) }) })
+                        QuantumGateModifier [10-15]: Inv
+                    name: Ident [16-18] "Rx"
+                    args: 
+                        Expr [19-25]: BinaryOpExpr:
+                            op: Div
+                            lhs: Expr [19-21]: Ident [19-21] "pi"
+                            rhs: Expr [24-25]: Lit: Int(2)
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [27-29]:
+                            name: Ident [27-29] "c1"
+                            indices: <empty>
+                        GateOperand IndexedIdent [31-33]:
+                            name: Ident [31-33] "c2"
+                            indices: <empty>
+                        GateOperand IndexedIdent [35-37]:
+                            name: Ident [35-37] "q0"
+                            indices: <empty>"#]],
     );
 }
 
@@ -137,11 +203,19 @@ fn parametrized_gate_call() {
         parse,
         "Name(2, 3) q;",
         &expect![[r#"
-            Stmt [0-13]
-                StmtKind: GateCall [0-13]: Ident [0-4] "Name"
-                Expr [5-6]: Lit: Int(2)
-                Expr [8-9]: Lit: Int(3)
-                GateOperand IndexedIdent [11-12]: Ident [11-12] "q"[]"#]],
+            Stmt [0-13]:
+                annotations: <empty>
+                kind: GateCall [0-13]:
+                    modifiers: <empty>
+                    name: Ident [0-4] "Name"
+                    args: 
+                        Expr [5-6]: Lit: Int(2)
+                        Expr [8-9]: Lit: Int(3)
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [11-12]:
+                            name: Ident [11-12] "q"
+                            indices: <empty>"#]],
     );
 }
 
@@ -151,12 +225,19 @@ fn parametrized_gate_call_with_designator() {
         parse,
         "Name(2, 3)[1] q;",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: GateCall [0-16]: Ident [0-4] "Name"
-                Expr [5-6]: Lit: Int(2)
-                Expr [8-9]: Lit: Int(3)
-                GateOperand IndexedIdent [14-15]: Ident [14-15] "q"[]
-                Expr [11-12]: Lit: Int(1)"#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: GateCall [0-16]:
+                    modifiers: <empty>
+                    name: Ident [0-4] "Name"
+                    args: 
+                        Expr [5-6]: Lit: Int(2)
+                        Expr [8-9]: Lit: Int(3)
+                    duration: Expr [11-12]: Lit: Int(1)
+                    qubits: 
+                        GateOperand IndexedIdent [14-15]:
+                            name: Ident [14-15] "q"
+                            indices: <empty>"#]],
     );
 }
 
@@ -184,10 +265,17 @@ fn gate_call_with_designator() {
         parse,
         "H[2us] q;",
         &expect![[r#"
-            Stmt [0-9]
-                StmtKind: GateCall [0-9]: Ident [0-1] "H"
-                GateOperand IndexedIdent [7-8]: Ident [7-8] "q"[]
-                Expr [2-5]: Lit: Duration(2.0, Us)"#]],
+            Stmt [0-9]:
+                annotations: <empty>
+                kind: GateCall [0-9]:
+                    modifiers: <empty>
+                    name: Ident [0-1] "H"
+                    args: <empty>
+                    duration: Expr [2-5]: Lit: Duration(2.0, Us)
+                    qubits: 
+                        GateOperand IndexedIdent [7-8]:
+                            name: Ident [7-8] "q"
+                            indices: <empty>"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
@@ -18,7 +18,7 @@ fn gate_call() {
                     name: Ident [0-1] "H"
                     args: <empty>
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [2-4]:
                             name: Ident [2-4] "q0"
                             indices: <empty>"#]],
@@ -38,11 +38,11 @@ fn gate_call_qubit_register() {
                     name: Ident [0-1] "H"
                     args: <empty>
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [2-6]:
                             name: Ident [2-3] "q"
-                            indices: 
-                                IndexElement: 
+                            indices:
+                                IndexElement:
                                     IndexSetItem Expr [4-5]: Lit: Int(2)"#]],
     );
 }
@@ -60,14 +60,14 @@ fn gate_multiple_qubits() {
                     name: Ident [0-4] "CNOT"
                     args: <empty>
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [5-7]:
                             name: Ident [5-7] "q0"
                             indices: <empty>
                         GateOperand IndexedIdent [9-13]:
                             name: Ident [9-10] "q"
-                            indices: 
-                                IndexElement: 
+                            indices:
+                                IndexElement:
                                     IndexSetItem Expr [11-12]: Lit: Int(4)"#]],
     );
 }
@@ -81,7 +81,7 @@ fn gate_with_no_qubits() {
             Stmt [0-8]:
                 annotations: <empty>
                 kind: GateCall [0-8]:
-                    modifiers: 
+                    modifiers:
                         QuantumGateModifier [0-5]: Inv
                     name: Ident [6-7] "H"
                     args: <empty>
@@ -112,13 +112,13 @@ fn gate_call_with_parameters() {
                 kind: GateCall [0-14]:
                     modifiers: <empty>
                     name: Ident [0-2] "Rx"
-                    args: 
+                    args:
                         Expr [3-9]: BinaryOpExpr:
                             op: Div
                             lhs: Expr [3-5]: Ident [3-5] "pi"
                             rhs: Expr [8-9]: Lit: Int(2)
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [11-13]:
                             name: Ident [11-13] "q0"
                             indices: <empty>"#]],
@@ -134,12 +134,12 @@ fn gate_call_inv_modifier() {
             Stmt [0-11]:
                 annotations: <empty>
                 kind: GateCall [0-11]:
-                    modifiers: 
+                    modifiers:
                         QuantumGateModifier [0-5]: Inv
                     name: Ident [6-7] "H"
                     args: <empty>
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [8-10]:
                             name: Ident [8-10] "q0"
                             indices: <empty>"#]],
@@ -155,17 +155,17 @@ fn gate_call_ctrl_inv_modifiers() {
             Stmt [0-38]:
                 annotations: <empty>
                 kind: GateCall [0-38]:
-                    modifiers: 
+                    modifiers:
                         QuantumGateModifier [0-9]: Ctrl Some(Expr { span: Span { lo: 5, hi: 6 }, kind: Lit(Lit { span: Span { lo: 5, hi: 6 }, kind: Int(2) }) })
                         QuantumGateModifier [10-15]: Inv
                     name: Ident [16-18] "Rx"
-                    args: 
+                    args:
                         Expr [19-25]: BinaryOpExpr:
                             op: Div
                             lhs: Expr [19-21]: Ident [19-21] "pi"
                             rhs: Expr [24-25]: Lit: Int(2)
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [27-29]:
                             name: Ident [27-29] "c1"
                             indices: <empty>
@@ -208,11 +208,11 @@ fn parametrized_gate_call() {
                 kind: GateCall [0-13]:
                     modifiers: <empty>
                     name: Ident [0-4] "Name"
-                    args: 
+                    args:
                         Expr [5-6]: Lit: Int(2)
                         Expr [8-9]: Lit: Int(3)
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [11-12]:
                             name: Ident [11-12] "q"
                             indices: <empty>"#]],
@@ -230,11 +230,11 @@ fn parametrized_gate_call_with_designator() {
                 kind: GateCall [0-16]:
                     modifiers: <empty>
                     name: Ident [0-4] "Name"
-                    args: 
+                    args:
                         Expr [5-6]: Lit: Int(2)
                         Expr [8-9]: Lit: Int(3)
                     duration: Expr [11-12]: Lit: Int(1)
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [14-15]:
                             name: Ident [14-15] "q"
                             indices: <empty>"#]],
@@ -272,7 +272,7 @@ fn gate_call_with_designator() {
                     name: Ident [0-1] "H"
                     args: <empty>
                     duration: Expr [2-5]: Lit: Duration(2.0, Us)
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [7-8]:
                             name: Ident [7-8] "q"
                             indices: <empty>"#]],

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gate_def.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gate_def.rs
@@ -13,9 +13,13 @@ fn no_qubits_no_classical() {
         parse,
         "gate c0q0 {}",
         &expect![[r#"
-            Stmt [0-12]
-                StmtKind: Gate [0-12]: Ident [5-9] "c0q0"(<no params>) 
-        "#]],
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: Gate [0-12]:
+                    ident: Ident [5-9] "c0q0"
+                    parameters: <empty>
+                    qubits: <empty>
+                    body: Block [10-12]: <empty>"#]],
     );
 }
 
@@ -25,9 +29,13 @@ fn no_qubits_no_classical_with_parens() {
         parse,
         "gate c0q0() {}",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: Gate [0-14]: Ident [5-9] "c0q0"(<no params>) 
-        "#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: Gate [0-14]:
+                    ident: Ident [5-9] "c0q0"
+                    parameters: <empty>
+                    qubits: <empty>
+                    body: Block [12-14]: <empty>"#]],
     );
 }
 
@@ -37,9 +45,14 @@ fn one_qubit_no_classical() {
         parse,
         "gate c0q1 a {}",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: Gate [0-14]: Ident [5-9] "c0q1"(<no params>) Ident [10-11] "a"
-        "#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: Gate [0-14]:
+                    ident: Ident [5-9] "c0q1"
+                    parameters: <empty>
+                    qubits: 
+                        Ident [10-11] "a"
+                    body: Block [12-14]: <empty>"#]],
     );
 }
 
@@ -49,9 +62,15 @@ fn two_qubits_no_classical() {
         parse,
         "gate c0q2 a, b {}",
         &expect![[r#"
-            Stmt [0-17]
-                StmtKind: Gate [0-17]: Ident [5-9] "c0q2"(<no params>) Ident [10-11] "a", Ident [13-14] "b"
-        "#]],
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: Gate [0-17]:
+                    ident: Ident [5-9] "c0q2"
+                    parameters: <empty>
+                    qubits: 
+                        Ident [10-11] "a"
+                        Ident [13-14] "b"
+                    body: Block [15-17]: <empty>"#]],
     );
 }
 
@@ -61,9 +80,16 @@ fn three_qubits_trailing_comma_no_classical() {
         parse,
         "gate c0q3 a, b, c, {}",
         &expect![[r#"
-            Stmt [0-21]
-                StmtKind: Gate [0-21]: Ident [5-9] "c0q3"(<no params>) Ident [10-11] "a", Ident [13-14] "b", Ident [16-17] "c"
-        "#]],
+            Stmt [0-21]:
+                annotations: <empty>
+                kind: Gate [0-21]:
+                    ident: Ident [5-9] "c0q3"
+                    parameters: <empty>
+                    qubits: 
+                        Ident [10-11] "a"
+                        Ident [13-14] "b"
+                        Ident [16-17] "c"
+                    body: Block [19-21]: <empty>"#]],
     );
 }
 
@@ -73,9 +99,14 @@ fn no_qubits_one_classical() {
         parse,
         "gate c1q0(a) {}",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: Gate [0-15]: Ident [5-9] "c1q0"(Ident [10-11] "a") 
-        "#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: Gate [0-15]:
+                    ident: Ident [5-9] "c1q0"
+                    parameters: 
+                        Ident [10-11] "a"
+                    qubits: <empty>
+                    body: Block [13-15]: <empty>"#]],
     );
 }
 
@@ -85,9 +116,15 @@ fn no_qubits_two_classical() {
         parse,
         "gate c2q0(a, b) {}",
         &expect![[r#"
-            Stmt [0-18]
-                StmtKind: Gate [0-18]: Ident [5-9] "c2q0"(Ident [10-11] "a", Ident [13-14] "b") 
-        "#]],
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: Gate [0-18]:
+                    ident: Ident [5-9] "c2q0"
+                    parameters: 
+                        Ident [10-11] "a"
+                        Ident [13-14] "b"
+                    qubits: <empty>
+                    body: Block [16-18]: <empty>"#]],
     );
 }
 
@@ -97,9 +134,16 @@ fn no_qubits_three_classical() {
         parse,
         "gate c3q0(a, b, c) {}",
         &expect![[r#"
-            Stmt [0-21]
-                StmtKind: Gate [0-21]: Ident [5-9] "c3q0"(Ident [10-11] "a", Ident [13-14] "b", Ident [16-17] "c") 
-        "#]],
+            Stmt [0-21]:
+                annotations: <empty>
+                kind: Gate [0-21]:
+                    ident: Ident [5-9] "c3q0"
+                    parameters: 
+                        Ident [10-11] "a"
+                        Ident [13-14] "b"
+                        Ident [16-17] "c"
+                    qubits: <empty>
+                    body: Block [19-21]: <empty>"#]],
     );
 }
 
@@ -109,9 +153,15 @@ fn one_qubit_one_classical() {
         parse,
         "gate c1q1(a) b {}",
         &expect![[r#"
-            Stmt [0-17]
-                StmtKind: Gate [0-17]: Ident [5-9] "c1q1"(Ident [10-11] "a") Ident [13-14] "b"
-        "#]],
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: Gate [0-17]:
+                    ident: Ident [5-9] "c1q1"
+                    parameters: 
+                        Ident [10-11] "a"
+                    qubits: 
+                        Ident [13-14] "b"
+                    body: Block [15-17]: <empty>"#]],
     );
 }
 
@@ -121,9 +171,17 @@ fn two_qubits_two_classical() {
         parse,
         "gate c2q2(a, b) c, d {}",
         &expect![[r#"
-            Stmt [0-23]
-                StmtKind: Gate [0-23]: Ident [5-9] "c2q2"(Ident [10-11] "a", Ident [13-14] "b") Ident [16-17] "c", Ident [19-20] "d"
-        "#]],
+            Stmt [0-23]:
+                annotations: <empty>
+                kind: Gate [0-23]:
+                    ident: Ident [5-9] "c2q2"
+                    parameters: 
+                        Ident [10-11] "a"
+                        Ident [13-14] "b"
+                    qubits: 
+                        Ident [16-17] "c"
+                        Ident [19-20] "d"
+                    body: Block [21-23]: <empty>"#]],
     );
 }
 
@@ -133,12 +191,26 @@ fn two_qubits_two_classical_with_body() {
         parse,
         "gate c2q2(a, b) c, d { float[32] x = a - b; }",
         &expect![[r#"
-            Stmt [0-45]
-                StmtKind: Gate [0-45]: Ident [5-9] "c2q2"(Ident [10-11] "a", Ident [13-14] "b") Ident [16-17] "c", Ident [19-20] "d"
-
-                Stmt [23-43]
-                    StmtKind: ClassicalDeclarationStmt [23-43]: ClassicalType [23-32]: FloatType[Expr [29-31]: Lit: Int(32)]: [23-32], Ident [33-34] "x", ValueExpression Expr [37-42]: BinOp (Sub):
-                        Expr [37-38]: Ident [37-38] "a"
-                        Expr [41-42]: Ident [41-42] "b""#]],
+            Stmt [0-45]:
+                annotations: <empty>
+                kind: Gate [0-45]:
+                    ident: Ident [5-9] "c2q2"
+                    parameters: 
+                        Ident [10-11] "a"
+                        Ident [13-14] "b"
+                    qubits: 
+                        Ident [16-17] "c"
+                        Ident [19-20] "d"
+                    body: Block [21-45]: 
+                        Stmt [23-43]:
+                            annotations: <empty>
+                            kind: ClassicalDeclarationStmt [23-43]:
+                                type: ScalarType [23-32]: FloatType [23-32]:
+                                    size: Expr [29-31]: Lit: Int(32)
+                                ident: Ident [33-34] "x"
+                                init_expr: ValueExpression Expr [37-42]: BinaryOpExpr:
+                                    op: Sub
+                                    lhs: Expr [37-38]: Ident [37-38] "a"
+                                    rhs: Expr [41-42]: Ident [41-42] "b""#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gate_def.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gate_def.rs
@@ -208,7 +208,7 @@ fn two_qubits_two_classical_with_body() {
                                 type: ScalarType [23-32]: FloatType [23-32]:
                                     size: Expr [29-31]: Lit: Int(32)
                                 ident: Ident [33-34] "x"
-                                init_expr: ValueExpression Expr [37-42]: BinaryOpExpr:
+                                init_expr: Expr [37-42]: BinaryOpExpr:
                                     op: Sub
                                     lhs: Expr [37-38]: Ident [37-38] "a"
                                     rhs: Expr [41-42]: Ident [41-42] "b""#]],

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gate_def.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gate_def.rs
@@ -50,7 +50,7 @@ fn one_qubit_no_classical() {
                 kind: Gate [0-14]:
                     ident: Ident [5-9] "c0q1"
                     parameters: <empty>
-                    qubits: 
+                    qubits:
                         Ident [10-11] "a"
                     body: Block [12-14]: <empty>"#]],
     );
@@ -67,7 +67,7 @@ fn two_qubits_no_classical() {
                 kind: Gate [0-17]:
                     ident: Ident [5-9] "c0q2"
                     parameters: <empty>
-                    qubits: 
+                    qubits:
                         Ident [10-11] "a"
                         Ident [13-14] "b"
                     body: Block [15-17]: <empty>"#]],
@@ -85,7 +85,7 @@ fn three_qubits_trailing_comma_no_classical() {
                 kind: Gate [0-21]:
                     ident: Ident [5-9] "c0q3"
                     parameters: <empty>
-                    qubits: 
+                    qubits:
                         Ident [10-11] "a"
                         Ident [13-14] "b"
                         Ident [16-17] "c"
@@ -103,7 +103,7 @@ fn no_qubits_one_classical() {
                 annotations: <empty>
                 kind: Gate [0-15]:
                     ident: Ident [5-9] "c1q0"
-                    parameters: 
+                    parameters:
                         Ident [10-11] "a"
                     qubits: <empty>
                     body: Block [13-15]: <empty>"#]],
@@ -120,7 +120,7 @@ fn no_qubits_two_classical() {
                 annotations: <empty>
                 kind: Gate [0-18]:
                     ident: Ident [5-9] "c2q0"
-                    parameters: 
+                    parameters:
                         Ident [10-11] "a"
                         Ident [13-14] "b"
                     qubits: <empty>
@@ -138,7 +138,7 @@ fn no_qubits_three_classical() {
                 annotations: <empty>
                 kind: Gate [0-21]:
                     ident: Ident [5-9] "c3q0"
-                    parameters: 
+                    parameters:
                         Ident [10-11] "a"
                         Ident [13-14] "b"
                         Ident [16-17] "c"
@@ -157,9 +157,9 @@ fn one_qubit_one_classical() {
                 annotations: <empty>
                 kind: Gate [0-17]:
                     ident: Ident [5-9] "c1q1"
-                    parameters: 
+                    parameters:
                         Ident [10-11] "a"
-                    qubits: 
+                    qubits:
                         Ident [13-14] "b"
                     body: Block [15-17]: <empty>"#]],
     );
@@ -175,10 +175,10 @@ fn two_qubits_two_classical() {
                 annotations: <empty>
                 kind: Gate [0-23]:
                     ident: Ident [5-9] "c2q2"
-                    parameters: 
+                    parameters:
                         Ident [10-11] "a"
                         Ident [13-14] "b"
-                    qubits: 
+                    qubits:
                         Ident [16-17] "c"
                         Ident [19-20] "d"
                     body: Block [21-23]: <empty>"#]],
@@ -195,13 +195,13 @@ fn two_qubits_two_classical_with_body() {
                 annotations: <empty>
                 kind: Gate [0-45]:
                     ident: Ident [5-9] "c2q2"
-                    parameters: 
+                    parameters:
                         Ident [10-11] "a"
                         Ident [13-14] "b"
-                    qubits: 
+                    qubits:
                         Ident [16-17] "c"
                         Ident [19-20] "d"
-                    body: Block [21-45]: 
+                    body: Block [21-45]:
                         Stmt [23-43]:
                             annotations: <empty>
                             kind: ClassicalDeclarationStmt [23-43]:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
@@ -11,11 +11,17 @@ fn gphase() {
         parse,
         "gphase(pi / 2);",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: GPhase [0-15]:
-                Expr [7-13]: BinOp (Div):
-                    Expr [7-9]: Ident [7-9] "pi"
-                    Expr [12-13]: Lit: Int(2)"#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: GPhase [0-15]:
+                    modifiers: <empty>
+                    args: 
+                        Expr [7-13]: BinaryOpExpr:
+                            op: Div
+                            lhs: Expr [7-9]: Ident [7-9] "pi"
+                            rhs: Expr [12-13]: Lit: Int(2)
+                    duration: <none>
+                    qubits: <empty>"#]],
     );
 }
 
@@ -25,10 +31,17 @@ fn gphase_qubit_ident() {
         parse,
         "gphase(a) q0;",
         &expect![[r#"
-            Stmt [0-13]
-                StmtKind: GPhase [0-13]:
-                Expr [7-8]: Ident [7-8] "a"
-                GateOperand IndexedIdent [10-12]: Ident [10-12] "q0"[]"#]],
+            Stmt [0-13]:
+                annotations: <empty>
+                kind: GPhase [0-13]:
+                    modifiers: <empty>
+                    args: 
+                        Expr [7-8]: Ident [7-8] "a"
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [10-12]:
+                            name: Ident [10-12] "q0"
+                            indices: <empty>"#]],
     );
 }
 
@@ -38,12 +51,19 @@ fn gphase_qubit_register() {
         parse,
         "gphase(a) q[2];",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: GPhase [0-15]:
-                Expr [7-8]: Ident [7-8] "a"
-                GateOperand IndexedIdent [10-14]: Ident [10-11] "q"[
-                IndexElement:
-                    IndexSetItem Expr [12-13]: Lit: Int(2)]"#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: GPhase [0-15]:
+                    modifiers: <empty>
+                    args: 
+                        Expr [7-8]: Ident [7-8] "a"
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [10-14]:
+                            name: Ident [10-11] "q"
+                            indices: 
+                                IndexElement: 
+                                    IndexSetItem Expr [12-13]: Lit: Int(2)"#]],
     );
 }
 
@@ -53,13 +73,22 @@ fn gphase_multiple_qubits() {
         parse,
         "gphase(a) q0, q[4];",
         &expect![[r#"
-            Stmt [0-19]
-                StmtKind: GPhase [0-19]:
-                Expr [7-8]: Ident [7-8] "a"
-                GateOperand IndexedIdent [10-12]: Ident [10-12] "q0"[]
-                GateOperand IndexedIdent [14-18]: Ident [14-15] "q"[
-                IndexElement:
-                    IndexSetItem Expr [16-17]: Lit: Int(4)]"#]],
+            Stmt [0-19]:
+                annotations: <empty>
+                kind: GPhase [0-19]:
+                    modifiers: <empty>
+                    args: 
+                        Expr [7-8]: Ident [7-8] "a"
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [10-12]:
+                            name: Ident [10-12] "q0"
+                            indices: <empty>
+                        GateOperand IndexedIdent [14-18]:
+                            name: Ident [14-15] "q"
+                            indices: 
+                                IndexElement: 
+                                    IndexSetItem Expr [16-17]: Lit: Int(4)"#]],
     );
 }
 
@@ -69,8 +98,13 @@ fn gphase_no_arguments() {
         parse,
         "gphase;",
         &expect![[r#"
-            Stmt [0-7]
-                StmtKind: GPhase [0-7]:
+            Stmt [0-7]:
+                annotations: <empty>
+                kind: GPhase [0-7]:
+                    modifiers: <empty>
+                    args: <empty>
+                    duration: <none>
+                    qubits: <empty>
 
             [
                 Error(
@@ -91,11 +125,17 @@ fn gphase_with_parameters() {
         parse,
         "gphase(pi / 2);",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: GPhase [0-15]:
-                Expr [7-13]: BinOp (Div):
-                    Expr [7-9]: Ident [7-9] "pi"
-                    Expr [12-13]: Lit: Int(2)"#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: GPhase [0-15]:
+                    modifiers: <empty>
+                    args: 
+                        Expr [7-13]: BinaryOpExpr:
+                            op: Div
+                            lhs: Expr [7-9]: Ident [7-9] "pi"
+                            rhs: Expr [12-13]: Lit: Int(2)
+                    duration: <none>
+                    qubits: <empty>"#]],
     );
 }
 
@@ -105,9 +145,15 @@ fn gphase_inv_modifier() {
         parse,
         "inv @ gphase(a);",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: GPhase [0-16]:
-                Expr [13-14]: Ident [13-14] "a""#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: GPhase [0-16]:
+                    modifiers: 
+                        QuantumGateModifier [0-5]: Inv
+                    args: 
+                        Expr [13-14]: Ident [13-14] "a"
+                    duration: <none>
+                    qubits: <empty>"#]],
     );
 }
 
@@ -117,11 +163,21 @@ fn gphase_ctrl_inv_modifiers() {
         parse,
         "ctrl @ inv @ gphase(pi / 2) q0;",
         &expect![[r#"
-            Stmt [0-31]
-                StmtKind: GPhase [0-31]:
-                Expr [20-26]: BinOp (Div):
-                    Expr [20-22]: Ident [20-22] "pi"
-                    Expr [25-26]: Lit: Int(2)
-                GateOperand IndexedIdent [28-30]: Ident [28-30] "q0"[]"#]],
+            Stmt [0-31]:
+                annotations: <empty>
+                kind: GPhase [0-31]:
+                    modifiers: 
+                        QuantumGateModifier [0-6]: Ctrl None
+                        QuantumGateModifier [7-12]: Inv
+                    args: 
+                        Expr [20-26]: BinaryOpExpr:
+                            op: Div
+                            lhs: Expr [20-22]: Ident [20-22] "pi"
+                            rhs: Expr [25-26]: Lit: Int(2)
+                    duration: <none>
+                    qubits: 
+                        GateOperand IndexedIdent [28-30]:
+                            name: Ident [28-30] "q0"
+                            indices: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
@@ -15,7 +15,7 @@ fn gphase() {
                 annotations: <empty>
                 kind: GPhase [0-15]:
                     modifiers: <empty>
-                    args: 
+                    args:
                         Expr [7-13]: BinaryOpExpr:
                             op: Div
                             lhs: Expr [7-9]: Ident [7-9] "pi"
@@ -35,10 +35,10 @@ fn gphase_qubit_ident() {
                 annotations: <empty>
                 kind: GPhase [0-13]:
                     modifiers: <empty>
-                    args: 
+                    args:
                         Expr [7-8]: Ident [7-8] "a"
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [10-12]:
                             name: Ident [10-12] "q0"
                             indices: <empty>"#]],
@@ -55,14 +55,14 @@ fn gphase_qubit_register() {
                 annotations: <empty>
                 kind: GPhase [0-15]:
                     modifiers: <empty>
-                    args: 
+                    args:
                         Expr [7-8]: Ident [7-8] "a"
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [10-14]:
                             name: Ident [10-11] "q"
-                            indices: 
-                                IndexElement: 
+                            indices:
+                                IndexElement:
                                     IndexSetItem Expr [12-13]: Lit: Int(2)"#]],
     );
 }
@@ -77,17 +77,17 @@ fn gphase_multiple_qubits() {
                 annotations: <empty>
                 kind: GPhase [0-19]:
                     modifiers: <empty>
-                    args: 
+                    args:
                         Expr [7-8]: Ident [7-8] "a"
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [10-12]:
                             name: Ident [10-12] "q0"
                             indices: <empty>
                         GateOperand IndexedIdent [14-18]:
                             name: Ident [14-15] "q"
-                            indices: 
-                                IndexElement: 
+                            indices:
+                                IndexElement:
                                     IndexSetItem Expr [16-17]: Lit: Int(4)"#]],
     );
 }
@@ -129,7 +129,7 @@ fn gphase_with_parameters() {
                 annotations: <empty>
                 kind: GPhase [0-15]:
                     modifiers: <empty>
-                    args: 
+                    args:
                         Expr [7-13]: BinaryOpExpr:
                             op: Div
                             lhs: Expr [7-9]: Ident [7-9] "pi"
@@ -148,9 +148,9 @@ fn gphase_inv_modifier() {
             Stmt [0-16]:
                 annotations: <empty>
                 kind: GPhase [0-16]:
-                    modifiers: 
+                    modifiers:
                         QuantumGateModifier [0-5]: Inv
-                    args: 
+                    args:
                         Expr [13-14]: Ident [13-14] "a"
                     duration: <none>
                     qubits: <empty>"#]],
@@ -166,16 +166,16 @@ fn gphase_ctrl_inv_modifiers() {
             Stmt [0-31]:
                 annotations: <empty>
                 kind: GPhase [0-31]:
-                    modifiers: 
+                    modifiers:
                         QuantumGateModifier [0-6]: Ctrl None
                         QuantumGateModifier [7-12]: Inv
-                    args: 
+                    args:
                         Expr [20-26]: BinaryOpExpr:
                             op: Div
                             lhs: Expr [20-22]: Ident [20-22] "pi"
                             rhs: Expr [25-26]: Lit: Int(2)
                     duration: <none>
-                    qubits: 
+                    qubits:
                         GateOperand IndexedIdent [28-30]:
                             name: Ident [28-30] "q0"
                             indices: <empty>"#]],

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
@@ -39,7 +39,7 @@ fn gphase_qubit_ident() {
                         Expr [7-8]: Ident [7-8] "a"
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [10-12]:
+                        IndexedIdent [10-12]:
                             name: Ident [10-12] "q0"
                             indices: <empty>"#]],
     );
@@ -59,11 +59,12 @@ fn gphase_qubit_register() {
                         Expr [7-8]: Ident [7-8] "a"
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [10-14]:
+                        IndexedIdent [10-14]:
                             name: Ident [10-11] "q"
                             indices:
-                                IndexSet:
-                                    Expr [12-13]: Lit: Int(2)"#]],
+                                IndexSet [12-13]:
+                                    values:
+                                        Expr [12-13]: Lit: Int(2)"#]],
     );
 }
 
@@ -81,14 +82,15 @@ fn gphase_multiple_qubits() {
                         Expr [7-8]: Ident [7-8] "a"
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [10-12]:
+                        IndexedIdent [10-12]:
                             name: Ident [10-12] "q0"
                             indices: <empty>
-                        GateOperand IndexedIdent [14-18]:
+                        IndexedIdent [14-18]:
                             name: Ident [14-15] "q"
                             indices:
-                                IndexSet:
-                                    Expr [16-17]: Lit: Int(4)"#]],
+                                IndexSet [16-17]:
+                                    values:
+                                        Expr [16-17]: Lit: Int(4)"#]],
     );
 }
 
@@ -176,7 +178,7 @@ fn gphase_ctrl_inv_modifiers() {
                             rhs: Expr [25-26]: Lit: Int(2)
                     duration: <none>
                     qubits:
-                        GateOperand IndexedIdent [28-30]:
+                        IndexedIdent [28-30]:
                             name: Ident [28-30] "q0"
                             indices: <empty>"#]],
     );

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
@@ -62,8 +62,8 @@ fn gphase_qubit_register() {
                         GateOperand IndexedIdent [10-14]:
                             name: Ident [10-11] "q"
                             indices:
-                                IndexElement:
-                                    IndexSetItem Expr [12-13]: Lit: Int(2)"#]],
+                                IndexSet:
+                                    Expr [12-13]: Lit: Int(2)"#]],
     );
 }
 
@@ -87,8 +87,8 @@ fn gphase_multiple_qubits() {
                         GateOperand IndexedIdent [14-18]:
                             name: Ident [14-15] "q"
                             indices:
-                                IndexElement:
-                                    IndexSetItem Expr [16-17]: Lit: Int(4)"#]],
+                                IndexSet:
+                                    Expr [16-17]: Lit: Int(4)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
@@ -23,14 +23,14 @@ fn simple_if_stmt() {
                         op: Eq
                         lhs: Expr [9-10]: Ident [9-10] "x"
                         rhs: Expr [14-15]: Ident [14-15] "y"
-                    if_block: 
+                    if_block:
                         Stmt [27-33]:
                             annotations: <empty>
                             kind: ExprStmt [27-33]:
                                 expr: Expr [27-32]: AssignExpr:
                                     lhs: Expr [27-28]: Ident [27-28] "a"
                                     rhs: Expr [31-32]: Lit: Int(0)
-                    else_block: 
+                    else_block:
                         Stmt [55-61]:
                             annotations: <empty>
                             kind: ExprStmt [55-61]:
@@ -57,7 +57,7 @@ fn if_stmt_missing_else() {
                         op: Eq
                         lhs: Expr [9-10]: Ident [9-10] "x"
                         rhs: Expr [14-15]: Ident [14-15] "y"
-                    if_block: 
+                    if_block:
                         Stmt [27-33]:
                             annotations: <empty>
                             kind: ExprStmt [27-33]:
@@ -95,7 +95,7 @@ fn nested_if_stmts() {
                         op: Eq
                         lhs: Expr [9-10]: Ident [9-10] "x"
                         rhs: Expr [14-15]: Ident [14-15] "y"
-                    if_block: 
+                    if_block:
                         Stmt [27-107]:
                             annotations: <empty>
                             kind: IfStmt [27-107]:
@@ -103,21 +103,21 @@ fn nested_if_stmts() {
                                     op: Eq
                                     lhs: Expr [31-33]: Ident [31-33] "x1"
                                     rhs: Expr [37-39]: Ident [37-39] "y1"
-                                if_block: 
+                                if_block:
                                     Stmt [55-61]:
                                         annotations: <empty>
                                         kind: ExprStmt [55-61]:
                                             expr: Expr [55-60]: AssignExpr:
                                                 lhs: Expr [55-56]: Ident [55-56] "a"
                                                 rhs: Expr [59-60]: Lit: Int(0)
-                                else_block: 
+                                else_block:
                                     Stmt [91-97]:
                                         annotations: <empty>
                                         kind: ExprStmt [91-97]:
                                             expr: Expr [91-96]: AssignExpr:
                                                 lhs: Expr [91-92]: Ident [91-92] "a"
                                                 rhs: Expr [95-96]: Lit: Int(1)
-                    else_block: 
+                    else_block:
                         Stmt [129-209]:
                             annotations: <empty>
                             kind: IfStmt [129-209]:
@@ -125,14 +125,14 @@ fn nested_if_stmts() {
                                     op: Eq
                                     lhs: Expr [133-135]: Ident [133-135] "x2"
                                     rhs: Expr [139-141]: Ident [139-141] "y2"
-                                if_block: 
+                                if_block:
                                     Stmt [157-163]:
                                         annotations: <empty>
                                         kind: ExprStmt [157-163]:
                                             expr: Expr [157-162]: AssignExpr:
                                                 lhs: Expr [157-158]: Ident [157-158] "a"
                                                 rhs: Expr [161-162]: Lit: Int(2)
-                                else_block: 
+                                else_block:
                                     Stmt [193-199]:
                                         annotations: <empty>
                                         kind: ExprStmt [193-199]:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
@@ -16,19 +16,27 @@ fn simple_if_stmt() {
     }
     ",
         &expect![[r#"
-            Stmt [5-67]
-                StmtKind: IfStmt [5-67]: Expr [9-15]: BinOp (Eq):
-                    Expr [9-10]: Ident [9-10] "x"
-                    Expr [14-15]: Ident [14-15] "y"
-                Stmt [27-33]
-                    StmtKind: ExprStmt [27-33]: Expr [27-32]: Assign:
-                        Expr [27-28]: Ident [27-28] "a"
-                        Expr [31-32]: Lit: Int(0)
-                Else:
-                Stmt [55-61]
-                    StmtKind: ExprStmt [55-61]: Expr [55-60]: Assign:
-                        Expr [55-56]: Ident [55-56] "a"
-                        Expr [59-60]: Lit: Int(1)"#]],
+            Stmt [5-67]:
+                annotations: <empty>
+                kind: IfStmt [5-67]:
+                    condition: Expr [9-15]: BinaryOpExpr:
+                        op: Eq
+                        lhs: Expr [9-10]: Ident [9-10] "x"
+                        rhs: Expr [14-15]: Ident [14-15] "y"
+                    if_block: 
+                        Stmt [27-33]:
+                            annotations: <empty>
+                            kind: ExprStmt [27-33]:
+                                expr: Expr [27-32]: AssignExpr:
+                                    lhs: Expr [27-28]: Ident [27-28] "a"
+                                    rhs: Expr [31-32]: Lit: Int(0)
+                    else_block: 
+                        Stmt [55-61]:
+                            annotations: <empty>
+                            kind: ExprStmt [55-61]:
+                                expr: Expr [55-60]: AssignExpr:
+                                    lhs: Expr [55-56]: Ident [55-56] "a"
+                                    rhs: Expr [59-60]: Lit: Int(1)"#]],
     );
 }
 
@@ -42,14 +50,21 @@ fn if_stmt_missing_else() {
     }
     ",
         &expect![[r#"
-            Stmt [5-39]
-                StmtKind: IfStmt [5-39]: Expr [9-15]: BinOp (Eq):
-                    Expr [9-10]: Ident [9-10] "x"
-                    Expr [14-15]: Ident [14-15] "y"
-                Stmt [27-33]
-                    StmtKind: ExprStmt [27-33]: Expr [27-32]: Assign:
-                        Expr [27-28]: Ident [27-28] "a"
-                        Expr [31-32]: Lit: Int(0)"#]],
+            Stmt [5-39]:
+                annotations: <empty>
+                kind: IfStmt [5-39]:
+                    condition: Expr [9-15]: BinaryOpExpr:
+                        op: Eq
+                        lhs: Expr [9-10]: Ident [9-10] "x"
+                        rhs: Expr [14-15]: Ident [14-15] "y"
+                    if_block: 
+                        Stmt [27-33]:
+                            annotations: <empty>
+                            kind: ExprStmt [27-33]:
+                                expr: Expr [27-32]: AssignExpr:
+                                    lhs: Expr [27-28]: Ident [27-28] "a"
+                                    rhs: Expr [31-32]: Lit: Int(0)
+                    else_block: <none>"#]],
     );
 }
 
@@ -73,36 +88,56 @@ fn nested_if_stmts() {
     }
     ",
         &expect![[r#"
-            Stmt [5-215]
-                StmtKind: IfStmt [5-215]: Expr [9-15]: BinOp (Eq):
-                    Expr [9-10]: Ident [9-10] "x"
-                    Expr [14-15]: Ident [14-15] "y"
-                Stmt [27-107]
-                    StmtKind: IfStmt [27-107]: Expr [31-39]: BinOp (Eq):
-                        Expr [31-33]: Ident [31-33] "x1"
-                        Expr [37-39]: Ident [37-39] "y1"
-                    Stmt [55-61]
-                        StmtKind: ExprStmt [55-61]: Expr [55-60]: Assign:
-                            Expr [55-56]: Ident [55-56] "a"
-                            Expr [59-60]: Lit: Int(0)
-                    Else:
-                    Stmt [91-97]
-                        StmtKind: ExprStmt [91-97]: Expr [91-96]: Assign:
-                            Expr [91-92]: Ident [91-92] "a"
-                            Expr [95-96]: Lit: Int(1)
-                Else:
-                Stmt [129-209]
-                    StmtKind: IfStmt [129-209]: Expr [133-141]: BinOp (Eq):
-                        Expr [133-135]: Ident [133-135] "x2"
-                        Expr [139-141]: Ident [139-141] "y2"
-                    Stmt [157-163]
-                        StmtKind: ExprStmt [157-163]: Expr [157-162]: Assign:
-                            Expr [157-158]: Ident [157-158] "a"
-                            Expr [161-162]: Lit: Int(2)
-                    Else:
-                    Stmt [193-199]
-                        StmtKind: ExprStmt [193-199]: Expr [193-198]: Assign:
-                            Expr [193-194]: Ident [193-194] "a"
-                            Expr [197-198]: Lit: Int(3)"#]],
+            Stmt [5-215]:
+                annotations: <empty>
+                kind: IfStmt [5-215]:
+                    condition: Expr [9-15]: BinaryOpExpr:
+                        op: Eq
+                        lhs: Expr [9-10]: Ident [9-10] "x"
+                        rhs: Expr [14-15]: Ident [14-15] "y"
+                    if_block: 
+                        Stmt [27-107]:
+                            annotations: <empty>
+                            kind: IfStmt [27-107]:
+                                condition: Expr [31-39]: BinaryOpExpr:
+                                    op: Eq
+                                    lhs: Expr [31-33]: Ident [31-33] "x1"
+                                    rhs: Expr [37-39]: Ident [37-39] "y1"
+                                if_block: 
+                                    Stmt [55-61]:
+                                        annotations: <empty>
+                                        kind: ExprStmt [55-61]:
+                                            expr: Expr [55-60]: AssignExpr:
+                                                lhs: Expr [55-56]: Ident [55-56] "a"
+                                                rhs: Expr [59-60]: Lit: Int(0)
+                                else_block: 
+                                    Stmt [91-97]:
+                                        annotations: <empty>
+                                        kind: ExprStmt [91-97]:
+                                            expr: Expr [91-96]: AssignExpr:
+                                                lhs: Expr [91-92]: Ident [91-92] "a"
+                                                rhs: Expr [95-96]: Lit: Int(1)
+                    else_block: 
+                        Stmt [129-209]:
+                            annotations: <empty>
+                            kind: IfStmt [129-209]:
+                                condition: Expr [133-141]: BinaryOpExpr:
+                                    op: Eq
+                                    lhs: Expr [133-135]: Ident [133-135] "x2"
+                                    rhs: Expr [139-141]: Ident [139-141] "y2"
+                                if_block: 
+                                    Stmt [157-163]:
+                                        annotations: <empty>
+                                        kind: ExprStmt [157-163]:
+                                            expr: Expr [157-162]: AssignExpr:
+                                                lhs: Expr [157-158]: Ident [157-158] "a"
+                                                rhs: Expr [161-162]: Lit: Int(2)
+                                else_block: 
+                                    Stmt [193-199]:
+                                        annotations: <empty>
+                                        kind: ExprStmt [193-199]:
+                                            expr: Expr [193-198]: AssignExpr:
+                                                lhs: Expr [193-194]: Ident [193-194] "a"
+                                                rhs: Expr [197-198]: Lit: Int(3)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/io_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/io_decl.rs
@@ -13,8 +13,13 @@ fn input_bit_decl() {
         parse,
         "input bit b;",
         &expect![[r#"
-            Stmt [0-12]
-                StmtKind: IODeclaration [0-12]: input, ClassicalType [6-9]: BitType, Ident [10-11] "b""#]],
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: IODeclaration [0-12]:
+                    io_keyword: input
+                    type: ScalarType [6-9]: BitType [6-9]:
+                        size: <none>
+                    ident: Ident [10-11] "b""#]],
     );
 }
 
@@ -24,8 +29,13 @@ fn output_bit_decl() {
         parse,
         "output bit b;",
         &expect![[r#"
-            Stmt [0-13]
-                StmtKind: IODeclaration [0-13]: output, ClassicalType [7-10]: BitType, Ident [11-12] "b""#]],
+            Stmt [0-13]:
+                annotations: <empty>
+                kind: IODeclaration [0-13]:
+                    io_keyword: output
+                    type: ScalarType [7-10]: BitType [7-10]:
+                        size: <none>
+                    ident: Ident [11-12] "b""#]],
     );
 }
 
@@ -35,8 +45,13 @@ fn input_bit_array_decl() {
         parse,
         "input bit[2] b;",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: IODeclaration [0-15]: input, ClassicalType [6-12]: BitType [6-12]: Expr [10-11]: Lit: Int(2), Ident [13-14] "b""#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: IODeclaration [0-15]:
+                    io_keyword: input
+                    type: ScalarType [6-12]: BitType [6-12]:
+                        size: Expr [10-11]: Lit: Int(2)
+                    ident: Ident [13-14] "b""#]],
     );
 }
 
@@ -46,8 +61,13 @@ fn output_bit_array_decl() {
         parse,
         "output bit[2] b;",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: IODeclaration [0-16]: output, ClassicalType [7-13]: BitType [7-13]: Expr [11-12]: Lit: Int(2), Ident [14-15] "b""#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: IODeclaration [0-16]:
+                    io_keyword: output
+                    type: ScalarType [7-13]: BitType [7-13]:
+                        size: Expr [11-12]: Lit: Int(2)
+                    ident: Ident [14-15] "b""#]],
     );
 }
 
@@ -57,8 +77,12 @@ fn intput_bool_decl() {
         parse,
         "input bool b;",
         &expect![[r#"
-            Stmt [0-13]
-                StmtKind: IODeclaration [0-13]: input, ClassicalType [6-10]: BoolType, Ident [11-12] "b""#]],
+            Stmt [0-13]:
+                annotations: <empty>
+                kind: IODeclaration [0-13]:
+                    io_keyword: input
+                    type: ScalarType [6-10]: BoolType
+                    ident: Ident [11-12] "b""#]],
     );
 }
 
@@ -68,8 +92,12 @@ fn output_bool_decl() {
         parse,
         "output bool b;",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: IODeclaration [0-14]: output, ClassicalType [7-11]: BoolType, Ident [12-13] "b""#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: IODeclaration [0-14]:
+                    io_keyword: output
+                    type: ScalarType [7-11]: BoolType
+                    ident: Ident [12-13] "b""#]],
     );
 }
 
@@ -79,8 +107,13 @@ fn input_complex_decl() {
         parse,
         "input complex c;",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: IODeclaration [0-16]: input, ClassicalType [6-13]: ComplexType [6-13], Ident [14-15] "c""#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: IODeclaration [0-16]:
+                    io_keyword: input
+                    type: ScalarType [6-13]: ComplexType [6-13]:
+                        base_size: <none>
+                    ident: Ident [14-15] "c""#]],
     );
 }
 
@@ -90,8 +123,13 @@ fn output_complex_decl() {
         parse,
         "output complex c;",
         &expect![[r#"
-            Stmt [0-17]
-                StmtKind: IODeclaration [0-17]: output, ClassicalType [7-14]: ComplexType [7-14], Ident [15-16] "c""#]],
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: IODeclaration [0-17]:
+                    io_keyword: output
+                    type: ScalarType [7-14]: ComplexType [7-14]:
+                        base_size: <none>
+                    ident: Ident [15-16] "c""#]],
     );
 }
 
@@ -101,8 +139,14 @@ fn input_complex_sized_decl() {
         parse,
         "input complex[float[32]] c;",
         &expect![[r#"
-            Stmt [0-27]
-                StmtKind: IODeclaration [0-27]: input, ClassicalType [6-24]: ComplexType[float[FloatType[Expr [20-22]: Lit: Int(32)]: [14-23]]]: [6-24], Ident [25-26] "c""#]],
+            Stmt [0-27]:
+                annotations: <empty>
+                kind: IODeclaration [0-27]:
+                    io_keyword: input
+                    type: ScalarType [6-24]: ComplexType [6-24]:
+                        base_size: FloatType [14-23]:
+                            size: Expr [20-22]: Lit: Int(32)
+                    ident: Ident [25-26] "c""#]],
     );
 }
 
@@ -112,8 +156,14 @@ fn output_complex_sized_decl() {
         parse,
         "output complex[float[32]] c;",
         &expect![[r#"
-            Stmt [0-28]
-                StmtKind: IODeclaration [0-28]: output, ClassicalType [7-25]: ComplexType[float[FloatType[Expr [21-23]: Lit: Int(32)]: [15-24]]]: [7-25], Ident [26-27] "c""#]],
+            Stmt [0-28]:
+                annotations: <empty>
+                kind: IODeclaration [0-28]:
+                    io_keyword: output
+                    type: ScalarType [7-25]: ComplexType [7-25]:
+                        base_size: FloatType [15-24]:
+                            size: Expr [21-23]: Lit: Int(32)
+                    ident: Ident [26-27] "c""#]],
     );
 }
 
@@ -123,8 +173,13 @@ fn input_int_decl() {
         parse,
         "input int i;",
         &expect![[r#"
-            Stmt [0-12]
-                StmtKind: IODeclaration [0-12]: input, ClassicalType [6-9]: IntType [6-9], Ident [10-11] "i""#]],
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: IODeclaration [0-12]:
+                    io_keyword: input
+                    type: ScalarType [6-9]: IntType [6-9]:
+                        size: <none>
+                    ident: Ident [10-11] "i""#]],
     );
 }
 
@@ -134,8 +189,13 @@ fn output_int_decl() {
         parse,
         "output int i;",
         &expect![[r#"
-            Stmt [0-13]
-                StmtKind: IODeclaration [0-13]: output, ClassicalType [7-10]: IntType [7-10], Ident [11-12] "i""#]],
+            Stmt [0-13]:
+                annotations: <empty>
+                kind: IODeclaration [0-13]:
+                    io_keyword: output
+                    type: ScalarType [7-10]: IntType [7-10]:
+                        size: <none>
+                    ident: Ident [11-12] "i""#]],
     );
 }
 
@@ -145,8 +205,13 @@ fn input_int_sized_decl() {
         parse,
         "input int[32] i;",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: IODeclaration [0-16]: input, ClassicalType [6-13]: IntType[Expr [10-12]: Lit: Int(32)]: [6-13], Ident [14-15] "i""#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: IODeclaration [0-16]:
+                    io_keyword: input
+                    type: ScalarType [6-13]: IntType [6-13]:
+                        size: Expr [10-12]: Lit: Int(32)
+                    ident: Ident [14-15] "i""#]],
     );
 }
 
@@ -156,8 +221,13 @@ fn output_int_sized_decl() {
         parse,
         "output int[32] i;",
         &expect![[r#"
-            Stmt [0-17]
-                StmtKind: IODeclaration [0-17]: output, ClassicalType [7-14]: IntType[Expr [11-13]: Lit: Int(32)]: [7-14], Ident [15-16] "i""#]],
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: IODeclaration [0-17]:
+                    io_keyword: output
+                    type: ScalarType [7-14]: IntType [7-14]:
+                        size: Expr [11-13]: Lit: Int(32)
+                    ident: Ident [15-16] "i""#]],
     );
 }
 
@@ -167,8 +237,13 @@ fn input_uint_decl() {
         parse,
         "input uint i;",
         &expect![[r#"
-            Stmt [0-13]
-                StmtKind: IODeclaration [0-13]: input, ClassicalType [6-10]: UIntType [6-10], Ident [11-12] "i""#]],
+            Stmt [0-13]:
+                annotations: <empty>
+                kind: IODeclaration [0-13]:
+                    io_keyword: input
+                    type: ScalarType [6-10]: UIntType [6-10]:
+                        size: <none>
+                    ident: Ident [11-12] "i""#]],
     );
 }
 
@@ -178,8 +253,13 @@ fn output_uint_decl() {
         parse,
         "output uint i;",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: IODeclaration [0-14]: output, ClassicalType [7-11]: UIntType [7-11], Ident [12-13] "i""#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: IODeclaration [0-14]:
+                    io_keyword: output
+                    type: ScalarType [7-11]: UIntType [7-11]:
+                        size: <none>
+                    ident: Ident [12-13] "i""#]],
     );
 }
 
@@ -189,8 +269,13 @@ fn input_uint_sized_decl() {
         parse,
         "input uint[32] i;",
         &expect![[r#"
-            Stmt [0-17]
-                StmtKind: IODeclaration [0-17]: input, ClassicalType [6-14]: UIntType[Expr [11-13]: Lit: Int(32)]: [6-14], Ident [15-16] "i""#]],
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: IODeclaration [0-17]:
+                    io_keyword: input
+                    type: ScalarType [6-14]: UIntType [6-14]:
+                        size: Expr [11-13]: Lit: Int(32)
+                    ident: Ident [15-16] "i""#]],
     );
 }
 
@@ -200,8 +285,13 @@ fn output_uint_sized_decl() {
         parse,
         "output uint[32] i;",
         &expect![[r#"
-            Stmt [0-18]
-                StmtKind: IODeclaration [0-18]: output, ClassicalType [7-15]: UIntType[Expr [12-14]: Lit: Int(32)]: [7-15], Ident [16-17] "i""#]],
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: IODeclaration [0-18]:
+                    io_keyword: output
+                    type: ScalarType [7-15]: UIntType [7-15]:
+                        size: Expr [12-14]: Lit: Int(32)
+                    ident: Ident [16-17] "i""#]],
     );
 }
 
@@ -211,8 +301,13 @@ fn input_float_decl() {
         parse,
         "input float f;",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: IODeclaration [0-14]: input, ClassicalType [6-11]: FloatType [6-11], Ident [12-13] "f""#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: IODeclaration [0-14]:
+                    io_keyword: input
+                    type: ScalarType [6-11]: FloatType [6-11]:
+                        size: <none>
+                    ident: Ident [12-13] "f""#]],
     );
 }
 
@@ -222,8 +317,13 @@ fn output_float_decl() {
         parse,
         "output float f;",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: IODeclaration [0-15]: output, ClassicalType [7-12]: FloatType [7-12], Ident [13-14] "f""#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: IODeclaration [0-15]:
+                    io_keyword: output
+                    type: ScalarType [7-12]: FloatType [7-12]:
+                        size: <none>
+                    ident: Ident [13-14] "f""#]],
     );
 }
 
@@ -233,8 +333,13 @@ fn input_float_sized_decl() {
         parse,
         "input float[32] f;",
         &expect![[r#"
-            Stmt [0-18]
-                StmtKind: IODeclaration [0-18]: input, ClassicalType [6-15]: FloatType[Expr [12-14]: Lit: Int(32)]: [6-15], Ident [16-17] "f""#]],
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: IODeclaration [0-18]:
+                    io_keyword: input
+                    type: ScalarType [6-15]: FloatType [6-15]:
+                        size: Expr [12-14]: Lit: Int(32)
+                    ident: Ident [16-17] "f""#]],
     );
 }
 
@@ -244,8 +349,13 @@ fn output_float_sized_decl() {
         parse,
         "output float[32] f;",
         &expect![[r#"
-            Stmt [0-19]
-                StmtKind: IODeclaration [0-19]: output, ClassicalType [7-16]: FloatType[Expr [13-15]: Lit: Int(32)]: [7-16], Ident [17-18] "f""#]],
+            Stmt [0-19]:
+                annotations: <empty>
+                kind: IODeclaration [0-19]:
+                    io_keyword: output
+                    type: ScalarType [7-16]: FloatType [7-16]:
+                        size: Expr [13-15]: Lit: Int(32)
+                    ident: Ident [17-18] "f""#]],
     );
 }
 
@@ -255,8 +365,13 @@ fn input_angle_decl() {
         parse,
         "input angle a;",
         &expect![[r#"
-            Stmt [0-14]
-                StmtKind: IODeclaration [0-14]: input, ClassicalType [6-11]: AngleType [6-11], Ident [12-13] "a""#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: IODeclaration [0-14]:
+                    io_keyword: input
+                    type: ScalarType [6-11]: AngleType [6-11]:
+                        size: <none>
+                    ident: Ident [12-13] "a""#]],
     );
 }
 
@@ -266,8 +381,13 @@ fn output_angle_decl() {
         parse,
         "output angle a;",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: IODeclaration [0-15]: output, ClassicalType [7-12]: AngleType [7-12], Ident [13-14] "a""#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: IODeclaration [0-15]:
+                    io_keyword: output
+                    type: ScalarType [7-12]: AngleType [7-12]:
+                        size: <none>
+                    ident: Ident [13-14] "a""#]],
     );
 }
 
@@ -277,8 +397,13 @@ fn input_angle_sized_decl() {
         parse,
         "input angle[32] a;",
         &expect![[r#"
-            Stmt [0-18]
-                StmtKind: IODeclaration [0-18]: input, ClassicalType [6-15]: AngleType [6-15]: Expr [12-14]: Lit: Int(32), Ident [16-17] "a""#]],
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: IODeclaration [0-18]:
+                    io_keyword: input
+                    type: ScalarType [6-15]: AngleType [6-15]:
+                        size: Expr [12-14]: Lit: Int(32)
+                    ident: Ident [16-17] "a""#]],
     );
 }
 
@@ -288,8 +413,13 @@ fn output_angle_sized_decl() {
         parse,
         "output angle[32] a;",
         &expect![[r#"
-            Stmt [0-19]
-                StmtKind: IODeclaration [0-19]: output, ClassicalType [7-16]: AngleType [7-16]: Expr [13-15]: Lit: Int(32), Ident [17-18] "a""#]],
+            Stmt [0-19]:
+                annotations: <empty>
+                kind: IODeclaration [0-19]:
+                    io_keyword: output
+                    type: ScalarType [7-16]: AngleType [7-16]:
+                        size: Expr [13-15]: Lit: Int(32)
+                    ident: Ident [17-18] "a""#]],
     );
 }
 
@@ -299,8 +429,12 @@ fn input_duration_decl() {
         parse,
         "input duration d;",
         &expect![[r#"
-            Stmt [0-17]
-                StmtKind: IODeclaration [0-17]: input, ClassicalType [6-14]: Duration, Ident [15-16] "d""#]],
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: IODeclaration [0-17]:
+                    io_keyword: input
+                    type: ScalarType [6-14]: Duration
+                    ident: Ident [15-16] "d""#]],
     );
 }
 
@@ -310,8 +444,12 @@ fn output_duration_decl() {
         parse,
         "output duration d;",
         &expect![[r#"
-            Stmt [0-18]
-                StmtKind: IODeclaration [0-18]: output, ClassicalType [7-15]: Duration, Ident [16-17] "d""#]],
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: IODeclaration [0-18]:
+                    io_keyword: output
+                    type: ScalarType [7-15]: Duration
+                    ident: Ident [16-17] "d""#]],
     );
 }
 
@@ -321,8 +459,12 @@ fn input_stretch_decl() {
         parse,
         "input stretch s;",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: IODeclaration [0-16]: input, ClassicalType [6-13]: Stretch, Ident [14-15] "s""#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: IODeclaration [0-16]:
+                    io_keyword: input
+                    type: ScalarType [6-13]: Stretch
+                    ident: Ident [14-15] "s""#]],
     );
 }
 
@@ -332,7 +474,11 @@ fn output_stretch_decl() {
         parse,
         "output stretch s;",
         &expect![[r#"
-            Stmt [0-17]
-                StmtKind: IODeclaration [0-17]: output, ClassicalType [7-14]: Stretch, Ident [15-16] "s""#]],
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: IODeclaration [0-17]:
+                    io_keyword: output
+                    type: ScalarType [7-14]: Stretch
+                    ident: Ident [15-16] "s""#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
@@ -70,8 +70,8 @@ fn measure_arrow_into_indented_ident() {
                 kind: MeasureStmt [0-18]:
                     target: IndexedIdent [13-17]:
                         name: Ident [13-14] "a"
-                        indices: 
-                            IndexElement: 
+                        indices:
+                            IndexElement:
                                 IndexSetItem Expr [15-16]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
@@ -15,7 +15,7 @@ fn measure_identifier() {
                 annotations: <empty>
                 kind: MeasureStmt [0-10]:
                     measurement: MeasureExpr [0-7]:
-                        operand: GateOperand IndexedIdent [8-9]:
+                        operand: IndexedIdent [8-9]:
                             name: Ident [8-9] "q"
                             indices: <empty>
                     target: <none>"#]],
@@ -32,11 +32,12 @@ fn measure_indented_ident() {
                 annotations: <empty>
                 kind: MeasureStmt [0-13]:
                     measurement: MeasureExpr [0-7]:
-                        operand: GateOperand IndexedIdent [8-12]:
+                        operand: IndexedIdent [8-12]:
                             name: Ident [8-9] "q"
                             indices:
-                                IndexSet:
-                                    Expr [10-11]: Lit: Int(2)
+                                IndexSet [10-11]:
+                                    values:
+                                        Expr [10-11]: Lit: Int(2)
                     target: <none>"#]],
     );
 }
@@ -51,7 +52,7 @@ fn measure_hardware_qubit() {
                 annotations: <empty>
                 kind: MeasureStmt [0-12]:
                     measurement: MeasureExpr [0-7]:
-                        operand: GateOperand HardwareQubit [8-11]: 42
+                        operand: HardwareQubit [8-11]: 42
                     target: <none>"#]],
     );
 }
@@ -66,7 +67,7 @@ fn measure_arrow_into_ident() {
                 annotations: <empty>
                 kind: MeasureStmt [0-15]:
                     measurement: MeasureExpr [0-7]:
-                        operand: GateOperand IndexedIdent [8-9]:
+                        operand: IndexedIdent [8-9]:
                             name: Ident [8-9] "q"
                             indices: <empty>
                     target: IndexedIdent [13-14]:
@@ -85,13 +86,14 @@ fn measure_arrow_into_indented_ident() {
                 annotations: <empty>
                 kind: MeasureStmt [0-18]:
                     measurement: MeasureExpr [0-7]:
-                        operand: GateOperand IndexedIdent [8-9]:
+                        operand: IndexedIdent [8-9]:
                             name: Ident [8-9] "q"
                             indices: <empty>
                     target: IndexedIdent [13-17]:
                         name: Ident [13-14] "a"
                         indices:
-                            IndexSet:
-                                Expr [15-16]: Lit: Int(1)"#]],
+                            IndexSet [15-16]:
+                                values:
+                                    Expr [15-16]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
@@ -35,8 +35,8 @@ fn measure_indented_ident() {
                         operand: GateOperand IndexedIdent [8-12]:
                             name: Ident [8-9] "q"
                             indices:
-                                IndexElement:
-                                    IndexSetItem Expr [10-11]: Lit: Int(2)
+                                IndexSet:
+                                    Expr [10-11]: Lit: Int(2)
                     target: <none>"#]],
     );
 }
@@ -91,7 +91,7 @@ fn measure_arrow_into_indented_ident() {
                     target: IndexedIdent [13-17]:
                         name: Ident [13-14] "a"
                         indices:
-                            IndexElement:
-                                IndexSetItem Expr [15-16]: Lit: Int(1)"#]],
+                            IndexSet:
+                                Expr [15-16]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
@@ -14,6 +14,10 @@ fn measure_identifier() {
             Stmt [0-10]:
                 annotations: <empty>
                 kind: MeasureStmt [0-10]:
+                    measurement: MeasureExpr [0-7]:
+                        operand: GateOperand IndexedIdent [8-9]:
+                            name: Ident [8-9] "q"
+                            indices: <empty>
                     target: <none>"#]],
     );
 }
@@ -27,6 +31,12 @@ fn measure_indented_ident() {
             Stmt [0-13]:
                 annotations: <empty>
                 kind: MeasureStmt [0-13]:
+                    measurement: MeasureExpr [0-7]:
+                        operand: GateOperand IndexedIdent [8-12]:
+                            name: Ident [8-9] "q"
+                            indices:
+                                IndexElement:
+                                    IndexSetItem Expr [10-11]: Lit: Int(2)
                     target: <none>"#]],
     );
 }
@@ -40,6 +50,8 @@ fn measure_hardware_qubit() {
             Stmt [0-12]:
                 annotations: <empty>
                 kind: MeasureStmt [0-12]:
+                    measurement: MeasureExpr [0-7]:
+                        operand: GateOperand HardwareQubit [8-11]: 42
                     target: <none>"#]],
     );
 }
@@ -53,6 +65,10 @@ fn measure_arrow_into_ident() {
             Stmt [0-15]:
                 annotations: <empty>
                 kind: MeasureStmt [0-15]:
+                    measurement: MeasureExpr [0-7]:
+                        operand: GateOperand IndexedIdent [8-9]:
+                            name: Ident [8-9] "q"
+                            indices: <empty>
                     target: IndexedIdent [13-14]:
                         name: Ident [13-14] "a"
                         indices: <empty>"#]],
@@ -68,6 +84,10 @@ fn measure_arrow_into_indented_ident() {
             Stmt [0-18]:
                 annotations: <empty>
                 kind: MeasureStmt [0-18]:
+                    measurement: MeasureExpr [0-7]:
+                        operand: GateOperand IndexedIdent [8-9]:
+                            name: Ident [8-9] "q"
+                            indices: <empty>
                     target: IndexedIdent [13-17]:
                         name: Ident [13-14] "a"
                         indices:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
@@ -11,8 +11,10 @@ fn measure_identifier() {
         parse,
         "measure q;",
         &expect![[r#"
-        Stmt [0-10]
-            StmtKind: MeasureStmt [0-10]: MeasureExpr [0-7]: GateOperand IndexedIdent [8-9]: Ident [8-9] "q"[]"#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: MeasureStmt [0-10]:
+                    target: <none>"#]],
     );
 }
 
@@ -22,10 +24,10 @@ fn measure_indented_ident() {
         parse,
         "measure q[2];",
         &expect![[r#"
-        Stmt [0-13]
-            StmtKind: MeasureStmt [0-13]: MeasureExpr [0-7]: GateOperand IndexedIdent [8-12]: Ident [8-9] "q"[
-            IndexElement:
-                IndexSetItem Expr [10-11]: Lit: Int(2)]"#]],
+            Stmt [0-13]:
+                annotations: <empty>
+                kind: MeasureStmt [0-13]:
+                    target: <none>"#]],
     );
 }
 
@@ -35,8 +37,10 @@ fn measure_hardware_qubit() {
         parse,
         "measure $42;",
         &expect![[r#"
-        Stmt [0-12]
-            StmtKind: MeasureStmt [0-12]: MeasureExpr [0-7]: GateOperand HardwareQubit [8-11]: 42"#]],
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: MeasureStmt [0-12]:
+                    target: <none>"#]],
     );
 }
 
@@ -46,8 +50,12 @@ fn measure_arrow_into_ident() {
         parse,
         "measure q -> a;",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: MeasureStmt [0-15]: MeasureExpr [0-7]: GateOperand IndexedIdent [8-9]: Ident [8-9] "q"[], IndexedIdent [13-14]: Ident [13-14] "a"[]"#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: MeasureStmt [0-15]:
+                    target: IndexedIdent [13-14]:
+                        name: Ident [13-14] "a"
+                        indices: <empty>"#]],
     );
 }
 
@@ -57,9 +65,13 @@ fn measure_arrow_into_indented_ident() {
         parse,
         "measure q -> a[1];",
         &expect![[r#"
-            Stmt [0-18]
-                StmtKind: MeasureStmt [0-18]: MeasureExpr [0-7]: GateOperand IndexedIdent [8-9]: Ident [8-9] "q"[], IndexedIdent [13-17]: Ident [13-14] "a"[
-                IndexElement:
-                    IndexSetItem Expr [15-16]: Lit: Int(1)]"#]],
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: MeasureStmt [0-18]:
+                    target: IndexedIdent [13-17]:
+                        name: Ident [13-14] "a"
+                        indices: 
+                            IndexElement: 
+                                IndexSetItem Expr [15-16]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/old_style_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/old_style_decl.rs
@@ -13,8 +13,13 @@ fn creg_decl() {
         parse,
         "creg c;",
         &expect![[r#"
-            Stmt [0-7]
-                StmtKind: ClassicalDeclarationStmt [0-7]: ClassicalType [0-7]: BitType, Ident [5-6] "c""#]],
+            Stmt [0-7]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-7]:
+                    type: ScalarType [0-7]: BitType [0-7]:
+                        size: <none>
+                    ident: Ident [5-6] "c"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -24,8 +29,13 @@ fn creg_array_decl() {
         parse,
         "creg c[n];",
         &expect![[r#"
-            Stmt [0-10]
-                StmtKind: ClassicalDeclarationStmt [0-10]: ClassicalType [0-10]: BitType [0-10]: Expr [7-8]: Ident [7-8] "n", Ident [5-6] "c""#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: ClassicalDeclarationStmt [0-10]:
+                    type: ScalarType [0-10]: BitType [0-10]:
+                        size: Expr [7-8]: Ident [7-8] "n"
+                    ident: Ident [5-6] "c"
+                    init_expr: <none>"#]],
     );
 }
 
@@ -35,8 +45,11 @@ fn qreg_decl() {
         parse,
         "qreg q;",
         &expect![[r#"
-            Stmt [0-7]
-                StmtKind: QubitDeclaration [0-7]: Ident [5-6] "q""#]],
+            Stmt [0-7]:
+                annotations: <empty>
+                kind: QubitDeclaration [0-7]:
+                    ident: Ident [5-6] "q"
+                    size: <none>"#]],
     );
 }
 
@@ -46,7 +59,10 @@ fn qreg_array_decl() {
         parse,
         "qreg q[n];",
         &expect![[r#"
-            Stmt [0-10]
-                StmtKind: QubitDeclaration [0-10]: Ident [5-6] "q", Expr [7-8]: Ident [7-8] "n""#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: QubitDeclaration [0-10]:
+                    ident: Ident [5-6] "q"
+                    size: Expr [7-8]: Ident [7-8] "n""#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/pragma.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/pragma.rs
@@ -16,8 +16,8 @@ fn pragma_decl() {
             Stmt [0-15]:
                 annotations: <empty>
                 kind: Pragma [0-15]:
-                    identifier: a.b.d
-                    value: 23"#]],
+                    identifier: "a.b.d"
+                    value: "23""#]],
     );
 }
 
@@ -30,7 +30,7 @@ fn pragma_decl_ident_only() {
             Stmt [0-12]:
                 annotations: <empty>
                 kind: Pragma [0-12]:
-                    identifier: a.b.d
+                    identifier: "a.b.d"
                     value: <none>"#]],
     );
 }
@@ -44,7 +44,7 @@ fn pragma_decl_missing_ident() {
             Stmt [0-7]:
                 annotations: <empty>
                 kind: Pragma [0-7]:
-                    identifier: 
+                    identifier: ""
                     value: <none>
 
             [
@@ -71,8 +71,8 @@ fn legacy_pragma_decl() {
             Stmt [0-16]:
                 annotations: <empty>
                 kind: Pragma [0-16]:
-                    identifier: a
-                    value: a.b.d 23"#]],
+                    identifier: "a"
+                    value: "a.b.d 23""#]],
     );
 }
 
@@ -85,8 +85,8 @@ fn legacy_pragma_decl_ident_only() {
             Stmt [0-13]:
                 annotations: <empty>
                 kind: Pragma [0-13]:
-                    identifier: a
-                    value: a.b.d"#]],
+                    identifier: "a"
+                    value: "a.b.d""#]],
     );
 }
 
@@ -99,7 +99,7 @@ fn legacy_pragma_ws_after_hash() {
             Stmt [2-14]:
                 annotations: <empty>
                 kind: Pragma [2-14]:
-                    identifier: a.b.d
+                    identifier: "a.b.d"
                     value: <none>
 
             [
@@ -129,7 +129,7 @@ fn legacy_pragma_decl_missing_ident() {
             Stmt [0-8]:
                 annotations: <empty>
                 kind: Pragma [0-8]:
-                    identifier: a
-                    value: "#]],
+                    identifier: "a"
+                    value: """#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/pragma.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/pragma.rs
@@ -13,8 +13,11 @@ fn pragma_decl() {
         parse,
         "pragma a.b.d 23",
         &expect![[r#"
-            Stmt [0-15]
-                StmtKind: Pragma [0-15]: (a.b.d, 23)"#]],
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: Pragma [0-15]:
+                    identifier: a.b.d
+                    value: 23"#]],
     );
 }
 
@@ -24,8 +27,11 @@ fn pragma_decl_ident_only() {
         parse,
         "pragma a.b.d",
         &expect![[r#"
-            Stmt [0-12]
-                StmtKind: Pragma [0-12]: (a.b.d)"#]],
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: Pragma [0-12]:
+                    identifier: a.b.d
+                    value: <none>"#]],
     );
 }
 
@@ -35,8 +41,11 @@ fn pragma_decl_missing_ident() {
         parse,
         "pragma ",
         &expect![[r#"
-            Stmt [0-7]
-                StmtKind: Pragma [0-7]: ()
+            Stmt [0-7]:
+                annotations: <empty>
+                kind: Pragma [0-7]:
+                    identifier: 
+                    value: <none>
 
             [
                 Error(
@@ -59,8 +68,11 @@ fn legacy_pragma_decl() {
         parse,
         "#pragma a.b.d 23",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: Pragma [0-16]: (a, a.b.d 23)"#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: Pragma [0-16]:
+                    identifier: a
+                    value: a.b.d 23"#]],
     );
 }
 
@@ -70,8 +82,11 @@ fn legacy_pragma_decl_ident_only() {
         parse,
         "#pragma a.b.d",
         &expect![[r#"
-            Stmt [0-13]
-                StmtKind: Pragma [0-13]: (a, a.b.d)"#]],
+            Stmt [0-13]:
+                annotations: <empty>
+                kind: Pragma [0-13]:
+                    identifier: a
+                    value: a.b.d"#]],
     );
 }
 
@@ -81,8 +96,11 @@ fn legacy_pragma_ws_after_hash() {
         parse,
         "# pragma a.b.d",
         &expect![[r#"
-            Stmt [2-14]
-                StmtKind: Pragma [2-14]: (a.b.d)
+            Stmt [2-14]:
+                annotations: <empty>
+                kind: Pragma [2-14]:
+                    identifier: a.b.d
+                    value: <none>
 
             [
                 Error(
@@ -108,7 +126,10 @@ fn legacy_pragma_decl_missing_ident() {
         parse,
         "#pragma ",
         &expect![[r#"
-            Stmt [0-8]
-                StmtKind: Pragma [0-8]: (a, )"#]],
+            Stmt [0-8]:
+                annotations: <empty>
+                kind: Pragma [0-8]:
+                    identifier: a
+                    value: "#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/quantum_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/quantum_decl.rs
@@ -31,7 +31,9 @@ fn annotated_quantum_decl() {
         &expect![[r#"
             Stmt [9-36]:
                 annotations:
-                    Annotation [9-19]: (a.b.c, 123)
+                    Annotation [9-19]:
+                        identifier: "a.b.c"
+                        value: "123"
                 kind: QubitDeclaration [28-36]:
                     ident: Ident [34-35] "q"
                     size: <none>"#]],
@@ -50,9 +52,15 @@ fn multi_annotated_quantum_decl() {
         &expect![[r#"
             Stmt [9-108]:
                 annotations:
-                    Annotation [9-57]: (g.h, dolor sit amet, consectetur adipiscing elit)
-                    Annotation [66-72]: (d.e.f)
-                    Annotation [81-91]: (a.b.c, 123)
+                    Annotation [9-57]:
+                        identifier: "g.h"
+                        value: "dolor sit amet, consectetur adipiscing elit"
+                    Annotation [66-72]:
+                        identifier: "d.e.f"
+                        value: <none>
+                    Annotation [81-91]:
+                        identifier: "a.b.c"
+                        value: "123"
                 kind: QubitDeclaration [100-108]:
                     ident: Ident [106-107] "q"
                     size: <none>"#]],

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/quantum_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/quantum_decl.rs
@@ -30,7 +30,7 @@ fn annotated_quantum_decl() {
         qubit q;"#,
         &expect![[r#"
             Stmt [9-36]:
-                annotations: 
+                annotations:
                     Annotation [9-19]: (a.b.c, 123)
                 kind: QubitDeclaration [28-36]:
                     ident: Ident [34-35] "q"
@@ -49,7 +49,7 @@ fn multi_annotated_quantum_decl() {
         qubit q;"#,
         &expect![[r#"
             Stmt [9-108]:
-                annotations: 
+                annotations:
                     Annotation [9-57]: (g.h, dolor sit amet, consectetur adipiscing elit)
                     Annotation [66-72]: (d.e.f)
                     Annotation [81-91]: (a.b.c, 123)

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/quantum_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/quantum_decl.rs
@@ -13,8 +13,11 @@ fn quantum_decl() {
         parse,
         "qubit q;",
         &expect![[r#"
-            Stmt [0-8]
-                StmtKind: QubitDeclaration [0-8]: Ident [6-7] "q""#]],
+            Stmt [0-8]:
+                annotations: <empty>
+                kind: QubitDeclaration [0-8]:
+                    ident: Ident [6-7] "q"
+                    size: <none>"#]],
     );
 }
 
@@ -26,9 +29,12 @@ fn annotated_quantum_decl() {
         @a.b.c 123
         qubit q;"#,
         &expect![[r#"
-            Stmt [9-36]
-                Annotation [9-19]: (a.b.c, 123)
-                StmtKind: QubitDeclaration [28-36]: Ident [34-35] "q""#]],
+            Stmt [9-36]:
+                annotations: 
+                    Annotation [9-19]: (a.b.c, 123)
+                kind: QubitDeclaration [28-36]:
+                    ident: Ident [34-35] "q"
+                    size: <none>"#]],
     );
 }
 
@@ -42,11 +48,14 @@ fn multi_annotated_quantum_decl() {
         @a.b.c 123
         qubit q;"#,
         &expect![[r#"
-            Stmt [9-108]
-                Annotation [9-57]: (g.h, dolor sit amet, consectetur adipiscing elit)
-                Annotation [66-72]: (d.e.f)
-                Annotation [81-91]: (a.b.c, 123)
-                StmtKind: QubitDeclaration [100-108]: Ident [106-107] "q""#]],
+            Stmt [9-108]:
+                annotations: 
+                    Annotation [9-57]: (g.h, dolor sit amet, consectetur adipiscing elit)
+                    Annotation [66-72]: (d.e.f)
+                    Annotation [81-91]: (a.b.c, 123)
+                kind: QubitDeclaration [100-108]:
+                    ident: Ident [106-107] "q"
+                    size: <none>"#]],
     );
 }
 
@@ -76,8 +85,11 @@ fn quantum_decl_with_designator() {
         parse,
         "qubit[5] qubits;",
         &expect![[r#"
-            Stmt [0-16]
-                StmtKind: QubitDeclaration [0-16]: Ident [9-15] "qubits", Expr [6-7]: Lit: Int(5)"#]],
+            Stmt [0-16]:
+                annotations: <empty>
+                kind: QubitDeclaration [0-16]:
+                    ident: Ident [9-15] "qubits"
+                    size: Expr [6-7]: Lit: Int(5)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
@@ -14,7 +14,7 @@ fn reset_ident() {
             Stmt [0-8]:
                 annotations: <empty>
                 kind: ResetStmt [0-8]:
-                    operand: GateOperand IndexedIdent [6-7]:
+                    operand: IndexedIdent [6-7]:
                         name: Ident [6-7] "a"
                         indices: <empty>"#]],
     );
@@ -29,11 +29,12 @@ fn reset_indexed_ident() {
             Stmt [0-11]:
                 annotations: <empty>
                 kind: ResetStmt [0-11]:
-                    operand: GateOperand IndexedIdent [6-10]:
+                    operand: IndexedIdent [6-10]:
                         name: Ident [6-7] "a"
                         indices:
-                            IndexSet:
-                                Expr [8-9]: Lit: Int(1)"#]],
+                            IndexSet [8-9]:
+                                values:
+                                    Expr [8-9]: Lit: Int(1)"#]],
     );
 }
 
@@ -46,6 +47,6 @@ fn reset_hardware_qubit() {
             Stmt [0-10]:
                 annotations: <empty>
                 kind: ResetStmt [0-10]:
-                    operand: GateOperand HardwareQubit [6-9]: 42"#]],
+                    operand: HardwareQubit [6-9]: 42"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
@@ -31,8 +31,8 @@ fn reset_indexed_ident() {
                 kind: ResetStmt [0-11]:
                     operand: GateOperand IndexedIdent [6-10]:
                         name: Ident [6-7] "a"
-                        indices: 
-                            IndexElement: 
+                        indices:
+                            IndexElement:
                                 IndexSetItem Expr [8-9]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
@@ -11,8 +11,12 @@ fn reset_ident() {
         parse,
         "reset a;",
         &expect![[r#"
-        Stmt [0-8]
-            StmtKind: ResetStmt [0-8]: GateOperand IndexedIdent [6-7]: Ident [6-7] "a"[]"#]],
+            Stmt [0-8]:
+                annotations: <empty>
+                kind: ResetStmt [0-8]:
+                    operand: GateOperand IndexedIdent [6-7]:
+                        name: Ident [6-7] "a"
+                        indices: <empty>"#]],
     );
 }
 
@@ -22,10 +26,14 @@ fn reset_indexed_ident() {
         parse,
         "reset a[1];",
         &expect![[r#"
-        Stmt [0-11]
-            StmtKind: ResetStmt [0-11]: GateOperand IndexedIdent [6-10]: Ident [6-7] "a"[
-            IndexElement:
-                IndexSetItem Expr [8-9]: Lit: Int(1)]"#]],
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: ResetStmt [0-11]:
+                    operand: GateOperand IndexedIdent [6-10]:
+                        name: Ident [6-7] "a"
+                        indices: 
+                            IndexElement: 
+                                IndexSetItem Expr [8-9]: Lit: Int(1)"#]],
     );
 }
 
@@ -35,7 +43,9 @@ fn reset_hardware_qubit() {
         parse,
         "reset $42;",
         &expect![[r#"
-        Stmt [0-10]
-            StmtKind: ResetStmt [0-10]: GateOperand HardwareQubit [6-9]: 42"#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: ResetStmt [0-10]:
+                    operand: GateOperand HardwareQubit [6-9]: 42"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
@@ -32,8 +32,8 @@ fn reset_indexed_ident() {
                     operand: GateOperand IndexedIdent [6-10]:
                         name: Ident [6-7] "a"
                         indices:
-                            IndexElement:
-                                IndexSetItem Expr [8-9]: Lit: Int(1)"#]],
+                            IndexSet:
+                                Expr [8-9]: Lit: Int(1)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/switch_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/switch_stmt.rs
@@ -16,13 +16,13 @@ fn simple_switch() {
     ",
         &expect![[r#"
             SwitchStmt [9-72]:
-                Target: Expr [17-18]: Ident [17-18] "x"
-                Cases:
-                    Labels:
-                        Expr [37-38]: Lit: Int(1)
-                    Block [39-41]: <empty>
-                    Default Case:
-                    Block [60-62]: <empty>"#]],
+                target: Expr [17-18]: Ident [17-18] "x"
+                cases: 
+                    SwitchCase [32-41]:
+                        labels: 
+                            Expr [37-38]: Lit: Int(1)
+                        block: Block [39-41]: <empty>
+                default_case: Block [60-62]: <empty>"#]],
     );
 }
 
@@ -35,9 +35,9 @@ fn no_cases_no_default() {
     ",
         &expect![[r#"
             SwitchStmt [9-22]:
-                Target: Expr [17-18]: Ident [17-18] "x"
-                <no cases>
-                <no default>
+                target: Expr [17-18]: Ident [17-18] "x"
+                cases: <empty>
+                default_case: <none>
 
             [
                 Error(
@@ -63,10 +63,9 @@ fn no_cases() {
     ",
         &expect![[r#"
             SwitchStmt [9-52]:
-                Target: Expr [17-18]: Ident [17-18] "x"
-                <no cases>
-                Default Case:
-                    Block [40-42]: <empty>
+                target: Expr [17-18]: Ident [17-18] "x"
+                cases: <empty>
+                default_case: Block [40-42]: <empty>
 
             [
                 Error(
@@ -92,13 +91,14 @@ fn no_default() {
     ",
         &expect![[r#"
             SwitchStmt [9-54]:
-                Target: Expr [17-18]: Ident [17-18] "x"
-                Cases:
-                    Labels:
-                        Expr [37-38]: Lit: Int(0)
-                        Expr [40-41]: Lit: Int(1)
-                    Block [42-44]: <empty>
-                    <no default>"#]],
+                target: Expr [17-18]: Ident [17-18] "x"
+                cases: 
+                    SwitchCase [32-44]:
+                        labels: 
+                            Expr [37-38]: Lit: Int(0)
+                            Expr [40-41]: Lit: Int(1)
+                        block: Block [42-44]: <empty>
+                default_case: <none>"#]],
     );
 }
 
@@ -113,11 +113,12 @@ fn case_with_no_labels() {
     ",
         &expect![[r#"
             SwitchStmt [9-49]:
-                Target: Expr [17-18]: Ident [17-18] "x"
-                Cases:
-                    <no labels>
-                    Block [37-39]: <empty>
-                    <no default>
+                target: Expr [17-18]: Ident [17-18] "x"
+                cases: 
+                    SwitchCase [32-39]:
+                        labels: <empty>
+                        block: Block [37-39]: <empty>
+                default_case: <none>
 
             [
                 Error(
@@ -144,18 +145,30 @@ fn multiple_cases() {
     ",
         &expect![[r#"
             SwitchStmt [9-95]:
-                Target: Expr [17-18]: Ident [17-18] "x"
-                Cases:
-                    Labels:
-                        Expr [37-38]: Lit: Int(0)
-                    Block [39-53]:
-                        Stmt [41-51]
-                            StmtKind: ClassicalDeclarationStmt [41-51]: ClassicalType [41-44]: IntType [41-44], Ident [45-46] "x", ValueExpression Expr [49-50]: Lit: Int(0)
-                    Labels:
-                        Expr [69-70]: Lit: Int(1)
-                    Block [71-85]:
-                        Stmt [73-83]
-                            StmtKind: ClassicalDeclarationStmt [73-83]: ClassicalType [73-76]: IntType [73-76], Ident [77-78] "y", ValueExpression Expr [81-82]: Lit: Int(1)
-                    <no default>"#]],
+                target: Expr [17-18]: Ident [17-18] "x"
+                cases: 
+                    SwitchCase [32-53]:
+                        labels: 
+                            Expr [37-38]: Lit: Int(0)
+                        block: Block [39-53]: 
+                            Stmt [41-51]:
+                                annotations: <empty>
+                                kind: ClassicalDeclarationStmt [41-51]:
+                                    type: ScalarType [41-44]: IntType [41-44]:
+                                        size: <none>
+                                    ident: Ident [45-46] "x"
+                                    init_expr: ValueExpression Expr [49-50]: Lit: Int(0)
+                    SwitchCase [64-85]:
+                        labels: 
+                            Expr [69-70]: Lit: Int(1)
+                        block: Block [71-85]: 
+                            Stmt [73-83]:
+                                annotations: <empty>
+                                kind: ClassicalDeclarationStmt [73-83]:
+                                    type: ScalarType [73-76]: IntType [73-76]:
+                                        size: <none>
+                                    ident: Ident [77-78] "y"
+                                    init_expr: ValueExpression Expr [81-82]: Lit: Int(1)
+                default_case: <none>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/switch_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/switch_stmt.rs
@@ -157,7 +157,7 @@ fn multiple_cases() {
                                     type: ScalarType [41-44]: IntType [41-44]:
                                         size: <none>
                                     ident: Ident [45-46] "x"
-                                    init_expr: ValueExpression Expr [49-50]: Lit: Int(0)
+                                    init_expr: Expr [49-50]: Lit: Int(0)
                     SwitchCase [64-85]:
                         labels:
                             Expr [69-70]: Lit: Int(1)
@@ -168,7 +168,7 @@ fn multiple_cases() {
                                     type: ScalarType [73-76]: IntType [73-76]:
                                         size: <none>
                                     ident: Ident [77-78] "y"
-                                    init_expr: ValueExpression Expr [81-82]: Lit: Int(1)
+                                    init_expr: Expr [81-82]: Lit: Int(1)
                 default_case: <none>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/switch_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/switch_stmt.rs
@@ -17,9 +17,9 @@ fn simple_switch() {
         &expect![[r#"
             SwitchStmt [9-72]:
                 target: Expr [17-18]: Ident [17-18] "x"
-                cases: 
+                cases:
                     SwitchCase [32-41]:
-                        labels: 
+                        labels:
                             Expr [37-38]: Lit: Int(1)
                         block: Block [39-41]: <empty>
                 default_case: Block [60-62]: <empty>"#]],
@@ -92,9 +92,9 @@ fn no_default() {
         &expect![[r#"
             SwitchStmt [9-54]:
                 target: Expr [17-18]: Ident [17-18] "x"
-                cases: 
+                cases:
                     SwitchCase [32-44]:
-                        labels: 
+                        labels:
                             Expr [37-38]: Lit: Int(0)
                             Expr [40-41]: Lit: Int(1)
                         block: Block [42-44]: <empty>
@@ -114,7 +114,7 @@ fn case_with_no_labels() {
         &expect![[r#"
             SwitchStmt [9-49]:
                 target: Expr [17-18]: Ident [17-18] "x"
-                cases: 
+                cases:
                     SwitchCase [32-39]:
                         labels: <empty>
                         block: Block [37-39]: <empty>
@@ -146,11 +146,11 @@ fn multiple_cases() {
         &expect![[r#"
             SwitchStmt [9-95]:
                 target: Expr [17-18]: Ident [17-18] "x"
-                cases: 
+                cases:
                     SwitchCase [32-53]:
-                        labels: 
+                        labels:
                             Expr [37-38]: Lit: Int(0)
-                        block: Block [39-53]: 
+                        block: Block [39-53]:
                             Stmt [41-51]:
                                 annotations: <empty>
                                 kind: ClassicalDeclarationStmt [41-51]:
@@ -159,9 +159,9 @@ fn multiple_cases() {
                                     ident: Ident [45-46] "x"
                                     init_expr: ValueExpression Expr [49-50]: Lit: Int(0)
                     SwitchCase [64-85]:
-                        labels: 
+                        labels:
                             Expr [69-70]: Lit: Int(1)
-                        block: Block [71-85]: 
+                        block: Block [71-85]:
                             Stmt [73-83]:
                                 annotations: <empty>
                                 kind: ClassicalDeclarationStmt [73-83]:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
@@ -13,14 +13,34 @@ fn simple_while() {
         a = 0;
     }",
         &expect![[r#"
-            Stmt [5-42]
-                StmtKind: WhileLoop [5-42]: Expr [12-18]: BinOp (Neq):
-                    Expr [12-13]: Ident [12-13] "x"
-                    Expr [17-18]: Lit: Int(2)
-                Stmt [30-36]
-                    StmtKind: ExprStmt [30-36]: Expr [30-35]: Assign:
-                        Expr [30-31]: Ident [30-31] "a"
-                        Expr [34-35]: Lit: Int(0)"#]],
+            Stmt [5-42]:
+                annotations: <empty>
+                kind: WhileLoop [5-42]:
+                    condition: Expr [12-18]: BinaryOpExpr:
+                        op: Neq
+                        lhs: Expr [12-13]: Ident [12-13] "x"
+                        rhs: Expr [17-18]: Lit: Int(2)
+                    block: 
+                        Stmt [30-36]:
+                            annotations: <empty>
+                            kind: ExprStmt [30-36]:
+                                expr: Expr [30-35]: AssignExpr:
+                                    lhs: Expr [30-31]: Ident [30-31] "a"
+                                    rhs: Expr [34-35]: Lit: Int(0)"#]],
+    );
+}
+
+#[test]
+fn empty_while() {
+    check(
+        parse,
+        "while (true) {}",
+        &expect![[r#"
+            Stmt [0-15]:
+                annotations: <empty>
+                kind: WhileLoop [0-15]:
+                    condition: Expr [7-11]: Lit: Bool(true)
+                    block: <empty>"#]],
     );
 }
 
@@ -32,14 +52,20 @@ fn while_stmt_body() {
     while (x != 2)
         a = 0;",
         &expect![[r#"
-            Stmt [5-34]
-                StmtKind: WhileLoop [5-34]: Expr [12-18]: BinOp (Neq):
-                    Expr [12-13]: Ident [12-13] "x"
-                    Expr [17-18]: Lit: Int(2)
-                Stmt [28-34]
-                    StmtKind: ExprStmt [28-34]: Expr [28-33]: Assign:
-                        Expr [28-29]: Ident [28-29] "a"
-                        Expr [32-33]: Lit: Int(0)"#]],
+            Stmt [5-34]:
+                annotations: <empty>
+                kind: WhileLoop [5-34]:
+                    condition: Expr [12-18]: BinaryOpExpr:
+                        op: Neq
+                        lhs: Expr [12-13]: Ident [12-13] "x"
+                        rhs: Expr [17-18]: Lit: Int(2)
+                    block: 
+                        Stmt [28-34]:
+                            annotations: <empty>
+                            kind: ExprStmt [28-34]:
+                                expr: Expr [28-33]: AssignExpr:
+                                    lhs: Expr [28-29]: Ident [28-29] "a"
+                                    rhs: Expr [32-33]: Lit: Int(0)"#]],
     );
 }
 
@@ -53,16 +79,23 @@ fn while_loop_with_continue_stmt() {
         continue;
     }",
         &expect![[r#"
-            Stmt [5-60]
-                StmtKind: WhileLoop [5-60]: Expr [12-18]: BinOp (Neq):
-                    Expr [12-13]: Ident [12-13] "x"
-                    Expr [17-18]: Lit: Int(2)
-                Stmt [30-36]
-                    StmtKind: ExprStmt [30-36]: Expr [30-35]: Assign:
-                        Expr [30-31]: Ident [30-31] "a"
-                        Expr [34-35]: Lit: Int(0)
-                Stmt [45-54]
-                    StmtKind: Continue [45-54]"#]],
+            Stmt [5-60]:
+                annotations: <empty>
+                kind: WhileLoop [5-60]:
+                    condition: Expr [12-18]: BinaryOpExpr:
+                        op: Neq
+                        lhs: Expr [12-13]: Ident [12-13] "x"
+                        rhs: Expr [17-18]: Lit: Int(2)
+                    block: 
+                        Stmt [30-36]:
+                            annotations: <empty>
+                            kind: ExprStmt [30-36]:
+                                expr: Expr [30-35]: AssignExpr:
+                                    lhs: Expr [30-31]: Ident [30-31] "a"
+                                    rhs: Expr [34-35]: Lit: Int(0)
+                        Stmt [45-54]:
+                            annotations: <empty>
+                            kind: Continue [45-54]"#]],
     );
 }
 
@@ -76,15 +109,22 @@ fn while_loop_with_break_stmt() {
         break;
     }",
         &expect![[r#"
-            Stmt [5-57]
-                StmtKind: WhileLoop [5-57]: Expr [12-18]: BinOp (Neq):
-                    Expr [12-13]: Ident [12-13] "x"
-                    Expr [17-18]: Lit: Int(2)
-                Stmt [30-36]
-                    StmtKind: ExprStmt [30-36]: Expr [30-35]: Assign:
-                        Expr [30-31]: Ident [30-31] "a"
-                        Expr [34-35]: Lit: Int(0)
-                Stmt [45-51]
-                    StmtKind: Break [45-51]"#]],
+            Stmt [5-57]:
+                annotations: <empty>
+                kind: WhileLoop [5-57]:
+                    condition: Expr [12-18]: BinaryOpExpr:
+                        op: Neq
+                        lhs: Expr [12-13]: Ident [12-13] "x"
+                        rhs: Expr [17-18]: Lit: Int(2)
+                    block: 
+                        Stmt [30-36]:
+                            annotations: <empty>
+                            kind: ExprStmt [30-36]:
+                                expr: Expr [30-35]: AssignExpr:
+                                    lhs: Expr [30-31]: Ident [30-31] "a"
+                                    rhs: Expr [34-35]: Lit: Int(0)
+                        Stmt [45-51]:
+                            annotations: <empty>
+                            kind: Break [45-51]"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
@@ -20,7 +20,7 @@ fn simple_while() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block: 
+                    block:
                         Stmt [30-36]:
                             annotations: <empty>
                             kind: ExprStmt [30-36]:
@@ -59,7 +59,7 @@ fn while_stmt_body() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block: 
+                    block:
                         Stmt [28-34]:
                             annotations: <empty>
                             kind: ExprStmt [28-34]:
@@ -86,7 +86,7 @@ fn while_loop_with_continue_stmt() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block: 
+                    block:
                         Stmt [30-36]:
                             annotations: <empty>
                             kind: ExprStmt [30-36]:
@@ -116,7 +116,7 @@ fn while_loop_with_break_stmt() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block: 
+                    block:
                         Stmt [30-36]:
                             annotations: <empty>
                             kind: ExprStmt [30-36]:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
@@ -95,7 +95,7 @@ fn while_loop_with_continue_stmt() {
                                     rhs: Expr [34-35]: Lit: Int(0)
                         Stmt [45-54]:
                             annotations: <empty>
-                            kind: Continue [45-54]"#]],
+                            kind: ContinueStmt [45-54]"#]],
     );
 }
 
@@ -125,6 +125,6 @@ fn while_loop_with_break_stmt() {
                                     rhs: Expr [34-35]: Lit: Int(0)
                         Stmt [45-51]:
                             annotations: <empty>
-                            kind: Break [45-51]"#]],
+                            kind: BreakStmt [45-51]"#]],
     );
 }


### PR DESCRIPTION
This PR doesn't change any behavior. It just touches the Display functions in the QASM3 parser to make unit tests easier to read.