### PR TITLE
Fix qasm const evaluator panic

### DIFF
--- a/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -39,8 +39,6 @@ pub enum ConstEvalError {
     UnsupportedBinaryOp(String, String, String, #[label] Span),
 }
 
-impl ConstEvalError {}
-
 impl Expr {
     /// Tries to evaluate the expression. It takes the current `Lowerer` as
     /// the evaluation context to resolve symbols and push errors in case

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -8,7 +8,7 @@ use std::fmt::{Display, Formatter};
 
 use crate::parser::ast as syntax;
 
-use super::ast::LiteralKind;
+use super::ast::{BinOp, LiteralKind};
 
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub enum Type {
@@ -788,4 +788,71 @@ pub(crate) fn is_complex_binop_supported(op: syntax::BinOp) -> bool {
             | syntax::BinOp::Div
             | syntax::BinOp::Exp
     )
+}
+
+/// Returns true if the binary op is supported for the `lhs` and `rhs` types.
+/// Any conversions have been made explicit by inserting casts during lowering.
+/// Note: the type of the binary expression doesn't need to be the same as the
+///       operands, for example, comparison operators can have integer operands
+///       but their type is boolean.
+/// We can write a simpler implementation under that assumption.
+///
+/// There are some exceptions:
+///  1. The rhs in Shl and Shr must be of type `UInt`.
+///  2. Angle can be multiplied and divided by `UInt`.
+pub(crate) fn binary_op_is_supported_for_types(op: BinOp, lhs_ty: &Type, rhs_ty: &Type) -> bool {
+    use Type::*;
+
+    match op {
+        // Bit Shifts: `rhs_ty` must always be `uint`.
+        BinOp::Shl | BinOp::Shr => {
+            matches!(lhs_ty, UInt(..) | Angle(..) | Bit(..) | BitArray(..))
+                && matches!(rhs_ty, UInt(..))
+        }
+
+        // Bitwise.
+        BinOp::AndB | BinOp::OrB | BinOp::XorB => {
+            base_types_equal(lhs_ty, rhs_ty)
+                && matches!(lhs_ty, UInt(..) | Angle(..) | Bit(..) | BitArray(..))
+        }
+
+        // Logical.
+        BinOp::AndL | BinOp::OrL => matches!(lhs_ty, Bool(..)) && matches!(rhs_ty, Bool(..)),
+
+        // Comparison.
+        BinOp::Eq | BinOp::Neq | BinOp::Gt | BinOp::Gte | BinOp::Lt | BinOp::Lte => {
+            base_types_equal(lhs_ty, rhs_ty)
+                && matches!(
+                    lhs_ty,
+                    Int(..) | UInt(..) | Angle(..) | Bit(..) | BitArray(..)
+                )
+        }
+
+        // Arithmetic
+        BinOp::Add | BinOp::Sub => {
+            base_types_equal(lhs_ty, rhs_ty)
+                && matches!(lhs_ty, Int(..) | UInt(..) | Float(..) | Angle(..))
+        }
+        BinOp::Mul => {
+            let uint_angle_exception = (matches!(lhs_ty, Angle(..)) && matches!(rhs_ty, UInt(..)))
+                || (matches!(lhs_ty, UInt(..)) && matches!(rhs_ty, Angle(..)));
+
+            let base_case = base_types_equal(lhs_ty, rhs_ty)
+                && matches!(lhs_ty, Int(..) | UInt(..) | Float(..));
+
+            uint_angle_exception || base_case
+        }
+        BinOp::Div => {
+            let uint_angle_exception = matches!(lhs_ty, Angle(..)) && matches!(rhs_ty, UInt(..));
+
+            let base_case = base_types_equal(lhs_ty, rhs_ty)
+                && matches!(lhs_ty, Int(..) | UInt(..) | Float(..) | Angle(..));
+
+            uint_angle_exception || base_case
+        }
+        BinOp::Mod => base_types_equal(lhs_ty, rhs_ty) && matches!(lhs_ty, Int(..) | UInt(..)),
+        BinOp::Exp => {
+            base_types_equal(lhs_ty, rhs_ty) && matches!(lhs_ty, Int(..) | UInt(..) | Float(..))
+        }
+    }
 }

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -792,14 +792,6 @@ pub(crate) fn is_complex_binop_supported(op: syntax::BinOp) -> bool {
 
 /// Returns true if the binary op is supported for the `lhs` and `rhs` types.
 /// Any conversions have been made explicit by inserting casts during lowering.
-/// Note: the type of the binary expression doesn't need to be the same as the
-///       operands, for example, comparison operators can have integer operands
-///       but their type is boolean.
-/// We can write a simpler implementation under that assumption.
-///
-/// There are some exceptions:
-///  1. The rhs in Shl and Shr must be of type `UInt`.
-///  2. Angle can be multiplied and divided by `UInt`.
 pub(crate) fn binary_op_is_supported_for_types(op: BinOp, lhs_ty: &Type, rhs_ty: &Type) -> bool {
     use Type::*;
 

--- a/compiler/qsc_qasm/src/tests/declaration/def.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/def.rs
@@ -234,14 +234,13 @@ fn capturing_non_const_evaluatable_external_variable_fails() {
     };
 
     expect![[r#"
-        [Qasm.Compiler.NegativeUIntValue
+        [Qasm.Lowerer.UnsupportedBinaryOp
 
-          x uint expression must evaluate to a non-negative value, but it evaluated
-          | to -3
-           ,-[Test.qasm:2:28]
+          x Shl is not supported between types Int(None, true) and UInt(None, true)
+           ,-[Test.qasm:2:23]
          1 | 
          2 |         const int a = 2 << (-3);
-           :                            ^^^^
+           :                       ^^^^^^^^^
          3 |         def f() -> int {
            `----
         , Qasm.Lowerer.ExprMustBeConst

--- a/compiler/qsc_qasm/src/tests/declaration/gate.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/gate.rs
@@ -156,14 +156,13 @@ fn capturing_non_const_evaluatable_external_variable_fails() {
     };
 
     expect![[r#"
-        [Qasm.Compiler.NegativeUIntValue
+        [Qasm.Lowerer.UnsupportedBinaryOp
 
-          x uint expression must evaluate to a non-negative value, but it evaluated
-          | to -3
-           ,-[Test.qasm:2:28]
+          x Shl is not supported between types Int(None, true) and UInt(None, true)
+           ,-[Test.qasm:2:23]
          1 | 
          2 |         const int a = 2 << (-3);
-           :                            ^^^^
+           :                       ^^^^^^^^^
          3 |         gate my_gate q {
            `----
         , Qasm.Lowerer.ExprMustBeConst

--- a/compiler/qsc_qasm/src/tests/fuzz.rs
+++ b/compiler/qsc_qasm/src/tests/fuzz.rs
@@ -70,3 +70,10 @@ fn fuzz_2298() {
     super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
+
+#[test]
+fn fuzz_2313() {
+    let source = r#"ctrl(π/0s)@a"#;
+    super::compare_qasm_and_qasharp_asts(source);
+    compile_qasm_best_effort(source, Profile::Unrestricted);
+}

--- a/compiler/qsc_qasm/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm/src/tests/statement/const_eval.rs
@@ -76,7 +76,7 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
     let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
     let errs_string = errs.join("\n");
     expect![[r#"
-        Qasm.Compiler.ExprMustBeConst
+        Qasm.Lowerer.ExprMustBeConst
 
           x expression must be const
            ,-[Test.qasm:5:13]
@@ -96,7 +96,7 @@ fn non_const_exprs_fail_in_bitarray_size_position() {
          6 |         bit[c] r2;
            `----
 
-        Qasm.Compiler.ExprMustBeConst
+        Qasm.Lowerer.ExprMustBeConst
 
           x expression must be const
            ,-[Test.qasm:6:13]
@@ -507,7 +507,7 @@ fn binary_op_shl_creg_fails() {
          5 |     
            `----
 
-        Qasm.Compiler.ExprMustBeConst
+        Qasm.Lowerer.ExprMustBeConst
 
           x expression must be const
            ,-[Test.qasm:4:13]
@@ -680,7 +680,7 @@ fn binary_op_shr_creg_fails() {
          5 |     
            `----
 
-        Qasm.Compiler.ExprMustBeConst
+        Qasm.Lowerer.ExprMustBeConst
 
           x expression must be const
            ,-[Test.qasm:4:13]
@@ -2025,7 +2025,7 @@ fn binary_op_err_type_fails() {
          3 |     
            `----
 
-        Qasm.Compiler.ExprMustBeConst
+        Qasm.Lowerer.ExprMustBeConst
 
           x expression must be const
            ,-[Test.qasm:2:13]
@@ -2108,7 +2108,7 @@ fn fuzzer_issue_2294() {
          3 |     
            `----
 
-        Qasm.Compiler.ExprMustBeConst
+        Qasm.Lowerer.ExprMustBeConst
 
           x expression must be const
            ,-[Test.qasm:2:16]


### PR DESCRIPTION
Fixes #2313. The issue was caused by an assertion in the const evaluator. The fix is surfacing the error to the user instead of panicking. I also made sure the check is exhaustive, since it was missing some cases.