### PR TITLE
Addressed Kata feedback

### DIFF
--- a/katas/content/preparing_states/three_states_two_qubits/Placeholder.qs
+++ b/katas/content/preparing_states/three_states_two_qubits/Placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation ThreeStates_TwoQubits (qs : Qubit[]) : Unit is Adj + Ctl {
+    operation ThreeStates_TwoQubits (qs : Qubit[]) : Unit {
         // Implement your solution here...
 
     }  

--- a/katas/content/preparing_states/three_states_two_qubits/SolutionB.qs
+++ b/katas/content/preparing_states/three_states_two_qubits/SolutionB.qs
@@ -1,7 +1,7 @@
 namespace Kata {
     import Std.Math.*;
 
-    operation ThreeStates_TwoQubits(qs : Qubit[]) : Unit is Adj + Ctl {
+    operation ThreeStates_TwoQubits(qs : Qubit[]) : Unit {
         let theta = ArcSin(1.0 / Sqrt(3.0));
         Ry(2.0 * theta, qs[0]);
         ApplyControlledOnInt(0, H, [qs[0]], qs[1]);

--- a/katas/content/preparing_states/wstate_power_of_two/Placeholder.qs
+++ b/katas/content/preparing_states/wstate_power_of_two/Placeholder.qs
@@ -1,5 +1,5 @@
 namespace Kata {
-    operation WState_PowerOfTwo (qs : Qubit[]) : Unit {
+    operation WState_PowerOfTwo (qs : Qubit[]) : Unit is Adj + Ctl {
         // Implement your solution here...
 
     }

--- a/katas/content/teleportation/reconstruct_message/solution.md
+++ b/katas/content/teleportation/reconstruct_message/solution.md
@@ -1,9 +1,9 @@
-Bob's qubit now contains the information about the amplitudes of the teleported state, but it needs correction based on the classical message received for his qubit to match the teleported state precisely. As we've seen in the solution for the previous task, there are four possible measurement outcomes:
+Bob's qubit now contains the information about the amplitudes of the teleported state, but it needs correction based on the classical message received for his qubit to match the teleported state precisely. As we've seen in the solution for the previous task, there are four possible measurement outcomes encoded as a tuple (b1, b2):
 
-- For 00, Bob's qubit ends up in the state $\alpha \ket{0} + \beta \ket{1}$, so no change is required.
-- For 01, Bob's qubit ends up in the state $\alpha \ket{0} - \beta \ket{1}$, so we need to apply a $Z$ correction.
-- For 10, Bob's qubit ends up in the state $\alpha \ket{1} + \beta \ket{0}$, so we need to apply an $X$ correction.
-- For 11, Bob's qubit ends up in the state $\alpha \ket{1} - \beta \ket{0}$, se we need to apply both $Z$ and $X$ corrections.
+- For (0,0), Bob's qubit ends up in the state $\alpha \ket{0} + \beta \ket{1}$, so no change is required.
+- For (0,1), Bob's qubit ends up in the state $\alpha \ket{1} + \beta \ket{0}$, so we need to apply an $X$ correction.
+- For (1,0), Bob's qubit ends up in the state $\alpha \ket{0} - \beta \ket{1}$, so we need to apply a $Z$ correction.
+- For (1,1), Bob's qubit ends up in the state $\alpha \ket{1} - \beta \ket{0}$, se we need to apply both $Z$ and $X$ corrections.
 
 @[solution]({
     "id": "teleportation__reconstruct_the_message_solution",

--- a/katas/content/teleportation/reconstruct_message_psi_plus/index.md
+++ b/katas/content/teleportation/reconstruct_message_psi_plus/index.md
@@ -1,2 +1,2 @@
 **Goal:** 
-Transform Bob's qubit `qBob` into the state in which the message qubit had been originally. It is given that `qAlice` and `qBob` were initially entangled in $\ket{\Psi ^{+}} = \frac{1}{\sqrt{2}}(\ket{00}+\ket{11})$ state.
+Transform Bob's qubit `qBob` into the state in which the message qubit had been originally. It is given that `qAlice` and `qBob` were initially entangled in $\ket{\Psi ^{+}} = \frac{1}{\sqrt{2}}(\ket{01}+\ket{10})$ state.


### PR DESCRIPTION
Addressed community feedback.

* In kata "Preparing Quantum States", lesson "Three Two-Qubit Basis States" removed Adj+Ctl from placeholder and solution.
* In kata "Preparing Quantum States", lesson "W State on Power of Two Number of Qubits" added Adj+Ctl to placeholer and solution.
* In kata "Teleportation", lesson "Reconstruct Message (Bob's Task)", updated text and labels of cases to fix an ordering mistake and make it clearer.
* In kata "Teleportation",  lesson "Reconstruct Message with |Ψ⁺⟩", fixed copy-paste error.

Thanks for reporting!