### PR TITLE
Added support for light/dark theme toggle in the Playground editor

### DIFF
--- a/npm/qsharp/ux/qsharp-ux.css
+++ b/npm/qsharp/ux/qsharp-ux.css
@@ -48,6 +48,7 @@ modern-normalize (see https://mattbrictson.com/blog/css-normalize-and-reset for 
   --error-background-color: #ffe3e3;
   --warning-background-color: #fff6d7;
   --bar-selected-outline: #587ddd;
+  --file-background: #fff;
 }
 
 /* TODO: Make the below playground specific classes */
@@ -142,7 +143,7 @@ modern-normalize (see https://mattbrictson.com/blog/css-normalize-and-reset for 
   text-align: center;
   height: 32px;
   line-height: 32px;
-  background-color: white;
+  background-color: var(--file-name-background);
 }
 
 .icon-row > * {

--- a/playground/public/index.html
+++ b/playground/public/index.html
@@ -16,7 +16,7 @@
       rel="icon"
       href="data:image/gif;base64,R0lGODlhEAAQAAAAACwAAAAAEAAQAAACDvAxdbn9YZSTVntx1qcAADs="
     />
-    <link rel="stylesheet" href="libs/katex/github-markdown-light.css" />
+    <link rel="stylesheet" href="libs/katex/github-markdown.css" />
     <link rel="stylesheet" href="libs/katex/katex.min.css" />
     <link rel="stylesheet" href="libs/main.css" />
     <title>Q# playground</title>

--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -76,7 +76,7 @@ export function getProfile(): TargetProfile {
 }
 
 // get the preferred theme from system setting
-export function getPreferredTheme(): "light" | "dark" {
+function getPreferredTheme(): "light" | "dark" {
   if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
     return "dark";
   }
@@ -257,10 +257,11 @@ export function Editor(props: {
 
   useEffect(() => {
     if (!editorDiv.current) return;
+    const initialTheme = getPreferredTheme();
     const newEditor = monaco.editor.create(editorDiv.current, {
       minimap: { enabled: false },
       lineNumbersMinChars: 3,
-      theme: theme === "dark" ? "vs-dark" : "vs",
+      theme: initialTheme === "dark" ? "vs-dark" : "vs",
     });
 
     editor.current = newEditor;

--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -75,15 +75,6 @@ export function getProfile(): TargetProfile {
     "unrestricted") as TargetProfile;
 }
 
-// get the preferred theme from system setting
-function getPreferredTheme(): "light" | "dark" {
-  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    return "dark";
-  }
-
-  return "light";
-}
-
 export function Editor(props: {
   code: string;
   compiler: ICompilerWorker;
@@ -103,6 +94,7 @@ export function Editor(props: {
   setQir: (qir: string) => void;
   activeTab: ActiveTab;
   languageService: ILanguageServiceWorker;
+  initialTheme?: "light" | "dark";
 }) {
   const editor = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const errMarks = useRef<ErrCollection>({ checkDiags: [], shotDiags: [] });
@@ -119,7 +111,7 @@ export function Editor(props: {
     { location: string; severity: monaco.MarkerSeverity; msg: string[] }[]
   >([]);
   const [hasCheckErrors, setHasCheckErrors] = useState(false);
-  const [theme, setTheme] = useState<"light" | "dark">(getPreferredTheme());
+  const [theme, setTheme] = useState<"light" | "dark">(props.initialTheme || "light");
 
   function markErrors() {
     const model = editor.current?.getModel();
@@ -257,11 +249,11 @@ export function Editor(props: {
 
   useEffect(() => {
     if (!editorDiv.current) return;
-    const initialTheme = getPreferredTheme();
+
     const newEditor = monaco.editor.create(editorDiv.current, {
       minimap: { enabled: false },
       lineNumbersMinChars: 3,
-      theme: initialTheme === "dark" ? "vs-dark" : "vs",
+      theme: props.initialTheme === "dark" ? "vs-dark" : "vs",
     });
 
     editor.current = newEditor;
@@ -315,10 +307,14 @@ export function Editor(props: {
   }, []);
 
   useEffect(() => {
-    if (editor.current) {
-      monaco.editor.setTheme(theme === "dark" ? "vs-dark" : "vs");
+    if (props.initialTheme && props.initialTheme !== theme) {
+      setTheme(props.initialTheme);
+
+      if (editor.current) {
+        monaco.editor.setTheme(props.initialTheme === "dark" ? "vs-dark" : "vs");
+      }
     }
-  }, [theme]);
+  }, [props.initialTheme]);
 
   useEffect(() => {
     props.languageService.updateConfiguration({
@@ -430,40 +426,11 @@ export function Editor(props: {
     setProfile(target.value as TargetProfile);
   }
 
-  function toggleTheme() {
-    setTheme(theme === "light" ? "dark" : "light");
-  }
-
   return (
     <div class="editor-column">
       <div style="display: flex; justify-content: space-between; align-items: center;">
         <div class="file-name">main.qs</div>
         <div class="icon-row">
-          <svg
-            onClick={toggleTheme}
-            width="24px"
-            height="24px"
-            viewBox="0 0 24 24"
-            fill="none"
-          >
-            <title>{theme === "light" ? "Switch to dark theme" : "Switch to light theme"}</title>
-            {theme === "light" ? (
-              <path
-                d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"
-                stroke="#0C0310"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            ) : (
-              <path
-                d="M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"
-                stroke="#0C0310"
-                stroke-width="2"
-                stroke-linecap="round"
-              />
-            )}
-          </svg>
           <svg
             onClick={onGetLink}
             width="24px"
@@ -474,7 +441,7 @@ export function Editor(props: {
             <title>Get a link to this code</title>
             <path
               d="M14 12C14 14.2091 12.2091 16 10 16H6C3.79086 16 2 14.2091 2 12C2 9.79086 3.79086 8 6 8H8M10 12C10 9.79086 11.7909 8 14 8H18C20.2091 8 22 9.79086 22 12C22 14.2091 20.2091 16 18 16H16"
-              stroke="#000000"
+              stroke="currentColor"
               stroke-width="2"
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -490,13 +457,13 @@ export function Editor(props: {
             <title>Reset code to initial state</title>
             <path
               d="M4,13 C4,17.4183 7.58172,21 12,21 C16.4183,21 20,17.4183 20,13 C20,8.58172 16.4183,5 12,5 C10.4407,5 8.98566,5.44609 7.75543,6.21762"
-              stroke="#0C0310"
+              stroke="currentColor"
               stroke-width="2"
               stroke-linecap="round"
             ></path>
             <path
               d="M9.2384,1.89795 L7.49856,5.83917 C7.27552,6.34441 7.50429,6.9348 8.00954,7.15784 L11.9508,8.89768"
-              stroke="#0C0310"
+              stroke="currentColor"
               stroke-width="2"
               stroke-linecap="round"
             ></path>

--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -75,13 +75,8 @@ export function getProfile(): TargetProfile {
     "unrestricted") as TargetProfile;
 }
 
-// get the preferred theme from localStorage
-// default to system setting
+// get the preferred theme from system setting
 export function getPreferredTheme(): "light" | "dark" {
-  const savedTheme = localStorage.getItem("qsharp-editor-theme");
-  if (savedTheme === "dark") return "dark";
-  if (savedTheme === "light") return "light";
-
   if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
     return "dark";
   }
@@ -322,7 +317,6 @@ export function Editor(props: {
     if (editor.current) {
       monaco.editor.setTheme(theme === "dark" ? "vs-dark" : "vs");
     }
-    localStorage.setItem("qsharp-editor-theme", theme);
   }, [theme]);
 
   useEffect(() => {

--- a/playground/src/kata.tsx
+++ b/playground/src/kata.tsx
@@ -28,6 +28,7 @@ type Props = {
   compilerState: CompilerState;
   onRestartCompiler: () => void;
   languageService: ILanguageServiceWorker;
+  theme?: "light" | "dark";
 };
 
 function ExplainedSolutionElem(props: { solution: ExplainedSolution }) {
@@ -117,6 +118,7 @@ function LessonElem(props: Props & { section: KataSection }) {
                     setQir={() => ({})}
                     activeTab="results-tab"
                     languageService={props.languageService}
+                    initialTheme={props.theme}
                   ></Editor>
                   <OutputTabs
                     evtTarget={evtHandler}
@@ -182,6 +184,7 @@ function ExerciseElem(props: Props & { section: KataSection }) {
           setQir={() => ({})}
           activeTab="results-tab"
           languageService={props.languageService}
+          initialTheme={props.theme}
         ></Editor>
         <OutputTabs
           evtTarget={evtHandler}

--- a/playground/src/main.css
+++ b/playground/src/main.css
@@ -17,8 +17,179 @@ html {
   line-height: 125%;
 }
 pre:has(code) {
-  background-color: White;
-  border-left: solid DarkBlue;
+  background-color: #fff;
+  border-left: solid var(--border-color, #ddd);
   margin: 5px 0px 5px 0px;
   padding: 0em 0em 0em 0.5em;
+}
+
+[data-theme="dark"] {
+  --heading-background: #6a6565;
+  --main-background: #222;
+  --main-color: #eee;
+  --qs-tr-nth-color: #333;
+  --nav-background: #222;
+  --nav-hover-background: #333;
+  --nav-current-background: #444;
+  --border-color: #555;
+  --menu-box-fill: #222;
+  --error-background-color: #422;
+  --warning-background-color: #665;
+  --bar-selected-outline: #789;
+  --file-background: #222;
+
+  textarea {
+    background-color: var(--menu-box-fill, #222);
+    color: var(--main-color, #eee);
+    border-color: var(--border-color, #555);
+  }
+
+  pre:has(code) {
+    background-color: #000;
+  }
+}
+
+body[data-theme="dark"] .markdown-body {
+    /*dark*/
+    color-scheme: dark;
+    --color-prettylights-syntax-comment: #8b949e;
+    --color-prettylights-syntax-constant: #79c0ff;
+    --color-prettylights-syntax-entity: #d2a8ff;
+    --color-prettylights-syntax-storage-modifier-import: #c9d1d9;
+    --color-prettylights-syntax-entity-tag: #7ee787;
+    --color-prettylights-syntax-keyword: #ff7b72;
+    --color-prettylights-syntax-string: #a5d6ff;
+    --color-prettylights-syntax-variable: #ffa657;
+    --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
+    --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
+    --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
+    --color-prettylights-syntax-carriage-return-text: #f0f6fc;
+    --color-prettylights-syntax-carriage-return-bg: #b62324;
+    --color-prettylights-syntax-string-regexp: #7ee787;
+    --color-prettylights-syntax-markup-list: #f2cc60;
+    --color-prettylights-syntax-markup-heading: #1f6feb;
+    --color-prettylights-syntax-markup-italic: #c9d1d9;
+    --color-prettylights-syntax-markup-bold: #c9d1d9;
+    --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
+    --color-prettylights-syntax-markup-deleted-bg: #67060c;
+    --color-prettylights-syntax-markup-inserted-text: #aff5b4;
+    --color-prettylights-syntax-markup-inserted-bg: #033a16;
+    --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+    --color-prettylights-syntax-markup-changed-bg: #5a1e02;
+    --color-prettylights-syntax-markup-ignored-text: #c9d1d9;
+    --color-prettylights-syntax-markup-ignored-bg: #1158c7;
+    --color-prettylights-syntax-meta-diff-range: #d2a8ff;
+    --color-prettylights-syntax-brackethighlighter-angle: #8b949e;
+    --color-prettylights-syntax-sublimelinter-gutter-mark: #484f58;
+    --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
+    --color-fg-default: #e6edf3;
+    --color-fg-muted: #848d97;
+    --color-fg-subtle: #6e7681;
+    --color-canvas-default: #0d1117;
+    --color-canvas-subtle: #161b22;
+    --color-border-default: #30363d;
+    --color-border-muted: #21262d;
+    --color-neutral-muted: rgba(110,118,129,0.4);
+    --color-accent-fg: #2f81f7;
+    --color-accent-emphasis: #1f6feb;
+    --color-success-fg: #3fb950;
+    --color-success-emphasis: #238636;
+    --color-attention-fg: #d29922;
+    --color-attention-emphasis: #9e6a03;
+    --color-attention-subtle: rgba(187,128,9,0.15);
+    --color-danger-fg: #f85149;
+    --color-danger-emphasis: #da3633;
+    --color-done-fg: #a371f7;
+    --color-done-emphasis: #8957e5;
+}
+
+body[data-theme="light"] .markdown-body {
+    /*light*/
+    color-scheme: light;
+    --color-prettylights-syntax-comment: #57606a;
+    --color-prettylights-syntax-constant: #0550ae;
+    --color-prettylights-syntax-entity: #6639ba;
+    --color-prettylights-syntax-storage-modifier-import: #24292f;
+    --color-prettylights-syntax-entity-tag: #116329;
+    --color-prettylights-syntax-keyword: #cf222e;
+    --color-prettylights-syntax-string: #0a3069;
+    --color-prettylights-syntax-variable: #953800;
+    --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
+    --color-prettylights-syntax-invalid-illegal-text: #f6f8fa;
+    --color-prettylights-syntax-invalid-illegal-bg: #82071e;
+    --color-prettylights-syntax-carriage-return-text: #f6f8fa;
+    --color-prettylights-syntax-carriage-return-bg: #cf222e;
+    --color-prettylights-syntax-string-regexp: #116329;
+    --color-prettylights-syntax-markup-list: #3b2300;
+    --color-prettylights-syntax-markup-heading: #0550ae;
+    --color-prettylights-syntax-markup-italic: #24292f;
+    --color-prettylights-syntax-markup-bold: #24292f;
+    --color-prettylights-syntax-markup-deleted-text: #82071e;
+    --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
+    --color-prettylights-syntax-markup-inserted-text: #116329;
+    --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
+    --color-prettylights-syntax-markup-changed-text: #953800;
+    --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
+    --color-prettylights-syntax-markup-ignored-text: #eaeef2;
+    --color-prettylights-syntax-markup-ignored-bg: #0550ae;
+    --color-prettylights-syntax-meta-diff-range: #8250df;
+    --color-prettylights-syntax-brackethighlighter-angle: #57606a;
+    --color-prettylights-syntax-sublimelinter-gutter-mark: #8c959f;
+    --color-prettylights-syntax-constant-other-reference-link: #0a3069;
+    --color-fg-default: #1F2328;
+    --color-fg-muted: #656d76;
+    --color-fg-subtle: #6e7781;
+    --color-canvas-default: #ffffff;
+    --color-canvas-subtle: #f6f8fa;
+    --color-border-default: #d0d7de;
+    --color-border-muted: hsla(210,18%,87%,1);
+    --color-neutral-muted: rgba(175,184,193,0.2);
+    --color-accent-fg: #0969da;
+    --color-accent-emphasis: #0969da;
+    --color-success-fg: #1a7f37;
+    --color-success-emphasis: #1f883d;
+    --color-attention-fg: #9a6700;
+    --color-attention-emphasis: #9a6700;
+    --color-attention-subtle: #fff8c5;
+    --color-danger-fg: #d1242f;
+    --color-danger-emphasis: #cf222e;
+    --color-done-fg: #8250df;
+    --color-done-emphasis: #8250df;
+}
+
+.nav-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 10px;
+}
+
+.theme-toggle {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+}
+
+.theme-toggle:hover {
+  background-color: var(--nav-hover-background, #eee);
+}
+
+.theme-toggle svg {
+  color: var(--main-color, #333);
+}
+
+[data-theme="dark"] .theme-toggle svg {
+  color: #eee;
+}
+
+[data-theme="light"] .theme-toggle svg {
+  color: #333;
+}
+
+[data-theme="dark"] .icon-row svg {
+  color: #eee;
 }

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -69,6 +69,17 @@ const modulePath = basePath + "libs/qsharp/qsc_wasm_bg.wasm";
 const compilerWorkerPath = basePath + "libs/compiler-worker.js";
 const languageServiceWorkerPath = basePath + "libs/language-service-worker.js";
 
+// get the preferred theme from system setting
+function getPreferredTheme(): "light" | "dark" {
+  if (
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  ) {
+    return "dark";
+  }
+  return "light";
+}
+
 function telemetryHandler({ id, data }: { id: string; data?: any }) {
   // NOTE: This is for demo purposes. Wire up to the real telemetry library.
   console.log(`Received telemetry event: "%s" with payload: %o`, id, data);
@@ -112,6 +123,12 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
   const [rir, setRir] = useState<string[]>(["", ""]);
   const [qir, setQir] = useState<string>("");
   const [activeTab, setActiveTab] = useState<ActiveTab>("results-tab");
+  const [theme, setTheme] = useState<"light" | "dark">(getPreferredTheme());
+
+  useEffect(() => {
+    // apply theme to document body when theme changes
+    document.body.setAttribute("data-theme", theme);
+  }, [theme]);
 
   const onRestartCompiler = () => {
     compiler.terminate();
@@ -157,6 +174,10 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
     setCurrentNavItem(name);
   }
 
+  const onThemeChange = (newTheme: "light" | "dark") => {
+    setTheme(newTheme);
+  };
+
   return (
     <>
       <header class="page-header">Q# playground</header>
@@ -166,6 +187,8 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
         katas={kataTitles}
         samples={sampleTitles}
         namespaces={getNamespaces(documentation)}
+        theme={theme}
+        onThemeChange={onThemeChange}
       ></Nav>
       {sampleCode ? (
         <>
@@ -187,6 +210,7 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
             setQir={setQir}
             activeTab={activeTab}
             languageService={languageService}
+            initialTheme={theme}
           ></Editor>
           <OutputTabs
             evtTarget={evtTarget}
@@ -208,6 +232,7 @@ function App(props: { katas: Kata[]; linkedCode?: string }) {
           compilerState={compilerState}
           onRestartCompiler={onRestartCompiler}
           languageService={languageService}
+          theme={theme}
         ></Katas>
       ) : (
         <DocumentationDisplay
@@ -249,6 +274,9 @@ async function loaded() {
       linkedCode = "// Unable to decode the code in the URL\n";
     }
   }
+
+  const initialTheme = getPreferredTheme();
+  document.body.setAttribute("data-theme", initialTheme);
 
   render(<App katas={katas} linkedCode={linkedCode}></App>, document.body);
 }

--- a/playground/src/nav.tsx
+++ b/playground/src/nav.tsx
@@ -7,15 +7,54 @@ export function Nav(props: {
   katas: string[];
   samples: string[];
   namespaces: string[];
+  theme?: "light" | "dark";
+  onThemeChange?: (theme: "light" | "dark") => void;
 }) {
   function onSelected(name: string) {
     props.navSelected(name);
   }
 
+  function toggleTheme() {
+    if (props.onThemeChange) {
+      props.onThemeChange(props.theme === "light" ? "dark" : "light");
+    }
+  }
+
   return (
     <nav class="nav-column">
-      <div class="nav-1">Samples</div>
-
+      <div class="nav-header">
+        <div class="nav-1">Samples</div>
+        {props.onThemeChange && (
+          <div class="theme-toggle" onClick={toggleTheme}>
+            <svg
+              width="20px"
+              height="20px"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              {props.theme === "light" ? (
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+              ) : (
+                <>
+                  <circle cx="12" cy="12" r="5"></circle>
+                  <line x1="12" y1="1" x2="12" y2="3"></line>
+                  <line x1="12" y1="21" x2="12" y2="23"></line>
+                  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                  <line x1="1" y1="12" x2="3" y2="12"></line>
+                  <line x1="21" y1="12" x2="23" y2="12"></line>
+                  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                </>
+              )}
+            </svg>
+          </div>
+        )}
+      </div>
       {props.samples.map((name) => (
         <div
           class={

--- a/vscode/build.mjs
+++ b/vscode/build.mjs
@@ -79,6 +79,10 @@ export function copyKatex(destDir) {
 
   // github markdown css
   copyFileSync(
+    join(libsDir, `github-markdown-css/github-markdown.css`),
+    join(katexDest, "github-markdown.css"),
+  );
+  copyFileSync(
     join(libsDir, `github-markdown-css/github-markdown-light.css`),
     join(katexDest, "github-markdown-light.css"),
   );


### PR DESCRIPTION
The playground editor theme is now in based on the current system theme.
There is also a new button to toggle between dark/light themes.

![out](https://github.com/user-attachments/assets/a549cb21-d341-4b2d-94c0-7bbac2df19fd)

