### PR TITLE
Update chemistry test imports

### DIFF
--- a/library/chemistry/src/Tests.qs
+++ b/library/chemistry/src/Tests.qs
@@ -6,10 +6,7 @@ import Std.Arrays.Mapped;
 import Std.Arrays.Reversed;
 import Std.Convert.ComplexAsComplexPolar;
 import Std.Convert.IntAsDouble;
-import Std.Diagnostics.CheckAllZero;
-import Std.Diagnostics.CheckZero;
-import Std.Diagnostics.DumpRegister;
-import Std.Diagnostics.Fact;
+import Std.Diagnostics.*;
 import Std.Math.*;
 import Std.StatePreparation.ApproximatelyPreparePureStateCP;
 


### PR DESCRIPTION
This is a minor change to the chemistry library's test imports that avoids a name resolution error when the QIR Profile is set to something other than "Unrestricted." The library still does not compile outside of Unrestricted, but now at least RCA feedback on the library implementation itself is visible.