### PR TITLE
Decompose measurement in QIR Base profile processing

### DIFF
--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -759,7 +759,6 @@ impl Interpreter {
             sim.chained.finish()
         } else {
             let mut sim = CircuitBuilder::new(CircuitConfig {
-                base_profile: self.capabilities.is_empty(),
                 max_operations: CircuitConfig::DEFAULT_MAX_OPERATIONS,
             });
 
@@ -1004,14 +1003,6 @@ fn sim_circuit_backend() -> BackendChain<SparseSim, CircuitBuilder> {
     BackendChain::new(
         SparseSim::new(),
         CircuitBuilder::new(CircuitConfig {
-            // When using in conjunction with the simulator,
-            // the circuit builder should *not* perform base profile
-            // decompositions, in order to match the simulator's behavior.
-            //
-            // Note that conditional compilation (e.g. @Config(Base) attributes)
-            // will still respect the selected profile. This also
-            // matches the behavior of the simulator.
-            base_profile: false,
             max_operations: CircuitConfig::DEFAULT_MAX_OPERATIONS,
         }),
     )

--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -202,11 +202,10 @@ fn m_base_profile() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    expect![[r"
-        q_0    ── H ──── Z ────────────────
-        q_1    ── H ──── ● ──── H ──── M ──
-                                       ╘═══
-    "]]
+    expect![[r#"
+        q_0    ── H ──── M ──
+                         ╘═══
+    "#]]
     .assert_eq(&circ.to_string());
 }
 
@@ -597,14 +596,12 @@ fn operation_with_qubits_base_profile() {
         .circuit(CircuitEntryPoint::Operation("Test.Test".into()), false)
         .expect("circuit generation should succeed");
 
-    expect![[r"
-        q_0    ── H ──── ● ──── Z ──────────────────────────────
-        q_1    ───────── X ─────┼──────────── Z ────────────────
-        q_2    ── H ─────────── ● ──── H ─────┼───── M ─────────
-                                              │      ╘══════════
-        q_3    ── H ───────────────────────── ● ──── H ──── M ──
-                                                            ╘═══
-    "]]
+    expect![[r#"
+        q_0    ── H ──── ● ──── M ──
+                         │      ╘═══
+        q_1    ───────── X ──── M ──
+                                ╘═══
+    "#]]
     .assert_eq(&circ.to_string());
 }
 
@@ -1071,29 +1068,22 @@ mod debugger_stepping {
         // be generated in Base Profile, but they are here, since
         // when running in tandem with the simulator, the resulting
         // circuit is intended to match the calls into the simulator.
-        //
-        // Note the circuit still looks different than what would be
-        // generated in Unrestricted Profile for the same code,
-        // due to conditional compilation in the standard library.
-        expect![["
+        expect![[r#"
             step:
             step:
             q_0
             step:
             q_0    ── H ──
             step:
-            q_0    ── H ──── Z ─────────────────────────
-            q_1    ── H ──── ● ──── H ──── M ──── |0〉 ──
-                                           ╘════════════
+            q_0    ── H ──── M ──
+                             ╘═══
             step:
-            q_0    ── H ──── Z ──── |0〉 ──────────────────
-            q_1    ── H ──── ● ───── H ───── M ──── |0〉 ──
-                                             ╘════════════
+            q_0    ── H ──── M ──── |0〉 ──
+                             ╘════════════
             step:
-            q_0    ── H ──── Z ──── |0〉 ──────────────────
-            q_1    ── H ──── ● ───── H ───── M ──── |0〉 ──
-                                             ╘════════════
-        "]]
+            q_0    ── H ──── M ──── |0〉 ──
+                             ╘════════════
+        "#]]
         .assert_eq(&circs);
     }
 

--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -1064,10 +1064,6 @@ mod debugger_stepping {
             Profile::Base,
         );
 
-        // Surprising but expected: Reset gates would *not* normally
-        // be generated in Base Profile, but they are here, since
-        // when running in tandem with the simulator, the resulting
-        // circuit is intended to match the calls into the simulator.
         expect![[r#"
             step:
             step:

--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -286,10 +286,10 @@ fn mresetz_base_profile() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    expect![[r"
-        q_0    ── H ──── M ──
-                         ╘═══
-    "]]
+    expect![[r#"
+        q_0    ── H ──── M ──── |0〉 ──
+                         ╘════════════
+    "#]]
     .assert_eq(&circ.to_string());
 }
 

--- a/compiler/qsc/src/interpret/tests.rs
+++ b/compiler/qsc/src/interpret/tests.rs
@@ -884,21 +884,17 @@ mod given_interpreter {
 
                 define void @ENTRYPOINT__main() #0 {
                 block_0:
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+                  call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
 
-                declare void @__quantum__qis__h__body(%Qubit*)
-
-                declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
                 declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+                declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
                 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="1" }
                 attributes #1 = { "irreversible" }
@@ -1083,21 +1079,17 @@ mod given_interpreter {
 
                 define void @ENTRYPOINT__main() #0 {
                 block_0:
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+                  call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
 
-                declare void @__quantum__qis__h__body(%Qubit*)
-
-                declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
                 declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+                declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
                 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="1" }
                 attributes #1 = { "irreversible" }
@@ -1131,21 +1123,17 @@ mod given_interpreter {
 
                 define void @ENTRYPOINT__main() #0 {
                 block_0:
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+                  call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
 
-                declare void @__quantum__qis__h__body(%Qubit*)
-
-                declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
                 declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+                declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
                 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="1" }
                 attributes #1 = { "irreversible" }
@@ -1211,21 +1199,17 @@ mod given_interpreter {
 
                 define void @ENTRYPOINT__main() #0 {
                 block_0:
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+                  call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
 
-                declare void @__quantum__qis__h__body(%Qubit*)
-
-                declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
                 declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+                declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
                 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="1" }
                 attributes #1 = { "irreversible" }
@@ -1271,21 +1255,17 @@ mod given_interpreter {
 
                 define void @ENTRYPOINT__main() #0 {
                 block_0:
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
-                  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+                  call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+                  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
                   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
                   ret void
                 }
 
-                declare void @__quantum__qis__h__body(%Qubit*)
-
-                declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
                 declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-                declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+                declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
 
                 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="1" }
                 attributes #1 = { "irreversible" }

--- a/compiler/qsc_circuit/src/builder/tests.rs
+++ b/compiler/qsc_circuit/src/builder/tests.rs
@@ -7,7 +7,6 @@ use expect_test::expect;
 #[test]
 fn exceed_max_operations() {
     let mut builder = Builder::new(Config {
-        base_profile: false,
         max_operations: 2,
     });
 
@@ -32,7 +31,6 @@ fn exceed_max_operations() {
 #[test]
 fn exceed_max_operations_deferred_measurements() {
     let mut builder = Builder::new(Config {
-        base_profile: true, // deferred measurements
         max_operations: 2,
     });
 
@@ -48,11 +46,10 @@ fn exceed_max_operations_deferred_measurements() {
 
     // The current behavior is to silently truncate the circuit
     // if it exceeds the maximum allowed number of operations.
-    // The measurement will be dropped.
+    // The second X will be dropped.
     expect![[r#"
-        q_0    ── X ──
-
-        q_1    ── X ──
+        q_0    ── X ──── M ──
+                         ╘═══
     "#]]
     .assert_eq(&circuit.to_string());
 }

--- a/compiler/qsc_circuit/src/builder/tests.rs
+++ b/compiler/qsc_circuit/src/builder/tests.rs
@@ -6,9 +6,7 @@ use expect_test::expect;
 
 #[test]
 fn exceed_max_operations() {
-    let mut builder = Builder::new(Config {
-        max_operations: 2,
-    });
+    let mut builder = Builder::new(Config { max_operations: 2 });
 
     let q = builder.qubit_allocate();
 
@@ -30,9 +28,7 @@ fn exceed_max_operations() {
 
 #[test]
 fn exceed_max_operations_deferred_measurements() {
-    let mut builder = Builder::new(Config {
-        max_operations: 2,
-    });
+    let mut builder = Builder::new(Config { max_operations: 2 });
 
     let q = builder.qubit_allocate();
 

--- a/compiler/qsc_circuit/src/circuit.rs
+++ b/compiler/qsc_circuit/src/circuit.rs
@@ -79,8 +79,6 @@ pub struct Qubit {
 
 #[derive(Clone, Debug, Copy, Default)]
 pub struct Config {
-    /// Perform Base Profile decompositions
-    pub base_profile: bool,
     /// Maximum number of operations the builder will add to the circuit
     pub max_operations: usize,
 }

--- a/library/std/src/Std/Intrinsic.qs
+++ b/library/std/src/Std/Intrinsic.qs
@@ -265,38 +265,6 @@ operation I(target : Qubit) : Unit is Adj + Ctl {
 /// ```qsharp
 /// Measure([PauliZ], [qubit]);
 /// ```
-@Config(QubitReset)
-operation M(qubit : Qubit) : Result {
-    __quantum__qis__m__body(qubit)
-}
-
-/// # Summary
-/// Performs a measurement of a single qubit in the
-/// Pauli _Z_ basis.
-///
-/// # Input
-/// ## qubit
-/// Qubit to be measured.
-///
-/// # Output
-/// `Zero` if the +1 eigenvalue is observed, and `One` if
-/// the -1 eigenvalue is observed.
-///
-/// # Remarks
-/// The output result is given by
-/// the distribution
-/// $$
-/// \begin{align}
-///     \Pr(\texttt{Zero} | \ket{\psi}) =
-///         \braket{\psi | 0} \braket{0 | \psi}.
-/// \end{align}
-/// $$
-///
-/// Equivalent to:
-/// ```qsharp
-/// Measure([PauliZ], [qubit]);
-/// ```
-@Config(not QubitReset)
 operation M(qubit : Qubit) : Result {
     Measure([PauliZ], [qubit])
 }
@@ -326,7 +294,6 @@ operation M(qubit : Qubit) : Result {
 /// $N$ is the `Length(bases)`.
 /// That is, measurement returns a `Result` $d$ such that the eigenvalue of the
 /// observed measurement effect is $(-1)^d$.
-@Config(QubitReset)
 operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
     if Length(bases) != Length(qubits) {
         fail "Arrays 'bases' and 'qubits' must be of the same length.";
@@ -348,50 +315,6 @@ operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
         }
         __quantum__qis__mresetz__body(aux)
     }
-}
-
-/// # Summary
-/// Performs a joint measurement of one or more qubits in the
-/// specified Pauli bases.
-///
-/// If the basis array and qubit array are different lengths, then the
-/// operation will fail.
-///
-/// # Input
-/// ## bases
-/// Array of single-qubit Pauli values indicating the tensor product
-/// factors on each qubit.
-/// ## qubits
-/// Register of qubits to be measured.
-///
-/// # Output
-/// `Zero` if the +1 eigenvalue is observed, and `One` if
-/// the -1 eigenvalue is observed.
-///
-/// # Remarks
-/// The probability of getting `Zero` is
-/// $\bra{\psi} \frac{I + P_0 \otimes \ldots \otimes P_{N-1}}{2} \ket{\psi}$
-/// where $P_i$ is the $i$-th element of `bases`, and where
-/// $N$ is the `Length(bases)`.
-/// That is, measurement returns a `Result` $d$ such that the eigenvalue of the
-/// observed measurement effect is $(-1)^d$.
-@Config(not QubitReset)
-operation Measure(bases : Pauli[], qubits : Qubit[]) : Result {
-    if Length(bases) != Length(qubits) {
-        fail "Arrays 'bases' and 'qubits' must be of the same length.";
-    }
-    // Because Base Profile does not allow qubit reuse, we always allocate a new qubit
-    // and use entanglement to measure the state while collapsing the original target(s) and
-    // leaving it available for later operations.
-    use aux = Qubit();
-    within {
-        H(aux);
-    } apply {
-        for i in 0..Length(bases) - 1 {
-            EntangleForJointMeasure(bases[i], aux, qubits[i]);
-        }
-    }
-    __quantum__qis__mresetz__body(aux)
 }
 
 /// # Summary

--- a/pip/tests-integration/test_base_qir.py
+++ b/pip/tests-integration/test_base_qir.py
@@ -32,22 +32,23 @@ def test_compile_qir_input_data() -> None:
     qir = operation._repr_qir_()
     assert isinstance(qir, bytes)
     module = Module.from_ir(Context(), qir.decode(), "module")
-    assert len(module.functions) == 5
+    assert len(module.functions) == 3
     assert module.functions[0].name == "ENTRYPOINT__main"
     func = module.functions[0]
     assert len(func.basic_blocks) == 1
-    assert len(func.basic_blocks[0].instructions) == 6
+    assert len(func.basic_blocks[0].instructions) == 3
     call_m = func.basic_blocks[0].instructions[0]
     assert isinstance(call_m, Call)
-    assert call_m.callee.name == "__quantum__qis__h__body"
-    assert len(call_m.args) == 1
-    assert qubit_id(call_m.args[0]) == 1
-    record_res = func.basic_blocks[0].instructions[4]
+    assert call_m.callee.name == "__quantum__qis__m__body"
+    assert len(call_m.args) == 2
+    assert qubit_id(call_m.args[0]) == 0
+    assert result_id(call_m.args[1]) == 0
+    record_res = func.basic_blocks[0].instructions[1]
     assert isinstance(record_res, Call)
     assert len(record_res.args) == 2
     assert record_res.callee.name == "__quantum__rt__result_record_output"
     assert result_id(record_res.args[0]) == 0
-    assert func.basic_blocks[0].instructions[5].opcode == Opcode.RET
+    assert func.basic_blocks[0].instructions[2].opcode == Opcode.RET
 
 
 @pytest.mark.skipif(not PYQIR_AVAILABLE, reason=SKIP_REASON)
@@ -87,7 +88,7 @@ def test_compile_qir_all_gates() -> None:
     assert module.functions[0].name == "ENTRYPOINT__main"
     func = module.functions[0]
     assert len(func.basic_blocks) == 1
-    assert len(func.basic_blocks[0].instructions) == 28
+    assert len(func.basic_blocks[0].instructions) == 26
 
     def check_call(i: int, name: str, num_args: int) -> None:
         call = func.basic_blocks[0].instructions[i]
@@ -114,14 +115,12 @@ def test_compile_qir_all_gates() -> None:
     check_call(16, "__quantum__qis__y__body", 1)
     check_call(17, "__quantum__qis__z__body", 1)
     check_call(18, "__quantum__qis__swap__body", 2)
-    check_call(19, "__quantum__qis__h__body", 1)
-    check_call(20, "__quantum__qis__cz__body", 2)
-    check_call(21, "__quantum__qis__h__body", 1)
-    check_call(22, "__quantum__qis__m__body", 2)
-    check_call(23, "__quantum__qis__m__body", 2)
-    check_call(24, "__quantum__rt__tuple_record_output", 2)
-    check_call(25, "__quantum__rt__result_record_output", 2)
-    check_call(26, "__quantum__rt__result_record_output", 2)
+    check_call(19, "__quantum__qis__cx__body", 2)
+    check_call(20, "__quantum__qis__m__body", 2)
+    check_call(21, "__quantum__qis__m__body", 2)
+    check_call(22, "__quantum__rt__tuple_record_output", 2)
+    check_call(23, "__quantum__rt__result_record_output", 2)
+    check_call(24, "__quantum__rt__result_record_output", 2)
 
     assert required_num_qubits(module.functions[0]) == 5
     assert required_num_results(module.functions[0]) == 2


### PR DESCRIPTION
This change simplifies the decomposition of `M` and `Measure` in the stdlib to no longer conditionally compile to different versions based on qubit reuse capability, instead offloading that to QIR processing, which already has similar logic.

One effect of this is simulation and circuit generation will match user expectation and patterns in the Q# code rather than more closely showing what occurs on hardware.