### PR TITLE
Capitalize the Rotation gate names in trace circuits

### DIFF
--- a/compiler/qsc/src/interpret/circuit_tests.rs
+++ b/compiler/qsc/src/interpret/circuit_tests.rs
@@ -148,9 +148,9 @@ fn rotation_gate() {
         .circuit(CircuitEntryPoint::EntryPoint, false)
         .expect("circuit generation should succeed");
 
-    expect![[r"
-        q_0    ─ rx(1.5708) ──
-    "]]
+    expect![[r#"
+        q_0    ─ Rx(1.5708) ──
+    "#]]
     .assert_eq(&circ.to_string());
 }
 
@@ -883,10 +883,10 @@ fn operation_with_long_gates_properly_aligned() {
     expect![[r#"
         q_0    ── H ────────────────────────────────────── ● ──────── M ────────────────────────────────── ● ─────────
                                                            │          ╘════════════════════════════════════╪══════════
-        q_1    ── H ──────── X ─────── ry(1.0000) ──────── X ───────────────────────────── rxx(1.0000) ────┼───── M ──
+        q_1    ── H ──────── X ─────── Ry(1.0000) ──────── X ───────────────────────────── Rxx(1.0000) ────┼───── M ──
                                                                                                 ┆          │      ╘═══
-        q_2    ── H ─── rx(1.0000) ──────── H ─────── rx(1.0000) ──── H ─── rx(1.0000) ─────────┆──────────┼──────────
-        q_3    ─────────────────────────────────────────────────────────────────────────── rxx(1.0000) ─── X ──── M ──
+        q_2    ── H ─── Rx(1.0000) ──────── H ─────── Rx(1.0000) ──── H ─── Rx(1.0000) ─────────┆──────────┼──────────
+        q_3    ─────────────────────────────────────────────────────────────────────────── Rxx(1.0000) ─── X ──── M ──
                                                                                                                   ╘═══
     "#]]
     .assert_eq(&circ.to_string());
@@ -919,12 +919,12 @@ fn operation_with_subsequent_qubits_gets_horizontal_lines() {
         .expect("circuit generation should succeed");
 
     expect![[r#"
-        q_0    ─ rxx(1.0000) ─
+        q_0    ─ Rxx(1.0000) ─
                       ┆
-        q_1    ─ rxx(1.0000) ─
-        q_2    ─ rxx(1.0000) ─
+        q_1    ─ Rxx(1.0000) ─
+        q_2    ─ Rxx(1.0000) ─
                       ┆
-        q_3    ─ rxx(1.0000) ─
+        q_3    ─ Rxx(1.0000) ─
     "#]]
     .assert_eq(&circ.to_string());
 }
@@ -953,9 +953,9 @@ fn operation_with_subsequent_qubits_no_double_rows() {
         .expect("circuit generation should succeed");
 
     expect![[r#"
-        q_0    ─ rxx(1.0000) ── rxx(1.0000) ─
+        q_0    ─ Rxx(1.0000) ── Rxx(1.0000) ─
                       ┆              ┆
-        q_1    ─ rxx(1.0000) ── rxx(1.0000) ─
+        q_1    ─ Rxx(1.0000) ── Rxx(1.0000) ─
     "#]]
     .assert_eq(&circ.to_string());
 }
@@ -989,12 +989,12 @@ fn operation_with_subsequent_qubits_no_added_rows() {
         .expect("circuit generation should succeed");
 
     expect![[r#"
-        q_0    ─ rxx(1.0000) ─── M ──
+        q_0    ─ Rxx(1.0000) ─── M ──
                       ┆          ╘═══
-        q_1    ─ rxx(1.0000) ────────
-        q_2    ─ rxx(1.0000) ─── M ──
+        q_1    ─ Rxx(1.0000) ────────
+        q_2    ─ Rxx(1.0000) ─── M ──
                       ┆          ╘═══
-        q_3    ─ rxx(1.0000) ────────
+        q_3    ─ Rxx(1.0000) ────────
     "#]]
     .assert_eq(&circ.to_string());
 }

--- a/compiler/qsc_circuit/src/builder.rs
+++ b/compiler/qsc_circuit/src/builder.rs
@@ -88,35 +88,35 @@ impl Backend for Builder {
 
     fn rx(&mut self, theta: f64, q: usize) {
         let q = self.map(q);
-        self.push_gate(rotation_gate("rx", theta, [q]));
+        self.push_gate(rotation_gate("Rx", theta, [q]));
     }
 
     fn rxx(&mut self, theta: f64, q0: usize, q1: usize) {
         let q0 = self.map(q0);
         let q1 = self.map(q1);
-        self.push_gate(rotation_gate("rxx", theta, [q0, q1]));
+        self.push_gate(rotation_gate("Rxx", theta, [q0, q1]));
     }
 
     fn ry(&mut self, theta: f64, q: usize) {
         let q = self.map(q);
-        self.push_gate(rotation_gate("ry", theta, [q]));
+        self.push_gate(rotation_gate("Ry", theta, [q]));
     }
 
     fn ryy(&mut self, theta: f64, q0: usize, q1: usize) {
         let q0 = self.map(q0);
         let q1 = self.map(q1);
-        self.push_gate(rotation_gate("ryy", theta, [q0, q1]));
+        self.push_gate(rotation_gate("Ryy", theta, [q0, q1]));
     }
 
     fn rz(&mut self, theta: f64, q: usize) {
         let q = self.map(q);
-        self.push_gate(rotation_gate("rz", theta, [q]));
+        self.push_gate(rotation_gate("Rz", theta, [q]));
     }
 
     fn rzz(&mut self, theta: f64, q0: usize, q1: usize) {
         let q0 = self.map(q0);
         let q1 = self.map(q1);
-        self.push_gate(rotation_gate("rzz", theta, [q0, q1]));
+        self.push_gate(rotation_gate("Rzz", theta, [q0, q1]));
     }
 
     fn sadj(&mut self, q: usize) {


### PR DESCRIPTION
The rotation gates created by the circuit builder were getting lower-case names: `rx`, `rxx` for example. These are inconsistent with the other gate names like `H` and `X`. It is also inconsistent with the Q# equivalent operations `Rx(theta, q)`.

This PR changes the output of the circuit builder to have upper-case names for the rotation gates, making them consistent with the other gate names and the Q# operations.