### PR TITLE
Add grammar docstrings to QASM3 parser

### DIFF
--- a/compiler/qsc_qasm3/src/parser/expr.rs
+++ b/compiler/qsc_qasm3/src/parser/expr.rs
@@ -680,6 +680,7 @@ fn unescape(s: &str) -> std::result::Result<String, usize> {
     Ok(buf)
 }
 
+/// Grammar: `LBRACKET expression RBRACKET`.
 pub(super) fn designator(s: &mut ParserContext) -> Result<Expr> {
     token(s, TokenKind::Open(Delim::Bracket))?;
     let expr = expr(s)?;
@@ -756,6 +757,7 @@ fn hardware_qubit(s: &mut ParserContext) -> Result<HardwareQubit> {
     })
 }
 
+/// Grammar: `Identifier indexOperator*`.
 pub(crate) fn indexed_identifier(s: &mut ParserContext) -> Result<IndexedIdent> {
     let lo = s.peek().span.lo;
     let name: Ident = ident(s)?;
@@ -768,6 +770,15 @@ pub(crate) fn indexed_identifier(s: &mut ParserContext) -> Result<IndexedIdent> 
     })
 }
 
+/// Grammar:
+/// ```g4
+/// LBRACKET
+/// (
+///     setExpression
+///     | (expression | rangeExpression) (COMMA (expression | rangeExpression))* COMMA?
+/// )
+/// RBRACKET
+/// ```
 fn index_operand(s: &mut ParserContext) -> Result<IndexElement> {
     token(s, TokenKind::Open(Delim::Bracket))?;
     let index = index_element(s)?;

--- a/compiler/qsc_qasm3/src/parser/prgm.rs
+++ b/compiler/qsc_qasm3/src/parser/prgm.rs
@@ -13,6 +13,7 @@ use crate::{
 
 use super::ParserContext;
 
+/// Grammar: `version? statementOrScope* EOF`.
 pub(super) fn parse(s: &mut ParserContext) -> Result<Program> {
     let lo = s.peek().span.lo;
     let version = opt(s, parse_version)?;
@@ -29,6 +30,7 @@ pub(super) fn parse(s: &mut ParserContext) -> Result<Program> {
     })
 }
 
+/// Grammar: `OPENQASM VersionSpecifier SEMICOLON`.
 fn parse_version(s: &mut ParserContext<'_>) -> Result<Version> {
     s.expect(WordKinds::OpenQASM);
     token(s, TokenKind::Keyword(crate::keyword::Keyword::OpenQASM))?;

--- a/compiler/qsc_qasm3/src/parser/stmt/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests.rs
@@ -4,6 +4,7 @@
 mod alias;
 mod annotation;
 mod barrier;
+mod block;
 mod box_stmt;
 mod cal;
 mod cal_grammar;

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/block.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/block.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::stmt::parse_block;
+use crate::parser::tests::check;
+use expect_test::expect;
+
+
+#[test]
+fn nested_blocks() {
+    check(parse_block,
+        "
+    {
+        {
+            int x = 1;
+            {
+                x = 2;
+            }
+        }
+    }", &expect![[r#"
+        Block [5-106]:
+            Stmt [15-100]:
+                annotations: <empty>
+                kind: Block [15-100]:
+                    Stmt [29-39]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [29-39]:
+                            type: ScalarType [29-32]: IntType [29-32]:
+                                size: <none>
+                            ident: Ident [33-34] "x"
+                            init_expr: Expr [37-38]: Lit: Int(1)
+                    Stmt [52-90]:
+                        annotations: <empty>
+                        kind: Block [52-90]:
+                            Stmt [70-76]:
+                                annotations: <empty>
+                                kind: AssignStmt [70-76]:
+                                    lhs: IndexedIdent [70-71]:
+                                        name: Ident [70-71] "x"
+                                        indices: <empty>
+                                    rhs: Expr [74-75]: Lit: Int(2)"#]]);
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts.rs
@@ -1,72 +1,11 @@
-use crate::parser::{stmt::parse, tests::check};
-use expect_test::expect;
-
-#[test]
-fn assignment_in_if_condition() {
-    check(
-        parse,
-        "if (x = 2) { 3; }",
-        &expect![[r#"
-            Stmt [0-17]:
-                annotations: <empty>
-                kind: IfStmt [0-17]:
-                    condition: Expr [4-5]: Ident [4-5] "x"
-                    if_block:
-                        Stmt [13-15]:
-                            annotations: <empty>
-                            kind: ExprStmt [13-15]:
-                                expr: Expr [13-14]: Lit: Int(3)
-                    else_block: <none>
-
-            [
-                Error(
-                    Token(
-                        Close(
-                            Paren,
-                        ),
-                        Eq,
-                        Span {
-                            lo: 6,
-                            hi: 7,
-                        },
-                    ),
-                ),
-            ]"#]],
-    );
-}
-
-#[test]
-fn binary_op_assignment_in_if_condition() {
-    check(
-        parse,
-        "if (x += 2) { 3; }",
-        &expect![[r#"
-            Stmt [0-18]:
-                annotations: <empty>
-                kind: IfStmt [0-18]:
-                    condition: Expr [4-5]: Ident [4-5] "x"
-                    if_block:
-                        Stmt [14-16]:
-                            annotations: <empty>
-                            kind: ExprStmt [14-16]:
-                                expr: Expr [14-15]: Lit: Int(3)
-                    else_block: <none>
-
-            [
-                Error(
-                    Token(
-                        Close(
-                            Paren,
-                        ),
-                        BinOpEq(
-                            Plus,
-                        ),
-                        Span {
-                            lo: 6,
-                            hi: 8,
-                        },
-                    ),
-                ),
-            ]"#]],
-    );
-}
+mod branch;
+mod cal;
+mod constant;
+mod decl;
+mod gate_calls;
+mod headers;
+mod io;
+mod loops;
+mod measure;
+mod switch;
+mod tokens;

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/branch.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/branch.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn if_condition_missing_parens() {
+    check(
+        parse,
+        "if true 3;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Keyword(
+                    True,
+                ),
+                Span {
+                    lo: 3,
+                    hi: 7,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn decl_in_if_condition() {
+    check(parse, "if (int[8] myvar = 1) { x $0; }", &expect![]);
+}
+
+#[test]
+fn assignment_in_if_condition() {
+    check(
+        parse,
+        "if (x = 2) { 3; }",
+        &expect![[r#"
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: IfStmt [0-17]:
+                    condition: Expr [4-5]: Ident [4-5] "x"
+                    if_block:
+                        Stmt [13-15]:
+                            annotations: <empty>
+                            kind: ExprStmt [13-15]:
+                                expr: Expr [13-14]: Lit: Int(3)
+                    else_block: <none>
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Eq,
+                        Span {
+                            lo: 6,
+                            hi: 7,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn binary_op_assignment_in_if_condition() {
+    check(
+        parse,
+        "if (x += 2) { 3; }",
+        &expect![[r#"
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: IfStmt [0-18]:
+                    condition: Expr [4-5]: Ident [4-5] "x"
+                    if_block:
+                        Stmt [14-16]:
+                            annotations: <empty>
+                            kind: ExprStmt [14-16]:
+                                expr: Expr [14-15]: Lit: Int(3)
+                    else_block: <none>
+
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        BinOpEq(
+                            Plus,
+                        ),
+                        Span {
+                            lo: 6,
+                            hi: 8,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn empty_if_block() {
+    check(parse, "if (true);", &expect![]);
+}
+
+#[test]
+fn empty_if_block_else() {
+    check(parse, "if (true) else x $0;", &expect![]);
+}
+
+#[test]
+fn empty_if_block_else_with_condition() {
+    check(parse, "if (true) else (false) x $0;", &expect![]);
+}
+
+#[test]
+fn reset_in_if_condition() {
+    check(parse, "if (reset $0) { x $1; }", &expect![]);
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/cal.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/cal.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn multiple_defcalgrammar_in_same_stmt() {
+    check(
+        parse,
+        r#"defcalgrammar "openpulse" defcalgrammar "openpulse";"#,
+        &expect![[r#"
+            Stmt [0-25]:
+                annotations: <empty>
+                kind: CalibrationGrammarStmt [0-25]:
+                    name: openpulse
+
+            [
+                Error(
+                    Token(
+                        Semicolon,
+                        Keyword(
+                            DefCalGrammar,
+                        ),
+                        Span {
+                            lo: 26,
+                            hi: 39,
+                        },
+                    ),
+                ),
+            ]"#]],
+    );
+}
+
+#[test]
+fn defcalgrammar_with_wrong_literal_kind() {
+    check(
+        parse,
+        "defcalgrammar 3;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "string literal",
+                Literal(
+                    Integer(
+                        Decimal,
+                    ),
+                ),
+                Span {
+                    lo: 14,
+                    hi: 15,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn defcal_bad_signature() {
+    check(
+        parse,
+        "defcal x $0 -> int[8] -> int[8] {}",
+        &expect![[r#"
+        Stmt [0-34]:
+            annotations: <empty>
+            kind: DefCalStmt [0-34]"#]],
+    );
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/constant.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/constant.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn const_decl_missing_type_and_init() {
+    check(parse, "const myvar;", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Identifier,
+                Span {
+                    lo: 6,
+                    hi: 11,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn const_decl_eq_missing_type_and_init() {
+    check(parse, "const myvar = ;", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Identifier,
+                Span {
+                    lo: 6,
+                    hi: 11,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn const_decl_missing_type() {
+    check(parse, "const myvar = 8.0;", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Identifier,
+                Span {
+                    lo: 6,
+                    hi: 11,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn invalid_input() {
+    check(parse, "input const myvar = 8;", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    Const,
+                ),
+                Span {
+                    lo: 6,
+                    hi: 11,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn invalid_output() {
+    check(parse, "output const myvar = 8;", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    Const,
+                ),
+                Span {
+                    lo: 7,
+                    hi: 12,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn invalid_const_input() {
+    check(parse, "const input myvar = 8;", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    Input,
+                ),
+                Span {
+                    lo: 6,
+                    hi: 11,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn invalid_const_output() {
+    check(parse, "const output myvar = 8;", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    Output,
+                ),
+                Span {
+                    lo: 6,
+                    hi: 12,
+                },
+            ),
+        )
+    "#]]);
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/decl.rs
@@ -1,0 +1,994 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn missing_ident() {
+    check(
+        parse,
+        "float;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Semicolon,
+                Span {
+                    lo: 5,
+                    hi: 6,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "uint[8];",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Semicolon,
+                Span {
+                    lo: 7,
+                    hi: 8,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "qreg[4];",
+        &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Open(
+                    Bracket,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "creg[4];",
+        &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Open(
+                    Bracket,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "complex[float[32]];",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Semicolon,
+                Span {
+                    lo: 18,
+                    hi: 19,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn incorrect_designators() {
+    check(
+        parse,
+        "int[8, 8] myvar;",
+        &expect![[r#"
+        Stmt [0-16]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-16]:
+                type: ScalarType [0-9]: IntType [0-9]:
+                    size: Expr [4-5]: Lit: Int(8)
+                ident: Ident [10-15] "myvar"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Close(
+                        Bracket,
+                    ),
+                    Comma,
+                    Span {
+                        lo: 5,
+                        hi: 6,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "uint[8, 8] myvar;",
+        &expect![[r#"
+        Stmt [0-17]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-17]:
+                type: ScalarType [0-10]: UIntType [0-10]:
+                    size: Expr [5-6]: Lit: Int(8)
+                ident: Ident [11-16] "myvar"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Close(
+                        Bracket,
+                    ),
+                    Comma,
+                    Span {
+                        lo: 6,
+                        hi: 7,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "float[8, 8] myvar;",
+        &expect![[r#"
+        Stmt [0-18]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-18]:
+                type: ScalarType [0-11]: FloatType [0-11]:
+                    size: Expr [6-7]: Lit: Int(8)
+                ident: Ident [12-17] "myvar"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Close(
+                        Bracket,
+                    ),
+                    Comma,
+                    Span {
+                        lo: 7,
+                        hi: 8,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "angle[8, 8] myvar;",
+        &expect![[r#"
+        Stmt [0-18]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-18]:
+                type: ScalarType [0-11]: AngleType [0-11]:
+                    size: Expr [6-7]: Lit: Int(8)
+                ident: Ident [12-17] "myvar"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Close(
+                        Bracket,
+                    ),
+                    Comma,
+                    Span {
+                        lo: 7,
+                        hi: 8,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "bool[4] myvar;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Open(
+                    Bracket,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "bool[4, 4] myvar;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Open(
+                    Bracket,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "bit[4, 4] myvar;",
+        &expect![[r#"
+        Stmt [0-16]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-16]:
+                type: ScalarType [0-9]: BitType [0-9]:
+                    size: Expr [4-5]: Lit: Int(4)
+                ident: Ident [10-15] "myvar"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Close(
+                        Bracket,
+                    ),
+                    Comma,
+                    Span {
+                        lo: 5,
+                        hi: 6,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "creg[2] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Open(
+                    Bracket,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "creg[2, 2] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Open(
+                    Bracket,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "qreg[2] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Open(
+                    Bracket,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "qreg[2, 2] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Open(
+                    Bracket,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "complex[32] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Literal(
+                    Integer(
+                        Decimal,
+                    ),
+                ),
+                Span {
+                    lo: 8,
+                    hi: 10,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "complex[mytype] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Identifier,
+                Span {
+                    lo: 8,
+                    hi: 14,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "complex[float[32], float[32]] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Comma,
+                Span {
+                    lo: 17,
+                    hi: 18,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "complex[qreg] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    QReg,
+                ),
+                Span {
+                    lo: 8,
+                    hi: 12,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "complex[creg] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    CReg,
+                ),
+                Span {
+                    lo: 8,
+                    hi: 12,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "complex[qreg[8]] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    QReg,
+                ),
+                Span {
+                    lo: 8,
+                    hi: 12,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "complex[creg[8]] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    CReg,
+                ),
+                Span {
+                    lo: 8,
+                    hi: 12,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn bad_array_specifiers() {
+    check(
+        parse,
+        "array myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Identifier,
+                Span {
+                    lo: 6,
+                    hi: 11,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "array[8] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Literal(
+                    Integer(
+                        Decimal,
+                    ),
+                ),
+                Span {
+                    lo: 6,
+                    hi: 7,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "array[not_a_type, 4] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Identifier,
+                Span {
+                    lo: 6,
+                    hi: 16,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "array[int[8], int[8], 2] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Comma,
+                Span {
+                    lo: 20,
+                    hi: 21,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn invalid_identifiers() {
+    check(
+        parse,
+        "int[8] int;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Type(
+                    Int,
+                ),
+                Span {
+                    lo: 7,
+                    hi: 10,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "int[8] def;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Keyword(
+                    Def,
+                ),
+                Span {
+                    lo: 7,
+                    hi: 10,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "int[8] 0;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Literal(
+                    Integer(
+                        Decimal,
+                    ),
+                ),
+                Span {
+                    lo: 7,
+                    hi: 8,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "int[8] input;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Keyword(
+                    Input,
+                ),
+                Span {
+                    lo: 7,
+                    hi: 12,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn bad_assignments() {
+    check(
+        parse,
+        "int[8] myvar = end;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Brace,
+                ),
+                Keyword(
+                    End,
+                ),
+                Span {
+                    lo: 15,
+                    hi: 18,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "int[8] myvar =;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Brace,
+                ),
+                Semicolon,
+                Span {
+                    lo: 14,
+                    hi: 15,
+                },
+            ),
+        )
+    "#]],
+    );
+    check(
+        parse,
+        "float[32] myvar_f = int[32] myvar_i = 2;",
+        &expect![[r#"
+            Error(
+                Token(
+                    Open(
+                        Paren,
+                    ),
+                    Identifier,
+                    Span {
+                        lo: 28,
+                        hi: 35,
+                    },
+                ),
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn array_initialiser_uses_braces() {
+    check(
+        parse,
+        "array[uint[8], 4] myvar = [4, 5, 6, 7];",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Brace,
+                ),
+                Open(
+                    Bracket,
+                ),
+                Span {
+                    lo: 26,
+                    hi: 27,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn cant_use_arithmetic_on_the_entire_initialiser() {
+    check(
+        parse,
+        "array[uint[8], 4] myvar = 2 * {1, 2, 3, 4};",
+        &expect![[r#"
+            Error(
+                Rule(
+                    "expression",
+                    Open(
+                        Brace,
+                    ),
+                    Span {
+                        lo: 30,
+                        hi: 31,
+                    },
+                ),
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn backed_arrays_cant_use_dim() {
+    check(
+        parse,
+        "array[uint[8], #dim=2] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Dim,
+                Span {
+                    lo: 15,
+                    hi: 19,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn cant_have_more_than_one_type_specification() {
+    check(
+        parse,
+        "array[int[8], int[8]] myvar;",
+        &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Close(
+                    Bracket,
+                ),
+                Span {
+                    lo: 20,
+                    hi: 21,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn incorrect_orders() {
+    check(
+        parse,
+        "myvar: int[8];",
+        &expect![[r#"
+        Stmt [0-5]:
+            annotations: <empty>
+            kind: ExprStmt [0-5]:
+                expr: Expr [0-5]: Ident [0-5] "myvar"
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Colon,
+                    Span {
+                        lo: 5,
+                        hi: 6,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "myvar int[8];",
+        &expect![[r#"
+        Stmt [0-5]:
+            annotations: <empty>
+            kind: ExprStmt [0-5]:
+                expr: Expr [0-5]: Ident [0-5] "myvar"
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Type(
+                        Int,
+                    ),
+                    Span {
+                        lo: 6,
+                        hi: 9,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "int myvar[8];",
+        &expect![[r#"
+        Stmt [0-9]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-9]:
+                type: ScalarType [0-3]: IntType [0-3]:
+                    size: <none>
+                ident: Ident [4-9] "myvar"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Open(
+                        Bracket,
+                    ),
+                    Span {
+                        lo: 9,
+                        hi: 10,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "uint myvar[8];",
+        &expect![[r#"
+        Stmt [0-10]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-10]:
+                type: ScalarType [0-4]: UIntType [0-4]:
+                    size: <none>
+                ident: Ident [5-10] "myvar"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Open(
+                        Bracket,
+                    ),
+                    Span {
+                        lo: 10,
+                        hi: 11,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "float myvar[32];",
+        &expect![[r#"
+        Stmt [0-11]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-11]:
+                type: ScalarType [0-5]: FloatType [0-5]:
+                    size: <none>
+                ident: Ident [6-11] "myvar"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Open(
+                        Bracket,
+                    ),
+                    Span {
+                        lo: 11,
+                        hi: 12,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+}
+
+#[test]
+fn compound_assigments() {
+    check(
+        parse,
+        "int[8] myvar1, myvar2;",
+        &expect![[r#"
+        Stmt [0-13]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-13]:
+                type: ScalarType [0-6]: IntType [0-6]:
+                    size: Expr [4-5]: Lit: Int(8)
+                ident: Ident [7-13] "myvar1"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Comma,
+                    Span {
+                        lo: 13,
+                        hi: 14,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "int[8] myvari, float[32] myvarf;",
+        &expect![[r#"
+        Stmt [0-13]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-13]:
+                type: ScalarType [0-6]: IntType [0-6]:
+                    size: Expr [4-5]: Lit: Int(8)
+                ident: Ident [7-13] "myvari"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Comma,
+                    Span {
+                        lo: 13,
+                        hi: 14,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+    check(
+        parse,
+        "int[8] myvari float[32] myvarf;",
+        &expect![[r#"
+        Stmt [0-13]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-13]:
+                type: ScalarType [0-6]: IntType [0-6]:
+                    size: Expr [4-5]: Lit: Int(8)
+                ident: Ident [7-13] "myvari"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Type(
+                        Float,
+                    ),
+                    Span {
+                        lo: 14,
+                        hi: 19,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/gate_calls.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/gate_calls.rs
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn u_gate_with_two_args() {
+    check(
+        parse,
+        "U (1)(2) $0;",
+        &expect![[r#"
+        Error(
+            Convert(
+                "identifier",
+                "",
+                Span {
+                    lo: 0,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn invalid_modifier() {
+    check(
+        parse,
+        "notmodifier @ x $0;",
+        &expect![[r#"
+        Stmt [0-11]:
+            annotations: <empty>
+            kind: ExprStmt [0-11]:
+                expr: Expr [0-11]: Ident [0-11] "notmodifier"
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    At,
+                    Span {
+                        lo: 12,
+                        hi: 13,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+}
+
+#[test]
+fn pow_without_arg() {
+    check(
+        parse,
+        "pow @ x $0;",
+        &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                At,
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+fn pow_with_two_args() {
+    check(
+        parse,
+        "pow(2, 3) @ x $0;",
+        &expect![[r#"
+        Stmt [0-17]:
+            annotations: <empty>
+            kind: GateCall [0-17]:
+                modifiers:
+                    QuantumGateModifier [0-11]: Pow Expr [4-5]: Lit: Int(2)
+                name: Ident [12-13] "x"
+                args: <empty>
+                duration: <none>
+                qubits:
+                    HardwareQubit [14-16]: 0
+
+        [
+            Error(
+                Token(
+                    Close(
+                        Paren,
+                    ),
+                    Comma,
+                    Span {
+                        lo: 5,
+                        hi: 6,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+}
+
+#[test]
+fn ctrl_with_two_args() {
+    check(
+        parse,
+        "ctrl(2, 3) @ x $0, $1;",
+        &expect![[r#"
+        Stmt [0-22]:
+            annotations: <empty>
+            kind: GateCall [0-22]:
+                modifiers:
+                    QuantumGateModifier [0-12]: Ctrl Some(Expr { span: Span { lo: 5, hi: 6 }, kind: Lit(Lit { span: Span { lo: 5, hi: 6 }, kind: Int(2) }) })
+                name: Ident [13-14] "x"
+                args: <empty>
+                duration: <none>
+                qubits:
+                    HardwareQubit [15-17]: 0
+                    HardwareQubit [19-21]: 1
+
+        [
+            Error(
+                Token(
+                    Close(
+                        Paren,
+                    ),
+                    Comma,
+                    Span {
+                        lo: 6,
+                        hi: 7,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+}
+
+#[test]
+fn negctrl_with_two_args() {
+    check(
+        parse,
+        "negctrl(2, 3) @ x $0, $1;",
+        &expect![[r#"
+        Stmt [0-25]:
+            annotations: <empty>
+            kind: GateCall [0-25]:
+                modifiers:
+                    QuantumGateModifier [0-15]: NegCtrl Some(Expr { span: Span { lo: 8, hi: 9 }, kind: Lit(Lit { span: Span { lo: 8, hi: 9 }, kind: Int(2) }) })
+                name: Ident [16-17] "x"
+                args: <empty>
+                duration: <none>
+                qubits:
+                    HardwareQubit [18-20]: 0
+                    HardwareQubit [22-24]: 1
+
+        [
+            Error(
+                Token(
+                    Close(
+                        Paren,
+                    ),
+                    Comma,
+                    Span {
+                        lo: 9,
+                        hi: 10,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+}
+
+#[test]
+fn inv_with_arg() {
+    check(
+        parse,
+        "inv(1) @ ctrl @ x $0, $1;",
+        &expect![[r#"
+        Stmt [0-25]:
+            annotations: <empty>
+            kind: GateCall [0-25]:
+                modifiers:
+                    QuantumGateModifier [0-8]: Inv
+                    QuantumGateModifier [9-15]: Ctrl None
+                name: Ident [16-17] "x"
+                args: <empty>
+                duration: <none>
+                qubits:
+                    HardwareQubit [18-20]: 0
+                    HardwareQubit [22-24]: 1
+
+        [
+            Error(
+                Token(
+                    At,
+                    Open(
+                        Paren,
+                    ),
+                    Span {
+                        lo: 3,
+                        hi: 4,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/headers.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/headers.rs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn invalid_version_type() {
+    check(parse, "OPENQASM int;", &expect![[r#"
+        Error(
+            Rule(
+                "statement",
+                Keyword(
+                    OpenQASM,
+                ),
+                Span {
+                    lo: 0,
+                    hi: 8,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn invalid_version_literal() {
+    check(parse, "OPENQASM 'hello, world';", &expect![[r#"
+        Error(
+            Rule(
+                "statement",
+                Keyword(
+                    OpenQASM,
+                ),
+                Span {
+                    lo: 0,
+                    hi: 8,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn invalid_version_missing_dot() {
+    check(parse, "OPENQASM 3 3;", &expect![[r#"
+        Error(
+            Rule(
+                "statement",
+                Keyword(
+                    OpenQASM,
+                ),
+                Span {
+                    lo: 0,
+                    hi: 8,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn invalid_version() {
+    check(parse, "OPENQASM 3.x;", &expect![[r#"
+        Error(
+            Rule(
+                "statement",
+                Keyword(
+                    OpenQASM,
+                ),
+                Span {
+                    lo: 0,
+                    hi: 8,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn include_int() {
+    check(parse, "include 3;", &expect![[r#"
+        Error(
+            Rule(
+                "string literal",
+                Literal(
+                    Integer(
+                        Decimal,
+                    ),
+                ),
+                Span {
+                    lo: 8,
+                    hi: 9,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn include_include() {
+    check(parse, "include include;", &expect![[r#"
+        Error(
+            Rule(
+                "string literal",
+                Keyword(
+                    Include,
+                ),
+                Span {
+                    lo: 8,
+                    hi: 15,
+                },
+            ),
+        )
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Keyword(
+                        Include,
+                    ),
+                    Span {
+                        lo: 8,
+                        hi: 15,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn include_def() {
+    check(parse, "include def;", &expect![[r#"
+        Error(
+            Rule(
+                "string literal",
+                Keyword(
+                    Def,
+                ),
+                Span {
+                    lo: 8,
+                    hi: 11,
+                },
+            ),
+        )
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Keyword(
+                        Def,
+                    ),
+                    Span {
+                        lo: 8,
+                        hi: 11,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn unclosed_string() {
+    check(parse, r#"include "hello;"#, &expect![[r#"
+        Error(
+            Rule(
+                "string literal",
+                Eof,
+                Span {
+                    lo: 15,
+                    hi: 15,
+                },
+            ),
+        )
+
+        [
+            Error(
+                Lex(
+                    UnterminatedString(
+                        Span {
+                            lo: 8,
+                            hi: 8,
+                        },
+                    ),
+                ),
+            ),
+            Error(
+                Token(
+                    Semicolon,
+                    Eof,
+                    Span {
+                        lo: 15,
+                        hi: 15,
+                    },
+                ),
+            ),
+        ]"#]]);
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/io.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/io.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn input_missing_ident() {
+    check(parse, "input int[8];", &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Semicolon,
+                Span {
+                    lo: 12,
+                    hi: 13,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn output_missing_ident() {
+    check(parse, "output int[8];", &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Semicolon,
+                Span {
+                    lo: 13,
+                    hi: 14,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn input_qreg_missing_ident() {
+    check(parse, "input qreg myvar[4];", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    QReg,
+                ),
+                Span {
+                    lo: 6,
+                    hi: 10,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn output_qreg_missing_ident() {
+    check(parse, "output qreg myvar[4];", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Keyword(
+                    QReg,
+                ),
+                Span {
+                    lo: 7,
+                    hi: 11,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn initialized_input() {
+    check(parse, "input int[8] myvar = 32;", &expect![[r#"
+        Stmt [0-18]:
+            annotations: <empty>
+            kind: IODeclaration [0-18]:
+                io_keyword: input
+                type: ScalarType [6-12]: IntType [6-12]:
+                    size: Expr [10-11]: Lit: Int(8)
+                ident: Ident [13-18] "myvar"
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Eq,
+                    Span {
+                        lo: 19,
+                        hi: 20,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn initialized_output() {
+    check(parse, "output int[8] myvar = 32;", &expect![[r#"
+        Stmt [0-19]:
+            annotations: <empty>
+            kind: IODeclaration [0-19]:
+                io_keyword: output
+                type: ScalarType [7-13]: IntType [7-13]:
+                    size: Expr [11-12]: Lit: Int(8)
+                ident: Ident [14-19] "myvar"
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Eq,
+                    Span {
+                        lo: 20,
+                        hi: 21,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn input_missing_type() {
+    check(parse, "input myvar;", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Identifier,
+                Span {
+                    lo: 6,
+                    hi: 11,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn output_missing_type() {
+    check(parse, "output myvar;", &expect![[r#"
+        Error(
+            Rule(
+                "scalar or array type",
+                Identifier,
+                Span {
+                    lo: 7,
+                    hi: 12,
+                },
+            ),
+        )
+    "#]]);
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/loops.rs
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn for_missing_var_type() {
+    check(parse, "for myvar in { 1, 2, 3 };", &expect![[r#"
+        Error(
+            Rule(
+                "scalar type",
+                Identifier,
+                Span {
+                    lo: 4,
+                    hi: 9,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn for_multiple_vars() {
+    check(
+        parse,
+        "for myvar1, myvar2 in { 1, 2, 3 } { x $0; }",
+        &expect![[r#"
+            Error(
+                Rule(
+                    "scalar type",
+                    Identifier,
+                    Span {
+                        lo: 4,
+                        hi: 10,
+                    },
+                ),
+            )
+        "#]],
+    );
+}
+
+#[test]
+fn for_missing_var_type_and_invalid_collection() {
+    check(parse, "for myvar in { x $0; } { x $0; }", &expect![[r#"
+        Error(
+            Rule(
+                "scalar type",
+                Identifier,
+                Span {
+                    lo: 4,
+                    hi: 9,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn for_missing_var_type_and_keyword_in_collection() {
+    check(parse, "for myvar in for { x $0; }", &expect![[r#"
+        Error(
+            Rule(
+                "scalar type",
+                Identifier,
+                Span {
+                    lo: 4,
+                    hi: 9,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn for_bad_syntax() {
+    check(parse, "for myvar { x $0; }", &expect![[r#"
+        Error(
+            Rule(
+                "scalar type",
+                Identifier,
+                Span {
+                    lo: 4,
+                    hi: 9,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn for_with_while_syntax() {
+    check(parse, "for (true) { x $0; }", &expect![[r#"
+        Error(
+            Rule(
+                "scalar type",
+                Open(
+                    Paren,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn for_missing_var_and_collection() {
+    check(parse, "for { x $0; }", &expect![[r#"
+        Error(
+            Rule(
+                "scalar type",
+                Open(
+                    Brace,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn for_invalid_var_name() {
+    check(parse, "for for in { 1, 2, 3 } { x $0; }", &expect![[r#"
+        Error(
+            Rule(
+                "scalar type",
+                Keyword(
+                    For,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 7,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn for_missing_var() {
+    check(parse, "for in { 1, 2, 3 } { x $0; }", &expect![[r#"
+        Error(
+            Rule(
+                "scalar type",
+                Keyword(
+                    In,
+                ),
+                Span {
+                    lo: 4,
+                    hi: 6,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn while_missing_parens() {
+    check(parse, "while true { x $0; }", &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Keyword(
+                    True,
+                ),
+                Span {
+                    lo: 6,
+                    hi: 10,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn while_multi_condition() {
+    check(parse, "while (true) (true) { x $0; }", &expect![[r#"
+        Stmt [0-19]:
+            annotations: <empty>
+            kind: WhileLoop [0-19]:
+                condition: Expr [7-11]: Lit: Bool(true)
+                block:
+                    Stmt [13-19]:
+                        annotations: <empty>
+                        kind: ExprStmt [13-19]:
+                            expr: Expr [13-19]: Paren Expr [14-18]: Lit: Bool(true)
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Open(
+                        Brace,
+                    ),
+                    Span {
+                        lo: 20,
+                        hi: 21,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn while_with_for_syntax() {
+    check(parse, "while x in { 1, 2, 3 } { x $0; }", &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Paren,
+                ),
+                Identifier,
+                Span {
+                    lo: 6,
+                    hi: 7,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn while_missing_body() {
+    check(parse, "while (true);", &expect![[r#"
+        Stmt [0-13]:
+            annotations: <empty>
+            kind: WhileLoop [0-13]:
+                condition: Expr [7-11]: Lit: Bool(true)
+                block:
+                    Stmt [12-13]:
+                        annotations: <empty>
+                        kind: Empty"#]]);
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/measure.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/measure.rs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn measure_multiple_qubits() {
+    check(parse, "measure $0, $1;", &expect![[r#"
+        Stmt [0-10]:
+            annotations: <empty>
+            kind: MeasureStmt [0-10]:
+                measurement: MeasureExpr [0-7]:
+                    operand: HardwareQubit [8-10]: 0
+                target: <none>
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Comma,
+                    Span {
+                        lo: 10,
+                        hi: 11,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn assign_measure_multiple_qubits() {
+    check(parse, "a[0:1] = measure $0, $1;", &expect![[r#"
+        Error(
+            Rule(
+                "expression",
+                Measure,
+                Span {
+                    lo: 9,
+                    hi: 16,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn assign_arrow() {
+    check(parse, "a = measure $0 -> b;", &expect![[r#"
+        Error(
+            Rule(
+                "expression",
+                Measure,
+                Span {
+                    lo: 4,
+                    hi: 11,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn initialized_creg() {
+    check(parse, "creg a[1] = measure $0;", &expect![[r#"
+        Stmt [0-9]:
+            annotations: <empty>
+            kind: ClassicalDeclarationStmt [0-9]:
+                type: ScalarType [0-9]: BitType [0-9]:
+                    size: Expr [7-8]: Lit: Int(1)
+                ident: Ident [5-6] "a"
+                init_expr: <none>
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Eq,
+                    Span {
+                        lo: 10,
+                        hi: 11,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn invalid_arrow_target() {
+    check(parse, "measure $0 -> creg a[1];", &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Keyword(
+                    CReg,
+                ),
+                Span {
+                    lo: 14,
+                    hi: 18,
+                },
+            ),
+        )
+    "#]]);
+    check(parse, "measure $0 -> bit[1] a;", &expect![[r#"
+        Error(
+            Rule(
+                "identifier",
+                Type(
+                    Bit,
+                ),
+                Span {
+                    lo: 14,
+                    hi: 17,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn measure_cant_be_used_in_sub_expressions() {
+    check(parse, "a = 2 * measure $0;", &expect![[r#"
+        Error(
+            Rule(
+                "expression",
+                Measure,
+                Span {
+                    lo: 8,
+                    hi: 15,
+                },
+            ),
+        )
+    "#]]);
+    check(parse, "a = (measure $0) + (measure $1);", &expect![[r#"
+        Error(
+            Token(
+                Close(
+                    Paren,
+                ),
+                Measure,
+                Span {
+                    lo: 5,
+                    hi: 12,
+                },
+            ),
+        )
+    "#]]);
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/switch.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/switch.rs
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn missing_target() {
+    check(parse, "switch () {}", &expect![[r#"
+        Error(
+            Rule(
+                "expression",
+                Close(
+                    Paren,
+                ),
+                Span {
+                    lo: 8,
+                    hi: 9,
+                },
+            ),
+        )
+    "#]]);
+}
+
+#[test]
+fn missing_cases() {
+    check(parse, "switch (i) { x $0 }", &expect![[r#"
+        Stmt [0-19]:
+            annotations: <empty>
+            kind: SwitchStmt [0-19]:
+                target: Expr [8-9]: Ident [8-9] "i"
+                cases: <empty>
+                default_case: <none>
+
+        [
+            Error(
+                MissingSwitchCases(
+                    Span {
+                        lo: 13,
+                        hi: 12,
+                    },
+                ),
+            ),
+            Error(
+                Token(
+                    Close(
+                        Brace,
+                    ),
+                    Identifier,
+                    Span {
+                        lo: 13,
+                        hi: 14,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn missing_case_labels() {
+    check(parse, "switch (i) { case {} }", &expect![[r#"
+        Stmt [0-22]:
+            annotations: <empty>
+            kind: SwitchStmt [0-22]:
+                target: Expr [8-9]: Ident [8-9] "i"
+                cases:
+                    SwitchCase [13-20]:
+                        labels: <empty>
+                        block: Block [18-20]: <empty>
+                default_case: <none>
+
+        [
+            Error(
+                MissingSwitchCaseLabels(
+                    Span {
+                        lo: 13,
+                        hi: 17,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn invalid_label_sequence() {
+    check(parse, "switch (i) { case 1,, {} }", &expect![[r#"
+        Stmt [0-26]:
+            annotations: <empty>
+            kind: SwitchStmt [0-26]:
+                target: Expr [8-9]: Ident [8-9] "i"
+                cases:
+                    SwitchCase [13-24]:
+                        labels:
+                            Expr [18-19]: Lit: Int(1)
+                            Expr [20-20]: Err
+                        block: Block [22-24]: <empty>
+                default_case: <none>
+
+        [
+            Error(
+                MissingSeqEntry(
+                    Span {
+                        lo: 20,
+                        hi: 20,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn default_case_with_label() {
+    check(parse, "switch (i) { default 0 {} }", &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Brace,
+                ),
+                Literal(
+                    Integer(
+                        Decimal,
+                    ),
+                ),
+                Span {
+                    lo: 21,
+                    hi: 22,
+                },
+            ),
+        )
+
+        [
+            Error(
+                MissingSwitchCases(
+                    Span {
+                        lo: 13,
+                        hi: 12,
+                    },
+                ),
+            ),
+        ]"#]]);
+}
+
+#[test]
+fn bad_case_syntax() {
+    check(parse, "switch (i) { default, default {} }", &expect![[r#"
+        Error(
+            Token(
+                Open(
+                    Brace,
+                ),
+                Comma,
+                Span {
+                    lo: 20,
+                    hi: 21,
+                },
+            ),
+        )
+
+        [
+            Error(
+                MissingSwitchCases(
+                    Span {
+                        lo: 13,
+                        hi: 12,
+                    },
+                ),
+            ),
+        ]"#]]);
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/tokens.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/tokens.rs
@@ -1,0 +1,298 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::parser::{stmt::parse, tests::check};
+use expect_test::expect;
+
+#[test]
+fn bad_tokens() {
+    check(
+        parse,
+        "#;",
+        &expect![[r#"
+        Stmt [1-2]:
+            annotations: <empty>
+            kind: Empty
+
+        [
+            Error(
+                Lex(
+                    Incomplete(
+                        Ident,
+                        Identifier,
+                        Single(
+                            Semi,
+                        ),
+                        Span {
+                            lo: 1,
+                            hi: 2,
+                        },
+                    ),
+                ),
+            ),
+        ]"#]],
+    );
+
+    check(
+        parse,
+        "3x;",
+        &expect![[r#"
+        Error(
+            ExpectedItem(
+                Identifier,
+                Span {
+                    lo: 0,
+                    hi: 1,
+                },
+            ),
+        )
+    "#]],
+    );
+
+    check(
+        parse,
+        "x@x;",
+        &expect![[r#"
+        Stmt [0-1]:
+            annotations: <empty>
+            kind: ExprStmt [0-1]:
+                expr: Expr [0-1]: Ident [0-1] "x"
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    At,
+                    Span {
+                        lo: 1,
+                        hi: 2,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+
+    check(
+        parse,
+        "3.4.3;",
+        &expect![[r#"
+        Stmt [0-3]:
+            annotations: <empty>
+            kind: ExprStmt [0-3]:
+                expr: Expr [0-3]: Lit: Float(3.4)
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Literal(
+                        Float,
+                    ),
+                    Span {
+                        lo: 3,
+                        hi: 5,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+
+    check(
+        parse,
+        "3.4e3e3;",
+        &expect![[r#"
+        Error(
+            ExpectedItem(
+                Identifier,
+                Span {
+                    lo: 0,
+                    hi: 5,
+                },
+            ),
+        )
+    "#]],
+    );
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn bad_integer_literals() {
+    check(
+        parse,
+        "3_4_;",
+        &expect![[r#"
+        Stmt [4-5]:
+            annotations: <empty>
+            kind: Empty
+
+        [
+            Error(
+                Lex(
+                    Unknown(
+                        '3',
+                        Span {
+                            lo: 0,
+                            hi: 4,
+                        },
+                    ),
+                ),
+            ),
+        ]"#]],
+    );
+
+    check(
+        parse,
+        "0b123;",
+        &expect![[r#"
+        Stmt [0-3]:
+            annotations: <empty>
+            kind: ExprStmt [0-3]:
+                expr: Expr [0-3]: Lit: Int(1)
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Literal(
+                        Integer(
+                            Decimal,
+                        ),
+                    ),
+                    Span {
+                        lo: 3,
+                        hi: 5,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+
+    check(
+        parse,
+        "0B123;",
+        &expect![[r#"
+        Stmt [0-3]:
+            annotations: <empty>
+            kind: ExprStmt [0-3]:
+                expr: Expr [0-3]: Lit: Int(1)
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Literal(
+                        Integer(
+                            Decimal,
+                        ),
+                    ),
+                    Span {
+                        lo: 3,
+                        hi: 5,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+
+    check(
+        parse,
+        "0o789;",
+        &expect![[r#"
+        Stmt [0-3]:
+            annotations: <empty>
+            kind: ExprStmt [0-3]:
+                expr: Expr [0-3]: Lit: Int(7)
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Literal(
+                        Integer(
+                            Decimal,
+                        ),
+                    ),
+                    Span {
+                        lo: 3,
+                        hi: 5,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+
+    check(
+        parse,
+        "0O789;",
+        &expect![[r#"
+        Stmt [0-3]:
+            annotations: <empty>
+            kind: ExprStmt [0-3]:
+                expr: Expr [0-3]: Lit: Int(7)
+
+        [
+            Error(
+                Token(
+                    Semicolon,
+                    Literal(
+                        Integer(
+                            Decimal,
+                        ),
+                    ),
+                    Span {
+                        lo: 3,
+                        hi: 5,
+                    },
+                ),
+            ),
+        ]"#]],
+    );
+
+    check(
+        parse,
+        "0x12g;",
+        &expect![[r#"
+        Error(
+            ExpectedItem(
+                Identifier,
+                Span {
+                    lo: 0,
+                    hi: 4,
+                },
+            ),
+        )
+    "#]],
+    );
+
+    check(
+        parse,
+        "0X12g;",
+        &expect![[r#"
+        Error(
+            ExpectedItem(
+                Identifier,
+                Span {
+                    lo: 0,
+                    hi: 4,
+                },
+            ),
+        )
+    "#]],
+    );
+
+    check(
+        parse,
+        "12af;",
+        &expect![[r#"
+        Error(
+            ExpectedItem(
+                Identifier,
+                Span {
+                    lo: 0,
+                    hi: 2,
+                },
+            ),
+        )
+    "#]],
+    );
+}


### PR DESCRIPTION
This PR fixes a bug with block statements and adds grammar docstrings to the QASM3 parser.