### PR TITLE
Added ApplyOperationPower to Std.Canon

### DIFF
--- a/compiler/qsc_qasm/src/stdlib/QasmStd/src/QasmStd/Convert.qs
+++ b/compiler/qsc_qasm/src/stdlib/QasmStd/src/QasmStd/Convert.qs
@@ -5,10 +5,7 @@ import Std.Math.AbsI;
 
 /// The POW function is used to implement the `pow` modifier in QASM for integers.
 operation __Pow__<'T>(N: Int, op: ('T => Unit is Adj + Ctl), target : 'T) : Unit {
-    let op = if N > 0 { () => op(target) } else { () => Adjoint op(target) };
-    for _ in 1..AbsI(N) {
-        op()
-    }
+    ApplyOperationPower(N, () => op(target));
 }
 
 /// The ``BARRIER`` function is used to implement the `barrier` statement in QASM.

--- a/library/src/tests/canon.rs
+++ b/library/src/tests/canon.rs
@@ -556,3 +556,18 @@ fn check_apply_xor_in_place_l() {
         &Value::Int(953),
     );
 }
+
+#[test]
+fn check_apply_operation_power_i() {
+    test_expression(
+        {
+            "{
+            use q = Qubit();
+            ApplyOperationPower(12, () => Rx(Std.Math.PI()/16.0, q));
+            ApplyOperationPower(-3, () => Rx(Std.Math.PI()/4.0, q));
+            M(q)
+        }"
+        },
+        &Value::RESULT_ZERO,
+    );
+}

--- a/library/std/src/Std/Canon.qs
+++ b/library/std/src/Std/Canon.qs
@@ -583,6 +583,25 @@ operation ApplyXorInPlaceL(value : BigInt, target : Qubit[]) : Unit is Adj + Ctl
     }
     adjoint self;
 }
+
+/// # Summary
+/// Applies operation `u` `power` times.
+/// If `power` is negative, the adjoint of `u` is used.
+/// If `power` is 0, operation `u` is not applied.
+///
+/// # Description
+/// Applies $U^n$ where $n$ = `power`.
+operation ApplyOperationPower(power: Int, u: Unit => Unit is Adj) : Unit is Adj {
+    let op = if power >= 0 {
+        u
+    } else {
+        Adjoint u
+    };
+    for _ in 1..AbsI(power) {
+        op();
+    }
+}
+
 /// # Summary
 /// Relabels the qubits in the `current` array with the qubits in the `updated` array. The `updated` array
 /// must be a valid permutation of the `current` array.
@@ -647,4 +666,5 @@ export
     SwapReverseRegister,
     ApplyXorInPlace,
     ApplyXorInPlaceL,
+    ApplyOperationPower,
     Relabel;


### PR DESCRIPTION
* Added ApplyOperationPower that applies operation $U^n$, where $n$ is an integer. If $n$ is negative, the adjoint of $U$ is used. If $n$ is 0, the operation is not applied.
* Used this operation in StdQasm.
* Seems to be useful in general.