### PR TITLE
Compile gphase, gatedef, and control flow statements

### DIFF
--- a/compiler/qsc_qasm3/src/ast_builder.rs
+++ b/compiler/qsc_qasm3/src/ast_builder.rs
@@ -1373,7 +1373,7 @@ pub(crate) fn build_gate_decl(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) fn build_gate_decl_lambda<S: AsRef<str>>(
     name: S,
     cargs: Vec<(String, Ty, Pat)>,
@@ -1417,10 +1417,18 @@ pub(crate) fn build_gate_decl_lambda<S: AsRef<str>>(
         })
         .map(Box::new)
         .collect::<Vec<_>>();
-    let input_pat = ast::Pat {
-        kind: Box::new(PatKind::Tuple(name_args.into_boxed_slice())),
-        span: Span { lo, hi },
-        ..Default::default()
+    let input_pat = if args.len() == 1 {
+        ast::Pat {
+            kind: Box::new(ast::PatKind::Paren(name_args[0].clone())),
+            span: Span { lo, hi },
+            ..Default::default()
+        }
+    } else {
+        ast::Pat {
+            kind: Box::new(PatKind::Tuple(name_args.into_boxed_slice())),
+            span: Span { lo, hi },
+            ..Default::default()
+        }
     };
 
     let block_expr = build_wrapped_block_expr(body.map_or_else(
@@ -1441,11 +1449,17 @@ pub(crate) fn build_gate_decl_lambda<S: AsRef<str>>(
         span: gate_span,
     };
     let ty_args = args.iter().map(|(_, ty, _)| ty.clone()).collect::<Vec<_>>();
-    let input_ty = ast::Ty {
-        kind: Box::new(ast::TyKind::Tuple(ty_args.into_boxed_slice())),
-        ..Default::default()
+    let input_ty = if args.len() == 1 {
+        ast::Ty {
+            kind: Box::new(ast::TyKind::Paren(Box::new(ty_args[0].clone()))),
+            ..Default::default()
+        }
+    } else {
+        ast::Ty {
+            kind: Box::new(ast::TyKind::Tuple(ty_args.into_boxed_slice())),
+            ..Default::default()
+        }
     };
-
     let return_type = if let Some(ty) = return_type {
         ty
     } else {

--- a/compiler/qsc_qasm3/src/ast_builder.rs
+++ b/compiler/qsc_qasm3/src/ast_builder.rs
@@ -843,9 +843,10 @@ pub(crate) fn build_call_with_param(
     }
 }
 
-pub(crate) fn build_call_with_no_params(
+pub(crate) fn build_call_with_params(
     name: &str,
     idents: &[&str],
+    operands: Vec<Expr>,
     name_span: Span,
     call_span: Span,
 ) -> Expr {
@@ -864,14 +865,7 @@ pub(crate) fn build_call_with_no_params(
         })))),
         ..Default::default()
     };
-    let call = ExprKind::Call(
-        Box::new(path_expr),
-        Box::new(Expr {
-            kind: Box::new(ExprKind::Tuple(Default::default())),
-            span: Default::default(),
-            ..Default::default()
-        }),
-    );
+    let call = ExprKind::Call(Box::new(path_expr), Box::new(build_tuple_expr(operands)));
 
     Expr {
         id: NodeId::default(),

--- a/compiler/qsc_qasm3/src/ast_builder.rs
+++ b/compiler/qsc_qasm3/src/ast_builder.rs
@@ -1186,8 +1186,10 @@ fn wrap_ty_in_array(ty: Ty) -> Ty {
 }
 
 pub(crate) fn build_for_stmt(
-    loop_var: &crate::symbols::Symbol,
-    iter: crate::types::QasmTypedExpr,
+    loop_var_name: &str,
+    loop_var_span: Span,
+    loop_var_qsharp_ty: &crate::types::Type,
+    iter: Expr,
     body: Block,
     stmt_span: Span,
 ) -> Stmt {
@@ -1197,15 +1199,15 @@ pub(crate) fn build_for_stmt(
                 Box::new(Pat {
                     kind: Box::new(PatKind::Bind(
                         Box::new(Ident {
-                            name: loop_var.name.clone().into(),
-                            span: loop_var.span,
+                            name: loop_var_name.into(),
+                            span: loop_var_span,
                             ..Default::default()
                         }),
-                        Some(Box::new(map_qsharp_type_to_ast_ty(&loop_var.qsharp_ty))),
+                        Some(Box::new(map_qsharp_type_to_ast_ty(loop_var_qsharp_ty))),
                     )),
                     ..Default::default()
                 }),
-                Box::new(iter.expr),
+                Box::new(iter),
                 Box::new(body),
             )),
             span: stmt_span,

--- a/compiler/qsc_qasm3/src/compile.rs
+++ b/compiler/qsc_qasm3/src/compile.rs
@@ -9,18 +9,17 @@ use crate::ast_builder::{
     build_barrier_call, build_binary_expr, build_cast_call, build_cast_call_two_params,
     build_classical_decl, build_complex_binary_expr, build_complex_from_expr,
     build_convert_call_expr, build_default_result_array_expr, build_expr_array_expr,
-    build_gate_call_param_expr, build_gate_decl_lambda, build_if_expr_then_block,
-    build_if_expr_then_block_else_block, build_if_expr_then_block_else_expr,
-    build_if_expr_then_expr_else_expr, build_implicit_return_stmt,
-    build_indexed_assignment_statement, build_lit_bigint_expr, build_lit_bool_expr,
-    build_lit_complex_expr, build_lit_double_expr, build_lit_int_expr,
-    build_lit_result_array_expr_from_bitstring, build_lit_result_expr, build_managed_qubit_alloc,
-    build_math_call_no_params, build_measure_call, build_operation_with_stmts,
-    build_path_ident_expr, build_range_expr, build_reset_call, build_stmt_semi_from_expr,
-    build_stmt_wrapped_block_expr, build_top_level_ns_with_item, build_tuple_expr,
-    build_unary_op_expr, build_unmanaged_qubit_alloc, build_unmanaged_qubit_alloc_array,
-    build_wrapped_block_expr, is_complex_binop_supported, managed_qubit_alloc_array,
-    map_qsharp_type_to_ast_ty,
+    build_gate_call_param_expr, build_if_expr_then_block, build_if_expr_then_block_else_block,
+    build_if_expr_then_block_else_expr, build_if_expr_then_expr_else_expr,
+    build_implicit_return_stmt, build_indexed_assignment_statement, build_lambda,
+    build_lit_bigint_expr, build_lit_bool_expr, build_lit_complex_expr, build_lit_double_expr,
+    build_lit_int_expr, build_lit_result_array_expr_from_bitstring, build_lit_result_expr,
+    build_managed_qubit_alloc, build_math_call_no_params, build_measure_call,
+    build_operation_with_stmts, build_path_ident_expr, build_range_expr, build_reset_call,
+    build_stmt_semi_from_expr, build_stmt_wrapped_block_expr, build_top_level_ns_with_item,
+    build_tuple_expr, build_unary_op_expr, build_unmanaged_qubit_alloc,
+    build_unmanaged_qubit_alloc_array, build_wrapped_block_expr, is_complex_binop_supported,
+    managed_qubit_alloc_array, map_qsharp_type_to_ast_ty,
 };
 
 use crate::oqasm_helpers::{
@@ -2474,7 +2473,7 @@ impl QasmCompiler {
                 gate_span,
             ))
         } else {
-            Some(build_gate_decl_lambda(
+            Some(build_lambda(
                 name.to_string(),
                 cargs,
                 qargs,
@@ -2483,6 +2482,7 @@ impl QasmCompiler {
                 body_span,
                 gate_span,
                 None,
+                ast::CallableKind::Operation,
             ))
         }
     }

--- a/compiler/qsc_qasm3/src/compile.rs
+++ b/compiler/qsc_qasm3/src/compile.rs
@@ -2482,6 +2482,7 @@ impl QasmCompiler {
                 name_span,
                 body_span,
                 gate_span,
+                None,
             ))
         }
     }

--- a/compiler/qsc_qasm3/src/compile.rs
+++ b/compiler/qsc_qasm3/src/compile.rs
@@ -2318,8 +2318,10 @@ impl QasmCompiler {
         };
 
         Some(ast_builder::build_for_stmt(
-            &loop_var_symbol,
-            iterable,
+            &loop_var_symbol.name,
+            loop_var_symbol.span,
+            &loop_var_symbol.qsharp_ty,
+            iterable.expr,
             body,
             stmt_span,
         ))

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -613,6 +613,9 @@ impl QasmCompiler {
         if symbol.name == "U" {
             self.runtime |= RuntimeFunctions::U;
         }
+        if symbol.name == "gphase" {
+            self.runtime |= RuntimeFunctions::Gphase;
+        }
         let mut qubits: Vec<_> = stmt
             .qubits
             .iter()
@@ -929,14 +932,10 @@ impl QasmCompiler {
 
     fn compile_expr(&mut self, expr: &semast::Expr) -> qsast::Expr {
         match expr.kind.as_ref() {
-            semast::ExprKind::Err => {
-                // todo: determine if we should push an error here
-                // Are we going to allow trying to compile a program with semantic errors?
-                qsast::Expr {
-                    span: expr.span,
-                    ..Default::default()
-                }
-            }
+            semast::ExprKind::Err => qsast::Expr {
+                span: expr.span,
+                ..Default::default()
+            },
             semast::ExprKind::Ident(symbol_id) => self.compile_ident_expr(*symbol_id),
             semast::ExprKind::IndexedIdentifier(indexed_ident) => {
                 self.compile_indexed_ident_expr(indexed_ident)

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -594,14 +594,7 @@ impl QasmCompiler {
                 .collect();
 
             if args.len() == 1 {
-                let lo = expr.args[0].span.lo;
-                let hi = expr
-                    .args
-                    .last()
-                    .expect("there is at least one argument")
-                    .span
-                    .hi;
-                let operand_span = Span { lo, hi };
+                let operand_span = expr.args[0].span;
                 let operand = args.into_iter().next().expect("there is one argument");
                 build_call_with_param(name, &[], operand, name_span, operand_span, expr.span)
             } else {

--- a/compiler/qsc_qasm3/src/compiler.rs
+++ b/compiler/qsc_qasm3/src/compiler.rs
@@ -393,10 +393,6 @@ impl QasmCompiler {
             return None;
         }
 
-        if indices.len() != stmt.indices.len() {
-            return None;
-        }
-
         let index_expr = indices[0].clone();
 
         let stmt = build_indexed_assignment_statement(
@@ -1331,11 +1327,6 @@ impl QasmCompiler {
         let operand_span = expr.span;
         let name_span = span;
         match ty {
-            &Type::Angle(..) => {
-                let msg = "Cast bit to angle";
-                self.push_unimplemented_error_message(msg, expr.span);
-                err_expr(span)
-            }
             &Type::Bool(..) => {
                 self.runtime |= RuntimeFunctions::ResultAsBool;
                 build_cast_call(
@@ -1364,7 +1355,6 @@ impl QasmCompiler {
                 self.runtime |= function;
                 build_cast_call(function, expr, name_span, operand_span)
             }
-
             _ => err_expr(span),
         }
     }

--- a/compiler/qsc_qasm3/src/parser/ast.rs
+++ b/compiler/qsc_qasm3/src/parser/ast.rs
@@ -1090,6 +1090,7 @@ impl Display for GateCall {
 #[derive(Clone, Debug)]
 pub struct GPhase {
     pub span: Span,
+    pub gphase_token_span: Span,
     pub modifiers: List<QuantumGateModifier>,
     pub args: List<Expr>,
     pub qubits: List<GateOperand>,
@@ -1099,6 +1100,7 @@ pub struct GPhase {
 impl Display for GPhase {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "GPhase", self.span)?;
+        writeln_field(f, "gphase_token_span", &self.gphase_token_span)?;
         writeln_list_field(f, "modifiers", &self.modifiers)?;
         writeln_list_field(f, "args", &self.args)?;
         writeln_opt_field(f, "duration", self.duration.as_ref())?;

--- a/compiler/qsc_qasm3/src/parser/mut_visit.rs
+++ b/compiler/qsc_qasm3/src/parser/mut_visit.rs
@@ -515,6 +515,7 @@ fn walk_gate_call_stmt(vis: &mut impl MutVisitor, stmt: &mut GateCall) {
 
 fn walk_gphase_stmt(vis: &mut impl MutVisitor, stmt: &mut GPhase) {
     vis.visit_span(&mut stmt.span);
+    vis.visit_span(&mut stmt.gphase_token_span);
     stmt.modifiers
         .iter_mut()
         .for_each(|m| vis.visit_gate_modifier(m));

--- a/compiler/qsc_qasm3/src/parser/stmt.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt.rs
@@ -1540,7 +1540,9 @@ fn parse_gphase(
     lo: u32,
     modifiers: List<QuantumGateModifier>,
 ) -> Result<GPhase> {
+    let gphase_token_lo = s.peek().span.lo;
     token(s, TokenKind::GPhase)?;
+    let gphase_token_span = s.span(gphase_token_lo);
 
     let args_lo = s.peek().span.lo;
     let args = opt(s, |s| {
@@ -1563,6 +1565,7 @@ fn parse_gphase(
 
     Ok(GPhase {
         span: s.span(lo),
+        gphase_token_span,
         modifiers,
         args,
         qubits,

--- a/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
+++ b/compiler/qsc_qasm3/src/parser/stmt/tests/gphase.rs
@@ -14,6 +14,7 @@ fn gphase() {
             Stmt [0-15]:
                 annotations: <empty>
                 kind: GPhase [0-15]:
+                    gphase_token_span: [0-6]
                     modifiers: <empty>
                     args:
                         Expr [7-13]: BinaryOpExpr:
@@ -34,6 +35,7 @@ fn gphase_qubit_ident() {
             Stmt [0-13]:
                 annotations: <empty>
                 kind: GPhase [0-13]:
+                    gphase_token_span: [0-6]
                     modifiers: <empty>
                     args:
                         Expr [7-8]: Ident [7-8] "a"
@@ -56,6 +58,7 @@ fn gphase_qubit_register() {
             Stmt [0-15]:
                 annotations: <empty>
                 kind: GPhase [0-15]:
+                    gphase_token_span: [0-6]
                     modifiers: <empty>
                     args:
                         Expr [7-8]: Ident [7-8] "a"
@@ -81,6 +84,7 @@ fn gphase_multiple_qubits() {
             Stmt [0-19]:
                 annotations: <empty>
                 kind: GPhase [0-19]:
+                    gphase_token_span: [0-6]
                     modifiers: <empty>
                     args:
                         Expr [7-8]: Ident [7-8] "a"
@@ -111,6 +115,7 @@ fn gphase_no_arguments() {
             Stmt [0-7]:
                 annotations: <empty>
                 kind: GPhase [0-7]:
+                    gphase_token_span: [0-6]
                     modifiers: <empty>
                     args: <empty>
                     duration: <none>
@@ -138,6 +143,7 @@ fn gphase_with_parameters() {
             Stmt [0-15]:
                 annotations: <empty>
                 kind: GPhase [0-15]:
+                    gphase_token_span: [0-6]
                     modifiers: <empty>
                     args:
                         Expr [7-13]: BinaryOpExpr:
@@ -158,6 +164,7 @@ fn gphase_inv_modifier() {
             Stmt [0-16]:
                 annotations: <empty>
                 kind: GPhase [0-16]:
+                    gphase_token_span: [6-12]
                     modifiers:
                         QuantumGateModifier [0-5]: Inv
                     args:
@@ -176,6 +183,7 @@ fn gphase_ctrl_inv_modifiers() {
             Stmt [0-31]:
                 annotations: <empty>
                 kind: GPhase [0-31]:
+                    gphase_token_span: [13-19]
                     modifiers:
                         QuantumGateModifier [0-6]: Ctrl None
                         QuantumGateModifier [7-12]: Inv

--- a/compiler/qsc_qasm3/src/semantic/ast.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast.rs
@@ -1043,16 +1043,16 @@ impl Display for QubitArrayDeclaration {
 #[derive(Clone, Debug)]
 pub struct QuantumGateDefinition {
     pub span: Span,
-    pub ident: Box<Ident>,
-    pub params: List<Ident>,
-    pub qubits: List<Ident>,
-    pub body: Box<Block>,
+    pub symbol_id: SymbolId,
+    pub params: Box<[SymbolId]>,
+    pub qubits: Box<[SymbolId]>,
+    pub body: Block,
 }
 
 impl Display for QuantumGateDefinition {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "Gate", self.span)?;
-        writeln_field(f, "ident", &self.ident)?;
+        writeln_field(f, "symbol_id", &self.symbol_id)?;
         writeln_list_field(f, "parameters", &self.params)?;
         writeln_list_field(f, "qubits", &self.qubits)?;
         write_field(f, "body", &self.body)
@@ -1094,8 +1094,8 @@ impl Display for GateCall {
         writeln_list_field(f, "modifiers", &self.modifiers)?;
         writeln_field(f, "symbol_id", &self.symbol_id)?;
         writeln_list_field(f, "args", &self.args)?;
-        writeln_opt_field(f, "duration", self.duration.as_ref())?;
         writeln_list_field(f, "qubits", &self.qubits)?;
+        writeln_opt_field(f, "duration", self.duration.as_ref())?;
         writeln_field(f, "quantum_arity", &self.quantum_arity)?;
         write_field(
             f,
@@ -1112,6 +1112,8 @@ pub struct GPhase {
     pub args: List<Expr>,
     pub qubits: List<GateOperand>,
     pub duration: Option<Expr>,
+    pub quantum_arity: u32,
+    pub quantum_arity_with_modifiers: u32,
 }
 
 impl Display for GPhase {
@@ -1119,8 +1121,14 @@ impl Display for GPhase {
         writeln_header(f, "GPhase", self.span)?;
         writeln_list_field(f, "modifiers", &self.modifiers)?;
         writeln_list_field(f, "args", &self.args)?;
+        writeln_list_field(f, "qubits", &self.qubits)?;
         writeln_opt_field(f, "duration", self.duration.as_ref())?;
-        write_list_field(f, "qubits", &self.qubits)
+        writeln_field(f, "quantum_arity", &self.quantum_arity)?;
+        write_field(
+            f,
+            "quantum_arity_with_modifiers",
+            &self.quantum_arity_with_modifiers,
+        )
     }
 }
 
@@ -1472,8 +1480,8 @@ impl Display for ExprKind {
 #[derive(Clone, Debug)]
 pub struct AssignStmt {
     pub span: Span,
-    pub name_span: Span,
     pub symbol_id: SymbolId,
+    pub lhs_span: Span,
     pub rhs: Expr,
 }
 
@@ -1481,7 +1489,7 @@ impl Display for AssignStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "AssignStmt", self.span)?;
         writeln_field(f, "symbol_id", &self.symbol_id)?;
-        writeln_field(f, "name_span", &self.name_span)?;
+        writeln_field(f, "lhs_span", &self.lhs_span)?;
         write_field(f, "rhs", &self.rhs)
     }
 }
@@ -1507,6 +1515,7 @@ impl Display for IndexedAssignStmt {
 pub struct AssignOpStmt {
     pub span: Span,
     pub symbol_id: SymbolId,
+    pub indices: List<IndexElement>,
     pub op: BinOp,
     pub lhs: Expr,
     pub rhs: Expr,
@@ -1516,6 +1525,7 @@ impl Display for AssignOpStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "AssignOpStmt", self.span)?;
         writeln_field(f, "symbol_id", &self.symbol_id)?;
+        writeln_list_field(f, "indices", &self.indices)?;
         writeln_field(f, "op", &self.op)?;
         writeln_field(f, "lhs", &self.rhs)?;
         write_field(f, "rhs", &self.rhs)

--- a/compiler/qsc_qasm3/src/semantic/ast.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast.rs
@@ -1084,8 +1084,8 @@ pub struct GateCall {
     pub args: List<Expr>,
     pub qubits: List<GateOperand>,
     pub duration: Option<Expr>,
+    pub classical_arity: u32,
     pub quantum_arity: u32,
-    pub quantum_arity_with_modifiers: u32,
 }
 
 impl Display for GateCall {
@@ -1096,12 +1096,8 @@ impl Display for GateCall {
         writeln_list_field(f, "args", &self.args)?;
         writeln_list_field(f, "qubits", &self.qubits)?;
         writeln_opt_field(f, "duration", self.duration.as_ref())?;
-        writeln_field(f, "quantum_arity", &self.quantum_arity)?;
-        write_field(
-            f,
-            "quantum_arity_with_modifiers",
-            &self.quantum_arity_with_modifiers,
-        )
+        writeln_field(f, "classical_arity", &self.classical_arity)?;
+        write_field(f, "quantum_arity", &self.quantum_arity)
     }
 }
 

--- a/compiler/qsc_qasm3/src/semantic/ast.rs
+++ b/compiler/qsc_qasm3/src/semantic/ast.rs
@@ -1261,6 +1261,7 @@ impl WithSpan for ArrayTypedParameter {
 pub struct DefStmt {
     pub span: Span,
     pub symbol_id: SymbolId,
+    pub has_qubit_params: bool,
     pub params: Box<[SymbolId]>,
     pub body: Block,
     pub return_type: Option<crate::types::Type>,
@@ -1270,6 +1271,7 @@ impl Display for DefStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "DefStmt", self.span)?;
         writeln_field(f, "symbol_id", &self.symbol_id)?;
+        writeln_field(f, "has_qubit_params", &self.has_qubit_params)?;
         writeln_list_field(f, "parameters", &self.params)?;
         writeln_opt_field(f, "return_type", self.return_type.as_ref())?;
         write_field(f, "body", &self.body)

--- a/compiler/qsc_qasm3/src/semantic/error.rs
+++ b/compiler/qsc_qasm3/src/semantic/error.rs
@@ -50,6 +50,9 @@ pub enum SemanticErrorKind {
     #[error("Cannot assign a value of {0} type to a classical variable of {1} type.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.CannotAssignToType"))]
     CannotAssignToType(String, String, #[label] Span),
+    #[error("Cannot call an expression that is not a function.")]
+    #[diagnostic(code("Qsc.Qasm3.Compile.CannotCallNonFunction"))]
+    CannotCallNonFunction(#[label] Span),
     #[error("Cannot call a gate that is not a gate.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.CannotCallNonGate"))]
     CannotCallNonGate(#[label] Span),
@@ -84,6 +87,9 @@ pub enum SemanticErrorKind {
     #[error("Array size must be a non-negative integer const expression.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.ArraySizeMustBeNonNegativeConstExpr"))]
     ArraySizeMustBeNonNegativeConstExpr(#[label] Span),
+    #[error("Def declarations must be done in global scope.")]
+    #[diagnostic(code("Qsc.Qasm3.Compile.DefDeclarationInNonGlobalScope"))]
+    DefDeclarationInNonGlobalScope(#[label] Span),
     #[error("Designator is too large.")]
     #[diagnostic(code("Qsc.Qasm3.Compile.DesignatorTooLarge"))]
     DesignatorTooLarge(#[label] Span),
@@ -258,6 +264,7 @@ impl SemanticErrorKind {
             Self::CannotAssignToType(lhs, rhs, span) => {
                 Self::CannotAssignToType(lhs, rhs, span + offset)
             }
+            Self::CannotCallNonFunction(span) => Self::CannotCallNonFunction(span + offset),
             Self::CannotCallNonGate(span) => Self::CannotCallNonGate(span + offset),
             Self::CannotIndexType(name, span) => Self::CannotIndexType(name, span + offset),
             Self::CannotUpdateConstVariable(name, span) => {
@@ -272,6 +279,9 @@ impl SemanticErrorKind {
             }
             Self::ArraySizeMustBeNonNegativeConstExpr(span) => {
                 Self::ArraySizeMustBeNonNegativeConstExpr(span + offset)
+            }
+            Self::DefDeclarationInNonGlobalScope(span) => {
+                Self::DefDeclarationInNonGlobalScope(span + offset)
             }
             Self::DesignatorTooLarge(span) => Self::DesignatorTooLarge(span + offset),
             Self::FailedToCompileExpressionList(span) => {

--- a/compiler/qsc_qasm3/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm3/src/semantic/lowerer.rs
@@ -398,10 +398,8 @@ impl Lowerer {
         let (symbol_id, symbol) =
             self.try_get_existing_or_insert_err_symbol(&ident.name, ident.span);
 
-        let indexed_ty = &symbol
-            .ty
-            .get_indexed_type()
-            .expect("we only get here if there is at least one index");
+        let indexed_ty =
+            &self.get_indexed_type(&symbol.ty, index_expr.name.span, index_expr.indices.len());
 
         let indices = list_from_iter(
             index_expr
@@ -444,13 +442,11 @@ impl Lowerer {
         let (symbol_id, symbol) =
             self.try_get_existing_or_insert_err_symbol(&ident.name, ident.span);
 
-        let indexed_ty = symbol.ty.get_indexed_type();
-        let ty = if let Some(ty) = &indexed_ty {
-            ty
-        } else {
+        let ty = if lhs.indices.len() == 0 {
             &symbol.ty
+        } else {
+            &self.get_indexed_type(&symbol.ty, lhs.name.span, lhs.indices.len())
         };
-
         let indices = list_from_iter(
             lhs.indices
                 .iter()

--- a/compiler/qsc_qasm3/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm3/src/semantic/lowerer.rs
@@ -1146,8 +1146,8 @@ impl Lowerer {
             args,
             qubits,
             duration,
+            classical_arity,
             quantum_arity,
-            quantum_arity_with_modifiers,
         })
 
         // The compiler will be left to do all things that need explicit Q# knowledge.
@@ -2951,7 +2951,6 @@ fn try_get_qsharp_name_and_implicit_modifiers<S: AsRef<str>>(
 
     // ch, crx, cry, crz, sdg, and tdg
     match gate_name.as_ref() {
-        "cx" => Some(("X".to_string(), make_modifier(Ctrl(1)))),
         "cy" => Some(("Y".to_string(), make_modifier(Ctrl(1)))),
         "cz" => Some(("Z".to_string(), make_modifier(Ctrl(1)))),
         "ch" => Some(("H".to_string(), make_modifier(Ctrl(1)))),

--- a/compiler/qsc_qasm3/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm3/src/semantic/lowerer.rs
@@ -992,7 +992,7 @@ impl Lowerer {
         let symbol_id = self.try_insert_or_get_existing_symbol_id(name, symbol);
 
         // Push the scope where the def lives.
-        self.symbols.push_scope(ScopeKind::Gate);
+        self.symbols.push_scope(ScopeKind::Function);
 
         let params = stmt
             .params

--- a/compiler/qsc_qasm3/src/semantic/types.rs
+++ b/compiler/qsc_qasm3/src/semantic/types.rs
@@ -43,7 +43,7 @@ pub enum Type {
 
     // realistically the sizes could be u3
     Gate(u32, u32),
-    Function(u32),
+    Function(u32, Option<Box<Type>>),
     Range,
     Set,
     Void,
@@ -75,7 +75,7 @@ impl Display for Type {
             Type::IntArray(width, dims) => write!(f, "IntArray({width:?}, {dims:?})"),
             Type::UIntArray(width, dims) => write!(f, "UIntArray({width:?}, {dims:?})"),
             Type::Gate(cargs, qargs) => write!(f, "Gate({cargs}, {qargs})"),
-            Type::Function(cargs) => write!(f, "Function({cargs})"),
+            Type::Function(cargs, return_ty) => write!(f, "Function({cargs}) -> {return_ty:?}"),
             Type::Range => write!(f, "Range"),
             Type::Set => write!(f, "Set"),
             Type::Void => write!(f, "Void"),

--- a/compiler/qsc_qasm3/src/semantic/types.rs
+++ b/compiler/qsc_qasm3/src/semantic/types.rs
@@ -43,6 +43,7 @@ pub enum Type {
 
     // realistically the sizes could be u3
     Gate(u32, u32),
+    Function(u32),
     Range,
     Set,
     Void,
@@ -74,6 +75,7 @@ impl Display for Type {
             Type::IntArray(width, dims) => write!(f, "IntArray({width:?}, {dims:?})"),
             Type::UIntArray(width, dims) => write!(f, "UIntArray({width:?}, {dims:?})"),
             Type::Gate(cargs, qargs) => write!(f, "Gate({cargs}, {qargs})"),
+            Type::Function(cargs) => write!(f, "Function({cargs})"),
             Type::Range => write!(f, "Range"),
             Type::Set => write!(f, "Set"),
             Type::Void => write!(f, "Void"),

--- a/compiler/qsc_qasm3/src/tests/declaration.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration.rs
@@ -5,6 +5,7 @@ mod array;
 mod bit;
 mod bool;
 mod complex;
+mod def;
 mod float;
 mod gate;
 mod integer;

--- a/compiler/qsc_qasm3/src/tests/declaration/def.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/def.rs
@@ -27,7 +27,7 @@ fn single_parameter() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        let square : (Int, ) => Int = (x, ) => {
+        let square : (Int) => Int = (x) => {
             return x * x;
         };
     "#]]
@@ -45,7 +45,7 @@ fn qubit_parameter() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        let square : (Qubit, ) => Int = (q, ) => {
+        let square : (Qubit) => Int = (q) => {
             return 1;
         };
     "#]]

--- a/compiler/qsc_qasm3/src/tests/declaration/def.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/def.rs
@@ -52,3 +52,21 @@ fn qubit_parameter() -> miette::Result<(), Vec<Report>> {
     .assert_eq(&qsharp);
     Ok(())
 }
+
+#[test]
+fn qubit_array_parameter() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        def square(qubit[3] qs) -> uint {
+            return 1;
+        }
+    "#;
+
+    let qsharp = compile_qasm_stmt_to_qsharp(source)?;
+    expect![[r#"
+        let square : (Qubit[]) => Int = (qs) => {
+            return 1;
+        };
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}

--- a/compiler/qsc_qasm3/src/tests/declaration/def.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/def.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::compile_qasm_stmt_to_qsharp;
+use expect_test::expect;
+use miette::Report;
+
+#[test]
+fn no_parameters_no_return() -> miette::Result<(), Vec<Report>> {
+    let source = "def square() {}";
+
+    let qsharp = compile_qasm_stmt_to_qsharp(source)?;
+    expect![[r#"
+        let square : () => Unit = () => {};
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn single_parameter() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        def square(int x) -> int {
+            return x * x;
+        }
+    "#;
+
+    let qsharp = compile_qasm_stmt_to_qsharp(source)?;
+    expect![[r#"
+        let square : (Int, ) => Int = (x, ) => {
+            return x * x;
+        };
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qubit_parameter() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        def square(qubit q) -> uint {
+            return 1;
+        }
+    "#;
+
+    let qsharp = compile_qasm_stmt_to_qsharp(source)?;
+    expect![[r#"
+        let square : (Qubit, ) => Int = (q, ) => {
+            return 1;
+        };
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}

--- a/compiler/qsc_qasm3/src/tests/declaration/def.rs
+++ b/compiler/qsc_qasm3/src/tests/declaration/def.rs
@@ -7,11 +7,11 @@ use miette::Report;
 
 #[test]
 fn no_parameters_no_return() -> miette::Result<(), Vec<Report>> {
-    let source = "def square() {}";
+    let source = "def empty() {}";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        let square : () => Unit = () => {};
+        let empty : () -> Unit = () -> {};
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -27,7 +27,7 @@ fn single_parameter() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        let square : (Int) => Int = (x) => {
+        let square : (Int) -> Int = (x) -> {
             return x * x;
         };
     "#]]

--- a/compiler/qsc_qasm3/src/tests/expression.rs
+++ b/compiler/qsc_qasm3/src/tests/expression.rs
@@ -3,6 +3,7 @@
 
 mod binary;
 mod bits;
+mod function_call;
 mod ident;
 mod implicit_cast_from_bit;
 mod implicit_cast_from_bitarray;

--- a/compiler/qsc_qasm3/src/tests/expression/function_call.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/function_call.rs
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::compile_qasm_to_qsharp;
+use expect_test::expect;
+use miette::Report;
+
+#[test]
+fn funcall_with_no_arguments_generates_correct_qsharp() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        def empty() {}
+        empty();
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let empty : () -> Unit = () -> {};
+        empty();
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn funcall_with_one_argument_generates_correct_qsharp() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        def square(int x) -> int {
+            return x * x;
+        }
+
+        square(2);
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let square : (Int) -> Int = (x) -> {
+            return x * x;
+        };
+        square(2);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn funcall_with_two_arguments_generates_correct_qsharp() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        def sum(int x, int y) -> int {
+            return x + y;
+        }
+
+        sum(2, 3);
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let sum : (Int, Int) -> Int = (x, y) -> {
+            return x + y;
+        };
+        sum((2, 3));
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn funcall_with_too_few_arguments_generates_error() {
+    let source = r#"
+        def square(int x) -> int {
+            return x * x;
+        }
+
+        square();
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qsc.Qasm3.Compile.InvalidNumberOfClassicalArgs
+
+          x Gate expects 1 classical arguments, but 0 were provided.
+           ,-[Test.qasm:6:9]
+         5 | 
+         6 |         square();
+           :         ^^^^^^^^
+         7 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}
+
+#[test]
+fn funcall_with_too_many_arguments_generates_error() {
+    let source = r#"
+        def square(int x) -> int {
+            return x * x;
+        }
+
+        square(2, 3);
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qsc.Qasm3.Compile.InvalidNumberOfClassicalArgs
+
+          x Gate expects 1 classical arguments, but 2 were provided.
+           ,-[Test.qasm:6:9]
+         5 | 
+         6 |         square(2, 3);
+           :         ^^^^^^^^^^^^
+         7 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}
+
+#[test]
+fn funcall_accepts_qubit_argument() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        def h_wrapper(qubit q) {
+            h q;
+        }
+
+        qubit q;
+        h_wrapper(q);
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let h_wrapper : (Qubit) => Unit = (q) => {
+            H(q);
+        };
+        let q = QIR.Runtime.__quantum__rt__qubit_allocate();
+        h_wrapper(q);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}

--- a/compiler/qsc_qasm3/src/tests/expression/ident.rs
+++ b/compiler/qsc_qasm3/src/tests/expression/ident.rs
@@ -12,11 +12,33 @@ fn unresolved_idenfiers_raise_symbol_error() {
         float x = t;
     ";
 
-    let Err(errors) = compile_qasm_stmt_to_qsharp(source) else {
-        panic!("Expected an error");
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("should have generated an error");
     };
-    assert_eq!(1, errors.len(), "Expected one error");
-    expect![r#"Undefined symbol: t."#].assert_eq(&errors[0].to_string());
+    let errs: Vec<_> = errors.iter().map(|e| format!("{e:?}")).collect();
+    let errs_string = errs.join("\n");
+    expect![[r#"
+        Qsc.Qasm3.Compile.UndefinedSymbol
+
+          x Undefined symbol: t.
+           ,-[Test.qasm:2:19]
+         1 | 
+         2 |         float x = t;
+           :                   ^
+         3 |     
+           `----
+
+        Qsc.Qasm3.Compile.CannotCast
+
+          x Cannot cast expression of type Err to type Float(None, false)
+           ,-[Test.qasm:2:19]
+         1 | 
+         2 |         float x = t;
+           :                   ^
+         3 |     
+           `----
+    "#]]
+    .assert_eq(&errs_string);
 }
 
 // this test verifies QASM behavior that would normally be allowed

--- a/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
@@ -52,7 +52,8 @@ fn gphase_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
             controlled adjoint auto;
         }
         gphase(2.);
-    "#]].assert_eq(&qsharp);
+    "#]]
+    .assert_eq(&qsharp);
     Ok(())
 }
 
@@ -193,4 +194,56 @@ fn barrier_can_be_called_on_two_qubit() -> miette::Result<(), Vec<Report>> {
     ]
     .assert_eq(&qsharp);
     Ok(())
+}
+
+#[test]
+fn cx_called_with_one_qubit_generates_error() {
+    let source = r#"
+        include "stdgates.inc";
+        qubit[2] q;
+        cx q[0];
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qsc.Qasm3.Compile.InvalidNumberOfQubitArgs
+
+          x Gate expects 2 qubit arguments, but 1 were provided.
+           ,-[Test.qasm:4:9]
+         3 |         qubit[2] q;
+         4 |         cx q[0];
+           :         ^^^^^^^^
+         5 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}
+
+#[test]
+fn cx_called_with_too_many_qubits_generates_error() {
+    let source = r#"
+        include "stdgates.inc";
+        qubit[3] q;
+        cx q[0], q[1], q[2];
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qsc.Qasm3.Compile.InvalidNumberOfQubitArgs
+
+          x Gate expects 2 qubit arguments, but 3 were provided.
+           ,-[Test.qasm:4:9]
+         3 |         qubit[3] q;
+         4 |         cx q[0], q[1], q[2];
+           :         ^^^^^^^^^^^^^^^^^^^^
+         5 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
 }

--- a/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
@@ -42,7 +42,17 @@ fn gphase_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
     "#;
 
     let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![r#""#].assert_eq(&qsharp);
+    expect![[r#"
+        operation gphase(theta : Double) : Unit is Adj + Ctl {
+            body ... {
+                Exp([], theta, [])
+            }
+            adjoint auto;
+            controlled auto;
+            controlled adjoint auto;
+        }
+        gphase(2.);
+    "#]].assert_eq(&qsharp);
     Ok(())
 }
 

--- a/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm3/src/tests/statement/gate_call.rs
@@ -247,3 +247,72 @@ fn cx_called_with_too_many_qubits_generates_error() {
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
 }
+
+#[test]
+fn rx_gate_with_no_angles_generates_error() {
+    let source = r#"
+        include "stdgates.inc";
+        qubit q;
+        rx q;
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qsc.Qasm3.Compile.InvalidNumberOfClassicalArgs
+
+          x Gate expects 1 classical arguments, but 0 were provided.
+           ,-[Test.qasm:4:9]
+         3 |         qubit q;
+         4 |         rx q;
+           :         ^^^^^
+         5 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}
+
+#[test]
+fn rx_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        qubit q;
+        rx(2.0) q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        let q = QIR.Runtime.__quantum__rt__qubit_allocate();
+        Rx(2., q);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn rx_gate_with_too_many_angles_generates_error() {
+    let source = r#"
+        include "stdgates.inc";
+        qubit q;
+        rx(2.0, 3.0) q;
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qsc.Qasm3.Compile.InvalidNumberOfClassicalArgs
+
+          x Gate expects 1 classical arguments, but 2 were provided.
+           ,-[Test.qasm:4:9]
+         3 |         qubit q;
+         4 |         rx(2.0, 3.0) q;
+           :         ^^^^^^^^^^^^^^^
+         5 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}


### PR DESCRIPTION
This PR completes the lowering and compilation for:
 - [x] gate definitions
 - [x] gphase
 - [x] for stmt
 - [x] if stmt
 - [x] switch stmt
 - [x] return stmt
 - [x] classical function calls
 - [x] classical function decls

It also does some partial work to make the compiler infallible, by returning `ExprKind::Err` instead of None when compiling expressions.