### PR TITLE
Add an icon to clear the copilot chat

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -240,6 +240,11 @@
           "command": "qsharp-vscode.workspacesAdd",
           "when": "view == quantum-workspaces",
           "group": "navigation"
+        },
+        {
+          "command": "qsharp-vscode.copilotClear",
+          "when": "view == quantum-copilot",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
@@ -385,6 +390,12 @@
         "category": "Q#",
         "title": "Remove workspace connection",
         "icon": "$(remove)"
+      },
+      {
+        "command": "qsharp-vscode.copilotClear",
+        "category": "Q#",
+        "title": "Clear Quantum Copilot chat",
+        "icon": "$(clear-all)"
       },
       {
         "command": "qsharp-vscode.workspacePythonCode",

--- a/vscode/src/copilot/webviewViewProvider.ts
+++ b/vscode/src/copilot/webviewViewProvider.ts
@@ -3,6 +3,7 @@
 
 import { log } from "qsharp-lang";
 import {
+  commands,
   CancellationToken,
   ExtensionContext,
   Uri,
@@ -13,6 +14,7 @@ import {
 } from "vscode";
 import { Copilot, CopilotUpdateHandler } from "./copilot";
 import { CopilotCommand } from "./shared";
+import { qsharpExtensionId } from "../common";
 
 export function registerCopilotPanel(context: ExtensionContext): void {
   const provider = new CopilotWebviewViewProvider(context.extensionUri);
@@ -24,6 +26,11 @@ export function registerCopilotPanel(context: ExtensionContext): void {
         webviewOptions: { retainContextWhenHidden: true },
       },
     ),
+  );
+  context.subscriptions.push(
+    commands.registerCommand(`${qsharpExtensionId}.copilotClear`, async () => {
+      provider.clearChat();
+    }),
   );
 }
 
@@ -97,6 +104,10 @@ class CopilotWebviewViewProvider implements WebviewViewProvider {
         <body>Error loading Copilot: ${e}</body>
         </html>`;
     }
+  }
+
+  clearChat() {
+    this.copilot?.restartChat([]);
   }
 
   handleMessageFromWebview(message: CopilotCommand) {


### PR DESCRIPTION
This add a "Clear chat" icon (see below on the right) to the Quantum Copilot chat panel, and wires up the pre-existing clear chat functioality to it

<img width="396" alt="image" src="https://github.com/user-attachments/assets/a22dfa83-d613-42d0-9b64-13c3d213e824" />
