### PR TITLE
Change default font to system-ui

### DIFF
--- a/vscode/src/copilot/webview/copilot.css
+++ b/vscode/src/copilot/webview/copilot.css
@@ -4,8 +4,8 @@
 body {
   padding: 12px;
   height: 100%;
-  /*  match the native vscode chat style */
-  font-family: "Segoe WPC", "Segoe UI", "sans-serif";
+  /*  system-ui works great on all platforms and browsers these days */
+  font-family: system-ui;
   font-size: 13px;
   background-color: var(--vscode-chat-list-background);
 }


### PR DESCRIPTION
Fix the copilot panel not rendering correctly on Mac or Linux. I tested this on all 3 platforms, and in the Firefox browser (which was the last platform/browser to have quirks with `system-ui` that I could find details on).