### PR TITLE
Added SimpleBellPair sample

### DIFF
--- a/samples/algorithms/SimpleBellPair.qs
+++ b/samples/algorithms/SimpleBellPair.qs
@@ -27,7 +27,7 @@ operation Main() : (Result, Result) {
 /// Prepare Bell pair |Φ+⟩ = (|00⟩+|11⟩)/√2 on two qubits.
 /// Qubits are assumed to be in |00⟩ state.
 operation PrepareBellPair(q1 : Qubit, q2 : Qubit) : Unit {
-    // Set qubit `q1` in superposition of |0⟩ and |1⟩ by applying the Hadamard gate.
+    // Set qubit `q1` in superposition of |0⟩ and |1⟩ by applying a Hadamard gate.
     H(q1);
 
     // Entangle the two qubits `q1` and `q2` using the `CNOT` gate.

--- a/samples/algorithms/SimpleBellPair.qs
+++ b/samples/algorithms/SimpleBellPair.qs
@@ -5,6 +5,9 @@
 /// Bell pairs are specific quantum states of two qubits that represent
 /// the simplest (and maximal) examples of quantum entanglement. This sample
 /// prepares |Φ+⟩ = (|00⟩+|11⟩)/√2. For other Bell states see BellState.qs
+///
+/// # References
+/// - [Bell state](https://en.wikipedia.org/wiki/Bell_state)
 operation Main() : (Result, Result) {
     // Allocate the two qubits that will be used to create a Bell pair.
     use q1 = Qubit();
@@ -16,15 +19,13 @@ operation Main() : (Result, Result) {
     // Show the state of qubits using the `DumpMachine` function.
     Std.Diagnostics.DumpMachine();
 
-    // Measure the two qubits and reset them.
+    // Measure the two qubits and reset them. Return measurement results.
     (MResetZ(q1), MResetZ(q2))
-
-    // Qubits `q1` and `q2` are automatically released at the end of the block.
 }
 
 /// # Summary
 /// Prepare Bell pair |Φ+⟩ = (|00⟩+|11⟩)/√2 on two qubits.
-/// Qubits are assumed to be in |00> state.
+/// Qubits are assumed to be in |00⟩ state.
 operation PrepareBellPair(q1 : Qubit, q2 : Qubit) : Unit {
     // Set qubit `q1` in superposition of |0⟩ and |1⟩ by applying the Hadamard gate.
     H(q1);

--- a/samples/algorithms/SimpleBellPair.qs
+++ b/samples/algorithms/SimpleBellPair.qs
@@ -1,0 +1,34 @@
+/// # Sample
+/// Simple Bell Pair
+///
+/// # Description
+/// Bell pairs are specific quantum states of two qubits that represent
+/// the simplest (and maximal) examples of quantum entanglement. This sample
+/// prepares |Φ+⟩ = (|00⟩+|11⟩)/√2. For other Bell states see BellState.qs
+operation Main() : (Result, Result) {
+    // Allocate the two qubits that will be used to create a Bell pair.
+    use q1 = Qubit();
+    use q2 = Qubit();
+
+    // Create Bell pair by calling `PrepareBellPair` operation defined below.
+    PrepareBellPair(q1, q2);
+
+    // Show the state of qubits using the `DumpMachine` function.
+    Std.Diagnostics.DumpMachine();
+
+    // Measure the two qubits and reset them.
+    (MResetZ(q1), MResetZ(q2))
+
+    // Qubits `q1` and `q2` are automatically released at the end of the block.
+}
+
+/// # Summary
+/// Prepare Bell pair |Φ+⟩ = (|00⟩+|11⟩)/√2 on two qubits.
+/// Qubits are assumed to be in |00> state.
+operation PrepareBellPair(q1 : Qubit, q2 : Qubit) : Unit {
+    // Set qubit `q1` in superposition of |0⟩ and |1⟩ by applying the Hadamard gate.
+    H(q1);
+
+    // Entangle the two qubits `q1` and `q2` using the `CNOT` gate.
+    CNOT(q1, q2);
+}

--- a/samples/algorithms/SimpleBellPair.qs
+++ b/samples/algorithms/SimpleBellPair.qs
@@ -4,7 +4,7 @@
 /// # Description
 /// Bell pairs are specific quantum states of two qubits that represent
 /// the simplest (and maximal) examples of quantum entanglement. This sample
-/// prepares |Φ+⟩ = (|00⟩+|11⟩)/√2. For other Bell states see BellState.qs
+/// prepares |Φ⁺⟩ = (|00⟩+|11⟩)/√2. For other Bell states see BellState.qs
 ///
 /// # References
 /// - [Bell state](https://en.wikipedia.org/wiki/Bell_state)
@@ -24,7 +24,7 @@ operation Main() : (Result, Result) {
 }
 
 /// # Summary
-/// Prepare Bell pair |Φ+⟩ = (|00⟩+|11⟩)/√2 on two qubits.
+/// Prepare Bell pair |Φ⁺⟩ = (|00⟩+|11⟩)/√2 on two qubits.
 /// Qubits are assumed to be in |00⟩ state.
 operation PrepareBellPair(q1 : Qubit, q2 : Qubit) : Unit {
     // Set qubit `q1` in superposition of |0⟩ and |1⟩ by applying a Hadamard gate.

--- a/samples/samples.mjs
+++ b/samples/samples.mjs
@@ -10,6 +10,7 @@ export default [
     { title: "Minimal", file: "./language/GettingStarted.qs", shots: 100 },
     { title: "Superposition", file: "./algorithms/Superposition.qs", shots: 100 },
     { title: "Entanglement", file: "./algorithms/Entanglement.qs", shots: 100 },
+    { title: "Simple Bell Pair", file: "./algorithms/SimpleBellPair.qs", shots: 1000 },
     { title: "Bell States", file: "./algorithms/BellState.qs", shots: 100 },
     { title: "Teleportation", file: "./algorithms/Teleportation.qs", shots: 1 },
     { title: "Random Bit", file: "./algorithms/RandomBit.qs", shots: 100 },

--- a/samples_test/src/tests/algorithms.rs
+++ b/samples_test/src/tests/algorithms.rs
@@ -254,6 +254,16 @@ pub const SHOR_EXPECT_DEBUG: Expect = expect![[r#"
     Found factor=17
     Found factorization 187 = 17 * 11
     (17, 11)"#]];
+pub const SIMPLEBELLPAIR_EXPECT: Expect = expect![[r#"
+    STATE:
+    |00⟩: 0.7071+0.0000𝑖
+    |11⟩: 0.7071+0.0000𝑖
+    (Zero, Zero)"#]];
+pub const SIMPLEBELLPAIR_EXPECT_DEBUG: Expect = expect![[r#"
+    STATE:
+    |00⟩: 0.7071+0.0000𝑖
+    |11⟩: 0.7071+0.0000𝑖
+    (Zero, Zero)"#]];
 pub const SIMPLEISING_EXPECT: Expect =
     expect!["[Zero, Zero, Zero, One, One, Zero, One, One, Zero]"];
 pub const SIMPLEISING_EXPECT_DEBUG: Expect =


### PR DESCRIPTION
We are now missing a **simple** Bell pair sample. This pull request adds one.
As this will likely be one of the first samples people encounter, please make sure that it is simple enough while reviewing.
