### PR TITLE
Add gate calls and the AST items it depends on to the new QASM3 compiler

### DIFF
--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -523,7 +523,7 @@ impl QasmCompiler {
     }
 
     fn compile_delay_stmt(&mut self, stmt: &semast::DelayStmt) -> Option<qsast::Stmt> {
-        self.push_unimplemented_error_message("dealy statements", stmt.span);
+        self.push_unimplemented_error_message("delay statements", stmt.span);
         None
     }
 

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -554,6 +554,9 @@ impl QasmCompiler {
 
     fn compile_gate_call_stmt(&mut self, stmt: &semast::GateCall) -> Option<qsast::Stmt> {
         let symbol = self.symbols[stmt.symbol_id].clone();
+        if symbol.name == "U" {
+            self.runtime |= RuntimeFunctions::U;
+        }
         let mut qubits: Vec<_> = stmt
             .qubits
             .iter()
@@ -644,6 +647,7 @@ impl QasmCompiler {
     }
 
     fn compile_gphase_stmt(&mut self, stmt: &semast::GPhase) -> Option<qsast::Stmt> {
+        self.runtime |= RuntimeFunctions::U;
         self.push_unimplemented_error_message("gphase statements", stmt.span);
         None
     }

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -762,7 +762,7 @@ impl QasmCompiler {
     }
 
     fn compile_while_stmt(&mut self, stmt: &semast::WhileLoop) -> Option<qsast::Stmt> {
-        let condition = self.compile_expr(&stmt.while_condition)?;
+        let condition = self.compile_expr(&stmt.condition)?;
         match &*stmt.body.kind {
             semast::StmtKind::Block(block) => {
                 let block = self.compile_block(block);

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -480,8 +480,7 @@ impl QasmCompiler {
         &mut self,
         decl: &semast::ClassicalDeclarationStmt,
     ) -> Option<qsast::Stmt> {
-        let symbol = &self.symbols[decl.symbol_id];
-        let symbol = symbol.clone();
+        let symbol = &self.symbols[decl.symbol_id].clone();
         let name = &symbol.name;
         let is_const = symbol.ty.is_const();
         let ty_span = decl.ty_span;
@@ -806,6 +805,7 @@ impl QasmCompiler {
             LiteralKind::Bitstring(big_int, width) => {
                 Self::compile_bitstring_literal(big_int, *width, span)
             }
+            LiteralKind::Bit(value) => Self::compile_bit_literal(*value, span),
             LiteralKind::Bool(value) => Self::compile_bool_literal(*value, span),
             LiteralKind::Duration(value, time_unit) => {
                 self.compile_duration_literal(*value, *time_unit, span)
@@ -925,6 +925,10 @@ impl QasmCompiler {
     fn compile_array_literal(&mut self, _value: &List<Expr>, span: Span) -> Option<qsast::Expr> {
         self.push_unimplemented_error_message("array literals", span);
         None
+    }
+
+    fn compile_bit_literal(value: bool, span: Span) -> Option<qsast::Expr> {
+        Some(build_lit_result_expr(value.into(), span))
     }
 
     fn compile_bool_literal(value: bool, span: Span) -> Option<qsast::Expr> {

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -647,7 +647,7 @@ impl QasmCompiler {
     }
 
     fn compile_gphase_stmt(&mut self, stmt: &semast::GPhase) -> Option<qsast::Stmt> {
-        self.runtime |= RuntimeFunctions::U;
+        self.runtime |= RuntimeFunctions::Gphase;
         self.push_unimplemented_error_message("gphase statements", stmt.span);
         None
     }

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -1056,7 +1056,11 @@ impl QasmCompiler {
 
     fn compile_bitstring_literal(value: &BigInt, width: u32, span: Span) -> Option<qsast::Expr> {
         let width = width as usize;
-        let bitstring = format!("Bitstring(\"{:0>width$}\")", value.to_str_radix(2));
+        let bitstring = if value == &BigInt::ZERO && width == 0 {
+            "Bitstring(\"\")".to_string()
+        } else {
+            format!("Bitstring(\"{:0>width$}\")", value.to_str_radix(2))
+        };
         Some(build_lit_result_array_expr_from_bitstring(bitstring, span))
     }
 

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -627,11 +627,7 @@ impl QasmCompiler {
         }
 
         let expr = build_gate_call_with_params_and_callee(args, callee, stmt.span);
-        Some(qsast::Stmt {
-            id: qsast::NodeId::default(),
-            span: stmt.span,
-            kind: Box::new(qsast::StmtKind::Expr(Box::new(expr))),
-        })
+        Some(build_stmt_semi_from_expr(expr))
     }
 
     fn compile_gphase_stmt(&mut self, stmt: &semast::GPhase) -> Option<qsast::Stmt> {

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -1027,7 +1027,7 @@ impl QasmCompiler {
             }
         }
 
-        self.push_unimplemented_error_message("index set expressions", set.span);
+        self.push_unsupported_error_message("index set expressions with multiple values", set.span);
         None
     }
 

--- a/compiler/qsc_qasm3/src/parser/ast.rs
+++ b/compiler/qsc_qasm3/src/parser/ast.rs
@@ -1024,6 +1024,7 @@ pub struct QubitDeclaration {
 impl Display for QubitDeclaration {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "QubitDeclaration", self.span)?;
+        writeln_field(f, "ty_span", &self.ty_span)?;
         writeln_field(f, "ident", &self.qubit)?;
         write_opt_field(f, "size", self.size.as_ref())
     }

--- a/compiler/qsc_qasm3/src/parser/ast.rs
+++ b/compiler/qsc_qasm3/src/parser/ast.rs
@@ -991,6 +991,7 @@ impl Display for IncludeStmt {
 #[derive(Clone, Debug)]
 pub struct QubitDeclaration {
     pub span: Span,
+    pub ty_span: Span,
     pub qubit: Ident,
     pub size: Option<Expr>,
 }
@@ -1129,7 +1130,7 @@ pub struct ClassicalDeclarationStmt {
     pub span: Span,
     pub ty: Box<TypeDef>,
     pub identifier: Ident,
-    pub init_expr: Option<Box<ValueExpression>>,
+    pub init_expr: Option<Box<ValueExpr>>,
 }
 
 impl Display for ClassicalDeclarationStmt {
@@ -1142,16 +1143,16 @@ impl Display for ClassicalDeclarationStmt {
 }
 
 #[derive(Clone, Debug)]
-pub enum ValueExpression {
+pub enum ValueExpr {
     Expr(Expr),
     Measurement(MeasureExpr),
 }
 
-impl Display for ValueExpression {
+impl Display for ValueExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ValueExpression::Expr(expr) => write!(f, "{expr}"),
-            ValueExpression::Measurement(measure) => write!(f, "{measure}"),
+            Self::Expr(expr) => write!(f, "{expr}"),
+            Self::Measurement(measure) => write!(f, "{measure}"),
         }
     }
 }
@@ -1178,7 +1179,7 @@ pub struct ConstantDeclStmt {
     pub span: Span,
     pub ty: TypeDef,
     pub identifier: Box<Ident>,
-    pub init_expr: Expr,
+    pub init_expr: ValueExpr,
 }
 
 impl Display for ConstantDeclStmt {
@@ -1339,7 +1340,7 @@ impl Display for DefStmt {
 #[derive(Clone, Debug)]
 pub struct ReturnStmt {
     pub span: Span,
-    pub expr: Option<Box<ValueExpression>>,
+    pub expr: Option<Box<ValueExpr>>,
 }
 
 impl Display for ReturnStmt {
@@ -1470,7 +1471,7 @@ impl Display for ExprKind {
 pub struct AssignStmt {
     pub span: Span,
     pub lhs: IndexedIdent,
-    pub rhs: Expr,
+    pub rhs: ValueExpr,
 }
 
 impl Display for AssignStmt {
@@ -1486,7 +1487,7 @@ pub struct AssignOpStmt {
     pub span: Span,
     pub op: BinOp,
     pub lhs: IndexedIdent,
-    pub rhs: Expr,
+    pub rhs: ValueExpr,
 }
 
 impl Display for AssignOpStmt {

--- a/compiler/qsc_qasm3/src/parser/ast.rs
+++ b/compiler/qsc_qasm3/src/parser/ast.rs
@@ -468,12 +468,14 @@ impl Display for BarrierStmt {
 #[derive(Clone, Debug)]
 pub struct ResetStmt {
     pub span: Span,
+    pub reset_token_span: Span,
     pub operand: Box<GateOperand>,
 }
 
 impl Display for ResetStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "ResetStmt", self.span)?;
+        writeln_field(f, "reset_token_span", &self.reset_token_span)?;
         write_field(f, "operand", &self.operand)
     }
 }

--- a/compiler/qsc_qasm3/src/parser/ast/display_utils.rs
+++ b/compiler/qsc_qasm3/src/parser/ast/display_utils.rs
@@ -129,7 +129,7 @@ pub(crate) fn writeln_opt_field<T: Display>(
     writeln!(f)
 }
 
-/// Writes an field of a structure to the given buffer
+/// Writes a field of a structure to the given buffer
 /// or stream with an additional indententation level.
 /// The field must be an iterable.
 pub(crate) fn write_list_field<'write, 'itemref, 'item, T, I>(
@@ -148,7 +148,7 @@ where
     write_list(&mut indent, vals)
 }
 
-/// Writes an field of a structure to the given buffer
+/// Writes a field of a structure to the given buffer
 /// or stream with an additional indententation level.
 /// The field must be an iterable.
 /// Inserts a newline afterwards.

--- a/compiler/qsc_qasm3/src/parser/expr/tests.rs
+++ b/compiler/qsc_qasm3/src/parser/expr/tests.rs
@@ -1146,8 +1146,9 @@ fn measure_hardware_qubit() {
         super::measure_expr,
         "measure $12",
         &expect![[r#"
-            MeasureExpr [0-7]:
-                operand: HardwareQubit [8-11]: 12"#]],
+            MeasureExpr [0-11]:
+                operand: GateOperand [8-11]:
+                    kind: HardwareQubit [8-11]: 12"#]],
     );
 }
 
@@ -1157,17 +1158,18 @@ fn measure_indexed_identifier() {
         super::measure_expr,
         "measure qubits[1][2]",
         &expect![[r#"
-            MeasureExpr [0-7]:
-                operand: IndexedIdent [8-20]:
-                    name: Ident [8-14] "qubits"
-                    index_span: [14-20]
-                    indices:
-                        IndexSet [15-16]:
-                            values:
-                                Expr [15-16]: Lit: Int(1)
-                        IndexSet [18-19]:
-                            values:
-                                Expr [18-19]: Lit: Int(2)"#]],
+            MeasureExpr [0-20]:
+                operand: GateOperand [8-20]:
+                    kind: IndexedIdent [8-20]:
+                        name: Ident [8-14] "qubits"
+                        index_span: [14-20]
+                        indices:
+                            IndexSet [15-16]:
+                                values:
+                                    Expr [15-16]: Lit: Int(1)
+                            IndexSet [18-19]:
+                                values:
+                                    Expr [18-19]: Lit: Int(2)"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/mut_visit.rs
+++ b/compiler/qsc_qasm3/src/parser/mut_visit.rs
@@ -14,7 +14,7 @@ use super::ast::{
     LiteralKind, MeasureExpr, MeasureStmt, Pragma, Program, QuantumGateDefinition,
     QuantumGateModifier, QuantumTypedParameter, QubitDeclaration, RangeDefinition, ResetStmt,
     ReturnStmt, ScalarType, ScalarTypedParameter, Stmt, StmtKind, SwitchCase, SwitchStmt, TypeDef,
-    TypedParameter, UnaryOp, UnaryOpExpr, ValueExpression, Version, WhileLoop,
+    TypedParameter, UnaryOp, UnaryOpExpr, ValueExpr, Version, WhileLoop,
 };
 
 pub trait MutVisitor: Sized {
@@ -190,7 +190,7 @@ pub trait MutVisitor: Sized {
         walk_index_expr(self, expr);
     }
 
-    fn visit_value_expr(&mut self, expr: &mut ValueExpression) {
+    fn visit_value_expr(&mut self, expr: &mut ValueExpr) {
         walk_value_expr(self, expr);
     }
 
@@ -379,14 +379,14 @@ fn walk_alias_decl_stmt(vis: &mut impl MutVisitor, stmt: &mut AliasDeclStmt) {
 fn walk_assign_stmt(vis: &mut impl MutVisitor, stmt: &mut AssignStmt) {
     vis.visit_span(&mut stmt.span);
     vis.visit_indexed_ident(&mut stmt.lhs);
-    vis.visit_expr(&mut stmt.rhs);
+    vis.visit_value_expr(&mut stmt.rhs);
 }
 
 fn walk_assign_op_stmt(vis: &mut impl MutVisitor, stmt: &mut AssignOpStmt) {
     vis.visit_span(&mut stmt.span);
     vis.visit_indexed_ident(&mut stmt.lhs);
     vis.visit_binop(&mut stmt.op);
-    vis.visit_expr(&mut stmt.rhs);
+    vis.visit_value_expr(&mut stmt.rhs);
 }
 
 fn walk_barrier_stmt(vis: &mut impl MutVisitor, stmt: &mut BarrierStmt) {
@@ -432,7 +432,7 @@ fn walk_const_decl_stmt(vis: &mut impl MutVisitor, stmt: &mut ConstantDeclStmt) 
     vis.visit_span(&mut stmt.span);
     vis.visit_tydef(&mut stmt.ty);
     vis.visit_ident(&mut stmt.identifier);
-    vis.visit_expr(&mut stmt.init_expr);
+    vis.visit_value_expr(&mut stmt.init_expr);
 }
 
 fn walk_continue_stmt(vis: &mut impl MutVisitor, stmt: &mut ContinueStmt) {
@@ -557,6 +557,7 @@ fn walk_quantum_gate_definition_stmt(vis: &mut impl MutVisitor, stmt: &mut Quant
 
 fn walk_quantum_decl_stmt(vis: &mut impl MutVisitor, stmt: &mut QubitDeclaration) {
     vis.visit_span(&mut stmt.span);
+    vis.visit_span(&mut stmt.ty_span);
     vis.visit_ident(&mut stmt.qubit);
     stmt.size.iter_mut().for_each(|s| vis.visit_expr(s));
 }
@@ -644,10 +645,10 @@ pub fn walk_index_expr(vis: &mut impl MutVisitor, expr: &mut IndexExpr) {
     vis.visit_index_element(&mut expr.index);
 }
 
-pub fn walk_value_expr(vis: &mut impl MutVisitor, expr: &mut ValueExpression) {
+pub fn walk_value_expr(vis: &mut impl MutVisitor, expr: &mut ValueExpr) {
     match &mut *expr {
-        ValueExpression::Expr(expr) => vis.visit_expr(expr),
-        ValueExpression::Measurement(measure_expr) => vis.visit_measure_expr(measure_expr),
+        ValueExpr::Expr(expr) => vis.visit_expr(expr),
+        ValueExpr::Measurement(measure_expr) => vis.visit_measure_expr(measure_expr),
     }
 }
 

--- a/compiler/qsc_qasm3/src/parser/mut_visit.rs
+++ b/compiler/qsc_qasm3/src/parser/mut_visit.rs
@@ -564,6 +564,7 @@ fn walk_quantum_decl_stmt(vis: &mut impl MutVisitor, stmt: &mut QubitDeclaration
 
 fn walk_reset_stmt(vis: &mut impl MutVisitor, stmt: &mut ResetStmt) {
     vis.visit_span(&mut stmt.span);
+    vis.visit_span(&mut stmt.reset_token_span);
     vis.visit_gate_operand(&mut stmt.operand);
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt.rs
@@ -27,7 +27,7 @@ use super::ast::{
     DelayStmt, EndStmt, EnumerableSet, Expr, ExprKind, ExprStmt, ExternDecl, ExternParameter,
     FloatType, ForStmt, FunctionCall, GPhase, GateCall, GateModifierKind, GateOperand,
     IODeclaration, IOKeyword, Ident, Identifier, IfStmt, IncludeStmt, IndexElement, IndexExpr,
-    IndexSetItem, IndexedIdent, IntType, List, LiteralKind, MeasureStmt, Pragma,
+    IndexSetItem, IndexedIdent, IntType, List, LiteralKind, MeasureArrowStmt, Pragma,
     QuantumGateDefinition, QuantumGateModifier, QuantumTypedParameter, QubitDeclaration,
     RangeDefinition, ResetStmt, ReturnStmt, ScalarType, ScalarTypeKind, ScalarTypedParameter, Stmt,
     StmtKind, SwitchCase, SwitchStmt, TypeDef, TypedParameter, UIntType, WhileLoop,
@@ -1764,7 +1764,7 @@ fn parse_reset(s: &mut ParserContext) -> Result<ResetStmt> {
 }
 
 /// Grammar: `measureExpression (ARROW indexedIdentifier)? SEMICOLON`.
-fn parse_measure_stmt(s: &mut ParserContext) -> Result<MeasureStmt> {
+fn parse_measure_stmt(s: &mut ParserContext) -> Result<MeasureArrowStmt> {
     let lo = s.peek().span.lo;
     let measure = expr::measure_expr(s)?;
 
@@ -1775,7 +1775,7 @@ fn parse_measure_stmt(s: &mut ParserContext) -> Result<MeasureStmt> {
 
     recovering_semi(s);
 
-    Ok(MeasureStmt {
+    Ok(MeasureArrowStmt {
         span: s.span(lo),
         measurement: measure,
         target,

--- a/compiler/qsc_qasm3/src/parser/stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt.rs
@@ -1754,11 +1754,13 @@ fn parse_delay(s: &mut ParserContext) -> Result<DelayStmt> {
 fn parse_reset(s: &mut ParserContext) -> Result<ResetStmt> {
     let lo = s.peek().span.lo;
     token(s, TokenKind::Keyword(Keyword::Reset))?;
+    let reset_token_span = s.span(lo);
     let operand = Box::new(gate_operand(s)?);
     recovering_semi(s);
 
     Ok(ResetStmt {
         span: s.span(lo),
+        reset_token_span,
         operand,
     })
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/barrier.rs
@@ -15,18 +15,21 @@ fn barrier() {
                 annotations: <empty>
                 kind: BarrierStmt [0-20]:
                     operands:
-                        IndexedIdent [8-9]:
-                            name: Ident [8-9] "r"
-                            index_span: [0-0]
-                            indices: <empty>
-                        IndexedIdent [11-15]:
-                            name: Ident [11-12] "q"
-                            index_span: [12-15]
-                            indices:
-                                IndexSet [13-14]:
-                                    values:
-                                        Expr [13-14]: Lit: Int(0)
-                        HardwareQubit [17-19]: 2"#]],
+                        GateOperand [8-9]:
+                            kind: IndexedIdent [8-9]:
+                                name: Ident [8-9] "r"
+                                index_span: [0-0]
+                                indices: <empty>
+                        GateOperand [11-15]:
+                            kind: IndexedIdent [11-15]:
+                                name: Ident [11-12] "q"
+                                index_span: [12-15]
+                                indices:
+                                    IndexSet [13-14]:
+                                        values:
+                                            Expr [13-14]: Lit: Int(0)
+                        GateOperand [17-19]:
+                            kind: HardwareQubit [17-19]: 2"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/box_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/box_stmt.rs
@@ -28,10 +28,11 @@ fn box_stmt() {
                                 args: <empty>
                                 duration: <none>
                                 qubits:
-                                    IndexedIdent [21-23]:
-                                        name: Ident [21-23] "q0"
-                                        index_span: [0-0]
-                                        indices: <empty>
+                                    GateOperand [21-23]:
+                                        kind: IndexedIdent [21-23]:
+                                            name: Ident [21-23] "q0"
+                                            index_span: [0-0]
+                                            indices: <empty>
                         Stmt [33-44]:
                             annotations: <empty>
                             kind: GateCall [33-44]:
@@ -41,10 +42,11 @@ fn box_stmt() {
                                     Expr [36-39]: Lit: Float(2.4)
                                 duration: <none>
                                 qubits:
-                                    IndexedIdent [41-43]:
-                                        name: Ident [41-43] "q1"
-                                        index_span: [0-0]
-                                        indices: <empty>"#]],
+                                    GateOperand [41-43]:
+                                        kind: IndexedIdent [41-43]:
+                                            name: Ident [41-43] "q1"
+                                            index_span: [0-0]
+                                            indices: <empty>"#]],
     );
 }
 
@@ -71,10 +73,11 @@ fn box_stmt_with_designator() {
                                 args: <empty>
                                 duration: <none>
                                 qubits:
-                                    IndexedIdent [26-28]:
-                                        name: Ident [26-28] "q0"
-                                        index_span: [0-0]
-                                        indices: <empty>
+                                    GateOperand [26-28]:
+                                        kind: IndexedIdent [26-28]:
+                                            name: Ident [26-28] "q0"
+                                            index_span: [0-0]
+                                            indices: <empty>
                         Stmt [38-49]:
                             annotations: <empty>
                             kind: GateCall [38-49]:
@@ -84,9 +87,10 @@ fn box_stmt_with_designator() {
                                     Expr [41-44]: Lit: Float(2.4)
                                 duration: <none>
                                 qubits:
-                                    IndexedIdent [46-48]:
-                                        name: Ident [46-48] "q1"
-                                        index_span: [0-0]
-                                        indices: <empty>"#]],
+                                    GateOperand [46-48]:
+                                        kind: IndexedIdent [46-48]:
+                                            name: Ident [46-48] "q1"
+                                            index_span: [0-0]
+                                            indices: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/classical_decl.rs
@@ -1071,8 +1071,9 @@ fn measure_hardware_qubit_decl() {
                     type: ScalarType [0-3]: BitType [0-3]:
                         size: <none>
                     ident: Ident [4-7] "res"
-                    init_expr: MeasureExpr [10-17]:
-                        operand: HardwareQubit [18-21]: 12"#]],
+                    init_expr: MeasureExpr [10-21]:
+                        operand: GateOperand [18-21]:
+                            kind: HardwareQubit [18-21]: 12"#]],
     );
 }
 
@@ -1088,16 +1089,17 @@ fn measure_register_decl() {
                     type: ScalarType [0-3]: BitType [0-3]:
                         size: <none>
                     ident: Ident [4-7] "res"
-                    init_expr: MeasureExpr [10-17]:
-                        operand: IndexedIdent [18-30]:
-                            name: Ident [18-24] "qubits"
-                            index_span: [24-30]
-                            indices:
-                                IndexSet [25-26]:
-                                    values:
-                                        Expr [25-26]: Lit: Int(2)
-                                IndexSet [28-29]:
-                                    values:
-                                        Expr [28-29]: Lit: Int(3)"#]],
+                    init_expr: MeasureExpr [10-30]:
+                        operand: GateOperand [18-30]:
+                            kind: IndexedIdent [18-30]:
+                                name: Ident [18-24] "qubits"
+                                index_span: [24-30]
+                                indices:
+                                    IndexSet [25-26]:
+                                        values:
+                                            Expr [25-26]: Lit: Int(2)
+                                    IndexSet [28-29]:
+                                        values:
+                                            Expr [28-29]: Lit: Int(3)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/delay.rs
@@ -16,19 +16,21 @@ fn delay() {
                 kind: DelayStmt [0-20]:
                     duration: Expr [6-7]: Ident [6-7] "a"
                     qubits:
-                        IndexedIdent [9-13]:
-                            name: Ident [9-10] "q"
-                            index_span: [10-13]
-                            indices:
-                                IndexSet [11-12]:
-                                    values:
-                                        Expr [11-12]: Lit: Int(0)
-                        IndexedIdent [15-19]:
-                            name: Ident [15-16] "q"
-                            index_span: [16-19]
-                            indices:
-                                IndexSet [17-18]:
-                                    values:
-                                        Expr [17-18]: Lit: Int(1)"#]],
+                        GateOperand [9-13]:
+                            kind: IndexedIdent [9-13]:
+                                name: Ident [9-10] "q"
+                                index_span: [10-13]
+                                indices:
+                                    IndexSet [11-12]:
+                                        values:
+                                            Expr [11-12]: Lit: Int(0)
+                        GateOperand [15-19]:
+                            kind: IndexedIdent [15-19]:
+                                name: Ident [15-16] "q"
+                                index_span: [16-19]
+                                indices:
+                                    IndexSet [17-18]:
+                                        values:
+                                            Expr [17-18]: Lit: Int(1)"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/for_loops.rs
@@ -283,10 +283,11 @@ fn single_stmt_for_stmt() {
                             args: <empty>
                             duration: <none>
                             qubits:
-                                IndexedIdent [18-19]:
-                                    name: Ident [18-19] "q"
-                                    index_span: [0-0]
-                                    indices: <empty>"#]],
+                                GateOperand [18-19]:
+                                    kind: IndexedIdent [18-19]:
+                                        name: Ident [18-19] "q"
+                                        index_span: [0-0]
+                                        indices: <empty>"#]],
     );
 }
 
@@ -355,10 +356,11 @@ fn nested_single_stmt_for_stmt() {
                                     args: <empty>
                                     duration: <none>
                                     qubits:
-                                        IndexedIdent [34-35]:
-                                            name: Ident [34-35] "q"
-                                            index_span: [0-0]
-                                            indices: <empty>"#]],
+                                        GateOperand [34-35]:
+                                            kind: IndexedIdent [34-35]:
+                                                name: Ident [34-35] "q"
+                                                index_span: [0-0]
+                                                indices: <empty>"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gate_call.rs
@@ -19,10 +19,11 @@ fn gate_call() {
                     args: <empty>
                     duration: <none>
                     qubits:
-                        IndexedIdent [2-4]:
-                            name: Ident [2-4] "q0"
-                            index_span: [0-0]
-                            indices: <empty>"#]],
+                        GateOperand [2-4]:
+                            kind: IndexedIdent [2-4]:
+                                name: Ident [2-4] "q0"
+                                index_span: [0-0]
+                                indices: <empty>"#]],
     );
 }
 
@@ -40,13 +41,14 @@ fn gate_call_qubit_register() {
                     args: <empty>
                     duration: <none>
                     qubits:
-                        IndexedIdent [2-6]:
-                            name: Ident [2-3] "q"
-                            index_span: [3-6]
-                            indices:
-                                IndexSet [4-5]:
-                                    values:
-                                        Expr [4-5]: Lit: Int(2)"#]],
+                        GateOperand [2-6]:
+                            kind: IndexedIdent [2-6]:
+                                name: Ident [2-3] "q"
+                                index_span: [3-6]
+                                indices:
+                                    IndexSet [4-5]:
+                                        values:
+                                            Expr [4-5]: Lit: Int(2)"#]],
     );
 }
 
@@ -64,17 +66,19 @@ fn gate_multiple_qubits() {
                     args: <empty>
                     duration: <none>
                     qubits:
-                        IndexedIdent [5-7]:
-                            name: Ident [5-7] "q0"
-                            index_span: [0-0]
-                            indices: <empty>
-                        IndexedIdent [9-13]:
-                            name: Ident [9-10] "q"
-                            index_span: [10-13]
-                            indices:
-                                IndexSet [11-12]:
-                                    values:
-                                        Expr [11-12]: Lit: Int(4)"#]],
+                        GateOperand [5-7]:
+                            kind: IndexedIdent [5-7]:
+                                name: Ident [5-7] "q0"
+                                index_span: [0-0]
+                                indices: <empty>
+                        GateOperand [9-13]:
+                            kind: IndexedIdent [9-13]:
+                                name: Ident [9-10] "q"
+                                index_span: [10-13]
+                                indices:
+                                    IndexSet [11-12]:
+                                        values:
+                                            Expr [11-12]: Lit: Int(4)"#]],
     );
 }
 
@@ -125,10 +129,11 @@ fn gate_call_with_parameters() {
                             rhs: Expr [8-9]: Lit: Int(2)
                     duration: <none>
                     qubits:
-                        IndexedIdent [11-13]:
-                            name: Ident [11-13] "q0"
-                            index_span: [0-0]
-                            indices: <empty>"#]],
+                        GateOperand [11-13]:
+                            kind: IndexedIdent [11-13]:
+                                name: Ident [11-13] "q0"
+                                index_span: [0-0]
+                                indices: <empty>"#]],
     );
 }
 
@@ -147,10 +152,11 @@ fn gate_call_inv_modifier() {
                     args: <empty>
                     duration: <none>
                     qubits:
-                        IndexedIdent [8-10]:
-                            name: Ident [8-10] "q0"
-                            index_span: [0-0]
-                            indices: <empty>"#]],
+                        GateOperand [8-10]:
+                            kind: IndexedIdent [8-10]:
+                                name: Ident [8-10] "q0"
+                                index_span: [0-0]
+                                indices: <empty>"#]],
     );
 }
 
@@ -174,18 +180,21 @@ fn gate_call_ctrl_inv_modifiers() {
                             rhs: Expr [24-25]: Lit: Int(2)
                     duration: <none>
                     qubits:
-                        IndexedIdent [27-29]:
-                            name: Ident [27-29] "c1"
-                            index_span: [0-0]
-                            indices: <empty>
-                        IndexedIdent [31-33]:
-                            name: Ident [31-33] "c2"
-                            index_span: [0-0]
-                            indices: <empty>
-                        IndexedIdent [35-37]:
-                            name: Ident [35-37] "q0"
-                            index_span: [0-0]
-                            indices: <empty>"#]],
+                        GateOperand [27-29]:
+                            kind: IndexedIdent [27-29]:
+                                name: Ident [27-29] "c1"
+                                index_span: [0-0]
+                                indices: <empty>
+                        GateOperand [31-33]:
+                            kind: IndexedIdent [31-33]:
+                                name: Ident [31-33] "c2"
+                                index_span: [0-0]
+                                indices: <empty>
+                        GateOperand [35-37]:
+                            kind: IndexedIdent [35-37]:
+                                name: Ident [35-37] "q0"
+                                index_span: [0-0]
+                                indices: <empty>"#]],
     );
 }
 
@@ -224,10 +233,11 @@ fn parametrized_gate_call() {
                         Expr [8-9]: Lit: Int(3)
                     duration: <none>
                     qubits:
-                        IndexedIdent [11-12]:
-                            name: Ident [11-12] "q"
-                            index_span: [0-0]
-                            indices: <empty>"#]],
+                        GateOperand [11-12]:
+                            kind: IndexedIdent [11-12]:
+                                name: Ident [11-12] "q"
+                                index_span: [0-0]
+                                indices: <empty>"#]],
     );
 }
 
@@ -247,10 +257,11 @@ fn parametrized_gate_call_with_designator() {
                         Expr [8-9]: Lit: Int(3)
                     duration: Expr [11-12]: Lit: Int(1)
                     qubits:
-                        IndexedIdent [14-15]:
-                            name: Ident [14-15] "q"
-                            index_span: [0-0]
-                            indices: <empty>"#]],
+                        GateOperand [14-15]:
+                            kind: IndexedIdent [14-15]:
+                                name: Ident [14-15] "q"
+                                index_span: [0-0]
+                                indices: <empty>"#]],
     );
 }
 
@@ -286,10 +297,11 @@ fn gate_call_with_designator() {
                     args: <empty>
                     duration: Expr [2-5]: Lit: Duration(2.0, Us)
                     qubits:
-                        IndexedIdent [7-8]:
-                            name: Ident [7-8] "q"
-                            index_span: [0-0]
-                            indices: <empty>"#]],
+                        GateOperand [7-8]:
+                            kind: IndexedIdent [7-8]:
+                                name: Ident [7-8] "q"
+                                index_span: [0-0]
+                                indices: <empty>"#]],
     );
 }
 
@@ -307,10 +319,11 @@ fn gate_call_with_invalid_designator() {
                     args: <empty>
                     duration: Expr [2-5]: Lit: Duration(2.0, Us)
                     qubits:
-                        IndexedIdent [10-11]:
-                            name: Ident [10-11] "q"
-                            index_span: [0-0]
-                            indices: <empty>
+                        GateOperand [10-11]:
+                            kind: IndexedIdent [10-11]:
+                                name: Ident [10-11] "q"
+                                index_span: [0-0]
+                                indices: <empty>
 
             [
                 Error(

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
@@ -39,10 +39,11 @@ fn gphase_qubit_ident() {
                         Expr [7-8]: Ident [7-8] "a"
                     duration: <none>
                     qubits:
-                        IndexedIdent [10-12]:
-                            name: Ident [10-12] "q0"
-                            index_span: [0-0]
-                            indices: <empty>"#]],
+                        GateOperand [10-12]:
+                            kind: IndexedIdent [10-12]:
+                                name: Ident [10-12] "q0"
+                                index_span: [0-0]
+                                indices: <empty>"#]],
     );
 }
 
@@ -60,13 +61,14 @@ fn gphase_qubit_register() {
                         Expr [7-8]: Ident [7-8] "a"
                     duration: <none>
                     qubits:
-                        IndexedIdent [10-14]:
-                            name: Ident [10-11] "q"
-                            index_span: [11-14]
-                            indices:
-                                IndexSet [12-13]:
-                                    values:
-                                        Expr [12-13]: Lit: Int(2)"#]],
+                        GateOperand [10-14]:
+                            kind: IndexedIdent [10-14]:
+                                name: Ident [10-11] "q"
+                                index_span: [11-14]
+                                indices:
+                                    IndexSet [12-13]:
+                                        values:
+                                            Expr [12-13]: Lit: Int(2)"#]],
     );
 }
 
@@ -84,17 +86,19 @@ fn gphase_multiple_qubits() {
                         Expr [7-8]: Ident [7-8] "a"
                     duration: <none>
                     qubits:
-                        IndexedIdent [10-12]:
-                            name: Ident [10-12] "q0"
-                            index_span: [0-0]
-                            indices: <empty>
-                        IndexedIdent [14-18]:
-                            name: Ident [14-15] "q"
-                            index_span: [15-18]
-                            indices:
-                                IndexSet [16-17]:
-                                    values:
-                                        Expr [16-17]: Lit: Int(4)"#]],
+                        GateOperand [10-12]:
+                            kind: IndexedIdent [10-12]:
+                                name: Ident [10-12] "q0"
+                                index_span: [0-0]
+                                indices: <empty>
+                        GateOperand [14-18]:
+                            kind: IndexedIdent [14-18]:
+                                name: Ident [14-15] "q"
+                                index_span: [15-18]
+                                indices:
+                                    IndexSet [16-17]:
+                                        values:
+                                            Expr [16-17]: Lit: Int(4)"#]],
     );
 }
 
@@ -182,9 +186,10 @@ fn gphase_ctrl_inv_modifiers() {
                             rhs: Expr [25-26]: Lit: Int(2)
                     duration: <none>
                     qubits:
-                        IndexedIdent [28-30]:
-                            name: Ident [28-30] "q0"
-                            index_span: [0-0]
-                            indices: <empty>"#]],
+                        GateOperand [28-30]:
+                            kind: IndexedIdent [28-30]:
+                                name: Ident [28-30] "q0"
+                                index_span: [0-0]
+                                indices: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/if_stmt.rs
@@ -192,10 +192,11 @@ fn single_stmt_if_stmt() {
                             args: <empty>
                             duration: <none>
                             qubits:
-                                IndexedIdent [9-10]:
-                                    name: Ident [9-10] "q"
-                                    index_span: [0-0]
-                                    indices: <empty>
+                                GateOperand [9-10]:
+                                    kind: IndexedIdent [9-10]:
+                                        name: Ident [9-10] "q"
+                                        index_span: [0-0]
+                                        indices: <empty>
                     else_body: <none>"#]],
     );
 }
@@ -254,10 +255,11 @@ fn nested_single_stmt_if_stmt() {
                                     args: <empty>
                                     duration: <none>
                                     qubits:
-                                        IndexedIdent [16-17]:
-                                            name: Ident [16-17] "q"
-                                            index_span: [0-0]
-                                            indices: <empty>
+                                        GateOperand [16-17]:
+                                            kind: IndexedIdent [16-17]:
+                                                name: Ident [16-17] "q"
+                                                index_span: [0-0]
+                                                indices: <empty>
                             else_body: <none>
                     else_body: <none>"#]],
     );
@@ -285,10 +287,11 @@ fn nested_single_stmt_if_else_stmt() {
                                     args: <empty>
                                     duration: <none>
                                     qubits:
-                                        IndexedIdent [16-17]:
-                                            name: Ident [16-17] "q"
-                                            index_span: [0-0]
-                                            indices: <empty>
+                                        GateOperand [16-17]:
+                                            kind: IndexedIdent [16-17]:
+                                                name: Ident [16-17] "q"
+                                                index_span: [0-0]
+                                                indices: <empty>
                             else_body: Stmt [24-42]:
                                 annotations: <empty>
                                 kind: IfStmt [24-42]:
@@ -305,10 +308,11 @@ fn nested_single_stmt_if_else_stmt() {
                                                     args: <empty>
                                                     duration: <none>
                                                     qubits:
-                                                        IndexedIdent [40-41]:
-                                                            name: Ident [40-41] "q"
-                                                            index_span: [0-0]
-                                                            indices: <empty>
+                                                        GateOperand [40-41]:
+                                                            kind: IndexedIdent [40-41]:
+                                                                name: Ident [40-41] "q"
+                                                                index_span: [0-0]
+                                                                indices: <empty>
                                             else_body: <none>
                                     else_body: <none>
                     else_body: <none>"#]],
@@ -333,10 +337,11 @@ fn single_stmt_if_stmt_else_stmt() {
                             args: <empty>
                             duration: <none>
                             qubits:
-                                IndexedIdent [9-10]:
-                                    name: Ident [9-10] "q"
-                                    index_span: [0-0]
-                                    indices: <empty>
+                                GateOperand [9-10]:
+                                    kind: IndexedIdent [9-10]:
+                                        name: Ident [9-10] "q"
+                                        index_span: [0-0]
+                                        indices: <empty>
                     else_body: Stmt [17-21]:
                         annotations: <empty>
                         kind: GateCall [17-21]:
@@ -345,9 +350,10 @@ fn single_stmt_if_stmt_else_stmt() {
                             args: <empty>
                             duration: <none>
                             qubits:
-                                IndexedIdent [19-20]:
-                                    name: Ident [19-20] "q"
-                                    index_span: [0-0]
-                                    indices: <empty>"#]],
+                                GateOperand [19-20]:
+                                    kind: IndexedIdent [19-20]:
+                                        name: Ident [19-20] "q"
+                                        index_span: [0-0]
+                                        indices: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/gate_calls.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/gate_calls.rs
@@ -78,31 +78,32 @@ fn pow_with_two_args() {
         parse,
         "pow(2, 3) @ x $0;",
         &expect![[r#"
-        Stmt [0-17]:
-            annotations: <empty>
-            kind: GateCall [0-17]:
-                modifiers:
-                    QuantumGateModifier [0-11]: Pow Expr [4-5]: Lit: Int(2)
-                name: Ident [12-13] "x"
-                args: <empty>
-                duration: <none>
-                qubits:
-                    HardwareQubit [14-16]: 0
+            Stmt [0-17]:
+                annotations: <empty>
+                kind: GateCall [0-17]:
+                    modifiers:
+                        QuantumGateModifier [0-11]: Pow Expr [4-5]: Lit: Int(2)
+                    name: Ident [12-13] "x"
+                    args: <empty>
+                    duration: <none>
+                    qubits:
+                        GateOperand [14-16]:
+                            kind: HardwareQubit [14-16]: 0
 
-        [
-            Error(
-                Token(
-                    Close(
-                        Paren,
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Comma,
+                        Span {
+                            lo: 5,
+                            hi: 6,
+                        },
                     ),
-                    Comma,
-                    Span {
-                        lo: 5,
-                        hi: 6,
-                    },
                 ),
-            ),
-        ]"#]],
+            ]"#]],
     );
 }
 
@@ -112,32 +113,34 @@ fn ctrl_with_two_args() {
         parse,
         "ctrl(2, 3) @ x $0, $1;",
         &expect![[r#"
-        Stmt [0-22]:
-            annotations: <empty>
-            kind: GateCall [0-22]:
-                modifiers:
-                    QuantumGateModifier [0-12]: Ctrl Some(Expr { span: Span { lo: 5, hi: 6 }, kind: Lit(Lit { span: Span { lo: 5, hi: 6 }, kind: Int(2) }) })
-                name: Ident [13-14] "x"
-                args: <empty>
-                duration: <none>
-                qubits:
-                    HardwareQubit [15-17]: 0
-                    HardwareQubit [19-21]: 1
+            Stmt [0-22]:
+                annotations: <empty>
+                kind: GateCall [0-22]:
+                    modifiers:
+                        QuantumGateModifier [0-12]: Ctrl Some(Expr { span: Span { lo: 5, hi: 6 }, kind: Lit(Lit { span: Span { lo: 5, hi: 6 }, kind: Int(2) }) })
+                    name: Ident [13-14] "x"
+                    args: <empty>
+                    duration: <none>
+                    qubits:
+                        GateOperand [15-17]:
+                            kind: HardwareQubit [15-17]: 0
+                        GateOperand [19-21]:
+                            kind: HardwareQubit [19-21]: 1
 
-        [
-            Error(
-                Token(
-                    Close(
-                        Paren,
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Comma,
+                        Span {
+                            lo: 6,
+                            hi: 7,
+                        },
                     ),
-                    Comma,
-                    Span {
-                        lo: 6,
-                        hi: 7,
-                    },
                 ),
-            ),
-        ]"#]],
+            ]"#]],
     );
 }
 
@@ -147,32 +150,34 @@ fn negctrl_with_two_args() {
         parse,
         "negctrl(2, 3) @ x $0, $1;",
         &expect![[r#"
-        Stmt [0-25]:
-            annotations: <empty>
-            kind: GateCall [0-25]:
-                modifiers:
-                    QuantumGateModifier [0-15]: NegCtrl Some(Expr { span: Span { lo: 8, hi: 9 }, kind: Lit(Lit { span: Span { lo: 8, hi: 9 }, kind: Int(2) }) })
-                name: Ident [16-17] "x"
-                args: <empty>
-                duration: <none>
-                qubits:
-                    HardwareQubit [18-20]: 0
-                    HardwareQubit [22-24]: 1
+            Stmt [0-25]:
+                annotations: <empty>
+                kind: GateCall [0-25]:
+                    modifiers:
+                        QuantumGateModifier [0-15]: NegCtrl Some(Expr { span: Span { lo: 8, hi: 9 }, kind: Lit(Lit { span: Span { lo: 8, hi: 9 }, kind: Int(2) }) })
+                    name: Ident [16-17] "x"
+                    args: <empty>
+                    duration: <none>
+                    qubits:
+                        GateOperand [18-20]:
+                            kind: HardwareQubit [18-20]: 0
+                        GateOperand [22-24]:
+                            kind: HardwareQubit [22-24]: 1
 
-        [
-            Error(
-                Token(
-                    Close(
-                        Paren,
+            [
+                Error(
+                    Token(
+                        Close(
+                            Paren,
+                        ),
+                        Comma,
+                        Span {
+                            lo: 9,
+                            hi: 10,
+                        },
                     ),
-                    Comma,
-                    Span {
-                        lo: 9,
-                        hi: 10,
-                    },
                 ),
-            ),
-        ]"#]],
+            ]"#]],
     );
 }
 
@@ -182,32 +187,34 @@ fn inv_with_arg() {
         parse,
         "inv(1) @ ctrl @ x $0, $1;",
         &expect![[r#"
-        Stmt [0-25]:
-            annotations: <empty>
-            kind: GateCall [0-25]:
-                modifiers:
-                    QuantumGateModifier [0-8]: Inv
-                    QuantumGateModifier [9-15]: Ctrl None
-                name: Ident [16-17] "x"
-                args: <empty>
-                duration: <none>
-                qubits:
-                    HardwareQubit [18-20]: 0
-                    HardwareQubit [22-24]: 1
+            Stmt [0-25]:
+                annotations: <empty>
+                kind: GateCall [0-25]:
+                    modifiers:
+                        QuantumGateModifier [0-8]: Inv
+                        QuantumGateModifier [9-15]: Ctrl None
+                    name: Ident [16-17] "x"
+                    args: <empty>
+                    duration: <none>
+                    qubits:
+                        GateOperand [18-20]:
+                            kind: HardwareQubit [18-20]: 0
+                        GateOperand [22-24]:
+                            kind: HardwareQubit [22-24]: 1
 
-        [
-            Error(
-                Token(
-                    At,
-                    Open(
-                        Paren,
+            [
+                Error(
+                    Token(
+                        At,
+                        Open(
+                            Paren,
+                        ),
+                        Span {
+                            lo: 3,
+                            hi: 4,
+                        },
                     ),
-                    Span {
-                        lo: 3,
-                        hi: 4,
-                    },
                 ),
-            ),
-        ]"#]],
+            ]"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/measure.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/invalid_stmts/measure.rs
@@ -10,25 +10,26 @@ fn measure_multiple_qubits() {
         parse,
         "measure $0, $1;",
         &expect![[r#"
-        Stmt [0-10]:
-            annotations: <empty>
-            kind: MeasureStmt [0-10]:
-                measurement: MeasureExpr [0-7]:
-                    operand: HardwareQubit [8-10]: 0
-                target: <none>
+            Stmt [0-10]:
+                annotations: <empty>
+                kind: MeasureArrowStmt [0-10]:
+                    measurement: MeasureExpr [0-10]:
+                        operand: GateOperand [8-10]:
+                            kind: HardwareQubit [8-10]: 0
+                    target: <none>
 
-        [
-            Error(
-                Token(
-                    Semicolon,
-                    Comma,
-                    Span {
-                        lo: 10,
-                        hi: 11,
-                    },
+            [
+                Error(
+                    Token(
+                        Semicolon,
+                        Comma,
+                        Span {
+                            lo: 10,
+                            hi: 11,
+                        },
+                    ),
                 ),
-            ),
-        ]"#]],
+            ]"#]],
     );
 }
 
@@ -38,17 +39,35 @@ fn assign_measure_multiple_qubits() {
         parse,
         "a[0:1] = measure $0, $1;",
         &expect![[r#"
-        Error(
-            Rule(
-                "expression",
-                Measure,
-                Span {
-                    lo: 9,
-                    hi: 16,
-                },
-            ),
-        )
-    "#]],
+            Stmt [0-19]:
+                annotations: <empty>
+                kind: AssignStmt [0-19]:
+                    lhs: IndexedIdent [0-6]:
+                        name: Ident [0-1] "a"
+                        index_span: [1-6]
+                        indices:
+                            IndexSet [2-5]:
+                                values:
+                                    RangeDefinition [2-5]:
+                                        start: Expr [2-3]: Lit: Int(0)
+                                        step: <none>
+                                        end: Expr [4-5]: Lit: Int(1)
+                    rhs: MeasureExpr [9-19]:
+                        operand: GateOperand [17-19]:
+                            kind: HardwareQubit [17-19]: 0
+
+            [
+                Error(
+                    Token(
+                        Semicolon,
+                        Comma,
+                        Span {
+                            lo: 19,
+                            hi: 20,
+                        },
+                    ),
+                ),
+            ]"#]],
     );
 }
 
@@ -58,17 +77,29 @@ fn assign_arrow() {
         parse,
         "a = measure $0 -> b;",
         &expect![[r#"
-        Error(
-            Rule(
-                "expression",
-                Measure,
-                Span {
-                    lo: 4,
-                    hi: 11,
-                },
-            ),
-        )
-    "#]],
+            Stmt [0-14]:
+                annotations: <empty>
+                kind: AssignStmt [0-14]:
+                    lhs: IndexedIdent [0-1]:
+                        name: Ident [0-1] "a"
+                        index_span: [0-0]
+                        indices: <empty>
+                    rhs: MeasureExpr [4-14]:
+                        operand: GateOperand [12-14]:
+                            kind: HardwareQubit [12-14]: 0
+
+            [
+                Error(
+                    Token(
+                        Semicolon,
+                        Arrow,
+                        Span {
+                            lo: 15,
+                            hi: 17,
+                        },
+                    ),
+                ),
+            ]"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
@@ -103,3 +103,20 @@ fn measure_arrow_into_indented_ident() {
                                     Expr [15-16]: Lit: Int(1)"#]],
     );
 }
+
+#[test]
+fn assign_measure_stmt() {
+    check(parse, "c = measure q;", &expect![[r#"
+        Stmt [0-14]:
+            annotations: <empty>
+            kind: AssignStmt [0-14]:
+                lhs: IndexedIdent [0-1]:
+                    name: Ident [0-1] "c"
+                    index_span: [0-0]
+                    indices: <empty>
+                rhs: MeasureExpr [4-11]:
+                    operand: IndexedIdent [12-13]:
+                        name: Ident [12-13] "q"
+                        index_span: [0-0]
+                        indices: <empty>"#]]);
+}

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/measure.rs
@@ -13,12 +13,13 @@ fn measure_identifier() {
         &expect![[r#"
             Stmt [0-10]:
                 annotations: <empty>
-                kind: MeasureStmt [0-10]:
-                    measurement: MeasureExpr [0-7]:
-                        operand: IndexedIdent [8-9]:
-                            name: Ident [8-9] "q"
-                            index_span: [0-0]
-                            indices: <empty>
+                kind: MeasureArrowStmt [0-10]:
+                    measurement: MeasureExpr [0-9]:
+                        operand: GateOperand [8-9]:
+                            kind: IndexedIdent [8-9]:
+                                name: Ident [8-9] "q"
+                                index_span: [0-0]
+                                indices: <empty>
                     target: <none>"#]],
     );
 }
@@ -31,15 +32,16 @@ fn measure_indented_ident() {
         &expect![[r#"
             Stmt [0-13]:
                 annotations: <empty>
-                kind: MeasureStmt [0-13]:
-                    measurement: MeasureExpr [0-7]:
-                        operand: IndexedIdent [8-12]:
-                            name: Ident [8-9] "q"
-                            index_span: [9-12]
-                            indices:
-                                IndexSet [10-11]:
-                                    values:
-                                        Expr [10-11]: Lit: Int(2)
+                kind: MeasureArrowStmt [0-13]:
+                    measurement: MeasureExpr [0-12]:
+                        operand: GateOperand [8-12]:
+                            kind: IndexedIdent [8-12]:
+                                name: Ident [8-9] "q"
+                                index_span: [9-12]
+                                indices:
+                                    IndexSet [10-11]:
+                                        values:
+                                            Expr [10-11]: Lit: Int(2)
                     target: <none>"#]],
     );
 }
@@ -52,9 +54,10 @@ fn measure_hardware_qubit() {
         &expect![[r#"
             Stmt [0-12]:
                 annotations: <empty>
-                kind: MeasureStmt [0-12]:
-                    measurement: MeasureExpr [0-7]:
-                        operand: HardwareQubit [8-11]: 42
+                kind: MeasureArrowStmt [0-12]:
+                    measurement: MeasureExpr [0-11]:
+                        operand: GateOperand [8-11]:
+                            kind: HardwareQubit [8-11]: 42
                     target: <none>"#]],
     );
 }
@@ -67,12 +70,13 @@ fn measure_arrow_into_ident() {
         &expect![[r#"
             Stmt [0-15]:
                 annotations: <empty>
-                kind: MeasureStmt [0-15]:
-                    measurement: MeasureExpr [0-7]:
-                        operand: IndexedIdent [8-9]:
-                            name: Ident [8-9] "q"
-                            index_span: [0-0]
-                            indices: <empty>
+                kind: MeasureArrowStmt [0-15]:
+                    measurement: MeasureExpr [0-9]:
+                        operand: GateOperand [8-9]:
+                            kind: IndexedIdent [8-9]:
+                                name: Ident [8-9] "q"
+                                index_span: [0-0]
+                                indices: <empty>
                     target: IndexedIdent [13-14]:
                         name: Ident [13-14] "a"
                         index_span: [0-0]
@@ -88,12 +92,13 @@ fn measure_arrow_into_indented_ident() {
         &expect![[r#"
             Stmt [0-18]:
                 annotations: <empty>
-                kind: MeasureStmt [0-18]:
-                    measurement: MeasureExpr [0-7]:
-                        operand: IndexedIdent [8-9]:
-                            name: Ident [8-9] "q"
-                            index_span: [0-0]
-                            indices: <empty>
+                kind: MeasureArrowStmt [0-18]:
+                    measurement: MeasureExpr [0-9]:
+                        operand: GateOperand [8-9]:
+                            kind: IndexedIdent [8-9]:
+                                name: Ident [8-9] "q"
+                                index_span: [0-0]
+                                indices: <empty>
                     target: IndexedIdent [13-17]:
                         name: Ident [13-14] "a"
                         index_span: [14-17]
@@ -106,7 +111,10 @@ fn measure_arrow_into_indented_ident() {
 
 #[test]
 fn assign_measure_stmt() {
-    check(parse, "c = measure q;", &expect![[r#"
+    check(
+        parse,
+        "c = measure q;",
+        &expect![[r#"
         Stmt [0-14]:
             annotations: <empty>
             kind: AssignStmt [0-14]:
@@ -114,9 +122,11 @@ fn assign_measure_stmt() {
                     name: Ident [0-1] "c"
                     index_span: [0-0]
                     indices: <empty>
-                rhs: MeasureExpr [4-11]:
-                    operand: IndexedIdent [12-13]:
-                        name: Ident [12-13] "q"
-                        index_span: [0-0]
-                        indices: <empty>"#]]);
+                rhs: MeasureExpr [4-13]:
+                    operand: GateOperand [12-13]:
+                        kind: IndexedIdent [12-13]:
+                            name: Ident [12-13] "q"
+                            index_span: [0-0]
+                            indices: <empty>"#]],
+    );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/old_style_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/old_style_decl.rs
@@ -48,6 +48,7 @@ fn qreg_decl() {
             Stmt [0-7]:
                 annotations: <empty>
                 kind: QubitDeclaration [0-7]:
+                    ty_span: [0-7]
                     ident: Ident [5-6] "q"
                     size: <none>"#]],
     );
@@ -62,6 +63,7 @@ fn qreg_array_decl() {
             Stmt [0-10]:
                 annotations: <empty>
                 kind: QubitDeclaration [0-10]:
+                    ty_span: [0-10]
                     ident: Ident [5-6] "q"
                     size: Expr [7-8]: Ident [7-8] "n""#]],
     );

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/quantum_decl.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/quantum_decl.rs
@@ -16,6 +16,7 @@ fn quantum_decl() {
             Stmt [0-8]:
                 annotations: <empty>
                 kind: QubitDeclaration [0-8]:
+                    ty_span: [0-5]
                     ident: Ident [6-7] "q"
                     size: <none>"#]],
     );
@@ -35,6 +36,7 @@ fn annotated_quantum_decl() {
                         identifier: "a.b.c"
                         value: "123"
                 kind: QubitDeclaration [28-36]:
+                    ty_span: [28-33]
                     ident: Ident [34-35] "q"
                     size: <none>"#]],
     );
@@ -62,6 +64,7 @@ fn multi_annotated_quantum_decl() {
                         identifier: "a.b.c"
                         value: "123"
                 kind: QubitDeclaration [100-108]:
+                    ty_span: [100-105]
                     ident: Ident [106-107] "q"
                     size: <none>"#]],
     );
@@ -96,6 +99,7 @@ fn quantum_decl_with_designator() {
             Stmt [0-16]:
                 annotations: <empty>
                 kind: QubitDeclaration [0-16]:
+                    ty_span: [0-8]
                     ident: Ident [9-15] "qubits"
                     size: Expr [6-7]: Lit: Int(5)"#]],
     );

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
@@ -14,6 +14,7 @@ fn reset_ident() {
             Stmt [0-8]:
                 annotations: <empty>
                 kind: ResetStmt [0-8]:
+                    reset_token_span: [0-5]
                     operand: GateOperand [6-7]:
                         kind: IndexedIdent [6-7]:
                             name: Ident [6-7] "a"
@@ -31,6 +32,7 @@ fn reset_indexed_ident() {
             Stmt [0-11]:
                 annotations: <empty>
                 kind: ResetStmt [0-11]:
+                    reset_token_span: [0-5]
                     operand: GateOperand [6-10]:
                         kind: IndexedIdent [6-10]:
                             name: Ident [6-7] "a"
@@ -51,6 +53,7 @@ fn reset_hardware_qubit() {
             Stmt [0-10]:
                 annotations: <empty>
                 kind: ResetStmt [0-10]:
+                    reset_token_span: [0-5]
                     operand: GateOperand [6-9]:
                         kind: HardwareQubit [6-9]: 42"#]],
     );

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/reset.rs
@@ -14,10 +14,11 @@ fn reset_ident() {
             Stmt [0-8]:
                 annotations: <empty>
                 kind: ResetStmt [0-8]:
-                    operand: IndexedIdent [6-7]:
-                        name: Ident [6-7] "a"
-                        index_span: [0-0]
-                        indices: <empty>"#]],
+                    operand: GateOperand [6-7]:
+                        kind: IndexedIdent [6-7]:
+                            name: Ident [6-7] "a"
+                            index_span: [0-0]
+                            indices: <empty>"#]],
     );
 }
 
@@ -30,13 +31,14 @@ fn reset_indexed_ident() {
             Stmt [0-11]:
                 annotations: <empty>
                 kind: ResetStmt [0-11]:
-                    operand: IndexedIdent [6-10]:
-                        name: Ident [6-7] "a"
-                        index_span: [7-10]
-                        indices:
-                            IndexSet [8-9]:
-                                values:
-                                    Expr [8-9]: Lit: Int(1)"#]],
+                    operand: GateOperand [6-10]:
+                        kind: IndexedIdent [6-10]:
+                            name: Ident [6-7] "a"
+                            index_span: [7-10]
+                            indices:
+                                IndexSet [8-9]:
+                                    values:
+                                        Expr [8-9]: Lit: Int(1)"#]],
     );
 }
 
@@ -49,6 +51,7 @@ fn reset_hardware_qubit() {
             Stmt [0-10]:
                 annotations: <empty>
                 kind: ResetStmt [0-10]:
-                    operand: HardwareQubit [6-9]: 42"#]],
+                    operand: GateOperand [6-9]:
+                        kind: HardwareQubit [6-9]: 42"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/while_loops.rs
@@ -162,10 +162,11 @@ fn single_stmt_while_stmt() {
                             args: <empty>
                             duration: <none>
                             qubits:
-                                IndexedIdent [12-13]:
-                                    name: Ident [12-13] "q"
-                                    index_span: [0-0]
-                                    indices: <empty>"#]],
+                                GateOperand [12-13]:
+                                    kind: IndexedIdent [12-13]:
+                                        name: Ident [12-13] "q"
+                                        index_span: [0-0]
+                                        indices: <empty>"#]],
     );
 }
 
@@ -222,9 +223,10 @@ fn nested_single_stmt_while_stmt() {
                                     args: <empty>
                                     duration: <none>
                                     qubits:
-                                        IndexedIdent [22-23]:
-                                            name: Ident [22-23] "q"
-                                            index_span: [0-0]
-                                            indices: <empty>"#]],
+                                        GateOperand [22-23]:
+                                            kind: IndexedIdent [22-23]:
+                                                name: Ident [22-23] "q"
+                                                index_span: [0-0]
+                                                indices: <empty>"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/semantic/ast.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast.rs
@@ -660,8 +660,8 @@ impl Display for QuantumGateModifier {
 pub enum GateModifierKind {
     Inv,
     Pow(Expr),
-    Ctrl(Option<Expr>),
-    NegCtrl(Option<Expr>),
+    Ctrl(u32),
+    NegCtrl(u32),
 }
 
 impl Display for GateModifierKind {
@@ -1060,7 +1060,7 @@ impl Display for ExternDecl {
 pub struct GateCall {
     pub span: Span,
     pub modifiers: List<QuantumGateModifier>,
-    pub name: Ident,
+    pub symbol_id: SymbolId,
     pub args: List<Expr>,
     pub qubits: List<GateOperand>,
     pub duration: Option<Expr>,
@@ -1070,7 +1070,7 @@ impl Display for GateCall {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "GateCall", self.span)?;
         writeln_list_field(f, "modifiers", &self.modifiers)?;
-        writeln_field(f, "name", &self.name)?;
+        writeln_field(f, "symbol_id", &self.symbol_id)?;
         writeln_list_field(f, "args", &self.args)?;
         writeln_opt_field(f, "duration", self.duration.as_ref())?;
         write_list_field(f, "qubits", &self.qubits)

--- a/compiler/qsc_qasm3/src/semantic/ast.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast.rs
@@ -1064,6 +1064,8 @@ pub struct GateCall {
     pub args: List<Expr>,
     pub qubits: List<GateOperand>,
     pub duration: Option<Expr>,
+    pub quantum_arity: u32,
+    pub quantum_arity_with_modifiers: u32,
 }
 
 impl Display for GateCall {

--- a/compiler/qsc_qasm3/src/semantic/ast.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast.rs
@@ -1353,14 +1353,14 @@ impl Display for ReturnStmt {
 #[derive(Clone, Debug)]
 pub struct WhileLoop {
     pub span: Span,
-    pub while_condition: Expr,
+    pub condition: Expr,
     pub body: Stmt,
 }
 
 impl Display for WhileLoop {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "WhileLoop", self.span)?;
-        writeln_field(f, "condition", &self.while_condition)?;
+        writeln_field(f, "condition", &self.condition)?;
         write_field(f, "body", &self.body)
     }
 }

--- a/compiler/qsc_qasm3/src/semantic/ast.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast.rs
@@ -1590,6 +1590,7 @@ pub enum LiteralKind {
     Int(i64),
     BigInt(BigInt),
     String(Rc<str>),
+    Bit(bool),
 }
 
 impl Display for LiteralKind {
@@ -1600,6 +1601,7 @@ impl Display for LiteralKind {
                 let width = *width as usize;
                 write!(f, "Bitstring(\"{:0>width$}\")", value.to_str_radix(2))
             }
+            LiteralKind::Bit(b) => write!(f, "Bit({:?})", u8::from(*b)),
             LiteralKind::Bool(b) => write!(f, "Bool({b:?})"),
             LiteralKind::Complex(real, imag) => write!(f, "Complex({real:?}, {imag:?})"),
             LiteralKind::Duration(value, unit) => {

--- a/compiler/qsc_qasm3/src/semantic/ast.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast.rs
@@ -471,12 +471,14 @@ impl Display for BarrierStmt {
 #[derive(Clone, Debug)]
 pub struct ResetStmt {
     pub span: Span,
+    pub reset_token_span: Span,
     pub operand: Box<GateOperand>,
 }
 
 impl Display for ResetStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "ResetStmt", self.span)?;
+        writeln_field(f, "reset_token_span", &self.reset_token_span)?;
         write_field(f, "operand", &self.operand)
     }
 }

--- a/compiler/qsc_qasm3/src/semantic/ast/const_eval.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast/const_eval.rs
@@ -147,10 +147,10 @@ impl BinaryOpExpr {
                 if let (LiteralKind::Float(lhs), LiteralKind::Float(rhs)) = (lhs, rhs) {
                     Some(match op {
                         BinOp::Add => LiteralKind::Float(lhs + rhs),
-                        BinOp::Div => LiteralKind::Float(lhs / rhs),
-                        BinOp::Exp => LiteralKind::Float(lhs.powf(rhs)),
                         BinOp::Sub => LiteralKind::Float(lhs - rhs),
                         BinOp::Mul => LiteralKind::Float(lhs * rhs),
+                        BinOp::Div => LiteralKind::Float(lhs / rhs),
+                        BinOp::Exp => LiteralKind::Float(lhs.powf(rhs)),
                         // If the output type is Float, we don't need to implement
                         // any of the comparison, bitwise, or mod operators.
                         BinOp::AndB
@@ -210,7 +210,10 @@ impl BinaryOpExpr {
                 };
 
                 match (lhs, rhs) {
-                    (LiteralKind::Bool(lhs), LiteralKind::Bool(rhs)) => {
+                    (
+                        LiteralKind::Bool(lhs) | LiteralKind::Bit(lhs),
+                        LiteralKind::Bool(rhs) | LiteralKind::Bit(rhs),
+                    ) => {
                         Some(match op {
                             // Logical and bitwise operators.
                             BinOp::AndB | BinOp::AndL => lit_kind(lhs && rhs),
@@ -439,7 +442,7 @@ fn cast_to_uint(ty: &Type, lit: LiteralKind) -> Option<LiteralKind> {
             }
         }
         // TODO: Int Overflowing behavior.
-        //       This is tricky because the inner repersentation
+        //       This is tricky because the inner representation
         //       is a i64. Therefore, even we might end with the
         //       same result anyways. Need to think through this.
         Type::Int(..) | Type::UInt(..) => Some(lit),

--- a/compiler/qsc_qasm3/src/semantic/ast/const_eval.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast/const_eval.rs
@@ -40,7 +40,7 @@ impl SymbolId {
     fn const_eval(self, symbols: &SymbolTable) -> Option<LiteralKind> {
         let symbol = symbols[self].clone();
         symbol
-            .const_eval() // get the value of the symbol (an Expr)
+            .get_const_expr() // get the value of the symbol (an Expr)
             .const_eval(symbols) // const eval that Expr
     }
 }

--- a/compiler/qsc_qasm3/src/semantic/ast/const_eval.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast/const_eval.rs
@@ -1,0 +1,500 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! This module allows us to perform const evaluation at lowering time.
+//! The purpose of this is to be able to compute the widths of types
+//! and sizes of arrays. Therefore, those are the only const evaluation
+//! paths that are implemented.
+
+use super::{
+    BinOp, BinaryOpExpr, Cast, Expr, ExprKind, FunctionCall, IndexExpr, IndexedIdent, LiteralKind,
+    SymbolId, UnaryOp, UnaryOpExpr,
+};
+use crate::semantic::{symbols::SymbolTable, types::Type};
+use num_bigint::BigInt;
+
+impl Expr {
+    pub fn const_eval(&self, symbols: &SymbolTable) -> Option<LiteralKind> {
+        let ty = &self.ty;
+        if !ty.is_const() {
+            return None;
+        }
+
+        match &*self.kind {
+            ExprKind::Ident(symbol_id) => symbol_id.const_eval(symbols),
+            ExprKind::IndexedIdentifier(indexed_ident) => indexed_ident.const_eval(symbols),
+            ExprKind::UnaryOp(unary_op_expr) => unary_op_expr.const_eval(symbols, ty),
+            ExprKind::BinaryOp(binary_op_expr) => binary_op_expr.const_eval(symbols, ty),
+            ExprKind::Lit(literal_kind) => Some(literal_kind.clone()),
+            ExprKind::FunctionCall(function_call) => function_call.const_eval(symbols, ty),
+            ExprKind::Cast(cast) => cast.const_eval(symbols, ty),
+            ExprKind::IndexExpr(index_expr) => index_expr.const_eval(symbols, ty),
+            ExprKind::Paren(expr) => expr.const_eval(symbols),
+            // Measurements are non-const, so we don't need to implement them.
+            ExprKind::Measure(_) | ExprKind::Err => None,
+        }
+    }
+}
+
+impl SymbolId {
+    fn const_eval(self, symbols: &SymbolTable) -> Option<LiteralKind> {
+        let symbol = symbols[self].clone();
+        symbol
+            .const_eval() // get the value of the symbol (an Expr)
+            .const_eval(symbols) // const eval that Expr
+    }
+}
+
+impl IndexedIdent {
+    #[allow(clippy::unused_self)]
+    fn const_eval(&self, _symbols: &SymbolTable) -> Option<LiteralKind> {
+        None
+    }
+}
+
+impl UnaryOpExpr {
+    fn const_eval(&self, symbols: &SymbolTable, ty: &Type) -> Option<LiteralKind> {
+        let lit = self.expr.const_eval(symbols)?;
+        let op = &self.op;
+
+        match ty {
+            Type::Float(..) => {
+                if let LiteralKind::Float(val) = lit {
+                    match op {
+                        UnaryOp::Neg => Some(LiteralKind::Float(-val)),
+                        UnaryOp::NotB | UnaryOp::NotL => None,
+                    }
+                } else {
+                    None
+                }
+            }
+            Type::Int(..) => match lit {
+                LiteralKind::Int(val) => match op {
+                    UnaryOp::Neg => Some(LiteralKind::Int(-val)),
+                    UnaryOp::NotB => Some(LiteralKind::Int(!val)),
+                    UnaryOp::NotL => Some(LiteralKind::Int(i64::from(val == 0))),
+                },
+                LiteralKind::BigInt(val) => match op {
+                    UnaryOp::Neg => Some(LiteralKind::BigInt(-val)),
+                    UnaryOp::NotB => Some(LiteralKind::BigInt(!val)),
+                    UnaryOp::NotL => Some(LiteralKind::Int(i64::from(val == BigInt::ZERO))),
+                },
+                _ => None,
+            },
+            Type::UInt(..) => match lit {
+                LiteralKind::Int(val) => match op {
+                    UnaryOp::Neg => {
+                        // C99 first negates the value, as if it were signed,
+                        let val = -val;
+
+                        // and then converts it to unsigned, wrapping around if necessary.
+                        // We convert to u64 to mimic the wrapping around behavior.
+                        // TODO: we need to issue the same lint in Q#.
+                        #[allow(clippy::cast_sign_loss)]
+                        let u_val = val as u64;
+
+                        // Finally we go back to i64 because that's our internal representation.
+                        // TODO: we need to issue the same lint in Q#.
+                        #[allow(clippy::cast_possible_wrap)]
+                        Some(LiteralKind::Int(u_val as i64))
+                    }
+                    UnaryOp::NotB => {
+                        // We convert our value to u64.
+                        // TODO: we need to issue the same lint in Q#.
+                        #[allow(clippy::cast_sign_loss)]
+                        let u_val = val as u64;
+
+                        // Then we apply the bitwise operator.
+                        let u_val = !u_val;
+
+                        // Finally we go back to i64 because that's our internal representation.
+                        // TODO: we need to issue the same lint in Q#.
+                        #[allow(clippy::cast_possible_wrap)]
+                        Some(LiteralKind::Int(u_val as i64))
+                    }
+                    UnaryOp::NotL => Some(LiteralKind::Int(i64::from(val == 0))),
+                },
+                // It doesn't make sense to have operations that result in BigInts for array sizes
+                // or type widths. So, we return `None`.
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+impl BinaryOpExpr {
+    #[allow(clippy::too_many_lines)]
+    fn const_eval(&self, symbols: &SymbolTable, ty: &Type) -> Option<LiteralKind> {
+        if !self.lhs.ty.is_const() || !self.rhs.ty.is_const() {
+            return None;
+        }
+
+        // By this point it is guaranteed that the lhs and rhs are of the same type.
+        // Any conversions have been made explicit by inserting casts during lowering.
+        // Note: the type of the binary expression doesn't need to be the same as the
+        //       operands, for example, comparison operators can have integer operands
+        //       but their type is boolean.
+        // We can write a simpler implementation under that assumption.
+        assert_eq!(self.lhs.ty, self.rhs.ty);
+
+        let lhs = self.lhs.const_eval(symbols)?;
+        let rhs = self.rhs.const_eval(symbols)?;
+        let op = &self.op;
+
+        match ty {
+            Type::Float(..) => {
+                if let (LiteralKind::Float(lhs), LiteralKind::Float(rhs)) = (lhs, rhs) {
+                    Some(match op {
+                        BinOp::Add => LiteralKind::Float(lhs + rhs),
+                        BinOp::Div => LiteralKind::Float(lhs / rhs),
+                        BinOp::Exp => LiteralKind::Float(lhs.powf(rhs)),
+                        BinOp::Sub => LiteralKind::Float(lhs - rhs),
+                        BinOp::Mul => LiteralKind::Float(lhs * rhs),
+                        // If the output type is Float, we don't need to implement
+                        // any of the comparison, bitwise, or mod operators.
+                        BinOp::AndB
+                        | BinOp::AndL
+                        | BinOp::Eq
+                        | BinOp::Gt
+                        | BinOp::Gte
+                        | BinOp::Lt
+                        | BinOp::Lte
+                        | BinOp::Mod
+                        | BinOp::Neq
+                        | BinOp::OrB
+                        | BinOp::OrL
+                        | BinOp::Shl
+                        | BinOp::Shr
+                        | BinOp::XorB => return None,
+                    })
+                } else {
+                    None
+                }
+            }
+            Type::Int(..) | Type::UInt(..) => {
+                if let (LiteralKind::Int(lhs), LiteralKind::Int(rhs)) = (lhs, rhs) {
+                    Some(match op {
+                        // Arithmetic.
+                        BinOp::Add => LiteralKind::Int(lhs + rhs),
+                        BinOp::Sub => LiteralKind::Int(lhs - rhs),
+                        BinOp::Mul => LiteralKind::Int(lhs * rhs),
+                        BinOp::Div => LiteralKind::Int(lhs / rhs),
+                        BinOp::Exp => LiteralKind::Int(lhs.wrapping_pow(u32::try_from(rhs).ok()?)),
+                        BinOp::Mod => LiteralKind::Int(lhs % rhs),
+                        // Bitwise.
+                        BinOp::Shl => LiteralKind::Int(lhs << rhs),
+                        BinOp::Shr => LiteralKind::Int(lhs >> rhs),
+                        BinOp::AndB => LiteralKind::Int(lhs & rhs),
+                        BinOp::OrB => LiteralKind::Int(lhs | rhs),
+                        BinOp::XorB => LiteralKind::Int(lhs ^ rhs),
+                        // Comparison.
+                        BinOp::AndL
+                        | BinOp::Eq
+                        | BinOp::Gt
+                        | BinOp::Gte
+                        | BinOp::Lt
+                        | BinOp::Lte
+                        | BinOp::Neq
+                        | BinOp::OrL => return None,
+                    })
+                } else {
+                    None
+                }
+            }
+            Type::Bool(..) | Type::Bit(..) => {
+                match (lhs, rhs) {
+                    (LiteralKind::Bool(lhs), LiteralKind::Bool(rhs)) => {
+                        Some(match op {
+                            // Logical and bitwise operators.
+                            BinOp::AndB | BinOp::AndL => LiteralKind::Bool(lhs && rhs),
+                            BinOp::OrB | BinOp::OrL => LiteralKind::Bool(lhs || rhs),
+                            BinOp::XorB => LiteralKind::Bool(lhs ^ rhs),
+                            // Comparison operators.
+                            BinOp::Eq => LiteralKind::Bool(lhs == rhs),
+                            BinOp::Neq => LiteralKind::Bool(lhs != rhs),
+                            // This was originally `lhs > rhs` but clippy suggested this expression.
+                            BinOp::Gt => LiteralKind::Bool(lhs && !rhs),
+                            BinOp::Gte => LiteralKind::Bool(lhs >= rhs),
+                            // This was originally `lhs < rhs` but clippy suggested this expression.
+                            BinOp::Lt => LiteralKind::Bool(!lhs & rhs),
+                            BinOp::Lte => LiteralKind::Bool(lhs <= rhs),
+                            // Arithmetic.
+                            BinOp::Add
+                            | BinOp::Div
+                            | BinOp::Exp
+                            | BinOp::Mod
+                            | BinOp::Mul
+                            | BinOp::Shl
+                            | BinOp::Shr
+                            | BinOp::Sub => return None,
+                        })
+                    }
+                    (LiteralKind::Int(lhs), LiteralKind::Int(rhs)) => {
+                        Some(match op {
+                            // Comparison operators.
+                            BinOp::Eq => LiteralKind::Bool(lhs == rhs),
+                            BinOp::Neq => LiteralKind::Bool(lhs != rhs),
+                            BinOp::Gt => LiteralKind::Bool(lhs > rhs),
+                            BinOp::Gte => LiteralKind::Bool(lhs >= rhs),
+                            BinOp::Lt => LiteralKind::Bool(lhs < rhs),
+                            BinOp::Lte => LiteralKind::Bool(lhs <= rhs),
+                            // Logical and bitwise operators.
+                            BinOp::AndB
+                            | BinOp::AndL
+                            | BinOp::OrB
+                            | BinOp::OrL
+                            | BinOp::XorB
+                            // Arithmetic.
+                            | BinOp::Add
+                            | BinOp::Div
+                            | BinOp::Exp
+                            | BinOp::Mod
+                            | BinOp::Mul
+                            | BinOp::Shl
+                            | BinOp::Shr
+                            | BinOp::Sub => return None,
+                        })
+                    }
+                    (LiteralKind::Float(lhs), LiteralKind::Float(rhs)) => {
+                        Some(match op {
+                            // Comparison operators.
+                            // This is non-ideal because since this never reaches the Q# compiler
+                            //  we are not issuing a double-comparison lint.
+                            #[allow(clippy::float_cmp)]
+                            BinOp::Eq => LiteralKind::Bool(lhs == rhs),
+                            #[allow(clippy::float_cmp)]
+                            BinOp::Neq => LiteralKind::Bool(lhs != rhs),
+                            BinOp::Gt => LiteralKind::Bool(lhs > rhs),
+                            BinOp::Gte => LiteralKind::Bool(lhs >= rhs),
+                            BinOp::Lt => LiteralKind::Bool(lhs < rhs),
+                            BinOp::Lte => LiteralKind::Bool(lhs <= rhs),
+                            // Logical and bitwise operators.
+                            BinOp::AndB
+                            | BinOp::AndL
+                            | BinOp::OrB
+                            | BinOp::OrL
+                            | BinOp::XorB
+                            // Arithmetic.
+                            | BinOp::Add
+                            | BinOp::Div
+                            | BinOp::Exp
+                            | BinOp::Mod
+                            | BinOp::Mul
+                            | BinOp::Shl
+                            | BinOp::Shr
+                            | BinOp::Sub => return None,
+                        })
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+impl FunctionCall {
+    #[allow(clippy::unused_self)]
+    fn const_eval(&self, _symbols: &SymbolTable, _ty: &Type) -> Option<LiteralKind> {
+        None
+    }
+}
+
+impl IndexExpr {
+    #[allow(clippy::unused_self)]
+    fn const_eval(&self, _symbols: &SymbolTable, _ty: &Type) -> Option<LiteralKind> {
+        None
+    }
+}
+
+impl Cast {
+    fn const_eval(&self, symbols: &SymbolTable, ty: &Type) -> Option<LiteralKind> {
+        let lit = self.expr.const_eval(symbols)?;
+        let from_ty = &self.expr.ty;
+
+        match ty {
+            Type::Bool(_) => cast_to_bool(from_ty, lit),
+            Type::Int(_, _) => cast_to_int(from_ty, lit),
+            Type::UInt(_, _) => cast_to_uint(from_ty, lit),
+            Type::Float(_, _) => cast_to_float(from_ty, lit),
+            Type::Angle(_, _) => cast_to_angle(from_ty, lit),
+            Type::Bit(_) => cast_to_bit(from_ty, lit),
+            _ => None,
+        }
+    }
+}
+
+/// +---------------+-----------------------------------------+
+/// | Allowed casts | Casting from                            |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | Casting to    | bool | int | uint | float | angle | bit |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | bool          | -    | Yes | Yes  | Yes   | Yes   | Yes |
+/// +---------------+------+-----+------+-------+-------+-----+
+fn cast_to_bool(ty: &Type, lit: LiteralKind) -> Option<LiteralKind> {
+    match ty {
+        Type::Bool(..) | Type::Bit(..) => Some(lit),
+        Type::Int(..) | Type::UInt(..) => {
+            if let LiteralKind::Int(val) = lit {
+                Some(LiteralKind::Bool(val != 0))
+            } else {
+                None
+            }
+        }
+        Type::Float(..) | Type::Angle(..) => {
+            if let LiteralKind::Float(val) = lit {
+                Some(LiteralKind::Bool(val != 0.0))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// +---------------+-----------------------------------------+
+/// | Allowed casts | Casting from                            |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | Casting to    | bool | int | uint | float | angle | bit |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | int           | Yes  | -   | Yes  | Yes   | No    | Yes |
+/// +---------------+------+-----+------+-------+-------+-----+
+fn cast_to_int(ty: &Type, lit: LiteralKind) -> Option<LiteralKind> {
+    match ty {
+        Type::Bool(..) | Type::Bit(..) => {
+            if let LiteralKind::Bool(val) = lit {
+                Some(LiteralKind::Int(i64::from(val)))
+            } else {
+                None
+            }
+        }
+        // TODO: UInt Overflowing behavior.
+        //       This is tricky because the inner repersentation
+        //       already is a i64. Therefore, there is nothing to do?
+        Type::Int(..) | Type::UInt(..) => Some(lit),
+        Type::Float(..) => {
+            if let LiteralKind::Float(val) = lit {
+                // TODO: we need to issue the same lint in Q#.
+                #[allow(clippy::cast_possible_truncation)]
+                Some(LiteralKind::Int(val as i64))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// +---------------+-----------------------------------------+
+/// | Allowed casts | Casting from                            |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | Casting from  | bool | int | uint | float | angle | bit |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | uint          | Yes  | Yes | -    | Yes   | No    | Yes |
+/// +---------------+------+-----+------+-------+-------+-----+
+fn cast_to_uint(ty: &Type, lit: LiteralKind) -> Option<LiteralKind> {
+    match ty {
+        Type::Bool(..) | Type::Bit(..) => {
+            if let LiteralKind::Bool(val) = lit {
+                Some(LiteralKind::Int(i64::from(val)))
+            } else {
+                None
+            }
+        }
+        // TODO: Int Overflowing behavior.
+        //       This is tricky because the inner repersentation
+        //       is a i64. Therefore, even we might end with the
+        //       same result anyways. Need to think through this.
+        Type::Int(..) | Type::UInt(..) => Some(lit),
+        Type::Float(..) => {
+            if let LiteralKind::Float(val) = lit {
+                // TODO: we need to issue the same lint in Q#.
+                #[allow(clippy::cast_possible_truncation)]
+                Some(LiteralKind::Int(val as i64))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// +---------------+-----------------------------------------+
+/// | Allowed casts | Casting from                            |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | Casting to    | bool | int | uint | float | angle | bit |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | float         | Yes  | Yes | Yes  | -     | No    | No  |
+/// +---------------+------+-----+------+-------+-------+-----+
+fn cast_to_float(ty: &Type, lit: LiteralKind) -> Option<LiteralKind> {
+    match ty {
+        Type::Bool(..) => {
+            if let LiteralKind::Bool(val) = lit {
+                Some(LiteralKind::Float(if val { 1.0 } else { 0.0 }))
+            } else {
+                None
+            }
+        }
+        Type::Int(..) | Type::UInt(..) => {
+            if let LiteralKind::Int(val) = lit {
+                // TODO: we need to issue the same lint in Q#.
+                #[allow(clippy::cast_precision_loss)]
+                Some(LiteralKind::Float(val as f64))
+            } else {
+                None
+            }
+        }
+        Type::Float(..) => Some(lit),
+        _ => None,
+    }
+}
+
+/// +---------------+-----------------------------------------+
+/// | Allowed casts | Casting from                            |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | Casting to    | bool | int | uint | float | angle | bit |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | angle         | No   | No  | No   | Yes   | -     | Yes |
+/// +---------------+------+-----+------+-------+-------+-----+
+fn cast_to_angle(ty: &Type, lit: LiteralKind) -> Option<LiteralKind> {
+    match ty {
+        Type::Float(..) | Type::Angle(..) => Some(lit),
+        Type::Bit(..) => {
+            if let LiteralKind::Bool(val) = lit {
+                Some(LiteralKind::Float(if val { 1.0 } else { 0.0 }))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// +---------------+-----------------------------------------+
+/// | Allowed casts | Casting from                            |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | Casting to    | bool | int | uint | float | angle | bit |
+/// +---------------+------+-----+------+-------+-------+-----+
+/// | bit           | Yes  | Yes | Yes  | No    | Yes   | -   |
+/// +---------------+------+-----+------+-------+-------+-----+
+fn cast_to_bit(ty: &Type, lit: LiteralKind) -> Option<LiteralKind> {
+    match ty {
+        Type::Bool(..) | Type::Bit(..) => Some(lit),
+        Type::Int(..) | Type::UInt(..) => {
+            if let LiteralKind::Int(val) = lit {
+                Some(LiteralKind::Bool(val != 0))
+            } else {
+                None
+            }
+        }
+        Type::Angle(..) => {
+            if let LiteralKind::Float(val) = lit {
+                Some(LiteralKind::Bool(val != 0.0))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}

--- a/compiler/qsc_qasm3/src/semantic/ast/const_eval.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast/const_eval.rs
@@ -259,10 +259,10 @@ impl BinaryOpExpr {
                     (LiteralKind::Float(lhs), LiteralKind::Float(rhs)) => {
                         Some(match op {
                             // Comparison operators.
-                            // This is non-ideal because since this never reaches the Q# compiler
-                            //  we are not issuing a double-comparison lint.
+                            // TODO: we need to issue the same lint in Q#.
                             #[allow(clippy::float_cmp)]
                             BinOp::Eq => LiteralKind::Bool(lhs == rhs),
+                            // TODO: we need to issue the same lint in Q#.
                             #[allow(clippy::float_cmp)]
                             BinOp::Neq => LiteralKind::Bool(lhs != rhs),
                             BinOp::Gt => LiteralKind::Bool(lhs > rhs),

--- a/compiler/qsc_qasm3/src/semantic/error.rs
+++ b/compiler/qsc_qasm3/src/semantic/error.rs
@@ -78,6 +78,12 @@ pub enum SemanticErrorKind {
     #[error("Designator must be a positive literal integer.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.DesignatorMustBePositiveIntLiteral"))]
     DesignatorMustBePositiveIntLiteral(#[label] Span),
+    #[error("Type width must be a positive integer const expression.")]
+    #[diagnostic(code("Qsc.Qasm3.Compile.TypeWidthMustBePositiveIntConstExpr"))]
+    TypeWidthMustBePositiveIntConstExpr(#[label] Span),
+    #[error("Array size must be a non-negative integer const expression.")]
+    #[diagnostic(code("Qsc.Qasm3.Compile.ArraySizeMustBeNonNegativeConstExpr"))]
+    ArraySizeMustBeNonNegativeConstExpr(#[label] Span),
     #[error("Designator is too large.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.DesignatorTooLarge"))]
     DesignatorTooLarge(#[label] Span),
@@ -257,6 +263,12 @@ impl SemanticErrorKind {
             Self::ComplexBinaryAssignment(span) => Self::ComplexBinaryAssignment(span + offset),
             Self::DesignatorMustBePositiveIntLiteral(span) => {
                 Self::DesignatorMustBePositiveIntLiteral(span + offset)
+            }
+            Self::TypeWidthMustBePositiveIntConstExpr(span) => {
+                Self::TypeWidthMustBePositiveIntConstExpr(span + offset)
+            }
+            Self::ArraySizeMustBeNonNegativeConstExpr(span) => {
+                Self::ArraySizeMustBeNonNegativeConstExpr(span + offset)
             }
             Self::DesignatorTooLarge(span) => Self::DesignatorTooLarge(span + offset),
             Self::FailedToCompileExpressionList(span) => {

--- a/compiler/qsc_qasm3/src/semantic/error.rs
+++ b/compiler/qsc_qasm3/src/semantic/error.rs
@@ -29,6 +29,12 @@ pub enum SemanticErrorKind {
     #[error("Array literals are only allowed in classical declarations.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.ArrayLiteralInNonClassicalDecl"))]
     ArrayLiteralInNonClassicalDecl(#[label] Span),
+    #[error("the size of an array type must fit in a u32")]
+    #[diagnostic(code("Qsc.Qasm3.Compile.ArrayTypeSizeMustFitInU32"))]
+    ArrayTypeSizeMustFitInU32(#[label] Span),
+    #[error("the size of an array type must be a const expression")]
+    #[diagnostic(code("Qsc.Qasm3.Compile.ArrayTypeSizeMustBeConst"))]
+    ArrayTypeSizeMustBeConst(#[label] Span),
     #[error("Annotation missing target statement.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.AnnotationWithoutStatement"))]
     AnnotationWithoutStatement(#[label] Span),
@@ -220,6 +226,8 @@ impl SemanticErrorKind {
             Self::ArrayLiteralInNonClassicalDecl(span) => {
                 Self::ArrayLiteralInNonClassicalDecl(span + offset)
             }
+            Self::ArrayTypeSizeMustBeConst(span) => Self::ArrayTypeSizeMustBeConst(span + offset),
+            Self::ArrayTypeSizeMustFitInU32(span) => Self::ArrayTypeSizeMustFitInU32(span + offset),
             Self::AnnotationWithoutStatement(span) => {
                 Self::AnnotationWithoutStatement(span + offset)
             }

--- a/compiler/qsc_qasm3/src/semantic/error.rs
+++ b/compiler/qsc_qasm3/src/semantic/error.rs
@@ -183,6 +183,9 @@ pub enum SemanticErrorKind {
     #[error("Return statements are only allowed within subroutines.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.ReturnNotInSubroutine"))]
     ReturnNotInSubroutine(#[label] Span),
+    #[error("Switch statement must have at least one non-default case.")]
+    #[diagnostic(code("Qsc.Qasm3.Compile.SwitchStatementMustHaveAtLeastOneCase"))]
+    SwitchStatementMustHaveAtLeastOneCase(#[label] Span),
     #[error("Too many controls specified.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.TooManyControls"))]
     TooManyControls(#[label] Span),
@@ -347,6 +350,9 @@ impl SemanticErrorKind {
                 Self::ResetExpressionMustHaveName(span + offset)
             }
             Self::ReturnNotInSubroutine(span) => Self::ReturnNotInSubroutine(span + offset),
+            Self::SwitchStatementMustHaveAtLeastOneCase(span) => {
+                Self::SwitchStatementMustHaveAtLeastOneCase(span + offset)
+            }
             Self::TooManyControls(span) => Self::TooManyControls(span + offset),
             Self::TooManyIndices(span) => Self::TooManyIndices(span + offset),
             Self::TypeDoesNotSupportBitwiseNot(name, span) => {

--- a/compiler/qsc_qasm3/src/semantic/error.rs
+++ b/compiler/qsc_qasm3/src/semantic/error.rs
@@ -29,12 +29,12 @@ pub enum SemanticErrorKind {
     #[error("Array literals are only allowed in classical declarations.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.ArrayLiteralInNonClassicalDecl"))]
     ArrayLiteralInNonClassicalDecl(#[label] Span),
-    #[error("the size of an array type must fit in a u32")]
-    #[diagnostic(code("Qsc.Qasm3.Compile.ArrayTypeSizeMustFitInU32"))]
-    ArrayTypeSizeMustFitInU32(#[label] Span),
-    #[error("the size of an array type must be a const expression")]
-    #[diagnostic(code("Qsc.Qasm3.Compile.ArrayTypeSizeMustBeConst"))]
-    ArrayTypeSizeMustBeConst(#[label] Span),
+    #[error("{0} must fit in a u32")]
+    #[diagnostic(code("Qsc.Qasm3.Compile.ExprMustFitInU32"))]
+    ExprMustFitInU32(String, #[label] Span),
+    #[error("{0} must be a const expression")]
+    #[diagnostic(code("Qsc.Qasm3.Compile.ExprMustBeConst"))]
+    ExprMustBeConst(String, #[label] Span),
     #[error("Annotation missing target statement.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.AnnotationWithoutStatement"))]
     AnnotationWithoutStatement(#[label] Span),
@@ -226,8 +226,8 @@ impl SemanticErrorKind {
             Self::ArrayLiteralInNonClassicalDecl(span) => {
                 Self::ArrayLiteralInNonClassicalDecl(span + offset)
             }
-            Self::ArrayTypeSizeMustBeConst(span) => Self::ArrayTypeSizeMustBeConst(span + offset),
-            Self::ArrayTypeSizeMustFitInU32(span) => Self::ArrayTypeSizeMustFitInU32(span + offset),
+            Self::ExprMustBeConst(name, span) => Self::ExprMustBeConst(name, span + offset),
+            Self::ExprMustFitInU32(name, span) => Self::ExprMustFitInU32(name, span + offset),
             Self::AnnotationWithoutStatement(span) => {
                 Self::AnnotationWithoutStatement(span + offset)
             }

--- a/compiler/qsc_qasm3/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm3/src/semantic/lowerer.rs
@@ -28,6 +28,7 @@ use crate::parser::QasmSource;
 use crate::semantic::types::can_cast_literal;
 use crate::semantic::types::can_cast_literal_with_value_knowledge;
 use crate::semantic::types::ArrayDimensions;
+use crate::types::get_qsharp_gate_name;
 
 use super::ast as semantic;
 use crate::parser::ast as syntax;
@@ -1013,6 +1014,8 @@ impl Lowerer {
             //    Q: Do we need this during lowering?
             //    A: Yes, we need it to check the gate_call arity.
             modifiers.push(implicit_modifier);
+        } else {
+            name = get_qsharp_gate_name(&name).unwrap_or(&name).to_string();
         }
 
         // 3. Check that the gate_name actually refers to a gate in the symbol table

--- a/compiler/qsc_qasm3/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm3/src/semantic/lowerer.rs
@@ -4,7 +4,6 @@
 use std::ops::ShlAssign;
 use std::rc::Rc;
 
-use super::ast::const_eval;
 use super::symbols::ScopeKind;
 use super::types::binop_requires_int_conversion_for_type;
 use super::types::binop_requires_symmetric_int_conversion;

--- a/compiler/qsc_qasm3/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm3/src/semantic/lowerer.rs
@@ -1483,7 +1483,7 @@ impl Lowerer {
             return None;
         };
 
-        if val < 1 {
+        if val < 0 {
             self.push_semantic_error(SemanticErrorKind::ArraySizeMustBeNonNegativeConstExpr(
                 expr.span,
             ));
@@ -1506,7 +1506,7 @@ impl Lowerer {
             return None;
         };
 
-        if val < 0 {
+        if val < 1 {
             self.push_semantic_error(SemanticErrorKind::TypeWidthMustBePositiveIntConstExpr(
                 expr.span,
             ));

--- a/compiler/qsc_qasm3/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm3/src/semantic/lowerer.rs
@@ -593,7 +593,7 @@ impl Lowerer {
 
     fn lower_unary_op_expr(&mut self, expr: &syntax::UnaryOpExpr) -> semantic::Expr {
         match expr.op {
-            syntax::UnaryOp::Neg | syntax::UnaryOp::NotB => {
+            syntax::UnaryOp::Neg => {
                 let op = expr.op;
                 let expr = self.lower_expr(&expr.expr);
                 let ty = expr.ty.clone();
@@ -608,6 +608,29 @@ impl Lowerer {
                 let unary = semantic::UnaryOpExpr {
                     span,
                     op: semantic::UnaryOp::Neg,
+                    expr,
+                };
+                semantic::Expr {
+                    span,
+                    kind: Box::new(semantic::ExprKind::UnaryOp(unary)),
+                    ty,
+                }
+            }
+            syntax::UnaryOp::NotB => {
+                let op = expr.op;
+                let expr = self.lower_expr(&expr.expr);
+                let ty = expr.ty.clone();
+                if !unary_op_can_be_applied_to_type(op, &ty) {
+                    let kind = SemanticErrorKind::TypeDoesNotSupportedUnaryNegation(
+                        expr.ty.to_string(),
+                        expr.span,
+                    );
+                    self.push_semantic_error(kind);
+                }
+                let span = expr.span;
+                let unary = semantic::UnaryOpExpr {
+                    span,
+                    op: semantic::UnaryOp::NotB,
                     expr,
                 };
                 semantic::Expr {

--- a/compiler/qsc_qasm3/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm3/src/semantic/lowerer.rs
@@ -366,9 +366,11 @@ impl Lowerer {
             syntax::ValueExpr::Expr(expr) => {
                 self.lower_expr_with_target_type(Some(expr), &ty, span)
             }
-            syntax::ValueExpr::Measurement(measure_expr) => self.lower_measure_expr(measure_expr),
+            syntax::ValueExpr::Measurement(measure_expr) => {
+                let expr = self.lower_measure_expr(measure_expr);
+                self.cast_expr_to_type(&ty, &expr)
+            }
         };
-        let rhs = self.cast_expr_to_type(&ty, &rhs);
 
         if ty.is_const() {
             let kind =
@@ -410,9 +412,11 @@ impl Lowerer {
             syntax::ValueExpr::Expr(expr) => {
                 self.lower_expr_with_target_type(Some(expr), indexed_ty, span)
             }
-            syntax::ValueExpr::Measurement(measure_expr) => self.lower_measure_expr(measure_expr),
+            syntax::ValueExpr::Measurement(measure_expr) => {
+                let expr = self.lower_measure_expr(measure_expr);
+                self.cast_expr_to_type(indexed_ty, &expr)
+            }
         };
-        let rhs = self.cast_expr_to_type(indexed_ty, &rhs);
 
         if symbol.ty.is_const() {
             let kind =
@@ -450,9 +454,11 @@ impl Lowerer {
             syntax::ValueExpr::Expr(expr) => {
                 self.lower_expr_with_target_type(Some(expr), ty, stmt.span)
             }
-            syntax::ValueExpr::Measurement(measure_expr) => self.lower_measure_expr(measure_expr),
+            syntax::ValueExpr::Measurement(measure_expr) => {
+                let expr = self.lower_measure_expr(measure_expr);
+                self.cast_expr_to_type(ty, &expr)
+            }
         };
-        let rhs = self.cast_expr_to_type(ty, &rhs);
 
         semantic::StmtKind::AssignOp(semantic::AssignOpStmt {
             span: stmt.span,
@@ -842,12 +848,12 @@ impl Lowerer {
                     self.lower_expr_with_target_type(Some(expr), &ty, stmt_span)
                 }
                 syntax::ValueExpr::Measurement(measure_expr) => {
-                    self.lower_measure_expr(measure_expr)
+                    let expr = self.lower_measure_expr(measure_expr);
+                    self.cast_expr_to_type(&ty, &expr)
                 }
             },
             None => self.lower_expr_with_target_type(None, &ty, stmt_span),
         };
-        let init_expr = self.cast_expr_to_type(&ty, &init_expr);
 
         let symbol_id =
             self.try_insert_or_get_existing_symbol_id(name, symbol, stmt.identifier.span);

--- a/compiler/qsc_qasm3/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm3/src/semantic/lowerer.rs
@@ -931,7 +931,6 @@ impl Lowerer {
                 "const decl init expr".to_string(),
                 init_expr.span,
             ));
-            return semantic::StmtKind::Err;
         }
 
         semantic::StmtKind::ClassicalDecl(semantic::ClassicalDeclarationStmt {
@@ -1390,10 +1389,11 @@ impl Lowerer {
         // It is a parse error to have a switch statement with no cases,
         // even if the default block is present. Getting here means the
         // parser is broken or they changed the grammar.
-        assert!(
-            !cases.is_empty(),
-            "switch statement must have a control expression and at least one case"
-        );
+        if cases.is_empty() {
+            self.push_semantic_error(SemanticErrorKind::SwitchStatementMustHaveAtLeastOneCase(
+                stmt.span,
+            ));
+        }
 
         // We push a semantic error on switch statements if version is less than 3.1,
         // as they were introduced in 3.1.

--- a/compiler/qsc_qasm3/src/semantic/symbols.rs
+++ b/compiler/qsc_qasm3/src/semantic/symbols.rs
@@ -293,6 +293,26 @@ impl Default for SymbolTable {
             current_id: SymbolId::default(),
         };
 
+        slf.insert_symbol(Symbol {
+            name: "U".to_string(),
+            span: Span::default(),
+            ty: Type::Gate(3, 1),
+            qsharp_ty: crate::types::Type::Callable(crate::types::CallableKind::Operation, 3, 1),
+            io_kind: IOKind::Default,
+            const_expr: None,
+        })
+        .unwrap_or_else(|_| panic!("Failed to insert symbol: U"));
+
+        slf.insert_symbol(Symbol {
+            name: "gphase".to_string(),
+            span: Span::default(),
+            ty: Type::Gate(1, 0),
+            qsharp_ty: crate::types::Type::Callable(crate::types::CallableKind::Operation, 1, 0),
+            io_kind: IOKind::Default,
+            const_expr: None,
+        })
+        .unwrap_or_else(|_| panic!("Failed to insert symbol: gphase"));
+
         // Define global constants.
         for (symbol, val) in BUILTIN_SYMBOLS {
             let ty = Type::Float(None, true);

--- a/compiler/qsc_qasm3/src/semantic/tests.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests.rs
@@ -243,7 +243,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                     Stmt [196-206]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [196-206]:
-                            symbol_id: 24
+                            symbol_id: 26
                             ty_span: [196-199]
                             init_expr: Expr [204-205]:
                                 ty: Bit(true)
@@ -251,7 +251,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                     Stmt [211-227]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [211-227]:
-                            symbol_id: 24
+                            symbol_id: 26
                             ty_span: [211-215]
                             init_expr: Expr [220-226]:
                                 ty: Bool(false)
@@ -259,18 +259,18 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                                     op: AndL
                                     lhs: Expr [220-221]:
                                         ty: Err
-                                        kind: SymbolId(25)
+                                        kind: SymbolId(27)
                                     rhs: Expr [225-226]:
                                         ty: Bool(false)
                                         kind: Cast [0-0]:
                                             ty: Bool(false)
                                             expr: Expr [225-226]:
                                                 ty: Bit(false)
-                                                kind: SymbolId(24)
+                                                kind: SymbolId(26)
                     Stmt [140-154]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [140-154]:
-                            symbol_id: 26
+                            symbol_id: 28
                             ty_span: [140-145]
                             init_expr: Expr [150-153]:
                                 ty: Angle(None, true)
@@ -278,7 +278,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                     Stmt [159-179]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [159-179]:
-                            symbol_id: 27
+                            symbol_id: 29
                             ty_span: [159-164]
                             init_expr: Expr [169-178]:
                                 ty: Float(None, false)
@@ -286,7 +286,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                                     op: Add
                                     lhs: Expr [169-170]:
                                         ty: Angle(None, false)
-                                        kind: SymbolId(26)
+                                        kind: SymbolId(28)
                                     rhs: Expr [173-178]:
                                         ty: Float(None, false)
                                         kind: Cast [0-0]:
@@ -297,11 +297,11 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                     Stmt [74-84]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [74-84]:
-                            symbol_id: 29
+                            symbol_id: 31
                             ty_span: [74-77]
                             init_expr: Expr [82-83]:
                                 ty: Err
-                                kind: SymbolId(28)
+                                kind: SymbolId(30)
 
             [Qsc.Qasm3.Compile.UndefinedSymbol
 

--- a/compiler/qsc_qasm3/src/semantic/tests.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests.rs
@@ -348,10 +348,10 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
             , Qsc.Qasm3.Compile.CannotCast
 
               x Cannot cast expression of type Err to type Bit(false)
-               ,-[source0.qasm:4:5]
+               ,-[source0.qasm:4:13]
              3 |     include "source1.qasm";
              4 |     bit c = r; // undefined symbol r
-               :     ^^^^^^^^^^
+               :             ^
              5 |     
                `----
             ]"#]],

--- a/compiler/qsc_qasm3/src/semantic/tests.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests.rs
@@ -247,7 +247,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                             ty_span: [196-199]
                             init_expr: Expr [204-205]:
                                 ty: Bit(true)
-                                kind: Lit: Int(1)
+                                kind: Lit: Bit(1)
                     Stmt [211-227]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [211-227]:

--- a/compiler/qsc_qasm3/src/semantic/tests/decls.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls.rs
@@ -67,100 +67,55 @@ fn scalar_ty_designator_must_be_positive() {
                                 ty: Err
                                 kind: Err
 
-            [Qsc.Qasm3.Compile.DesignatorMustBePositiveIntLiteral
+            [Qsc.Qasm3.Compile.TypeWidthMustBePositiveIntConstExpr
 
-              x Designator must be a positive literal integer.
+              x Type width must be a positive integer const expression.
                ,-[test:1:5]
              1 | int[-5] i;
                :     ^^
-               `----
-            , Qsc.Qasm3.Compile.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: Converting Err
-              | to Q# type
-               ,-[test:1:1]
-             1 | int[-5] i;
-               : ^^^^^^^
-               `----
-            , Qsc.Qasm3.Compile.NotSupported
-
-              x Default values for Err are unsupported. are not supported.
-               ,-[test:1:1]
-             1 | int[-5] i;
-               : ^^^^^^^^^^
                `----
             ]"#]],
     );
 }
 
 #[test]
-fn scalar_ty_designator_must_be_int_literal() {
+fn scalar_ty_designator_must_be_castable_to_const_int() {
     check(
-        r#"int[size] i; float[0.0] j;"#,
+        r#"const angle size = 2.0; int[size] i;"#,
         &expect![[r#"
             Program:
                 version: <none>
                 statements:
-                    Stmt [0-12]:
+                    Stmt [0-23]:
                         annotations: <empty>
-                        kind: ClassicalDeclarationStmt [0-12]:
+                        kind: ClassicalDeclarationStmt [0-23]:
                             symbol_id: 6
-                            ty_span: [0-9]
-                            init_expr: Expr [0-0]:
-                                ty: Err
-                                kind: Err
-                    Stmt [13-26]:
+                            ty_span: [6-11]
+                            init_expr: Expr [19-22]:
+                                ty: Angle(None, true)
+                                kind: Lit: Float(2.0)
+                    Stmt [24-36]:
                         annotations: <empty>
-                        kind: ClassicalDeclarationStmt [13-26]:
+                        kind: ClassicalDeclarationStmt [24-36]:
                             symbol_id: 7
-                            ty_span: [13-23]
+                            ty_span: [24-33]
                             init_expr: Expr [0-0]:
                                 ty: Err
                                 kind: Err
 
-            [Qsc.Qasm3.Compile.DesignatorMustBePositiveIntLiteral
+            [Qsc.Qasm3.Compile.CannotCast
 
-              x Designator must be a positive literal integer.
-               ,-[test:1:5]
-             1 | int[size] i; float[0.0] j;
-               :     ^^^^
+              x Cannot cast expression of type Angle(None, true) to type UInt(None, true)
+               ,-[test:1:29]
+             1 | const angle size = 2.0; int[size] i;
+               :                             ^^^^
                `----
-            , Qsc.Qasm3.Compile.Unimplemented
+            , Qsc.Qasm3.Compile.TypeWidthMustBePositiveIntConstExpr
 
-              x this statement is not yet handled during OpenQASM 3 import: Converting Err
-              | to Q# type
-               ,-[test:1:1]
-             1 | int[size] i; float[0.0] j;
-               : ^^^^^^^^^
-               `----
-            , Qsc.Qasm3.Compile.NotSupported
-
-              x Default values for Err are unsupported. are not supported.
-               ,-[test:1:1]
-             1 | int[size] i; float[0.0] j;
-               : ^^^^^^^^^^^^
-               `----
-            , Qsc.Qasm3.Compile.DesignatorMustBePositiveIntLiteral
-
-              x Designator must be a positive literal integer.
-               ,-[test:1:20]
-             1 | int[size] i; float[0.0] j;
-               :                    ^^^
-               `----
-            , Qsc.Qasm3.Compile.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: Converting Err
-              | to Q# type
-               ,-[test:1:14]
-             1 | int[size] i; float[0.0] j;
-               :              ^^^^^^^^^^
-               `----
-            , Qsc.Qasm3.Compile.NotSupported
-
-              x Default values for Err are unsupported. are not supported.
-               ,-[test:1:14]
-             1 | int[size] i; float[0.0] j;
-               :              ^^^^^^^^^^^^^
+              x Type width must be a positive integer const expression.
+               ,-[test:1:29]
+             1 | const angle size = 2.0; int[size] i;
+               :                             ^^^^
                `----
             ]"#]],
     );

--- a/compiler/qsc_qasm3/src/semantic/tests/decls.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls.rs
@@ -61,7 +61,7 @@ fn scalar_ty_designator_must_be_positive() {
                     Stmt [0-10]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [0-10]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [0-7]
                             init_expr: Expr [0-0]:
                                 ty: Err
@@ -89,7 +89,7 @@ fn scalar_ty_designator_must_be_castable_to_const_int() {
                     Stmt [0-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [0-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [6-11]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -97,7 +97,7 @@ fn scalar_ty_designator_must_be_castable_to_const_int() {
                     Stmt [24-36]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [24-36]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [24-33]
                             init_expr: Expr [0-0]:
                                 ty: Err

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/angle.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/angle.rs
@@ -11,12 +11,12 @@ fn implicit_bitness_default() {
         "angle x;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-8]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [0-0]:
                     ty: Angle(None, true)
                     kind: Lit: Float(0.0)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
@@ -30,12 +30,12 @@ fn lit() {
         "angle x = 42.1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
@@ -49,12 +49,12 @@ fn const_lit() {
         "const angle x = 42.1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-20]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Angle(None, true)
                 qsharp_type: Double
@@ -68,12 +68,12 @@ fn lit_explicit_width() {
         "angle[64] x = 42.1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-9]
                 init_expr: Expr [14-18]:
                     ty: Angle(Some(64), true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: x
                 type: Angle(Some(64), false)
                 qsharp_type: Double
@@ -87,12 +87,12 @@ fn const_explicit_width_lit() {
         "const angle[64] x = 42.1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-25]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-15]
                 init_expr: Expr [20-24]:
                     ty: Angle(Some(64), true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [16-17]:
+            [8] Symbol [16-17]:
                 name: x
                 type: Angle(Some(64), true)
                 qsharp_type: Double
@@ -106,12 +106,12 @@ fn lit_decl_leading_dot() {
         "angle x = .421;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
                     ty: Angle(None, true)
                     kind: Lit: Float(0.421)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
@@ -125,12 +125,12 @@ fn const_lit_decl_leading_dot() {
         "const angle x = .421;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-20]:
                     ty: Angle(None, true)
                     kind: Lit: Float(0.421)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Angle(None, true)
                 qsharp_type: Double
@@ -144,12 +144,12 @@ fn const_lit_decl_leading_dot_scientific() {
         "const angle x = .421e2;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-22]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Angle(None, true)
                 qsharp_type: Double
@@ -163,12 +163,12 @@ fn lit_decl_trailing_dot() {
         "angle x = 421.;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
                     ty: Angle(None, true)
                     kind: Lit: Float(421.0)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
@@ -182,12 +182,12 @@ fn const_lit_decl_trailing_dot() {
         "const angle x = 421.;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-20]:
                     ty: Angle(None, true)
                     kind: Lit: Float(421.0)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Angle(None, true)
                 qsharp_type: Double
@@ -201,12 +201,12 @@ fn lit_decl_scientific() {
         "angle x = 4.21e1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-17]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-16]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
@@ -220,12 +220,12 @@ fn const_lit_decl_scientific() {
         "const angle x = 4.21e1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-22]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Angle(None, true)
                 qsharp_type: Double
@@ -239,12 +239,12 @@ fn lit_decl_scientific_signed_pos() {
         "angle x = 4.21e+1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-18]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-17]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
@@ -258,12 +258,12 @@ fn const_lit_decl_scientific_signed_pos() {
         "const angle x = 4.21e+1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-24]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-23]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Angle(None, true)
                 qsharp_type: Double
@@ -277,12 +277,12 @@ fn lit_decl_scientific_cap_e() {
         "angle x = 4.21E1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-17]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-16]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
@@ -296,12 +296,12 @@ fn const_lit_decl_scientific_cap_e() {
         "const angle x = 4.21E1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-22]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Angle(None, true)
                 qsharp_type: Double
@@ -315,12 +315,12 @@ fn lit_decl_scientific_signed_neg() {
         "angle x = 421.0e-1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-18]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
@@ -334,12 +334,12 @@ fn const_lit_decl_scientific_signed_neg() {
         "const angle x = 421.0e-1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-25]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-24]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Angle(None, true)
                 qsharp_type: Double
@@ -353,7 +353,7 @@ fn const_lit_decl_signed_float_lit_cast_neg() {
         "const angle x = -7.;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [17-19]:
                     ty: Angle(None, true)
@@ -366,7 +366,7 @@ fn const_lit_decl_signed_float_lit_cast_neg() {
                                 expr: Expr [17-19]:
                                     ty: Float(None, true)
                                     kind: Lit: Float(7.0)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Angle(None, true)
                 qsharp_type: Double
@@ -385,7 +385,7 @@ fn const_lit_decl_signed_int_lit_cast_neg_fails() {
                     Stmt [0-19]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [0-19]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [6-11]
                             init_expr: Expr [17-18]:
                                 ty: Int(None, true)

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/angle.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/angle.rs
@@ -398,9 +398,9 @@ fn const_lit_decl_signed_int_lit_cast_neg_fails() {
             [Qsc.Qasm3.Compile.CannotCast
 
               x Cannot cast expression of type Int(None, true) to type Angle(None, true)
-               ,-[test:1:1]
+               ,-[test:1:18]
              1 | const angle x = -7;
-               : ^^^^^^^^^^^^^^^^^^^
+               :                  ^
                `----
             ]"#]],
     );

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/bit.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/bit.rs
@@ -15,7 +15,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
                 ty_span: [0-3]
                 init_expr: Expr [0-0]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [6] Symbol [4-5]:
                 name: a
                 type: Bit(false)
@@ -56,7 +56,7 @@ fn decl_with_lit_0_init_expr() {
                 ty_span: [0-3]
                 init_expr: Expr [8-9]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [6] Symbol [4-5]:
                 name: a
                 type: Bit(false)
@@ -75,7 +75,7 @@ fn decl_with_lit_1_init_expr() {
                 ty_span: [0-3]
                 init_expr: Expr [8-9]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [4-5]:
                 name: a
                 type: Bit(false)
@@ -94,7 +94,7 @@ fn const_decl_with_lit_0_init_expr() {
                 ty_span: [6-9]
                 init_expr: Expr [14-15]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [6] Symbol [10-11]:
                 name: a
                 type: Bit(true)
@@ -113,7 +113,7 @@ fn const_decl_with_lit_1_init_expr() {
                 ty_span: [6-9]
                 init_expr: Expr [14-15]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [10-11]:
                 name: a
                 type: Bit(true)

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/bit.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/bit.rs
@@ -25,24 +25,21 @@ fn with_no_init_expr_has_generated_lit_expr() {
 }
 
 #[test]
-#[ignore = "Unimplemented"]
 fn array_with_no_init_expr_has_generated_lit_expr() {
     check_classical_decl(
         "bit[4] a;",
         &expect![[r#"
-            Program:
-                version: <none>
-                statements: <empty>
-
-            [Qsc.Qasm3.Compile.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: bit array
-              | default value
-               ,-[test:1:1]
-             1 | bit[4] a;
-               : ^^^^^^^^^
-               `----
-            ]"#]],
+            ClassicalDeclarationStmt [0-9]:
+                symbol_id: 8
+                ty_span: [0-6]
+                init_expr: Expr [0-0]:
+                    ty: BitArray(One(4), true)
+                    kind: Lit: Bitstring("0000")
+            [8] Symbol [7-8]:
+                name: a
+                type: BitArray(One(4), false)
+                qsharp_type: Result[]
+                io_kind: Default"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/bit.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/bit.rs
@@ -11,12 +11,12 @@ fn with_no_init_expr_has_generated_lit_expr() {
         "bit a;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-6]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [0-0]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: a
                 type: Bit(false)
                 qsharp_type: Result
@@ -52,12 +52,12 @@ fn decl_with_lit_0_init_expr() {
         "bit a = 0;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-10]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-9]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: a
                 type: Bit(false)
                 qsharp_type: Result
@@ -71,12 +71,12 @@ fn decl_with_lit_1_init_expr() {
         "bit a = 1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-10]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-9]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: a
                 type: Bit(false)
                 qsharp_type: Result
@@ -90,12 +90,12 @@ fn const_decl_with_lit_0_init_expr() {
         "const bit a = 0;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-16]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-15]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: a
                 type: Bit(true)
                 qsharp_type: Result
@@ -109,12 +109,12 @@ fn const_decl_with_lit_1_init_expr() {
         "const bit a = 1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-16]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-15]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: a
                 type: Bit(true)
                 qsharp_type: Result

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/bool.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/bool.rs
@@ -11,12 +11,12 @@ fn with_no_init_expr_has_generated_lit_expr() {
         "bool a;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-7]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [0-0]:
                     ty: Bool(true)
                     kind: Lit: Bool(false)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -52,12 +52,12 @@ fn decl_with_lit_false_init_expr() {
         "bool a = false;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-14]:
                     ty: Bool(false)
                     kind: Lit: Bool(false)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -71,12 +71,12 @@ fn decl_with_lit_true_init_expr() {
         "bool a = true;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-14]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-13]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -90,12 +90,12 @@ fn const_decl_with_lit_false_init_expr() {
         "const bool a = false;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-20]:
                     ty: Bool(true)
                     kind: Lit: Bool(false)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: a
                 type: Bool(true)
                 qsharp_type: bool
@@ -109,12 +109,12 @@ fn const_decl_with_lit_true_init_expr() {
         "const bool a = true;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-19]:
                     ty: Bool(true)
                     kind: Lit: Bool(true)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: a
                 type: Bool(true)
                 qsharp_type: bool

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/bool.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/bool.rs
@@ -55,7 +55,7 @@ fn decl_with_lit_false_init_expr() {
                 symbol_id: 6
                 ty_span: [0-4]
                 init_expr: Expr [9-14]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(false)
             [6] Symbol [5-6]:
                 name: a
@@ -74,7 +74,7 @@ fn decl_with_lit_true_init_expr() {
                 symbol_id: 6
                 ty_span: [0-4]
                 init_expr: Expr [9-13]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(true)
             [6] Symbol [5-6]:
                 name: a

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/complex.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/complex.rs
@@ -11,12 +11,12 @@ fn implicit_bitness_default() {
         "complex[float] x;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-17]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [0-0]:
                     ty: Complex(None, true)
                     kind: Lit: Complex(0.0, 0.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Complex(None, false)
                 qsharp_type: Complex
@@ -30,12 +30,12 @@ fn explicit_bitness_default() {
         "complex[float[42]] x;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-18]
                 init_expr: Expr [0-0]:
                     ty: Complex(Some(42), true)
                     kind: Lit: Complex(0.0, 0.0)
-            [6] Symbol [19-20]:
+            [8] Symbol [19-20]:
                 name: x
                 type: Complex(Some(42), false)
                 qsharp_type: Complex
@@ -48,17 +48,17 @@ fn const_implicit_bitness_double_img_only() {
     check_classical_decl(
         "const complex[float] x = 1.01im;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-32]:
-            symbol_id: 6
-            ty_span: [6-20]
-            init_expr: Expr [25-31]:
-                ty: Complex(None, true)
-                kind: Lit: Complex(0.0, 1.01)
-        [6] Symbol [21-22]:
-            name: x
-            type: Complex(None, true)
-            qsharp_type: Complex
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-32]:
+                symbol_id: 8
+                ty_span: [6-20]
+                init_expr: Expr [25-31]:
+                    ty: Complex(None, true)
+                    kind: Lit: Complex(0.0, 1.01)
+            [8] Symbol [21-22]:
+                name: x
+                type: Complex(None, true)
+                qsharp_type: Complex
+                io_kind: Default"#]],
     );
 }
 
@@ -67,17 +67,17 @@ fn const_implicit_bitness_int_img_only() {
     check_classical_decl(
         "const complex[float] x = 1im;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-29]:
-            symbol_id: 6
-            ty_span: [6-20]
-            init_expr: Expr [25-28]:
-                ty: Complex(None, true)
-                kind: Lit: Complex(0.0, 1.0)
-        [6] Symbol [21-22]:
-            name: x
-            type: Complex(None, true)
-            qsharp_type: Complex
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-29]:
+                symbol_id: 8
+                ty_span: [6-20]
+                init_expr: Expr [25-28]:
+                    ty: Complex(None, true)
+                    kind: Lit: Complex(0.0, 1.0)
+            [8] Symbol [21-22]:
+                name: x
+                type: Complex(None, true)
+                qsharp_type: Complex
+                io_kind: Default"#]],
     );
 }
 
@@ -87,12 +87,12 @@ fn const_explicit_bitness_double_img_only() {
         "const complex[float[42]] x = 1.01im;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-36]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-24]
                 init_expr: Expr [29-35]:
                     ty: Complex(Some(42), true)
                     kind: Lit: Complex(0.0, 1.01)
-            [6] Symbol [25-26]:
+            [8] Symbol [25-26]:
                 name: x
                 type: Complex(Some(42), true)
                 qsharp_type: Complex
@@ -106,12 +106,12 @@ fn const_explicit_bitness_int_img_only() {
         "const complex[float[42]] x = 1im;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-33]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-24]
                 init_expr: Expr [29-32]:
                     ty: Complex(Some(42), true)
                     kind: Lit: Complex(0.0, 1.0)
-            [6] Symbol [25-26]:
+            [8] Symbol [25-26]:
                 name: x
                 type: Complex(Some(42), true)
                 qsharp_type: Complex
@@ -125,12 +125,12 @@ fn implicit_bitness_double_img_only() {
         "complex[float] x = 1.01im;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-26]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-25]:
                     ty: Complex(None, false)
                     kind: Lit: Complex(0.0, 1.01)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Complex(None, false)
                 qsharp_type: Complex
@@ -144,12 +144,12 @@ fn implicit_bitness_int_img_only() {
         "complex[float] x = 1im;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-22]:
                     ty: Complex(None, false)
                     kind: Lit: Complex(0.0, 1.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Complex(None, false)
                 qsharp_type: Complex
@@ -162,17 +162,17 @@ fn const_implicit_bitness_double_real_only() {
     check_classical_decl(
         "const complex[float] x = 1.01;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-30]:
-            symbol_id: 6
-            ty_span: [6-20]
-            init_expr: Expr [25-29]:
-                ty: Complex(None, true)
-                kind: Lit: Complex(1.01, 0.0)
-        [6] Symbol [21-22]:
-            name: x
-            type: Complex(None, true)
-            qsharp_type: Complex
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-30]:
+                symbol_id: 8
+                ty_span: [6-20]
+                init_expr: Expr [25-29]:
+                    ty: Complex(None, true)
+                    kind: Lit: Complex(1.01, 0.0)
+            [8] Symbol [21-22]:
+                name: x
+                type: Complex(None, true)
+                qsharp_type: Complex
+                io_kind: Default"#]],
     );
 }
 
@@ -181,17 +181,17 @@ fn const_implicit_bitness_int_real_only() {
     check_classical_decl(
         "const complex[float] x = 1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-27]:
-            symbol_id: 6
-            ty_span: [6-20]
-            init_expr: Expr [25-26]:
-                ty: Complex(None, true)
-                kind: Lit: Complex(1.0, 0.0)
-        [6] Symbol [21-22]:
-            name: x
-            type: Complex(None, true)
-            qsharp_type: Complex
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-27]:
+                symbol_id: 8
+                ty_span: [6-20]
+                init_expr: Expr [25-26]:
+                    ty: Complex(None, true)
+                    kind: Lit: Complex(1.0, 0.0)
+            [8] Symbol [21-22]:
+                name: x
+                type: Complex(None, true)
+                qsharp_type: Complex
+                io_kind: Default"#]],
     );
 }
 
@@ -201,12 +201,12 @@ fn implicit_bitness_double_real_only() {
         "complex[float] x = 1.01;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-24]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-23]:
                     ty: Complex(None, true)
                     kind: Lit: Complex(1.01, 0.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Complex(None, false)
                 qsharp_type: Complex
@@ -220,12 +220,12 @@ fn implicit_bitness_int_real_only() {
         "complex[float] x = 1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-20]:
                     ty: Complex(None, true)
                     kind: Lit: Complex(1.0, 0.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Complex(None, false)
                 qsharp_type: Complex

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/complex.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/complex.rs
@@ -124,17 +124,17 @@ fn implicit_bitness_double_img_only() {
     check_classical_decl(
         "complex[float] x = 1.01im;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-26]:
-            symbol_id: 6
-            ty_span: [0-14]
-            init_expr: Expr [19-25]:
-                ty: Complex(None, true)
-                kind: Lit: Complex(0.0, 1.01)
-        [6] Symbol [15-16]:
-            name: x
-            type: Complex(None, false)
-            qsharp_type: Complex
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-26]:
+                symbol_id: 6
+                ty_span: [0-14]
+                init_expr: Expr [19-25]:
+                    ty: Complex(None, false)
+                    kind: Lit: Complex(0.0, 1.01)
+            [6] Symbol [15-16]:
+                name: x
+                type: Complex(None, false)
+                qsharp_type: Complex
+                io_kind: Default"#]],
     );
 }
 
@@ -143,17 +143,17 @@ fn implicit_bitness_int_img_only() {
     check_classical_decl(
         "complex[float] x = 1im;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-23]:
-            symbol_id: 6
-            ty_span: [0-14]
-            init_expr: Expr [19-22]:
-                ty: Complex(None, true)
-                kind: Lit: Complex(0.0, 1.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Complex(None, false)
-            qsharp_type: Complex
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-23]:
+                symbol_id: 6
+                ty_span: [0-14]
+                init_expr: Expr [19-22]:
+                    ty: Complex(None, false)
+                    kind: Lit: Complex(0.0, 1.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Complex(None, false)
+                qsharp_type: Complex
+                io_kind: Default"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/creg.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/creg.rs
@@ -15,7 +15,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
                 ty_span: [0-7]
                 init_expr: Expr [0-0]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [6] Symbol [5-6]:
                 name: a
                 type: Bit(false)

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/creg.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/creg.rs
@@ -11,12 +11,12 @@ fn with_no_init_expr_has_generated_lit_expr() {
         "creg a;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-7]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-7]
                 init_expr: Expr [0-0]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: a
                 type: Bit(false)
                 qsharp_type: Result

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/creg.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/creg.rs
@@ -25,23 +25,20 @@ fn with_no_init_expr_has_generated_lit_expr() {
 }
 
 #[test]
-#[ignore = "Unimplemented"]
 fn array_with_no_init_expr_has_generated_lit_expr() {
     check_classical_decl(
         "creg a[4];",
         &expect![[r#"
-            Program:
-                version: <none>
-                statements: <empty>
-
-            [Qsc.Qasm3.Compile.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: bit array
-              | default value
-               ,-[test:1:1]
-             1 | creg a[4];
-               : ^^^^^^^^^^
-               `----
-            ]"#]],
+            ClassicalDeclarationStmt [0-10]:
+                symbol_id: 8
+                ty_span: [0-10]
+                init_expr: Expr [0-0]:
+                    ty: BitArray(One(4), true)
+                    kind: Lit: Bitstring("0000")
+            [8] Symbol [5-6]:
+                name: a
+                type: BitArray(One(4), false)
+                qsharp_type: Result[]
+                io_kind: Default"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/duration.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/duration.rs
@@ -16,7 +16,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
                     Stmt [0-11]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [0-11]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [0-8]
                             init_expr: Expr [0-0]:
                                 ty: Duration(true)

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/float.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/float.rs
@@ -11,12 +11,12 @@ fn implicit_bitness_default() {
         "float x;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-8]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [0-0]:
                     ty: Float(None, true)
                     kind: Lit: Float(0.0)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
@@ -30,12 +30,12 @@ fn lit() {
         "float x = 42.1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
@@ -48,17 +48,17 @@ fn const_lit() {
     check_classical_decl(
         "const float x = 42.1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-21]:
-            symbol_id: 6
-            ty_span: [6-11]
-            init_expr: Expr [16-20]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [12-13]:
-            name: x
-            type: Float(None, true)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-21]:
+                symbol_id: 8
+                ty_span: [6-11]
+                init_expr: Expr [16-20]:
+                    ty: Float(None, true)
+                    kind: Lit: Float(42.1)
+            [8] Symbol [12-13]:
+                name: x
+                type: Float(None, true)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -68,12 +68,12 @@ fn lit_explicit_width() {
         "float[64] x = 42.1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-9]
                 init_expr: Expr [14-18]:
                     ty: Float(Some(64), true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: x
                 type: Float(Some(64), false)
                 qsharp_type: Double
@@ -87,12 +87,12 @@ fn const_explicit_width_lit() {
         "const float[64] x = 42.1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-25]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-15]
                 init_expr: Expr [20-24]:
                     ty: Float(Some(64), true)
                     kind: Lit: Float(42.1)
-            [6] Symbol [16-17]:
+            [8] Symbol [16-17]:
                 name: x
                 type: Float(Some(64), true)
                 qsharp_type: Double
@@ -106,12 +106,12 @@ fn lit_decl_leading_dot() {
         "float x = .421;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
                     ty: Float(None, false)
                     kind: Lit: Float(0.421)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
@@ -124,17 +124,17 @@ fn const_lit_decl_leading_dot() {
     check_classical_decl(
         "const float x = .421;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-21]:
-            symbol_id: 6
-            ty_span: [6-11]
-            init_expr: Expr [16-20]:
-                ty: Float(None, true)
-                kind: Lit: Float(0.421)
-        [6] Symbol [12-13]:
-            name: x
-            type: Float(None, true)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-21]:
+                symbol_id: 8
+                ty_span: [6-11]
+                init_expr: Expr [16-20]:
+                    ty: Float(None, true)
+                    kind: Lit: Float(0.421)
+            [8] Symbol [12-13]:
+                name: x
+                type: Float(None, true)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -143,17 +143,17 @@ fn const_lit_decl_leading_dot_scientific() {
     check_classical_decl(
         "const float x = .421e2;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-23]:
-            symbol_id: 6
-            ty_span: [6-11]
-            init_expr: Expr [16-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [12-13]:
-            name: x
-            type: Float(None, true)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-23]:
+                symbol_id: 8
+                ty_span: [6-11]
+                init_expr: Expr [16-22]:
+                    ty: Float(None, true)
+                    kind: Lit: Float(42.1)
+            [8] Symbol [12-13]:
+                name: x
+                type: Float(None, true)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -163,12 +163,12 @@ fn lit_decl_trailing_dot() {
         "float x = 421.;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
                     ty: Float(None, false)
                     kind: Lit: Float(421.0)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
@@ -181,17 +181,17 @@ fn const_lit_decl_trailing_dot() {
     check_classical_decl(
         "const float x = 421.;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-21]:
-            symbol_id: 6
-            ty_span: [6-11]
-            init_expr: Expr [16-20]:
-                ty: Float(None, true)
-                kind: Lit: Float(421.0)
-        [6] Symbol [12-13]:
-            name: x
-            type: Float(None, true)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-21]:
+                symbol_id: 8
+                ty_span: [6-11]
+                init_expr: Expr [16-20]:
+                    ty: Float(None, true)
+                    kind: Lit: Float(421.0)
+            [8] Symbol [12-13]:
+                name: x
+                type: Float(None, true)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -201,12 +201,12 @@ fn lit_decl_scientific() {
         "float x = 4.21e1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-17]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-16]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
@@ -219,17 +219,17 @@ fn const_lit_decl_scientific() {
     check_classical_decl(
         "const float x = 4.21e1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-23]:
-            symbol_id: 6
-            ty_span: [6-11]
-            init_expr: Expr [16-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [12-13]:
-            name: x
-            type: Float(None, true)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-23]:
+                symbol_id: 8
+                ty_span: [6-11]
+                init_expr: Expr [16-22]:
+                    ty: Float(None, true)
+                    kind: Lit: Float(42.1)
+            [8] Symbol [12-13]:
+                name: x
+                type: Float(None, true)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -239,12 +239,12 @@ fn lit_decl_scientific_signed_pos() {
         "float x = 4.21e+1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-18]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-17]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
@@ -257,17 +257,17 @@ fn const_lit_decl_scientific_signed_pos() {
     check_classical_decl(
         "const float x = 4.21e+1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-24]:
-            symbol_id: 6
-            ty_span: [6-11]
-            init_expr: Expr [16-23]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [12-13]:
-            name: x
-            type: Float(None, true)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-24]:
+                symbol_id: 8
+                ty_span: [6-11]
+                init_expr: Expr [16-23]:
+                    ty: Float(None, true)
+                    kind: Lit: Float(42.1)
+            [8] Symbol [12-13]:
+                name: x
+                type: Float(None, true)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -277,12 +277,12 @@ fn lit_decl_scientific_cap_e() {
         "float x = 4.21E1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-17]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-16]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
@@ -295,17 +295,17 @@ fn const_lit_decl_scientific_cap_e() {
     check_classical_decl(
         "const float x = 4.21E1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-23]:
-            symbol_id: 6
-            ty_span: [6-11]
-            init_expr: Expr [16-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [12-13]:
-            name: x
-            type: Float(None, true)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-23]:
+                symbol_id: 8
+                ty_span: [6-11]
+                init_expr: Expr [16-22]:
+                    ty: Float(None, true)
+                    kind: Lit: Float(42.1)
+            [8] Symbol [12-13]:
+                name: x
+                type: Float(None, true)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -315,12 +315,12 @@ fn lit_decl_scientific_signed_neg() {
         "float x = 421.0e-1;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-18]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.1)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
@@ -333,17 +333,17 @@ fn const_lit_decl_scientific_signed_neg() {
     check_classical_decl(
         "const float x = 421.0e-1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-25]:
-            symbol_id: 6
-            ty_span: [6-11]
-            init_expr: Expr [16-24]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [12-13]:
-            name: x
-            type: Float(None, true)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-25]:
+                symbol_id: 8
+                ty_span: [6-11]
+                init_expr: Expr [16-24]:
+                    ty: Float(None, true)
+                    kind: Lit: Float(42.1)
+            [8] Symbol [12-13]:
+                name: x
+                type: Float(None, true)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -353,7 +353,7 @@ fn const_lit_decl_signed_float_lit_cast_neg() {
         "const float x = -7.;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [17-19]:
                     ty: Float(None, true)
@@ -362,7 +362,7 @@ fn const_lit_decl_signed_float_lit_cast_neg() {
                         expr: Expr [17-19]:
                             ty: Float(None, true)
                             kind: Lit: Float(7.0)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Float(None, true)
                 qsharp_type: Double
@@ -376,7 +376,7 @@ fn const_lit_decl_signed_int_lit_cast_neg() {
         "const float x = -7;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [17-18]:
                     ty: Float(None, true)
@@ -389,7 +389,7 @@ fn const_lit_decl_signed_int_lit_cast_neg() {
                                 expr: Expr [17-18]:
                                     ty: Int(None, true)
                                     kind: Lit: Int(7)
-            [6] Symbol [12-13]:
+            [8] Symbol [12-13]:
                 name: x
                 type: Float(None, true)
                 qsharp_type: Double
@@ -404,12 +404,12 @@ fn init_float_with_int_value_equal_max_safely_representable_values() {
         &format!("float a = {max_exact_int};"),
         &expect![[r#"
             ClassicalDeclarationStmt [0-27]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-26]:
                     ty: Float(None, true)
                     kind: Lit: Float(9007199254740992.0)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: a
                 type: Float(None, false)
                 qsharp_type: Double
@@ -430,7 +430,7 @@ fn init_float_with_int_value_greater_than_safely_representable_values() {
                     Stmt [0-27]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [0-27]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [0-5]
                             init_expr: Expr [10-26]:
                                 ty: Int(None, true)
@@ -463,7 +463,7 @@ fn init_float_with_int_value_equal_min_safely_representable_values() {
         &format!("float a = {min_exact_int};"),
         &expect![[r#"
             ClassicalDeclarationStmt [0-28]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [11-27]:
                     ty: Float(None, false)
@@ -476,7 +476,7 @@ fn init_float_with_int_value_equal_min_safely_representable_values() {
                                 expr: Expr [11-27]:
                                     ty: Int(None, true)
                                     kind: Lit: Int(9007199254740992)
-            [6] Symbol [6-7]:
+            [8] Symbol [6-7]:
                 name: a
                 type: Float(None, false)
                 qsharp_type: Double

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/float.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/float.rs
@@ -29,17 +29,17 @@ fn lit() {
     check_classical_decl(
         "float x = 42.1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-15]:
-            symbol_id: 6
-            ty_span: [0-5]
-            init_expr: Expr [10-14]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [6-7]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-15]:
+                symbol_id: 6
+                ty_span: [0-5]
+                init_expr: Expr [10-14]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.1)
+            [6] Symbol [6-7]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -105,17 +105,17 @@ fn lit_decl_leading_dot() {
     check_classical_decl(
         "float x = .421;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-15]:
-            symbol_id: 6
-            ty_span: [0-5]
-            init_expr: Expr [10-14]:
-                ty: Float(None, true)
-                kind: Lit: Float(0.421)
-        [6] Symbol [6-7]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-15]:
+                symbol_id: 6
+                ty_span: [0-5]
+                init_expr: Expr [10-14]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(0.421)
+            [6] Symbol [6-7]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -162,17 +162,17 @@ fn lit_decl_trailing_dot() {
     check_classical_decl(
         "float x = 421.;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-15]:
-            symbol_id: 6
-            ty_span: [0-5]
-            init_expr: Expr [10-14]:
-                ty: Float(None, true)
-                kind: Lit: Float(421.0)
-        [6] Symbol [6-7]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-15]:
+                symbol_id: 6
+                ty_span: [0-5]
+                init_expr: Expr [10-14]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(421.0)
+            [6] Symbol [6-7]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -200,17 +200,17 @@ fn lit_decl_scientific() {
     check_classical_decl(
         "float x = 4.21e1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-17]:
-            symbol_id: 6
-            ty_span: [0-5]
-            init_expr: Expr [10-16]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [6-7]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-17]:
+                symbol_id: 6
+                ty_span: [0-5]
+                init_expr: Expr [10-16]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.1)
+            [6] Symbol [6-7]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -238,17 +238,17 @@ fn lit_decl_scientific_signed_pos() {
     check_classical_decl(
         "float x = 4.21e+1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-18]:
-            symbol_id: 6
-            ty_span: [0-5]
-            init_expr: Expr [10-17]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [6-7]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-18]:
+                symbol_id: 6
+                ty_span: [0-5]
+                init_expr: Expr [10-17]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.1)
+            [6] Symbol [6-7]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -276,17 +276,17 @@ fn lit_decl_scientific_cap_e() {
     check_classical_decl(
         "float x = 4.21E1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-17]:
-            symbol_id: 6
-            ty_span: [0-5]
-            init_expr: Expr [10-16]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [6-7]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-17]:
+                symbol_id: 6
+                ty_span: [0-5]
+                init_expr: Expr [10-16]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.1)
+            [6] Symbol [6-7]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 
@@ -314,17 +314,17 @@ fn lit_decl_scientific_signed_neg() {
     check_classical_decl(
         "float x = 421.0e-1;",
         &expect![[r#"
-        ClassicalDeclarationStmt [0-19]:
-            symbol_id: 6
-            ty_span: [0-5]
-            init_expr: Expr [10-18]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.1)
-        [6] Symbol [6-7]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default"#]],
+            ClassicalDeclarationStmt [0-19]:
+                symbol_id: 6
+                ty_span: [0-5]
+                init_expr: Expr [10-18]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.1)
+            [6] Symbol [6-7]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default"#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/int.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/int.rs
@@ -11,7 +11,7 @@ fn implicit_bitness_int_negative() {
         "int x = -42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-12]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [9-11]:
                     ty: Int(None, false)
@@ -20,7 +20,7 @@ fn implicit_bitness_int_negative() {
                         expr: Expr [9-11]:
                             ty: Int(None, true)
                             kind: Lit: Int(42)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
@@ -34,7 +34,7 @@ fn implicit_bitness_int_const_negative() {
         "const int x = -42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-18]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [15-17]:
                     ty: Int(None, true)
@@ -43,7 +43,7 @@ fn implicit_bitness_int_const_negative() {
                         expr: Expr [15-17]:
                             ty: Int(None, true)
                             kind: Lit: Int(42)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: x
                 type: Int(None, true)
                 qsharp_type: Int
@@ -57,12 +57,12 @@ fn implicit_bitness_int_default() {
         "int x;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-6]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [0-0]:
                     ty: Int(None, true)
                     kind: Lit: Int(0)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
@@ -76,12 +76,12 @@ fn const_implicit_bitness_int_lit() {
         "const int x = 42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-17]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-16]:
                     ty: Int(None, true)
                     kind: Lit: Int(42)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: x
                 type: Int(None, true)
                 qsharp_type: Int
@@ -95,12 +95,12 @@ fn implicit_bitness_int_hex_cap() {
         "int x = 0XFa_1F;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-16]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-15]:
                     ty: Int(None, false)
                     kind: Lit: Int(64031)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
@@ -114,12 +114,12 @@ fn const_implicit_bitness_int_hex_cap() {
         "const int y = 0XFa_1F;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-22]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-21]:
                     ty: Int(None, true)
                     kind: Lit: Int(64031)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: y
                 type: Int(None, true)
                 qsharp_type: Int
@@ -133,12 +133,12 @@ fn implicit_bitness_int_octal() {
         "int x = 0o42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-13]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-12]:
                     ty: Int(None, false)
                     kind: Lit: Int(34)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
@@ -152,12 +152,12 @@ fn const_implicit_bitness_int_octal() {
         "const int x = 0o42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-18]:
                     ty: Int(None, true)
                     kind: Lit: Int(34)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: x
                 type: Int(None, true)
                 qsharp_type: Int
@@ -171,12 +171,12 @@ fn const_implicit_bitness_int_octal_cap() {
         "const int x = 0O42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-18]:
                     ty: Int(None, true)
                     kind: Lit: Int(34)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: x
                 type: Int(None, true)
                 qsharp_type: Int
@@ -190,12 +190,12 @@ fn implicit_bitness_int_binary_low() {
         "int x = 0b1001_1001;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(153)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
@@ -209,12 +209,12 @@ fn implicit_bitness_int_binary_cap() {
         "int x = 0B1010;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-14]:
                     ty: Int(None, false)
                     kind: Lit: Int(10)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
@@ -228,12 +228,12 @@ fn const_implicit_bitness_int_binary_low() {
         "const int x = 0b1001_1001;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-26]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-25]:
                     ty: Int(None, true)
                     kind: Lit: Int(153)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: x
                 type: Int(None, true)
                 qsharp_type: Int
@@ -247,12 +247,12 @@ fn const_implicit_bitness_int_binary_cap() {
         "const int x = 0B1010;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-20]:
                     ty: Int(None, true)
                     kind: Lit: Int(10)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: x
                 type: Int(None, true)
                 qsharp_type: Int
@@ -266,12 +266,12 @@ fn implicit_bitness_int_formatted() {
         "int x = 2_0_00;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-14]:
                     ty: Int(None, false)
                     kind: Lit: Int(2000)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
@@ -285,12 +285,12 @@ fn const_implicit_bitness_int_formatted() {
         "const int x = 2_0_00;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-20]:
                     ty: Int(None, true)
                     kind: Lit: Int(2000)
-            [6] Symbol [10-11]:
+            [8] Symbol [10-11]:
                 name: x
                 type: Int(None, true)
                 qsharp_type: Int
@@ -304,12 +304,12 @@ fn explicit_bitness_int_default() {
         "int[10] x;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-10]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-7]
                 init_expr: Expr [0-0]:
                     ty: Int(Some(10), true)
                     kind: Lit: Int(0)
-            [6] Symbol [8-9]:
+            [8] Symbol [8-9]:
                 name: x
                 type: Int(Some(10), false)
                 qsharp_type: Int
@@ -323,12 +323,12 @@ fn explicit_bitness_int() {
         "int[10] x = 42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-7]
                 init_expr: Expr [12-14]:
                     ty: Int(Some(10), true)
                     kind: Lit: Int(42)
-            [6] Symbol [8-9]:
+            [8] Symbol [8-9]:
                 name: x
                 type: Int(Some(10), false)
                 qsharp_type: Int
@@ -342,12 +342,12 @@ fn const_explicit_bitness_int() {
         "const int[10] x = 42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-13]
                 init_expr: Expr [18-20]:
                     ty: Int(Some(10), true)
                     kind: Lit: Int(42)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Int(Some(10), true)
                 qsharp_type: Int
@@ -361,7 +361,7 @@ fn implicit_bitness_int_negative_float_decl_is_runtime_conversion() {
         "int x = -42.;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-13]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [9-12]:
                     ty: Int(None, false)
@@ -374,7 +374,7 @@ fn implicit_bitness_int_negative_float_decl_is_runtime_conversion() {
                                 expr: Expr [9-12]:
                                     ty: Float(None, true)
                                     kind: Lit: Float(42.0)
-            [6] Symbol [4-5]:
+            [8] Symbol [4-5]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/int.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/int.rs
@@ -14,7 +14,7 @@ fn implicit_bitness_int_negative() {
                 symbol_id: 6
                 ty_span: [0-3]
                 init_expr: Expr [9-11]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: UnaryOpExpr [9-11]:
                         op: Neg
                         expr: Expr [9-11]:
@@ -98,7 +98,7 @@ fn implicit_bitness_int_hex_cap() {
                 symbol_id: 6
                 ty_span: [0-3]
                 init_expr: Expr [8-15]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(64031)
             [6] Symbol [4-5]:
                 name: x
@@ -136,7 +136,7 @@ fn implicit_bitness_int_octal() {
                 symbol_id: 6
                 ty_span: [0-3]
                 init_expr: Expr [8-12]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(34)
             [6] Symbol [4-5]:
                 name: x
@@ -193,7 +193,7 @@ fn implicit_bitness_int_binary_low() {
                 symbol_id: 6
                 ty_span: [0-3]
                 init_expr: Expr [8-19]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(153)
             [6] Symbol [4-5]:
                 name: x
@@ -212,7 +212,7 @@ fn implicit_bitness_int_binary_cap() {
                 symbol_id: 6
                 ty_span: [0-3]
                 init_expr: Expr [8-14]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(10)
             [6] Symbol [4-5]:
                 name: x
@@ -269,7 +269,7 @@ fn implicit_bitness_int_formatted() {
                 symbol_id: 6
                 ty_span: [0-3]
                 init_expr: Expr [8-14]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(2000)
             [6] Symbol [4-5]:
                 name: x

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/qreg.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/qreg.rs
@@ -14,3 +14,15 @@ fn with_no_init_expr() {
                 symbol_id: 8"#]],
     );
 }
+
+#[test]
+fn array_with_no_init_expr() {
+    check_stmt_kind(
+        "qreg a[3];",
+        &expect![[r#"
+            QubitArrayDeclaration [0-10]:
+                symbol_id: 8
+                size: 3
+                size_span: [7-8]"#]],
+    );
+}

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/qreg.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/qreg.rs
@@ -11,6 +11,6 @@ fn with_no_init_expr() {
         "qreg a;",
         &expect![[r#"
             QubitDeclaration [0-7]:
-                symbol_id: 6"#]],
+                symbol_id: 8"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/qreg.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/qreg.rs
@@ -6,23 +6,11 @@ use expect_test::expect;
 use crate::semantic::tests::check_stmt_kind;
 
 #[test]
-#[ignore = "unimplemented"]
-fn with_no_init_expr_has_generated_lit_expr() {
+fn with_no_init_expr() {
     check_stmt_kind(
         "qreg a;",
         &expect![[r#"
-            Program:
-                version: <none>
-                statements: <empty>
-
-            [Qsc.Qasm3.Compile.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: qubit decl
-              | stmt
-               ,-[test:1:1]
-             1 | qreg a;
-               : ^^^^^^^
-               `----
-            ]"#]],
+            QubitDeclaration [0-7]:
+                symbol_id: 6"#]],
     );
 }

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/stretch.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/stretch.rs
@@ -16,7 +16,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
                     Stmt [0-10]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [0-10]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [0-7]
                             init_expr: Expr [0-0]:
                                 ty: Stretch(true)

--- a/compiler/qsc_qasm3/src/semantic/tests/decls/uint.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/decls/uint.rs
@@ -11,12 +11,12 @@ fn implicit_bitness_int_default() {
         "uint x;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-7]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [0-0]:
                     ty: UInt(None, true)
                     kind: Lit: Int(0)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -30,12 +30,12 @@ fn const_implicit_bitness_int_lit() {
         "const uint x = 42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-18]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-17]:
                     ty: UInt(None, true)
                     kind: Lit: Int(42)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: x
                 type: UInt(None, true)
                 qsharp_type: Int
@@ -49,12 +49,12 @@ fn implicit_bitness_int_hex_cap() {
         "uint x = 0XFa_1F;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-17]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-16]:
                     ty: UInt(None, true)
                     kind: Lit: Int(64031)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -68,12 +68,12 @@ fn const_implicit_bitness_int_hex_low() {
         "const uint x = 0xFa_1F;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-22]:
                     ty: UInt(None, true)
                     kind: Lit: Int(64031)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: x
                 type: UInt(None, true)
                 qsharp_type: Int
@@ -87,12 +87,12 @@ fn const_implicit_bitness_int_hex_cap() {
         "const uint y = 0XFa_1F;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-22]:
                     ty: UInt(None, true)
                     kind: Lit: Int(64031)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: y
                 type: UInt(None, true)
                 qsharp_type: Int
@@ -106,12 +106,12 @@ fn implicit_bitness_int_octal_low() {
         "uint x = 0o42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-14]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-13]:
                     ty: UInt(None, true)
                     kind: Lit: Int(34)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -125,12 +125,12 @@ fn implicit_bitness_int_octal_cap() {
         "uint x = 0O42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-14]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-13]:
                     ty: UInt(None, true)
                     kind: Lit: Int(34)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -144,12 +144,12 @@ fn const_implicit_bitness_int_octal_low() {
         "const uint x = 0o42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-19]:
                     ty: UInt(None, true)
                     kind: Lit: Int(34)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: x
                 type: UInt(None, true)
                 qsharp_type: Int
@@ -163,12 +163,12 @@ fn const_implicit_bitness_int_octal_cap() {
         "const uint x = 0O42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-19]:
                     ty: UInt(None, true)
                     kind: Lit: Int(34)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: x
                 type: UInt(None, true)
                 qsharp_type: Int
@@ -182,12 +182,12 @@ fn implicit_bitness_int_binary_low() {
         "uint x = 0b1001_1001;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-21]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-20]:
                     ty: UInt(None, true)
                     kind: Lit: Int(153)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -201,12 +201,12 @@ fn implicit_bitness_int_binary_cap() {
         "uint x = 0B1010;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-16]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-15]:
                     ty: UInt(None, true)
                     kind: Lit: Int(10)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -220,12 +220,12 @@ fn const_implicit_bitness_int_binary_low() {
         "const uint x = 0b1001_1001;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-27]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-26]:
                     ty: UInt(None, true)
                     kind: Lit: Int(153)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: x
                 type: UInt(None, true)
                 qsharp_type: Int
@@ -239,12 +239,12 @@ fn const_implicit_bitness_int_binary_cap() {
         "const uint x = 0B1010;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-22]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-21]:
                     ty: UInt(None, true)
                     kind: Lit: Int(10)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: x
                 type: UInt(None, true)
                 qsharp_type: Int
@@ -258,12 +258,12 @@ fn implicit_bitness_int_formatted() {
         "uint x = 2_0_00;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-16]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-15]:
                     ty: UInt(None, true)
                     kind: Lit: Int(2000)
-            [6] Symbol [5-6]:
+            [8] Symbol [5-6]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -277,12 +277,12 @@ fn const_implicit_bitness_int_formatted() {
         "const uint x = 2_0_00;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-22]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-21]:
                     ty: UInt(None, true)
                     kind: Lit: Int(2000)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: x
                 type: UInt(None, true)
                 qsharp_type: Int
@@ -296,12 +296,12 @@ fn const_explicit_bitness_int() {
         "uint[10] x;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-11]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [0-8]
                 init_expr: Expr [0-0]:
                     ty: UInt(Some(10), true)
                     kind: Lit: Int(0)
-            [6] Symbol [9-10]:
+            [8] Symbol [9-10]:
                 name: x
                 type: UInt(Some(10), false)
                 qsharp_type: Int
@@ -315,7 +315,7 @@ fn assigning_uint_to_negative_lit() {
         "const uint[10] x = -42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-14]
                 init_expr: Expr [20-22]:
                     ty: UInt(Some(10), true)
@@ -328,7 +328,7 @@ fn assigning_uint_to_negative_lit() {
                                 expr: Expr [20-22]:
                                     ty: Int(None, true)
                                     kind: Lit: Int(42)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: UInt(Some(10), true)
                 qsharp_type: Int
@@ -342,7 +342,7 @@ fn implicit_bitness_uint_const_negative_decl() {
         "const uint x = -42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [16-18]:
                     ty: UInt(None, true)
@@ -355,7 +355,7 @@ fn implicit_bitness_uint_const_negative_decl() {
                                 expr: Expr [16-18]:
                                     ty: Int(None, true)
                                     kind: Lit: Int(42)
-            [6] Symbol [11-12]:
+            [8] Symbol [11-12]:
                 name: x
                 type: UInt(None, true)
                 qsharp_type: Int
@@ -369,7 +369,7 @@ fn explicit_bitness_uint_const_negative_decl() {
         "const uint[32] x = -42;",
         &expect![[r#"
             ClassicalDeclarationStmt [0-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [6-14]
                 init_expr: Expr [20-22]:
                     ty: UInt(Some(32), true)
@@ -382,7 +382,7 @@ fn explicit_bitness_uint_const_negative_decl() {
                                 expr: Expr [20-22]:
                                     ty: Int(None, true)
                                     kind: Lit: Int(42)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: UInt(Some(32), true)
                 qsharp_type: Int

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/arithmetic_conversions.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/arithmetic_conversions.rs
@@ -16,30 +16,30 @@ fn int_idents_without_width_can_be_multiplied() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-19]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-18]:
-                ty: Int(None, true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [28-38]:
-            symbol_id: 7
-            ty_span: [28-31]
-            init_expr: Expr [36-37]:
-                ty: Int(None, true)
-                kind: Lit: Int(3)
-        ExprStmt [47-53]:
-            expr: Expr [47-52]:
-                ty: Int(None, false)
-                kind: BinaryOpExpr:
-                    op: Mul
-                    lhs: Expr [47-48]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-                    rhs: Expr [51-52]:
-                        ty: Int(None, false)
-                        kind: SymbolId(7)
-    "#]],
+            ClassicalDeclarationStmt [9-19]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-18]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [28-38]:
+                symbol_id: 7
+                ty_span: [28-31]
+                init_expr: Expr [36-37]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(3)
+            ExprStmt [47-53]:
+                expr: Expr [47-52]:
+                    ty: Int(None, false)
+                    kind: BinaryOpExpr:
+                        op: Mul
+                        lhs: Expr [47-48]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+                        rhs: Expr [51-52]:
+                            ty: Int(None, false)
+                            kind: SymbolId(7)
+        "#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/arithmetic_conversions.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/arithmetic_conversions.rs
@@ -17,13 +17,13 @@ fn int_idents_without_width_can_be_multiplied() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Int(None, false)
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Int(None, false)
@@ -35,10 +35,10 @@ fn int_idents_without_width_can_be_multiplied() {
                         op: Mul
                         lhs: Expr [47-48]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [51-52]:
                             ty: Int(None, false)
-                            kind: SymbolId(7)
+                            kind: SymbolId(9)
         "#]],
     );
 }
@@ -54,30 +54,30 @@ fn int_idents_with_same_width_can_be_multiplied() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-16]
-            init_expr: Expr [21-22]:
-                ty: Int(Some(32), true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [32-46]:
-            symbol_id: 7
-            ty_span: [32-39]
-            init_expr: Expr [44-45]:
-                ty: Int(Some(32), true)
-                kind: Lit: Int(3)
-        ExprStmt [55-61]:
-            expr: Expr [55-60]:
-                ty: Int(Some(32), false)
-                kind: BinaryOpExpr:
-                    op: Mul
-                    lhs: Expr [55-56]:
-                        ty: Int(Some(32), false)
-                        kind: SymbolId(6)
-                    rhs: Expr [59-60]:
-                        ty: Int(Some(32), false)
-                        kind: SymbolId(7)
-    "#]],
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 8
+                ty_span: [9-16]
+                init_expr: Expr [21-22]:
+                    ty: Int(Some(32), true)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [32-46]:
+                symbol_id: 9
+                ty_span: [32-39]
+                init_expr: Expr [44-45]:
+                    ty: Int(Some(32), true)
+                    kind: Lit: Int(3)
+            ExprStmt [55-61]:
+                expr: Expr [55-60]:
+                    ty: Int(Some(32), false)
+                    kind: BinaryOpExpr:
+                        op: Mul
+                        lhs: Expr [55-56]:
+                            ty: Int(Some(32), false)
+                            kind: SymbolId(8)
+                        rhs: Expr [59-60]:
+                            ty: Int(Some(32), false)
+                            kind: SymbolId(9)
+        "#]],
     );
 }
 
@@ -92,34 +92,34 @@ fn int_idents_with_different_width_can_be_multiplied() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-16]
-            init_expr: Expr [21-22]:
-                ty: Int(Some(32), true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [32-46]:
-            symbol_id: 7
-            ty_span: [32-39]
-            init_expr: Expr [44-45]:
-                ty: Int(Some(64), true)
-                kind: Lit: Int(3)
-        ExprStmt [55-61]:
-            expr: Expr [55-60]:
-                ty: Int(Some(64), false)
-                kind: BinaryOpExpr:
-                    op: Mul
-                    lhs: Expr [55-56]:
-                        ty: Int(Some(64), false)
-                        kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 8
+                ty_span: [9-16]
+                init_expr: Expr [21-22]:
+                    ty: Int(Some(32), true)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [32-46]:
+                symbol_id: 9
+                ty_span: [32-39]
+                init_expr: Expr [44-45]:
+                    ty: Int(Some(64), true)
+                    kind: Lit: Int(3)
+            ExprStmt [55-61]:
+                expr: Expr [55-60]:
+                    ty: Int(Some(64), false)
+                    kind: BinaryOpExpr:
+                        op: Mul
+                        lhs: Expr [55-56]:
                             ty: Int(Some(64), false)
-                            expr: Expr [55-56]:
-                                ty: Int(Some(32), false)
-                                kind: SymbolId(6)
-                    rhs: Expr [59-60]:
-                        ty: Int(Some(64), false)
-                        kind: SymbolId(7)
-    "#]],
+                            kind: Cast [0-0]:
+                                ty: Int(Some(64), false)
+                                expr: Expr [55-56]:
+                                    ty: Int(Some(32), false)
+                                    kind: SymbolId(8)
+                        rhs: Expr [59-60]:
+                            ty: Int(Some(64), false)
+                            kind: SymbolId(9)
+        "#]],
     );
 }
 
@@ -134,36 +134,36 @@ fn multiplying_int_idents_with_different_width_result_in_higher_width_result() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-16]
-            init_expr: Expr [21-22]:
-                ty: Int(Some(32), true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [32-46]:
-            symbol_id: 7
-            ty_span: [32-39]
-            init_expr: Expr [44-45]:
-                ty: Int(Some(64), true)
-                kind: Lit: Int(3)
-        ClassicalDeclarationStmt [55-73]:
-            symbol_id: 8
-            ty_span: [55-62]
-            init_expr: Expr [67-72]:
-                ty: Int(Some(64), false)
-                kind: BinaryOpExpr:
-                    op: Mul
-                    lhs: Expr [67-68]:
-                        ty: Int(Some(64), false)
-                        kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 8
+                ty_span: [9-16]
+                init_expr: Expr [21-22]:
+                    ty: Int(Some(32), true)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [32-46]:
+                symbol_id: 9
+                ty_span: [32-39]
+                init_expr: Expr [44-45]:
+                    ty: Int(Some(64), true)
+                    kind: Lit: Int(3)
+            ClassicalDeclarationStmt [55-73]:
+                symbol_id: 10
+                ty_span: [55-62]
+                init_expr: Expr [67-72]:
+                    ty: Int(Some(64), false)
+                    kind: BinaryOpExpr:
+                        op: Mul
+                        lhs: Expr [67-68]:
                             ty: Int(Some(64), false)
-                            expr: Expr [67-68]:
-                                ty: Int(Some(32), false)
-                                kind: SymbolId(6)
-                    rhs: Expr [71-72]:
-                        ty: Int(Some(64), false)
-                        kind: SymbolId(7)
-    "#]],
+                            kind: Cast [0-0]:
+                                ty: Int(Some(64), false)
+                                expr: Expr [67-68]:
+                                    ty: Int(Some(32), false)
+                                    kind: SymbolId(8)
+                        rhs: Expr [71-72]:
+                            ty: Int(Some(64), false)
+                            kind: SymbolId(9)
+        "#]],
     );
 }
 
@@ -178,40 +178,40 @@ fn multiplying_int_idents_with_different_width_result_in_no_width_result() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-16]
-            init_expr: Expr [21-22]:
-                ty: Int(Some(32), true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [32-46]:
-            symbol_id: 7
-            ty_span: [32-39]
-            init_expr: Expr [44-45]:
-                ty: Int(Some(64), true)
-                kind: Lit: Int(3)
-        ClassicalDeclarationStmt [55-69]:
-            symbol_id: 8
-            ty_span: [55-58]
-            init_expr: Expr [63-68]:
-                ty: Int(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 8
+                ty_span: [9-16]
+                init_expr: Expr [21-22]:
+                    ty: Int(Some(32), true)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [32-46]:
+                symbol_id: 9
+                ty_span: [32-39]
+                init_expr: Expr [44-45]:
+                    ty: Int(Some(64), true)
+                    kind: Lit: Int(3)
+            ClassicalDeclarationStmt [55-69]:
+                symbol_id: 10
+                ty_span: [55-58]
+                init_expr: Expr [63-68]:
                     ty: Int(None, false)
-                    expr: Expr [63-68]:
-                        ty: Int(Some(64), false)
-                        kind: BinaryOpExpr:
-                            op: Mul
-                            lhs: Expr [63-64]:
-                                ty: Int(Some(64), false)
-                                kind: Cast [0-0]:
+                    kind: Cast [0-0]:
+                        ty: Int(None, false)
+                        expr: Expr [63-68]:
+                            ty: Int(Some(64), false)
+                            kind: BinaryOpExpr:
+                                op: Mul
+                                lhs: Expr [63-64]:
                                     ty: Int(Some(64), false)
-                                    expr: Expr [63-64]:
-                                        ty: Int(Some(32), false)
-                                        kind: SymbolId(6)
-                            rhs: Expr [67-68]:
-                                ty: Int(Some(64), false)
-                                kind: SymbolId(7)
-    "#]],
+                                    kind: Cast [0-0]:
+                                        ty: Int(Some(64), false)
+                                        expr: Expr [63-64]:
+                                            ty: Int(Some(32), false)
+                                            kind: SymbolId(8)
+                                rhs: Expr [67-68]:
+                                    ty: Int(Some(64), false)
+                                    kind: SymbolId(9)
+        "#]],
     );
 }
 
@@ -226,39 +226,39 @@ fn multiplying_int_idents_with_width_greater_than_64_result_in_bigint_result() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-16]
-            init_expr: Expr [21-22]:
-                ty: Int(Some(32), true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [32-46]:
-            symbol_id: 7
-            ty_span: [32-39]
-            init_expr: Expr [44-45]:
-                ty: Int(Some(64), true)
-                kind: Lit: Int(3)
-        ClassicalDeclarationStmt [55-73]:
-            symbol_id: 8
-            ty_span: [55-62]
-            init_expr: Expr [67-72]:
-                ty: Int(Some(67), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 8
+                ty_span: [9-16]
+                init_expr: Expr [21-22]:
+                    ty: Int(Some(32), true)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [32-46]:
+                symbol_id: 9
+                ty_span: [32-39]
+                init_expr: Expr [44-45]:
+                    ty: Int(Some(64), true)
+                    kind: Lit: Int(3)
+            ClassicalDeclarationStmt [55-73]:
+                symbol_id: 10
+                ty_span: [55-62]
+                init_expr: Expr [67-72]:
                     ty: Int(Some(67), false)
-                    expr: Expr [67-72]:
-                        ty: Int(Some(64), false)
-                        kind: BinaryOpExpr:
-                            op: Mul
-                            lhs: Expr [67-68]:
-                                ty: Int(Some(64), false)
-                                kind: Cast [0-0]:
+                    kind: Cast [0-0]:
+                        ty: Int(Some(67), false)
+                        expr: Expr [67-72]:
+                            ty: Int(Some(64), false)
+                            kind: BinaryOpExpr:
+                                op: Mul
+                                lhs: Expr [67-68]:
                                     ty: Int(Some(64), false)
-                                    expr: Expr [67-68]:
-                                        ty: Int(Some(32), false)
-                                        kind: SymbolId(6)
-                            rhs: Expr [71-72]:
-                                ty: Int(Some(64), false)
-                                kind: SymbolId(7)
-    "#]],
+                                    kind: Cast [0-0]:
+                                        ty: Int(Some(64), false)
+                                        expr: Expr [67-68]:
+                                            ty: Int(Some(32), false)
+                                            kind: SymbolId(8)
+                                rhs: Expr [71-72]:
+                                    ty: Int(Some(64), false)
+                                    kind: SymbolId(9)
+        "#]],
     );
 }

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/bit_to_bit.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/bit_to_bit.rs
@@ -21,7 +21,7 @@ fn logical_and() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -32,7 +32,7 @@ fn logical_and() {
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [7] Symbol [32-33]:
                 name: y
                 type: Bit(false)
@@ -84,7 +84,7 @@ fn logical_or() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -95,7 +95,7 @@ fn logical_or() {
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [7] Symbol [32-33]:
                 name: y
                 type: Bit(false)
@@ -147,7 +147,7 @@ fn unop_not_logical_and_unop_not() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -158,7 +158,7 @@ fn unop_not_logical_and_unop_not() {
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [7] Symbol [32-33]:
                 name: y
                 type: Bit(false)
@@ -218,7 +218,7 @@ fn unop_not_logical_or_unop_not() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -229,7 +229,7 @@ fn unop_not_logical_or_unop_not() {
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [7] Symbol [32-33]:
                 name: y
                 type: Bit(false)
@@ -289,7 +289,7 @@ fn unop_not_logical_and() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -300,7 +300,7 @@ fn unop_not_logical_and() {
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [7] Symbol [32-33]:
                 name: y
                 type: Bit(false)
@@ -356,7 +356,7 @@ fn unop_not_logical_or() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -367,7 +367,7 @@ fn unop_not_logical_or() {
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [7] Symbol [32-33]:
                 name: y
                 type: Bit(false)
@@ -423,7 +423,7 @@ fn logical_and_unop_not() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -434,7 +434,7 @@ fn logical_and_unop_not() {
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [7] Symbol [32-33]:
                 name: y
                 type: Bit(false)
@@ -490,7 +490,7 @@ fn logical_or_unop_not() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -501,7 +501,7 @@ fn logical_or_unop_not() {
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
-                    kind: Lit: Int(0)
+                    kind: Lit: Bit(0)
             [7] Symbol [32-33]:
                 name: y
                 type: Bit(false)

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/bit_to_bit.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/bit_to_bit.rs
@@ -17,29 +17,29 @@ fn logical_and() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
                     ty: Bool(false)
@@ -51,15 +51,15 @@ fn logical_and() {
                                 ty: Bool(false)
                                 expr: Expr [56-57]:
                                     ty: Bit(false)
-                                    kind: SymbolId(6)
+                                    kind: SymbolId(8)
                         rhs: Expr [61-62]:
                             ty: Bool(false)
                             kind: Cast [0-0]:
                                 ty: Bool(false)
                                 expr: Expr [61-62]:
                                     ty: Bit(false)
-                                    kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                                    kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -80,29 +80,29 @@ fn logical_or() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
                     ty: Bool(false)
@@ -114,15 +114,15 @@ fn logical_or() {
                                 ty: Bool(false)
                                 expr: Expr [56-57]:
                                     ty: Bit(false)
-                                    kind: SymbolId(6)
+                                    kind: SymbolId(8)
                         rhs: Expr [61-62]:
                             ty: Bool(false)
                             kind: Cast [0-0]:
                                 ty: Bool(false)
                                 expr: Expr [61-62]:
                                     ty: Bit(false)
-                                    kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                                    kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -143,29 +143,29 @@ fn unop_not_logical_and_unop_not() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-65]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-64]:
                     ty: Bool(false)
@@ -181,7 +181,7 @@ fn unop_not_logical_and_unop_not() {
                                         ty: Bool(false)
                                         expr: Expr [57-58]:
                                             ty: Bit(false)
-                                            kind: SymbolId(6)
+                                            kind: SymbolId(8)
                         rhs: Expr [63-64]:
                             ty: Bool(false)
                             kind: UnaryOpExpr [63-64]:
@@ -192,8 +192,8 @@ fn unop_not_logical_and_unop_not() {
                                         ty: Bool(false)
                                         expr: Expr [63-64]:
                                             ty: Bit(false)
-                                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -214,29 +214,29 @@ fn unop_not_logical_or_unop_not() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-65]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-64]:
                     ty: Bool(false)
@@ -252,7 +252,7 @@ fn unop_not_logical_or_unop_not() {
                                         ty: Bool(false)
                                         expr: Expr [57-58]:
                                             ty: Bit(false)
-                                            kind: SymbolId(6)
+                                            kind: SymbolId(8)
                         rhs: Expr [63-64]:
                             ty: Bool(false)
                             kind: UnaryOpExpr [63-64]:
@@ -263,8 +263,8 @@ fn unop_not_logical_or_unop_not() {
                                         ty: Bool(false)
                                         expr: Expr [63-64]:
                                             ty: Bit(false)
-                                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -285,29 +285,29 @@ fn unop_not_logical_and() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-64]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-63]:
                     ty: Bool(false)
@@ -323,15 +323,15 @@ fn unop_not_logical_and() {
                                         ty: Bool(false)
                                         expr: Expr [57-58]:
                                             ty: Bit(false)
-                                            kind: SymbolId(6)
+                                            kind: SymbolId(8)
                         rhs: Expr [62-63]:
                             ty: Bool(false)
                             kind: Cast [0-0]:
                                 ty: Bool(false)
                                 expr: Expr [62-63]:
                                     ty: Bit(false)
-                                    kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                                    kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -352,29 +352,29 @@ fn unop_not_logical_or() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-64]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-63]:
                     ty: Bool(false)
@@ -390,15 +390,15 @@ fn unop_not_logical_or() {
                                         ty: Bool(false)
                                         expr: Expr [57-58]:
                                             ty: Bit(false)
-                                            kind: SymbolId(6)
+                                            kind: SymbolId(8)
                         rhs: Expr [62-63]:
                             ty: Bool(false)
                             kind: Cast [0-0]:
                                 ty: Bool(false)
                                 expr: Expr [62-63]:
                                     ty: Bit(false)
-                                    kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                                    kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -419,29 +419,29 @@ fn logical_and_unop_not() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-64]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-63]:
                     ty: Bool(false)
@@ -453,7 +453,7 @@ fn logical_and_unop_not() {
                                 ty: Bool(false)
                                 expr: Expr [56-57]:
                                     ty: Bit(false)
-                                    kind: SymbolId(6)
+                                    kind: SymbolId(8)
                         rhs: Expr [62-63]:
                             ty: Bool(false)
                             kind: UnaryOpExpr [62-63]:
@@ -464,8 +464,8 @@ fn logical_and_unop_not() {
                                         ty: Bool(false)
                                         expr: Expr [62-63]:
                                             ty: Bit(false)
-                                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -486,29 +486,29 @@ fn logical_or_unop_not() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Bit(true)
                     kind: Lit: Bit(0)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-64]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-63]:
                     ty: Bool(false)
@@ -520,7 +520,7 @@ fn logical_or_unop_not() {
                                 ty: Bool(false)
                                 expr: Expr [56-57]:
                                     ty: Bit(false)
-                                    kind: SymbolId(6)
+                                    kind: SymbolId(8)
                         rhs: Expr [62-63]:
                             ty: Bool(false)
                             kind: UnaryOpExpr [62-63]:
@@ -531,8 +531,8 @@ fn logical_or_unop_not() {
                                         ty: Bool(false)
                                         expr: Expr [62-63]:
                                             ty: Bit(false)
-                                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/bool_to_bool.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/bool_to_bool.rs
@@ -17,29 +17,29 @@ fn logical_and() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
                     ty: Bool(false)
                     kind: Lit: Bool(false)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-72]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-71]:
                     ty: Bool(false)
@@ -47,11 +47,11 @@ fn logical_and() {
                         op: AndL
                         lhs: Expr [65-66]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [70-71]:
                             ty: Bool(false)
-                            kind: SymbolId(7)
-            [8] Symbol [61-62]:
+                            kind: SymbolId(9)
+            [10] Symbol [61-62]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -72,29 +72,29 @@ fn logical_or() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
                     ty: Bool(false)
                     kind: Lit: Bool(false)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-72]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-71]:
                     ty: Bool(false)
@@ -102,11 +102,11 @@ fn logical_or() {
                         op: OrL
                         lhs: Expr [65-66]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [70-71]:
                             ty: Bool(false)
-                            kind: SymbolId(7)
-            [8] Symbol [61-62]:
+                            kind: SymbolId(9)
+            [10] Symbol [61-62]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -127,29 +127,29 @@ fn unop_not_logical_and_unop_not() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
                     ty: Bool(false)
                     kind: Lit: Bool(false)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-74]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-73]:
                     ty: Bool(false)
@@ -161,15 +161,15 @@ fn unop_not_logical_and_unop_not() {
                                 op: NotL
                                 expr: Expr [66-67]:
                                     ty: Bool(false)
-                                    kind: SymbolId(6)
+                                    kind: SymbolId(8)
                         rhs: Expr [72-73]:
                             ty: Bool(false)
                             kind: UnaryOpExpr [72-73]:
                                 op: NotL
                                 expr: Expr [72-73]:
                                     ty: Bool(false)
-                                    kind: SymbolId(7)
-            [8] Symbol [61-62]:
+                                    kind: SymbolId(9)
+            [10] Symbol [61-62]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -190,29 +190,29 @@ fn unop_not_logical_or_unop_not() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
                     ty: Bool(false)
                     kind: Lit: Bool(false)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-74]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-73]:
                     ty: Bool(false)
@@ -224,15 +224,15 @@ fn unop_not_logical_or_unop_not() {
                                 op: NotL
                                 expr: Expr [66-67]:
                                     ty: Bool(false)
-                                    kind: SymbolId(6)
+                                    kind: SymbolId(8)
                         rhs: Expr [72-73]:
                             ty: Bool(false)
                             kind: UnaryOpExpr [72-73]:
                                 op: NotL
                                 expr: Expr [72-73]:
                                     ty: Bool(false)
-                                    kind: SymbolId(7)
-            [8] Symbol [61-62]:
+                                    kind: SymbolId(9)
+            [10] Symbol [61-62]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -253,29 +253,29 @@ fn unop_not_logical_and() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
                     ty: Bool(false)
                     kind: Lit: Bool(false)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-73]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-72]:
                     ty: Bool(false)
@@ -287,11 +287,11 @@ fn unop_not_logical_and() {
                                 op: NotL
                                 expr: Expr [66-67]:
                                     ty: Bool(false)
-                                    kind: SymbolId(6)
+                                    kind: SymbolId(8)
                         rhs: Expr [71-72]:
                             ty: Bool(false)
-                            kind: SymbolId(7)
-            [8] Symbol [61-62]:
+                            kind: SymbolId(9)
+            [10] Symbol [61-62]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -312,29 +312,29 @@ fn unop_not_logical_or() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
                     ty: Bool(false)
                     kind: Lit: Bool(false)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-73]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-72]:
                     ty: Bool(false)
@@ -346,11 +346,11 @@ fn unop_not_logical_or() {
                                 op: NotL
                                 expr: Expr [66-67]:
                                     ty: Bool(false)
-                                    kind: SymbolId(6)
+                                    kind: SymbolId(8)
                         rhs: Expr [71-72]:
                             ty: Bool(false)
-                            kind: SymbolId(7)
-            [8] Symbol [61-62]:
+                            kind: SymbolId(9)
+            [10] Symbol [61-62]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -371,29 +371,29 @@ fn logical_and_unop_not() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
                     ty: Bool(false)
                     kind: Lit: Bool(false)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-73]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-72]:
                     ty: Bool(false)
@@ -401,15 +401,15 @@ fn logical_and_unop_not() {
                         op: AndL
                         lhs: Expr [65-66]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [71-72]:
                             ty: Bool(false)
                             kind: UnaryOpExpr [71-72]:
                                 op: NotL
                                 expr: Expr [71-72]:
                                     ty: Bool(false)
-                                    kind: SymbolId(7)
-            [8] Symbol [61-62]:
+                                    kind: SymbolId(9)
+            [10] Symbol [61-62]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -430,29 +430,29 @@ fn logical_or_unop_not() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
                     ty: Bool(false)
                     kind: Lit: Bool(false)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-73]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-72]:
                     ty: Bool(false)
@@ -460,15 +460,15 @@ fn logical_or_unop_not() {
                         op: OrL
                         lhs: Expr [65-66]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [71-72]:
                             ty: Bool(false)
                             kind: UnaryOpExpr [71-72]:
                                 op: NotL
                                 expr: Expr [71-72]:
                                     ty: Bool(false)
-                                    kind: SymbolId(7)
-            [8] Symbol [61-62]:
+                                    kind: SymbolId(9)
+            [10] Symbol [61-62]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/bool_to_bool.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/bool_to_bool.rs
@@ -20,7 +20,7 @@ fn logical_and() {
                 symbol_id: 6
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(true)
             [6] Symbol [14-15]:
                 name: x
@@ -31,7 +31,7 @@ fn logical_and() {
                 symbol_id: 7
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(false)
             [7] Symbol [37-38]:
                 name: y
@@ -75,7 +75,7 @@ fn logical_or() {
                 symbol_id: 6
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(true)
             [6] Symbol [14-15]:
                 name: x
@@ -86,7 +86,7 @@ fn logical_or() {
                 symbol_id: 7
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(false)
             [7] Symbol [37-38]:
                 name: y
@@ -130,7 +130,7 @@ fn unop_not_logical_and_unop_not() {
                 symbol_id: 6
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(true)
             [6] Symbol [14-15]:
                 name: x
@@ -141,7 +141,7 @@ fn unop_not_logical_and_unop_not() {
                 symbol_id: 7
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(false)
             [7] Symbol [37-38]:
                 name: y
@@ -193,7 +193,7 @@ fn unop_not_logical_or_unop_not() {
                 symbol_id: 6
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(true)
             [6] Symbol [14-15]:
                 name: x
@@ -204,7 +204,7 @@ fn unop_not_logical_or_unop_not() {
                 symbol_id: 7
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(false)
             [7] Symbol [37-38]:
                 name: y
@@ -256,7 +256,7 @@ fn unop_not_logical_and() {
                 symbol_id: 6
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(true)
             [6] Symbol [14-15]:
                 name: x
@@ -267,7 +267,7 @@ fn unop_not_logical_and() {
                 symbol_id: 7
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(false)
             [7] Symbol [37-38]:
                 name: y
@@ -315,7 +315,7 @@ fn unop_not_logical_or() {
                 symbol_id: 6
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(true)
             [6] Symbol [14-15]:
                 name: x
@@ -326,7 +326,7 @@ fn unop_not_logical_or() {
                 symbol_id: 7
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(false)
             [7] Symbol [37-38]:
                 name: y
@@ -374,7 +374,7 @@ fn logical_and_unop_not() {
                 symbol_id: 6
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(true)
             [6] Symbol [14-15]:
                 name: x
@@ -385,7 +385,7 @@ fn logical_and_unop_not() {
                 symbol_id: 7
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(false)
             [7] Symbol [37-38]:
                 name: y
@@ -433,7 +433,7 @@ fn logical_or_unop_not() {
                 symbol_id: 6
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(true)
             [6] Symbol [14-15]:
                 name: x
@@ -444,7 +444,7 @@ fn logical_or_unop_not() {
                 symbol_id: 7
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(true)
+                    ty: Bool(false)
                     kind: Lit: Bool(false)
             [7] Symbol [37-38]:
                 name: y

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/float_to_float.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/float_to_float.rs
@@ -20,7 +20,7 @@ fn greater_than() {
                 symbol_id: 6
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(5.0)
             [6] Symbol [15-16]:
                 name: x
@@ -31,7 +31,7 @@ fn greater_than() {
                 symbol_id: 7
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(3.0)
             [7] Symbol [37-38]:
                 name: y
@@ -75,7 +75,7 @@ fn greater_than_equals() {
                 symbol_id: 6
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(5.0)
             [6] Symbol [15-16]:
                 name: x
@@ -86,7 +86,7 @@ fn greater_than_equals() {
                 symbol_id: 7
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(3.0)
             [7] Symbol [37-38]:
                 name: y
@@ -130,7 +130,7 @@ fn less_than() {
                 symbol_id: 6
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(5.0)
             [6] Symbol [15-16]:
                 name: x
@@ -141,7 +141,7 @@ fn less_than() {
                 symbol_id: 7
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(3.0)
             [7] Symbol [37-38]:
                 name: y
@@ -185,7 +185,7 @@ fn less_than_equals() {
                 symbol_id: 6
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(5.0)
             [6] Symbol [15-16]:
                 name: x
@@ -196,7 +196,7 @@ fn less_than_equals() {
                 symbol_id: 7
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(3.0)
             [7] Symbol [37-38]:
                 name: y
@@ -240,7 +240,7 @@ fn equals() {
                 symbol_id: 6
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(5.0)
             [6] Symbol [15-16]:
                 name: x
@@ -251,7 +251,7 @@ fn equals() {
                 symbol_id: 7
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(3.0)
             [7] Symbol [37-38]:
                 name: y
@@ -295,7 +295,7 @@ fn not_equals() {
                 symbol_id: 6
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(5.0)
             [6] Symbol [15-16]:
                 name: x
@@ -306,7 +306,7 @@ fn not_equals() {
                 symbol_id: 7
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: Lit: Float(3.0)
             [7] Symbol [37-38]:
                 name: y

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/float_to_float.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/float_to_float.rs
@@ -17,29 +17,29 @@ fn greater_than() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-22]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
                     ty: Float(None, false)
                     kind: Lit: Float(5.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
                     ty: Float(None, false)
                     kind: Lit: Float(3.0)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-68]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-67]:
                     ty: Bool(false)
@@ -47,11 +47,11 @@ fn greater_than() {
                         op: Gt
                         lhs: Expr [62-63]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [66-67]:
                             ty: Float(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [58-59]:
+                            kind: SymbolId(9)
+            [10] Symbol [58-59]:
                 name: f
                 type: Bool(false)
                 qsharp_type: bool
@@ -72,29 +72,29 @@ fn greater_than_equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-22]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
                     ty: Float(None, false)
                     kind: Lit: Float(5.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
                     ty: Float(None, false)
                     kind: Lit: Float(3.0)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-69]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-68]:
                     ty: Bool(false)
@@ -102,11 +102,11 @@ fn greater_than_equals() {
                         op: Gte
                         lhs: Expr [62-63]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [67-68]:
                             ty: Float(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [58-59]:
+                            kind: SymbolId(9)
+            [10] Symbol [58-59]:
                 name: e
                 type: Bool(false)
                 qsharp_type: bool
@@ -127,29 +127,29 @@ fn less_than() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-22]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
                     ty: Float(None, false)
                     kind: Lit: Float(5.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
                     ty: Float(None, false)
                     kind: Lit: Float(3.0)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-68]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-67]:
                     ty: Bool(false)
@@ -157,11 +157,11 @@ fn less_than() {
                         op: Lt
                         lhs: Expr [62-63]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [66-67]:
                             ty: Float(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [58-59]:
+                            kind: SymbolId(9)
+            [10] Symbol [58-59]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -182,29 +182,29 @@ fn less_than_equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-22]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
                     ty: Float(None, false)
                     kind: Lit: Float(5.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
                     ty: Float(None, false)
                     kind: Lit: Float(3.0)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-69]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-68]:
                     ty: Bool(false)
@@ -212,11 +212,11 @@ fn less_than_equals() {
                         op: Lte
                         lhs: Expr [62-63]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [67-68]:
                             ty: Float(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [58-59]:
+                            kind: SymbolId(9)
+            [10] Symbol [58-59]:
                 name: c
                 type: Bool(false)
                 qsharp_type: bool
@@ -237,29 +237,29 @@ fn equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-22]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
                     ty: Float(None, false)
                     kind: Lit: Float(5.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
                     ty: Float(None, false)
                     kind: Lit: Float(3.0)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-69]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-68]:
                     ty: Bool(false)
@@ -267,11 +267,11 @@ fn equals() {
                         op: Eq
                         lhs: Expr [62-63]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [67-68]:
                             ty: Float(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [58-59]:
+                            kind: SymbolId(9)
+            [10] Symbol [58-59]:
                 name: b
                 type: Bool(false)
                 qsharp_type: bool
@@ -292,29 +292,29 @@ fn not_equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-22]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
                     ty: Float(None, false)
                     kind: Lit: Float(5.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
                     ty: Float(None, false)
                     kind: Lit: Float(3.0)
-            [7] Symbol [37-38]:
+            [9] Symbol [37-38]:
                 name: y
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-69]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-68]:
                     ty: Bool(false)
@@ -322,11 +322,11 @@ fn not_equals() {
                         op: Neq
                         lhs: Expr [62-63]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [67-68]:
                             ty: Float(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [58-59]:
+                            kind: SymbolId(9)
+            [10] Symbol [58-59]:
                 name: d
                 type: Bool(false)
                 qsharp_type: bool

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/int_to_int.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/int_to_int.rs
@@ -20,7 +20,7 @@ fn greater_than() {
                 symbol_id: 6
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(5)
             [6] Symbol [13-14]:
                 name: x
@@ -31,7 +31,7 @@ fn greater_than() {
                 symbol_id: 7
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(3)
             [7] Symbol [32-33]:
                 name: y
@@ -75,7 +75,7 @@ fn greater_than_equals() {
                 symbol_id: 6
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(5)
             [6] Symbol [13-14]:
                 name: x
@@ -86,7 +86,7 @@ fn greater_than_equals() {
                 symbol_id: 7
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(3)
             [7] Symbol [32-33]:
                 name: y
@@ -130,7 +130,7 @@ fn less_than() {
                 symbol_id: 6
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(5)
             [6] Symbol [13-14]:
                 name: x
@@ -141,7 +141,7 @@ fn less_than() {
                 symbol_id: 7
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(3)
             [7] Symbol [32-33]:
                 name: y
@@ -185,7 +185,7 @@ fn less_than_equals() {
                 symbol_id: 6
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(5)
             [6] Symbol [13-14]:
                 name: x
@@ -196,7 +196,7 @@ fn less_than_equals() {
                 symbol_id: 7
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(3)
             [7] Symbol [32-33]:
                 name: y
@@ -240,7 +240,7 @@ fn equals() {
                 symbol_id: 6
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(5)
             [6] Symbol [13-14]:
                 name: x
@@ -251,7 +251,7 @@ fn equals() {
                 symbol_id: 7
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(3)
             [7] Symbol [32-33]:
                 name: y
@@ -295,7 +295,7 @@ fn not_equals() {
                 symbol_id: 6
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(5)
             [6] Symbol [13-14]:
                 name: x
@@ -306,7 +306,7 @@ fn not_equals() {
                 symbol_id: 7
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(3)
             [7] Symbol [32-33]:
                 name: y

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/int_to_int.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/int_to_int.rs
@@ -17,29 +17,29 @@ fn greater_than() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Int(None, false)
                     kind: Lit: Int(5)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Int(None, false)
                     kind: Lit: Int(3)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-62]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-61]:
                     ty: Bool(false)
@@ -47,11 +47,11 @@ fn greater_than() {
                         op: Gt
                         lhs: Expr [56-57]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [60-61]:
                             ty: Int(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: f
                 type: Bool(false)
                 qsharp_type: bool
@@ -72,29 +72,29 @@ fn greater_than_equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Int(None, false)
                     kind: Lit: Int(5)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Int(None, false)
                     kind: Lit: Int(3)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
                     ty: Bool(false)
@@ -102,11 +102,11 @@ fn greater_than_equals() {
                         op: Gte
                         lhs: Expr [56-57]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [61-62]:
                             ty: Int(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: e
                 type: Bool(false)
                 qsharp_type: bool
@@ -127,29 +127,29 @@ fn less_than() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Int(None, false)
                     kind: Lit: Int(5)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Int(None, false)
                     kind: Lit: Int(3)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-62]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-61]:
                     ty: Bool(false)
@@ -157,11 +157,11 @@ fn less_than() {
                         op: Lt
                         lhs: Expr [56-57]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [60-61]:
                             ty: Int(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -182,29 +182,29 @@ fn less_than_equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Int(None, false)
                     kind: Lit: Int(5)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Int(None, false)
                     kind: Lit: Int(3)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
                     ty: Bool(false)
@@ -212,11 +212,11 @@ fn less_than_equals() {
                         op: Lte
                         lhs: Expr [56-57]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [61-62]:
                             ty: Int(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: c
                 type: Bool(false)
                 qsharp_type: bool
@@ -237,29 +237,29 @@ fn equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Int(None, false)
                     kind: Lit: Int(5)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Int(None, false)
                     kind: Lit: Int(3)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
                     ty: Bool(false)
@@ -267,11 +267,11 @@ fn equals() {
                         op: Eq
                         lhs: Expr [56-57]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [61-62]:
                             ty: Int(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: b
                 type: Bool(false)
                 qsharp_type: bool
@@ -292,29 +292,29 @@ fn not_equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Int(None, false)
                     kind: Lit: Int(5)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Int(None, false)
                     kind: Lit: Int(3)
-            [7] Symbol [32-33]:
+            [9] Symbol [32-33]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
                     ty: Bool(false)
@@ -322,11 +322,11 @@ fn not_equals() {
                         op: Neq
                         lhs: Expr [56-57]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [61-62]:
                             ty: Int(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [52-53]:
+                            kind: SymbolId(9)
+            [10] Symbol [52-53]:
                 name: d
                 type: Bool(false)
                 qsharp_type: bool

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/uint_to_uint.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/comparison/uint_to_uint.rs
@@ -17,29 +17,29 @@ fn greater_than() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
                     ty: UInt(None, true)
                     kind: Lit: Int(5)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: UInt(None, true)
                     kind: Lit: Int(3)
-            [7] Symbol [34-35]:
+            [9] Symbol [34-35]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-64]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-63]:
                     ty: Bool(false)
@@ -47,11 +47,11 @@ fn greater_than() {
                         op: Gt
                         lhs: Expr [58-59]:
                             ty: UInt(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [62-63]:
                             ty: UInt(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [54-55]:
+                            kind: SymbolId(9)
+            [10] Symbol [54-55]:
                 name: f
                 type: Bool(false)
                 qsharp_type: bool
@@ -72,29 +72,29 @@ fn greater_than_equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
                     ty: UInt(None, true)
                     kind: Lit: Int(5)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: UInt(None, true)
                     kind: Lit: Int(3)
-            [7] Symbol [34-35]:
+            [9] Symbol [34-35]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-65]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-64]:
                     ty: Bool(false)
@@ -102,11 +102,11 @@ fn greater_than_equals() {
                         op: Gte
                         lhs: Expr [58-59]:
                             ty: UInt(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [63-64]:
                             ty: UInt(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [54-55]:
+                            kind: SymbolId(9)
+            [10] Symbol [54-55]:
                 name: e
                 type: Bool(false)
                 qsharp_type: bool
@@ -127,29 +127,29 @@ fn less_than() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
                     ty: UInt(None, true)
                     kind: Lit: Int(5)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: UInt(None, true)
                     kind: Lit: Int(3)
-            [7] Symbol [34-35]:
+            [9] Symbol [34-35]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-64]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-63]:
                     ty: Bool(false)
@@ -157,11 +157,11 @@ fn less_than() {
                         op: Lt
                         lhs: Expr [58-59]:
                             ty: UInt(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [62-63]:
                             ty: UInt(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [54-55]:
+                            kind: SymbolId(9)
+            [10] Symbol [54-55]:
                 name: a
                 type: Bool(false)
                 qsharp_type: bool
@@ -182,29 +182,29 @@ fn less_than_equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
                     ty: UInt(None, true)
                     kind: Lit: Int(5)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: UInt(None, true)
                     kind: Lit: Int(3)
-            [7] Symbol [34-35]:
+            [9] Symbol [34-35]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-65]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-64]:
                     ty: Bool(false)
@@ -212,11 +212,11 @@ fn less_than_equals() {
                         op: Lte
                         lhs: Expr [58-59]:
                             ty: UInt(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [63-64]:
                             ty: UInt(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [54-55]:
+                            kind: SymbolId(9)
+            [10] Symbol [54-55]:
                 name: c
                 type: Bool(false)
                 qsharp_type: bool
@@ -237,29 +237,29 @@ fn equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
                     ty: UInt(None, true)
                     kind: Lit: Int(5)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: UInt(None, true)
                     kind: Lit: Int(3)
-            [7] Symbol [34-35]:
+            [9] Symbol [34-35]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-65]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-64]:
                     ty: Bool(false)
@@ -267,11 +267,11 @@ fn equals() {
                         op: Eq
                         lhs: Expr [58-59]:
                             ty: UInt(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [63-64]:
                             ty: UInt(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [54-55]:
+                            kind: SymbolId(9)
+            [10] Symbol [54-55]:
                 name: b
                 type: Bool(false)
                 qsharp_type: bool
@@ -292,29 +292,29 @@ fn not_equals() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
                     ty: UInt(None, true)
                     kind: Lit: Int(5)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: UInt(None, true)
                     kind: Lit: Int(3)
-            [7] Symbol [34-35]:
+            [9] Symbol [34-35]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-65]:
-                symbol_id: 8
+                symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-64]:
                     ty: Bool(false)
@@ -322,11 +322,11 @@ fn not_equals() {
                         op: Neq
                         lhs: Expr [58-59]:
                             ty: UInt(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [63-64]:
                             ty: UInt(None, false)
-                            kind: SymbolId(7)
-            [8] Symbol [54-55]:
+                            kind: SymbolId(9)
+            [10] Symbol [54-55]:
                 name: d
                 type: Bool(false)
                 qsharp_type: bool

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/ident.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/ident.rs
@@ -16,13 +16,13 @@ fn mutable_int_idents_without_width_can_be_multiplied() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Int(None, false)
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Int(None, false)
@@ -34,10 +34,10 @@ fn mutable_int_idents_without_width_can_be_multiplied() {
                         op: Mul
                         lhs: Expr [47-48]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [51-52]:
                             ty: Int(None, false)
-                            kind: SymbolId(7)
+                            kind: SymbolId(9)
         "#]],
     );
 }
@@ -53,30 +53,30 @@ fn const_int_idents_without_width_can_be_multiplied() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-25]:
-            symbol_id: 6
-            ty_span: [15-18]
-            init_expr: Expr [23-24]:
-                ty: Int(None, true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [34-50]:
-            symbol_id: 7
-            ty_span: [40-43]
-            init_expr: Expr [48-49]:
-                ty: Int(None, true)
-                kind: Lit: Int(3)
-        ExprStmt [59-65]:
-            expr: Expr [59-64]:
-                ty: Int(None, true)
-                kind: BinaryOpExpr:
-                    op: Mul
-                    lhs: Expr [59-60]:
-                        ty: Int(None, true)
-                        kind: SymbolId(6)
-                    rhs: Expr [63-64]:
-                        ty: Int(None, true)
-                        kind: SymbolId(7)
-    "#]],
+            ClassicalDeclarationStmt [9-25]:
+                symbol_id: 8
+                ty_span: [15-18]
+                init_expr: Expr [23-24]:
+                    ty: Int(None, true)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [34-50]:
+                symbol_id: 9
+                ty_span: [40-43]
+                init_expr: Expr [48-49]:
+                    ty: Int(None, true)
+                    kind: Lit: Int(3)
+            ExprStmt [59-65]:
+                expr: Expr [59-64]:
+                    ty: Int(None, true)
+                    kind: BinaryOpExpr:
+                        op: Mul
+                        lhs: Expr [59-60]:
+                            ty: Int(None, true)
+                            kind: SymbolId(8)
+                        rhs: Expr [63-64]:
+                            ty: Int(None, true)
+                            kind: SymbolId(9)
+        "#]],
     );
 }
 
@@ -92,13 +92,13 @@ fn const_and_mut_int_idents_without_width_can_be_multiplied() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Int(None, false)
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [28-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [34-37]
                 init_expr: Expr [42-43]:
                     ty: Int(None, true)
@@ -110,10 +110,10 @@ fn const_and_mut_int_idents_without_width_can_be_multiplied() {
                         op: Mul
                         lhs: Expr [53-54]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
+                            kind: SymbolId(8)
                         rhs: Expr [57-58]:
                             ty: Int(None, false)
-                            kind: SymbolId(7)
+                            kind: SymbolId(9)
         "#]],
     );
 }
@@ -129,33 +129,33 @@ fn const_int_idents_widthless_lhs_can_be_multiplied_by_explicit_width_int() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-29]:
-            symbol_id: 6
-            ty_span: [15-22]
-            init_expr: Expr [27-28]:
-                ty: Int(Some(32), true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [38-54]:
-            symbol_id: 7
-            ty_span: [44-47]
-            init_expr: Expr [52-53]:
-                ty: Int(None, true)
-                kind: Lit: Int(3)
-        ExprStmt [63-69]:
-            expr: Expr [63-68]:
-                ty: Int(None, true)
-                kind: BinaryOpExpr:
-                    op: Mul
-                    lhs: Expr [63-64]:
-                        ty: Int(None, true)
-                        kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-29]:
+                symbol_id: 8
+                ty_span: [15-22]
+                init_expr: Expr [27-28]:
+                    ty: Int(Some(32), true)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [38-54]:
+                symbol_id: 9
+                ty_span: [44-47]
+                init_expr: Expr [52-53]:
+                    ty: Int(None, true)
+                    kind: Lit: Int(3)
+            ExprStmt [63-69]:
+                expr: Expr [63-68]:
+                    ty: Int(None, true)
+                    kind: BinaryOpExpr:
+                        op: Mul
+                        lhs: Expr [63-64]:
                             ty: Int(None, true)
-                            expr: Expr [63-64]:
-                                ty: Int(Some(32), true)
-                                kind: SymbolId(6)
-                    rhs: Expr [67-68]:
-                        ty: Int(None, true)
-                        kind: SymbolId(7)
-    "#]],
+                            kind: Cast [0-0]:
+                                ty: Int(None, true)
+                                expr: Expr [63-64]:
+                                    ty: Int(Some(32), true)
+                                    kind: SymbolId(8)
+                        rhs: Expr [67-68]:
+                            ty: Int(None, true)
+                            kind: SymbolId(9)
+        "#]],
     );
 }

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/binary/ident.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/binary/ident.rs
@@ -15,30 +15,30 @@ fn mutable_int_idents_without_width_can_be_multiplied() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-19]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-18]:
-                ty: Int(None, true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [28-38]:
-            symbol_id: 7
-            ty_span: [28-31]
-            init_expr: Expr [36-37]:
-                ty: Int(None, true)
-                kind: Lit: Int(3)
-        ExprStmt [47-53]:
-            expr: Expr [47-52]:
-                ty: Int(None, false)
-                kind: BinaryOpExpr:
-                    op: Mul
-                    lhs: Expr [47-48]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-                    rhs: Expr [51-52]:
-                        ty: Int(None, false)
-                        kind: SymbolId(7)
-    "#]],
+            ClassicalDeclarationStmt [9-19]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-18]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [28-38]:
+                symbol_id: 7
+                ty_span: [28-31]
+                init_expr: Expr [36-37]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(3)
+            ExprStmt [47-53]:
+                expr: Expr [47-52]:
+                    ty: Int(None, false)
+                    kind: BinaryOpExpr:
+                        op: Mul
+                        lhs: Expr [47-48]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+                        rhs: Expr [51-52]:
+                            ty: Int(None, false)
+                            kind: SymbolId(7)
+        "#]],
     );
 }
 
@@ -91,30 +91,30 @@ fn const_and_mut_int_idents_without_width_can_be_multiplied() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-19]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-18]:
-                ty: Int(None, true)
-                kind: Lit: Int(5)
-        ClassicalDeclarationStmt [28-44]:
-            symbol_id: 7
-            ty_span: [34-37]
-            init_expr: Expr [42-43]:
-                ty: Int(None, true)
-                kind: Lit: Int(3)
-        ExprStmt [53-59]:
-            expr: Expr [53-58]:
-                ty: Int(None, false)
-                kind: BinaryOpExpr:
-                    op: Mul
-                    lhs: Expr [53-54]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-                    rhs: Expr [57-58]:
-                        ty: Int(None, true)
-                        kind: SymbolId(7)
-    "#]],
+            ClassicalDeclarationStmt [9-19]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-18]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [28-44]:
+                symbol_id: 7
+                ty_span: [34-37]
+                init_expr: Expr [42-43]:
+                    ty: Int(None, true)
+                    kind: Lit: Int(3)
+            ExprStmt [53-59]:
+                expr: Expr [53-58]:
+                    ty: Int(None, false)
+                    kind: BinaryOpExpr:
+                        op: Mul
+                        lhs: Expr [53-54]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+                        rhs: Expr [57-58]:
+                            ty: Int(None, false)
+                            kind: SymbolId(7)
+        "#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_angle.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_angle.rs
@@ -15,33 +15,33 @@ fn to_bit_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Angle(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Angle(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-42]:
-            symbol_id: 7
-            ty_span: [32-35]
-            init_expr: Expr [40-41]:
-                ty: Bit(false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 8
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Angle(None, true)
+                    kind: Lit: Float(42.0)
+            [8] Symbol [15-16]:
+                name: x
+                type: Angle(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-42]:
+                symbol_id: 9
+                ty_span: [32-35]
+                init_expr: Expr [40-41]:
                     ty: Bit(false)
-                    expr: Expr [40-41]:
-                        ty: Angle(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [36-37]:
-            name: y
-            type: Bit(false)
-            qsharp_type: Result
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Bit(false)
+                        expr: Expr [40-41]:
+                            ty: Angle(None, false)
+                            kind: SymbolId(8)
+            [9] Symbol [36-37]:
+                name: y
+                type: Bit(false)
+                qsharp_type: Result
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -55,33 +55,33 @@ fn explicit_width_to_bit_implicitly_fails() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-27]:
-            symbol_id: 6
-            ty_span: [9-18]
-            init_expr: Expr [23-26]:
-                ty: Angle(Some(64), true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [19-20]:
-            name: x
-            type: Angle(Some(64), false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [36-46]:
-            symbol_id: 7
-            ty_span: [36-39]
-            init_expr: Expr [44-45]:
-                ty: Bit(false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-27]:
+                symbol_id: 8
+                ty_span: [9-18]
+                init_expr: Expr [23-26]:
+                    ty: Angle(Some(64), true)
+                    kind: Lit: Float(42.0)
+            [8] Symbol [19-20]:
+                name: x
+                type: Angle(Some(64), false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [36-46]:
+                symbol_id: 9
+                ty_span: [36-39]
+                init_expr: Expr [44-45]:
                     ty: Bit(false)
-                    expr: Expr [44-45]:
-                        ty: Angle(Some(64), false)
-                        kind: SymbolId(6)
-        [7] Symbol [40-41]:
-            name: y
-            type: Bit(false)
-            qsharp_type: Result
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Bit(false)
+                        expr: Expr [44-45]:
+                            ty: Angle(Some(64), false)
+                            kind: SymbolId(8)
+            [9] Symbol [40-41]:
+                name: y
+                type: Bit(false)
+                qsharp_type: Result
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -94,33 +94,33 @@ fn to_bool_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Angle(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Angle(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-43]:
-            symbol_id: 7
-            ty_span: [32-36]
-            init_expr: Expr [41-42]:
-                ty: Bool(false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 8
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Angle(None, true)
+                    kind: Lit: Float(42.0)
+            [8] Symbol [15-16]:
+                name: x
+                type: Angle(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-43]:
+                symbol_id: 9
+                ty_span: [32-36]
+                init_expr: Expr [41-42]:
                     ty: Bool(false)
-                    expr: Expr [41-42]:
-                        ty: Angle(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [37-38]:
-            name: y
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Bool(false)
+                        expr: Expr [41-42]:
+                            ty: Angle(None, false)
+                            kind: SymbolId(8)
+            [9] Symbol [37-38]:
+                name: y
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -140,7 +140,7 @@ fn to_implicit_int_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -148,11 +148,11 @@ fn to_implicit_int_implicitly_fails() {
                     Stmt [32-42]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-42]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-35]
                             init_expr: Expr [40-41]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -183,7 +183,7 @@ fn to_explicit_int_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -191,11 +191,11 @@ fn to_explicit_int_implicitly_fails() {
                     Stmt [32-46]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-46]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-39]
                             init_expr: Expr [44-45]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -227,7 +227,7 @@ fn to_implicit_uint_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -235,11 +235,11 @@ fn to_implicit_uint_implicitly_fails() {
                     Stmt [32-43]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-43]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-36]
                             init_expr: Expr [41-42]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -271,7 +271,7 @@ fn negative_lit_to_implicit_uint_implicitly_fails() {
                     Stmt [9-24]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-24]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [20-23]:
                                 ty: Angle(None, false)
@@ -287,11 +287,11 @@ fn negative_lit_to_implicit_uint_implicitly_fails() {
                     Stmt [33-44]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [33-44]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [33-37]
                             init_expr: Expr [42-43]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -323,7 +323,7 @@ fn to_explicit_uint_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -331,11 +331,11 @@ fn to_explicit_uint_implicitly_fails() {
                     Stmt [32-47]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-47]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-40]
                             init_expr: Expr [45-46]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -367,7 +367,7 @@ fn to_explicit_bigint_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -375,11 +375,11 @@ fn to_explicit_bigint_implicitly_fails() {
                     Stmt [32-46]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-46]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-39]
                             init_expr: Expr [44-45]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -411,7 +411,7 @@ fn to_implicit_float_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -419,11 +419,11 @@ fn to_implicit_float_implicitly_fails() {
                     Stmt [32-44]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-44]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-37]
                             init_expr: Expr [42-43]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -455,7 +455,7 @@ fn to_explicit_float_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -463,11 +463,11 @@ fn to_explicit_float_implicitly_fails() {
                     Stmt [32-48]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-48]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-41]
                             init_expr: Expr [46-47]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -499,7 +499,7 @@ fn to_implicit_complex_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -507,11 +507,11 @@ fn to_implicit_complex_implicitly_fails() {
                     Stmt [32-53]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-53]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-46]
                             init_expr: Expr [51-52]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -543,7 +543,7 @@ fn to_explicit_complex_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Angle(None, true)
@@ -551,11 +551,11 @@ fn to_explicit_complex_implicitly_fails() {
                     Stmt [32-57]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-57]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-50]
                             init_expr: Expr [55-56]:
                                 ty: Angle(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -582,23 +582,23 @@ fn to_angle_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-37]
                 init_expr: Expr [42-43]:
                     ty: Angle(None, false)
-                    kind: SymbolId(6)
-            [7] Symbol [38-39]:
+                    kind: SymbolId(8)
+            [9] Symbol [38-39]:
                 name: y
                 type: Angle(None, false)
                 qsharp_type: Double
@@ -618,23 +618,23 @@ fn to_explicit_angle_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Angle(None, true)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Angle(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
                     ty: Angle(Some(4), false)
-                    kind: SymbolId(6)
-            [7] Symbol [41-42]:
+                    kind: SymbolId(8)
+            [9] Symbol [41-42]:
                 name: y
                 type: Angle(Some(4), false)
                 qsharp_type: Double

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_angle.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_angle.rs
@@ -157,10 +157,10 @@ fn to_implicit_int_implicitly_fails() {
             [Qsc.Qasm3.Compile.CannotCast
 
               x Cannot cast expression of type Angle(None, false) to type Int(None, false)
-               ,-[test:3:9]
+               ,-[test:3:17]
              2 |         angle x = 42.;
              3 |         int y = x;
-               :         ^^^^^^^^^^
+               :                 ^
              4 |     
                `----
             ]"#]],
@@ -201,10 +201,10 @@ fn to_explicit_int_implicitly_fails() {
 
               x Cannot cast expression of type Angle(None, false) to type Int(Some(32),
               | false)
-               ,-[test:3:9]
+               ,-[test:3:21]
              2 |         angle x = 42.;
              3 |         int[32] y = x;
-               :         ^^^^^^^^^^^^^^
+               :                     ^
              4 |     
                `----
             ]"#]],
@@ -245,10 +245,10 @@ fn to_implicit_uint_implicitly_fails() {
 
               x Cannot cast expression of type Angle(None, false) to type UInt(None,
               | false)
-               ,-[test:3:9]
+               ,-[test:3:18]
              2 |         angle x = 42.;
              3 |         uint y = x;
-               :         ^^^^^^^^^^^
+               :                  ^
              4 |     
                `----
             ]"#]],
@@ -297,10 +297,10 @@ fn negative_lit_to_implicit_uint_implicitly_fails() {
 
               x Cannot cast expression of type Angle(None, false) to type UInt(None,
               | false)
-               ,-[test:3:9]
+               ,-[test:3:18]
              2 |         angle x = -42.;
              3 |         uint y = x;
-               :         ^^^^^^^^^^^
+               :                  ^
              4 |     
                `----
             ]"#]],
@@ -341,10 +341,10 @@ fn to_explicit_uint_implicitly_fails() {
 
               x Cannot cast expression of type Angle(None, false) to type UInt(Some(32),
               | false)
-               ,-[test:3:9]
+               ,-[test:3:22]
              2 |         angle x = 42.;
              3 |         uint[32] y = x;
-               :         ^^^^^^^^^^^^^^^
+               :                      ^
              4 |     
                `----
             ]"#]],
@@ -385,10 +385,10 @@ fn to_explicit_bigint_implicitly_fails() {
 
               x Cannot cast expression of type Angle(None, false) to type Int(Some(65),
               | false)
-               ,-[test:3:9]
+               ,-[test:3:21]
              2 |         angle x = 42.;
              3 |         int[65] y = x;
-               :         ^^^^^^^^^^^^^^
+               :                     ^
              4 |     
                `----
             ]"#]],
@@ -429,10 +429,10 @@ fn to_implicit_float_implicitly_fails() {
 
               x Cannot cast expression of type Angle(None, false) to type Float(None,
               | false)
-               ,-[test:3:9]
+               ,-[test:3:19]
              2 |         angle x = 42.;
              3 |         float y = x;
-               :         ^^^^^^^^^^^^
+               :                   ^
              4 |     
                `----
             ]"#]],
@@ -473,10 +473,10 @@ fn to_explicit_float_implicitly_fails() {
 
               x Cannot cast expression of type Angle(None, false) to type Float(Some(32),
               | false)
-               ,-[test:3:9]
+               ,-[test:3:23]
              2 |         angle x = 42.;
              3 |         float[32] y = x;
-               :         ^^^^^^^^^^^^^^^^
+               :                       ^
              4 |     
                `----
             ]"#]],
@@ -517,10 +517,10 @@ fn to_implicit_complex_implicitly_fails() {
 
               x Cannot cast expression of type Angle(None, false) to type Complex(None,
               | false)
-               ,-[test:3:9]
+               ,-[test:3:28]
              2 |         angle x = 42.;
              3 |         complex[float] y = x;
-               :         ^^^^^^^^^^^^^^^^^^^^^
+               :                            ^
              4 |     
                `----
             ]"#]],
@@ -561,10 +561,10 @@ fn to_explicit_complex_implicitly_fails() {
 
               x Cannot cast expression of type Angle(None, false) to type
               | Complex(Some(32), false)
-               ,-[test:3:9]
+               ,-[test:3:32]
              2 |         angle x = 42.;
              3 |         complex[float[32]] y = x;
-               :         ^^^^^^^^^^^^^^^^^^^^^^^^^
+               :                                ^
              4 |     
                `----
             ]"#]],

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bit.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bit.rs
@@ -42,7 +42,7 @@ fn to_bool_implicitly() {
                 ty_span: [10-13]
                 init_expr: Expr [18-19]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [14-15]:
                 name: x
                 type: Bit(false)
@@ -82,7 +82,7 @@ fn to_implicit_int_implicitly() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -122,7 +122,7 @@ fn to_explicit_int_implicitly() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -162,7 +162,7 @@ fn to_implicit_uint_implicitly() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -202,7 +202,7 @@ fn to_explicit_uint_implicitly() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -242,7 +242,7 @@ fn to_explicit_bigint_implicitly() {
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
-                    kind: Lit: Int(1)
+                    kind: Lit: Bit(1)
             [6] Symbol [13-14]:
                 name: x
                 type: Bit(false)
@@ -287,7 +287,7 @@ fn to_implicit_float_implicitly_fails() {
                             ty_span: [9-12]
                             init_expr: Expr [17-18]:
                                 ty: Bit(true)
-                                kind: Lit: Int(1)
+                                kind: Lit: Bit(1)
                     Stmt [28-40]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [28-40]:

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bit.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bit.rs
@@ -38,18 +38,18 @@ fn to_bool_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [10-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [10-13]
                 init_expr: Expr [18-19]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [30-41]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [30-34]
                 init_expr: Expr [39-40]:
                     ty: Bool(false)
@@ -57,8 +57,8 @@ fn to_bool_implicitly() {
                         ty: Bool(false)
                         expr: Expr [39-40]:
                             ty: Bit(false)
-                            kind: SymbolId(6)
-            [7] Symbol [35-36]:
+                            kind: SymbolId(8)
+            [9] Symbol [35-36]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
@@ -78,18 +78,18 @@ fn to_implicit_int_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: Int(None, false)
@@ -97,8 +97,8 @@ fn to_implicit_int_implicitly() {
                         ty: Int(None, false)
                         expr: Expr [36-37]:
                             ty: Bit(false)
-                            kind: SymbolId(6)
-            [7] Symbol [32-33]:
+                            kind: SymbolId(8)
+            [9] Symbol [32-33]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
@@ -118,18 +118,18 @@ fn to_explicit_int_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-42]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-35]
                 init_expr: Expr [40-41]:
                     ty: Int(Some(32), false)
@@ -137,8 +137,8 @@ fn to_explicit_int_implicitly() {
                         ty: Int(Some(32), false)
                         expr: Expr [40-41]:
                             ty: Bit(false)
-                            kind: SymbolId(6)
-            [7] Symbol [36-37]:
+                            kind: SymbolId(8)
+            [9] Symbol [36-37]:
                 name: y
                 type: Int(Some(32), false)
                 qsharp_type: Int
@@ -158,18 +158,18 @@ fn to_implicit_uint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-39]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-32]
                 init_expr: Expr [37-38]:
                     ty: UInt(None, false)
@@ -177,8 +177,8 @@ fn to_implicit_uint_implicitly() {
                         ty: UInt(None, false)
                         expr: Expr [37-38]:
                             ty: Bit(false)
-                            kind: SymbolId(6)
-            [7] Symbol [33-34]:
+                            kind: SymbolId(8)
+            [9] Symbol [33-34]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -198,18 +198,18 @@ fn to_explicit_uint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-43]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-36]
                 init_expr: Expr [41-42]:
                     ty: UInt(Some(32), false)
@@ -217,8 +217,8 @@ fn to_explicit_uint_implicitly() {
                         ty: UInt(Some(32), false)
                         expr: Expr [41-42]:
                             ty: Bit(false)
-                            kind: SymbolId(6)
-            [7] Symbol [37-38]:
+                            kind: SymbolId(8)
+            [9] Symbol [37-38]:
                 name: y
                 type: UInt(Some(32), false)
                 qsharp_type: Int
@@ -238,18 +238,18 @@ fn to_explicit_bigint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-19]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
                     ty: Bit(true)
                     kind: Lit: Bit(1)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Bit(false)
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-42]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [28-35]
                 init_expr: Expr [40-41]:
                     ty: Int(Some(65), false)
@@ -257,8 +257,8 @@ fn to_explicit_bigint_implicitly() {
                         ty: Int(Some(65), false)
                         expr: Expr [40-41]:
                             ty: Bit(false)
-                            kind: SymbolId(6)
-            [7] Symbol [36-37]:
+                            kind: SymbolId(8)
+            [9] Symbol [36-37]:
                 name: y
                 type: Int(Some(65), false)
                 qsharp_type: BigInt
@@ -283,7 +283,7 @@ fn to_implicit_float_implicitly_fails() {
                     Stmt [9-19]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-19]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [17-18]:
                                 ty: Bit(true)
@@ -291,11 +291,11 @@ fn to_implicit_float_implicitly_fails() {
                     Stmt [28-40]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [28-40]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [28-33]
                             init_expr: Expr [38-39]:
                                 ty: Bit(false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bit.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bit.rs
@@ -300,10 +300,10 @@ fn to_implicit_float_implicitly_fails() {
             [Qsc.Qasm3.Compile.CannotCast
 
               x Cannot cast expression of type Bit(false) to type Float(None, false)
-               ,-[test:3:9]
+               ,-[test:3:19]
              2 |         bit x = 1;
              3 |         float y = x;
-               :         ^^^^^^^^^^^^
+               :                   ^
              4 |     
                `----
             ]"#]],

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bool.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bool.rs
@@ -15,33 +15,33 @@ fn to_bit_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-13]
-            init_expr: Expr [18-22]:
-                ty: Bool(true)
-                kind: Lit: Bool(true)
-        [6] Symbol [14-15]:
-            name: x
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-        ClassicalDeclarationStmt [32-42]:
-            symbol_id: 7
-            ty_span: [32-35]
-            init_expr: Expr [40-41]:
-                ty: Bit(false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-13]
+                init_expr: Expr [18-22]:
+                    ty: Bool(false)
+                    kind: Lit: Bool(true)
+            [6] Symbol [14-15]:
+                name: x
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+            ClassicalDeclarationStmt [32-42]:
+                symbol_id: 7
+                ty_span: [32-35]
+                init_expr: Expr [40-41]:
                     ty: Bit(false)
-                    expr: Expr [40-41]:
-                        ty: Bool(false)
-                        kind: SymbolId(6)
-        [7] Symbol [36-37]:
-            name: y
-            type: Bit(false)
-            qsharp_type: Result
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Bit(false)
+                        expr: Expr [40-41]:
+                            ty: Bool(false)
+                            kind: SymbolId(6)
+            [7] Symbol [36-37]:
+                name: y
+                type: Bit(false)
+                qsharp_type: Result
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -55,33 +55,33 @@ fn to_implicit_int_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-13]
-            init_expr: Expr [18-22]:
-                ty: Bool(true)
-                kind: Lit: Bool(true)
-        [6] Symbol [14-15]:
-            name: x
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-        ClassicalDeclarationStmt [32-42]:
-            symbol_id: 7
-            ty_span: [32-35]
-            init_expr: Expr [40-41]:
-                ty: Int(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-13]
+                init_expr: Expr [18-22]:
+                    ty: Bool(false)
+                    kind: Lit: Bool(true)
+            [6] Symbol [14-15]:
+                name: x
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+            ClassicalDeclarationStmt [32-42]:
+                symbol_id: 7
+                ty_span: [32-35]
+                init_expr: Expr [40-41]:
                     ty: Int(None, false)
-                    expr: Expr [40-41]:
-                        ty: Bool(false)
-                        kind: SymbolId(6)
-        [7] Symbol [36-37]:
-            name: y
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Int(None, false)
+                        expr: Expr [40-41]:
+                            ty: Bool(false)
+                            kind: SymbolId(6)
+            [7] Symbol [36-37]:
+                name: y
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -95,33 +95,33 @@ fn to_explicit_int_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-13]
-            init_expr: Expr [18-22]:
-                ty: Bool(true)
-                kind: Lit: Bool(true)
-        [6] Symbol [14-15]:
-            name: x
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-        ClassicalDeclarationStmt [32-46]:
-            symbol_id: 7
-            ty_span: [32-39]
-            init_expr: Expr [44-45]:
-                ty: Int(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-13]
+                init_expr: Expr [18-22]:
+                    ty: Bool(false)
+                    kind: Lit: Bool(true)
+            [6] Symbol [14-15]:
+                name: x
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+            ClassicalDeclarationStmt [32-46]:
+                symbol_id: 7
+                ty_span: [32-39]
+                init_expr: Expr [44-45]:
                     ty: Int(Some(32), false)
-                    expr: Expr [44-45]:
-                        ty: Bool(false)
-                        kind: SymbolId(6)
-        [7] Symbol [40-41]:
-            name: y
-            type: Int(Some(32), false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Int(Some(32), false)
+                        expr: Expr [44-45]:
+                            ty: Bool(false)
+                            kind: SymbolId(6)
+            [7] Symbol [40-41]:
+                name: y
+                type: Int(Some(32), false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -135,33 +135,33 @@ fn to_implicit_uint_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-13]
-            init_expr: Expr [18-22]:
-                ty: Bool(true)
-                kind: Lit: Bool(true)
-        [6] Symbol [14-15]:
-            name: x
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-        ClassicalDeclarationStmt [32-43]:
-            symbol_id: 7
-            ty_span: [32-36]
-            init_expr: Expr [41-42]:
-                ty: UInt(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-13]
+                init_expr: Expr [18-22]:
+                    ty: Bool(false)
+                    kind: Lit: Bool(true)
+            [6] Symbol [14-15]:
+                name: x
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+            ClassicalDeclarationStmt [32-43]:
+                symbol_id: 7
+                ty_span: [32-36]
+                init_expr: Expr [41-42]:
                     ty: UInt(None, false)
-                    expr: Expr [41-42]:
-                        ty: Bool(false)
-                        kind: SymbolId(6)
-        [7] Symbol [37-38]:
-            name: y
-            type: UInt(None, false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: UInt(None, false)
+                        expr: Expr [41-42]:
+                            ty: Bool(false)
+                            kind: SymbolId(6)
+            [7] Symbol [37-38]:
+                name: y
+                type: UInt(None, false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -175,33 +175,33 @@ fn to_explicit_uint_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-13]
-            init_expr: Expr [18-22]:
-                ty: Bool(true)
-                kind: Lit: Bool(true)
-        [6] Symbol [14-15]:
-            name: x
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-        ClassicalDeclarationStmt [32-47]:
-            symbol_id: 7
-            ty_span: [32-40]
-            init_expr: Expr [45-46]:
-                ty: UInt(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-13]
+                init_expr: Expr [18-22]:
+                    ty: Bool(false)
+                    kind: Lit: Bool(true)
+            [6] Symbol [14-15]:
+                name: x
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+            ClassicalDeclarationStmt [32-47]:
+                symbol_id: 7
+                ty_span: [32-40]
+                init_expr: Expr [45-46]:
                     ty: UInt(Some(32), false)
-                    expr: Expr [45-46]:
-                        ty: Bool(false)
-                        kind: SymbolId(6)
-        [7] Symbol [41-42]:
-            name: y
-            type: UInt(Some(32), false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: UInt(Some(32), false)
+                        expr: Expr [45-46]:
+                            ty: Bool(false)
+                            kind: SymbolId(6)
+            [7] Symbol [41-42]:
+                name: y
+                type: UInt(Some(32), false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -215,33 +215,33 @@ fn to_explicit_bigint_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-13]
-            init_expr: Expr [18-22]:
-                ty: Bool(true)
-                kind: Lit: Bool(true)
-        [6] Symbol [14-15]:
-            name: x
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-        ClassicalDeclarationStmt [32-46]:
-            symbol_id: 7
-            ty_span: [32-39]
-            init_expr: Expr [44-45]:
-                ty: Int(Some(65), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-13]
+                init_expr: Expr [18-22]:
+                    ty: Bool(false)
+                    kind: Lit: Bool(true)
+            [6] Symbol [14-15]:
+                name: x
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+            ClassicalDeclarationStmt [32-46]:
+                symbol_id: 7
+                ty_span: [32-39]
+                init_expr: Expr [44-45]:
                     ty: Int(Some(65), false)
-                    expr: Expr [44-45]:
-                        ty: Bool(false)
-                        kind: SymbolId(6)
-        [7] Symbol [40-41]:
-            name: y
-            type: Int(Some(65), false)
-            qsharp_type: BigInt
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Int(Some(65), false)
+                        expr: Expr [44-45]:
+                            ty: Bool(false)
+                            kind: SymbolId(6)
+            [7] Symbol [40-41]:
+                name: y
+                type: Int(Some(65), false)
+                qsharp_type: BigInt
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -255,33 +255,33 @@ fn to_implicit_float_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-13]
-            init_expr: Expr [18-22]:
-                ty: Bool(true)
-                kind: Lit: Bool(true)
-        [6] Symbol [14-15]:
-            name: x
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-        ClassicalDeclarationStmt [32-44]:
-            symbol_id: 7
-            ty_span: [32-37]
-            init_expr: Expr [42-43]:
-                ty: Float(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-13]
+                init_expr: Expr [18-22]:
+                    ty: Bool(false)
+                    kind: Lit: Bool(true)
+            [6] Symbol [14-15]:
+                name: x
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+            ClassicalDeclarationStmt [32-44]:
+                symbol_id: 7
+                ty_span: [32-37]
+                init_expr: Expr [42-43]:
                     ty: Float(None, false)
-                    expr: Expr [42-43]:
-                        ty: Bool(false)
-                        kind: SymbolId(6)
-        [7] Symbol [38-39]:
-            name: y
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Float(None, false)
+                        expr: Expr [42-43]:
+                            ty: Bool(false)
+                            kind: SymbolId(6)
+            [7] Symbol [38-39]:
+                name: y
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -295,32 +295,32 @@ fn to_explicit_float_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-13]
-            init_expr: Expr [18-22]:
-                ty: Bool(true)
-                kind: Lit: Bool(true)
-        [6] Symbol [14-15]:
-            name: x
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-        ClassicalDeclarationStmt [32-48]:
-            symbol_id: 7
-            ty_span: [32-41]
-            init_expr: Expr [46-47]:
-                ty: Float(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-13]
+                init_expr: Expr [18-22]:
+                    ty: Bool(false)
+                    kind: Lit: Bool(true)
+            [6] Symbol [14-15]:
+                name: x
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+            ClassicalDeclarationStmt [32-48]:
+                symbol_id: 7
+                ty_span: [32-41]
+                init_expr: Expr [46-47]:
                     ty: Float(Some(32), false)
-                    expr: Expr [46-47]:
-                        ty: Bool(false)
-                        kind: SymbolId(6)
-        [7] Symbol [42-43]:
-            name: y
-            type: Float(Some(32), false)
-            qsharp_type: Double
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Float(Some(32), false)
+                        expr: Expr [46-47]:
+                            ty: Bool(false)
+                            kind: SymbolId(6)
+            [7] Symbol [42-43]:
+                name: y
+                type: Float(Some(32), false)
+                qsharp_type: Double
+                io_kind: Default
+        "#]],
     );
 }

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bool.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_bool.rs
@@ -16,18 +16,18 @@ fn to_bit_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-42]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
                     ty: Bit(false)
@@ -35,8 +35,8 @@ fn to_bit_implicitly() {
                         ty: Bit(false)
                         expr: Expr [40-41]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
-            [7] Symbol [36-37]:
+                            kind: SymbolId(8)
+            [9] Symbol [36-37]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
@@ -56,18 +56,18 @@ fn to_implicit_int_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-42]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
                     ty: Int(None, false)
@@ -75,8 +75,8 @@ fn to_implicit_int_implicitly() {
                         ty: Int(None, false)
                         expr: Expr [40-41]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
-            [7] Symbol [36-37]:
+                            kind: SymbolId(8)
+            [9] Symbol [36-37]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
@@ -96,18 +96,18 @@ fn to_explicit_int_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-46]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
                     ty: Int(Some(32), false)
@@ -115,8 +115,8 @@ fn to_explicit_int_implicitly() {
                         ty: Int(Some(32), false)
                         expr: Expr [44-45]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
-            [7] Symbol [40-41]:
+                            kind: SymbolId(8)
+            [9] Symbol [40-41]:
                 name: y
                 type: Int(Some(32), false)
                 qsharp_type: Int
@@ -136,18 +136,18 @@ fn to_implicit_uint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-43]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
                     ty: UInt(None, false)
@@ -155,8 +155,8 @@ fn to_implicit_uint_implicitly() {
                         ty: UInt(None, false)
                         expr: Expr [41-42]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
-            [7] Symbol [37-38]:
+                            kind: SymbolId(8)
+            [9] Symbol [37-38]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -176,18 +176,18 @@ fn to_explicit_uint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
                     ty: UInt(Some(32), false)
@@ -195,8 +195,8 @@ fn to_explicit_uint_implicitly() {
                         ty: UInt(Some(32), false)
                         expr: Expr [45-46]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
-            [7] Symbol [41-42]:
+                            kind: SymbolId(8)
+            [9] Symbol [41-42]:
                 name: y
                 type: UInt(Some(32), false)
                 qsharp_type: Int
@@ -216,18 +216,18 @@ fn to_explicit_bigint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-46]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
                     ty: Int(Some(65), false)
@@ -235,8 +235,8 @@ fn to_explicit_bigint_implicitly() {
                         ty: Int(Some(65), false)
                         expr: Expr [44-45]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
-            [7] Symbol [40-41]:
+                            kind: SymbolId(8)
+            [9] Symbol [40-41]:
                 name: y
                 type: Int(Some(65), false)
                 qsharp_type: BigInt
@@ -256,18 +256,18 @@ fn to_implicit_float_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-37]
                 init_expr: Expr [42-43]:
                     ty: Float(None, false)
@@ -275,8 +275,8 @@ fn to_implicit_float_implicitly() {
                         ty: Float(None, false)
                         expr: Expr [42-43]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
-            [7] Symbol [38-39]:
+                            kind: SymbolId(8)
+            [9] Symbol [38-39]:
                 name: y
                 type: Float(None, false)
                 qsharp_type: Double
@@ -296,18 +296,18 @@ fn to_explicit_float_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
                     ty: Bool(false)
                     kind: Lit: Bool(true)
-            [6] Symbol [14-15]:
+            [8] Symbol [14-15]:
                 name: x
                 type: Bool(false)
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-48]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-41]
                 init_expr: Expr [46-47]:
                     ty: Float(Some(32), false)
@@ -315,8 +315,8 @@ fn to_explicit_float_implicitly() {
                         ty: Float(Some(32), false)
                         expr: Expr [46-47]:
                             ty: Bool(false)
-                            kind: SymbolId(6)
-            [7] Symbol [42-43]:
+                            kind: SymbolId(8)
+            [9] Symbol [42-43]:
                 name: y
                 type: Float(Some(32), false)
                 qsharp_type: Double

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_float.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_float.rs
@@ -21,7 +21,7 @@ fn to_bit_implicitly_fails() {
                     Stmt [9-23]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-23]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
                                 ty: Float(None, false)
@@ -29,11 +29,11 @@ fn to_bit_implicitly_fails() {
                     Stmt [32-42]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [32-42]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [32-35]
                             init_expr: Expr [40-41]:
                                 ty: Float(None, false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -64,7 +64,7 @@ fn explicit_width_to_bit_implicitly_fails() {
                     Stmt [9-27]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [9-27]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [23-26]:
                                 ty: Float(Some(64), true)
@@ -72,11 +72,11 @@ fn explicit_width_to_bit_implicitly_fails() {
                     Stmt [36-46]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [36-46]:
-                            symbol_id: 7
+                            symbol_id: 9
                             ty_span: [36-39]
                             init_expr: Expr [44-45]:
                                 ty: Float(Some(64), false)
-                                kind: SymbolId(6)
+                                kind: SymbolId(8)
 
             [Qsc.Qasm3.Compile.CannotCast
 
@@ -101,18 +101,18 @@ fn to_bool_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-43]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
                     ty: Bool(false)
@@ -120,8 +120,8 @@ fn to_bool_implicitly() {
                         ty: Bool(false)
                         expr: Expr [41-42]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [37-38]:
+                            kind: SymbolId(8)
+            [9] Symbol [37-38]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
@@ -141,18 +141,18 @@ fn to_implicit_int_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-42]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
                     ty: Int(None, false)
@@ -160,8 +160,8 @@ fn to_implicit_int_implicitly() {
                         ty: Int(None, false)
                         expr: Expr [40-41]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [36-37]:
+                            kind: SymbolId(8)
+            [9] Symbol [36-37]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
@@ -181,18 +181,18 @@ fn to_explicit_int_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-46]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
                     ty: Int(Some(32), false)
@@ -200,8 +200,8 @@ fn to_explicit_int_implicitly() {
                         ty: Int(Some(32), false)
                         expr: Expr [44-45]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [40-41]:
+                            kind: SymbolId(8)
+            [9] Symbol [40-41]:
                 name: y
                 type: Int(Some(32), false)
                 qsharp_type: Int
@@ -221,18 +221,18 @@ fn to_implicit_uint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-43]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
                     ty: UInt(None, false)
@@ -240,8 +240,8 @@ fn to_implicit_uint_implicitly() {
                         ty: UInt(None, false)
                         expr: Expr [41-42]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [37-38]:
+                            kind: SymbolId(8)
+            [9] Symbol [37-38]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -261,7 +261,7 @@ fn negative_lit_to_implicit_uint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-24]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [20-23]:
                     ty: Float(None, false)
@@ -270,13 +270,13 @@ fn negative_lit_to_implicit_uint_implicitly() {
                         expr: Expr [20-23]:
                             ty: Float(None, true)
                             kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [33-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [33-37]
                 init_expr: Expr [42-43]:
                     ty: UInt(None, false)
@@ -284,8 +284,8 @@ fn negative_lit_to_implicit_uint_implicitly() {
                         ty: UInt(None, false)
                         expr: Expr [42-43]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [38-39]:
+                            kind: SymbolId(8)
+            [9] Symbol [38-39]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -305,18 +305,18 @@ fn to_explicit_uint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
                     ty: UInt(Some(32), false)
@@ -324,8 +324,8 @@ fn to_explicit_uint_implicitly() {
                         ty: UInt(Some(32), false)
                         expr: Expr [45-46]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [41-42]:
+                            kind: SymbolId(8)
+            [9] Symbol [41-42]:
                 name: y
                 type: UInt(Some(32), false)
                 qsharp_type: Int
@@ -345,18 +345,18 @@ fn to_explicit_bigint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-46]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
                     ty: Int(Some(65), false)
@@ -364,8 +364,8 @@ fn to_explicit_bigint_implicitly() {
                         ty: Int(Some(65), false)
                         expr: Expr [44-45]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [40-41]:
+                            kind: SymbolId(8)
+            [9] Symbol [40-41]:
                 name: y
                 type: Int(Some(65), false)
                 qsharp_type: BigInt
@@ -385,23 +385,23 @@ fn to_implicit_float_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-37]
                 init_expr: Expr [42-43]:
                     ty: Float(None, false)
-                    kind: SymbolId(6)
-            [7] Symbol [38-39]:
+                    kind: SymbolId(8)
+            [9] Symbol [38-39]:
                 name: y
                 type: Float(None, false)
                 qsharp_type: Double
@@ -421,23 +421,23 @@ fn to_explicit_float_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-48]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-41]
                 init_expr: Expr [46-47]:
                     ty: Float(Some(32), false)
-                    kind: SymbolId(6)
-            [7] Symbol [42-43]:
+                    kind: SymbolId(8)
+            [9] Symbol [42-43]:
                 name: y
                 type: Float(Some(32), false)
                 qsharp_type: Double
@@ -457,18 +457,18 @@ fn to_implicit_complex_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-53]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-46]
                 init_expr: Expr [51-52]:
                     ty: Complex(None, false)
@@ -476,8 +476,8 @@ fn to_implicit_complex_implicitly() {
                         ty: Complex(None, false)
                         expr: Expr [51-52]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [47-48]:
+                            kind: SymbolId(8)
+            [9] Symbol [47-48]:
                 name: y
                 type: Complex(None, false)
                 qsharp_type: Complex
@@ -497,18 +497,18 @@ fn to_explicit_complex_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-23]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
                     ty: Float(None, false)
                     kind: Lit: Float(42.0)
-            [6] Symbol [15-16]:
+            [8] Symbol [15-16]:
                 name: x
                 type: Float(None, false)
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-57]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [32-50]
                 init_expr: Expr [55-56]:
                     ty: Complex(Some(32), false)
@@ -516,8 +516,8 @@ fn to_explicit_complex_implicitly() {
                         ty: Complex(Some(32), false)
                         expr: Expr [55-56]:
                             ty: Float(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [51-52]:
+                            kind: SymbolId(8)
+            [9] Symbol [51-52]:
                 name: y
                 type: Complex(Some(32), false)
                 qsharp_type: Complex

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_float.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_float.rs
@@ -24,7 +24,7 @@ fn to_bit_implicitly_fails() {
                             symbol_id: 6
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Float(None, true)
+                                ty: Float(None, false)
                                 kind: Lit: Float(42.0)
                     Stmt [32-42]:
                         annotations: <empty>
@@ -38,10 +38,10 @@ fn to_bit_implicitly_fails() {
             [Qsc.Qasm3.Compile.CannotCast
 
               x Cannot cast expression of type Float(None, false) to type Bit(false)
-               ,-[test:3:9]
+               ,-[test:3:17]
              2 |         float x = 42.;
              3 |         bit y = x;
-               :         ^^^^^^^^^^
+               :                 ^
              4 |     
                `----
             ]"#]],
@@ -81,10 +81,10 @@ fn explicit_width_to_bit_implicitly_fails() {
             [Qsc.Qasm3.Compile.CannotCast
 
               x Cannot cast expression of type Float(Some(64), false) to type Bit(false)
-               ,-[test:3:9]
+               ,-[test:3:17]
              2 |         float[64] x = 42.;
              3 |         bit y = x;
-               :         ^^^^^^^^^^
+               :                 ^
              4 |     
                `----
             ]"#]],
@@ -100,33 +100,33 @@ fn to_bool_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-43]:
-            symbol_id: 7
-            ty_span: [32-36]
-            init_expr: Expr [41-42]:
-                ty: Bool(false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-43]:
+                symbol_id: 7
+                ty_span: [32-36]
+                init_expr: Expr [41-42]:
                     ty: Bool(false)
-                    expr: Expr [41-42]:
-                        ty: Float(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [37-38]:
-            name: y
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Bool(false)
+                        expr: Expr [41-42]:
+                            ty: Float(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [37-38]:
+                name: y
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -140,33 +140,33 @@ fn to_implicit_int_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-42]:
-            symbol_id: 7
-            ty_span: [32-35]
-            init_expr: Expr [40-41]:
-                ty: Int(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-42]:
+                symbol_id: 7
+                ty_span: [32-35]
+                init_expr: Expr [40-41]:
                     ty: Int(None, false)
-                    expr: Expr [40-41]:
-                        ty: Float(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [36-37]:
-            name: y
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Int(None, false)
+                        expr: Expr [40-41]:
+                            ty: Float(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [36-37]:
+                name: y
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -180,33 +180,33 @@ fn to_explicit_int_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-46]:
-            symbol_id: 7
-            ty_span: [32-39]
-            init_expr: Expr [44-45]:
-                ty: Int(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-46]:
+                symbol_id: 7
+                ty_span: [32-39]
+                init_expr: Expr [44-45]:
                     ty: Int(Some(32), false)
-                    expr: Expr [44-45]:
-                        ty: Float(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [40-41]:
-            name: y
-            type: Int(Some(32), false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Int(Some(32), false)
+                        expr: Expr [44-45]:
+                            ty: Float(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [40-41]:
+                name: y
+                type: Int(Some(32), false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -220,33 +220,33 @@ fn to_implicit_uint_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-43]:
-            symbol_id: 7
-            ty_span: [32-36]
-            init_expr: Expr [41-42]:
-                ty: UInt(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-43]:
+                symbol_id: 7
+                ty_span: [32-36]
+                init_expr: Expr [41-42]:
                     ty: UInt(None, false)
-                    expr: Expr [41-42]:
-                        ty: Float(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [37-38]:
-            name: y
-            type: UInt(None, false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: UInt(None, false)
+                        expr: Expr [41-42]:
+                            ty: Float(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [37-38]:
+                name: y
+                type: UInt(None, false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -264,7 +264,7 @@ fn negative_lit_to_implicit_uint_implicitly() {
                 symbol_id: 6
                 ty_span: [9-14]
                 init_expr: Expr [20-23]:
-                    ty: Float(None, true)
+                    ty: Float(None, false)
                     kind: UnaryOpExpr [20-23]:
                         op: Neg
                         expr: Expr [20-23]:
@@ -304,33 +304,33 @@ fn to_explicit_uint_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-47]:
-            symbol_id: 7
-            ty_span: [32-40]
-            init_expr: Expr [45-46]:
-                ty: UInt(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-47]:
+                symbol_id: 7
+                ty_span: [32-40]
+                init_expr: Expr [45-46]:
                     ty: UInt(Some(32), false)
-                    expr: Expr [45-46]:
-                        ty: Float(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [41-42]:
-            name: y
-            type: UInt(Some(32), false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: UInt(Some(32), false)
+                        expr: Expr [45-46]:
+                            ty: Float(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [41-42]:
+                name: y
+                type: UInt(Some(32), false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -344,33 +344,33 @@ fn to_explicit_bigint_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-46]:
-            symbol_id: 7
-            ty_span: [32-39]
-            init_expr: Expr [44-45]:
-                ty: Int(Some(65), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-46]:
+                symbol_id: 7
+                ty_span: [32-39]
+                init_expr: Expr [44-45]:
                     ty: Int(Some(65), false)
-                    expr: Expr [44-45]:
-                        ty: Float(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [40-41]:
-            name: y
-            type: Int(Some(65), false)
-            qsharp_type: BigInt
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Int(Some(65), false)
+                        expr: Expr [44-45]:
+                            ty: Float(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [40-41]:
+                name: y
+                type: Int(Some(65), false)
+                qsharp_type: BigInt
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -384,29 +384,29 @@ fn to_implicit_float_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-44]:
-            symbol_id: 7
-            ty_span: [32-37]
-            init_expr: Expr [42-43]:
-                ty: Float(None, false)
-                kind: SymbolId(6)
-        [7] Symbol [38-39]:
-            name: y
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-    "#]],
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-44]:
+                symbol_id: 7
+                ty_span: [32-37]
+                init_expr: Expr [42-43]:
+                    ty: Float(None, false)
+                    kind: SymbolId(6)
+            [7] Symbol [38-39]:
+                name: y
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -420,29 +420,29 @@ fn to_explicit_float_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-48]:
-            symbol_id: 7
-            ty_span: [32-41]
-            init_expr: Expr [46-47]:
-                ty: Float(Some(32), false)
-                kind: SymbolId(6)
-        [7] Symbol [42-43]:
-            name: y
-            type: Float(Some(32), false)
-            qsharp_type: Double
-            io_kind: Default
-    "#]],
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-48]:
+                symbol_id: 7
+                ty_span: [32-41]
+                init_expr: Expr [46-47]:
+                    ty: Float(Some(32), false)
+                    kind: SymbolId(6)
+            [7] Symbol [42-43]:
+                name: y
+                type: Float(Some(32), false)
+                qsharp_type: Double
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -456,33 +456,33 @@ fn to_implicit_complex_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-53]:
-            symbol_id: 7
-            ty_span: [32-46]
-            init_expr: Expr [51-52]:
-                ty: Complex(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-53]:
+                symbol_id: 7
+                ty_span: [32-46]
+                init_expr: Expr [51-52]:
                     ty: Complex(None, false)
-                    expr: Expr [51-52]:
-                        ty: Float(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [47-48]:
-            name: y
-            type: Complex(None, false)
-            qsharp_type: Complex
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Complex(None, false)
+                        expr: Expr [51-52]:
+                            ty: Float(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [47-48]:
+                name: y
+                type: Complex(None, false)
+                qsharp_type: Complex
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -496,33 +496,33 @@ fn to_explicit_complex_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-23]:
-            symbol_id: 6
-            ty_span: [9-14]
-            init_expr: Expr [19-22]:
-                ty: Float(None, true)
-                kind: Lit: Float(42.0)
-        [6] Symbol [15-16]:
-            name: x
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-        ClassicalDeclarationStmt [32-57]:
-            symbol_id: 7
-            ty_span: [32-50]
-            init_expr: Expr [55-56]:
-                ty: Complex(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 6
+                ty_span: [9-14]
+                init_expr: Expr [19-22]:
+                    ty: Float(None, false)
+                    kind: Lit: Float(42.0)
+            [6] Symbol [15-16]:
+                name: x
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+            ClassicalDeclarationStmt [32-57]:
+                symbol_id: 7
+                ty_span: [32-50]
+                init_expr: Expr [55-56]:
                     ty: Complex(Some(32), false)
-                    expr: Expr [55-56]:
-                        ty: Float(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [51-52]:
-            name: y
-            type: Complex(Some(32), false)
-            qsharp_type: Complex
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Complex(Some(32), false)
+                        expr: Expr [55-56]:
+                            ty: Float(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [51-52]:
+                name: y
+                type: Complex(Some(32), false)
+                qsharp_type: Complex
+                io_kind: Default
+        "#]],
     );
 }
 

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_int.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_int.rs
@@ -16,18 +16,18 @@ fn to_bit_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-39]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-32]
                 init_expr: Expr [37-38]:
                     ty: Bit(false)
@@ -35,8 +35,8 @@ fn to_bit_implicitly() {
                         ty: Bit(false)
                         expr: Expr [37-38]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [33-34]:
+                            kind: SymbolId(8)
+            [9] Symbol [33-34]:
                 name: y
                 type: Bit(false)
                 qsharp_type: Result
@@ -56,18 +56,18 @@ fn to_bool_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: Bool(false)
@@ -75,8 +75,8 @@ fn to_bool_implicitly() {
                         ty: Bool(false)
                         expr: Expr [38-39]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [34-35]:
+                            kind: SymbolId(8)
+            [9] Symbol [34-35]:
                 name: y
                 type: Bool(false)
                 qsharp_type: bool
@@ -96,23 +96,23 @@ fn to_implicit_int_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-39]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-32]
                 init_expr: Expr [37-38]:
                     ty: Int(None, false)
-                    kind: SymbolId(6)
-            [7] Symbol [33-34]:
+                    kind: SymbolId(8)
+            [9] Symbol [33-34]:
                 name: y
                 type: Int(None, false)
                 qsharp_type: Int
@@ -132,18 +132,18 @@ fn to_explicit_int_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-43]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-36]
                 init_expr: Expr [41-42]:
                     ty: Int(Some(32), false)
@@ -151,8 +151,8 @@ fn to_explicit_int_implicitly() {
                         ty: Int(Some(32), false)
                         expr: Expr [41-42]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [37-38]:
+                            kind: SymbolId(8)
+            [9] Symbol [37-38]:
                 name: y
                 type: Int(Some(32), false)
                 qsharp_type: Int
@@ -172,18 +172,18 @@ fn to_implicit_uint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: UInt(None, false)
@@ -191,8 +191,8 @@ fn to_implicit_uint_implicitly() {
                         ty: UInt(None, false)
                         expr: Expr [38-39]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [34-35]:
+                            kind: SymbolId(8)
+            [9] Symbol [34-35]:
                 name: y
                 type: UInt(None, false)
                 qsharp_type: Int
@@ -212,18 +212,18 @@ fn to_explicit_uint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-44]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-37]
                 init_expr: Expr [42-43]:
                     ty: UInt(Some(32), false)
@@ -231,8 +231,8 @@ fn to_explicit_uint_implicitly() {
                         ty: UInt(Some(32), false)
                         expr: Expr [42-43]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [38-39]:
+                            kind: SymbolId(8)
+            [9] Symbol [38-39]:
                 name: y
                 type: UInt(Some(32), false)
                 qsharp_type: Int
@@ -252,18 +252,18 @@ fn to_explicit_bigint_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-43]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-36]
                 init_expr: Expr [41-42]:
                     ty: Int(Some(65), false)
@@ -271,8 +271,8 @@ fn to_explicit_bigint_implicitly() {
                         ty: Int(Some(65), false)
                         expr: Expr [41-42]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [37-38]:
+                            kind: SymbolId(8)
+            [9] Symbol [37-38]:
                 name: y
                 type: Int(Some(65), false)
                 qsharp_type: BigInt
@@ -292,18 +292,18 @@ fn to_implicit_float_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-41]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-34]
                 init_expr: Expr [39-40]:
                     ty: Float(None, false)
@@ -311,8 +311,8 @@ fn to_implicit_float_implicitly() {
                         ty: Float(None, false)
                         expr: Expr [39-40]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [35-36]:
+                            kind: SymbolId(8)
+            [9] Symbol [35-36]:
                 name: y
                 type: Float(None, false)
                 qsharp_type: Double
@@ -332,18 +332,18 @@ fn to_explicit_float_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-45]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-38]
                 init_expr: Expr [43-44]:
                     ty: Float(Some(32), false)
@@ -351,8 +351,8 @@ fn to_explicit_float_implicitly() {
                         ty: Float(Some(32), false)
                         expr: Expr [43-44]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [39-40]:
+                            kind: SymbolId(8)
+            [9] Symbol [39-40]:
                 name: y
                 type: Float(Some(32), false)
                 qsharp_type: Double
@@ -372,18 +372,18 @@ fn to_implicit_complex_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-50]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-43]
                 init_expr: Expr [48-49]:
                     ty: Complex(None, false)
@@ -391,8 +391,8 @@ fn to_implicit_complex_implicitly() {
                         ty: Complex(None, false)
                         expr: Expr [48-49]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [44-45]:
+                            kind: SymbolId(8)
+            [9] Symbol [44-45]:
                 name: y
                 type: Complex(None, false)
                 qsharp_type: Complex
@@ -412,18 +412,18 @@ fn to_explicit_complex_implicitly() {
         input,
         &expect![[r#"
             ClassicalDeclarationStmt [9-20]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
                     ty: Int(None, false)
                     kind: Lit: Int(42)
-            [6] Symbol [13-14]:
+            [8] Symbol [13-14]:
                 name: x
                 type: Int(None, false)
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-54]:
-                symbol_id: 7
+                symbol_id: 9
                 ty_span: [29-47]
                 init_expr: Expr [52-53]:
                     ty: Complex(Some(32), false)
@@ -431,8 +431,8 @@ fn to_explicit_complex_implicitly() {
                         ty: Complex(Some(32), false)
                         expr: Expr [52-53]:
                             ty: Int(None, false)
-                            kind: SymbolId(6)
-            [7] Symbol [48-49]:
+                            kind: SymbolId(8)
+            [9] Symbol [48-49]:
                 name: y
                 type: Complex(Some(32), false)
                 qsharp_type: Complex

--- a/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_int.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/expression/implicit_cast_from_int.rs
@@ -15,33 +15,33 @@ fn to_bit_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-39]:
-            symbol_id: 7
-            ty_span: [29-32]
-            init_expr: Expr [37-38]:
-                ty: Bit(false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-39]:
+                symbol_id: 7
+                ty_span: [29-32]
+                init_expr: Expr [37-38]:
                     ty: Bit(false)
-                    expr: Expr [37-38]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [33-34]:
-            name: y
-            type: Bit(false)
-            qsharp_type: Result
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Bit(false)
+                        expr: Expr [37-38]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [33-34]:
+                name: y
+                type: Bit(false)
+                qsharp_type: Result
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -55,33 +55,33 @@ fn to_bool_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-40]:
-            symbol_id: 7
-            ty_span: [29-33]
-            init_expr: Expr [38-39]:
-                ty: Bool(false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-40]:
+                symbol_id: 7
+                ty_span: [29-33]
+                init_expr: Expr [38-39]:
                     ty: Bool(false)
-                    expr: Expr [38-39]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [34-35]:
-            name: y
-            type: Bool(false)
-            qsharp_type: bool
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Bool(false)
+                        expr: Expr [38-39]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [34-35]:
+                name: y
+                type: Bool(false)
+                qsharp_type: bool
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -95,29 +95,29 @@ fn to_implicit_int_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-39]:
-            symbol_id: 7
-            ty_span: [29-32]
-            init_expr: Expr [37-38]:
-                ty: Int(None, false)
-                kind: SymbolId(6)
-        [7] Symbol [33-34]:
-            name: y
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-39]:
+                symbol_id: 7
+                ty_span: [29-32]
+                init_expr: Expr [37-38]:
+                    ty: Int(None, false)
+                    kind: SymbolId(6)
+            [7] Symbol [33-34]:
+                name: y
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -131,33 +131,33 @@ fn to_explicit_int_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-43]:
-            symbol_id: 7
-            ty_span: [29-36]
-            init_expr: Expr [41-42]:
-                ty: Int(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-43]:
+                symbol_id: 7
+                ty_span: [29-36]
+                init_expr: Expr [41-42]:
                     ty: Int(Some(32), false)
-                    expr: Expr [41-42]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [37-38]:
-            name: y
-            type: Int(Some(32), false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Int(Some(32), false)
+                        expr: Expr [41-42]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [37-38]:
+                name: y
+                type: Int(Some(32), false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -171,33 +171,33 @@ fn to_implicit_uint_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-40]:
-            symbol_id: 7
-            ty_span: [29-33]
-            init_expr: Expr [38-39]:
-                ty: UInt(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-40]:
+                symbol_id: 7
+                ty_span: [29-33]
+                init_expr: Expr [38-39]:
                     ty: UInt(None, false)
-                    expr: Expr [38-39]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [34-35]:
-            name: y
-            type: UInt(None, false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: UInt(None, false)
+                        expr: Expr [38-39]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [34-35]:
+                name: y
+                type: UInt(None, false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -211,33 +211,33 @@ fn to_explicit_uint_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-44]:
-            symbol_id: 7
-            ty_span: [29-37]
-            init_expr: Expr [42-43]:
-                ty: UInt(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-44]:
+                symbol_id: 7
+                ty_span: [29-37]
+                init_expr: Expr [42-43]:
                     ty: UInt(Some(32), false)
-                    expr: Expr [42-43]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [38-39]:
-            name: y
-            type: UInt(Some(32), false)
-            qsharp_type: Int
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: UInt(Some(32), false)
+                        expr: Expr [42-43]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [38-39]:
+                name: y
+                type: UInt(Some(32), false)
+                qsharp_type: Int
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -251,33 +251,33 @@ fn to_explicit_bigint_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-43]:
-            symbol_id: 7
-            ty_span: [29-36]
-            init_expr: Expr [41-42]:
-                ty: Int(Some(65), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-43]:
+                symbol_id: 7
+                ty_span: [29-36]
+                init_expr: Expr [41-42]:
                     ty: Int(Some(65), false)
-                    expr: Expr [41-42]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [37-38]:
-            name: y
-            type: Int(Some(65), false)
-            qsharp_type: BigInt
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Int(Some(65), false)
+                        expr: Expr [41-42]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [37-38]:
+                name: y
+                type: Int(Some(65), false)
+                qsharp_type: BigInt
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -291,33 +291,33 @@ fn to_implicit_float_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-41]:
-            symbol_id: 7
-            ty_span: [29-34]
-            init_expr: Expr [39-40]:
-                ty: Float(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-41]:
+                symbol_id: 7
+                ty_span: [29-34]
+                init_expr: Expr [39-40]:
                     ty: Float(None, false)
-                    expr: Expr [39-40]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [35-36]:
-            name: y
-            type: Float(None, false)
-            qsharp_type: Double
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Float(None, false)
+                        expr: Expr [39-40]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [35-36]:
+                name: y
+                type: Float(None, false)
+                qsharp_type: Double
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -331,33 +331,33 @@ fn to_explicit_float_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-45]:
-            symbol_id: 7
-            ty_span: [29-38]
-            init_expr: Expr [43-44]:
-                ty: Float(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-45]:
+                symbol_id: 7
+                ty_span: [29-38]
+                init_expr: Expr [43-44]:
                     ty: Float(Some(32), false)
-                    expr: Expr [43-44]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [39-40]:
-            name: y
-            type: Float(Some(32), false)
-            qsharp_type: Double
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Float(Some(32), false)
+                        expr: Expr [43-44]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [39-40]:
+                name: y
+                type: Float(Some(32), false)
+                qsharp_type: Double
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -371,33 +371,33 @@ fn to_implicit_complex_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-50]:
-            symbol_id: 7
-            ty_span: [29-43]
-            init_expr: Expr [48-49]:
-                ty: Complex(None, false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-50]:
+                symbol_id: 7
+                ty_span: [29-43]
+                init_expr: Expr [48-49]:
                     ty: Complex(None, false)
-                    expr: Expr [48-49]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [44-45]:
-            name: y
-            type: Complex(None, false)
-            qsharp_type: Complex
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Complex(None, false)
+                        expr: Expr [48-49]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [44-45]:
+                name: y
+                type: Complex(None, false)
+                qsharp_type: Complex
+                io_kind: Default
+        "#]],
     );
 }
 
@@ -411,32 +411,32 @@ fn to_explicit_complex_implicitly() {
     check_classical_decls(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-20]:
-            symbol_id: 6
-            ty_span: [9-12]
-            init_expr: Expr [17-19]:
-                ty: Int(None, true)
-                kind: Lit: Int(42)
-        [6] Symbol [13-14]:
-            name: x
-            type: Int(None, false)
-            qsharp_type: Int
-            io_kind: Default
-        ClassicalDeclarationStmt [29-54]:
-            symbol_id: 7
-            ty_span: [29-47]
-            init_expr: Expr [52-53]:
-                ty: Complex(Some(32), false)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-20]:
+                symbol_id: 6
+                ty_span: [9-12]
+                init_expr: Expr [17-19]:
+                    ty: Int(None, false)
+                    kind: Lit: Int(42)
+            [6] Symbol [13-14]:
+                name: x
+                type: Int(None, false)
+                qsharp_type: Int
+                io_kind: Default
+            ClassicalDeclarationStmt [29-54]:
+                symbol_id: 7
+                ty_span: [29-47]
+                init_expr: Expr [52-53]:
                     ty: Complex(Some(32), false)
-                    expr: Expr [52-53]:
-                        ty: Int(None, false)
-                        kind: SymbolId(6)
-        [7] Symbol [48-49]:
-            name: y
-            type: Complex(Some(32), false)
-            qsharp_type: Complex
-            io_kind: Default
-    "#]],
+                    kind: Cast [0-0]:
+                        ty: Complex(Some(32), false)
+                        expr: Expr [52-53]:
+                            ty: Int(None, false)
+                            kind: SymbolId(6)
+            [7] Symbol [48-49]:
+                name: y
+                type: Complex(Some(32), false)
+                qsharp_type: Complex
+                io_kind: Default
+        "#]],
     );
 }

--- a/compiler/qsc_qasm3/src/semantic/tests/statements/for_stmt.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/statements/for_stmt.rs
@@ -27,7 +27,7 @@ fn shadowing_loop_variable_in_single_stmt_body_fails() {
                                     symbol_id: 6
                                     ty_span: [29-32]
                                     init_expr: Expr [37-38]:
-                                        ty: Int(None, true)
+                                        ty: Int(None, false)
                                         kind: Lit: Int(2)
 
             [Qsc.Qasm3.Compile.RedefinedSymbol
@@ -65,7 +65,7 @@ fn shadowing_loop_variable_in_block_body_succeeds() {
                                 symbol_id: 7
                                 ty_span: [31-34]
                                 init_expr: Expr [39-40]:
-                                    ty: Int(None, true)
+                                    ty: Int(None, false)
                                     kind: Lit: Int(2)
         "#]],
     );
@@ -87,7 +87,7 @@ fn loop_creates_its_own_scope() {
                 symbol_id: 6
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, true)
+                    ty: Int(None, false)
                     kind: Lit: Int(0)
             ForStmt [20-177]:
                 loop_variable: 7
@@ -99,7 +99,7 @@ fn loop_creates_its_own_scope() {
                         symbol_id: 8
                         ty_span: [167-170]
                         init_expr: Expr [175-176]:
-                            ty: Int(None, true)
+                            ty: Int(None, false)
                             kind: Lit: Int(1)
         "#]],
     );

--- a/compiler/qsc_qasm3/src/semantic/tests/statements/for_stmt.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/statements/for_stmt.rs
@@ -18,13 +18,13 @@ fn shadowing_loop_variable_in_single_stmt_body_fails() {
                     Stmt [5-39]:
                         annotations: <empty>
                         kind: ForStmt [5-39]:
-                            loop_variable: 6
+                            loop_variable: 8
                             iterable: DiscreteSet [18-20]:
                                 values: <empty>
                             body: Stmt [29-39]:
                                 annotations: <empty>
                                 kind: ClassicalDeclarationStmt [29-39]:
-                                    symbol_id: 6
+                                    symbol_id: 8
                                     ty_span: [29-32]
                                     init_expr: Expr [37-38]:
                                         ty: Int(None, false)
@@ -53,7 +53,7 @@ fn shadowing_loop_variable_in_block_body_succeeds() {
     ",
         &expect![[r#"
             ForStmt [5-47]:
-                loop_variable: 6
+                loop_variable: 8
                 iterable: DiscreteSet [18-20]:
                     values: <empty>
                 body: Stmt [21-47]:
@@ -62,7 +62,7 @@ fn shadowing_loop_variable_in_block_body_succeeds() {
                         Stmt [31-41]:
                             annotations: <empty>
                             kind: ClassicalDeclarationStmt [31-41]:
-                                symbol_id: 7
+                                symbol_id: 9
                                 ty_span: [31-34]
                                 init_expr: Expr [39-40]:
                                     ty: Int(None, false)
@@ -84,19 +84,19 @@ fn loop_creates_its_own_scope() {
     ",
         &expect![[r#"
             ClassicalDeclarationStmt [5-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
                     ty: Int(None, false)
                     kind: Lit: Int(0)
             ForStmt [20-177]:
-                loop_variable: 7
+                loop_variable: 9
                 iterable: DiscreteSet [33-35]:
                     values: <empty>
                 body: Stmt [167-177]:
                     annotations: <empty>
                     kind: ClassicalDeclarationStmt [167-177]:
-                        symbol_id: 8
+                        symbol_id: 10
                         ty_span: [167-170]
                         init_expr: Expr [175-176]:
                             ty: Int(None, false)

--- a/compiler/qsc_qasm3/src/semantic/tests/statements/if_stmt.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/statements/if_stmt.rs
@@ -8,7 +8,7 @@ use expect_test::expect;
 fn if_branch_doesnt_create_its_own_scope() {
     check_stmt_kinds(
         "
-    int a = 0;
+    int a = 2;
     if (true) int a = 1;
     ",
         &expect![[r#"
@@ -21,8 +21,8 @@ fn if_branch_doesnt_create_its_own_scope() {
                             symbol_id: 6
                             ty_span: [5-8]
                             init_expr: Expr [13-14]:
-                                ty: Int(None, true)
-                                kind: Lit: Int(0)
+                                ty: Int(None, false)
+                                kind: Lit: Int(2)
                     Stmt [20-40]:
                         annotations: <empty>
                         kind: IfStmt [20-40]:
@@ -35,7 +35,7 @@ fn if_branch_doesnt_create_its_own_scope() {
                                     symbol_id: 6
                                     ty_span: [30-33]
                                     init_expr: Expr [38-39]:
-                                        ty: Int(None, true)
+                                        ty: Int(None, false)
                                         kind: Lit: Int(1)
                             else_body: <none>
 
@@ -43,7 +43,7 @@ fn if_branch_doesnt_create_its_own_scope() {
 
               x Redefined symbol: a.
                ,-[test:3:19]
-             2 |     int a = 0;
+             2 |     int a = 2;
              3 |     if (true) int a = 1;
                :                   ^
              4 |     
@@ -56,7 +56,7 @@ fn if_branch_doesnt_create_its_own_scope() {
 fn else_branch_doesnt_create_its_own_scope() {
     check_stmt_kinds(
         "
-    int a = 0;
+    int a = 2;
     if (true) {}
     else int a = 1;
     ",
@@ -70,8 +70,8 @@ fn else_branch_doesnt_create_its_own_scope() {
                             symbol_id: 6
                             ty_span: [5-8]
                             init_expr: Expr [13-14]:
-                                ty: Int(None, true)
-                                kind: Lit: Int(0)
+                                ty: Int(None, false)
+                                kind: Lit: Int(2)
                     Stmt [20-52]:
                         annotations: <empty>
                         kind: IfStmt [20-52]:
@@ -87,7 +87,7 @@ fn else_branch_doesnt_create_its_own_scope() {
                                     symbol_id: 6
                                     ty_span: [42-45]
                                     init_expr: Expr [50-51]:
-                                        ty: Int(None, true)
+                                        ty: Int(None, false)
                                         kind: Lit: Int(1)
 
             [Qsc.Qasm3.Compile.RedefinedSymbol
@@ -107,7 +107,7 @@ fn else_branch_doesnt_create_its_own_scope() {
 fn branch_block_creates_a_new_scope() {
     check_stmt_kinds(
         "
-    int a = 0;
+    int a = 2;
     if (true) { int a = 1; }
     ",
         &expect![[r#"
@@ -115,8 +115,8 @@ fn branch_block_creates_a_new_scope() {
                 symbol_id: 6
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, true)
-                    kind: Lit: Int(0)
+                    ty: Int(None, false)
+                    kind: Lit: Int(2)
             IfStmt [20-44]:
                 condition: Expr [24-28]:
                     ty: Bool(true)
@@ -130,7 +130,7 @@ fn branch_block_creates_a_new_scope() {
                                 symbol_id: 7
                                 ty_span: [32-35]
                                 init_expr: Expr [40-41]:
-                                    ty: Int(None, true)
+                                    ty: Int(None, false)
                                     kind: Lit: Int(1)
                 else_body: <none>
         "#]],
@@ -141,7 +141,7 @@ fn branch_block_creates_a_new_scope() {
 fn if_scope_and_else_scope_are_different() {
     check_stmt_kinds(
         "
-    int a = 0;
+    int a = 2;
     if (true) { int a = 1; }
     else { int a = 2; }
     ",
@@ -150,8 +150,8 @@ fn if_scope_and_else_scope_are_different() {
                 symbol_id: 6
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, true)
-                    kind: Lit: Int(0)
+                    ty: Int(None, false)
+                    kind: Lit: Int(2)
             IfStmt [20-68]:
                 condition: Expr [24-28]:
                     ty: Bool(true)
@@ -165,7 +165,7 @@ fn if_scope_and_else_scope_are_different() {
                                 symbol_id: 7
                                 ty_span: [32-35]
                                 init_expr: Expr [40-41]:
-                                    ty: Int(None, true)
+                                    ty: Int(None, false)
                                     kind: Lit: Int(1)
                 else_body: Stmt [54-68]:
                     annotations: <empty>
@@ -176,7 +176,7 @@ fn if_scope_and_else_scope_are_different() {
                                 symbol_id: 8
                                 ty_span: [56-59]
                                 init_expr: Expr [64-65]:
-                                    ty: Int(None, true)
+                                    ty: Int(None, false)
                                     kind: Lit: Int(2)
         "#]],
     );
@@ -187,21 +187,21 @@ fn condition_cast() {
     check_stmt_kinds(
         "if (1) true;",
         &expect![[r#"
-        IfStmt [0-12]:
-            condition: Expr [4-5]:
-                ty: Bool(false)
-                kind: Cast [0-0]:
-                    ty: Bool(false)
-                    expr: Expr [4-5]:
-                        ty: Int(None, true)
-                        kind: Lit: Int(1)
-            if_body: Stmt [7-12]:
-                annotations: <empty>
-                kind: ExprStmt [7-12]:
-                    expr: Expr [7-11]:
+            IfStmt [0-12]:
+                condition: Expr [4-5]:
+                    ty: Bool(true)
+                    kind: Cast [0-0]:
                         ty: Bool(true)
-                        kind: Lit: Bool(true)
-            else_body: <none>
-    "#]],
+                        expr: Expr [4-5]:
+                            ty: Int(None, true)
+                            kind: Lit: Int(1)
+                if_body: Stmt [7-12]:
+                    annotations: <empty>
+                    kind: ExprStmt [7-12]:
+                        expr: Expr [7-11]:
+                            ty: Bool(true)
+                            kind: Lit: Bool(true)
+                else_body: <none>
+        "#]],
     );
 }

--- a/compiler/qsc_qasm3/src/semantic/tests/statements/if_stmt.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/statements/if_stmt.rs
@@ -18,7 +18,7 @@ fn if_branch_doesnt_create_its_own_scope() {
                     Stmt [5-15]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [5-15]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [5-8]
                             init_expr: Expr [13-14]:
                                 ty: Int(None, false)
@@ -32,7 +32,7 @@ fn if_branch_doesnt_create_its_own_scope() {
                             if_body: Stmt [30-40]:
                                 annotations: <empty>
                                 kind: ClassicalDeclarationStmt [30-40]:
-                                    symbol_id: 6
+                                    symbol_id: 8
                                     ty_span: [30-33]
                                     init_expr: Expr [38-39]:
                                         ty: Int(None, false)
@@ -67,7 +67,7 @@ fn else_branch_doesnt_create_its_own_scope() {
                     Stmt [5-15]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [5-15]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [5-8]
                             init_expr: Expr [13-14]:
                                 ty: Int(None, false)
@@ -84,7 +84,7 @@ fn else_branch_doesnt_create_its_own_scope() {
                             else_body: Stmt [42-52]:
                                 annotations: <empty>
                                 kind: ClassicalDeclarationStmt [42-52]:
-                                    symbol_id: 6
+                                    symbol_id: 8
                                     ty_span: [42-45]
                                     init_expr: Expr [50-51]:
                                         ty: Int(None, false)
@@ -112,7 +112,7 @@ fn branch_block_creates_a_new_scope() {
     ",
         &expect![[r#"
             ClassicalDeclarationStmt [5-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
                     ty: Int(None, false)
@@ -127,7 +127,7 @@ fn branch_block_creates_a_new_scope() {
                         Stmt [32-42]:
                             annotations: <empty>
                             kind: ClassicalDeclarationStmt [32-42]:
-                                symbol_id: 7
+                                symbol_id: 9
                                 ty_span: [32-35]
                                 init_expr: Expr [40-41]:
                                     ty: Int(None, false)
@@ -147,7 +147,7 @@ fn if_scope_and_else_scope_are_different() {
     ",
         &expect![[r#"
             ClassicalDeclarationStmt [5-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
                     ty: Int(None, false)
@@ -162,7 +162,7 @@ fn if_scope_and_else_scope_are_different() {
                         Stmt [32-42]:
                             annotations: <empty>
                             kind: ClassicalDeclarationStmt [32-42]:
-                                symbol_id: 7
+                                symbol_id: 9
                                 ty_span: [32-35]
                                 init_expr: Expr [40-41]:
                                     ty: Int(None, false)
@@ -173,7 +173,7 @@ fn if_scope_and_else_scope_are_different() {
                         Stmt [56-66]:
                             annotations: <empty>
                             kind: ClassicalDeclarationStmt [56-66]:
-                                symbol_id: 8
+                                symbol_id: 10
                                 ty_span: [56-59]
                                 init_expr: Expr [64-65]:
                                     ty: Int(None, false)

--- a/compiler/qsc_qasm3/src/semantic/tests/statements/switch_stmt.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/statements/switch_stmt.rs
@@ -55,7 +55,7 @@ fn cases_introduce_their_own_scope() {
     "#,
         &expect![[r#"
             ClassicalDeclarationStmt [5-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
                     ty: Int(None, false)
@@ -74,7 +74,7 @@ fn cases_introduce_their_own_scope() {
                             Stmt [50-60]:
                                 annotations: <empty>
                                 kind: ClassicalDeclarationStmt [50-60]:
-                                    symbol_id: 7
+                                    symbol_id: 9
                                     ty_span: [50-53]
                                     init_expr: Expr [58-59]:
                                         ty: Int(None, false)
@@ -91,7 +91,7 @@ fn cases_introduce_their_own_scope() {
                             Stmt [83-93]:
                                 annotations: <empty>
                                 kind: ClassicalDeclarationStmt [83-93]:
-                                    symbol_id: 8
+                                    symbol_id: 10
                                     ty_span: [83-86]
                                     init_expr: Expr [91-92]:
                                         ty: Int(None, false)

--- a/compiler/qsc_qasm3/src/semantic/tests/statements/switch_stmt.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/statements/switch_stmt.rs
@@ -47,7 +47,7 @@ fn not_supported_before_version_3_1() {
 fn cases_introduce_their_own_scope() {
     check_stmt_kinds(
         r#"
-    int a = 0;
+    int a = 3;
     switch (1) {
         case 1 { int a = 1; }
         case 2, 3 { int a = 2; }
@@ -58,8 +58,8 @@ fn cases_introduce_their_own_scope() {
                 symbol_id: 6
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, true)
-                    kind: Lit: Int(0)
+                    ty: Int(None, false)
+                    kind: Lit: Int(3)
             SwitchStmt [20-101]:
                 target: Expr [28-29]:
                     ty: Int(None, true)
@@ -77,7 +77,7 @@ fn cases_introduce_their_own_scope() {
                                     symbol_id: 7
                                     ty_span: [50-53]
                                     init_expr: Expr [58-59]:
-                                        ty: Int(None, true)
+                                        ty: Int(None, false)
                                         kind: Lit: Int(1)
                     SwitchCase [71-95]:
                         labels:
@@ -94,7 +94,7 @@ fn cases_introduce_their_own_scope() {
                                     symbol_id: 8
                                     ty_span: [83-86]
                                     init_expr: Expr [91-92]:
-                                        ty: Int(None, true)
+                                        ty: Int(None, false)
                                         kind: Lit: Int(2)
                 default_case: <none>
         "#]],
@@ -108,9 +108,9 @@ fn target_cast() {
         &expect![[r#"
             SwitchStmt [0-31]:
                 target: Expr [8-12]:
-                    ty: Int(None, false)
+                    ty: Int(None, true)
                     kind: Cast [0-0]:
-                        ty: Int(None, false)
+                        ty: Int(None, true)
                         expr: Expr [8-12]:
                             ty: Bool(true)
                             kind: Lit: Bool(true)
@@ -118,9 +118,9 @@ fn target_cast() {
                     SwitchCase [16-29]:
                         labels:
                             Expr [21-26]:
-                                ty: Int(None, false)
+                                ty: Int(None, true)
                                 kind: Cast [0-0]:
-                                    ty: Int(None, false)
+                                    ty: Int(None, true)
                                     expr: Expr [21-26]:
                                         ty: Bool(true)
                                         kind: Lit: Bool(false)

--- a/compiler/qsc_qasm3/src/semantic/tests/statements/while_stmt.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/statements/while_stmt.rs
@@ -18,7 +18,7 @@ fn single_stmt_body_doesnt_creates_its_own_scope() {
                     Stmt [5-15]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [5-15]:
-                            symbol_id: 6
+                            symbol_id: 8
                             ty_span: [5-8]
                             init_expr: Expr [13-14]:
                                 ty: Int(None, false)
@@ -32,7 +32,7 @@ fn single_stmt_body_doesnt_creates_its_own_scope() {
                             body: Stmt [32-42]:
                                 annotations: <empty>
                                 kind: ClassicalDeclarationStmt [32-42]:
-                                    symbol_id: 6
+                                    symbol_id: 8
                                     ty_span: [32-35]
                                     init_expr: Expr [40-41]:
                                         ty: Int(None, false)
@@ -60,7 +60,7 @@ fn block_body_creates_its_own_scope() {
     ",
         &expect![[r#"
             ClassicalDeclarationStmt [5-15]:
-                symbol_id: 6
+                symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
                     ty: Int(None, false)
@@ -75,7 +75,7 @@ fn block_body_creates_its_own_scope() {
                         Stmt [34-44]:
                             annotations: <empty>
                             kind: ClassicalDeclarationStmt [34-44]:
-                                symbol_id: 7
+                                symbol_id: 9
                                 ty_span: [34-37]
                                 init_expr: Expr [42-43]:
                                     ty: Int(None, false)

--- a/compiler/qsc_qasm3/src/semantic/tests/statements/while_stmt.rs
+++ b/compiler/qsc_qasm3/src/semantic/tests/statements/while_stmt.rs
@@ -8,7 +8,7 @@ use expect_test::expect;
 fn single_stmt_body_doesnt_creates_its_own_scope() {
     check_stmt_kinds(
         "
-    int a = 0;
+    int a = 3;
     while(true) int a = 1;
     ",
         &expect![[r#"
@@ -21,8 +21,8 @@ fn single_stmt_body_doesnt_creates_its_own_scope() {
                             symbol_id: 6
                             ty_span: [5-8]
                             init_expr: Expr [13-14]:
-                                ty: Int(None, true)
-                                kind: Lit: Int(0)
+                                ty: Int(None, false)
+                                kind: Lit: Int(3)
                     Stmt [20-42]:
                         annotations: <empty>
                         kind: WhileLoop [20-42]:
@@ -35,14 +35,14 @@ fn single_stmt_body_doesnt_creates_its_own_scope() {
                                     symbol_id: 6
                                     ty_span: [32-35]
                                     init_expr: Expr [40-41]:
-                                        ty: Int(None, true)
+                                        ty: Int(None, false)
                                         kind: Lit: Int(1)
 
             [Qsc.Qasm3.Compile.RedefinedSymbol
 
               x Redefined symbol: a.
                ,-[test:3:21]
-             2 |     int a = 0;
+             2 |     int a = 3;
              3 |     while(true) int a = 1;
                :                     ^
              4 |     
@@ -55,7 +55,7 @@ fn single_stmt_body_doesnt_creates_its_own_scope() {
 fn block_body_creates_its_own_scope() {
     check_stmt_kinds(
         "
-    int a = 0;
+    int a = 3;
     while(true) { int a = 1; }
     ",
         &expect![[r#"
@@ -63,8 +63,8 @@ fn block_body_creates_its_own_scope() {
                 symbol_id: 6
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, true)
-                    kind: Lit: Int(0)
+                    ty: Int(None, false)
+                    kind: Lit: Int(3)
             WhileLoop [20-46]:
                 condition: Expr [26-30]:
                     ty: Bool(true)
@@ -78,7 +78,7 @@ fn block_body_creates_its_own_scope() {
                                 symbol_id: 7
                                 ty_span: [34-37]
                                 init_expr: Expr [42-43]:
-                                    ty: Int(None, true)
+                                    ty: Int(None, false)
                                     kind: Lit: Int(1)
         "#]],
     );
@@ -91,9 +91,9 @@ fn condition_cast() {
         &expect![[r#"
             WhileLoop [0-15]:
                 condition: Expr [7-8]:
-                    ty: Bool(false)
+                    ty: Bool(true)
                     kind: Cast [0-0]:
-                        ty: Bool(false)
+                        ty: Bool(true)
                         expr: Expr [7-8]:
                             ty: Int(None, true)
                             kind: Lit: Int(1)

--- a/compiler/qsc_qasm3/src/semantic/types.rs
+++ b/compiler/qsc_qasm3/src/semantic/types.rs
@@ -235,6 +235,22 @@ impl Type {
         }
     }
 
+    pub(crate) fn as_non_const(&self) -> Type {
+        match self {
+            Type::Bit(_) => Self::Bit(false),
+            Type::Bool(_) => Self::Bool(false),
+            Type::Duration(_) => Self::Duration(false),
+            Type::Stretch(_) => Self::Stretch(false),
+            Type::Angle(w, _) => Self::Angle(*w, false),
+            Type::Complex(w, _) => Self::Complex(*w, false),
+            Type::Float(w, _) => Self::Float(*w, false),
+            Type::Int(w, _) => Self::Int(*w, false),
+            Type::UInt(w, _) => Self::UInt(*w, false),
+            Type::BitArray(dims, _) => Self::BitArray(dims.clone(), false),
+            _ => self.clone(),
+        }
+    }
+
     pub(crate) fn is_quantum(&self) -> bool {
         matches!(
             self,

--- a/compiler/qsc_qasm3/src/semantic/types.rs
+++ b/compiler/qsc_qasm3/src/semantic/types.rs
@@ -398,8 +398,10 @@ pub(crate) fn promote_to_uint_ty(
 }
 
 fn get_uint_ty(ty: &Type) -> Option<Type> {
-    if matches!(ty, Type::UInt(..) | Type::Angle(..)) {
+    if matches!(ty, Type::Int(..) | Type::UInt(..) | Type::Angle(..)) {
         Some(Type::UInt(ty.width(), ty.is_const()))
+    } else if matches!(ty, Type::Bool(..) | Type::Bit(..)) {
+        Some(Type::UInt(Some(1), ty.is_const()))
     } else if let Type::BitArray(dims, _) = ty {
         match dims {
             ArrayDimensions::One(d) => Some(Type::UInt(Some(*d), ty.is_const())),

--- a/compiler/qsc_qasm3/src/semantic/types.rs
+++ b/compiler/qsc_qasm3/src/semantic/types.rs
@@ -177,187 +177,43 @@ impl Type {
     #[must_use]
     pub fn get_indexed_type(&self) -> Option<Self> {
         let ty = match self {
-            Type::BitArray(dims, is_const) => match dims {
-                ArrayDimensions::One(_) => Type::Bit(*is_const),
-                ArrayDimensions::Two(d1, _) => Type::BitArray(ArrayDimensions::One(*d1), *is_const),
-                ArrayDimensions::Three(d1, d2, _) => {
-                    Type::BitArray(ArrayDimensions::Two(*d1, *d2), *is_const)
-                }
-                ArrayDimensions::Four(d1, d2, d3, _) => {
-                    Type::BitArray(ArrayDimensions::Three(*d1, *d2, *d3), *is_const)
-                }
-                ArrayDimensions::Five(d1, d2, d3, d4, _) => {
-                    Type::BitArray(ArrayDimensions::Four(*d1, *d2, *d3, *d4), *is_const)
-                }
-                ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
-                    Type::BitArray(ArrayDimensions::Five(*d1, *d2, *d3, *d4, *d5), *is_const)
-                }
-                ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => Type::BitArray(
-                    ArrayDimensions::Six(*d1, *d2, *d3, *d4, *d5, *d6),
-                    *is_const,
-                ),
-                ArrayDimensions::Err => Type::Err,
-            },
-            Type::QubitArray(dims) => match dims {
-                ArrayDimensions::One(_) => Type::Qubit,
-                ArrayDimensions::Two(d1, _) => Type::QubitArray(ArrayDimensions::One(*d1)),
-                ArrayDimensions::Three(d1, d2, _) => {
-                    Type::QubitArray(ArrayDimensions::Two(*d1, *d2))
-                }
-                ArrayDimensions::Four(d1, d2, d3, _) => {
-                    Type::QubitArray(ArrayDimensions::Three(*d1, *d2, *d3))
-                }
-                ArrayDimensions::Five(d1, d2, d3, d4, _) => {
-                    Type::QubitArray(ArrayDimensions::Four(*d1, *d2, *d3, *d4))
-                }
-                ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
-                    Type::QubitArray(ArrayDimensions::Five(*d1, *d2, *d3, *d4, *d5))
-                }
-                ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => {
-                    Type::QubitArray(ArrayDimensions::Six(*d1, *d2, *d3, *d4, *d5, *d6))
-                }
-                ArrayDimensions::Err => Type::Err,
-            },
-            Type::BoolArray(dims) => match dims {
-                ArrayDimensions::One(_) => Type::Bool(false),
-                ArrayDimensions::Two(d1, _) => Type::BoolArray(ArrayDimensions::One(*d1)),
-                ArrayDimensions::Three(d1, d2, _) => {
-                    Type::BoolArray(ArrayDimensions::Two(*d1, *d2))
-                }
-                ArrayDimensions::Four(d1, d2, d3, _) => {
-                    Type::BoolArray(ArrayDimensions::Three(*d1, *d2, *d3))
-                }
-                ArrayDimensions::Five(d1, d2, d3, d4, _) => {
-                    Type::BoolArray(ArrayDimensions::Four(*d1, *d2, *d3, *d4))
-                }
-                ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
-                    Type::BoolArray(ArrayDimensions::Five(*d1, *d2, *d3, *d4, *d5))
-                }
-                ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => {
-                    Type::BoolArray(ArrayDimensions::Six(*d1, *d2, *d3, *d4, *d5, *d6))
-                }
-                ArrayDimensions::Err => Type::Err,
-            },
-            Type::AngleArray(size, dims) => match dims {
-                ArrayDimensions::One(_) => Type::Angle(*size, false),
-                ArrayDimensions::Two(d1, _) => Type::AngleArray(*size, ArrayDimensions::One(*d1)),
-                ArrayDimensions::Three(d1, d2, _) => {
-                    Type::AngleArray(*size, ArrayDimensions::Two(*d1, *d2))
-                }
-                ArrayDimensions::Four(d1, d2, d3, _) => {
-                    Type::AngleArray(*size, ArrayDimensions::Three(*d1, *d2, *d3))
-                }
-                ArrayDimensions::Five(d1, d2, d3, d4, _) => {
-                    Type::AngleArray(*size, ArrayDimensions::Four(*d1, *d2, *d3, *d4))
-                }
-                ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
-                    Type::AngleArray(*size, ArrayDimensions::Five(*d1, *d2, *d3, *d4, *d5))
-                }
-                ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => {
-                    Type::AngleArray(*size, ArrayDimensions::Six(*d1, *d2, *d3, *d4, *d5, *d6))
-                }
-                ArrayDimensions::Err => Type::Err,
-            },
-            Type::ComplexArray(size, dims) => match dims {
-                ArrayDimensions::One(_) => Type::Complex(*size, false),
-                ArrayDimensions::Two(d1, _) => Type::ComplexArray(*size, ArrayDimensions::One(*d1)),
-                ArrayDimensions::Three(d1, d2, _) => {
-                    Type::ComplexArray(*size, ArrayDimensions::Two(*d1, *d2))
-                }
-                ArrayDimensions::Four(d1, d2, d3, _) => {
-                    Type::ComplexArray(*size, ArrayDimensions::Three(*d1, *d2, *d3))
-                }
-                ArrayDimensions::Five(d1, d2, d3, d4, _) => {
-                    Type::ComplexArray(*size, ArrayDimensions::Four(*d1, *d2, *d3, *d4))
-                }
-                ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
-                    Type::ComplexArray(*size, ArrayDimensions::Five(*d1, *d2, *d3, *d4, *d5))
-                }
-                ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => {
-                    Type::ComplexArray(*size, ArrayDimensions::Six(*d1, *d2, *d3, *d4, *d5, *d6))
-                }
-                ArrayDimensions::Err => Type::Err,
-            },
-            Type::DurationArray(dims) => match dims {
-                ArrayDimensions::One(_) => Type::Duration(false),
-                ArrayDimensions::Two(d1, _) => Type::DurationArray(ArrayDimensions::One(*d1)),
-                ArrayDimensions::Three(d1, d2, _) => {
-                    Type::DurationArray(ArrayDimensions::Two(*d1, *d2))
-                }
-                ArrayDimensions::Four(d1, d2, d3, _) => {
-                    Type::DurationArray(ArrayDimensions::Three(*d1, *d2, *d3))
-                }
-                ArrayDimensions::Five(d1, d2, d3, d4, _) => {
-                    Type::DurationArray(ArrayDimensions::Four(*d1, *d2, *d3, *d4))
-                }
-                ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
-                    Type::DurationArray(ArrayDimensions::Five(*d1, *d2, *d3, *d4, *d5))
-                }
-                ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => {
-                    Type::DurationArray(ArrayDimensions::Six(*d1, *d2, *d3, *d4, *d5, *d6))
-                }
-                ArrayDimensions::Err => Type::Err,
-            },
-            Type::FloatArray(size, dims) => match dims {
-                ArrayDimensions::One(_) => Type::Float(*size, false),
-                ArrayDimensions::Two(d1, _) => Type::FloatArray(*size, ArrayDimensions::One(*d1)),
-                ArrayDimensions::Three(d1, d2, _) => {
-                    Type::FloatArray(*size, ArrayDimensions::Two(*d1, *d2))
-                }
-                ArrayDimensions::Four(d1, d2, d3, _) => {
-                    Type::FloatArray(*size, ArrayDimensions::Three(*d1, *d2, *d3))
-                }
-                ArrayDimensions::Five(d1, d2, d3, d4, _) => {
-                    Type::FloatArray(*size, ArrayDimensions::Four(*d1, *d2, *d3, *d4))
-                }
-                ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
-                    Type::FloatArray(*size, ArrayDimensions::Five(*d1, *d2, *d3, *d4, *d5))
-                }
-                ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => {
-                    Type::FloatArray(*size, ArrayDimensions::Six(*d1, *d2, *d3, *d4, *d5, *d6))
-                }
-                ArrayDimensions::Err => Type::Err,
-            },
-            Type::IntArray(size, dims) => match dims {
-                ArrayDimensions::One(_) => Type::Int(*size, false),
-                ArrayDimensions::Two(d1, _) => Type::IntArray(*size, ArrayDimensions::One(*d1)),
-                ArrayDimensions::Three(d1, d2, _) => {
-                    Type::IntArray(*size, ArrayDimensions::Two(*d1, *d2))
-                }
-                ArrayDimensions::Four(d1, d2, d3, _) => {
-                    Type::IntArray(*size, ArrayDimensions::Three(*d1, *d2, *d3))
-                }
-                ArrayDimensions::Five(d1, d2, d3, d4, _) => {
-                    Type::IntArray(*size, ArrayDimensions::Four(*d1, *d2, *d3, *d4))
-                }
-                ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
-                    Type::IntArray(*size, ArrayDimensions::Five(*d1, *d2, *d3, *d4, *d5))
-                }
-                ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => {
-                    Type::IntArray(*size, ArrayDimensions::Six(*d1, *d2, *d3, *d4, *d5, *d6))
-                }
-                ArrayDimensions::Err => Type::Err,
-            },
-            Type::UIntArray(size, dims) => match dims {
-                ArrayDimensions::One(_) => Type::UInt(*size, false),
-                ArrayDimensions::Two(d1, _) => Type::UIntArray(*size, ArrayDimensions::One(*d1)),
-                ArrayDimensions::Three(d1, d2, _) => {
-                    Type::UIntArray(*size, ArrayDimensions::Two(*d1, *d2))
-                }
-                ArrayDimensions::Four(d1, d2, d3, _) => {
-                    Type::UIntArray(*size, ArrayDimensions::Three(*d1, *d2, *d3))
-                }
-                ArrayDimensions::Five(d1, d2, d3, d4, _) => {
-                    Type::UIntArray(*size, ArrayDimensions::Four(*d1, *d2, *d3, *d4))
-                }
-                ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
-                    Type::UIntArray(*size, ArrayDimensions::Five(*d1, *d2, *d3, *d4, *d5))
-                }
-                ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => {
-                    Type::UIntArray(*size, ArrayDimensions::Six(*d1, *d2, *d3, *d4, *d5, *d6))
-                }
-                ArrayDimensions::Err => Type::Err,
-            },
+            Type::BitArray(dims, is_const) => indexed_type_builder(
+                || Type::Bit(*is_const),
+                |d| Type::BitArray(d, *is_const),
+                dims,
+            ),
+            Type::QubitArray(dims) => indexed_type_builder(|| Type::Qubit, Type::QubitArray, dims),
+            Type::BoolArray(dims) => {
+                indexed_type_builder(|| Type::Bool(false), Type::BoolArray, dims)
+            }
+            Type::AngleArray(size, dims) => indexed_type_builder(
+                || Type::Angle(*size, false),
+                |d| Type::AngleArray(*size, d),
+                dims,
+            ),
+            Type::ComplexArray(size, dims) => indexed_type_builder(
+                || Type::Complex(*size, false),
+                |d| Type::ComplexArray(*size, d),
+                dims,
+            ),
+            Type::DurationArray(dims) => {
+                indexed_type_builder(|| Type::Duration(false), Type::DurationArray, dims)
+            }
+            Type::FloatArray(size, dims) => indexed_type_builder(
+                || Type::Float(*size, false),
+                |d| Type::FloatArray(*size, d),
+                dims,
+            ),
+            Type::IntArray(size, dims) => indexed_type_builder(
+                || Type::Int(*size, false),
+                |d| Type::IntArray(*size, d),
+                dims,
+            ),
+            Type::UIntArray(size, dims) => indexed_type_builder(
+                || Type::UInt(*size, false),
+                |d| Type::UIntArray(*size, d),
+                dims,
+            ),
             _ => return None,
         };
         Some(ty)
@@ -387,7 +243,28 @@ impl Type {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+fn indexed_type_builder(
+    ty: impl Fn() -> Type,
+    ty_array: impl Fn(ArrayDimensions) -> Type,
+    dims: &ArrayDimensions,
+) -> Type {
+    match dims.clone() {
+        ArrayDimensions::One(_) => ty(),
+        ArrayDimensions::Two(d1, _) => ty_array(ArrayDimensions::One(d1)),
+        ArrayDimensions::Three(d1, d2, _) => ty_array(ArrayDimensions::Two(d1, d2)),
+        ArrayDimensions::Four(d1, d2, d3, _) => ty_array(ArrayDimensions::Three(d1, d2, d3)),
+        ArrayDimensions::Five(d1, d2, d3, d4, _) => ty_array(ArrayDimensions::Four(d1, d2, d3, d4)),
+        ArrayDimensions::Six(d1, d2, d3, d4, d5, _) => {
+            ty_array(ArrayDimensions::Five(d1, d2, d3, d4, d5))
+        }
+        ArrayDimensions::Seven(d1, d2, d3, d4, d5, d6, _) => {
+            ty_array(ArrayDimensions::Six(d1, d2, d3, d4, d5, d6))
+        }
+        ArrayDimensions::Err => Type::Err,
+    }
+}
+
+#[derive(Debug, Clone, Default, Eq, Hash, PartialEq)]
 pub enum ArrayDimensions {
     One(u32),
     Two(u32, u32),
@@ -398,6 +275,12 @@ pub enum ArrayDimensions {
     Seven(u32, u32, u32, u32, u32, u32, u32),
     #[default]
     Err,
+}
+
+impl From<u32> for ArrayDimensions {
+    fn from(value: u32) -> Self {
+        Self::One(value)
+    }
 }
 
 impl Display for ArrayDimensions {

--- a/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bit.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bit.rs
@@ -199,6 +199,6 @@ fn to_implicit_float_implicitly_fails() {
         panic!("Expected error")
     };
 
-    expect![r#"Cannot cast expression of type Bit(False) to type Float(None, False)"#]
+    expect!["Cannot cast expression of type Bit(false) to type Float(None, false)"]
         .assert_eq(&error[0].to_string());
 }

--- a/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bitarray.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_bitarray.rs
@@ -106,7 +106,7 @@ fn to_int_with_higher_width_implicitly_fails() {
         panic!("Expected error")
     };
 
-    expect![r#"Cannot cast expression of type BitArray(D1(5), False) to type Int(Some(6), False)"#]
+    expect!["Cannot cast expression of type BitArray(One(5), false) to type Int(Some(6), false)"]
         .assert_eq(&error[0].to_string());
 }
 
@@ -121,7 +121,7 @@ fn to_int_with_higher_width_decl_implicitly_fails() {
         panic!("Expected error")
     };
 
-    expect![r#"Cannot cast expression of type BitArray(D1(5), False) to type Int(Some(6), False)"#]
+    expect!["Cannot cast expression of type BitArray(One(5), false) to type Int(Some(6), false)"]
         .assert_eq(&error[0].to_string());
 }
 
@@ -137,7 +137,7 @@ fn to_int_with_lower_width_implicitly_fails() {
         panic!("Expected error")
     };
 
-    expect![r#"Cannot cast expression of type BitArray(D1(5), False) to type Int(Some(4), False)"#]
+    expect!["Cannot cast expression of type BitArray(One(5), false) to type Int(Some(4), false)"]
         .assert_eq(&error[0].to_string());
 }
 
@@ -152,6 +152,6 @@ fn to_int_with_lower_width_decl_implicitly_fails() {
         panic!("Expected error")
     };
 
-    expect![r#"Cannot cast expression of type BitArray(D1(5), False) to type Int(Some(4), False)"#]
+    expect!["Cannot cast expression of type BitArray(One(5), false) to type Int(Some(4), false)"]
         .assert_eq(&error[0].to_string());
 }

--- a/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_float.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/implicit_cast_from_float.rs
@@ -17,7 +17,7 @@ fn to_bit_implicitly() {
         panic!("Expected error")
     };
 
-    expect![r#"Cannot cast expression of type Float(None, False) to type Bit(False)"#]
+    expect!["Cannot cast expression of type Float(None, false) to type Bit(false)"]
         .assert_eq(&error[0].to_string());
 }
 

--- a/compiler/qsc_qasm3/src/tests/statement.rs
+++ b/compiler/qsc_qasm3/src/tests/statement.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 mod annotation;
+mod const_eval;
 mod end;
 mod for_loop;
 mod gate_call;

--- a/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
@@ -455,7 +455,8 @@ fn binary_op_shl_creg_fails() {
            :             ^
          5 |     
            `----
-    "#]].assert_eq(&errs_string);
+    "#]]
+    .assert_eq(&errs_string);
 }
 
 // Shr
@@ -618,7 +619,8 @@ fn binary_op_shr_creg_fails() {
            :             ^
          5 |     
            `----
-    "#]].assert_eq(&errs_string);
+    "#]]
+    .assert_eq(&errs_string);
 }
 
 // BinaryOp: Bitwise

--- a/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! The tests in this file need to check that const exprs are
+//! evaluatable at lowering time. To do that we use them in
+//! contexts where they need to be const-evaluated, like array
+//! sizes or type widths.
+
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;
@@ -81,27 +86,6 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
          6 |         bit[c] r2;
            `----
 
-        Qsc.Qasm3.Compile.Unimplemented
-
-          x this statement is not yet handled during OpenQASM 3 import: Converting Err
-          | to Q# type
-           ,-[Test.qasm:5:9]
-         4 |         int c = a + 3;
-         5 |         bit[b] r1;
-           :         ^^^^^^
-         6 |         bit[c] r2;
-           `----
-
-        Qsc.Qasm3.Compile.NotSupported
-
-          x Default values for Err are unsupported. are not supported.
-           ,-[Test.qasm:5:9]
-         4 |         int c = a + 3;
-         5 |         bit[b] r1;
-           :         ^^^^^^^^^^
-         6 |         bit[c] r2;
-           `----
-
         Qsc.Qasm3.Compile.ExprMustBeConst
 
           x designator must be a const expression
@@ -109,28 +93,7 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
          5 |         bit[b] r1;
          6 |         bit[c] r2;
            :             ^
-         7 |     
-           `----
-
-        Qsc.Qasm3.Compile.Unimplemented
-
-          x this statement is not yet handled during OpenQASM 3 import: Converting Err
-          | to Q# type
-           ,-[Test.qasm:6:9]
-         5 |         bit[b] r1;
-         6 |         bit[c] r2;
-           :         ^^^^^^
-         7 |     
-           `----
-
-        Qsc.Qasm3.Compile.NotSupported
-
-          x Default values for Err are unsupported. are not supported.
-           ,-[Test.qasm:6:9]
-         5 |         bit[b] r1;
-         6 |         bit[c] r2;
-           :         ^^^^^^^^^^
-         7 |     
+         7 |
            `----
 
     "#]]

--- a/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
@@ -55,7 +55,7 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
     let source = r#"
         const int a = 1;
         int b = 2 + a;
-        int b = a + 3;
+        int c = a + 3;
         bit[b] r1;
         bit[c] r2;
     "#;
@@ -74,32 +74,63 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
         Qsc.Qasm3.Compile.ExprMustBeConst
 
           x designator must be a const expression
-           ,-[Test.qasm:4:13]
-         3 |         int b = 2 + a;
-         4 |         bit[b] r1;
+           ,-[Test.qasm:5:13]
+         4 |         int c = a + 3;
+         5 |         bit[b] r1;
            :             ^
-         5 |
+         6 |         bit[c] r2;
            `----
 
         Qsc.Qasm3.Compile.Unimplemented
 
           x this statement is not yet handled during OpenQASM 3 import: Converting Err
           | to Q# type
-           ,-[Test.qasm:4:9]
-         3 |         int b = 2 + a;
-         4 |         bit[b] r1;
+           ,-[Test.qasm:5:9]
+         4 |         int c = a + 3;
+         5 |         bit[b] r1;
            :         ^^^^^^
-         5 |
+         6 |         bit[c] r2;
            `----
 
         Qsc.Qasm3.Compile.NotSupported
 
           x Default values for Err are unsupported. are not supported.
-           ,-[Test.qasm:4:9]
-         3 |         int b = 2 + a;
-         4 |         bit[b] r1;
+           ,-[Test.qasm:5:9]
+         4 |         int c = a + 3;
+         5 |         bit[b] r1;
            :         ^^^^^^^^^^
-         5 |
+         6 |         bit[c] r2;
+           `----
+
+        Qsc.Qasm3.Compile.ExprMustBeConst
+
+          x designator must be a const expression
+           ,-[Test.qasm:6:13]
+         5 |         bit[b] r1;
+         6 |         bit[c] r2;
+           :             ^
+         7 |     
+           `----
+
+        Qsc.Qasm3.Compile.Unimplemented
+
+          x this statement is not yet handled during OpenQASM 3 import: Converting Err
+          | to Q# type
+           ,-[Test.qasm:6:9]
+         5 |         bit[b] r1;
+         6 |         bit[c] r2;
+           :         ^^^^^^
+         7 |     
+           `----
+
+        Qsc.Qasm3.Compile.NotSupported
+
+          x Default values for Err are unsupported. are not supported.
+           ,-[Test.qasm:6:9]
+         5 |         bit[b] r1;
+         6 |         bit[c] r2;
+           :         ^^^^^^^^^^
+         7 |     
            `----
 
     "#]]

--- a/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
@@ -128,6 +128,7 @@ fn ident_const() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
+#[ignore = "indexed ident is not yet supported"]
 fn indexed_ident() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const uint[2] a = {1, 2};
@@ -147,7 +148,7 @@ fn indexed_ident() -> miette::Result<(), Vec<Report>> {
 // UnaryOp Float
 
 #[test]
-fn unary_op_float_neg() -> miette::Result<(), Vec<Report>> {
+fn unary_op_neg_float() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const float a = -1.0;
         const float b = -a;
@@ -165,63 +166,7 @@ fn unary_op_float_neg() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn unary_op_float_notb_fails() {
-    let source = r#"
-        const float a = -1.0;
-        const float b = ~a;
-        bit[b] r;
-    "#;
-
-    let Err(errs) = compile_qasm_to_qsharp(source) else {
-        panic!("should have generated an error");
-    };
-    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
-    let errs_string = errs.join("\n");
-    expect![[r#"
-        Qsc.Qasm3.Compile.TypeDoesNotSupportedUnaryNegation
-
-          x Unary negation is not allowed for instances of Float(None, true).
-           ,-[Test.qasm:3:26]
-         2 |         const float a = -1.0;
-         3 |         const float b = ~a;
-           :                          ^
-         4 |         bit[b] r;
-           `----
-    "#]]
-    .assert_eq(&errs_string);
-}
-
-#[test]
-fn unary_op_float_notl_fails() {
-    let source = r#"
-        const float a = -1.0;
-        const float b = !a;
-        bit[b] r;
-    "#;
-
-    let Err(errs) = compile_qasm_to_qsharp(source) else {
-        panic!("should have generated an error");
-    };
-    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
-    let errs_string = errs.join("\n");
-    expect![[r#"
-        Qsc.Qasm3.Compile.ExprMustBeConst
-
-          x designator must be a const expression
-           ,-[Test.qasm:4:13]
-         3 |         const float b = !a;
-         4 |         bit[b] r;
-           :             ^
-         5 |
-           `----
-    "#]]
-    .assert_eq(&errs_string);
-}
-
-// UnaryOp Int
-
-#[test]
-fn unary_op_int_neg() -> miette::Result<(), Vec<Report>> {
+fn unary_op_neg_int() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const int a = -1;
         const int b = -a;
@@ -239,46 +184,68 @@ fn unary_op_int_neg() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn unary_op_int_notb() -> miette::Result<(), Vec<Report>> {
+#[ignore = "casting float to angle is not yet supported"]
+fn unary_op_neg_angle() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        const int a = 1;
-        const int b = ~a;
+        const angle a = -1.0;
+        const bool b = a;
         bit[b] r;
     "#;
 
     let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 1;
-        mutable r = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
+    expect![[r#""#]].assert_eq(&qsharp);
     Ok(())
 }
 
 #[test]
-fn unary_op_int_notl() -> miette::Result<(), Vec<Report>> {
+fn unary_op_negb_uint() {
     let source = r#"
-        const int a = 1;
-        const int b = !a;
+        const uint a = 5;
+        const uint b = ~a;
+        bit[~a] r;
+    "#;
+
+    let Err(errs) = compile_qasm_to_qsharp(source) else {
+        panic!("should have generated an error");
+    };
+    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
+    let errs_string = errs.join("\n");
+    expect![[r#"
+        Qsc.Qasm3.Compile.ExprMustBeConst
+
+          x designator must be a const expression
+           ,-[Test.qasm:4:14]
+         3 |         const uint b = ~a;
+         4 |         bit[~a] r;
+           :              ^
+         5 |
+           `----
+    "#]]
+    .assert_eq(&errs_string);
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn unary_op_negb_angle() {
+    let source = r#"
+        const angle a = 1.0;
+        const bool b = ~a;
         bit[b] r;
     "#;
 
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 1;
-        mutable r = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
+    let Err(errs) = compile_qasm_to_qsharp(source) else {
+        panic!("should have generated an error");
+    };
+    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
+    let errs_string = errs.join("\n");
+    expect![[r#""#]].assert_eq(&errs_string);
 }
 
-// UnaryOp UInt
-
 #[test]
-fn unary_op_uint_neg_not_allowed() {
+fn unary_op_negb_bit() {
     let source = r#"
-        const uint a = -1;
-        const uint b = -a;
+        const bit a = 0;
+        const bit b = ~a;
         bit[b] r;
     "#;
 
@@ -288,52 +255,44 @@ fn unary_op_uint_neg_not_allowed() {
     let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
     let errs_string = errs.join("\n");
     expect![[r#"
-        Qsc.Qasm3.Compile.TypeDoesNotSupportedUnaryNegation
+        Qsc.Qasm3.Compile.ExprMustBeConst
 
-          x Unary negation is not allowed for instances of UInt(None, true).
-           ,-[Test.qasm:3:25]
-         2 |         const uint a = -1;
-         3 |         const uint b = -a;
-           :                         ^
+          x designator must be a const expression
+           ,-[Test.qasm:4:13]
+         3 |         const bit b = ~a;
          4 |         bit[b] r;
+           :             ^
+         5 |
            `----
     "#]]
     .assert_eq(&errs_string);
 }
 
 #[test]
-fn unary_op_uint_notb() -> miette::Result<(), Vec<Report>> {
+fn unary_op_negb_bitarray() {
     let source = r#"
-        const uint a = 1;
-        const uint b = ~a;
+        const bit[3] a = "101";
+        const uint[3] b = ~a;
         bit[b] r;
     "#;
 
-    let qsharp = compile_qasm_to_qsharp(source)?;
+    let Err(errs) = compile_qasm_to_qsharp(source) else {
+        panic!("should have generated an error");
+    };
+    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
+    let errs_string = errs.join("\n");
     expect![[r#"
-        let a = Microsoft.Quantum.Math.Truncate(-1.);
-        let b = -a;
-        mutable r = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
+        Qsc.Qasm3.Compile.ExprMustBeConst
 
-#[test]
-fn unary_op_uint_notl() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const uint a = 1;
-        const uint b = !a;
-        bit[b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 1;
-        mutable r = [Zero];
+          x designator must be a const expression
+           ,-[Test.qasm:4:13]
+         3 |         const uint[3] b = ~a;
+         4 |         bit[b] r;
+           :             ^
+         5 |
+           `----
     "#]]
-    .assert_eq(&qsharp);
-    Ok(())
+    .assert_eq(&errs_string);
 }
 
 // BinaryOp
@@ -358,10 +317,574 @@ fn lhs_ty_equals_rhs_ty_assumption_holds() -> miette::Result<(), Vec<Report>> {
     Ok(())
 }
 
-// BinaryOp Float
+// BinaryOp: Bit Shifts
+
+// Shl
 
 #[test]
-fn binary_op_float_add() -> miette::Result<(), Vec<Report>> {
+fn binary_op_shl_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 1;
+        const uint b = a << 2;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a <<< 2;
+        mutable r = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn binary_op_shl_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const angle a = 1;
+        const angle b = a << 2;
+        const bool c = b;
+        bit[c] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_shl_bit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 1;
+        const bit b = a << 2;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a <<< 2;
+        mutable r = [];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_shl_bitarray() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit[3] a = "101";
+        const bit[3] b = a << 2;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 5;
+        let b = a <<< 2;
+        mutable r = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// Shr
+
+#[test]
+fn binary_op_shr_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 5;
+        const uint b = a >> 2;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 5;
+        let b = a >>> 2;
+        mutable r = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn binary_op_shr_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const angle a = 1;
+        const angle b = a >> 2;
+        const bool c = b;
+        bit[c] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_shr_bit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 1;
+        const bit b = a >> 2;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a >>> 2;
+        mutable r = [];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_shr_bitarray() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit[4] a = "1011";
+        const bit[4] b = a >> 2;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a <<< 2;
+        mutable r = [Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// BinaryOp: Bitwise
+
+// AndB
+
+#[test]
+fn binary_op_andb_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 5;
+        const uint b = a & 6;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 5;
+        let b = a &&& 6;
+        mutable r = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn binary_op_andb_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const angle a = 1;
+        const angle b = a & 2;
+        const bool c = b;
+        bit[c] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_andb_bit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 1;
+        const bit b = a & 0;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a &&& 0;
+        mutable r = [];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_andb_bitarray() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit[4] a = "1011";
+        const bit[4] b = a & "0110";
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 11;
+        let b = a &&& 6;
+        mutable r = [Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// OrB
+
+#[test]
+fn binary_op_orb_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 5;
+        const uint b = a | 6;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 6;
+        let b = a ||| 6;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn binary_op_orb_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const angle a = 1.0;
+        const angle b = a | 2.0;
+        const bool c = b;
+        bit[c] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_orb_bit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 1;
+        const bit b = a | 0;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a ||| 0;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_orb_bitarray() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit[3] a = "001";
+        const bit[3] b = a | "100";
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a <<< 4;
+        mutable r = [Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// XorB
+
+#[test]
+fn binary_op_xorb_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 5;
+        const uint b = a ^ 6;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a <<< 2;
+        mutable r = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn binary_op_xorb_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const angle a = 1;
+        const angle b = a ^ 2;
+        const bool c = b;
+        bit[c] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_xorb_bit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 1;
+        const bit b = a ^ 1;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a <<< 2;
+        mutable r = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_xorb_bitarray() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit[4] a = "1011";
+        const bit[4] b = a ^ "1110";
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = a <<< 2;
+        mutable r = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// Binary Logical
+
+#[test]
+fn binary_op_andl_bool() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool f = false;
+        const bool t = true;
+        bit[f && f] r1;
+        bit[f && t] r2;
+        bit[t && f] r3;
+        bit[t && t] r4;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let f = false;
+        let t = true;
+        mutable r1 = [];
+        mutable r2 = [];
+        mutable r3 = [];
+        mutable r4 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_orl_bool() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool f = false;
+        const bool t = true;
+        bit[f || f] r1;
+        bit[f || t] r2;
+        bit[t || f] r3;
+        bit[t || t] r4;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let f = false;
+        let t = true;
+        mutable r1 = [];
+        mutable r2 = [Zero];
+        mutable r3 = [Zero];
+        mutable r4 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// BinaryOp: Comparison
+
+// Eq
+
+#[test]
+fn binary_op_comparison_int() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 2;
+        bit[a == a] r1;
+        bit[a != a] r2;
+        bit[a > a] r3;
+        bit[a >= a] r4;
+        bit[a < a] r5;
+        bit[a <= a] r6;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 2;
+        mutable r1 = [Zero];
+        mutable r2 = [];
+        mutable r3 = [];
+        mutable r4 = [Zero];
+        mutable r5 = [];
+        mutable r6 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_comparison_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 2;
+        bit[a == a] r1;
+        bit[a != a] r2;
+        bit[a > a] r3;
+        bit[a >= a] r4;
+        bit[a < a] r5;
+        bit[a <= a] r6;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 2;
+        mutable r1 = [Zero];
+        mutable r2 = [];
+        mutable r3 = [];
+        mutable r4 = [Zero];
+        mutable r5 = [];
+        mutable r6 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn binary_op_comparison_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const angle a = 2.0;
+        bit[a == a] r1;
+        bit[a != a] r2;
+        bit[a > a] r3;
+        bit[a >= a] r4;
+        bit[a < a] r5;
+        bit[a <= a] r6;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_comparison_bit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 1;
+        bit[a == a] r1;
+        bit[a != a] r2;
+        bit[a > a] r3;
+        bit[a >= a] r4;
+        bit[a < a] r5;
+        bit[a <= a] r6;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = One;
+        mutable r1 = [Zero];
+        mutable r2 = [];
+        mutable r3 = [];
+        mutable r4 = [Zero];
+        mutable r5 = [];
+        mutable r6 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_comparison_bitarray() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit[2] a = "10";
+        bit[a == a] r1;
+        bit[a != a] r2;
+        bit[a > a] r3;
+        bit[a >= a] r4;
+        bit[a < a] r5;
+        bit[a <= a] r6;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+// BinaryOp: Arithmetic
+
+// Add
+
+#[test]
+fn binary_op_add_int() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 1;
+        const int b = 2;
+        bit[a + b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_add_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 1;
+        const uint b = 2;
+        bit[a + b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_add_float() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const float a = 1.0;
         const float b = 2.0;
@@ -379,99 +902,23 @@ fn binary_op_float_add() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn binary_op_float_sub() -> miette::Result<(), Vec<Report>> {
+#[ignore = "angles are not yet supported"]
+fn binary_op_add_angle() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        const float a = 3.0;
-        const float b = 2.0;
-        bit[a - b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3.;
-        let b = 2.;
-        mutable r = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_float_mul() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const float a = 3.0;
-        const float b = 2.0;
-        bit[a * b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3.;
-        let b = 2.;
-        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_float_div() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const float a = 6.0;
-        const float b = 2.0;
-        bit[a / b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 6.;
-        let b = 2.;
-        mutable r = [Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_float_pow() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const float a = 2.0;
-        const float b = 3.0;
-        bit[a ** b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 2.;
-        let b = 3.;
-        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-// BinaryOp Int
-
-#[test]
-fn binary_op_int_add() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const int a = 1;
-        const int b = 2;
+        const angle a = 1.0;
+        const angle b = 2.0;
         bit[a + b] r;
     "#;
 
     let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 1;
-        let b = 2;
-        mutable r = [Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
+    expect![[r#""#]].assert_eq(&qsharp);
     Ok(())
 }
 
+// Sub
+
 #[test]
-fn binary_op_int_sub() -> miette::Result<(), Vec<Report>> {
+fn binary_op_sub_int() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const int a = 3;
         const int b = 2;
@@ -489,7 +936,59 @@ fn binary_op_int_sub() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn binary_op_int_mul() -> miette::Result<(), Vec<Report>> {
+fn binary_op_sub_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 3;
+        const uint b = 2;
+        bit[a - b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 2;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_sub_float() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 3.0;
+        const float b = 2.0;
+        bit[a - b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3.;
+        let b = 2.;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn binary_op_sub_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 3.0;
+        const float b = 2.0;
+        bit[a - b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+// Mul
+
+#[test]
+fn binary_op_mul_int() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const int a = 3;
         const int b = 2;
@@ -507,7 +1006,60 @@ fn binary_op_int_mul() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn binary_op_int_div() -> miette::Result<(), Vec<Report>> {
+fn binary_op_mul_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 3;
+        const uint b = 2;
+        bit[a * b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_mul_float() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 3.0;
+        const float b = 2.0;
+        bit[a * b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3.;
+        let b = 2.;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn binary_op_mul_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 3.0;
+        const uint b = 2;
+        bit[a * b] r1;
+        bit[b * a] r2;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+// Div
+
+#[test]
+fn binary_op_div_int() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const int a = 6;
         const int b = 2;
@@ -525,171 +1077,7 @@ fn binary_op_int_div() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn binary_op_int_pow() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const int a = 2;
-        const int b = 3;
-        bit[a ** b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 2;
-        let b = 3;
-        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_int_shl() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const int a = 1;
-        const int b = 2;
-        bit[a << b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 1;
-        let b = 2;
-        mutable r = [Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_int_shr() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const int a = 8;
-        const int b = 2;
-        bit[a >> b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 8;
-        let b = 2;
-        mutable r = [Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_int_andb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const int a = 3;
-        const int b = 6;
-        bit[a & b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3;
-        let b = 6;
-        mutable r = [Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_int_orb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const int a = 3;
-        const int b = 6;
-        bit[a | b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3;
-        let b = 6;
-        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_int_xorb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const int a = 3;
-        const int b = 6;
-        bit[a ^ b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3;
-        let b = 6;
-        mutable r = [Zero, Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-// BinaryOp UInt
-
-#[test]
-fn binary_op_uint_add() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const uint a = 1;
-        const uint b = 2;
-        bit[a + b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 1;
-        let b = 2;
-        mutable r = [Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_uint_sub() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const uint a = 3;
-        const uint b = 2;
-        bit[a - b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3;
-        let b = 2;
-        mutable r = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_uint_mul() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const uint a = 3;
-        const uint b = 2;
-        bit[a * b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3;
-        let b = 2;
-        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_uint_div() -> miette::Result<(), Vec<Report>> {
+fn binary_op_div_uint() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const uint a = 6;
         const uint b = 2;
@@ -707,7 +1095,93 @@ fn binary_op_uint_div() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn binary_op_uint_pow() -> miette::Result<(), Vec<Report>> {
+fn binary_op_div_float() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 6.0;
+        const float b = 2.0;
+        bit[a / b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 6.;
+        let b = 2.;
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn binary_op_div_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const angle a = 6.0;
+        const uint b = 2;
+        bit[a / b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+// Mod
+
+#[test]
+fn binary_op_mod_int() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 8;
+        bit[a % 3] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 8;
+        mutable r = [Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_mod_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 8;
+        bit[a % 3] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 8;
+        mutable r = [Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// Pow
+
+#[test]
+fn binary_op_pow_int() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 2;
+        const int b = 3;
+        bit[a ** b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 2;
+        let b = 3;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_pow_uint() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const uint a = 2;
         const uint b = 3;
@@ -725,442 +1199,284 @@ fn binary_op_uint_pow() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn binary_op_uint_shl() -> miette::Result<(), Vec<Report>> {
+fn binary_op_pow_float() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        const uint a = 1;
-        const uint b = 2;
-        bit[a << b] r;
+        const float a = 2.0;
+        const float b = 3.0;
+        bit[a ** b] r;
     "#;
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        let a = 1;
-        let b = 2;
-        mutable r = [Zero, Zero, Zero, Zero];
+        let a = 2.;
+        let b = 3.;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
     "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
 
+// Cast
+
 #[test]
-fn binary_op_uint_shr() -> miette::Result<(), Vec<Report>> {
+fn cast_to_bool() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        const uint a = 8;
-        const uint b = 2;
-        bit[a >> b] r;
+        const int a = 0;
+        const uint b = 1;
+        const float c = 2.0;
+        // const angle d = 2.0;
+        const bit e = 1;
+
+        const bool s1 = a;
+        const bool s2 = b;
+        const bool s3 = c;
+        // const bool s4 = d;
+        const bool s5 = e;
+
+        bit[s1] r1;
+        bit[s2] r2;
+        bit[s3] r3;
+        // bit[s4] r4;
+        bit[s5] r5;
     "#;
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        let a = 8;
-        let b = 2;
-        mutable r = [Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_uint_andb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const uint a = 3;
-        const uint b = 6;
-        bit[a & b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3;
-        let b = 6;
-        mutable r = [Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_uint_orb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const uint a = 3;
-        const uint b = 6;
-        bit[a | b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3;
-        let b = 6;
-        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_uint_xorb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const uint a = 3;
-        const uint b = 6;
-        bit[a ^ b] r;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3;
-        let b = 6;
-        mutable r = [Zero, Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-// Binary Bool
-
-#[test]
-fn binary_op_bool_andb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bool a = true;
-        const bool b = true;
-        bit[a & b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = true;
-        let b = true;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bool_andl() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bool a = true;
-        const bool b = true;
-        bit[a && b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = true;
-        let b = true;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bool_orb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bool a = false;
-        const bool b = true;
-        bit[a | b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = false;
-        let b = true;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bool_orl() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bool a = false;
-        const bool b = true;
-        bit[a || b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = false;
-        let b = true;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bool_xor() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bool a = false;
-        const bool b = true;
-        bit[a ^ b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = false;
-        let b = true;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bool_eq() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bool a = true;
-        const bool b = true;
-        bit[a == b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = true;
-        let b = true;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bool_neq() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bool a = false;
-        const bool b = true;
-        bit[a != b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = false;
-        let b = true;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bool_gt() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bool a = false;
-        const bool b = true;
-        bit[b > a] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = false;
-        let b = true;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bool_lt() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bool a = false;
-        const bool b = true;
-        bit[a < b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = false;
-        let b = true;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-// BinaryOp Bit
-
-#[test]
-fn binary_op_bit_andb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bit a = 1;
-        const bit b = 1;
-        bit[a & b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let f = 1;
-        let t = 1;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bit_andl() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bit a = 1;
-        const bit b = 1;
-        bit[a && b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = One;
-        let b = One;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bit_orb() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bit a = 0;
-        const bit b = 1;
-        bit[a | b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let f = false;
-        let t = 1;
-        mutable r1 = [Zero];
+        function __ResultAsBool__(input : Result) : Bool {
+            Microsoft.Quantum.Convert.ResultAsBool(input)
+        }
+        let a = 0;
+        let b = 1;
+        let c = 2.;
+        let e = One;
+        let s1 = if a == 0 {
+            false
+        } else {
+            true
+        };
+        let s2 = if b == 0 {
+            false
+        } else {
+            true
+        };
+        let s3 = if Microsoft.Quantum.Math.Truncate(c) == 0 {
+            false
+        } else {
+            true
+        };
+        let s5 = __ResultAsBool__(e);
+        mutable r1 = [];
         mutable r2 = [Zero];
         mutable r3 = [Zero];
-        mutable r4 = [Zero];
+        mutable r5 = [Zero];
     "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
 
 #[test]
-fn binary_op_bit_orl() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bit a = 0;
-        const bit b = 1;
-        bit[a || b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = Zero;
-        let b = One;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bit_xor() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bit a = 0;
-        const bit b = 1;
-        bit[a ^ b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let f = false;
-        let t = 1;
-        mutable r1 = [Zero];
-        mutable r2 = [Zero];
-        mutable r3 = [Zero];
-        mutable r4 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bit_eq() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bit a = 1;
-        const bit b = 1;
-        bit[a == b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = One;
-        let b = One;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bit_neq() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bit a = 0;
-        const bit b = 1;
-        bit[a != b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = Zero;
-        let b = One;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bit_gt() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bit a = 0;
-        const bit b = 1;
-        bit[b > a] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = Zero;
-        let b = One;
-        mutable r1 = [Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-#[test]
-fn binary_op_bit_lt() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        const bit a = 0;
-        const bit b = 1;
-        bit[a > b] r1;
-    "#;
-
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        let a = 3;
-        let b = 6;
-        mutable r = [Zero, Zero, Zero, Zero, Zero];
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
-}
-
-// Casting
-
-#[test]
-fn casting_bool_to_uint() -> miette::Result<(), Vec<Report>> {
+fn cast_to_int() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const bool a = true;
-        bit[a] r;
+        const uint b = 2;
+        const float c = 3.0;
+        const bit d = 0;
+
+        const int s1 = a;
+        const int s2 = b;
+        const int s3 = c;
+        const int s4 = d;
+
+        bit[s1] r1;
+        bit[s2] r2;
+        bit[s3] r3;
+        bit[s4] r4;
     "#;
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
+        function __BoolAsInt__(value : Bool) : Int {
+            if value {
+                1
+            } else {
+                0
+            }
+        }
+        function __ResultAsInt__(input : Result) : Int {
+            if Microsoft.Quantum.Convert.ResultAsBool(input) {
+                1
+            } else {
+                0
+            }
+        }
         let a = true;
-        mutable r = [Zero];
+        let b = 2;
+        let c = 3.;
+        let d = Zero;
+        let s1 = __BoolAsInt__(a);
+        let s2 = b;
+        let s3 = Microsoft.Quantum.Math.Truncate(c);
+        let s4 = __ResultAsInt__(d);
+        mutable r1 = [Zero];
+        mutable r2 = [Zero, Zero];
+        mutable r3 = [Zero, Zero, Zero];
+        mutable r4 = [];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn cast_to_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = true;
+        const uint b = 2;
+        const float c = 3.0;
+        const bit d = 0;
+
+        const uint s1 = a;
+        const uint s2 = b;
+        const uint s3 = c;
+        const uint s4 = d;
+
+        bit[s1] r1;
+        bit[s2] r2;
+        bit[s3] r3;
+        bit[s4] r4;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        function __BoolAsInt__(value : Bool) : Int {
+            if value {
+                1
+            } else {
+                0
+            }
+        }
+        function __ResultAsInt__(input : Result) : Int {
+            if Microsoft.Quantum.Convert.ResultAsBool(input) {
+                1
+            } else {
+                0
+            }
+        }
+        let a = true;
+        let b = 2;
+        let c = 3.;
+        let d = Zero;
+        let s1 = __BoolAsInt__(a);
+        let s2 = b;
+        let s3 = Microsoft.Quantum.Math.Truncate(c);
+        let s4 = __ResultAsInt__(d);
+        mutable r1 = [Zero];
+        mutable r2 = [Zero, Zero];
+        mutable r3 = [Zero, Zero, Zero];
+        mutable r4 = [];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn cast_to_float() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = true;
+        const int b = 2;
+        const uint c = 3;
+
+        const float s1 = a;
+        const float s2 = b;
+        const float s3 = c;
+
+        bit[s1] r1;
+        bit[s2] r2;
+        bit[s3] r3;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        function __BoolAsDouble__(value : Bool) : Double {
+            if value {
+                1.
+            } else {
+                0.
+            }
+        }
+        let a = true;
+        let b = 2;
+        let c = 3;
+        let s1 = __BoolAsDouble__(a);
+        let s2 = Microsoft.Quantum.Convert.IntAsDouble(b);
+        let s3 = Microsoft.Quantum.Convert.IntAsDouble(c);
+        mutable r1 = [Zero];
+        mutable r2 = [Zero, Zero];
+        mutable r3 = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "angles are not yet supported"]
+fn cast_to_angle() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 2.0;
+        const bit b = 1;
+
+        const angle s1 = a;
+        const angle s2 = b;
+
+        bit[s1] r1;
+        bit[s2] r2;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#""#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn cast_to_bit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = false;
+        const int b = 1;
+        const uint c = 2;
+        // const angle d = 3.0;
+
+        const bit s1 = a;
+        const bit s2 = b;
+        const bit s3 = c;
+        // const bit s4 = d;
+
+        bit[s1] r1;
+        bit[s2] r2;
+        bit[s3] r3;
+        // bit[s4] r4;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        function __BoolAsResult__(input : Bool) : Result {
+            Microsoft.Quantum.Convert.BoolAsResult(input)
+        }
+        let a = false;
+        let b = 1;
+        let c = 2;
+        let s1 = __BoolAsResult__(a);
+        let s2 = if b == 0 {
+            One
+        } else {
+            Zero
+        };
+        let s3 = if c == 0 {
+            One
+        } else {
+            Zero
+        };
+        mutable r1 = [];
+        mutable r2 = [Zero];
+        mutable r3 = [Zero];
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::compile_qasm_to_qsharp;
+use expect_test::expect;
+use miette::Report;
+use std::fmt::Write;
+
+#[test]
+fn const_exprs_work_in_bitarray_size_position() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 1;
+        const int b = 2 + a;
+        const int c = a + 3;
+        bit[b] r1;
+        bit[c] r2;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2 + a;
+        let c = a + 3;
+        mutable r1 = [Zero, Zero, Zero];
+        mutable r2 = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn const_exprs_implicit_cast_work_in_bitarray_size_position() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 1;
+        const float b = 2.0 + a;
+        const float c = a + 3.0;
+        bit[b] r1;
+        bit[c] r2;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2. + Microsoft.Quantum.Convert.IntAsDouble(a);
+        let c = Microsoft.Quantum.Convert.IntAsDouble(a) + 3.;
+        mutable r1 = [Zero, Zero, Zero];
+        mutable r2 = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn non_const_exprs_fail_in_bitarray_size_position() {
+    let source = r#"
+        const int a = 1;
+        int b = 2 + a;
+        int b = a + 3;
+        bit[b] r1;
+        bit[c] r2;
+    "#;
+
+    let Err(errs) = compile_qasm_to_qsharp(source) else {
+        panic!("non const array size should have generated an error");
+    };
+
+    let mut errs_string = String::new();
+
+    for err in errs {
+        writeln!(&mut errs_string, "{err:?}").expect("");
+    }
+
+    expect![[r#"
+        Qsc.Qasm3.Compile.ExprMustBeConst
+
+          x designator must be a const expression
+           ,-[Test.qasm:4:13]
+         3 |         int b = 2 + a;
+         4 |         bit[b] r1;
+           :             ^
+         5 |
+           `----
+
+        Qsc.Qasm3.Compile.Unimplemented
+
+          x this statement is not yet handled during OpenQASM 3 import: Converting Err
+          | to Q# type
+           ,-[Test.qasm:4:9]
+         3 |         int b = 2 + a;
+         4 |         bit[b] r1;
+           :         ^^^^^^
+         5 |
+           `----
+
+        Qsc.Qasm3.Compile.NotSupported
+
+          x Default values for Err are unsupported. are not supported.
+           ,-[Test.qasm:4:9]
+         3 |         int b = 2 + a;
+         4 |         bit[b] r1;
+           :         ^^^^^^^^^^
+         5 |
+           `----
+
+    "#]]
+    .assert_eq(&errs_string);
+}
+
+#[test]
+fn can_assign_const_expr_to_non_const_decl() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 1;
+        const int b = 2;
+        int c = a + b;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2;
+        mutable c = a + b;
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}

--- a/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
@@ -93,7 +93,7 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
          5 |         bit[b] r1;
          6 |         bit[c] r2;
            :             ^
-         7 |
+         7 |     
            `----
 
     "#]]

--- a/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
@@ -87,7 +87,7 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
          5 |         bit[b] r1;
          6 |         bit[c] r2;
            :             ^
-         7 |
+         7 |     
            `----
     "#]]
     .assert_eq(&errs_string);
@@ -218,7 +218,7 @@ fn unary_op_negb_uint() {
          3 |         const uint b = ~a;
          4 |         bit[~a] r;
            :              ^
-         5 |
+         5 |     
            `----
     "#]]
     .assert_eq(&errs_string);
@@ -262,7 +262,7 @@ fn unary_op_negb_bit() {
          3 |         const bit b = ~a;
          4 |         bit[b] r;
            :             ^
-         5 |
+         5 |     
            `----
     "#]]
     .assert_eq(&errs_string);
@@ -289,7 +289,7 @@ fn unary_op_negb_bitarray() {
          3 |         const uint[3] b = ~a;
          4 |         bit[b] r;
            :             ^
-         5 |
+         5 |     
            `----
     "#]]
     .assert_eq(&errs_string);

--- a/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/const_eval.rs
@@ -9,7 +9,6 @@
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;
-use std::fmt::Write;
 
 #[test]
 fn const_exprs_work_in_bitarray_size_position() -> miette::Result<(), Vec<Report>> {
@@ -66,15 +65,10 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
     "#;
 
     let Err(errs) = compile_qasm_to_qsharp(source) else {
-        panic!("non const array size should have generated an error");
+        panic!("should have generated an error");
     };
-
-    let mut errs_string = String::new();
-
-    for err in errs {
-        writeln!(&mut errs_string, "{err:?}").expect("");
-    }
-
+    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
+    let errs_string = errs.join("\n");
     expect![[r#"
         Qsc.Qasm3.Compile.ExprMustBeConst
 
@@ -93,9 +87,8 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
          5 |         bit[b] r1;
          6 |         bit[c] r2;
            :             ^
-         7 |     
+         7 |
            `----
-
     "#]]
     .assert_eq(&errs_string);
 }
@@ -113,6 +106,1061 @@ fn can_assign_const_expr_to_non_const_decl() -> miette::Result<(), Vec<Report>> 
         let a = 1;
         let b = 2;
         mutable c = a + b;
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn ident_const() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 1;
+        bit[a] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn indexed_ident() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint[2] a = {1, 2};
+        bit[a[1]] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2;
+        mutable c = a + b;
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// UnaryOp Float
+
+#[test]
+fn unary_op_float_neg() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = -1.0;
+        const float b = -a;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = -1.;
+        let b = -a;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn unary_op_float_notb_fails() {
+    let source = r#"
+        const float a = -1.0;
+        const float b = ~a;
+        bit[b] r;
+    "#;
+
+    let Err(errs) = compile_qasm_to_qsharp(source) else {
+        panic!("should have generated an error");
+    };
+    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
+    let errs_string = errs.join("\n");
+    expect![[r#"
+        Qsc.Qasm3.Compile.TypeDoesNotSupportedUnaryNegation
+
+          x Unary negation is not allowed for instances of Float(None, true).
+           ,-[Test.qasm:3:26]
+         2 |         const float a = -1.0;
+         3 |         const float b = ~a;
+           :                          ^
+         4 |         bit[b] r;
+           `----
+    "#]]
+    .assert_eq(&errs_string);
+}
+
+#[test]
+fn unary_op_float_notl_fails() {
+    let source = r#"
+        const float a = -1.0;
+        const float b = !a;
+        bit[b] r;
+    "#;
+
+    let Err(errs) = compile_qasm_to_qsharp(source) else {
+        panic!("should have generated an error");
+    };
+    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
+    let errs_string = errs.join("\n");
+    expect![[r#"
+        Qsc.Qasm3.Compile.ExprMustBeConst
+
+          x designator must be a const expression
+           ,-[Test.qasm:4:13]
+         3 |         const float b = !a;
+         4 |         bit[b] r;
+           :             ^
+         5 |
+           `----
+    "#]]
+    .assert_eq(&errs_string);
+}
+
+// UnaryOp Int
+
+#[test]
+fn unary_op_int_neg() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = -1;
+        const int b = -a;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = -1;
+        let b = -a;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn unary_op_int_notb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 1;
+        const int b = ~a;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn unary_op_int_notl() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 1;
+        const int b = !a;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// UnaryOp UInt
+
+#[test]
+fn unary_op_uint_neg_not_allowed() {
+    let source = r#"
+        const uint a = -1;
+        const uint b = -a;
+        bit[b] r;
+    "#;
+
+    let Err(errs) = compile_qasm_to_qsharp(source) else {
+        panic!("should have generated an error");
+    };
+    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
+    let errs_string = errs.join("\n");
+    expect![[r#"
+        Qsc.Qasm3.Compile.TypeDoesNotSupportedUnaryNegation
+
+          x Unary negation is not allowed for instances of UInt(None, true).
+           ,-[Test.qasm:3:25]
+         2 |         const uint a = -1;
+         3 |         const uint b = -a;
+           :                         ^
+         4 |         bit[b] r;
+           `----
+    "#]]
+    .assert_eq(&errs_string);
+}
+
+#[test]
+fn unary_op_uint_notb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 1;
+        const uint b = ~a;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = Microsoft.Quantum.Math.Truncate(-1.);
+        let b = -a;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn unary_op_uint_notl() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 1;
+        const uint b = !a;
+        bit[b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// BinaryOp
+
+#[test]
+fn lhs_ty_equals_rhs_ty_assumption_holds() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 1;
+        const float b = 2.0;
+        const uint c = a + b;
+        bit[c] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2.;
+        let c = Microsoft.Quantum.Math.Truncate(Microsoft.Quantum.Convert.IntAsDouble(a) + b);
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// BinaryOp Float
+
+#[test]
+fn binary_op_float_add() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 1.0;
+        const float b = 2.0;
+        bit[a + b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1.;
+        let b = 2.;
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_float_sub() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 3.0;
+        const float b = 2.0;
+        bit[a - b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3.;
+        let b = 2.;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_float_mul() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 3.0;
+        const float b = 2.0;
+        bit[a * b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3.;
+        let b = 2.;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_float_div() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 6.0;
+        const float b = 2.0;
+        bit[a / b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 6.;
+        let b = 2.;
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_float_pow() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const float a = 2.0;
+        const float b = 3.0;
+        bit[a ** b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 2.;
+        let b = 3.;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// BinaryOp Int
+
+#[test]
+fn binary_op_int_add() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 1;
+        const int b = 2;
+        bit[a + b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_int_sub() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 3;
+        const int b = 2;
+        bit[a - b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 2;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_int_mul() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 3;
+        const int b = 2;
+        bit[a * b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_int_div() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 6;
+        const int b = 2;
+        bit[a / b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 6;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_int_pow() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 2;
+        const int b = 3;
+        bit[a ** b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 2;
+        let b = 3;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_int_shl() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 1;
+        const int b = 2;
+        bit[a << b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_int_shr() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 8;
+        const int b = 2;
+        bit[a >> b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 8;
+        let b = 2;
+        mutable r = [Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_int_andb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 3;
+        const int b = 6;
+        bit[a & b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 6;
+        mutable r = [Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_int_orb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 3;
+        const int b = 6;
+        bit[a | b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 6;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_int_xorb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const int a = 3;
+        const int b = 6;
+        bit[a ^ b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 6;
+        mutable r = [Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// BinaryOp UInt
+
+#[test]
+fn binary_op_uint_add() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 1;
+        const uint b = 2;
+        bit[a + b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_uint_sub() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 3;
+        const uint b = 2;
+        bit[a - b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 2;
+        mutable r = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_uint_mul() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 3;
+        const uint b = 2;
+        bit[a * b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_uint_div() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 6;
+        const uint b = 2;
+        bit[a / b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 6;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_uint_pow() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 2;
+        const uint b = 3;
+        bit[a ** b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 2;
+        let b = 3;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_uint_shl() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 1;
+        const uint b = 2;
+        bit[a << b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 1;
+        let b = 2;
+        mutable r = [Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_uint_shr() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 8;
+        const uint b = 2;
+        bit[a >> b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 8;
+        let b = 2;
+        mutable r = [Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_uint_andb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 3;
+        const uint b = 6;
+        bit[a & b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 6;
+        mutable r = [Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_uint_orb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 3;
+        const uint b = 6;
+        bit[a | b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 6;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_uint_xorb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const uint a = 3;
+        const uint b = 6;
+        bit[a ^ b] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 6;
+        mutable r = [Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// Binary Bool
+
+#[test]
+fn binary_op_bool_andb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = true;
+        const bool b = true;
+        bit[a & b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = true;
+        let b = true;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bool_andl() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = true;
+        const bool b = true;
+        bit[a && b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = true;
+        let b = true;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bool_orb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = false;
+        const bool b = true;
+        bit[a | b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = false;
+        let b = true;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bool_orl() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = false;
+        const bool b = true;
+        bit[a || b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = false;
+        let b = true;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bool_xor() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = false;
+        const bool b = true;
+        bit[a ^ b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = false;
+        let b = true;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bool_eq() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = true;
+        const bool b = true;
+        bit[a == b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = true;
+        let b = true;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bool_neq() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = false;
+        const bool b = true;
+        bit[a != b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = false;
+        let b = true;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bool_gt() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = false;
+        const bool b = true;
+        bit[b > a] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = false;
+        let b = true;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bool_lt() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = false;
+        const bool b = true;
+        bit[a < b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = false;
+        let b = true;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// BinaryOp Bit
+
+#[test]
+fn binary_op_bit_andb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 1;
+        const bit b = 1;
+        bit[a & b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let f = 1;
+        let t = 1;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bit_andl() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 1;
+        const bit b = 1;
+        bit[a && b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = One;
+        let b = One;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bit_orb() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 0;
+        const bit b = 1;
+        bit[a | b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let f = false;
+        let t = 1;
+        mutable r1 = [Zero];
+        mutable r2 = [Zero];
+        mutable r3 = [Zero];
+        mutable r4 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bit_orl() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 0;
+        const bit b = 1;
+        bit[a || b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = Zero;
+        let b = One;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bit_xor() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 0;
+        const bit b = 1;
+        bit[a ^ b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let f = false;
+        let t = 1;
+        mutable r1 = [Zero];
+        mutable r2 = [Zero];
+        mutable r3 = [Zero];
+        mutable r4 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bit_eq() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 1;
+        const bit b = 1;
+        bit[a == b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = One;
+        let b = One;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bit_neq() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 0;
+        const bit b = 1;
+        bit[a != b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = Zero;
+        let b = One;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bit_gt() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 0;
+        const bit b = 1;
+        bit[b > a] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = Zero;
+        let b = One;
+        mutable r1 = [Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn binary_op_bit_lt() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bit a = 0;
+        const bit b = 1;
+        bit[a > b] r1;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = 3;
+        let b = 6;
+        mutable r = [Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+// Casting
+
+#[test]
+fn casting_bool_to_uint() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        const bool a = true;
+        bit[a] r;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let a = true;
+        mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
@@ -36,6 +36,35 @@ fn u_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
+fn gphase_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        qubit q;
+        gphase(2.0);
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![
+        r#"
+        operation U(theta : Double, phi : Double, lambda : Double, qubit : Qubit) : Unit is Adj + Ctl {
+            body ... {
+                Rz(lambda, qubit);
+                Ry(theta, qubit);
+                Rz(phi, qubit);
+                R(PauliI, -lambda - phi - theta, qubit);
+            }
+            adjoint auto;
+            controlled auto;
+            controlled adjoint auto;
+        }
+        let q = QIR.Runtime.__quantum__rt__qubit_allocate();
+        U(1., 2., 3., q);
+        "#
+    ]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
 fn x_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";

--- a/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
@@ -38,29 +38,11 @@ fn u_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 #[test]
 fn gphase_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        qubit q;
         gphase(2.0);
     "#;
 
     let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![
-        r#"
-        operation U(theta : Double, phi : Double, lambda : Double, qubit : Qubit) : Unit is Adj + Ctl {
-            body ... {
-                Rz(lambda, qubit);
-                Ry(theta, qubit);
-                Rz(phi, qubit);
-                R(PauliI, -lambda - phi - theta, qubit);
-            }
-            adjoint auto;
-            controlled auto;
-            controlled adjoint auto;
-        }
-        let q = QIR.Runtime.__quantum__rt__qubit_allocate();
-        U(1., 2., 3., q);
-        "#
-    ]
-    .assert_eq(&qsharp);
+    expect![r#""#].assert_eq(&qsharp);
     Ok(())
 }
 

--- a/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
@@ -7,6 +7,35 @@ use miette::Report;
 use qsc::target::Profile;
 
 #[test]
+fn u_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        qubit q;
+        U(1.0, 2.0, 3.0) q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![
+        r#"
+        operation U(theta : Double, phi : Double, lambda : Double, qubit : Qubit) : Unit is Adj + Ctl {
+            body ... {
+                Rz(lambda, qubit);
+                Ry(theta, qubit);
+                Rz(phi, qubit);
+                R(PauliI, -lambda - phi - theta, qubit);
+            }
+            adjoint auto;
+            controlled auto;
+            controlled adjoint auto;
+        }
+        let q = QIR.Runtime.__quantum__rt__qubit_allocate();
+        U(1., 2., 3., q);
+        "#
+    ]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
 fn x_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";

--- a/compiler/qsc_qasm3/src/tests/statement/if_stmt.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/if_stmt.rs
@@ -147,6 +147,6 @@ fn using_cond_that_cannot_implicit_cast_to_bool_fail() {
         panic!("Expected error");
     };
 
-    expect![r#"Cannot cast expression of type Qubit to type Bool(False)"#]
+    expect!["Cannot cast expression of type Qubit to type Bool(false)"]
         .assert_eq(&errors[0].to_string());
 }

--- a/compiler/qsc_qasm3/src/tests/statement/switch.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/switch.rs
@@ -8,7 +8,7 @@ use miette::Report;
 #[test]
 fn default_is_optional() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        OPENQASM 3.0;
+        OPENQASM 3.1;
         int i = 15;
         switch (i) {
             case 1 {
@@ -33,7 +33,7 @@ fn default_is_optional() -> miette::Result<(), Vec<Report>> {
 #[test]
 fn default_as_only_case_causes_parse_error() {
     let source = r#"
-        OPENQASM 3.0;
+        OPENQASM 3.1;
         int i = 15;
         switch (i) {
             default {
@@ -53,7 +53,7 @@ fn default_as_only_case_causes_parse_error() {
 #[test]
 fn no_cases_causes_parse_error() {
     let source = r#"
-        OPENQASM 3.0;
+        OPENQASM 3.1;
         int i = 15;
         switch (i) {
         }
@@ -70,7 +70,7 @@ fn no_cases_causes_parse_error() {
 #[test]
 fn spec_case_1() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        OPENQASM 3.0;
+        OPENQASM 3.1;
         include "stdgates.inc";
         qubit q;
 
@@ -115,7 +115,7 @@ fn spec_case_1() -> miette::Result<(), Vec<Report>> {
 #[test]
 fn spec_case_2() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        OPENQASM 3.0;
+        OPENQASM 3.1;
         include "stdgates.inc";
         qubit q;
 
@@ -164,7 +164,7 @@ fn spec_case_2() -> miette::Result<(), Vec<Report>> {
 #[test]
 fn spec_case_3() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        OPENQASM 3.0;
+        OPENQASM 3.1;
         include "stdgates.inc";
         qubit q;
         bit[2] b;
@@ -217,7 +217,7 @@ fn spec_case_3() -> miette::Result<(), Vec<Report>> {
 #[ignore = "Function decls are not supported yet"]
 fn spec_case_4() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        OPENQASM 3.0;
+        OPENQASM 3.1;
         include "stdgates.inc";
         qubit q;
         bit[2] b;
@@ -260,7 +260,7 @@ fn spec_case_4() -> miette::Result<(), Vec<Report>> {
 #[test]
 fn spec_case_5() -> miette::Result<(), Vec<Report>> {
     let source = r#"
-        OPENQASM 3.0;
+        OPENQASM 3.1;
         include "stdgates.inc";
 
 

--- a/compiler/qsc_qasm3/src/tests/statement/while_loop.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/while_loop.rs
@@ -55,6 +55,6 @@ fn using_cond_that_cannot_implicit_cast_to_bool_fail() {
         panic!("Expected error");
     };
 
-    expect![r#"Cannot cast expression of type Qubit to type Bool(False)"#]
+    expect!["Cannot cast expression of type Qubit to type Bool(false)"]
         .assert_eq(&errors[0].to_string());
 }


### PR DESCRIPTION
This PR adds gate calls and the AST items it depends on to the new QASM3 compiler:
 - [x] Constant evaluation (needed for array sizes and type widths).
   - [x] Unit tests.
 - [x] QuantumDeclStmt
 - [x] IndexedAssignStmt.
 - [x] Bitarrays.
 - [x] MeasureExpr / MeasureStmt.
 - [x] Compilation to Result type (introduces `LiteralKind::Bit(bool)`) variant.
 - [x] GatecallStmt
 - [x] barrier
 - [x] reset