### PR TITLE
Support Enter and Escape Keys with Prompts

### DIFF
--- a/compiler/qsc_circuit/src/circuit_to_qsharp.rs
+++ b/compiler/qsc_circuit/src/circuit_to_qsharp.rs
@@ -113,12 +113,10 @@ fn build_operation_def(circuit_name: &str, circuit: &Circuit) -> String {
                 }
             }
 
-            // Look for a "π" or "pi" in the args
+            // Look for a "π" in the args
             let args = op.args();
             if !should_add_pi && !args.is_empty() {
-                should_add_pi = args
-                    .iter()
-                    .any(|arg| arg.contains("π") || arg.to_lowercase().contains("pi"));
+                should_add_pi = args.iter().any(|arg| arg.contains("π"));
             }
         }
     }
@@ -328,8 +326,6 @@ fn operation_call(unitary: &Unitary, qubits: &FxHashMap<usize, String>) -> Strin
 
     // Create the regex for matching numbers (both integers and doubles)
     let number_regex = Regex::new(r"((\d+(\.\d*)?)|(\.\d+))").expect("Regex should compile");
-    // Create the regex for matching "pi" (case-insensitive)
-    let pi_regex = Regex::new(r"(?i)pi").expect("Regex should compile");
 
     // Convert ints to doubles by appending a `.` to the end of the integer
     for arg in &unitary.args {
@@ -344,9 +340,6 @@ fn operation_call(unitary: &Unitary, qubits: &FxHashMap<usize, String>) -> Strin
                 }
             })
             .to_string();
-
-        // Replace "pi" (case-insensitive) with "π"
-        let updated_arg = pi_regex.replace_all(&updated_arg, "π").to_string();
 
         args.push(updated_arg);
     }

--- a/npm/qsharp/ux/circuit-vis/events.ts
+++ b/npm/qsharp/ux/circuit-vis/events.ts
@@ -789,6 +789,7 @@ const _createConfirmPrompt = (
   okButton.addEventListener("click", () => {
     callback(true); // User confirmed
     document.body.removeChild(overlay);
+    document.removeEventListener("keydown", handleGlobalKeyDown, true);
   });
 
   // Create the Cancel button
@@ -798,7 +799,20 @@ const _createConfirmPrompt = (
   cancelButton.addEventListener("click", () => {
     callback(false); // User canceled
     document.body.removeChild(overlay);
+    document.removeEventListener("keydown", handleGlobalKeyDown, true);
   });
+
+  // Handle Enter and Escape keys globally while prompt is open
+  const handleGlobalKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      okButton.click();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      cancelButton.click();
+    }
+  };
+  document.addEventListener("keydown", handleGlobalKeyDown, true);
 
   buttonsContainer.appendChild(okButton);
   buttonsContainer.appendChild(cancelButton);


### PR DESCRIPTION
- Enables the use of the "Enter" key to affirm input and the "Escape" key to cancel input in argument prompt.
- Enables the use of the "Enter" key to confirm and the "Escape" key to cancel on remove-qubit confirmation prompt.
- Automatically replaces "pi" with the symbol "π" in user input for arguments for better readability.