### PR TITLE
Distance coefficient power parameter in QEC scheme

### DIFF
--- a/pip/qsharp/estimator/_estimator.py
+++ b/pip/qsharp/estimator/_estimator.py
@@ -227,8 +227,10 @@ class EstimatorQecScheme(AutoValidatingParams):
     name: Optional[str] = None
     error_correction_threshold: Optional[float] = validating_field(_check_error_rate)
     crossing_prefactor: Optional[float] = None
+    distance_coefficient_power: Optional[int] = None
     logical_cycle_time: Optional[str] = None
     physical_qubits_per_logical_qubit: Optional[str] = None
+    max_code_distance: Optional[int] = None
 
 
 @dataclass

--- a/resource_estimator/src/estimates/physical_estimation.rs
+++ b/resource_estimator/src/estimates/physical_estimation.rs
@@ -222,7 +222,7 @@ impl<
             // ensures that the first code parameter is always tried. After
             // that, the last code parameter governs the reuse of the magic
             // state factory.
-            if last_code_parameter.as_ref().map_or(true, |d| {
+            if last_code_parameter.as_ref().is_none_or(|d| {
                 self.ftp
                     .code_parameter_cmp(self.qubit.as_ref(), d, &code_parameter)
                     .is_gt()
@@ -293,7 +293,7 @@ impl<
 
                 if best_estimation_result
                     .as_ref()
-                    .map_or(true, |r| result.physical_qubits() < r.physical_qubits())
+                    .is_none_or(|r| result.physical_qubits() < r.physical_qubits())
                 {
                     best_estimation_result = Some(result);
                 }
@@ -372,7 +372,7 @@ impl<
             // ensures that the first code parameter is always tried. After
             // that, the last code parameter governs the reuse of the magic
             // state factory.
-            if last_code_parameter.as_ref().map_or(true, |d| {
+            if last_code_parameter.as_ref().is_none_or(|d| {
                 self.ftp
                     .code_parameter_cmp(self.qubit.as_ref(), d, &code_parameter)
                     .is_gt()
@@ -443,7 +443,7 @@ impl<
 
                 if best_estimation_result
                     .as_ref()
-                    .map_or(true, |r| result.runtime() < r.runtime())
+                    .is_none_or(|r| result.runtime() < r.runtime())
                 {
                     best_estimation_result = Some(result);
                 }

--- a/resource_estimator/src/estimates/physical_estimation/estimate_frontier.rs
+++ b/resource_estimator/src/estimates/physical_estimation/estimate_frontier.rs
@@ -89,7 +89,7 @@ impl<
             // ensures that the first code parameter is always tried. After
             // that, the last code parameter governs the reuse of the magic
             // state factory.
-            if last_code_parameter.as_ref().map_or(true, |d| {
+            if last_code_parameter.as_ref().is_none_or(|d| {
                 self.ftp
                     .code_parameter_cmp(self.qubit.as_ref(), d, &code_parameter)
                     .is_gt()

--- a/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
+++ b/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
@@ -274,7 +274,7 @@ impl<
         error_budget: &ErrorBudget,
         num_cycles: u64,
     ) -> bool {
-        self.max_factories.map_or(true, |max_factories| {
+        self.max_factories.is_none_or(|max_factories| {
             max_factories >= self.num_factories(logical_patch, 0, factory, error_budget, num_cycles)
         })
     }

--- a/resource_estimator/src/system/modeling/fault_tolerance/tests.rs
+++ b/resource_estimator/src/system/modeling/fault_tolerance/tests.rs
@@ -17,3 +17,21 @@ fn compute_code_distance() -> Result<(), String> {
 
     Ok(())
 }
+
+#[test]
+fn compute_distance_is_inverse() -> Result<(), String> {
+    let qubit = PhysicalQubit::default();
+    let mut ftp = surface_code_gate_based();
+
+    for distance_coefficient_power in [0, 1, 2] {
+        ftp.set_distance_coefficient_power(distance_coefficient_power);
+
+        for code_distance in (1..=49).step_by(2) {
+            let error_rate = ftp.logical_error_rate(&qubit, &code_distance)?;
+            let computed_distance = ftp.compute_code_parameter(&qubit, error_rate)?;
+            assert_eq!(computed_distance, code_distance);
+        }
+    }
+
+    Ok(())
+}

--- a/resource_estimator/src/system/test_report.json
+++ b/resource_estimator/src/system/test_report.json
@@ -10,6 +10,7 @@
     "estimateType": "singlePoint",
     "qecScheme": {
       "crossingPrefactor": 0.03,
+      "distanceCoefficientPower": 0,
       "errorCorrectionThreshold": 0.01,
       "logicalCycleTime": "(4 * twoQubitGateTime + 2 * oneQubitMeasurementTime) * codeDistance",
       "maxCodeDistance": 50,


### PR DESCRIPTION
This PR extends the formula template for QEC logical error rate formulas from:

$$ a \left(\frac{p}{p_{\mathrm{th}}}\right)^{\frac{d+1}{2}} $$

to

$$ a d^k \left(\frac{p}{p_{\mathrm{th}}}\right)^{\frac{d+1}{2}} $$

where $k$ is the new distance coefficient power discussed in [arXiv:2411.10406, Section III.B, page 25](https://arxiv.org/pdf/2411.10406#page=25).

For $k = 0$, the default, the formula remains unchanged compared to the current one. However, changing $k$ to other values allows to model a different error correction behavior, as motivated by the paper.

The parameter is called `distance_coefficient_power` or `distanceCoefficientPower` in the JSON parameter. It is also added to the Python RE parameter utility structure (together with `max_code_distance` which was absent so far).