### PR TITLE
Removes |1> Gate from Circuit Editor

### DIFF
--- a/compiler/qsc_circuit/src/circuit_to_qsharp/tests.rs
+++ b/compiler/qsc_circuit/src/circuit_to_qsharp/tests.rs
@@ -468,9 +468,6 @@ fn empty_circuit_with_qubits() {
         &expect![[r#"
             /// Expects a qubit register of size 2.
             operation Test(qs : Qubit[]) : Unit is Ctl + Adj {
-                if Length(qs) != 2 {
-                    fail "Invalid number of qubits. Operation Test expects a qubit register of size 2.";
-                }
             }
 
         "#]],
@@ -482,7 +479,13 @@ fn circuit_with_qubit_missing_num_results() {
     check(
         r#"
 {
-  "componentGrid": [],
+  "componentGrid": [
+    {
+      "components": [
+        { "kind": "unitary", "gate": "H", "targets": [{ "qubit": 0 }] }
+      ]
+    }
+  ],
   "qubits": [
     { "id": 0 }
   ]
@@ -493,6 +496,7 @@ fn circuit_with_qubit_missing_num_results() {
                 if Length(qs) != 1 {
                     fail "Invalid number of qubits. Operation Test expects a qubit register of size 1.";
                 }
+                H(qs[0]);
             }
 
         "#]],

--- a/compiler/qsc_circuit/src/circuit_to_qsharp/tests.rs
+++ b/compiler/qsc_circuit/src/circuit_to_qsharp/tests.rs
@@ -458,6 +458,26 @@ fn empty_circuit() {
 }
 
 #[test]
+fn empty_circuit_with_qubits() {
+    check(
+        r#"
+{
+  "componentGrid": [],
+  "qubits": [{ "id": 0 }, { "id": 1 }]
+}"#,
+        &expect![[r#"
+            /// Expects a qubit register of size 2.
+            operation Test(qs : Qubit[]) : Unit is Ctl + Adj {
+                if Length(qs) != 2 {
+                    fail "Invalid number of qubits. Operation Test expects a qubit register of size 2.";
+                }
+            }
+
+        "#]],
+    );
+}
+
+#[test]
 fn circuit_with_qubit_missing_num_results() {
     check(
         r#"
@@ -505,8 +525,7 @@ fn circuit_with_ket_gates() {
                     fail "Invalid number of qubits. Operation Test expects a qubit register of size 2.";
                 }
                 Reset(qs[0]);
-                Reset(qs[1]);
-                X(qs[1]);
+                fail "Unsupported ket operation: |1〉";
             }
 
         "#]],

--- a/npm/qsharp/ux/circuit-vis/panel.ts
+++ b/npm/qsharp/ux/circuit-vis/panel.ts
@@ -322,7 +322,6 @@ const toolboxGateDictionary: GateDictionary = {
   H: _makeUnitary("H"),
   SX: _makeUnitary("SX"),
   Reset: _makeKet("0"),
-  ResetOne: _makeKet("1"),
   Measure: _makeMeasurement("Measure"),
 };
 


### PR DESCRIPTION
Removes |1> gate from toolbox and qsharp gen.

Also fixes lint about making the circuit a function when empty.