### PR TITLE
Handle division by zero error in const evaluator

### DIFF
--- a/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -469,7 +469,13 @@ impl BinaryOpExpr {
                     })
                 }
                 Type::Float(..) => {
-                    rewrap_lit!((lhs, rhs), (Float(lhs), Float(rhs)), Float(lhs / rhs))
+                    rewrap_lit!((lhs, rhs), (Float(lhs), Float(rhs)), {
+                        if rhs == 0. {
+                            ctx.push_const_eval_error(ConstEvalError::DivisionByZero(self.span()));
+                            return None;
+                        }
+                        Float(lhs / rhs)
+                    })
                 }
                 Type::Angle(..) => match &self.rhs.ty {
                     Type::UInt(..) => {

--- a/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -506,7 +506,13 @@ impl BinaryOpExpr {
             },
             BinOp::Mod => match lhs_ty {
                 Type::Int(..) | Type::UInt(..) => {
-                    rewrap_lit!((lhs, rhs), (Int(lhs), Int(rhs)), Int(lhs % rhs))
+                    rewrap_lit!((lhs, rhs), (Int(lhs), Int(rhs)), {
+                        if rhs == 0 {
+                            ctx.push_const_eval_error(ConstEvalError::DivisionByZero(self.span()));
+                            return None;
+                        }
+                        Int(lhs % rhs)
+                    })
                 }
                 _ => None,
             },

--- a/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -627,24 +627,28 @@ impl Lowerer {
             self.symbols.is_scope_rooted_in_gate_or_subroutine();
 
         // This is true if the symbol is outside the most inner gate or function scope.
-        let is_symbol_outside_most_inner_gate_or_function_scope = self
+        let is_symbol_declaration_outside_gate_or_function_scope = self
             .symbols
             .is_symbol_outside_most_inner_gate_or_function_scope(symbol_id);
 
-        let is_const_evaluation_necessary = symbol.is_const()
-            && is_symbol_inside_gate_or_function_scope
-            && is_symbol_outside_most_inner_gate_or_function_scope;
+        let need_to_capture_symbol = is_symbol_inside_gate_or_function_scope
+            && is_symbol_declaration_outside_gate_or_function_scope;
 
-        let kind = if is_const_evaluation_necessary {
+        let kind = if need_to_capture_symbol && symbol.is_const() {
             if let Some(val) = symbol.get_const_expr().const_eval(self) {
                 semantic::ExprKind::Lit(val)
             } else {
-                self.push_semantic_error(SemanticErrorKind::ExprMustBeConst(
-                    "a captured variable".into(),
-                    ident.span,
-                ));
-                semantic::ExprKind::Err
+                // If the const evaluation fails, we return Err but don't push
+                // any additional error. The error was already pushed in the
+                // const_eval function.
+                semantic::ExprKind::Ident(symbol_id)
             }
+        } else if need_to_capture_symbol && !symbol.is_const() {
+            self.push_semantic_error(SemanticErrorKind::ExprMustBeConst(
+                "a captured variable".into(),
+                ident.span,
+            ));
+            semantic::ExprKind::Ident(symbol_id)
         } else {
             semantic::ExprKind::Ident(symbol_id)
         };

--- a/compiler/qsc_qasm/src/tests/declaration/def.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/def.rs
@@ -207,6 +207,15 @@ fn capturing_non_const_external_variable_fails() {
            :                    ^
          5 |         }
            `----
+        , Qasm.Lowerer.ExprMustBeConst
+
+          x a captured variable must be a const expression
+           ,-[Test.qasm:4:20]
+         3 |         def f() -> int {
+         4 |             return a;
+           :                    ^
+         5 |         }
+           `----
         , Qasm.Lowerer.CannotCast
 
           x cannot cast expression of type Err to type Int(None, false)
@@ -242,15 +251,6 @@ fn capturing_non_const_evaluatable_external_variable_fails() {
          2 |         const int a = 2 << (-3);
            :                       ^^^^^^^^^
          3 |         def f() -> int {
-           `----
-        , Qasm.Lowerer.ExprMustBeConst
-
-          x a captured variable must be a const expression
-           ,-[Test.qasm:4:20]
-         3 |         def f() -> int {
-         4 |             return a;
-           :                    ^
-         5 |         }
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));

--- a/compiler/qsc_qasm/src/tests/declaration/gate.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/gate.rs
@@ -129,6 +129,15 @@ fn capturing_non_const_external_variable_fails() {
            :                     ^
          5 |         }
            `----
+        , Qasm.Lowerer.ExprMustBeConst
+
+          x a captured variable must be a const expression
+           ,-[Test.qasm:4:21]
+         3 |         gate my_gate q {
+         4 |             int x = a;
+           :                     ^
+         5 |         }
+           `----
         , Qasm.Lowerer.CannotCast
 
           x cannot cast expression of type Err to type Int(None, false)
@@ -164,15 +173,6 @@ fn capturing_non_const_evaluatable_external_variable_fails() {
          2 |         const int a = 2 << (-3);
            :                       ^^^^^^^^^
          3 |         gate my_gate q {
-           `----
-        , Qasm.Lowerer.ExprMustBeConst
-
-          x a captured variable must be a const expression
-           ,-[Test.qasm:4:21]
-         3 |         gate my_gate q {
-         4 |             int x = a;
-           :                     ^
-         5 |         }
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));

--- a/compiler/qsc_qasm/src/tests/fuzz.rs
+++ b/compiler/qsc_qasm/src/tests/fuzz.rs
@@ -77,3 +77,10 @@ fn fuzz_2313() {
     super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
+
+#[test]
+fn fuzz_2332() {
+    let source = r#"ctrl(0/0)@s"#;
+    super::compare_qasm_and_qasharp_asts(source);
+    compile_qasm_best_effort(source, Profile::Unrestricted);
+}

--- a/compiler/qsc_qasm/src/tests/fuzz.rs
+++ b/compiler/qsc_qasm/src/tests/fuzz.rs
@@ -84,3 +84,10 @@ fn fuzz_2332() {
     super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
+
+#[test]
+fn fuzz_2348() {
+    let source = r#"ctrl(0%0)@s"#;
+    super::compare_qasm_and_qasharp_asts(source);
+    compile_qasm_best_effort(source, Profile::Unrestricted);
+}

--- a/compiler/qsc_qasm/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm/src/tests/statement/const_eval.rs
@@ -2164,16 +2164,6 @@ fn binary_op_with_non_supported_types_fails() {
          3 |         def f() { a; }
            `----
 
-        Qasm.Lowerer.ExprMustBeConst
-
-          x a captured variable must be a const expression
-           ,-[Test.qasm:3:19]
-         2 |         const int a = 2 / 0s;
-         3 |         def f() { a; }
-           :                   ^
-         4 |     
-           `----
-
         Qasm.Compiler.NotSupported
 
           x timing literals are not supported
@@ -2209,16 +2199,6 @@ fn division_of_int_by_zero_int_errors() {
            :                       ^^^^^
          3 |         def f() { a; }
            `----
-
-        Qasm.Lowerer.ExprMustBeConst
-
-          x a captured variable must be a const expression
-           ,-[Test.qasm:3:19]
-         2 |         const int a = 2 / 0;
-         3 |         def f() { a; }
-           :                   ^
-         4 |     
-           `----
     "#]]
     .assert_eq(&errs_string);
 }
@@ -2246,16 +2226,6 @@ fn division_of_angle_by_zero_int_errors() {
            :                         ^^^^^
          4 |         def f() { b; }
            `----
-
-        Qasm.Lowerer.ExprMustBeConst
-
-          x a captured variable must be a const expression
-           ,-[Test.qasm:4:19]
-         3 |         const angle b = a / 0;
-         4 |         def f() { b; }
-           :                   ^
-         5 |     
-           `----
     "#]]
     .assert_eq(&errs_string);
 }
@@ -2281,16 +2251,6 @@ fn division_by_zero_float_errors() {
          2 |         const float a = 2.0 / 0.0;
            :                         ^^^^^^^^^
          3 |         def f() { a; }
-           `----
-
-        Qasm.Lowerer.ExprMustBeConst
-
-          x a captured variable must be a const expression
-           ,-[Test.qasm:3:19]
-         2 |         const float a = 2.0 / 0.0;
-         3 |         def f() { a; }
-           :                   ^
-         4 |     
            `----
     "#]]
     .assert_eq(&errs_string);
@@ -2319,16 +2279,6 @@ fn division_by_zero_angle_errors() {
          4 |         const uint c = a / b;
            :                        ^^^^^
          5 |         def f() { c; }
-           `----
-
-        Qasm.Lowerer.ExprMustBeConst
-
-          x a captured variable must be a const expression
-           ,-[Test.qasm:5:19]
-         4 |         const uint c = a / b;
-         5 |         def f() { c; }
-           :                   ^
-         6 |     
            `----
     "#]]
     .assert_eq(&errs_string);

--- a/compiler/qsc_qasm/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm/src/tests/statement/const_eval.rs
@@ -2283,3 +2283,29 @@ fn division_by_zero_angle_errors() {
     "#]]
     .assert_eq(&errs_string);
 }
+
+#[test]
+fn modulo_of_int_by_zero_int_errors() {
+    let source = r#"
+        const int a = 2 % 0;
+        def f() { a; }
+    "#;
+
+    let Err(errs) = compile_qasm_to_qsharp(source) else {
+        panic!("should have generated an error");
+    };
+    let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
+    let errs_string = errs.join("\n");
+    expect![[r#"
+        Qasm.Lowerer.DivisionByZero
+
+          x division by error during const evaluation
+           ,-[Test.qasm:2:23]
+         1 | 
+         2 |         const int a = 2 % 0;
+           :                       ^^^^^
+         3 |         def f() { a; }
+           `----
+    "#]]
+    .assert_eq(&errs_string);
+}


### PR DESCRIPTION
This PR fixes #2332 and #2348. It handles the division by zero case in the const evaluator for `int`, `float`, and `angle` types; and the modulo by zero case for the `int` type.