### PR TITLE
Fix Test Explorer issues

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -22,7 +22,7 @@ export function isQsharpDocument(document: TextDocument): boolean {
     (Utils.extname(document.uri) === ".qs" || document.isUntitled) &&
     document.uri.scheme !== "git" &&
     document.uri.scheme !== "pr" &&
-    // The Copilot Chat window also creates documents with various schemes that start 
+    // The Copilot Chat window also creates documents with various schemes that start
     // with "chat", such as "chat-editing-text-model" and others.
     !document.uri.scheme.startsWith("chat")
   );

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -22,6 +22,8 @@ export function isQsharpDocument(document: TextDocument): boolean {
     (Utils.extname(document.uri) === ".qs" || document.isUntitled) &&
     document.uri.scheme !== "git" &&
     document.uri.scheme !== "pr" &&
+    // The Copilot Chat window also creates documents with various schemes that start 
+    // with "chat", such as "chat-editing-text-model" and others.
     !document.uri.scheme.startsWith("chat")
   );
 }

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -21,7 +21,8 @@ export function isQsharpDocument(document: TextDocument): boolean {
     document.languageId === qsharpLanguageId &&
     (Utils.extname(document.uri) === ".qs" || document.isUntitled) &&
     document.uri.scheme !== "git" &&
-    document.uri.scheme !== "pr"
+    document.uri.scheme !== "pr" &&
+    !document.uri.scheme.startsWith("chat")
   );
 }
 

--- a/vscode/src/language-service/testExplorer.ts
+++ b/vscode/src/language-service/testExplorer.ts
@@ -93,20 +93,26 @@ export function startTestDiscovery(
       if (msg.detail.success) {
         run.passed(testCase);
       } else {
-        const failureLocation =
+        const failureLocationUri =
           msg.detail?.value?.uri ||
           (msg.detail?.value?.related &&
             msg.detail.value.related[0].location?.source) ||
           null;
+        // If there was no 'uri' on 'value', then the 'range' on 'value' tends to be unreliable too,
+        // so use the span on the first related location if available.
+        const failureLocationRange =
+          !msg.detail?.value?.uri && msg.detail?.value?.related?.[0]
+            ? msg.detail.value.related[0].location.span
+            : msg.detail.value.range;
 
         const message: vscode.TestMessage = {
           message: msg.detail.value.message,
           location:
-            failureLocation === null
+            failureLocationUri === null
               ? undefined
               : {
-                  range: toVsCodeRange(msg.detail.value.range),
-                  uri: vscode.Uri.parse(failureLocation),
+                  range: toVsCodeRange(failureLocationRange),
+                  uri: vscode.Uri.parse(failureLocationUri),
                 },
         };
         run.failed(testCase, message);


### PR DESCRIPTION
This PR fixes two issues.

Firstly, Q# code used in chat contexts was showing up in the Test Explorer as additional documents (and possibly other locations). It seems to use a few schemes all starting with 'chat', so excluding those.

Secondly, the location given for failing tests was often wrong, and falling back to the first 'related' location span when we're also using that for the document uri anyway resolves that issue. (And seems like the correct thing to do anyway).