### PR TITLE
fix(#2231) layout monaco editor

### DIFF
--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -250,6 +250,7 @@ export function Editor(props: {
     const newEditor = monaco.editor.create(editorDiv.current, {
       minimap: { enabled: false },
       lineNumbersMinChars: 3,
+      automaticLayout: true,
     });
 
     editor.current = newEditor;


### PR DESCRIPTION
I added `automaticLayout` to the monaco editor object props. This fix #2231 