### PR TITLE
Add confirmation prompt

### DIFF
--- a/vscode/src/copilot/azqTools.ts
+++ b/vscode/src/copilot/azqTools.ts
@@ -18,6 +18,7 @@ import { getJobFiles, submitJob } from "../azure/workspaceActions.js";
 import { HistogramData } from "./shared.js";
 import { getQirForVisibleQs } from "../qirGeneration.js";
 import { CopilotToolError, ToolResult, ToolState } from "./tools.js";
+import { CopilotWebviewViewProvider as CopilotView } from "./webviewViewProvider.js";
 
 /**
  * These tool definitions correspond to the ones declared
@@ -409,6 +410,11 @@ async function submitToTarget(
   if (!qir) throw new CopilotToolError("Failed to generate QIR.");
 
   const quantumUris = new QuantumUris(workspace.endpointUri, workspace.id);
+
+  const confirmed = await CopilotView.getConfirmation("Confirm job submission");
+  if (!confirmed) {
+    return { result: "Job submission was cancelled by the user" };
+  }
 
   try {
     const token = await getTokenForWorkspace(workspace);

--- a/vscode/src/copilot/shared.d.ts
+++ b/vscode/src/copilot/shared.d.ts
@@ -10,6 +10,10 @@ export type CopilotCommand =
       request: string;
     }
   | {
+      command: "confirmation";
+      confirmed: boolean;
+    }
+  | {
       command: "restartChat";
       history: ChatElement[];
       service?: ServiceType;
@@ -38,7 +42,8 @@ export type CopilotUpdate =
   | {
       kind: "appendDelta";
       payload: { delta: string; status: Status };
-    };
+    }
+  | { kind: "showConfirmation"; payload: { confirmText: string } };
 
 export type QuantumChatMessage = UserMessage | AssistantMessage | ToolMessage;
 
@@ -85,6 +90,10 @@ type Status =
   | {
       status: "executingTool";
       toolName: string;
+    }
+  | {
+      status: "awaitingConfirmation";
+      confirmText: string;
     }
   | {
       status: "assistantConnectionError";

--- a/vscode/src/copilot/webview/copilot.css
+++ b/vscode/src/copilot/webview/copilot.css
@@ -42,7 +42,8 @@ h1 {
   justify-content: flex-end;
   flex-wrap: wrap;
   align-content: center;
-  height: 28px;
+  align-items: center;
+  margin: 0.6em 0;
   font-style: italic;
   font-size: 0.9em;
 }
@@ -94,7 +95,7 @@ h1 {
 .user-message,
 .assistant-message {
   padding: 0 16px;
-  margin-bottom: 16px;
+  margin-top: 16px;
   border: 1px solid #ccc;
   border-radius: 0.5em;
 }
@@ -168,7 +169,7 @@ pre code {
 
 .histogram-container {
   width: 100%;
-  margin-bottom: 10px;
+  margin-top: 1em;
 }
 
 /* If not specified it defaults to the 'pre code' default monospace font  */
@@ -340,4 +341,17 @@ code.hljs {
   font-size: 0.8em;
   color: gray;
   margin-top: 0.8em;
+}
+
+.confirm-button {
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border: none;
+  border-radius: 4px;
+  padding: 0.3em 0.6em;
+  margin-top: 0.2em;
+  margin-bottom: 0.2em;
+  margin-left: 0.6em;
+  margin-right: 0;
+  cursor: pointer;
 }

--- a/vscode/src/copilot/webview/copilot.tsx
+++ b/vscode/src/copilot/webview/copilot.tsx
@@ -293,6 +293,26 @@ function StatusIndicator({ status }: { status: Status }) {
         </>
       ) : status.status === "assistantConnectionError" ? (
         "There was an error communicating with Azure Quantum Copilot. Please check your Internet connection and try again."
+      ) : status.status === "awaitingConfirmation" ? (
+        <>
+          <div>{status.confirmText}</div>
+          <div>
+            <button
+              type="button"
+              class="confirm-button"
+              onClick={() => submitConfirmation(true)}
+            >
+              Yes
+            </button>
+            <button
+              type="button"
+              class="confirm-button"
+              onClick={() => submitConfirmation(false)}
+            >
+              No
+            </button>
+          </div>
+        </>
       ) : (
         ""
       )}
@@ -464,6 +484,10 @@ function submitUserMessage(content: string) {
   });
 }
 
+function submitConfirmation(confirmed: boolean) {
+  postMessageToExtension({ command: "confirmation", confirmed });
+}
+
 /**
  * Copilot command to restart the chat with a new history.
  * The service backend can be changed here as well.
@@ -514,6 +538,12 @@ function onMessage(event: MessageEvent<CopilotUpdate>) {
       model.status = message.payload.status;
       model.debugUi = message.payload.debugUi;
       vscodeApi.setState(message.payload.history);
+      break;
+    case "showConfirmation":
+      model.status = {
+        status: "awaitingConfirmation",
+        confirmText: message.payload.confirmText,
+      };
       break;
     default:
       console.error("Unknown message kind: ", (message as any).kind);


### PR DESCRIPTION
Whenever the copilot is going to do something that might cost money or lose data, it's a good idea to confirm with the user first. Added this for job submission for now.