### PR TITLE
Specific suggestion what to run if formatting check fails

### DIFF
--- a/build.py
+++ b/build.py
@@ -174,7 +174,11 @@ if npm_install_needed:
 
 if args.check:
     step_start("Running eslint and prettier checks")
-    subprocess.run([npm_cmd, "run", "check"], check=True, text=True, cwd=root_dir)
+    try:
+        subprocess.run([npm_cmd, "run", "check"], check=True, text=True, cwd=root_dir)
+    except subprocess.CalledProcessError:
+        print("Consider running 'npm run prettier:fix' to fix prettier errors.")
+        raise
 
     if build_wasm or build_cli:
         # If we're going to check the Rust code, do this before we try to compile it


### PR DESCRIPTION
This change suggests running specific command 'npm run prettier:fix' to fix prettier errors if the formatting check fails. Could be hard to figure out what to run by just looking at 'Run Prettier with --write to fix' message.