### PR TITLE
Use fresh env for `qsharp.run` with Python interop functions wrapping Q# operations

### DIFF
--- a/compiler/qsc/src/interpret.rs
+++ b/compiler/qsc/src/interpret.rs
@@ -567,8 +567,8 @@ impl Interpreter {
         })
     }
 
-    // Invokes the given callable with the given arguments using the current environment and compilation but with a fresh
-    // simulator configured with the given noise, if any.
+    // Invokes the given callable with the given arguments using the current compilation but with a fresh
+    // environment and simulator configured with the given noise, if any.
     pub fn invoke_with_noise(
         &mut self,
         receiver: &mut impl Receiver,
@@ -580,24 +580,7 @@ impl Interpreter {
             Some(noise) => SparseSim::new_with_noise(&noise),
             None => SparseSim::new(),
         };
-        qsc_eval::invoke(
-            self.package,
-            self.classical_seed,
-            &self.fir_store,
-            &mut self.env,
-            &mut sim,
-            receiver,
-            callable,
-            args,
-        )
-        .map_err(|(error, call_stack)| {
-            eval_error(
-                self.compiler.package_store(),
-                &self.fir_store,
-                call_stack,
-                error,
-            )
-        })
+        self.invoke_with_sim(&mut sim, receiver, callable, args)
     }
 
     /// Runs the given entry expression on a new instance of the environment and simulator,

--- a/pip/tests/test_qsharp.py
+++ b/pip/tests/test_qsharp.py
@@ -431,7 +431,21 @@ def test_run_with_result(capsys) -> None:
 
 def test_run_with_result_from_callable(capsys) -> None:
     qsharp.init()
-    qsharp.eval('operation Foo() : Result { Message("Hello, world!"); Zero }')
+    qsharp.eval(
+        'operation Foo() : Result { Message("Hello, world!"); use q = Qubit(); M(q) }'
+    )
+    results = qsharp.run(qsharp.code.Foo, 3)
+    assert results == [qsharp.Result.Zero, qsharp.Result.Zero, qsharp.Result.Zero]
+    stdout = capsys.readouterr().out
+    assert stdout == "Hello, world!\nHello, world!\nHello, world!\n"
+
+
+def test_run_with_result_from_callable_while_global_qubits_allocated(capsys) -> None:
+    qsharp.init()
+    qsharp.eval("use q = Qubit();")
+    qsharp.eval(
+        'operation Foo() : Result { Message("Hello, world!"); use q = Qubit(); M(q) }'
+    )
     results = qsharp.run(qsharp.code.Foo, 3)
     assert results == [qsharp.Result.Zero, qsharp.Result.Zero, qsharp.Result.Zero]
     stdout = capsys.readouterr().out


### PR DESCRIPTION
This matches the behavior used for other places when a fresh simulator instance is paired with a fresh environment for isolated execution.

Fixes #2253