### PR TITLE
Fix name resolution from a project's Main.qs

### DIFF
--- a/compiler/qsc_frontend/src/resolve.rs
+++ b/compiler/qsc_frontend/src/resolve.rs
@@ -1626,9 +1626,11 @@ impl GlobalTable {
             global.visibility == hir::Visibility::Public
                 || matches!(&global.kind, global::Kind::Term(t) if t.intrinsic)
         }) {
-            // If the namespace is `Main`, we treat it as the root of the package, so there's no
-            // namespace prefix.
-            let global_namespace = if global.namespace.len() == 1 && &*global.namespace[0] == "Main"
+            // If the namespace is `Main` and we have an alias, we treat it as the root of the package, so there's no
+            // namespace prefix between the dependency alias and the defined items.
+            let global_namespace = if global.namespace.len() == 1
+                && &*global.namespace[0] == "Main"
+                && alias.is_some()
             {
                 vec![]
             } else {
@@ -2309,7 +2311,7 @@ fn find_symbol_in_namespace<O>(
         return;
     }
 
-    // Attempt to get the symbol from the global scope. If the namespace is None, use the candidate_namespace_id as a fallback
+    // Attempt to get the symbol from the global scope.
     let res = namespace.and_then(|ns_id| globals.get(kind, ns_id, &provided_symbol_name.name));
 
     // If a symbol was found, insert it into the candidates map


### PR DESCRIPTION
This fixes an issue where items from the Main.qs in a project would not be visible with the explicit `Main` namespace. When the dependency has no alias we should skip the special handling that elides the `Main` so that items are accessible as expected (and as documented in [Running the Programs](https://learn.microsoft.com/en-us/azure/quantum/how-to-work-with-qsharp-projects?tabs=tabid-qsharp%2Ctabid-notebook-run#running-the-programs))

Fixes #2207