### PR TITLE
Added copy button to code blocks in copilot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "github-markdown-css": "^5.3.0",
         "globals": "^15.9.0",
         "highlight.js": "^11.10.0",
+        "highlightjs-copy": "^1.0.6",
         "markdown-it": "^14.1.0",
         "mocha": "^10.8.2",
         "modern-normalize": "^2.0.0",
@@ -4073,6 +4074,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/highlightjs-copy": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/highlightjs-copy/-/highlightjs-copy-1.0.6.tgz",
+      "integrity": "sha512-UaHIlJ4rkk5R4OVDnpgxevIuYdHggN5sPgs3E/2FKLxypvzAQVTOZl66hm8cEnhrEoLHTGkQymLtfJ/efyv24Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/http-assert": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "github-markdown-css": "^5.3.0",
     "globals": "^15.9.0",
     "highlight.js": "^11.10.0",
+    "highlightjs-copy": "^1.0.6",
     "markdown-it": "^14.1.0",
     "mocha": "^10.8.2",
     "modern-normalize": "^2.0.0",

--- a/vscode/src/copilot/webview/copilot.css
+++ b/vscode/src/copilot/webview/copilot.css
@@ -166,3 +166,8 @@ pre code {
 .histogram-container {
   width: 100%;
 }
+
+/* If not specified it defaults to the 'pre code' default monospace font  */
+.hljs-copy-button {
+  font-family: system-ui;
+}

--- a/vscode/src/copilot/webview/types.d.ts
+++ b/vscode/src/copilot/webview/types.d.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This module has no types available, so we declare it as any.
+declare module "highlightjs-copy";


### PR DESCRIPTION
This adds a button to copy to clipboard to the top right of code blocks, e.g.

<img width="473" alt="image" src="https://github.com/user-attachments/assets/72c7be4a-56d5-4d7b-8cc2-fc9a34ad3689" />
