### PR TITLE
Make control flow stmts use Stmt instead of List<Stmt> for their bodies.

### DIFF
--- a/compiler/qsc_qasm3/src/parser/ast.rs
+++ b/compiler/qsc_qasm3/src/parser/ast.rs
@@ -317,7 +317,7 @@ pub enum StmtKind {
     Barrier(BarrierStmt),
     Box(BoxStmt),
     Break(BreakStmt),
-    Block(Box<Block>),
+    Block(Block),
     Cal(CalibrationStmt),
     CalibrationGrammar(CalibrationGrammarStmt),
     ClassicalDecl(ClassicalDeclarationStmt),
@@ -419,16 +419,16 @@ impl Display for DefCalStmt {
 pub struct IfStmt {
     pub span: Span,
     pub condition: Expr,
-    pub if_block: List<Stmt>,
-    pub else_block: Option<List<Stmt>>,
+    pub if_block: Block,
+    pub else_block: Option<Block>,
 }
 
 impl Display for IfStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "IfStmt", self.span)?;
         writeln_field(f, "condition", &self.condition)?;
-        writeln_list_field(f, "if_block", &self.if_block)?;
-        write_opt_list_field(f, "else_block", self.else_block.as_ref())
+        writeln_field(f, "if_block", &self.if_block)?;
+        write_opt_field(f, "else_block", self.else_block.as_ref())
     }
 }
 
@@ -1323,8 +1323,8 @@ pub struct DefStmt {
     pub span: Span,
     pub name: Box<Ident>,
     pub params: List<TypedParameter>,
-    pub body: Box<Block>,
-    pub return_type: Option<ScalarType>,
+    pub body: Block,
+    pub return_type: Option<Box<ScalarType>>,
 }
 
 impl Display for DefStmt {
@@ -1354,14 +1354,14 @@ impl Display for ReturnStmt {
 pub struct WhileLoop {
     pub span: Span,
     pub while_condition: Expr,
-    pub block: List<Stmt>,
+    pub block: Block,
 }
 
 impl Display for WhileLoop {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "WhileLoop", self.span)?;
         writeln_field(f, "condition", &self.while_condition)?;
-        write_list_field(f, "block", &self.block)
+        write_field(f, "block", &self.block)
     }
 }
 
@@ -1371,7 +1371,7 @@ pub struct ForStmt {
     pub ty: ScalarType,
     pub identifier: Identifier,
     pub set_declaration: Box<EnumerableSet>,
-    pub block: List<Stmt>,
+    pub block: Block,
 }
 
 impl Display for ForStmt {
@@ -1380,7 +1380,7 @@ impl Display for ForStmt {
         writeln_field(f, "variable_type", &self.ty)?;
         writeln_field(f, "variable_name", &self.identifier)?;
         writeln_field(f, "iterable", &self.set_declaration)?;
-        write_list_field(f, "block", &self.block)
+        write_field(f, "block", &self.block)
     }
 }
 

--- a/compiler/qsc_qasm3/src/parser/ast.rs
+++ b/compiler/qsc_qasm3/src/parser/ast.rs
@@ -419,16 +419,16 @@ impl Display for DefCalStmt {
 pub struct IfStmt {
     pub span: Span,
     pub condition: Expr,
-    pub if_block: Block,
-    pub else_block: Option<Block>,
+    pub if_body: Stmt,
+    pub else_body: Option<Stmt>,
 }
 
 impl Display for IfStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "IfStmt", self.span)?;
         writeln_field(f, "condition", &self.condition)?;
-        writeln_field(f, "if_block", &self.if_block)?;
-        write_opt_field(f, "else_block", self.else_block.as_ref())
+        writeln_field(f, "if_body", &self.if_body)?;
+        write_opt_field(f, "else_body", self.else_body.as_ref())
     }
 }
 
@@ -1354,14 +1354,14 @@ impl Display for ReturnStmt {
 pub struct WhileLoop {
     pub span: Span,
     pub while_condition: Expr,
-    pub block: Block,
+    pub body: Stmt,
 }
 
 impl Display for WhileLoop {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "WhileLoop", self.span)?;
         writeln_field(f, "condition", &self.while_condition)?;
-        write_field(f, "block", &self.block)
+        write_field(f, "body", &self.body)
     }
 }
 
@@ -1371,7 +1371,7 @@ pub struct ForStmt {
     pub ty: ScalarType,
     pub identifier: Identifier,
     pub set_declaration: Box<EnumerableSet>,
-    pub block: Block,
+    pub body: Stmt,
 }
 
 impl Display for ForStmt {
@@ -1380,7 +1380,7 @@ impl Display for ForStmt {
         writeln_field(f, "variable_type", &self.ty)?;
         writeln_field(f, "variable_name", &self.identifier)?;
         writeln_field(f, "iterable", &self.set_declaration)?;
-        write_field(f, "block", &self.block)
+        write_field(f, "body", &self.body)
     }
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
@@ -24,7 +24,7 @@ fn simple_for_loop() {
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block:
+                    block: Block [28-50]:
                         Stmt [38-44]:
                             annotations: <empty>
                             kind: AssignStmt [38-44]:
@@ -49,7 +49,7 @@ fn empty_for_loop() {
                     variable_name: Ident [8-9] "x"
                     iterable: DiscreteSet [13-15]:
                         values: <empty>
-                    block: <empty>"#]],
+                    block: Block [16-18]: <empty>"#]],
     );
 }
 
@@ -73,7 +73,7 @@ fn simple_for_loop_stmt_body() {
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block:
+                    block: Block [36-42]:
                         Stmt [36-42]:
                             annotations: <empty>
                             kind: AssignStmt [36-42]:
@@ -103,7 +103,7 @@ fn for_loop_range() {
                         start: Expr [19-20]: Lit: Int(0)
                         step: Expr [21-22]: Lit: Int(2)
                         end: Expr [23-24]: Lit: Int(7)
-                    block:
+                    block: Block [26-48]:
                         Stmt [36-42]:
                             annotations: <empty>
                             kind: AssignStmt [36-42]:
@@ -133,7 +133,7 @@ fn for_loop_range_no_step() {
                         start: Expr [19-20]: Lit: Int(0)
                         step: <none>
                         end: Expr [21-22]: Lit: Int(7)
-                    block:
+                    block: Block [24-46]:
                         Stmt [34-40]:
                             annotations: <empty>
                             kind: AssignStmt [34-40]:
@@ -160,7 +160,7 @@ fn for_loop_expr() {
                         size: <none>
                     variable_name: Ident [13-14] "x"
                     iterable: Expr [18-20]: Ident [18-20] "xs"
-                    block:
+                    block: Block [21-43]:
                         Stmt [31-37]:
                             annotations: <empty>
                             kind: AssignStmt [31-37]:
@@ -192,7 +192,7 @@ fn for_loop_with_continue_stmt() {
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block:
+                    block: Block [28-68]:
                         Stmt [38-44]:
                             annotations: <empty>
                             kind: AssignStmt [38-44]:
@@ -227,7 +227,7 @@ fn for_loop_with_break_stmt() {
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block:
+                    block: Block [28-65]:
                         Stmt [38-44]:
                             annotations: <empty>
                             kind: AssignStmt [38-44]:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
@@ -24,14 +24,16 @@ fn simple_for_loop() {
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block: Block [28-50]:
-                        Stmt [38-44]:
-                            annotations: <empty>
-                            kind: AssignStmt [38-44]:
-                                lhs: IndexedIdent [38-39]:
-                                    name: Ident [38-39] "a"
-                                    indices: <empty>
-                                rhs: Expr [42-43]: Lit: Int(0)"#]],
+                    body: Stmt [28-50]:
+                        annotations: <empty>
+                        kind: Block [28-50]:
+                            Stmt [38-44]:
+                                annotations: <empty>
+                                kind: AssignStmt [38-44]:
+                                    lhs: IndexedIdent [38-39]:
+                                        name: Ident [38-39] "a"
+                                        indices: <empty>
+                                    rhs: Expr [42-43]: Lit: Int(0)"#]],
     );
 }
 
@@ -49,7 +51,9 @@ fn empty_for_loop() {
                     variable_name: Ident [8-9] "x"
                     iterable: DiscreteSet [13-15]:
                         values: <empty>
-                    block: Block [16-18]: <empty>"#]],
+                    body: Stmt [16-18]:
+                        annotations: <empty>
+                        kind: Block [16-18]: <empty>"#]],
     );
 }
 
@@ -73,14 +77,13 @@ fn simple_for_loop_stmt_body() {
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block: Block [36-42]:
-                        Stmt [36-42]:
-                            annotations: <empty>
-                            kind: AssignStmt [36-42]:
-                                lhs: IndexedIdent [36-37]:
-                                    name: Ident [36-37] "a"
-                                    indices: <empty>
-                                rhs: Expr [40-41]: Lit: Int(0)"#]],
+                    body: Stmt [36-42]:
+                        annotations: <empty>
+                        kind: AssignStmt [36-42]:
+                            lhs: IndexedIdent [36-37]:
+                                name: Ident [36-37] "a"
+                                indices: <empty>
+                            rhs: Expr [40-41]: Lit: Int(0)"#]],
     );
 }
 
@@ -103,14 +106,16 @@ fn for_loop_range() {
                         start: Expr [19-20]: Lit: Int(0)
                         step: Expr [21-22]: Lit: Int(2)
                         end: Expr [23-24]: Lit: Int(7)
-                    block: Block [26-48]:
-                        Stmt [36-42]:
-                            annotations: <empty>
-                            kind: AssignStmt [36-42]:
-                                lhs: IndexedIdent [36-37]:
-                                    name: Ident [36-37] "a"
-                                    indices: <empty>
-                                rhs: Expr [40-41]: Lit: Int(0)"#]],
+                    body: Stmt [26-48]:
+                        annotations: <empty>
+                        kind: Block [26-48]:
+                            Stmt [36-42]:
+                                annotations: <empty>
+                                kind: AssignStmt [36-42]:
+                                    lhs: IndexedIdent [36-37]:
+                                        name: Ident [36-37] "a"
+                                        indices: <empty>
+                                    rhs: Expr [40-41]: Lit: Int(0)"#]],
     );
 }
 
@@ -133,14 +138,16 @@ fn for_loop_range_no_step() {
                         start: Expr [19-20]: Lit: Int(0)
                         step: <none>
                         end: Expr [21-22]: Lit: Int(7)
-                    block: Block [24-46]:
-                        Stmt [34-40]:
-                            annotations: <empty>
-                            kind: AssignStmt [34-40]:
-                                lhs: IndexedIdent [34-35]:
-                                    name: Ident [34-35] "a"
-                                    indices: <empty>
-                                rhs: Expr [38-39]: Lit: Int(0)"#]],
+                    body: Stmt [24-46]:
+                        annotations: <empty>
+                        kind: Block [24-46]:
+                            Stmt [34-40]:
+                                annotations: <empty>
+                                kind: AssignStmt [34-40]:
+                                    lhs: IndexedIdent [34-35]:
+                                        name: Ident [34-35] "a"
+                                        indices: <empty>
+                                    rhs: Expr [38-39]: Lit: Int(0)"#]],
     );
 }
 
@@ -160,14 +167,16 @@ fn for_loop_expr() {
                         size: <none>
                     variable_name: Ident [13-14] "x"
                     iterable: Expr [18-20]: Ident [18-20] "xs"
-                    block: Block [21-43]:
-                        Stmt [31-37]:
-                            annotations: <empty>
-                            kind: AssignStmt [31-37]:
-                                lhs: IndexedIdent [31-32]:
-                                    name: Ident [31-32] "a"
-                                    indices: <empty>
-                                rhs: Expr [35-36]: Lit: Int(0)"#]],
+                    body: Stmt [21-43]:
+                        annotations: <empty>
+                        kind: Block [21-43]:
+                            Stmt [31-37]:
+                                annotations: <empty>
+                                kind: AssignStmt [31-37]:
+                                    lhs: IndexedIdent [31-32]:
+                                        name: Ident [31-32] "a"
+                                        indices: <empty>
+                                    rhs: Expr [35-36]: Lit: Int(0)"#]],
     );
 }
 
@@ -192,17 +201,19 @@ fn for_loop_with_continue_stmt() {
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block: Block [28-68]:
-                        Stmt [38-44]:
-                            annotations: <empty>
-                            kind: AssignStmt [38-44]:
-                                lhs: IndexedIdent [38-39]:
-                                    name: Ident [38-39] "a"
-                                    indices: <empty>
-                                rhs: Expr [42-43]: Lit: Int(0)
-                        Stmt [53-62]:
-                            annotations: <empty>
-                            kind: ContinueStmt [53-62]"#]],
+                    body: Stmt [28-68]:
+                        annotations: <empty>
+                        kind: Block [28-68]:
+                            Stmt [38-44]:
+                                annotations: <empty>
+                                kind: AssignStmt [38-44]:
+                                    lhs: IndexedIdent [38-39]:
+                                        name: Ident [38-39] "a"
+                                        indices: <empty>
+                                    rhs: Expr [42-43]: Lit: Int(0)
+                            Stmt [53-62]:
+                                annotations: <empty>
+                                kind: ContinueStmt [53-62]"#]],
     );
 }
 
@@ -227,16 +238,116 @@ fn for_loop_with_break_stmt() {
                             Expr [19-20]: Lit: Int(1)
                             Expr [22-23]: Lit: Int(2)
                             Expr [25-26]: Lit: Int(3)
-                    block: Block [28-65]:
-                        Stmt [38-44]:
-                            annotations: <empty>
-                            kind: AssignStmt [38-44]:
-                                lhs: IndexedIdent [38-39]:
-                                    name: Ident [38-39] "a"
-                                    indices: <empty>
-                                rhs: Expr [42-43]: Lit: Int(0)
-                        Stmt [53-59]:
-                            annotations: <empty>
-                            kind: BreakStmt [53-59]"#]],
+                    body: Stmt [28-65]:
+                        annotations: <empty>
+                        kind: Block [28-65]:
+                            Stmt [38-44]:
+                                annotations: <empty>
+                                kind: AssignStmt [38-44]:
+                                    lhs: IndexedIdent [38-39]:
+                                        name: Ident [38-39] "a"
+                                        indices: <empty>
+                                    rhs: Expr [42-43]: Lit: Int(0)
+                            Stmt [53-59]:
+                                annotations: <empty>
+                                kind: BreakStmt [53-59]"#]],
+    );
+}
+
+#[test]
+fn single_stmt_for_stmt() {
+    check(
+        parse,
+        "for int x in {} z q;",
+        &expect![[r#"
+            Stmt [0-20]:
+                annotations: <empty>
+                kind: ForStmt [0-20]:
+                    variable_type: ScalarType [4-7]: IntType [4-7]:
+                        size: <none>
+                    variable_name: Ident [8-9] "x"
+                    iterable: DiscreteSet [13-15]:
+                        values: <empty>
+                    body: Stmt [16-20]:
+                        annotations: <empty>
+                        kind: GateCall [16-20]:
+                            modifiers: <empty>
+                            name: Ident [16-17] "z"
+                            args: <empty>
+                            duration: <none>
+                            qubits:
+                                IndexedIdent [18-19]:
+                                    name: Ident [18-19] "q"
+                                    indices: <empty>"#]],
+    );
+}
+
+#[test]
+fn annotations_in_single_stmt_for_stmt() {
+    check(
+        parse,
+        "
+    for int x in {}
+        @foo
+        @bar
+        x = 5;",
+        &expect![[r#"
+            Stmt [5-61]:
+                annotations: <empty>
+                kind: ForStmt [5-61]:
+                    variable_type: ScalarType [9-12]: IntType [9-12]:
+                        size: <none>
+                    variable_name: Ident [13-14] "x"
+                    iterable: DiscreteSet [18-20]:
+                        values: <empty>
+                    body: Stmt [29-61]:
+                        annotations:
+                            Annotation [29-33]:
+                                identifier: "foo"
+                                value: <none>
+                            Annotation [42-46]:
+                                identifier: "bar"
+                                value: <none>
+                        kind: AssignStmt [55-61]:
+                            lhs: IndexedIdent [55-56]:
+                                name: Ident [55-56] "x"
+                                indices: <empty>
+                            rhs: Expr [59-60]: Lit: Int(5)"#]],
+    );
+}
+
+#[test]
+fn nested_single_stmt_for_stmt() {
+    check(
+        parse,
+        "for int x in {} for int y in {} z q;",
+        &expect![[r#"
+            Stmt [0-36]:
+                annotations: <empty>
+                kind: ForStmt [0-36]:
+                    variable_type: ScalarType [4-7]: IntType [4-7]:
+                        size: <none>
+                    variable_name: Ident [8-9] "x"
+                    iterable: DiscreteSet [13-15]:
+                        values: <empty>
+                    body: Stmt [16-36]:
+                        annotations: <empty>
+                        kind: ForStmt [16-36]:
+                            variable_type: ScalarType [20-23]: IntType [20-23]:
+                                size: <none>
+                            variable_name: Ident [24-25] "y"
+                            iterable: DiscreteSet [29-31]:
+                                values: <empty>
+                            body: Stmt [32-36]:
+                                annotations: <empty>
+                                kind: GateCall [32-36]:
+                                    modifiers: <empty>
+                                    name: Ident [32-33] "z"
+                                    args: <empty>
+                                    duration: <none>
+                                    qubits:
+                                        IndexedIdent [34-35]:
+                                            name: Ident [34-35] "q"
+                                            indices: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
@@ -23,22 +23,26 @@ fn simple_if_stmt() {
                         op: Eq
                         lhs: Expr [9-10]: Ident [9-10] "x"
                         rhs: Expr [14-15]: Ident [14-15] "y"
-                    if_block: Block [17-39]:
-                        Stmt [27-33]:
-                            annotations: <empty>
-                            kind: AssignStmt [27-33]:
-                                lhs: IndexedIdent [27-28]:
-                                    name: Ident [27-28] "a"
-                                    indices: <empty>
-                                rhs: Expr [31-32]: Lit: Int(0)
-                    else_block: Block [45-67]:
-                        Stmt [55-61]:
-                            annotations: <empty>
-                            kind: AssignStmt [55-61]:
-                                lhs: IndexedIdent [55-56]:
-                                    name: Ident [55-56] "a"
-                                    indices: <empty>
-                                rhs: Expr [59-60]: Lit: Int(1)"#]],
+                    if_body: Stmt [17-39]:
+                        annotations: <empty>
+                        kind: Block [17-39]:
+                            Stmt [27-33]:
+                                annotations: <empty>
+                                kind: AssignStmt [27-33]:
+                                    lhs: IndexedIdent [27-28]:
+                                        name: Ident [27-28] "a"
+                                        indices: <empty>
+                                    rhs: Expr [31-32]: Lit: Int(0)
+                    else_body: Stmt [45-67]:
+                        annotations: <empty>
+                        kind: Block [45-67]:
+                            Stmt [55-61]:
+                                annotations: <empty>
+                                kind: AssignStmt [55-61]:
+                                    lhs: IndexedIdent [55-56]:
+                                        name: Ident [55-56] "a"
+                                        indices: <empty>
+                                    rhs: Expr [59-60]: Lit: Int(1)"#]],
     );
 }
 
@@ -59,15 +63,17 @@ fn if_stmt_missing_else() {
                         op: Eq
                         lhs: Expr [9-10]: Ident [9-10] "x"
                         rhs: Expr [14-15]: Ident [14-15] "y"
-                    if_block: Block [17-39]:
-                        Stmt [27-33]:
-                            annotations: <empty>
-                            kind: AssignStmt [27-33]:
-                                lhs: IndexedIdent [27-28]:
-                                    name: Ident [27-28] "a"
-                                    indices: <empty>
-                                rhs: Expr [31-32]: Lit: Int(0)
-                    else_block: <none>"#]],
+                    if_body: Stmt [17-39]:
+                        annotations: <empty>
+                        kind: Block [17-39]:
+                            Stmt [27-33]:
+                                annotations: <empty>
+                                kind: AssignStmt [27-33]:
+                                    lhs: IndexedIdent [27-28]:
+                                        name: Ident [27-28] "a"
+                                        indices: <empty>
+                                    rhs: Expr [31-32]: Lit: Int(0)
+                    else_body: <none>"#]],
     );
 }
 
@@ -98,53 +104,236 @@ fn nested_if_stmts() {
                         op: Eq
                         lhs: Expr [9-10]: Ident [9-10] "x"
                         rhs: Expr [14-15]: Ident [14-15] "y"
-                    if_block: Block [17-113]:
-                        Stmt [27-107]:
-                            annotations: <empty>
-                            kind: IfStmt [27-107]:
-                                condition: Expr [31-39]: BinaryOpExpr:
-                                    op: Eq
-                                    lhs: Expr [31-33]: Ident [31-33] "x1"
-                                    rhs: Expr [37-39]: Ident [37-39] "y1"
-                                if_block: Block [41-71]:
-                                    Stmt [55-61]:
+                    if_body: Stmt [17-113]:
+                        annotations: <empty>
+                        kind: Block [17-113]:
+                            Stmt [27-107]:
+                                annotations: <empty>
+                                kind: IfStmt [27-107]:
+                                    condition: Expr [31-39]: BinaryOpExpr:
+                                        op: Eq
+                                        lhs: Expr [31-33]: Ident [31-33] "x1"
+                                        rhs: Expr [37-39]: Ident [37-39] "y1"
+                                    if_body: Stmt [41-71]:
                                         annotations: <empty>
-                                        kind: AssignStmt [55-61]:
-                                            lhs: IndexedIdent [55-56]:
-                                                name: Ident [55-56] "a"
-                                                indices: <empty>
-                                            rhs: Expr [59-60]: Lit: Int(0)
-                                else_block: Block [77-107]:
-                                    Stmt [91-97]:
+                                        kind: Block [41-71]:
+                                            Stmt [55-61]:
+                                                annotations: <empty>
+                                                kind: AssignStmt [55-61]:
+                                                    lhs: IndexedIdent [55-56]:
+                                                        name: Ident [55-56] "a"
+                                                        indices: <empty>
+                                                    rhs: Expr [59-60]: Lit: Int(0)
+                                    else_body: Stmt [77-107]:
                                         annotations: <empty>
-                                        kind: AssignStmt [91-97]:
-                                            lhs: IndexedIdent [91-92]:
-                                                name: Ident [91-92] "a"
-                                                indices: <empty>
-                                            rhs: Expr [95-96]: Lit: Int(1)
-                    else_block: Block [119-215]:
-                        Stmt [129-209]:
-                            annotations: <empty>
-                            kind: IfStmt [129-209]:
-                                condition: Expr [133-141]: BinaryOpExpr:
-                                    op: Eq
-                                    lhs: Expr [133-135]: Ident [133-135] "x2"
-                                    rhs: Expr [139-141]: Ident [139-141] "y2"
-                                if_block: Block [143-173]:
-                                    Stmt [157-163]:
+                                        kind: Block [77-107]:
+                                            Stmt [91-97]:
+                                                annotations: <empty>
+                                                kind: AssignStmt [91-97]:
+                                                    lhs: IndexedIdent [91-92]:
+                                                        name: Ident [91-92] "a"
+                                                        indices: <empty>
+                                                    rhs: Expr [95-96]: Lit: Int(1)
+                    else_body: Stmt [119-215]:
+                        annotations: <empty>
+                        kind: Block [119-215]:
+                            Stmt [129-209]:
+                                annotations: <empty>
+                                kind: IfStmt [129-209]:
+                                    condition: Expr [133-141]: BinaryOpExpr:
+                                        op: Eq
+                                        lhs: Expr [133-135]: Ident [133-135] "x2"
+                                        rhs: Expr [139-141]: Ident [139-141] "y2"
+                                    if_body: Stmt [143-173]:
                                         annotations: <empty>
-                                        kind: AssignStmt [157-163]:
-                                            lhs: IndexedIdent [157-158]:
-                                                name: Ident [157-158] "a"
-                                                indices: <empty>
-                                            rhs: Expr [161-162]: Lit: Int(2)
-                                else_block: Block [179-209]:
-                                    Stmt [193-199]:
+                                        kind: Block [143-173]:
+                                            Stmt [157-163]:
+                                                annotations: <empty>
+                                                kind: AssignStmt [157-163]:
+                                                    lhs: IndexedIdent [157-158]:
+                                                        name: Ident [157-158] "a"
+                                                        indices: <empty>
+                                                    rhs: Expr [161-162]: Lit: Int(2)
+                                    else_body: Stmt [179-209]:
                                         annotations: <empty>
-                                        kind: AssignStmt [193-199]:
-                                            lhs: IndexedIdent [193-194]:
-                                                name: Ident [193-194] "a"
-                                                indices: <empty>
-                                            rhs: Expr [197-198]: Lit: Int(3)"#]],
+                                        kind: Block [179-209]:
+                                            Stmt [193-199]:
+                                                annotations: <empty>
+                                                kind: AssignStmt [193-199]:
+                                                    lhs: IndexedIdent [193-194]:
+                                                        name: Ident [193-194] "a"
+                                                        indices: <empty>
+                                                    rhs: Expr [197-198]: Lit: Int(3)"#]],
+    );
+}
+
+#[test]
+fn single_stmt_if_stmt() {
+    check(
+        parse,
+        "if (x) z q;",
+        &expect![[r#"
+            Stmt [0-11]:
+                annotations: <empty>
+                kind: IfStmt [0-11]:
+                    condition: Expr [4-5]: Ident [4-5] "x"
+                    if_body: Stmt [7-11]:
+                        annotations: <empty>
+                        kind: GateCall [7-11]:
+                            modifiers: <empty>
+                            name: Ident [7-8] "z"
+                            args: <empty>
+                            duration: <none>
+                            qubits:
+                                IndexedIdent [9-10]:
+                                    name: Ident [9-10] "q"
+                                    indices: <empty>
+                    else_body: <none>"#]],
+    );
+}
+
+#[test]
+fn annotations_in_single_stmt_if_stmt() {
+    check(
+        parse,
+        "
+    if (x)
+        @foo
+        @bar
+        x = 5;",
+        &expect![[r#"
+            Stmt [5-52]:
+                annotations: <empty>
+                kind: IfStmt [5-52]:
+                    condition: Expr [9-10]: Ident [9-10] "x"
+                    if_body: Stmt [20-52]:
+                        annotations:
+                            Annotation [20-24]:
+                                identifier: "foo"
+                                value: <none>
+                            Annotation [33-37]:
+                                identifier: "bar"
+                                value: <none>
+                        kind: AssignStmt [46-52]:
+                            lhs: IndexedIdent [46-47]:
+                                name: Ident [46-47] "x"
+                                indices: <empty>
+                            rhs: Expr [50-51]: Lit: Int(5)
+                    else_body: <none>"#]],
+    );
+}
+
+#[test]
+fn nested_single_stmt_if_stmt() {
+    check(
+        parse,
+        "if (x) if (y) z q;",
+        &expect![[r#"
+            Stmt [0-18]:
+                annotations: <empty>
+                kind: IfStmt [0-18]:
+                    condition: Expr [4-5]: Ident [4-5] "x"
+                    if_body: Stmt [7-18]:
+                        annotations: <empty>
+                        kind: IfStmt [7-18]:
+                            condition: Expr [11-12]: Ident [11-12] "y"
+                            if_body: Stmt [14-18]:
+                                annotations: <empty>
+                                kind: GateCall [14-18]:
+                                    modifiers: <empty>
+                                    name: Ident [14-15] "z"
+                                    args: <empty>
+                                    duration: <none>
+                                    qubits:
+                                        IndexedIdent [16-17]:
+                                            name: Ident [16-17] "q"
+                                            indices: <empty>
+                            else_body: <none>
+                    else_body: <none>"#]],
+    );
+}
+
+#[test]
+fn nested_single_stmt_if_else_stmt() {
+    check(
+        parse,
+        "if (x) if (y) z q; else if (a) if (b) h q;",
+        &expect![[r#"
+            Stmt [0-42]:
+                annotations: <empty>
+                kind: IfStmt [0-42]:
+                    condition: Expr [4-5]: Ident [4-5] "x"
+                    if_body: Stmt [7-42]:
+                        annotations: <empty>
+                        kind: IfStmt [7-42]:
+                            condition: Expr [11-12]: Ident [11-12] "y"
+                            if_body: Stmt [14-18]:
+                                annotations: <empty>
+                                kind: GateCall [14-18]:
+                                    modifiers: <empty>
+                                    name: Ident [14-15] "z"
+                                    args: <empty>
+                                    duration: <none>
+                                    qubits:
+                                        IndexedIdent [16-17]:
+                                            name: Ident [16-17] "q"
+                                            indices: <empty>
+                            else_body: Stmt [24-42]:
+                                annotations: <empty>
+                                kind: IfStmt [24-42]:
+                                    condition: Expr [28-29]: Ident [28-29] "a"
+                                    if_body: Stmt [31-42]:
+                                        annotations: <empty>
+                                        kind: IfStmt [31-42]:
+                                            condition: Expr [35-36]: Ident [35-36] "b"
+                                            if_body: Stmt [38-42]:
+                                                annotations: <empty>
+                                                kind: GateCall [38-42]:
+                                                    modifiers: <empty>
+                                                    name: Ident [38-39] "h"
+                                                    args: <empty>
+                                                    duration: <none>
+                                                    qubits:
+                                                        IndexedIdent [40-41]:
+                                                            name: Ident [40-41] "q"
+                                                            indices: <empty>
+                                            else_body: <none>
+                                    else_body: <none>
+                    else_body: <none>"#]],
+    );
+}
+
+#[test]
+fn single_stmt_if_stmt_else_stmt() {
+    check(
+        parse,
+        "if (x) z q; else x q;",
+        &expect![[r#"
+            Stmt [0-21]:
+                annotations: <empty>
+                kind: IfStmt [0-21]:
+                    condition: Expr [4-5]: Ident [4-5] "x"
+                    if_body: Stmt [7-11]:
+                        annotations: <empty>
+                        kind: GateCall [7-11]:
+                            modifiers: <empty>
+                            name: Ident [7-8] "z"
+                            args: <empty>
+                            duration: <none>
+                            qubits:
+                                IndexedIdent [9-10]:
+                                    name: Ident [9-10] "q"
+                                    indices: <empty>
+                    else_body: Stmt [17-21]:
+                        annotations: <empty>
+                        kind: GateCall [17-21]:
+                            modifiers: <empty>
+                            name: Ident [17-18] "x"
+                            args: <empty>
+                            duration: <none>
+                            qubits:
+                                IndexedIdent [19-20]:
+                                    name: Ident [19-20] "q"
+                                    indices: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
@@ -23,7 +23,7 @@ fn simple_if_stmt() {
                         op: Eq
                         lhs: Expr [9-10]: Ident [9-10] "x"
                         rhs: Expr [14-15]: Ident [14-15] "y"
-                    if_block:
+                    if_block: Block [17-39]:
                         Stmt [27-33]:
                             annotations: <empty>
                             kind: AssignStmt [27-33]:
@@ -31,7 +31,7 @@ fn simple_if_stmt() {
                                     name: Ident [27-28] "a"
                                     indices: <empty>
                                 rhs: Expr [31-32]: Lit: Int(0)
-                    else_block:
+                    else_block: Block [45-67]:
                         Stmt [55-61]:
                             annotations: <empty>
                             kind: AssignStmt [55-61]:
@@ -59,7 +59,7 @@ fn if_stmt_missing_else() {
                         op: Eq
                         lhs: Expr [9-10]: Ident [9-10] "x"
                         rhs: Expr [14-15]: Ident [14-15] "y"
-                    if_block:
+                    if_block: Block [17-39]:
                         Stmt [27-33]:
                             annotations: <empty>
                             kind: AssignStmt [27-33]:
@@ -98,7 +98,7 @@ fn nested_if_stmts() {
                         op: Eq
                         lhs: Expr [9-10]: Ident [9-10] "x"
                         rhs: Expr [14-15]: Ident [14-15] "y"
-                    if_block:
+                    if_block: Block [17-113]:
                         Stmt [27-107]:
                             annotations: <empty>
                             kind: IfStmt [27-107]:
@@ -106,7 +106,7 @@ fn nested_if_stmts() {
                                     op: Eq
                                     lhs: Expr [31-33]: Ident [31-33] "x1"
                                     rhs: Expr [37-39]: Ident [37-39] "y1"
-                                if_block:
+                                if_block: Block [41-71]:
                                     Stmt [55-61]:
                                         annotations: <empty>
                                         kind: AssignStmt [55-61]:
@@ -114,7 +114,7 @@ fn nested_if_stmts() {
                                                 name: Ident [55-56] "a"
                                                 indices: <empty>
                                             rhs: Expr [59-60]: Lit: Int(0)
-                                else_block:
+                                else_block: Block [77-107]:
                                     Stmt [91-97]:
                                         annotations: <empty>
                                         kind: AssignStmt [91-97]:
@@ -122,7 +122,7 @@ fn nested_if_stmts() {
                                                 name: Ident [91-92] "a"
                                                 indices: <empty>
                                             rhs: Expr [95-96]: Lit: Int(1)
-                    else_block:
+                    else_block: Block [119-215]:
                         Stmt [129-209]:
                             annotations: <empty>
                             kind: IfStmt [129-209]:
@@ -130,7 +130,7 @@ fn nested_if_stmts() {
                                     op: Eq
                                     lhs: Expr [133-135]: Ident [133-135] "x2"
                                     rhs: Expr [139-141]: Ident [139-141] "y2"
-                                if_block:
+                                if_block: Block [143-173]:
                                     Stmt [157-163]:
                                         annotations: <empty>
                                         kind: AssignStmt [157-163]:
@@ -138,7 +138,7 @@ fn nested_if_stmts() {
                                                 name: Ident [157-158] "a"
                                                 indices: <empty>
                                             rhs: Expr [161-162]: Lit: Int(2)
-                                else_block:
+                                else_block: Block [179-209]:
                                     Stmt [193-199]:
                                         annotations: <empty>
                                         kind: AssignStmt [193-199]:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/branch.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/branch.rs
@@ -60,12 +60,14 @@ fn assignment_in_if_condition() {
                 annotations: <empty>
                 kind: IfStmt [0-17]:
                     condition: Expr [4-5]: Ident [4-5] "x"
-                    if_block: Block [11-17]:
-                        Stmt [13-15]:
-                            annotations: <empty>
-                            kind: ExprStmt [13-15]:
-                                expr: Expr [13-14]: Lit: Int(3)
-                    else_block: <none>
+                    if_body: Stmt [11-17]:
+                        annotations: <empty>
+                        kind: Block [11-17]:
+                            Stmt [13-15]:
+                                annotations: <empty>
+                                kind: ExprStmt [13-15]:
+                                    expr: Expr [13-14]: Lit: Int(3)
+                    else_body: <none>
 
             [
                 Error(
@@ -94,12 +96,14 @@ fn binary_op_assignment_in_if_condition() {
                 annotations: <empty>
                 kind: IfStmt [0-18]:
                     condition: Expr [4-5]: Ident [4-5] "x"
-                    if_block: Block [12-18]:
-                        Stmt [14-16]:
-                            annotations: <empty>
-                            kind: ExprStmt [14-16]:
-                                expr: Expr [14-15]: Lit: Int(3)
-                    else_block: <none>
+                    if_body: Stmt [12-18]:
+                        annotations: <empty>
+                        kind: Block [12-18]:
+                            Stmt [14-16]:
+                                annotations: <empty>
+                                kind: ExprStmt [14-16]:
+                                    expr: Expr [14-15]: Lit: Int(3)
+                    else_body: <none>
 
             [
                 Error(
@@ -130,11 +134,10 @@ fn empty_if_block() {
                 annotations: <empty>
                 kind: IfStmt [0-10]:
                     condition: Expr [4-8]: Lit: Bool(true)
-                    if_block: Block [9-10]:
-                        Stmt [9-10]:
-                            annotations: <empty>
-                            kind: Empty
-                    else_block: <none>"#]],
+                    if_body: Stmt [9-10]:
+                        annotations: <empty>
+                        kind: Empty
+                    else_body: <none>"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/branch.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/branch.rs
@@ -60,7 +60,7 @@ fn assignment_in_if_condition() {
                 annotations: <empty>
                 kind: IfStmt [0-17]:
                     condition: Expr [4-5]: Ident [4-5] "x"
-                    if_block:
+                    if_block: Block [11-17]:
                         Stmt [13-15]:
                             annotations: <empty>
                             kind: ExprStmt [13-15]:
@@ -94,7 +94,7 @@ fn binary_op_assignment_in_if_condition() {
                 annotations: <empty>
                 kind: IfStmt [0-18]:
                     condition: Expr [4-5]: Ident [4-5] "x"
-                    if_block:
+                    if_block: Block [12-18]:
                         Stmt [14-16]:
                             annotations: <empty>
                             kind: ExprStmt [14-16]:
@@ -126,15 +126,15 @@ fn empty_if_block() {
         parse,
         "if (true);",
         &expect![[r#"
-        Stmt [0-10]:
-            annotations: <empty>
-            kind: IfStmt [0-10]:
-                condition: Expr [4-8]: Lit: Bool(true)
-                if_block:
-                    Stmt [9-10]:
-                        annotations: <empty>
-                        kind: Empty
-                else_block: <none>"#]],
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: IfStmt [0-10]:
+                    condition: Expr [4-8]: Lit: Bool(true)
+                    if_block: Block [9-10]:
+                        Stmt [9-10]:
+                            annotations: <empty>
+                            kind: Empty
+                    else_block: <none>"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/loops.rs
@@ -222,30 +222,30 @@ fn while_multi_condition() {
         parse,
         "while (true) (true) { x $0; }",
         &expect![[r#"
-        Stmt [0-19]:
-            annotations: <empty>
-            kind: WhileLoop [0-19]:
-                condition: Expr [7-11]: Lit: Bool(true)
-                block:
-                    Stmt [13-19]:
-                        annotations: <empty>
-                        kind: ExprStmt [13-19]:
-                            expr: Expr [13-19]: Paren Expr [14-18]: Lit: Bool(true)
+            Stmt [0-19]:
+                annotations: <empty>
+                kind: WhileLoop [0-19]:
+                    condition: Expr [7-11]: Lit: Bool(true)
+                    block: Block [13-19]:
+                        Stmt [13-19]:
+                            annotations: <empty>
+                            kind: ExprStmt [13-19]:
+                                expr: Expr [13-19]: Paren Expr [14-18]: Lit: Bool(true)
 
-        [
-            Error(
-                Token(
-                    Semicolon,
-                    Open(
-                        Brace,
+            [
+                Error(
+                    Token(
+                        Semicolon,
+                        Open(
+                            Brace,
+                        ),
+                        Span {
+                            lo: 20,
+                            hi: 21,
+                        },
                     ),
-                    Span {
-                        lo: 20,
-                        hi: 21,
-                    },
                 ),
-            ),
-        ]"#]],
+            ]"#]],
     );
 }
 
@@ -277,13 +277,13 @@ fn while_missing_body() {
         parse,
         "while (true);",
         &expect![[r#"
-        Stmt [0-13]:
-            annotations: <empty>
-            kind: WhileLoop [0-13]:
-                condition: Expr [7-11]: Lit: Bool(true)
-                block:
-                    Stmt [12-13]:
-                        annotations: <empty>
-                        kind: Empty"#]],
+            Stmt [0-13]:
+                annotations: <empty>
+                kind: WhileLoop [0-13]:
+                    condition: Expr [7-11]: Lit: Bool(true)
+                    block: Block [12-13]:
+                        Stmt [12-13]:
+                            annotations: <empty>
+                            kind: Empty"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/loops.rs
@@ -226,11 +226,10 @@ fn while_multi_condition() {
                 annotations: <empty>
                 kind: WhileLoop [0-19]:
                     condition: Expr [7-11]: Lit: Bool(true)
-                    block: Block [13-19]:
-                        Stmt [13-19]:
-                            annotations: <empty>
-                            kind: ExprStmt [13-19]:
-                                expr: Expr [13-19]: Paren Expr [14-18]: Lit: Bool(true)
+                    body: Stmt [13-19]:
+                        annotations: <empty>
+                        kind: ExprStmt [13-19]:
+                            expr: Expr [13-19]: Paren Expr [14-18]: Lit: Bool(true)
 
             [
                 Error(
@@ -281,9 +280,8 @@ fn while_missing_body() {
                 annotations: <empty>
                 kind: WhileLoop [0-13]:
                     condition: Expr [7-11]: Lit: Bool(true)
-                    block: Block [12-13]:
-                        Stmt [12-13]:
-                            annotations: <empty>
-                            kind: Empty"#]],
+                    body: Stmt [12-13]:
+                        annotations: <empty>
+                        kind: Empty"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
@@ -20,7 +20,7 @@ fn simple_while() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block:
+                    block: Block [20-42]:
                         Stmt [30-36]:
                             annotations: <empty>
                             kind: AssignStmt [30-36]:
@@ -41,7 +41,7 @@ fn empty_while() {
                 annotations: <empty>
                 kind: WhileLoop [0-15]:
                     condition: Expr [7-11]: Lit: Bool(true)
-                    block: <empty>"#]],
+                    block: Block [13-15]: <empty>"#]],
     );
 }
 
@@ -60,7 +60,7 @@ fn while_stmt_body() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block:
+                    block: Block [28-34]:
                         Stmt [28-34]:
                             annotations: <empty>
                             kind: AssignStmt [28-34]:
@@ -88,7 +88,7 @@ fn while_loop_with_continue_stmt() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block:
+                    block: Block [20-60]:
                         Stmt [30-36]:
                             annotations: <empty>
                             kind: AssignStmt [30-36]:
@@ -119,7 +119,7 @@ fn while_loop_with_break_stmt() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block:
+                    block: Block [20-57]:
                         Stmt [30-36]:
                             annotations: <empty>
                             kind: AssignStmt [30-36]:

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
@@ -20,14 +20,16 @@ fn simple_while() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block: Block [20-42]:
-                        Stmt [30-36]:
-                            annotations: <empty>
-                            kind: AssignStmt [30-36]:
-                                lhs: IndexedIdent [30-31]:
-                                    name: Ident [30-31] "a"
-                                    indices: <empty>
-                                rhs: Expr [34-35]: Lit: Int(0)"#]],
+                    body: Stmt [20-42]:
+                        annotations: <empty>
+                        kind: Block [20-42]:
+                            Stmt [30-36]:
+                                annotations: <empty>
+                                kind: AssignStmt [30-36]:
+                                    lhs: IndexedIdent [30-31]:
+                                        name: Ident [30-31] "a"
+                                        indices: <empty>
+                                    rhs: Expr [34-35]: Lit: Int(0)"#]],
     );
 }
 
@@ -41,7 +43,9 @@ fn empty_while() {
                 annotations: <empty>
                 kind: WhileLoop [0-15]:
                     condition: Expr [7-11]: Lit: Bool(true)
-                    block: Block [13-15]: <empty>"#]],
+                    body: Stmt [13-15]:
+                        annotations: <empty>
+                        kind: Block [13-15]: <empty>"#]],
     );
 }
 
@@ -60,14 +64,13 @@ fn while_stmt_body() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block: Block [28-34]:
-                        Stmt [28-34]:
-                            annotations: <empty>
-                            kind: AssignStmt [28-34]:
-                                lhs: IndexedIdent [28-29]:
-                                    name: Ident [28-29] "a"
-                                    indices: <empty>
-                                rhs: Expr [32-33]: Lit: Int(0)"#]],
+                    body: Stmt [28-34]:
+                        annotations: <empty>
+                        kind: AssignStmt [28-34]:
+                            lhs: IndexedIdent [28-29]:
+                                name: Ident [28-29] "a"
+                                indices: <empty>
+                            rhs: Expr [32-33]: Lit: Int(0)"#]],
     );
 }
 
@@ -88,17 +91,19 @@ fn while_loop_with_continue_stmt() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block: Block [20-60]:
-                        Stmt [30-36]:
-                            annotations: <empty>
-                            kind: AssignStmt [30-36]:
-                                lhs: IndexedIdent [30-31]:
-                                    name: Ident [30-31] "a"
-                                    indices: <empty>
-                                rhs: Expr [34-35]: Lit: Int(0)
-                        Stmt [45-54]:
-                            annotations: <empty>
-                            kind: ContinueStmt [45-54]"#]],
+                    body: Stmt [20-60]:
+                        annotations: <empty>
+                        kind: Block [20-60]:
+                            Stmt [30-36]:
+                                annotations: <empty>
+                                kind: AssignStmt [30-36]:
+                                    lhs: IndexedIdent [30-31]:
+                                        name: Ident [30-31] "a"
+                                        indices: <empty>
+                                    rhs: Expr [34-35]: Lit: Int(0)
+                            Stmt [45-54]:
+                                annotations: <empty>
+                                kind: ContinueStmt [45-54]"#]],
     );
 }
 
@@ -119,16 +124,100 @@ fn while_loop_with_break_stmt() {
                         op: Neq
                         lhs: Expr [12-13]: Ident [12-13] "x"
                         rhs: Expr [17-18]: Lit: Int(2)
-                    block: Block [20-57]:
-                        Stmt [30-36]:
-                            annotations: <empty>
-                            kind: AssignStmt [30-36]:
-                                lhs: IndexedIdent [30-31]:
-                                    name: Ident [30-31] "a"
-                                    indices: <empty>
-                                rhs: Expr [34-35]: Lit: Int(0)
-                        Stmt [45-51]:
-                            annotations: <empty>
-                            kind: BreakStmt [45-51]"#]],
+                    body: Stmt [20-57]:
+                        annotations: <empty>
+                        kind: Block [20-57]:
+                            Stmt [30-36]:
+                                annotations: <empty>
+                                kind: AssignStmt [30-36]:
+                                    lhs: IndexedIdent [30-31]:
+                                        name: Ident [30-31] "a"
+                                        indices: <empty>
+                                    rhs: Expr [34-35]: Lit: Int(0)
+                            Stmt [45-51]:
+                                annotations: <empty>
+                                kind: BreakStmt [45-51]"#]],
+    );
+}
+
+#[test]
+fn single_stmt_while_stmt() {
+    check(
+        parse,
+        "while (x) z q;",
+        &expect![[r#"
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: WhileLoop [0-14]:
+                    condition: Expr [7-8]: Ident [7-8] "x"
+                    body: Stmt [10-14]:
+                        annotations: <empty>
+                        kind: GateCall [10-14]:
+                            modifiers: <empty>
+                            name: Ident [10-11] "z"
+                            args: <empty>
+                            duration: <none>
+                            qubits:
+                                IndexedIdent [12-13]:
+                                    name: Ident [12-13] "q"
+                                    indices: <empty>"#]],
+    );
+}
+
+#[test]
+fn annotations_in_single_stmt_while_stmt() {
+    check(
+        parse,
+        "
+    while (x)
+        @foo
+        @bar
+        x = 5;",
+        &expect![[r#"
+            Stmt [5-55]:
+                annotations: <empty>
+                kind: WhileLoop [5-55]:
+                    condition: Expr [12-13]: Ident [12-13] "x"
+                    body: Stmt [23-55]:
+                        annotations:
+                            Annotation [23-27]:
+                                identifier: "foo"
+                                value: <none>
+                            Annotation [36-40]:
+                                identifier: "bar"
+                                value: <none>
+                        kind: AssignStmt [49-55]:
+                            lhs: IndexedIdent [49-50]:
+                                name: Ident [49-50] "x"
+                                indices: <empty>
+                            rhs: Expr [53-54]: Lit: Int(5)"#]],
+    );
+}
+
+#[test]
+fn nested_single_stmt_while_stmt() {
+    check(
+        parse,
+        "while (x) while (y) z q;",
+        &expect![[r#"
+            Stmt [0-24]:
+                annotations: <empty>
+                kind: WhileLoop [0-24]:
+                    condition: Expr [7-8]: Ident [7-8] "x"
+                    body: Stmt [10-24]:
+                        annotations: <empty>
+                        kind: WhileLoop [10-24]:
+                            condition: Expr [17-18]: Ident [17-18] "y"
+                            body: Stmt [20-24]:
+                                annotations: <empty>
+                                kind: GateCall [20-24]:
+                                    modifiers: <empty>
+                                    name: Ident [20-21] "z"
+                                    args: <empty>
+                                    duration: <none>
+                                    qubits:
+                                        IndexedIdent [22-23]:
+                                            name: Ident [22-23] "q"
+                                            indices: <empty>"#]],
     );
 }


### PR DESCRIPTION
If/else blocks, while, and for loops in QASM introduce new scopes only when their body enclosed by curly braces. To make lowering easier, this PR changes their bodies from `List<Stmt>` to `Stmt`. In the body enclosed in curly braces case, the Stmt will be of kind Block.