### PR TITLE
Make Assign and AssignOp valid only in expression statements

### DIFF
--- a/compiler/qsc_qasm3/src/parser/expr/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/expr/tests.rs
@@ -1113,38 +1113,6 @@ fn lit_array() {
 }
 
 #[test]
-fn assignment_and_unop() {
-    check_expr(
-        "c = a && !b",
-        &expect![[r#"
-            Expr [0-11]: AssignExpr:
-                lhs: Expr [0-1]: Ident [0-1] "c"
-                rhs: Expr [4-11]: BinaryOpExpr:
-                    op: AndL
-                    lhs: Expr [4-5]: Ident [4-5] "a"
-                    rhs: Expr [9-11]: UnaryOpExpr:
-                        op: NotL
-                        expr: Expr [10-11]: Ident [10-11] "b""#]],
-    );
-}
-
-#[test]
-fn assignment_unop_and() {
-    check_expr(
-        "d = !a && b",
-        &expect![[r#"
-            Expr [0-11]: AssignExpr:
-                lhs: Expr [0-1]: Ident [0-1] "d"
-                rhs: Expr [4-11]: BinaryOpExpr:
-                    op: AndL
-                    lhs: Expr [4-6]: UnaryOpExpr:
-                        op: NotL
-                        expr: Expr [5-6]: Ident [5-6] "a"
-                    rhs: Expr [10-11]: Ident [10-11] "b""#]],
-    );
-}
-
-#[test]
 fn hardware_qubit() {
     check(
         super::hardware_qubit,

--- a/compiler/qsc_qasm3/src/parser/stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt.rs
@@ -1266,7 +1266,7 @@ fn parse_gate_call_stmt(s: &mut ParserContext) -> Result<StmtKind> {
         )?));
     }
 
-    // We parse the recovering semi after we call parse_expr_stmt
+    // We parse the recovering semi after we call parse_expr_stmt.
     recovering_semi(s);
 
     // Reinterpret the function call or ident as a gate call.

--- a/compiler/qsc_qasm3/src/parser/stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt.rs
@@ -17,16 +17,16 @@ use super::{
 use crate::{
     ast::{
         list_from_iter, AccessControl, AliasDeclStmt, AngleType, Annotation, ArrayBaseTypeKind,
-        ArrayReferenceType, ArrayType, ArrayTypedParameter, BarrierStmt, BitType, Block, BoxStmt,
-        BreakStmt, CalibrationGrammarStmt, CalibrationStmt, Cast, ClassicalDeclarationStmt,
-        ComplexType, ConstantDeclStmt, ContinueStmt, DefCalStmt, DefStmt, DelayStmt, EndStmt,
-        EnumerableSet, Expr, ExprKind, ExprStmt, ExternDecl, ExternParameter, FloatType, ForStmt,
-        FunctionCall, GPhase, GateCall, GateModifierKind, GateOperand, IODeclaration, IOKeyword,
-        Ident, Identifier, IfStmt, IncludeStmt, IndexElement, IndexExpr, IndexSetItem, IntType,
-        List, LiteralKind, MeasureStmt, Pragma, QuantumGateDefinition, QuantumGateModifier,
-        QuantumTypedParameter, QubitDeclaration, RangeDefinition, ResetStmt, ReturnStmt,
-        ScalarType, ScalarTypeKind, ScalarTypedParameter, Stmt, StmtKind, SwitchCase, SwitchStmt,
-        TypeDef, TypedParameter, UIntType, WhileLoop,
+        ArrayReferenceType, ArrayType, ArrayTypedParameter, AssignExpr, BarrierStmt, BitType,
+        Block, BoxStmt, BreakStmt, CalibrationGrammarStmt, CalibrationStmt, Cast,
+        ClassicalDeclarationStmt, ComplexType, ConstantDeclStmt, ContinueStmt, DefCalStmt, DefStmt,
+        DelayStmt, EndStmt, EnumerableSet, Expr, ExprKind, ExprStmt, ExternDecl, ExternParameter,
+        FloatType, ForStmt, FunctionCall, GPhase, GateCall, GateModifierKind, GateOperand,
+        IODeclaration, IOKeyword, Ident, Identifier, IfStmt, IncludeStmt, IndexElement, IndexExpr,
+        IndexSetItem, IntType, List, LiteralKind, MeasureStmt, Pragma, QuantumGateDefinition,
+        QuantumGateModifier, QuantumTypedParameter, QubitDeclaration, RangeDefinition, ResetStmt,
+        ReturnStmt, ScalarType, ScalarTypeKind, ScalarTypedParameter, Stmt, StmtKind, SwitchCase,
+        SwitchStmt, TypeDef, TypedParameter, UIntType, WhileLoop,
     },
     keyword::Keyword,
     lex::{cooked::Type, Delim, TokenKind},
@@ -1095,10 +1095,30 @@ fn parse_end_stmt(s: &mut ParserContext) -> Result<EndStmt> {
     Ok(EndStmt { span: s.span(lo) })
 }
 
-/// Grammar: `expression SEMICOLON`.
+/// Grammar: `(expression | assignExpr | AssignOpExpr) SEMICOLON`.
 fn parse_expression_stmt(s: &mut ParserContext, lhs: Option<Expr>) -> Result<ExprStmt> {
     let expr = if let Some(lhs) = lhs {
-        expr::expr_with_lhs(s, lhs)?
+        if opt(s, |s| token(s, TokenKind::Eq))?.is_some() {
+            let rhs = expr::expr(s)?;
+            Expr {
+                span: s.span(lhs.span.lo),
+                kind: Box::new(ExprKind::Assign(AssignExpr { lhs, rhs })),
+            }
+        } else if let TokenKind::BinOpEq(op) = s.peek().kind {
+            s.advance();
+            let op = expr::closed_bin_op(op);
+            let rhs = expr::expr(s)?;
+            Expr {
+                span: s.span(lhs.span.lo),
+                kind: Box::new(ExprKind::AssignOp(crate::ast::AssignOpExpr {
+                    op,
+                    lhs,
+                    rhs,
+                })),
+            }
+        } else {
+            expr::expr_with_lhs(s, lhs)?
+        }
     } else {
         expr::expr(s)?
     };
@@ -1237,15 +1257,17 @@ fn parse_gate_call_stmt(s: &mut ParserContext) -> Result<StmtKind> {
 
     let mut duration = opt(s, designator)?;
     let qubits = gate_operand_list(s)?;
-    recovering_semi(s);
 
     // If didn't parse modifiers, a duration, nor qubit args then this is an expr, not a gate call.
     if modifiers.is_empty() && duration.is_none() && qubits.is_empty() {
-        return Ok(StmtKind::ExprStmt(ExprStmt {
-            span: s.span(lo),
-            expr: gate_or_expr,
-        }));
+        return Ok(StmtKind::ExprStmt(parse_expression_stmt(
+            s,
+            Some(gate_or_expr),
+        )?));
     }
+
+    // We parse the recovering semi after we call parse_expr_stmt
+    recovering_semi(s);
 
     // Reinterpret the function call or ident as a gate call.
     let (name, args) = match *gate_or_expr.kind {

--- a/compiler/qsc_qasm3/src/parser/stmt/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests.rs
@@ -19,6 +19,7 @@ mod gate_def;
 mod gphase;
 mod if_stmt;
 mod include;
+mod invalid_stmts;
 mod io_decl;
 mod measure;
 mod old_style_decl;

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/expr_stmt.rs
@@ -34,6 +34,77 @@ fn identifier_plus_number() {
     );
 }
 
+#[test]
+fn assignment() {
+    check(
+        parse,
+        "a = 1;",
+        &expect![[r#"
+        Stmt [0-6]:
+            annotations: <empty>
+            kind: ExprStmt [0-6]:
+                expr: Expr [0-5]: AssignExpr:
+                    lhs: Expr [0-1]: Ident [0-1] "a"
+                    rhs: Expr [4-5]: Lit: Int(1)"#]],
+    );
+}
+
+#[test]
+fn binary_assignment() {
+    check(
+        parse,
+        "a += 1;",
+        &expect![[r#"
+        Stmt [0-7]:
+            annotations: <empty>
+            kind: ExprStmt [0-7]:
+                expr: Expr [0-6]: AssignOpExpr:
+                    op: Add
+                    lhs: Expr [0-1]: Ident [0-1] "a"
+                    rhs: Expr [5-6]: Lit: Int(1)"#]],
+    );
+}
+
+#[test]
+fn assignment_and_unop() {
+    check(
+        parse,
+        "c = a && !b;",
+        &expect![[r#"
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: ExprStmt [0-12]:
+                    expr: Expr [0-11]: AssignExpr:
+                        lhs: Expr [0-1]: Ident [0-1] "c"
+                        rhs: Expr [4-11]: BinaryOpExpr:
+                            op: AndL
+                            lhs: Expr [4-5]: Ident [4-5] "a"
+                            rhs: Expr [9-11]: UnaryOpExpr:
+                                op: NotL
+                                expr: Expr [10-11]: Ident [10-11] "b""#]],
+    );
+}
+
+#[test]
+fn assignment_unop_and() {
+    check(
+        parse,
+        "d = !a && b;",
+        &expect![[r#"
+            Stmt [0-12]:
+                annotations: <empty>
+                kind: ExprStmt [0-12]:
+                    expr: Expr [0-11]: AssignExpr:
+                        lhs: Expr [0-1]: Ident [0-1] "d"
+                        rhs: Expr [4-11]: BinaryOpExpr:
+                            op: AndL
+                            lhs: Expr [4-6]: UnaryOpExpr:
+                                op: NotL
+                                expr: Expr [5-6]: Ident [5-6] "a"
+                            rhs: Expr [10-11]: Ident [10-11] "b""#]],
+    );
+}
+
 // These are negative unit tests for gate calls:
 
 #[test]

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts.rs
@@ -1,0 +1,72 @@
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn assignment_in_if_condition() {
+    check(
+        parse,
+        "if (x = 2) { 3; }",
+        &expect![[r#"
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: IfStmt [0-17]:
+                    condition: Expr [4-5]: Ident [4-5] "x"
+                    if_block:
+                        Stmt [13-15]:
+                            annotations: <empty>
+                            kind: ExprStmt [13-15]:
+                                expr: Expr [13-14]: Lit: Int(3)
+                    else_block: <none>
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eq,
+                        Span {
+                            lo: 6,
+                            hi: 7,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn binary_op_assignment_in_if_condition() {
+    check(
+        parse,
+        "if (x += 2) { 3; }",
+        &expect![[r#"
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: IfStmt [0-18]:
+                    condition: Expr [4-5]: Ident [4-5] "x"
+                    if_block:
+                        Stmt [14-16]:
+                            annotations: <empty>
+                            kind: ExprStmt [14-16]:
+                                expr: Expr [14-15]: Lit: Int(3)
+                    else_block: <none>
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        BinOpEq(
+                            Plus,
+                        ),
+                        Span {
+                            lo: 6,
+                            hi: 8,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}


### PR DESCRIPTION
Previously assignments and binary assignments were valid in any part of the expression tree. This PR makes Assign and AssignOp valid only in expression statements.