### PR TITLE
Remove Base Profile sections in circuits sample notebook

### DIFF
--- a/samples/notebooks/circuits.ipynb
+++ b/samples/notebooks/circuits.ipynb
@@ -195,66 +195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we generate a circuit for the same program, but targeting the Base profile, the resulting circuit avoids reset gates and uses two qubits instead."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "qsharp.init(target_profile=qsharp.TargetProfile.Base)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "qsharp"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%%qsharp\n",
-    "\n",
-    "operation TwoRandomBits() : Result[] {\n",
-    "    let r1 = RandomBit();\n",
-    "    let r2 = RandomBit();\n",
-    "    return [r1, r2];\n",
-    "}\n",
-    "\n",
-    "operation RandomBit() : Result {\n",
-    "    use q = Qubit();\n",
-    "    H(q);\n",
-    "    MResetZ(q)\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Circuit(qsharp.circuit(\"TwoRandomBits()\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Regardless of the target chosen, conditionals that compare `Result` values are not permitted during circuit synthesis. This is because they may introduce nondeterminism such that the circuit will look different depending on measurement outcome. Representing conditionals visually is not supported."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "qsharp.init(target_profile=qsharp.TargetProfile.Unrestricted)"
+    "Conditionals that compare `Result` values are not permitted during circuit synthesis. This is because they may introduce nondeterminism such that the circuit will look different depending on measurement outcome. Representing conditionals visually is not supported."
    ]
   },
   {
@@ -354,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Now that the measurement decompositions are handled lower in the stack (see #2230), the examples for how measurements show up differently for circuits from Base profile vs Unrestricted no longer make sense. This removes them.

Likewise the section in the wiki on circuits for different profiles should be updated or removed (see https://github.com/microsoft/qsharp/wiki/Circuit-Diagrams-from-Q%23-Code#target-profile)