### PR TITLE
Swap Control and Target

### DIFF
--- a/npm/qsharp/ux/circuit-vis/events.ts
+++ b/npm/qsharp/ux/circuit-vis/events.ts
@@ -483,7 +483,7 @@ class CircuitEvents {
                 targetLoc,
                 this.selectedWire,
                 targetWire,
-                false,
+                this.movingControl,
                 insertNewColumn,
               );
             } else {


### PR DESCRIPTION
In circuit editing, when moving a control onto a target or vise-versa, the control and target should swap positions.

![Swap control target](https://github.com/user-attachments/assets/29a422d4-fc2c-4b5e-9021-2bdd946ad897)

This also fixes an issue with copy-moving controls. The behavior is now that it will create a new control for the same operation and possibly move the operation horizontally in the circuit.

![Copy-move control](https://github.com/user-attachments/assets/462253ec-f7a1-453c-8b57-e2b744104755)
