### PR TITLE
Removed usage of deprecated set keyword from the samples

### DIFF
--- a/samples/algorithms/BellState.qs
+++ b/samples/algorithms/BellState.qs
@@ -27,7 +27,7 @@ operation Main() : (Result, Result)[] {
         prepare(register);
         Message($"Bell state {label}:");
         DumpMachine();
-        set measurements += [(MResetZ(register[0]), MResetZ(register[1]))];
+        measurements += [(MResetZ(register[0]), MResetZ(register[1]))];
     }
     return measurements;
 }

--- a/samples/algorithms/BernsteinVazirani.qs
+++ b/samples/algorithms/BernsteinVazirani.qs
@@ -46,7 +46,7 @@ operation Main() : Int[] {
         );
 
         Message($"Successfully decoded bit string as int: {decodedInteger}");
-        set decodedIntegers += [decodedInteger];
+        decodedIntegers += [decodedInteger];
     }
 
     return decodedIntegers;

--- a/samples/algorithms/DeutschJozsa.qs
+++ b/samples/algorithms/DeutschJozsa.qs
@@ -43,7 +43,7 @@ operation Main() : (String, Bool)[] {
 
         let isConstantStr = isConstant ? "constant" | "balanced";
         Message($"{name} is {isConstantStr}");
-        set results += [(name, isConstant)];
+        results += [(name, isConstant)];
     }
 
     return results;
@@ -105,7 +105,7 @@ operation DeutschJozsa(Uf : ((Qubit[], Qubit) => Unit), n : Int) : Bool {
     mutable result = true;
     for q in queryRegister {
         if MResetZ(q) == One {
-            set result = false;
+            result = false;
         }
     }
 

--- a/samples/algorithms/DotProductViaPhaseEstimation.qs
+++ b/samples/algorithms/DotProductViaPhaseEstimation.qs
@@ -117,7 +117,7 @@ operation IterativePhaseEstimation(
         set MeasureControlReg w/= (Measurements - 1 - index) <- MResetZ(ControlReg);
         if MeasureControlReg[Measurements - 1 - index] == One {
             //Assign bitValue based on previous measurement
-            set bitValue += 2^(index);
+            bitValue += 2^(index);
         }
     }
     return bitValue;

--- a/samples/algorithms/HiddenShift.qs
+++ b/samples/algorithms/HiddenShift.qs
@@ -33,7 +33,7 @@ operation Main() : Int[] {
         );
         let hiddenShift = ResultArrayAsInt(hiddenShiftBitString);
         Message($"Found {shift} successfully!");
-        set hiddenShifts += [hiddenShift];
+        hiddenShifts += [hiddenShift];
     }
 
     // Note: returned array should match shifts array

--- a/samples/algorithms/QRNG.qs
+++ b/samples/algorithms/QRNG.qs
@@ -25,7 +25,7 @@ operation GenerateRandomNumberInRange(max : Int) : Int {
     mutable bits = [];
     let nBits = BitSizeI(max);
     for idxBit in 1..nBits {
-        set bits += [GenerateRandomBit()];
+        bits += [GenerateRandomBit()];
     }
     let sample = ResultArrayAsInt(bits);
 

--- a/samples/algorithms/Shor.qs
+++ b/samples/algorithms/Shor.qs
@@ -62,7 +62,7 @@ operation FactorSemiprimeInteger(number : Int) : (Int, Int) {
 
             // Set the flag and factors values if the continued
             // fractions classical algorithm succeeds.
-            set (foundFactors, factors) = MaybeFactorsFromPeriod(number, generator, period);
+            (foundFactors, factors) = MaybeFactorsFromPeriod(number, generator, period);
         }
         // In this case, we guessed a divisor by accident.
         else {
@@ -72,10 +72,10 @@ operation FactorSemiprimeInteger(number : Int) : (Int, Int) {
 
             // Set the flag `foundFactors` to true, indicating that we
             // succeeded in finding factors.
-            set foundFactors = true;
-            set factors = (gcd, number / gcd);
+            foundFactors = true;
+            factors = (gcd, number / gcd);
         }
-        set attempt = attempt + 1;
+        attempt = attempt + 1;
         if (attempt > 100) {
             fail "Failed to find factors: too many attempts!";
         }
@@ -283,7 +283,7 @@ operation EstimateFrequency(generator : Int, modulus : Int, bitsize : Int) : Int
         H(c);
         if M(c) == One {
             X(c); // Reset
-            set frequencyEstimate += 1 <<< (bitsPrecision - 1 - idx);
+            frequencyEstimate += 1 <<< (bitsPrecision - 1 - idx);
         }
     }
 

--- a/samples/algorithms/Teleportation.qs
+++ b/samples/algorithms/Teleportation.qs
@@ -42,7 +42,7 @@ operation Main() : Result[] {
         // Measure target in the corresponding basis and reset the qubits to
         // continue teleporting more messages.
         let result = Measure([basis], [target]);
-        set results += [result];
+        results += [result];
         ResetAll([message, target]);
     }
 

--- a/samples/algorithms/ThreeQubitRepetitionCode.qs
+++ b/samples/algorithms/ThreeQubitRepetitionCode.qs
@@ -30,7 +30,7 @@ operation Main() : (Bool, Int) {
             let (parity01, parity12) = MeasureBitFlipSyndrome(encodedRegister);
             let bitFlipReverted = RevertBitFlip(encodedRegister, parity01, parity12);
             if (bitFlipReverted) {
-                set bitFlipCount += 1;
+                bitFlipCount += 1;
             }
         }
     }
@@ -82,7 +82,7 @@ operation RevertBitFlip(register : Qubit[], parity01 : Result, parity12 : Result
         if parity12 == One {
             X(register[2]);
         } else {
-            set result = false;
+            result = false;
         }
     }
     return result;

--- a/samples/estimation/ShorRE.qs
+++ b/samples/estimation/ShorRE.qs
@@ -79,7 +79,7 @@ operation EstimateFrequency(
             R1Frac(frequencyEstimate, bitsPrecision - 1 - idx, c);
         }
         if MResetZ(c) == One {
-            set frequencyEstimate += 1 <<< (bitsPrecision - 1 - idx);
+            frequencyEstimate += 1 <<< (bitsPrecision - 1 - idx);
         }
     }
 

--- a/samples/language/Range.qs
+++ b/samples/language/Range.qs
@@ -42,7 +42,7 @@ function Main() : Range {
     // The array [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100].
     mutable array = [];
     for i in 0..10 {
-        set array += [i^2];
+        array += [i^2];
     }
     Message($"Array: {array}");
 

--- a/samples/language/RepeatUntilLoops.qs
+++ b/samples/language/RepeatUntilLoops.qs
@@ -12,7 +12,7 @@ operation Main() : Unit {
     // Repeat-Until loop
     mutable x = 0;
     repeat {
-        set x += 1;
+        x += 1;
     } until x > 3;
 
     // Repeat-Until loop with fixup

--- a/samples/language/Variables.qs
+++ b/samples/language/Variables.qs
@@ -13,7 +13,7 @@ function Main() : Unit {
     mutable mutableInt = 43;
     Message($"Mutable Int: {mutableInt}");
 
-    // Mutable variables can be mutated or reassigned
+    // Mutable variables can be mutated or reassigned.
     mutableInt -= 1;
     Message($"Mutable Int after mutation: {mutableInt}");
 

--- a/samples/language/Variables.qs
+++ b/samples/language/Variables.qs
@@ -13,9 +13,12 @@ function Main() : Unit {
     mutable mutableInt = 43;
     Message($"Mutable Int: {mutableInt}");
 
-    // Mutable variables can be mutated with the `set` keyword:
-    set mutableInt -= 1;
+    // Mutable variables can be mutated or reassigned
+    mutableInt -= 1;
     Message($"Mutable Int after mutation: {mutableInt}");
+
+    mutableInt = 10;
+    Message($"Mutable Int after reassignment: {mutableInt}");
 
     // This is not mutation, rather, this is declaring a new variable
     // entirely.
@@ -30,7 +33,7 @@ function Main() : Unit {
 
     // The below line copies `point`, moves the X coordinate by +1.0,
     // and reassign the new `Point3d` to `point`.
-    set point = new Point3d { ...point, X = point.X + 1.0 };
+    point = new Point3d { ...point, X = point.X + 1.0 };
 
 }
 

--- a/samples/language/WhileLoops.qs
+++ b/samples/language/WhileLoops.qs
@@ -10,6 +10,6 @@
 function Main() : Unit {
     mutable x = 0;
     while x < 3 {
-        set x += 1;
+        x += 1;
     }
 }

--- a/samples_test/src/tests/language.rs
+++ b/samples_test/src/tests/language.rs
@@ -334,12 +334,14 @@ pub const VARIABLES_EXPECT: Expect = expect![[r#"
     Immutable Int: 42
     Mutable Int: 43
     Mutable Int after mutation: 42
+    Mutable Int after reassignment: 10
     Shadowed Immutable Int: 0
     ()"#]];
 pub const VARIABLES_EXPECT_DEBUG: Expect = expect![[r#"
     Immutable Int: 42
     Mutable Int: 43
     Mutable Int after mutation: 42
+    Mutable Int after reassignment: 10
     Shadowed Immutable Int: 0
     ()"#]];
 pub const WHILELOOPS_EXPECT: Expect = expect!["()"];


### PR DESCRIPTION
The language samples still stated:

> // Mutable variables can be mutated with the `set` keyword

Technically this is true, but since `set` is now [deprecated](https://github.com/microsoft/qsharp/pull/2062) I removed it from all the samples.