### PR TITLE
Fix two issues that cause the latest Clippy to fail the build.

### DIFF
--- a/compiler/qsc_frontend/src/typeck/convert.rs
+++ b/compiler/qsc_frontend/src/typeck/convert.rs
@@ -256,11 +256,8 @@ pub(super) fn scheme_for_ast_callable(
     names: &Names,
     callable: &CallableDecl,
 ) -> (Scheme, Vec<TyConversionError>) {
-    let (mut type_parameters, errors) = type_parameters_for_ast_callable(names, &callable.generics);
-    let mut errors = errors
-        .into_iter()
-        .map(TyConversionError::from)
-        .collect::<Vec<_>>();
+    let (mut type_parameters, mut errors) =
+        type_parameters_for_ast_callable(names, &callable.generics);
     let kind = callable_kind_from_ast(callable.kind);
 
     let (mut input, new_errors) = ast_pat_ty(names, &callable.input);

--- a/language_service/src/completion/ast_context.rs
+++ b/language_service/src/completion/ast_context.rs
@@ -71,7 +71,7 @@ impl<'a> Visitor<'a> for AstContext<'a> {
                         && item
                             .alias
                             .as_ref()
-                            .map_or(true, |a| !a.span.touches(self.offset))
+                            .is_none_or(|a| !a.span.touches(self.offset))
                     {
                         // Special case when the cursor falls *between* the
                         // `Path` and the glob asterisk,


### PR DESCRIPTION
Remove unnecessary conversion picked up by the latest Clippy in convert.rs

Switch to use .is_none_or instead of .map_or in ast_context.rs.

Fixes #2256