### PR TITLE
Retain circuit editor when hidden

### DIFF
--- a/vscode/src/circuitEditor.ts
+++ b/vscode/src/circuitEditor.ts
@@ -12,6 +12,7 @@ export class CircuitEditorProvider implements vscode.CustomTextEditorProvider {
     const providerRegistration = vscode.window.registerCustomEditorProvider(
       CircuitEditorProvider.viewType,
       provider,
+      { webviewOptions: { retainContextWhenHidden: true } },
     );
     return providerRegistration;
   }


### PR DESCRIPTION
This avoid the delay when switching away from the circuit editor and then back while it reloads the UX.