### PR TITLE
Added BigIntAsInt to Std.Convert

### DIFF
--- a/compiler/qsc_qasm/src/stdlib/QasmStd/src/QasmStd/Angle.qs
+++ b/compiler/qsc_qasm/src/stdlib/QasmStd/src/QasmStd/Angle.qs
@@ -232,7 +232,7 @@ function __MultiplyAngleByBigInt__(angle : __Angle__, factor : BigInt) : __Angle
     let (value, size) = angle!;
     let value : BigInt = Std.Convert.IntAsBigInt(value);
     let value = (value * factor) % Std.Convert.IntAsBigInt(1 <<< size);
-    let value = Std.Convert.BoolArrayAsInt(Std.Convert.BigIntAsBoolArray(value, size));
+    let value = Std.Convert.BigIntAsInt(value);
     new __Angle__ { Value = value, Size = size }
 }
 

--- a/library/src/tests/convert.rs
+++ b/library/src/tests/convert.rs
@@ -171,6 +171,37 @@ fn check_bigint_as_bool_array() {
 }
 
 #[test]
+fn check_big_int_as_int_0() {
+    test_expression("Std.Convert.BigIntAsInt(0L)", &Value::Int(0));
+}
+
+#[test]
+fn check_big_int_as_int_1() {
+    test_expression("Std.Convert.BigIntAsInt(1L)", &Value::Int(1));
+}
+
+#[test]
+fn check_big_int_as_int_n1() {
+    test_expression("Std.Convert.BigIntAsInt(-1L)", &Value::Int(-1));
+}
+
+#[test]
+fn check_big_int_as_int_max() {
+    test_expression(
+        "Std.Convert.BigIntAsInt(9_223_372_036_854_775_807L)",
+        &Value::Int(i64::MAX),
+    );
+}
+
+#[test]
+fn check_big_int_as_int_min() {
+    test_expression(
+        "Std.Convert.BigIntAsInt(-9_223_372_036_854_775_808L)",
+        &Value::Int(i64::MIN),
+    );
+}
+
+#[test]
 fn check_bool_array_as_big_int() {
     test_expression(
         "Microsoft.Quantum.Convert.BoolArrayAsBigInt([false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false])",

--- a/library/std/src/Std/Convert.qs
+++ b/library/std/src/Std/Convert.qs
@@ -171,7 +171,7 @@ function BigIntAsBoolArray(number : BigInt, bits : Int) : Bool[] {
 ///
 /// # Output
 /// Int representation of a number.
-function BigIntAsInt(number: BigInt) : Int {
+function BigIntAsInt(number : BigInt) : Int {
     let max = 9_223_372_036_854_775_807L;
     let min = -9_223_372_036_854_775_808L;
     Fact(number >= min and number <= max, $"`number`=number is too big to fit into Int.");

--- a/library/std/src/Std/Convert.qs
+++ b/library/std/src/Std/Convert.qs
@@ -163,6 +163,34 @@ function BigIntAsBoolArray(number : BigInt, bits : Int) : Bool[] {
 }
 
 /// # Summary
+/// Converts a BigInt number into Int. Raises an error if the number is too large to fit.
+///
+/// # Input
+/// ## number
+/// A BigInt number to be converted.
+///
+/// # Output
+/// Int representation of a number.
+function BigIntAsInt(number: BigInt) : Int {
+    let max = 9_223_372_036_854_775_807L;
+    let min = -9_223_372_036_854_775_808L;
+    Fact(number >= min and number <= max, $"`number`=number is too big to fit into Int.");
+
+    mutable result = 0;
+    mutable powL = 1L;
+    mutable pow = 1;
+    for _ in 0..63 {
+        if number &&& powL != 0L {
+            result |||= pow;
+        }
+        powL <<<= 1;
+        pow <<<= 1;
+    }
+
+    result
+}
+
+/// # Summary
 /// Produces a non-negative integer from a string of Results in little-endian format.
 ///
 /// # Input
@@ -289,6 +317,7 @@ export
     IntAsBoolArray,
     BoolArrayAsBigInt,
     BigIntAsBoolArray,
+    BigIntAsInt,
     ResultArrayAsInt,
     ResultArrayAsBoolArray,
     BoolArrayAsResultArray,


### PR DESCRIPTION
Added BigIntAsInt, which converts BigInt to Int if it fits. I saw bool array workaround used for this a few times - I think it's about time to include this conversion directly. Added code without using intrinsics.