### PR TITLE
Refactoring qasm std lib

### DIFF
--- a/compiler/qsc_qasm/src/compiler.rs
+++ b/compiler/qsc_qasm/src/compiler.rs
@@ -13,13 +13,13 @@ use qsc_frontend::{compile::SourceMap, error::WithSource};
 
 use crate::{
     ast_builder::{
-        build_adj_plus_ctl_functor, build_arg_pat, build_array_reverse_expr,
+        build_adj_plus_ctl_functor, build_angle_cast_call_by_name,
+        build_angle_convert_call_with_two_params, build_arg_pat, build_array_reverse_expr,
         build_assignment_statement, build_attr, build_barrier_call, build_binary_expr,
-        build_call_no_params, build_call_with_param, build_call_with_params,
-        build_cast_call_by_name, build_classical_decl, build_complex_from_expr,
-        build_convert_call_expr, build_end_stmt, build_expr_array_expr, build_for_stmt,
-        build_function_or_operation, build_gate_call_param_expr,
-        build_gate_call_with_params_and_callee, build_global_call_with_two_params,
+        build_call_no_params, build_call_with_param, build_call_with_params, build_classical_decl,
+        build_complex_from_expr, build_convert_call_expr, build_convert_cast_call_by_name,
+        build_end_stmt, build_expr_array_expr, build_for_stmt, build_function_or_operation,
+        build_gate_call_param_expr, build_gate_call_with_params_and_callee,
         build_if_expr_then_block, build_if_expr_then_block_else_block,
         build_if_expr_then_block_else_expr, build_if_expr_then_expr_else_expr,
         build_implicit_return_stmt, build_index_expr, build_indexed_assignment_statement,
@@ -28,12 +28,12 @@ use crate::{
         build_lit_result_expr, build_managed_qubit_alloc, build_math_call_from_exprs,
         build_math_call_no_params, build_measure_call, build_operation_with_stmts,
         build_path_ident_expr, build_path_ident_ty, build_qasm_import_decl,
-        build_qasm_import_items, build_range_expr, build_reset_call, build_return_expr,
-        build_return_unit, build_stmt_semi_from_expr, build_stmt_semi_from_expr_with_span,
-        build_top_level_ns_with_items, build_tuple_expr, build_unary_op_expr,
-        build_unmanaged_qubit_alloc, build_unmanaged_qubit_alloc_array, build_while_stmt,
-        build_wrapped_block_expr, managed_qubit_alloc_array, map_qsharp_type_to_ast_ty,
-        wrap_expr_in_parens,
+        build_qasm_import_items, build_qasmstd_convert_call_with_two_params, build_range_expr,
+        build_reset_call, build_return_expr, build_return_unit, build_stmt_semi_from_expr,
+        build_stmt_semi_from_expr_with_span, build_top_level_ns_with_items, build_tuple_expr,
+        build_unary_op_expr, build_unmanaged_qubit_alloc, build_unmanaged_qubit_alloc_array,
+        build_while_stmt, build_wrapped_block_expr, managed_qubit_alloc_array,
+        map_qsharp_type_to_ast_ty, wrap_expr_in_parens,
     },
     io::SourceResolver,
     parser::ast::{list_from_iter, List},
@@ -331,11 +331,9 @@ impl QasmCompiler {
                             build_path_ident_expr(symbol.name.as_str(), symbol.span, symbol.span);
                         if matches!(symbol.ty, Type::Angle(..)) {
                             // we can't output a struct, so we need to convert it to a double
-                            build_call_with_param(
-                                "__AngleAsDouble__",
-                                &[],
+                            build_angle_cast_call_by_name(
+                                "AngleAsDouble",
                                 ident,
-                                symbol.span,
                                 symbol.span,
                                 symbol.span,
                             )
@@ -829,7 +827,8 @@ impl QasmCompiler {
                 semast::GateModifierKind::Pow(expr) => {
                     let exponent_expr = self.compile_expr(expr);
                     args = build_tuple_expr(vec![exponent_expr, callee, args]);
-                    callee = build_path_ident_expr("__Pow__", modifier.span, stmt.span);
+                    callee =
+                        build_path_ident_expr("ApplyOperationPowerA", modifier.span, stmt.span);
                 }
                 semast::GateModifierKind::Ctrl(num_ctrls) => {
                     // remove the last n qubits from the qubit list
@@ -1236,7 +1235,7 @@ impl QasmCompiler {
         let compiled_expr = self.compile_expr(expr);
 
         if matches!(expr.ty, Type::Angle(..)) {
-            build_call_with_param("__NegAngle__", &[], compiled_expr, span, expr.span, span)
+            build_angle_cast_call_by_name("NegAngle", compiled_expr, span, expr.span)
         } else {
             build_unary_op_expr(qsast::UnOp::Neg, compiled_expr, span)
         }
@@ -1246,7 +1245,14 @@ impl QasmCompiler {
         let compiled_expr = self.compile_expr(expr);
 
         if matches!(expr.ty, Type::Angle(..)) {
-            build_call_with_param("__AngleNotB__", &[], compiled_expr, span, expr.span, span)
+            build_call_with_param(
+                "AngleNotB",
+                &["QasmStd", "Angle"],
+                compiled_expr,
+                span,
+                expr.span,
+                span,
+            )
         } else {
             build_unary_op_expr(qsast::UnOp::NotB, compiled_expr, span)
         }
@@ -1294,39 +1300,39 @@ impl QasmCompiler {
         let fn_name: &str = match op {
             // Bit shift
             qsast::BinOp::Shl => "__AngleShl__",
-            qsast::BinOp::Shr => "__AngleShr__",
+            qsast::BinOp::Shr => "AngleShr",
 
             // Bitwise
-            qsast::BinOp::AndB => "__AngleAndB__",
-            qsast::BinOp::OrB => "__AngleOrB__",
-            qsast::BinOp::XorB => "__AngleXorB__",
+            qsast::BinOp::AndB => "AngleAndB",
+            qsast::BinOp::OrB => "AngleOrB",
+            qsast::BinOp::XorB => "AngleXorB",
 
             // Comparison
-            qsast::BinOp::Eq => "__AngleEq__",
-            qsast::BinOp::Neq => "__AngleNeq__",
-            qsast::BinOp::Gt => "__AngleGt__",
-            qsast::BinOp::Gte => "__AngleGte__",
-            qsast::BinOp::Lt => "__AngleLt__",
-            qsast::BinOp::Lte => "__AngleLte__",
+            qsast::BinOp::Eq => "AngleEq",
+            qsast::BinOp::Neq => "AngleNeq",
+            qsast::BinOp::Gt => "AngleGt",
+            qsast::BinOp::Gte => "AngleGte",
+            qsast::BinOp::Lt => "AngleLt",
+            qsast::BinOp::Lte => "AngleLte",
 
             // Arithmetic
-            qsast::BinOp::Add => "__AddAngles__",
-            qsast::BinOp::Sub => "__SubtractAngles__",
+            qsast::BinOp::Add => "AddAngles",
+            qsast::BinOp::Sub => "SubtractAngles",
             qsast::BinOp::Mul => {
                 // if we are doing `int * angle` we need to
-                // reverse the order of the args to __MultiplyAngleByInt__
+                // reverse the order of the args to MultiplyAngleByInt
                 if matches!(lhs_ty, Type::Int(..) | Type::UInt(..)) {
                     operands.reverse();
                 }
-                "__MultiplyAngleByInt__"
+                "MultiplyAngleByInt"
             }
             qsast::BinOp::Div => {
                 if matches!(lhs_ty, Type::Angle(..))
                     && matches!(rhs_ty, Type::Int(..) | Type::UInt(..))
                 {
-                    "__DivideAngleByInt__"
+                    "DivideAngleByInt"
                 } else {
-                    "__DivideAngleByAngle__"
+                    "DivideAngleByAngle"
                 }
             }
 
@@ -1336,7 +1342,7 @@ impl QasmCompiler {
             }
         };
 
-        build_call_with_params(fn_name, &[], operands, span, span)
+        build_call_with_params(fn_name, &["QasmStd", "Angle"], operands, span, span)
     }
 
     fn compile_complex_binary_op(
@@ -1615,8 +1621,8 @@ impl QasmCompiler {
                 if promoted_ty.width().is_some() && promoted_ty.width() != expr_ty.width() {
                     // we need to convert the angle to a different width
                     let width = promoted_ty.width().expect("width should be set");
-                    build_global_call_with_two_params(
-                        "__ConvertAngleToWidthNoTrunc__",
+                    build_angle_convert_call_with_two_params(
+                        "AdjustAngleSizeNoTruncation",
                         expr,
                         build_lit_int_expr(width.into(), span),
                         span,
@@ -1626,13 +1632,11 @@ impl QasmCompiler {
                     expr
                 }
             }
-            Type::Bit(..) => {
-                build_call_with_param("__AngleAsResult__", &[], expr, span, span, span)
-            }
+            Type::Bit(..) => build_angle_cast_call_by_name("AngleAsResult", expr, span, span),
             Type::BitArray(..) => {
-                build_call_with_param("__AngleAsResultArray__", &[], expr, span, span, span)
+                build_angle_cast_call_by_name("AngleAsResultArray", expr, span, span)
             }
-            Type::Bool(..) => build_call_with_param("__AngleAsBool__", &[], expr, span, span, span),
+            Type::Bool(..) => build_angle_cast_call_by_name("AngleAsBool", expr, span, span),
             _ => err_expr(span),
         }
     }
@@ -1657,10 +1661,10 @@ impl QasmCompiler {
         let name_span = span;
         match ty {
             &Type::Angle(..) => {
-                build_cast_call_by_name("__ResultAsAngle__", expr, name_span, operand_span)
+                build_angle_cast_call_by_name("ResultAsAngle", expr, name_span, operand_span)
             }
             &Type::Bool(..) => {
-                build_cast_call_by_name("__ResultAsBool__", expr, name_span, operand_span)
+                build_convert_cast_call_by_name("ResultAsBool", expr, name_span, operand_span)
             }
             &Type::Float(..) => {
                 // The spec says that this cast isn't supported, but it
@@ -1671,15 +1675,15 @@ impl QasmCompiler {
             &Type::Int(w, _) | &Type::UInt(w, _) => {
                 let function = if let Some(width) = w {
                     if width > 64 {
-                        "__ResultAsBigInt__"
+                        "ResultAsBigInt"
                     } else {
-                        "__ResultAsInt__"
+                        "ResultAsInt"
                     }
                 } else {
-                    "__ResultAsInt__"
+                    "ResultAsInt"
                 };
 
-                build_cast_call_by_name(function, expr, name_span, operand_span)
+                build_convert_cast_call_by_name(function, expr, name_span, operand_span)
             }
             _ => err_expr(span),
         }
@@ -1708,7 +1712,7 @@ impl QasmCompiler {
         let int_width = ty.width();
 
         if int_width.is_none() || (int_width == Some(size)) {
-            build_cast_call_by_name("__ResultArrayAsIntBE__", expr, name_span, operand_span)
+            build_convert_cast_call_by_name("ResultArrayAsIntBE", expr, name_span, operand_span)
         } else {
             err_expr(span)
         }
@@ -1732,22 +1736,22 @@ impl QasmCompiler {
         let operand_span = span;
         match ty {
             Type::Bit(..) => {
-                build_cast_call_by_name("__BoolAsResult__", expr, name_span, operand_span)
+                build_convert_cast_call_by_name("BoolAsResult", expr, name_span, operand_span)
             }
             Type::Float(..) => {
-                build_cast_call_by_name("__BoolAsDouble__", expr, name_span, operand_span)
+                build_convert_cast_call_by_name("BoolAsDouble", expr, name_span, operand_span)
             }
             Type::Int(w, _) | Type::UInt(w, _) => {
                 let function = if let Some(width) = w {
                     if *width > 64 {
-                        "__BoolAsBigInt__"
+                        "BoolAsBigInt"
                     } else {
-                        "__BoolAsInt__"
+                        "BoolAsInt"
                     }
                 } else {
-                    "__BoolAsInt__"
+                    "BoolAsInt"
                 };
-                build_cast_call_by_name(function, expr, name_span, operand_span)
+                build_convert_cast_call_by_name(function, expr, name_span, operand_span)
             }
             _ => err_expr(span),
         }
@@ -1799,8 +1803,8 @@ impl QasmCompiler {
                 let width =
                     build_lit_int_expr(width.unwrap_or(f64::MANTISSA_DIGITS).into(), expr_span);
                 build_call_with_params(
-                    "__DoubleAsAngle__",
-                    &[],
+                    "DoubleAsAngle",
+                    &["QasmStd", "Angle"],
                     vec![expr, width],
                     expr_span,
                     expr_span,
@@ -1869,8 +1873,8 @@ impl QasmCompiler {
                 let size = i64::from(*size);
 
                 let size_expr = build_lit_int_expr(size, Span::default());
-                build_global_call_with_two_params(
-                    "__IntAsResultArrayBE__",
+                build_qasmstd_convert_call_with_two_params(
+                    "IntAsResultArrayBE",
                     expr,
                     size_expr,
                     name_span,

--- a/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -337,7 +337,6 @@ impl Lowerer {
         // Remaining gates that are not in the qasm std library, but are standard gates in Qiskit
         // that Qiskit wont emit correctly.
         // dcx, ecr, r, rzx, cs, csdg, sxdg, csx, cu1, cu3, rccx, c3sqrtx, c3x, rc3x, xx_minus_yy, xx_plus_yy, ccz;
-        //iter)
         let gates = FxHashMap::from_iter([
             ("rxx", gate_symbol("rxx", 1, 2)),
             ("ryy", gate_symbol("ryy", 1, 2)),

--- a/compiler/qsc_qasm/src/stdlib/QasmStd/src/QasmStd/Convert.qs
+++ b/compiler/qsc_qasm/src/stdlib/QasmStd/src/QasmStd/Convert.qs
@@ -1,30 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import Std.Math.AbsI;
-
-/// The POW function is used to implement the `pow` modifier in QASM for integers.
-operation __Pow__<'T>(N: Int, op: ('T => Unit is Adj + Ctl), target : 'T) : Unit {
-    ApplyOperationPowerA(N, op, target);
-}
-
-/// The ``BARRIER`` function is used to implement the `barrier` statement in QASM.
-/// The `@SimulatableIntrinsic` attribute is used to mark the operation for QIR
-/// generation.
-/// Q# doesn't support barriers, so this is a no-op. We need to figure out what
-/// barriers mean in the context of QIR in the future for better support.
-@SimulatableIntrinsic()
-operation __quantum__qis__barrier__body() : Unit {}
-
+/// This file defines the type conversion for casting gerneral types.
+/// It is an internal implementation detail for OpenQASM compilation
+/// and is not intended for use outside of this context.
 
 /// The ``BOOL_AS_RESULT`` function is used to implement the cast expr in QASM for bool to bit.
 /// This already exists in the Q# library, but is defined as a marker for casts from QASM.
-function __BoolAsResult__(input: Bool) : Result {
-    Microsoft.Quantum.Convert.BoolAsResult(input)
+function BoolAsResult(input : Bool) : Result {
+    Std.Convert.BoolAsResult(input)
 }
 
 /// The ``BOOL_AS_INT`` function is used to implement the cast expr in QASM for bool to int.
-function __BoolAsInt__(value: Bool) : Int {
+function BoolAsInt(value : Bool) : Int {
     if value {
         1
     } else {
@@ -33,8 +21,7 @@ function __BoolAsInt__(value: Bool) : Int {
 }
 
 /// The ``BOOL_AS_BIGINT`` function is used to implement the cast expr in QASM for bool to big int.
-
-function __BoolAsBigInt__(value: Bool) : BigInt {
+function BoolAsBigInt(value : Bool) : BigInt {
     if value {
         1L
     } else {
@@ -43,8 +30,7 @@ function __BoolAsBigInt__(value: Bool) : BigInt {
 }
 
 /// The ``BOOL_AS_DOUBLE`` function is used to implement the cast expr in QASM for bool to int.
-
-function __BoolAsDouble__(value: Bool) : Double {
+function BoolAsDouble(value : Bool) : Double {
     if value {
         1.
     } else {
@@ -54,22 +40,22 @@ function __BoolAsDouble__(value: Bool) : Double {
 
 /// The ``RESULT_AS_BOOL`` function is used to implement the cast expr in QASM for bit to bool.
 /// This already exists in the Q# library, but is defined as a marker for casts from QASM.
-function __ResultAsBool__(input: Result) : Bool {
-    Microsoft.Quantum.Convert.ResultAsBool(input)
+function ResultAsBool(input : Result) : Bool {
+    Std.Convert.ResultAsBool(input)
 }
 
-/// The ``RESULT_AS_INT`` function is used to implement the cast expr in QASM for bit to bool.
-function __ResultAsInt__(input: Result) : Int {
-    if Microsoft.Quantum.Convert.ResultAsBool(input) {
+/// The ``RESULT_AS_INT`` function is used to implement the cast expr in QASM for bit to int.
+function ResultAsInt(input : Result) : Int {
+    if Std.Convert.ResultAsBool(input) {
         1
     } else {
         0
     }
 }
 
-/// The ``RESULT_AS_BIGINT`` function is used to implement the cast expr in QASM for bit to bool.
-function __ResultAsBigInt__(input: Result) : BigInt {
-    if Microsoft.Quantum.Convert.ResultAsBool(input) {
+/// The ``RESULT_AS_BIGINT`` function is used to implement the cast expr in QASM for bit to big int.
+function ResultAsBigInt(input : Result) : BigInt {
+    if Std.Convert.ResultAsBool(input) {
         1L
     } else {
         0L
@@ -78,20 +64,20 @@ function __ResultAsBigInt__(input: Result) : BigInt {
 
 /// The ``INT_AS_RESULT_ARRAY_BE`` function is used to implement the cast expr in QASM for int to bit[].
 /// with big-endian order. This is needed for round-trip conversion for bin ops.
-function __IntAsResultArrayBE__(number : Int, bits : Int) : Result[] {
+function IntAsResultArrayBE(number : Int, bits : Int) : Result[] {
     mutable runningValue = number;
     mutable result = [];
     for _ in 1..bits {
-        set result += [__BoolAsResult__((runningValue &&& 1) != 0)];
+        set result += [BoolAsResult((runningValue &&& 1) != 0)];
         set runningValue >>>= 1;
     }
-    Microsoft.Quantum.Arrays.Reversed(result)
+    Std.Arrays.Reversed(result)
 }
 
 /// The ``RESULT_ARRAY_AS_INT_BE`` function is used to implement the cast expr in QASM for bit[] to uint.
 /// with big-endian order. This is needed for round-trip conversion for bin ops.
-function __ResultArrayAsIntBE__(results : Result[]) : Int {
-     Microsoft.Quantum.Convert.ResultArrayAsInt(Microsoft.Quantum.Arrays.Reversed(results))
+function ResultArrayAsIntBE(results : Result[]) : Int {
+    Std.Convert.ResultArrayAsInt(Std.Arrays.Reversed(results))
 }
 
-export __Pow__, __quantum__qis__barrier__body, __BoolAsResult__, __BoolAsInt__, __BoolAsBigInt__, __BoolAsDouble__, __ResultAsBool__, __ResultAsInt__, __ResultAsBigInt__, __IntAsResultArrayBE__, __ResultArrayAsIntBE__, ;
+export BoolAsResult, BoolAsInt, BoolAsBigInt, BoolAsDouble, ResultAsBool, ResultAsInt, ResultAsBigInt, IntAsResultArrayBE, ResultArrayAsIntBE,;

--- a/compiler/qsc_qasm/src/stdlib/QasmStd/src/QasmStd/Intrinsic.qs
+++ b/compiler/qsc_qasm/src/stdlib/QasmStd/src/QasmStd/Intrinsic.qs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/// This file defines the standard gates for OpenQASM and Qiskit.
+/// It is an internal implementation detail for OpenQASM compilation
+/// and is not intended for use outside of this context.
+
+
 // stdgates.inc, gates with implied modifiers are omitted as they are mapped
 // to the base gate with modifiers in the lowerer.
 export gphase, U, p, x, y, z, h, s, sdg, t, tdg, sx, rx, ry, rz, cx, cp, swap, ccx, cu, phase, id, u1, u2, u3;
@@ -15,56 +20,58 @@ export rxx, ryy, rzz;
 // that Qiskit wont emit correctly.
 export dcx, ecr, r, rzx, cs, csdg, sxdg, csx, cu1, cu3, rccx, c3sqrtx, c3x, rc3x, xx_minus_yy, xx_plus_yy, ccz;
 
+export __quantum__qis__barrier__body;
+
 import Angle.*;
 
 import Std.Intrinsic.*;
 
-function ZERO_ANGLE() : __Angle__ {
-    return __DoubleAsAngle__(0., 1);
+function ZERO_ANGLE() : Angle {
+    return DoubleAsAngle(0., 1);
 }
 
-function PI_OVER_2() : __Angle__ {
-    return __DoubleAsAngle__(Std.Math.PI() / 2., 53);
+function PI_OVER_2() : Angle {
+    return DoubleAsAngle(Std.Math.PI() / 2., 53);
 }
 
-function PI_OVER_4() : __Angle__ {
-    return __DoubleAsAngle__(Std.Math.PI() / 4., 53);
+function PI_OVER_4() : Angle {
+    return DoubleAsAngle(Std.Math.PI() / 4., 53);
 }
 
-function PI_OVER_8() : __Angle__ {
-    return __DoubleAsAngle__(Std.Math.PI() / 8., 53);
+function PI_OVER_8() : Angle {
+    return DoubleAsAngle(Std.Math.PI() / 8., 53);
 }
 
-function PI_ANGLE() : __Angle__ {
-    return __DoubleAsAngle__(Std.Math.PI(), 53);
+function PI_ANGLE() : Angle {
+    return DoubleAsAngle(Std.Math.PI(), 53);
 }
 
-function NEG_PI_OVER_2() : __Angle__ {
-    return __DoubleAsAngle__(-Std.Math.PI() / 2., 53);
+function NEG_PI_OVER_2() : Angle {
+    return DoubleAsAngle(-Std.Math.PI() / 2., 53);
 }
 
-function NEG_PI_OVER_4() : __Angle__ {
-    return __DoubleAsAngle__(-Std.Math.PI() / 4., 53);
+function NEG_PI_OVER_4() : Angle {
+    return DoubleAsAngle(-Std.Math.PI() / 4., 53);
 }
 
-function NEG_PI_OVER_8() : __Angle__ {
-    return __DoubleAsAngle__(-Std.Math.PI() / 8., 53);
+function NEG_PI_OVER_8() : Angle {
+    return DoubleAsAngle(-Std.Math.PI() / 8., 53);
 }
 
-operation gphase(theta : __Angle__) : Unit is Adj + Ctl {
+operation gphase(theta : Angle) : Unit is Adj + Ctl {
     body ... {
-        Exp([], __AngleAsDouble__(theta), [])
+        Exp([], AngleAsDouble(theta), [])
     }
     adjoint auto;
     controlled auto;
     controlled adjoint auto;
 }
 
-operation U(theta : __Angle__, phi : __Angle__, lambda : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
+operation U(theta : Angle, phi : Angle, lambda : Angle, qubit : Qubit) : Unit is Adj + Ctl {
     body ... {
-        let theta = __AngleAsDouble__(theta);
-        let phi = __AngleAsDouble__(phi);
-        let lambda = __AngleAsDouble__(lambda);
+        let theta = AngleAsDouble(theta);
+        let phi = AngleAsDouble(phi);
+        let lambda = AngleAsDouble(lambda);
 
         Rz(lambda, qubit);
         Ry(theta, qubit);
@@ -76,7 +83,7 @@ operation U(theta : __Angle__, phi : __Angle__, lambda : __Angle__, qubit : Qubi
     controlled adjoint auto;
 }
 
-operation p(lambda : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
+operation p(lambda : Angle, qubit : Qubit) : Unit is Adj + Ctl {
     Controlled gphase([qubit], lambda);
 }
 
@@ -117,18 +124,18 @@ operation sx(qubit : Qubit) : Unit is Adj + Ctl {
     Adjoint R(PauliI, Std.Math.PI() / 2., qubit);
 }
 
-operation rx(theta : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
-    let theta = __AngleAsDouble__(theta);
+operation rx(theta : Angle, qubit : Qubit) : Unit is Adj + Ctl {
+    let theta = AngleAsDouble(theta);
     Rx(theta, qubit);
 }
 
-operation ry(theta : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
-    let theta = __AngleAsDouble__(theta);
+operation ry(theta : Angle, qubit : Qubit) : Unit is Adj + Ctl {
+    let theta = AngleAsDouble(theta);
     Ry(theta, qubit);
 }
 
-operation rz(theta : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
-    let theta = __AngleAsDouble__(theta);
+operation rz(theta : Angle, qubit : Qubit) : Unit is Adj + Ctl {
+    let theta = AngleAsDouble(theta);
     Rz(theta, qubit);
 }
 
@@ -136,7 +143,7 @@ operation cx(ctrl : Qubit, qubit : Qubit) : Unit is Adj + Ctl {
     CNOT(ctrl, qubit);
 }
 
-operation cp(lambda : __Angle__, ctrl : Qubit, qubit : Qubit) : Unit is Adj + Ctl {
+operation cp(lambda : Angle, ctrl : Qubit, qubit : Qubit) : Unit is Adj + Ctl {
     Controlled p([ctrl], (lambda, qubit));
 }
 
@@ -148,13 +155,13 @@ operation ccx(ctrl1 : Qubit, ctrl2 : Qubit, target : Qubit) : Unit is Adj + Ctl 
     CCNOT(ctrl1, ctrl2, target);
 }
 
-operation cu(theta : __Angle__, phi : __Angle__, lambda : __Angle__, gamma : __Angle__, qubit1 : Qubit, qubit2 : Qubit) : Unit is Adj + Ctl {
-    p(__SubtractAngles__(gamma, __DivideAngleByInt__(theta, 2)), qubit1);
+operation cu(theta : Angle, phi : Angle, lambda : Angle, gamma : Angle, qubit1 : Qubit, qubit2 : Qubit) : Unit is Adj + Ctl {
+    p(SubtractAngles(gamma, DivideAngleByInt(theta, 2)), qubit1);
     Controlled U([qubit2], (theta, phi, lambda, qubit1));
 }
 
 // Gates for OpenQASM 2 backwards compatibility
-operation phase(lambda : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
+operation phase(lambda : Angle, qubit : Qubit) : Unit is Adj + Ctl {
     U(ZERO_ANGLE(), ZERO_ANGLE(), lambda, qubit);
 }
 
@@ -162,14 +169,14 @@ operation id(qubit : Qubit) : Unit is Adj + Ctl {
     I(qubit)
 }
 
-operation u1(lambda : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
+operation u1(lambda : Angle, qubit : Qubit) : Unit is Adj + Ctl {
     U(ZERO_ANGLE(), ZERO_ANGLE(), lambda, qubit);
 }
 
-operation u2(phi : __Angle__, lambda : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
-    gphase(__NegAngle__(__DivideAngleByInt__(__AddAngles__(
+operation u2(phi : Angle, lambda : Angle, qubit : Qubit) : Unit is Adj + Ctl {
+    gphase(NegAngle(DivideAngleByInt(AddAngles(
         phi,
-        __AddAngles__(
+        AddAngles(
             lambda,
             PI_OVER_2()
         )
@@ -178,10 +185,10 @@ operation u2(phi : __Angle__, lambda : __Angle__, qubit : Qubit) : Unit is Adj +
     U(PI_OVER_2(), phi, lambda, qubit);
 }
 
-operation u3(theta : __Angle__, phi : __Angle__, lambda : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
-    gphase(__NegAngle__(__DivideAngleByInt__(__AddAngles__(
+operation u3(theta : Angle, phi : Angle, lambda : Angle, qubit : Qubit) : Unit is Adj + Ctl {
+    gphase(NegAngle(DivideAngleByInt(AddAngles(
         phi,
-        __AddAngles__(
+        AddAngles(
             lambda,
             theta
         )
@@ -192,18 +199,18 @@ operation u3(theta : __Angle__, phi : __Angle__, lambda : __Angle__, qubit : Qub
 
 
 /// rxx: gate rxx(theta) a, b { h a; h b; cx a, b; rz(theta) b; cx a, b; h b; h a; }
-operation rxx(theta : __Angle__, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
-    Rxx(__AngleAsDouble__(theta), qubit0, qubit1);
+operation rxx(theta : Angle, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
+    Rxx(AngleAsDouble(theta), qubit0, qubit1);
 }
 
 /// ryy: gate ryy(theta) a, b { rx(pi/2) a; rx(pi/2) b; cx a, b; rz(theta) b; cx a, b; rx(-pi/2) a; rx(-pi/2) b; }
-operation ryy(theta : __Angle__, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
-    Ryy(__AngleAsDouble__(theta), qubit0, qubit1);
+operation ryy(theta : Angle, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
+    Ryy(AngleAsDouble(theta), qubit0, qubit1);
 }
 
 /// rzz: gate rzz(theta) a, b { cx a, b; u1(theta) b; cx a, b; }
-operation rzz(theta : __Angle__, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
-    Rzz(__AngleAsDouble__(theta), qubit0, qubit1);
+operation rzz(theta : Angle, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
+    Rzz(AngleAsDouble(theta), qubit0, qubit1);
 }
 
 /// Double-CNOT gate.
@@ -228,8 +235,8 @@ operation ecr(qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
 
 /// Rotation θ around the cos(φ)x + sin(φ)y axis.
 /// `gate r(θ, φ) a {u3(θ, φ - π/2, -φ + π/2) a;}`
-operation r(theta : __Angle__, phi : __Angle__, qubit : Qubit) : Unit is Adj + Ctl {
-    u3(theta, PI_OVER_4(), __SubtractAngles__(
+operation r(theta : Angle, phi : Angle, qubit : Qubit) : Unit is Adj + Ctl {
+    u3(theta, PI_OVER_4(), SubtractAngles(
         phi,
         NEG_PI_OVER_2()
     ), qubit);
@@ -237,7 +244,7 @@ operation r(theta : __Angle__, phi : __Angle__, qubit : Qubit) : Unit is Adj + C
 
 /// A parametric 2-qubit `Z ⊗ X` interaction (rotation about ZX).
 /// `gate rzx(theta) a, b { h b; cx a, b; u1(theta) b; cx a, b; h b; }`
-operation rzx(theta : __Angle__, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
+operation rzx(theta : Angle, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
     h(qubit1);
     cx(qubit0, qubit1);
     u1(theta, qubit1);
@@ -281,7 +288,7 @@ operation csx(qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
 ///     u1(lambda/2) b;
 /// }
 /// ```
-operation cu1(lambda : __Angle__, ctrl : Qubit, target : Qubit) : Unit is Adj + Ctl {
+operation cu1(lambda : Angle, ctrl : Qubit, target : Qubit) : Unit is Adj + Ctl {
     Controlled u1([ctrl], (lambda, target));
 }
 
@@ -297,7 +304,7 @@ operation cu1(lambda : __Angle__, ctrl : Qubit, target : Qubit) : Unit is Adj + 
 ///     u3(theta/2,phi,0) t;
 /// }
 /// ```
-operation cu3(theta : __Angle__, phi : __Angle__, lambda : __Angle__, ctrl : Qubit, target : Qubit) : Unit is Adj + Ctl {
+operation cu3(theta : Angle, phi : Angle, lambda : Angle, ctrl : Qubit, target : Qubit) : Unit is Adj + Ctl {
     Controlled u3([ctrl], (theta, phi, lambda, target));
 }
 
@@ -508,15 +515,15 @@ operation rc3x(a : Qubit, b : Qubit, c : Qubit, d : Qubit) : Unit is Adj + Ctl {
 ///     rz(beta) b;
 /// }
 /// ```
-operation xx_minus_yy(theta : __Angle__, beta : __Angle__, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
-    rz(__NegAngle__(beta), qubit1);
+operation xx_minus_yy(theta : Angle, beta : Angle, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
+    rz(NegAngle(beta), qubit1);
     rz(NEG_PI_OVER_2(), qubit0);
     sx(qubit0);
     rz(PI_OVER_2(), qubit0);
     s(qubit1);
     cx(qubit0, qubit1);
-    ry(__DivideAngleByInt__(theta, 2), qubit0);
-    ry(__NegAngle__(__DivideAngleByInt__(theta, 2)), qubit1);
+    ry(DivideAngleByInt(theta, 2), qubit0);
+    ry(NegAngle(DivideAngleByInt(theta, 2)), qubit1);
     cx(qubit0, qubit1);
     sdg(qubit1);
     rz(NEG_PI_OVER_2(), qubit0);
@@ -544,21 +551,21 @@ operation xx_minus_yy(theta : __Angle__, beta : __Angle__, qubit0 : Qubit, qubit
 ///     rz(-beta) b;
 /// }
 /// ```
-operation xx_plus_yy(theta : __Angle__, beta : __Angle__, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
+operation xx_plus_yy(theta : Angle, beta : Angle, qubit0 : Qubit, qubit1 : Qubit) : Unit is Adj + Ctl {
     rz(beta, qubit1);
     rz(NEG_PI_OVER_2(), qubit0);
     sx(qubit0);
     rz(PI_OVER_2(), qubit0);
     s(qubit1);
     cx(qubit0, qubit1);
-    ry(__DivideAngleByInt__(theta, 2), qubit0);
-    ry(__DivideAngleByInt__(theta, 2), qubit1);
+    ry(DivideAngleByInt(theta, 2), qubit0);
+    ry(DivideAngleByInt(theta, 2), qubit1);
     cx(qubit0, qubit1);
     sdg(qubit1);
     rz(NEG_PI_OVER_2(), qubit0);
     sxdg(qubit0);
     rz(PI_OVER_2(), qubit0);
-    rz(__NegAngle__(beta), qubit1);
+    rz(NegAngle(beta), qubit1);
 }
 
 /// CCZ gate.
@@ -568,3 +575,11 @@ operation ccz(ctrl1 : Qubit, ctrl2 : Qubit, target : Qubit) : Unit is Adj + Ctl 
     ccx(ctrl1, ctrl2, target);
     h(target);
 }
+
+/// The ``BARRIER`` function is used to implement the `barrier` statement in QASM.
+/// The `@SimulatableIntrinsic` attribute is used to mark the operation for QIR
+/// generation.
+/// Q# doesn't support barriers, so this is a no-op. We need to figure out what
+/// barriers mean in the context of QIR in the future for better support.
+@SimulatableIntrinsic()
+operation __quantum__qis__barrier__body() : Unit {}

--- a/compiler/qsc_qasm/src/stdlib/angle.rs
+++ b/compiler/qsc_qasm/src/stdlib/angle.rs
@@ -275,7 +275,7 @@ impl Neg for Angle {
 
     fn neg(self) -> Self {
         Angle {
-            value: (1u64 << self.size) - self.value,
+            value: ((1u64 << self.size) - self.value) % (1u64 << self.size),
             size: self.size,
         }
     }

--- a/compiler/qsc_qasm/src/stdlib/angle/tests.rs
+++ b/compiler/qsc_qasm/src/stdlib/angle/tests.rs
@@ -120,6 +120,20 @@ fn test_angle_unary_negation() {
 }
 
 #[test]
+fn test_angle_unary_negation_of_zero_float() {
+    let angle = Angle::from_f64_sized(0., 16);
+    let result = -angle;
+    assert_eq!(angle, result);
+}
+
+#[test]
+fn test_angle_unary_negation_of_zero_angle() {
+    let angle = Angle::new(0, 16);
+    let result = -angle;
+    assert_eq!(angle, result);
+}
+
+#[test]
 fn test_angle_compound_addition() {
     let mut angle1 = Angle::from_f64_sized(PI / 2.0, 4);
     let angle2 = Angle::from_f64_sized(PI / 2.0, 4);

--- a/compiler/qsc_qasm/src/tests/declaration/complex.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/complex.rs
@@ -13,11 +13,9 @@ fn implicit_bitness_default_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.Complex(0., 0.);
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.Complex(0., 0.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -29,11 +27,9 @@ fn explicit_bitness_default_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.Complex(0., 0.);
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.Complex(0., 0.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -45,11 +41,9 @@ fn const_implicit_bitness_double_img_only_decl() -> miette::Result<(), Vec<Repor
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Math.Complex(0., 1.01);
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Math.Complex(0., 1.01);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -61,11 +55,9 @@ fn const_implicit_bitness_int_img_only_decl() -> miette::Result<(), Vec<Report>>
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Math.Complex(0., 1.);
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Math.Complex(0., 1.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -77,11 +69,9 @@ fn const_explicit_bitness_double_img_only_decl() -> miette::Result<(), Vec<Repor
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Math.Complex(0., 1.01);
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Math.Complex(0., 1.01);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -93,11 +83,9 @@ fn const_explicit_bitness_int_img_only_decl() -> miette::Result<(), Vec<Report>>
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Math.Complex(0., 1.);
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Math.Complex(0., 1.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -109,11 +97,9 @@ fn implicit_bitness_double_img_only_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.Complex(0., 1.01);
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.Complex(0., 1.01);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -125,11 +111,9 @@ fn implicit_bitness_int_img_only_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.Complex(0., 1.);
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.Complex(0., 1.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -142,11 +126,9 @@ fn implicit_bitness_int_img_only_tab_between_suffix_decl() -> miette::Result<(),
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.Complex(0., 1.);
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.Complex(0., 1.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -158,11 +140,9 @@ fn const_implicit_bitness_double_real_only_decl() -> miette::Result<(), Vec<Repo
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Math.Complex(1.01, 0.);
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Math.Complex(1.01, 0.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -174,11 +154,9 @@ fn const_implicit_bitness_int_real_only_decl() -> miette::Result<(), Vec<Report>
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Math.Complex(1., 0.);
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Math.Complex(1., 0.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -190,11 +168,9 @@ fn implicit_bitness_double_real_only_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.Complex(1.01, 0.);
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.Complex(1.01, 0.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -206,11 +182,9 @@ fn implicit_bitness_int_real_only_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.Complex(1., 0.);
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.Complex(1., 0.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -222,11 +196,9 @@ fn implicit_bitness_simple_double_pos_im_decl() -> miette::Result<(), Vec<Report
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.PlusC(Microsoft.Quantum.Math.Complex(1.1, 0.), Microsoft.Quantum.Math.Complex(0., 2.2));
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.PlusC(Std.Math.Complex(1.1, 0.), Std.Math.Complex(0., 2.2));
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -238,11 +210,9 @@ fn const_implicit_bitness_simple_double_pos_im_decl() -> miette::Result<(), Vec<
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Math.PlusC(Microsoft.Quantum.Math.Complex(1.1, 0.), Microsoft.Quantum.Math.Complex(0., 2.2));
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Math.PlusC(Std.Math.Complex(1.1, 0.), Std.Math.Complex(0., 2.2));
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -254,11 +224,9 @@ fn implicit_bitness_simple_double_neg_im_decl() -> miette::Result<(), Vec<Report
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.MinusC(Microsoft.Quantum.Math.Complex(1.1, 0.), Microsoft.Quantum.Math.Complex(0., 2.2));
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.MinusC(Std.Math.Complex(1.1, 0.), Std.Math.Complex(0., 2.2));
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -270,11 +238,9 @@ fn const_implicit_bitness_simple_double_neg_im_decl() -> miette::Result<(), Vec<
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Math.MinusC(Microsoft.Quantum.Math.Complex(1.1, 0.), Microsoft.Quantum.Math.Complex(0., 2.2));
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Math.MinusC(Std.Math.Complex(1.1, 0.), Std.Math.Complex(0., 2.2));
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -286,11 +252,9 @@ fn implicit_bitness_simple_double_neg_real_decl() -> miette::Result<(), Vec<Repo
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.PlusC(Microsoft.Quantum.Math.Complex(-1.1, 0.), Microsoft.Quantum.Math.Complex(0., 2.2));
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.PlusC(Std.Math.Complex(-1.1, 0.), Std.Math.Complex(0., 2.2));
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -302,11 +266,9 @@ fn const_implicit_bitness_simple_double_neg_real_decl() -> miette::Result<(), Ve
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Math.PlusC(Microsoft.Quantum.Math.Complex(-1.1, 0.), Microsoft.Quantum.Math.Complex(0., 2.2));
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Math.PlusC(Std.Math.Complex(-1.1, 0.), Std.Math.Complex(0., 2.2));
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }

--- a/compiler/qsc_qasm/src/tests/declaration/float.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/float.rs
@@ -13,11 +13,9 @@ fn implicit_bitness_default_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 0.;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -29,11 +27,9 @@ fn lit_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -45,11 +41,9 @@ fn const_lit_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -61,11 +55,9 @@ fn lit_explicit_width_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -77,11 +69,9 @@ fn const_explicit_width_lit_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -93,11 +83,9 @@ fn lit_decl_leading_dot() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 0.421;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -109,11 +97,9 @@ fn const_lit_decl_leading_dot() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 0.421;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -125,11 +111,9 @@ fn const_lit_decl_leading_dot_scientific() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -141,11 +125,9 @@ fn lit_decl_trailing_dot() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 421.;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -157,11 +139,9 @@ fn const_lit_decl_trailing_dot() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 421.;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -173,11 +153,9 @@ fn lit_decl_scientific() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -189,11 +167,9 @@ fn const_lit_decl_scientific() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -205,11 +181,9 @@ fn lit_decl_scientific_signed_pos() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -221,11 +195,9 @@ fn const_lit_decl_scientific_signed_pos() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -237,11 +209,9 @@ fn lit_decl_scientific_cap_e() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -253,11 +223,9 @@ fn const_lit_decl_scientific_cap_e() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -269,11 +237,9 @@ fn lit_decl_scientific_signed_neg() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -285,11 +251,9 @@ fn const_lit_decl_scientific_signed_neg() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 42.1;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -301,11 +265,9 @@ fn const_lit_decl_signed_float_lit_cast_neg() -> miette::Result<(), Vec<Report>>
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = -7.;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -317,11 +279,9 @@ fn const_lit_decl_signed_int_lit_cast_neg() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        let x = Microsoft.Quantum.Convert.IntAsDouble(-7);
-    "#
-    ]
+    expect![[r#"
+        let x = Std.Convert.IntAsDouble(-7);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -333,11 +293,9 @@ fn init_float_with_int_value_less_than_safely_representable_values_is_runtime_co
     let next = min_exact_int - 1;
     let source = &format!("float a = {next};");
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable a = Microsoft.Quantum.Convert.IntAsDouble(-9007199254740993);
-    "#
-    ]
+    expect![[r#"
+        mutable a = Std.Convert.IntAsDouble(-9007199254740993);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }

--- a/compiler/qsc_qasm/src/tests/declaration/gate.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/gate.rs
@@ -56,7 +56,7 @@ fn single_angle_single_qubit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        operation my_h(θ : __Angle__, q : Qubit) : Unit is Adj + Ctl {
+        operation my_h(θ : QasmStd.Angle.Angle, q : Qubit) : Unit is Adj + Ctl {
             rx(θ, q);
         }
     "#]]
@@ -76,7 +76,7 @@ fn two_angles_two_qubits() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        operation my_h(θ : __Angle__, φ : __Angle__, q : Qubit, q2 : Qubit) : Unit is Adj + Ctl {
+        operation my_h(θ : QasmStd.Angle.Angle, φ : QasmStd.Angle.Angle, q : Qubit, q2 : Qubit) : Unit is Adj + Ctl {
             rx(θ, q2);
             ry(φ, q);
         }

--- a/compiler/qsc_qasm/src/tests/declaration/integer.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/integer.rs
@@ -13,11 +13,9 @@ fn implicit_bitness_int_negative_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = -42;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -29,11 +27,9 @@ fn implicit_bitness_int_const_negative_decl() -> miette::Result<(), Vec<Report>>
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = -42;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -45,11 +41,9 @@ fn implicit_bitness_int_default_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 0;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -61,11 +55,9 @@ fn const_implicit_bitness_int_lit_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 42;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -77,11 +69,9 @@ fn implicit_bitness_int_hex_cap_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 64031;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -93,11 +83,9 @@ fn const_implicit_bitness_int_hex_low_decl() -> miette::Result<(), Vec<Report>> 
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 64031;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -109,11 +97,9 @@ fn const_implicit_bitness_int_hex_cap_decl() -> miette::Result<(), Vec<Report>> 
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 64031;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -125,11 +111,9 @@ fn implicit_bitness_int_octal_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 34;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -141,11 +125,9 @@ fn const_implicit_bitness_int_octal_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 34;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -157,11 +139,9 @@ fn implicit_bitness_int_binary_low_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 153;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -173,11 +153,9 @@ fn implicit_bitness_int_binary_cap_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 10;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -189,11 +167,9 @@ fn const_implicit_bitness_int_binary_low_decl() -> miette::Result<(), Vec<Report
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 153;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -205,11 +181,9 @@ fn const_implicit_bitness_int_binary_cap_decl() -> miette::Result<(), Vec<Report
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 10;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -221,11 +195,9 @@ fn implicit_bitness_int_formatted_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 2000;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -237,11 +209,9 @@ fn const_implicit_bitness_int_formatted_decl() -> miette::Result<(), Vec<Report>
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 2000;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -253,11 +223,9 @@ fn explicit_bitness_int_default_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 0;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -269,11 +237,9 @@ fn explicit_bitness_int_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         mutable x = 42;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -285,11 +251,9 @@ fn const_explicit_bitness_int_decl() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
+    expect![[r#"
         let x = 42;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -302,11 +266,9 @@ fn implicit_bitness_int_negative_float_decl_creates_truncation_call(
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.Truncate(-42.);
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.Truncate(-42.);
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }

--- a/compiler/qsc_qasm/src/tests/declaration/io/explicit_input.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/io/explicit_input.rs
@@ -15,8 +15,6 @@ input bit[2] c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(c : Result[]) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -34,8 +32,6 @@ input bit c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(c : Result) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -52,8 +48,6 @@ input bool c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(c : Bool) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -69,9 +63,7 @@ input complex[float] c;
 
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
-        operation Test(c : Microsoft.Quantum.Math.Complex) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
+        operation Test(c : Std.Math.Complex) : Unit {
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -88,8 +80,6 @@ input float f;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(f : Double) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -106,8 +96,6 @@ input float[60] f;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(f : Double) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -124,8 +112,6 @@ input int i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(i : Int) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -142,8 +128,6 @@ input int[60] i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(i : Int) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -160,8 +144,6 @@ input uint i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(i : Int) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -178,8 +160,6 @@ input uint[60] i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(i : Int) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -196,8 +176,6 @@ input int[65] i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test(i : BigInt) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
         }
     "#]]
@@ -252,9 +230,7 @@ input bit[2] b2;
 
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
-        operation Test(bi : BigInt, i : Int, ui : Int, u : Int, f : Double, b : Bool, c : Result, cf : Microsoft.Quantum.Math.Complex, b2 : Result[]) : Unit {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
+        operation Test(bi : BigInt, i : Int, ui : Int, u : Int, f : Double, b : Bool, c : Result, cf : Std.Math.Complex, b2 : Result[]) : Unit {
             import QasmStd.Intrinsic.*;
         }
     "#]]

--- a/compiler/qsc_qasm/src/tests/declaration/io/explicit_output.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/io/explicit_output.rs
@@ -14,8 +14,6 @@ output bit[2] c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Result[] {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable c = [Zero, Zero];
             c
@@ -34,8 +32,6 @@ output bit c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Result {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable c = Zero;
             c
@@ -54,8 +50,6 @@ output bool c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Bool {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable c = false;
             c
@@ -73,11 +67,9 @@ output complex[float] c;
 
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
-        operation Test() : Microsoft.Quantum.Math.Complex {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
+        operation Test() : Std.Math.Complex {
             import QasmStd.Intrinsic.*;
-            mutable c = Microsoft.Quantum.Math.Complex(0., 0.);
+            mutable c = Std.Math.Complex(0., 0.);
             c
         }
     "#]]
@@ -94,8 +86,6 @@ output float f;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Double {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable f = 0.;
             f
@@ -114,8 +104,6 @@ output float[42] f;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Double {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable f = 0.;
             f
@@ -134,8 +122,6 @@ output int[42] i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Int {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -154,8 +140,6 @@ output int i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Int {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -174,8 +158,6 @@ output uint i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Int {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -194,8 +176,6 @@ output uint[42] i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Int {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -214,8 +194,6 @@ output int[65] i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : BigInt {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -256,9 +234,7 @@ output bit[2] b2;
 
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
-        operation Test() : (BigInt, Int, Int, Int, Double, Bool, Result, Microsoft.Quantum.Math.Complex, Result[]) {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
+        operation Test() : (BigInt, Int, Int, Int, Double, Bool, Result, Std.Math.Complex, Result[]) {
             import QasmStd.Intrinsic.*;
             mutable bi = 0;
             mutable i = 0;
@@ -267,7 +243,7 @@ output bit[2] b2;
             mutable f = 0.;
             mutable b = false;
             mutable c = Zero;
-            mutable cf = Microsoft.Quantum.Math.Complex(0., 0.);
+            mutable cf = Std.Math.Complex(0., 0.);
             mutable b2 = [Zero, Zero];
             (bi, i, ui, u, f, b, c, cf, b2)
         }
@@ -285,14 +261,12 @@ output angle c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Double {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
-            mutable c = new __Angle__ {
+            mutable c = new QasmStd.Angle.Angle {
                 Value = 0,
                 Size = 53
             };
-            __AngleAsDouble__(c)
+            QasmStd.Angle.AngleAsDouble(c)
         }
     "#]]
     .assert_eq(&qsharp);

--- a/compiler/qsc_qasm/src/tests/declaration/io/implicit_output.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/io/implicit_output.rs
@@ -14,8 +14,6 @@ bit[2] c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Result[] {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable c = [Zero, Zero];
             c
@@ -34,8 +32,6 @@ bit c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Result {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable c = Zero;
             c
@@ -54,8 +50,6 @@ bool c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Bool {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable c = false;
             c
@@ -73,11 +67,9 @@ complex[float] c;
 
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
-        operation Test() : Microsoft.Quantum.Math.Complex {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
+        operation Test() : Std.Math.Complex {
             import QasmStd.Intrinsic.*;
-            mutable c = Microsoft.Quantum.Math.Complex(0., 0.);
+            mutable c = Std.Math.Complex(0., 0.);
             c
         }
     "#]]
@@ -94,8 +86,6 @@ float f;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Double {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable f = 0.;
             f
@@ -114,8 +104,6 @@ float[42] f;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Double {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable f = 0.;
             f
@@ -134,8 +122,6 @@ int[42] i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Int {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -154,8 +140,6 @@ int i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Int {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -174,8 +158,6 @@ uint i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Int {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -194,8 +176,6 @@ uint[42] i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Int {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -214,8 +194,6 @@ int[65] i;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : BigInt {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             mutable i = 0;
             i
@@ -241,9 +219,7 @@ bit[2] b2;
 
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
-        operation Test() : (BigInt, Int, Int, Int, Double, Bool, Result, Microsoft.Quantum.Math.Complex, Result[]) {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
+        operation Test() : (BigInt, Int, Int, Int, Double, Bool, Result, Std.Math.Complex, Result[]) {
             import QasmStd.Intrinsic.*;
             mutable bi = 0;
             mutable i = 0;
@@ -252,7 +228,7 @@ bit[2] b2;
             mutable f = 0.;
             mutable b = false;
             mutable c = Zero;
-            mutable cf = Microsoft.Quantum.Math.Complex(0., 0.);
+            mutable cf = Std.Math.Complex(0., 0.);
             mutable b2 = [Zero, Zero];
             (bi, i, ui, u, f, b, c, cf, b2)
         }
@@ -270,14 +246,12 @@ angle c;
     let qsharp = compile_qasm_to_qsharp_operation(source)?;
     expect![[r#"
         operation Test() : Double {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
-            mutable c = new __Angle__ {
+            mutable c = new QasmStd.Angle.Angle {
                 Value = 0,
                 Size = 53
             };
-            __AngleAsDouble__(c)
+            QasmStd.Angle.AngleAsDouble(c)
         }
     "#]]
     .assert_eq(&qsharp);

--- a/compiler/qsc_qasm/src/tests/expression/binary/angle.rs
+++ b/compiler/qsc_qasm/src/tests/expression/binary/angle.rs
@@ -17,7 +17,7 @@ fn shl() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleShl__(a, b);
+        mutable x = QasmStd.Angle.__AngleShl__(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -33,7 +33,7 @@ fn shr() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleShr__(a, b);
+        mutable x = QasmStd.Angle.AngleShr(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -51,7 +51,7 @@ fn andb() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleAndB__(a, b);
+        mutable x = QasmStd.Angle.AngleAndB(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -67,7 +67,7 @@ fn orb() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleOrB__(a, b);
+        mutable x = QasmStd.Angle.AngleOrB(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -83,7 +83,7 @@ fn xorb() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleXorB__(a, b);
+        mutable x = QasmStd.Angle.AngleXorB(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -101,7 +101,7 @@ fn eq() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleEq__(a, b);
+        mutable x = QasmStd.Angle.AngleEq(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -117,7 +117,7 @@ fn neq() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleNeq__(a, b);
+        mutable x = QasmStd.Angle.AngleNeq(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -133,7 +133,7 @@ fn gt() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleGt__(a, b);
+        mutable x = QasmStd.Angle.AngleGt(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -149,7 +149,7 @@ fn gte() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleGte__(a, b);
+        mutable x = QasmStd.Angle.AngleGte(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -165,7 +165,7 @@ fn lt() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleLt__(a, b);
+        mutable x = QasmStd.Angle.AngleLt(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -181,7 +181,7 @@ fn lte() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AngleLte__(a, b);
+        mutable x = QasmStd.Angle.AngleLte(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -199,7 +199,7 @@ fn addition() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __AddAngles__(a, b);
+        mutable x = QasmStd.Angle.AddAngles(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -215,7 +215,7 @@ fn subtraction() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __SubtractAngles__(a, b);
+        mutable x = QasmStd.Angle.SubtractAngles(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -231,7 +231,7 @@ fn multiplication_by_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __MultiplyAngleByInt__(a, b);
+        mutable x = QasmStd.Angle.MultiplyAngleByInt(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -247,7 +247,7 @@ fn division_by_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __DivideAngleByInt__(a, b);
+        mutable x = QasmStd.Angle.DivideAngleByInt(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -263,7 +263,7 @@ fn division_by_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = __DivideAngleByAngle__(a, b);
+        mutable x = QasmStd.Angle.DivideAngleByAngle(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/binary/arithmetic_conversions.rs
+++ b/compiler/qsc_qasm/src/tests/expression/binary/arithmetic_conversions.rs
@@ -16,8 +16,6 @@ fn int_idents_without_width_can_be_multiplied() -> miette::Result<(), Vec<Report
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 5;
         mutable y = 3;
@@ -37,8 +35,6 @@ fn int_idents_with_same_width_can_be_multiplied() -> miette::Result<(), Vec<Repo
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 5;
         mutable y = 3;
@@ -58,8 +54,6 @@ fn int_idents_with_different_width_can_be_multiplied() -> miette::Result<(), Vec
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 5;
         mutable y = 3;
@@ -80,8 +74,6 @@ fn multiplying_int_idents_with_different_width_result_in_higher_width_result(
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 5;
         mutable y = 3;
@@ -102,8 +94,6 @@ fn multiplying_int_idents_with_different_width_result_in_no_width_result(
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 5;
         mutable y = 3;
@@ -124,12 +114,10 @@ fn multiplying_int_idents_with_width_greater_than_64_result_in_bigint_result(
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 5;
         mutable y = 3;
-        mutable z = Microsoft.Quantum.Convert.IntAsBigInt(x * y);
+        mutable z = Std.Convert.IntAsBigInt(x * y);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/binary/comparison.rs
+++ b/compiler/qsc_qasm/src/tests/expression/binary/comparison.rs
@@ -25,8 +25,6 @@ fn int_var_comparisons_can_be_translated() -> miette::Result<(), Vec<Report>> {
     let qsharp = compile_qasm_to_qsharp_file(source)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : (Int, Int, Bool, Bool, Bool, Bool, Bool, Bool) {
@@ -61,8 +59,6 @@ fn uint_var_comparisons_can_be_translated() -> miette::Result<(), Vec<Report>> {
     let qsharp = compile_qasm_to_qsharp_file(source)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : (Int, Int, Bool, Bool, Bool, Bool, Bool, Bool) {
@@ -97,8 +93,6 @@ fn bit_var_comparisons_can_be_translated() -> miette::Result<(), Vec<Report>> {
     let qsharp = compile_qasm_to_qsharp_file(source)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : (Result, Result, Bool, Bool, Bool, Bool, Bool, Bool) {
@@ -133,19 +127,17 @@ fn bitarray_var_comparisons_can_be_translated() -> miette::Result<(), Vec<Report
     let qsharp = compile_qasm_to_qsharp_file(source)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : (Result[], Result[], Bool, Bool, Bool, Bool, Bool, Bool) {
                 mutable x = [One];
                 mutable y = [Zero];
-                mutable f = (__ResultArrayAsIntBE__(x) > __ResultArrayAsIntBE__(y));
-                mutable e = (__ResultArrayAsIntBE__(x) >= __ResultArrayAsIntBE__(y));
-                mutable a = (__ResultArrayAsIntBE__(x) < __ResultArrayAsIntBE__(y));
-                mutable c = (__ResultArrayAsIntBE__(x) <= __ResultArrayAsIntBE__(y));
-                mutable b = (__ResultArrayAsIntBE__(x) == __ResultArrayAsIntBE__(y));
-                mutable d = (__ResultArrayAsIntBE__(x) != __ResultArrayAsIntBE__(y));
+                mutable f = (QasmStd.Convert.ResultArrayAsIntBE(x) > QasmStd.Convert.ResultArrayAsIntBE(y));
+                mutable e = (QasmStd.Convert.ResultArrayAsIntBE(x) >= QasmStd.Convert.ResultArrayAsIntBE(y));
+                mutable a = (QasmStd.Convert.ResultArrayAsIntBE(x) < QasmStd.Convert.ResultArrayAsIntBE(y));
+                mutable c = (QasmStd.Convert.ResultArrayAsIntBE(x) <= QasmStd.Convert.ResultArrayAsIntBE(y));
+                mutable b = (QasmStd.Convert.ResultArrayAsIntBE(x) == QasmStd.Convert.ResultArrayAsIntBE(y));
+                mutable d = (QasmStd.Convert.ResultArrayAsIntBE(x) != QasmStd.Convert.ResultArrayAsIntBE(y));
                 (x, y, f, e, a, c, b, d)
             }
         }"#]]
@@ -175,23 +167,21 @@ fn bitarray_var_comparison_to_int_can_be_translated() -> miette::Result<(), Vec<
     let qsharp = compile_qasm_to_qsharp_file(source)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             operation Test(y : Int) : (Result[], Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool) {
                 mutable x = [One];
-                mutable a = (__ResultArrayAsIntBE__(x) > y);
-                mutable b = (__ResultArrayAsIntBE__(x) >= y);
-                mutable c = (__ResultArrayAsIntBE__(x) < y);
-                mutable d = (__ResultArrayAsIntBE__(x) <= y);
-                mutable e = (__ResultArrayAsIntBE__(x) == y);
-                mutable f = (__ResultArrayAsIntBE__(x) != y);
-                mutable g = (y > __ResultArrayAsIntBE__(x));
-                mutable h = (y >= __ResultArrayAsIntBE__(x));
-                mutable i = (y < __ResultArrayAsIntBE__(x));
-                mutable j = (y <= __ResultArrayAsIntBE__(x));
-                mutable k = (y == __ResultArrayAsIntBE__(x));
-                mutable l = (y != __ResultArrayAsIntBE__(x));
+                mutable a = (QasmStd.Convert.ResultArrayAsIntBE(x) > y);
+                mutable b = (QasmStd.Convert.ResultArrayAsIntBE(x) >= y);
+                mutable c = (QasmStd.Convert.ResultArrayAsIntBE(x) < y);
+                mutable d = (QasmStd.Convert.ResultArrayAsIntBE(x) <= y);
+                mutable e = (QasmStd.Convert.ResultArrayAsIntBE(x) == y);
+                mutable f = (QasmStd.Convert.ResultArrayAsIntBE(x) != y);
+                mutable g = (y > QasmStd.Convert.ResultArrayAsIntBE(x));
+                mutable h = (y >= QasmStd.Convert.ResultArrayAsIntBE(x));
+                mutable i = (y < QasmStd.Convert.ResultArrayAsIntBE(x));
+                mutable j = (y <= QasmStd.Convert.ResultArrayAsIntBE(x));
+                mutable k = (y == QasmStd.Convert.ResultArrayAsIntBE(x));
+                mutable l = (y != QasmStd.Convert.ResultArrayAsIntBE(x));
                 (x, a, b, c, d, e, f, g, h, i, j, k, l)
             }
         }"#]]
@@ -215,8 +205,6 @@ fn float_var_comparisons_can_be_translated() -> miette::Result<(), Vec<Report>> 
     let qsharp = compile_qasm_to_qsharp_file(source)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : (Double, Double, Bool, Bool, Bool, Bool, Bool, Bool) {
@@ -253,8 +241,6 @@ fn bool_var_comparisons_can_be_translated() -> miette::Result<(), Vec<Report>> {
     let qsharp = compile_qasm_to_qsharp_file(source)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : (Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool, Bool) {

--- a/compiler/qsc_qasm/src/tests/expression/binary/complex.rs
+++ b/compiler/qsc_qasm/src/tests/expression/binary/complex.rs
@@ -15,7 +15,7 @@ fn addition() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = Microsoft.Quantum.Math.PlusC(a, b);
+        mutable x = Std.Math.PlusC(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -31,7 +31,7 @@ fn addition_assign_op() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        set x = Microsoft.Quantum.Math.PlusC(x, a);
+        set x = Std.Math.PlusC(x, a);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -47,7 +47,7 @@ fn subtraction() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = Microsoft.Quantum.Math.MinusC(a, b);
+        mutable x = Std.Math.MinusC(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -63,7 +63,7 @@ fn subtraction_assign_op() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        set x = Microsoft.Quantum.Math.MinusC(x, a);
+        set x = Std.Math.MinusC(x, a);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -79,7 +79,7 @@ fn multiplication() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = Microsoft.Quantum.Math.TimesC(a, b);
+        mutable x = Std.Math.TimesC(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -95,7 +95,7 @@ fn multiplication_assign_op() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        set x = Microsoft.Quantum.Math.TimesC(x, a);
+        set x = Std.Math.TimesC(x, a);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -111,7 +111,7 @@ fn division() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = Microsoft.Quantum.Math.DividedByC(a, b);
+        mutable x = Std.Math.DividedByC(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -127,7 +127,7 @@ fn division_assign_op() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        set x = Microsoft.Quantum.Math.DividedByC(x, a);
+        set x = Std.Math.DividedByC(x, a);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -143,7 +143,7 @@ fn power() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        mutable x = Microsoft.Quantum.Math.PowC(a, b);
+        mutable x = Std.Math.PowC(a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -159,7 +159,7 @@ fn power_assign_op() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
-        set x = Microsoft.Quantum.Math.PowC(x, a);
+        set x = Std.Math.PowC(x, a);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/binary/ident.rs
+++ b/compiler/qsc_qasm/src/tests/expression/binary/ident.rs
@@ -16,8 +16,6 @@ fn mutable_int_idents_without_width_can_be_multiplied() -> miette::Result<(), Ve
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 5;
         mutable y = 3;
@@ -37,8 +35,6 @@ fn const_int_idents_without_width_can_be_multiplied() -> miette::Result<(), Vec<
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let x = 5;
         let y = 3;
@@ -59,8 +55,6 @@ fn const_int_idents_widthless_lhs_can_be_multiplied_by_explicit_width_int(
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let x = 5;
         let y = 3;

--- a/compiler/qsc_qasm/src/tests/expression/bits.rs
+++ b/compiler/qsc_qasm/src/tests/expression/bits.rs
@@ -27,23 +27,21 @@ fn bit_array_bits_and_register_ops() -> miette::Result<(), Vec<Report>> {
     let qsharp = compile_qasm_to_qsharp_file(source)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : (Result[], Result[], Result[], Result[], Result[]) {
                 mutable a = [One, Zero, Zero, Zero, One, One, One, One];
                 mutable b = [Zero, One, One, One, Zero, Zero, Zero, Zero];
                 mutable ls_a_1 = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-                set ls_a_1 = (__IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) <<< 1, 8));
+                set ls_a_1 = (QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) <<< 1, 8));
                 mutable a_or_b = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-                set a_or_b = (__IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) ||| __ResultArrayAsIntBE__(b), 8));
+                set a_or_b = (QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) ||| QasmStd.Convert.ResultArrayAsIntBE(b), 8));
                 mutable a_and_b = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-                set a_and_b = (__IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) &&& __ResultArrayAsIntBE__(b), 8));
+                set a_and_b = (QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) &&& QasmStd.Convert.ResultArrayAsIntBE(b), 8));
                 mutable a_xor_b = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-                set a_xor_b = (__IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) ^^^ __ResultArrayAsIntBE__(b), 8));
+                set a_xor_b = (QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) ^^^ QasmStd.Convert.ResultArrayAsIntBE(b), 8));
                 mutable rs_a_1 = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-                set rs_a_1 = (__IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) >>> 1, 8));
+                set rs_a_1 = (QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) >>> 1, 8));
                 (ls_a_1, a_or_b, a_and_b, a_xor_b, rs_a_1)
             }
         }"#]]
@@ -61,12 +59,10 @@ fn bit_array_left_shift() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable a = [One, Zero, Zero, Zero, One, One, One, One];
         mutable ls_a_1 = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-        set ls_a_1 = (__IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) <<< 1, 8));
+        set ls_a_1 = (QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) <<< 1, 8));
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/function_call.rs
+++ b/compiler/qsc_qasm/src/tests/expression/function_call.rs
@@ -15,8 +15,6 @@ fn funcall_with_no_arguments_generates_correct_qsharp() -> miette::Result<(), Ve
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         function empty() : Unit {}
         empty();
@@ -34,8 +32,6 @@ fn void_function_with_one_argument_generates_correct_qsharp() -> miette::Result<
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         function f(x : Int) : Unit {}
         f(2);
@@ -56,8 +52,6 @@ fn funcall_with_one_argument_generates_correct_qsharp() -> miette::Result<(), Ve
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         function square(x : Int) : Int {
             return x * x;
@@ -80,8 +74,6 @@ fn funcall_with_two_arguments_generates_correct_qsharp() -> miette::Result<(), V
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         function sum(x : Int, y : Int) : Int {
             return x + y;
@@ -107,13 +99,11 @@ fn funcall_with_qubit_argument() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation parity(qs : Qubit[]) : Result {
             mutable a = QIR.Intrinsic.__quantum__qis__m__body(qs[0]);
             mutable b = QIR.Intrinsic.__quantum__qis__m__body(qs[1]);
-            return if __ResultAsInt__(a) ^^^ __ResultAsInt__(b) == 0 {
+            return if QasmStd.Convert.ResultAsInt(a) ^^^ QasmStd.Convert.ResultAsInt(b) == 0 {
                 One
             } else {
                 Zero
@@ -196,8 +186,6 @@ fn funcall_accepts_qubit_argument() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation h_wrapper(q : Qubit) : Unit {
             h(q);
@@ -221,8 +209,6 @@ fn classical_decl_initialized_with_funcall() -> miette::Result<(), Vec<Report>> 
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         function square(x : Int) : Int {
             return x * x;
@@ -273,8 +259,6 @@ fn funcall_implicit_arg_cast_uint_to_bitarray() -> miette::Result<(), Vec<Report
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         function parity(arr : Result[]) : Result {
             return if 1 == 0 {
@@ -283,7 +267,7 @@ fn funcall_implicit_arg_cast_uint_to_bitarray() -> miette::Result<(), Vec<Report
                 Zero
             };
         }
-        mutable p = parity(__IntAsResultArrayBE__(2, 2));
+        mutable p = parity(QasmStd.Convert.IntAsResultArrayBE(2, 2));
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/ident.rs
+++ b/compiler/qsc_qasm/src/tests/expression/ident.rs
@@ -65,15 +65,11 @@ fn resolved_idenfiers_are_compiled_as_refs() -> miette::Result<(), Vec<Report>> 
     ";
 
     let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![
-        r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
+    expect![[r#"
         import QasmStd.Intrinsic.*;
-        mutable p = Microsoft.Quantum.Math.PI();
+        mutable p = Std.Math.PI();
         mutable x = p;
-    "#
-    ]
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -85,11 +81,9 @@ fn euler_latin_is_resolved() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.E();
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.E();
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -101,11 +95,9 @@ fn euler_unicode_is_resolved() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.E();
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.E();
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -117,11 +109,9 @@ fn pi_latin_is_resolved() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.PI();
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.PI();
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -133,11 +123,9 @@ fn pi_unicode_is_resolved() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = Microsoft.Quantum.Math.PI();
-    "#
-    ]
+    expect![[r#"
+        mutable x = Std.Math.PI();
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -149,11 +137,9 @@ fn tau_latin_is_resolved() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = 2. * Microsoft.Quantum.Math.PI();
-    "#
-    ]
+    expect![[r#"
+        mutable x = 2. * Std.Math.PI();
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }
@@ -165,11 +151,9 @@ fn tau_unicode_is_resolved() -> miette::Result<(), Vec<Report>> {
     ";
 
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
-    expect![
-        r#"
-        mutable x = 2. * Microsoft.Quantum.Math.PI();
-    "#
-    ]
+    expect![[r#"
+        mutable x = 2. * Std.Math.PI();
+    "#]]
     .assert_eq(&qsharp);
     Ok(())
 }

--- a/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_bit.rs
+++ b/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_bit.rs
@@ -22,16 +22,14 @@ fn to_bool_and_back_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable _bool0 = false;
         mutable _bool1 = false;
         set _bool0 = true;
-        set _bool1 = __ResultAsBool__(a);
+        set _bool1 = QasmStd.Convert.ResultAsBool(a);
         set _bool0 = _bool1;
         set _bool0 = _bool1;
-        set a = __BoolAsResult__(_bool1);
+        set a = QasmStd.Convert.BoolAsResult(_bool1);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -46,11 +44,9 @@ fn to_bool_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = One;
-        mutable y = __ResultAsBool__(x);
+        mutable y = QasmStd.Convert.ResultAsBool(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -65,11 +61,9 @@ fn to_implicit_int_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = One;
-        mutable y = __ResultAsInt__(x);
+        mutable y = QasmStd.Convert.ResultAsInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -84,11 +78,9 @@ fn to_explicit_int_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = One;
-        mutable y = __ResultAsInt__(x);
+        mutable y = QasmStd.Convert.ResultAsInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -103,11 +95,9 @@ fn to_implicit_uint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = One;
-        mutable y = __ResultAsInt__(x);
+        mutable y = QasmStd.Convert.ResultAsInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -122,11 +112,9 @@ fn to_explicit_uint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = One;
-        mutable y = __ResultAsInt__(x);
+        mutable y = QasmStd.Convert.ResultAsInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -141,11 +129,9 @@ fn to_explicit_bigint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = One;
-        mutable y = __ResultAsBigInt__(x);
+        mutable y = QasmStd.Convert.ResultAsBigInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_bitarray.rs
+++ b/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_bitarray.rs
@@ -15,11 +15,9 @@ fn to_int_decl_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable reg = [Zero, Zero, Zero, Zero, Zero];
-        mutable b = __ResultArrayAsIntBE__(reg);
+        mutable b = QasmStd.Convert.ResultArrayAsIntBE(reg);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -35,12 +33,10 @@ fn to_int_assignment_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable reg = [Zero, Zero, Zero, Zero, Zero];
         mutable a = 0;
-        set a = __ResultArrayAsIntBE__(reg);
+        set a = QasmStd.Convert.ResultArrayAsIntBE(reg);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -56,12 +52,10 @@ fn to_int_with_equal_width_in_assignment_implicitly() -> miette::Result<(), Vec<
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable reg = [Zero, Zero, Zero, Zero, Zero];
         mutable a = 0;
-        set a = __ResultArrayAsIntBE__(reg);
+        set a = QasmStd.Convert.ResultArrayAsIntBE(reg);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -76,11 +70,9 @@ fn to_int_with_equal_width_in_decl_implicitly() -> miette::Result<(), Vec<Report
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable reg = [Zero, Zero, Zero, Zero, Zero];
-        mutable a = __ResultArrayAsIntBE__(reg);
+        mutable a = QasmStd.Convert.ResultArrayAsIntBE(reg);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_bool.rs
+++ b/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_bool.rs
@@ -22,16 +22,14 @@ fn to_bit_and_back_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable _bit0 = Zero;
         mutable _bit1 = Zero;
         set _bit0 = One;
-        set _bit1 = __BoolAsResult__(a);
+        set _bit1 = QasmStd.Convert.BoolAsResult(a);
         set _bit0 = _bit1;
         set _bit0 = _bit1;
-        set a = __ResultAsBool__(_bit1);
+        set a = QasmStd.Convert.ResultAsBool(_bit1);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -46,11 +44,9 @@ fn to_bit_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = true;
-        mutable y = __BoolAsResult__(x);
+        mutable y = QasmStd.Convert.BoolAsResult(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -65,11 +61,9 @@ fn to_implicit_int_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = true;
-        mutable y = __BoolAsInt__(x);
+        mutable y = QasmStd.Convert.BoolAsInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -84,11 +78,9 @@ fn to_explicit_int_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = true;
-        mutable y = __BoolAsInt__(x);
+        mutable y = QasmStd.Convert.BoolAsInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -103,11 +95,9 @@ fn to_implicit_uint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = true;
-        mutable y = __BoolAsInt__(x);
+        mutable y = QasmStd.Convert.BoolAsInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -122,11 +112,9 @@ fn to_explicit_uint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = true;
-        mutable y = __BoolAsInt__(x);
+        mutable y = QasmStd.Convert.BoolAsInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -141,11 +129,9 @@ fn to_explicit_bigint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = true;
-        mutable y = __BoolAsBigInt__(x);
+        mutable y = QasmStd.Convert.BoolAsBigInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -160,11 +146,9 @@ fn to_implicit_float_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = true;
-        mutable y = __BoolAsDouble__(x);
+        mutable y = QasmStd.Convert.BoolAsDouble(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -179,11 +163,9 @@ fn to_explicit_float_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = true;
-        mutable y = __BoolAsDouble__(x);
+        mutable y = QasmStd.Convert.BoolAsDouble(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_float.rs
+++ b/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_float.rs
@@ -45,11 +45,9 @@ fn to_bool_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
-        mutable y = if Microsoft.Quantum.Math.Truncate(x) == 0 {
+        mutable y = if Std.Math.Truncate(x) == 0 {
             false
         } else {
             true
@@ -68,11 +66,9 @@ fn to_implicit_int_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
-        mutable y = Microsoft.Quantum.Math.Truncate(x);
+        mutable y = Std.Math.Truncate(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -87,11 +83,9 @@ fn to_explicit_int_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
-        mutable y = Microsoft.Quantum.Math.Truncate(x);
+        mutable y = Std.Math.Truncate(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -106,11 +100,9 @@ fn to_implicit_uint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
-        mutable y = Microsoft.Quantum.Math.Truncate(x);
+        mutable y = Std.Math.Truncate(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -125,11 +117,9 @@ fn to_explicit_uint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
-        mutable y = Microsoft.Quantum.Math.Truncate(x);
+        mutable y = Std.Math.Truncate(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -144,11 +134,9 @@ fn to_explicit_bigint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
-        mutable y = Microsoft.Quantum.Convert.IntAsBigInt(Microsoft.Quantum.Math.Truncate(x));
+        mutable y = Std.Convert.IntAsBigInt(Std.Math.Truncate(x));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -163,8 +151,6 @@ fn to_implicit_float_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
         mutable y = x;
@@ -182,8 +168,6 @@ fn to_explicit_float_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
         mutable y = x;
@@ -201,11 +185,9 @@ fn to_implicit_complex_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
-        mutable y = Microsoft.Quantum.Math.Complex(x, 0.);
+        mutable y = Std.Math.Complex(x, 0.);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -220,11 +202,9 @@ fn to_explicit_complex_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42.;
-        mutable y = Microsoft.Quantum.Math.Complex(x, 0.);
+        mutable y = Std.Math.Complex(x, 0.);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_int.rs
+++ b/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_int.rs
@@ -15,8 +15,6 @@ fn to_bit_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
         mutable y = if x == 0 {
@@ -38,8 +36,6 @@ fn to_bool_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
         mutable y = if x == 0 {
@@ -61,8 +57,6 @@ fn to_implicit_int_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
         mutable y = x;
@@ -80,8 +74,6 @@ fn to_explicit_int_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
         mutable y = x;
@@ -99,8 +91,6 @@ fn to_implicit_uint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
         mutable y = x;
@@ -118,8 +108,6 @@ fn to_explicit_uint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
         mutable y = x;
@@ -137,11 +125,9 @@ fn to_explicit_bigint_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
-        mutable y = Microsoft.Quantum.Convert.IntAsBigInt(x);
+        mutable y = Std.Convert.IntAsBigInt(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -156,11 +142,9 @@ fn to_implicit_float_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
-        mutable y = Microsoft.Quantum.Convert.IntAsDouble(x);
+        mutable y = Std.Convert.IntAsDouble(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -175,11 +159,9 @@ fn to_explicit_float_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
-        mutable y = Microsoft.Quantum.Convert.IntAsDouble(x);
+        mutable y = Std.Convert.IntAsDouble(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -194,11 +176,9 @@ fn to_implicit_complex_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
-        mutable y = Microsoft.Quantum.Math.Complex(Microsoft.Quantum.Convert.IntAsDouble(x), 0.);
+        mutable y = Std.Math.Complex(Std.Convert.IntAsDouble(x), 0.);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -213,11 +193,9 @@ fn to_explicit_complex_implicitly() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 42;
-        mutable y = Microsoft.Quantum.Math.Complex(Microsoft.Quantum.Convert.IntAsDouble(x), 0.);
+        mutable y = Std.Math.Complex(Std.Convert.IntAsDouble(x), 0.);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/expression/indexed.rs
+++ b/compiler/qsc_qasm/src/tests/expression/indexed.rs
@@ -34,11 +34,9 @@ fn indexed_bit_can_implicitly_convert_to_int() -> miette::Result<(), Vec<Report>
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = [Zero, Zero, Zero, Zero, Zero];
-        if __ResultAsInt__(x[0]) == 1 {
+        if QasmStd.Convert.ResultAsInt(x[0]) == 1 {
             set x w/= 1 <- One;
         };
     "#]]
@@ -57,11 +55,9 @@ fn indexed_bit_can_implicitly_convert_to_bool() -> miette::Result<(), Vec<Report
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = [Zero, Zero, Zero, Zero, Zero];
-        if __ResultAsBool__(x[0]) {
+        if QasmStd.Convert.ResultAsBool(x[0]) {
             set x w/= 1 <- One;
         };
     "#]]
@@ -78,8 +74,6 @@ fn bit_indexed_ty_is_same_as_element_ty() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = [Zero, Zero, Zero, Zero, Zero];
         mutable y = x[0];

--- a/compiler/qsc_qasm/src/tests/expression/unary.rs
+++ b/compiler/qsc_qasm/src/tests/expression/unary.rs
@@ -40,8 +40,6 @@ fn not_bool() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = true;
         mutable y = not x;
@@ -59,11 +57,9 @@ fn not_result() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = One;
-        mutable y = __BoolAsResult__(not __ResultAsBool__(x));
+        mutable y = QasmStd.Convert.BoolAsResult(not QasmStd.Convert.ResultAsBool(x));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -78,8 +74,6 @@ fn logical_not_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable x = 159;
         mutable y = not if x == 0 {
@@ -118,11 +112,9 @@ fn logical_not_indexed_bit_array_in_if_cond() -> miette::Result<(), Vec<Report>>
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable Classical = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
-        if not __ResultAsBool__(Classical[1]) {
+        if not QasmStd.Convert.ResultAsBool(Classical[1]) {
             set Classical w/= 0 <- One;
         };
     "#]]
@@ -139,14 +131,12 @@ fn neg_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        mutable x = new __Angle__ {
+        mutable x = new QasmStd.Angle.Angle {
             Value = 3,
             Size = 4
         };
-        mutable y = __NegAngle__(x);
+        mutable y = QasmStd.Angle.NegAngle(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -161,14 +151,12 @@ fn notb_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        mutable x = new __Angle__ {
+        mutable x = new QasmStd.Angle.Angle {
             Value = 3,
             Size = 4
         };
-        mutable y = __AngleNotB__(x);
+        mutable y = QasmStd.Angle.AngleNotB(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/output.rs
+++ b/compiler/qsc_qasm/src/tests/output.rs
@@ -40,15 +40,13 @@ fn using_re_semantics_removes_output() -> miette::Result<(), Vec<Report>> {
     let qsharp = gen_qsharp(&unit.package);
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             operation Test(theta : Double, beta : Int) : Unit {
                 mutable c = [Zero, Zero];
                 let q = QIR.Runtime.AllocateQubitArray(2);
                 mutable gamma = 0.;
                 mutable delta = 0.;
-                rz(__DoubleAsAngle__(theta, 53), q[0]);
+                rz(QasmStd.Angle.DoubleAsAngle(theta, 53), q[0]);
                 h(q[0]);
                 cx(q[0], q[1]);
                 set c w/= 0 <- QIR.Intrinsic.__quantum__qis__m__body(q[0]);
@@ -91,15 +89,13 @@ fn using_qasm_semantics_captures_all_classical_decls_as_output() -> miette::Resu
     let qsharp = gen_qsharp(&unit.package);
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             operation Test(theta : Double, beta : Int) : (Result[], Double, Double) {
                 mutable c = [Zero, Zero];
                 let q = QIR.Runtime.AllocateQubitArray(2);
                 mutable gamma = 0.;
                 mutable delta = 0.;
-                rz(__DoubleAsAngle__(theta, 53), q[0]);
+                rz(QasmStd.Angle.DoubleAsAngle(theta, 53), q[0]);
                 h(q[0]);
                 cx(q[0], q[1]);
                 set c w/= 0 <- QIR.Intrinsic.__quantum__qis__m__body(q[0]);
@@ -142,20 +138,18 @@ fn using_qiskit_semantics_only_bit_array_is_captured_and_reversed(
     let qsharp = gen_qsharp(&unit.package);
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             operation Test(theta : Double, beta : Int) : Result[] {
                 mutable c = [Zero, Zero];
                 let q = QIR.Runtime.AllocateQubitArray(2);
                 mutable gamma = 0.;
                 mutable delta = 0.;
-                rz(__DoubleAsAngle__(theta, 53), q[0]);
+                rz(QasmStd.Angle.DoubleAsAngle(theta, 53), q[0]);
                 h(q[0]);
                 cx(q[0], q[1]);
                 set c w/= 0 <- QIR.Intrinsic.__quantum__qis__m__body(q[0]);
                 set c w/= 1 <- QIR.Intrinsic.__quantum__qis__m__body(q[1]);
-                Microsoft.Quantum.Arrays.Reversed(c)
+                Std.Arrays.Reversed(c)
             }
         }"#]]
     .assert_eq(&qsharp);
@@ -201,8 +195,6 @@ c2[2] = measure q[4];
     let qsharp = gen_qsharp(&package.clone());
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             operation Test(theta : Double, beta : Int) : (Result[], Result[]) {
                 mutable c = [Zero, Zero];
@@ -210,7 +202,7 @@ c2[2] = measure q[4];
                 let q = QIR.Runtime.AllocateQubitArray(5);
                 mutable gamma = 0.;
                 mutable delta = 0.;
-                rz(__DoubleAsAngle__(theta, 53), q[0]);
+                rz(QasmStd.Angle.DoubleAsAngle(theta, 53), q[0]);
                 h(q[0]);
                 cx(q[0], q[1]);
                 x(q[2]);
@@ -221,7 +213,7 @@ c2[2] = measure q[4];
                 set c2 w/= 0 <- QIR.Intrinsic.__quantum__qis__m__body(q[2]);
                 set c2 w/= 1 <- QIR.Intrinsic.__quantum__qis__m__body(q[3]);
                 set c2 w/= 2 <- QIR.Intrinsic.__quantum__qis__m__body(q[4]);
-                (Microsoft.Quantum.Arrays.Reversed(c2), Microsoft.Quantum.Arrays.Reversed(c))
+                (Std.Arrays.Reversed(c2), Std.Arrays.Reversed(c))
             }
         }"#]]
     .assert_eq(&qsharp);

--- a/compiler/qsc_qasm/src/tests/scopes.rs
+++ b/compiler/qsc_qasm/src/tests/scopes.rs
@@ -21,8 +21,6 @@ fn can_access_const_decls_from_global_scope() -> miette::Result<(), Vec<Report>>
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let i = 7;
         operation my_h(q : Qubit) : Unit is Adj + Ctl {
@@ -72,8 +70,6 @@ fn gates_can_call_previously_declared_gates() -> miette::Result<(), Vec<Report>>
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation my_h(q : Qubit) : Unit is Adj + Ctl {
             h(q);
@@ -106,8 +102,6 @@ fn def_can_call_previously_declared_def() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation apply_h(q : Qubit) : Unit {
             h(q);
@@ -140,8 +134,6 @@ fn gate_can_call_previously_declared_def() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation apply_h(q : Qubit) : Unit {
             h(q);
@@ -174,8 +166,6 @@ fn def_can_call_previously_declared_gate() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation my_h(q : Qubit) : Unit is Adj + Ctl {
             h(q);
@@ -208,8 +198,6 @@ fn def_can_call_itself_recursively() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation apply_hx(limit : Int, q : Qubit) : Unit {
             if limit > 0 {

--- a/compiler/qsc_qasm/src/tests/statement/annotation.rs
+++ b/compiler/qsc_qasm/src/tests/statement/annotation.rs
@@ -17,8 +17,6 @@ fn simulatable_intrinsic_can_be_applied_to_gate() -> miette::Result<(), Vec<Repo
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         @SimulatableIntrinsic()
         operation my_h(q : Qubit) : Unit {
@@ -41,8 +39,6 @@ fn simulatable_intrinsic_can_be_applied_to_def() -> miette::Result<(), Vec<Repor
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         @SimulatableIntrinsic()
         operation my_h(q : Qubit) : Unit {
@@ -65,8 +61,6 @@ fn config_can_be_applied_to_gate() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         @Config(Base)
         operation my_h(q : Qubit) : Unit is Adj + Ctl {
@@ -89,8 +83,6 @@ fn config_can_be_applied_to_def() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         @Config(Base)
         operation my_h(q : Qubit) : Unit {

--- a/compiler/qsc_qasm/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm/src/tests/statement/const_eval.rs
@@ -22,8 +22,6 @@ fn const_exprs_work_in_bitarray_size_position() -> miette::Result<(), Vec<Report
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 1;
         let b = 2 + a;
@@ -47,12 +45,10 @@ fn const_exprs_implicit_cast_work_in_bitarray_size_position() -> miette::Result<
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 1;
-        let b = 2. + Microsoft.Quantum.Convert.IntAsDouble(a);
-        let c = Microsoft.Quantum.Convert.IntAsDouble(a) + 3.;
+        let b = 2. + Std.Convert.IntAsDouble(a);
+        let c = Std.Convert.IntAsDouble(a) + 3.;
         mutable r1 = [Zero, Zero, Zero];
         mutable r2 = [Zero, Zero, Zero, Zero];
     "#]]
@@ -129,8 +125,6 @@ fn can_assign_const_expr_to_non_const_decl() -> miette::Result<(), Vec<Report>> 
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 1;
         let b = 2;
@@ -149,8 +143,6 @@ fn ident_const() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 1;
         mutable r = [Zero];
@@ -189,8 +181,6 @@ fn unary_op_neg_float() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = -1.;
         let b = -a;
@@ -210,8 +200,6 @@ fn unary_op_neg_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = -1;
         let b = -a;
@@ -231,11 +219,9 @@ fn unary_op_neg_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = __DoubleAsAngle__(-1., 32);
-        let b = __AngleAsResult__(a);
+        let a = QasmStd.Angle.DoubleAsAngle(-1., 32);
+        let b = QasmStd.Angle.AngleAsResult(a);
         mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -252,8 +238,6 @@ fn unary_op_negb_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 5;
         let b = ~~~a;
@@ -274,14 +258,12 @@ fn unary_op_negb_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 683565276,
             Size = 32
         };
-        let b = __AngleAsResult__(__AngleNotB__(a));
+        let b = QasmStd.Angle.AngleAsResult(QasmStd.Angle.AngleNotB(a));
         mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -298,8 +280,6 @@ fn unary_op_negb_bit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = Zero;
         let b = ~~~a;
@@ -319,11 +299,9 @@ fn unary_op_negb_bitarray() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = [One, Zero, One];
-        let b = __ResultArrayAsIntBE__(~~~a);
+        let b = QasmStd.Convert.ResultArrayAsIntBE(~~~a);
         mutable r = [Zero, Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -343,12 +321,10 @@ fn lhs_ty_equals_rhs_ty_assumption_holds() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 1;
         let b = 2.;
-        let c = Microsoft.Quantum.Math.Truncate(Microsoft.Quantum.Convert.IntAsDouble(a) + b);
+        let c = Std.Math.Truncate(Std.Convert.IntAsDouble(a) + b);
         mutable r = [Zero, Zero, Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -369,8 +345,6 @@ fn binary_op_shl_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 1;
         let b = a <<< 2;
@@ -392,15 +366,13 @@ fn binary_op_shl_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 683565276,
             Size = 32
         };
-        let b = __AngleShl__(a, 2);
-        let c = __AngleAsResult__(b);
+        let b = QasmStd.Angle.__AngleShl__(a, 2);
+        let c = QasmStd.Angle.AngleAsResult(b);
         mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -417,11 +389,9 @@ fn binary_op_shl_bit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = One;
-        let b = if __ResultAsInt__(a) <<< 2 == 0 {
+        let b = if QasmStd.Convert.ResultAsInt(a) <<< 2 == 0 {
             One
         } else {
             Zero
@@ -442,11 +412,9 @@ fn binary_op_shl_bitarray() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = [One, Zero, One];
-        let b = __IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) <<< 2, 3);
+        let b = QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) <<< 2, 3);
         mutable r = [Zero, Zero, Zero, Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -542,8 +510,6 @@ fn binary_op_shr_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 5;
         let b = a >>> 2;
@@ -565,15 +531,13 @@ fn binary_op_shr_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 683565276,
             Size = 32
         };
-        let b = __AngleShr__(a, 2);
-        let c = __AngleAsResult__(b);
+        let b = QasmStd.Angle.AngleShr(a, 2);
+        let c = QasmStd.Angle.AngleAsResult(b);
         mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -590,11 +554,9 @@ fn binary_op_shr_bit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = One;
-        let b = if __ResultAsInt__(a) >>> 2 == 0 {
+        let b = if QasmStd.Convert.ResultAsInt(a) >>> 2 == 0 {
             One
         } else {
             Zero
@@ -615,11 +577,9 @@ fn binary_op_shr_bitarray() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = [One, Zero, One, One];
-        let b = __IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) >>> 2, 4);
+        let b = QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) >>> 2, 4);
         mutable r = [Zero, Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -717,8 +677,6 @@ fn binary_op_andb_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 5;
         let b = a &&& 6;
@@ -741,19 +699,17 @@ fn binary_op_andb_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 683565276,
             Size = 32
         };
-        let b = new __Angle__ {
+        let b = new QasmStd.Angle.Angle {
             Value = 1367130551,
             Size = 32
         };
-        let c = __AngleAndB__(a, b);
-        let d = __AngleAsResult__(c);
+        let c = QasmStd.Angle.AngleAndB(a, b);
+        let d = QasmStd.Angle.AngleAsResult(c);
         mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -770,11 +726,9 @@ fn binary_op_andb_bit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = One;
-        let b = if __ResultAsInt__(a) &&& 0 == 0 {
+        let b = if QasmStd.Convert.ResultAsInt(a) &&& 0 == 0 {
             One
         } else {
             Zero
@@ -795,11 +749,9 @@ fn binary_op_andb_bitarray() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = [One, Zero, One, One];
-        let b = __IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) &&& __ResultArrayAsIntBE__([Zero, One, One, Zero]), 4);
+        let b = QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) &&& QasmStd.Convert.ResultArrayAsIntBE([Zero, One, One, Zero]), 4);
         mutable r = [Zero, Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -818,8 +770,6 @@ fn binary_op_orb_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 5;
         let b = a ||| 6;
@@ -842,19 +792,17 @@ fn binary_op_orb_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 683565276,
             Size = 32
         };
-        let b = new __Angle__ {
+        let b = new QasmStd.Angle.Angle {
             Value = 1367130551,
             Size = 32
         };
-        let c = __AngleOrB__(a, b);
-        let d = __AngleAsBool__(c);
+        let c = QasmStd.Angle.AngleOrB(a, b);
+        let d = QasmStd.Angle.AngleAsBool(c);
         mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -871,11 +819,9 @@ fn binary_op_orb_bit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = One;
-        let b = if __ResultAsInt__(a) ||| 0 == 0 {
+        let b = if QasmStd.Convert.ResultAsInt(a) ||| 0 == 0 {
             One
         } else {
             Zero
@@ -896,11 +842,9 @@ fn binary_op_orb_bitarray() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = [Zero, Zero, One];
-        let b = __IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) ||| __ResultArrayAsIntBE__([One, Zero, Zero]), 3);
+        let b = QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) ||| QasmStd.Convert.ResultArrayAsIntBE([One, Zero, Zero]), 3);
         mutable r = [Zero, Zero, Zero, Zero, Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -919,8 +863,6 @@ fn binary_op_xorb_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 5;
         let b = a ^^^ 6;
@@ -943,19 +885,17 @@ fn binary_op_xorb_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 683565276,
             Size = 32
         };
-        let b = new __Angle__ {
+        let b = new QasmStd.Angle.Angle {
             Value = 1367130551,
             Size = 32
         };
-        let c = __AngleXorB__(a, b);
-        let d = __AngleAsResult__(c);
+        let c = QasmStd.Angle.AngleXorB(a, b);
+        let d = QasmStd.Angle.AngleAsResult(c);
         mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -972,11 +912,9 @@ fn binary_op_xorb_bit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = One;
-        let b = if __ResultAsInt__(a) ^^^ 1 == 0 {
+        let b = if QasmStd.Convert.ResultAsInt(a) ^^^ 1 == 0 {
             One
         } else {
             Zero
@@ -997,11 +935,9 @@ fn binary_op_xorb_bitarray() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = [One, Zero, One, One];
-        let b = __IntAsResultArrayBE__(__ResultArrayAsIntBE__(a) ^^^ __ResultArrayAsIntBE__([One, One, One, Zero]), 4);
+        let b = QasmStd.Convert.IntAsResultArrayBE(QasmStd.Convert.ResultArrayAsIntBE(a) ^^^ QasmStd.Convert.ResultArrayAsIntBE([One, One, One, Zero]), 4);
         mutable r = [Zero, Zero, Zero, Zero, Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -1023,8 +959,6 @@ fn binary_op_andl_bool() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let f = false;
         let t = true;
@@ -1050,8 +984,6 @@ fn binary_op_orl_bool() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let f = false;
         let t = true;
@@ -1082,8 +1014,6 @@ fn binary_op_comparison_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 2;
         mutable r1 = [Zero];
@@ -1111,8 +1041,6 @@ fn binary_op_comparison_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 2;
         mutable r1 = [Zero];
@@ -1141,10 +1069,8 @@ fn binary_op_comparison_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 1367130551,
             Size = 32
         };
@@ -1173,8 +1099,6 @@ fn binary_op_comparison_bit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = One;
         mutable r1 = [Zero];
@@ -1202,8 +1126,6 @@ fn binary_op_comparison_bitarray() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = [One, Zero];
         mutable r1 = [Zero];
@@ -1231,8 +1153,6 @@ fn binary_op_add_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 1;
         let b = 2;
@@ -1252,8 +1172,6 @@ fn binary_op_add_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 1;
         let b = 2;
@@ -1273,8 +1191,6 @@ fn binary_op_add_float() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 1.;
         let b = 2.;
@@ -1296,18 +1212,16 @@ fn binary_op_add_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 683565276,
             Size = 32
         };
-        let b = new __Angle__ {
+        let b = new QasmStd.Angle.Angle {
             Value = 1367130551,
             Size = 32
         };
-        let c = __AngleAsResult__(__AddAngles__(a, b));
+        let c = QasmStd.Angle.AngleAsResult(QasmStd.Angle.AddAngles(a, b));
         mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -1326,8 +1240,6 @@ fn binary_op_sub_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 3;
         let b = 2;
@@ -1347,8 +1259,6 @@ fn binary_op_sub_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 3;
         let b = 2;
@@ -1368,8 +1278,6 @@ fn binary_op_sub_float() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 3.;
         let b = 2.;
@@ -1391,18 +1299,16 @@ fn binary_op_sub_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 683565276,
             Size = 32
         };
-        let b = new __Angle__ {
+        let b = new QasmStd.Angle.Angle {
             Value = 1367130551,
             Size = 32
         };
-        let c = __AngleAsResult__(__SubtractAngles__(a, b));
+        let c = QasmStd.Angle.AngleAsResult(QasmStd.Angle.SubtractAngles(a, b));
         mutable r = [Zero];
     "#]]
     .assert_eq(&qsharp);
@@ -1421,8 +1327,6 @@ fn binary_op_mul_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 3;
         let b = 2;
@@ -1442,8 +1346,6 @@ fn binary_op_mul_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 3;
         let b = 2;
@@ -1463,8 +1365,6 @@ fn binary_op_mul_float() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 3.;
         let b = 2.;
@@ -1488,16 +1388,14 @@ fn binary_op_mul_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 683565276,
             Size = 32
         };
         let b = 2;
-        let c1 = __AngleAsResult__(__MultiplyAngleByInt__(a, b));
-        let c2 = __AngleAsResult__(__MultiplyAngleByInt__(a, b));
+        let c1 = QasmStd.Angle.AngleAsResult(QasmStd.Angle.MultiplyAngleByInt(a, b));
+        let c2 = QasmStd.Angle.AngleAsResult(QasmStd.Angle.MultiplyAngleByInt(a, b));
         mutable r1 = [Zero];
         mutable r2 = [Zero];
     "#]]
@@ -1517,8 +1415,6 @@ fn binary_op_div_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 6;
         let b = 2;
@@ -1538,8 +1434,6 @@ fn binary_op_div_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 6;
         let b = 2;
@@ -1559,8 +1453,6 @@ fn binary_op_div_float() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 6.;
         let b = 2.;
@@ -1585,24 +1477,22 @@ fn binary_op_div_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        let a = new __Angle__ {
+        let a = new QasmStd.Angle.Angle {
             Value = 3907816011,
             Size = 32
         };
-        let b = new __Angle__ {
+        let b = new QasmStd.Angle.Angle {
             Value = 268788803401062,
             Size = 48
         };
         let c = 2;
-        let d = if __DivideAngleByAngle__(__ConvertAngleToWidthNoTrunc__(a, 48), b) == 0 {
+        let d = if QasmStd.Angle.DivideAngleByAngle(QasmStd.Angle.AdjustAngleSizeNoTruncation(a, 48), b) == 0 {
             One
         } else {
             Zero
         };
-        let e = __AngleAsResult__(__DivideAngleByInt__(a, c));
+        let e = QasmStd.Angle.AngleAsResult(QasmStd.Angle.DivideAngleByInt(a, c));
         mutable r1 = [];
         mutable r2 = [Zero];
     "#]]
@@ -1621,8 +1511,6 @@ fn binary_op_mod_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 8;
         mutable r = [Zero, Zero];
@@ -1640,8 +1528,6 @@ fn binary_op_mod_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 8;
         mutable r = [Zero, Zero];
@@ -1662,8 +1548,6 @@ fn binary_op_pow_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 2;
         let b = 3;
@@ -1683,8 +1567,6 @@ fn binary_op_pow_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 2;
         let b = 3;
@@ -1704,8 +1586,6 @@ fn binary_op_pow_float() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 2.;
         let b = 3.;
@@ -1741,13 +1621,11 @@ fn cast_to_bool() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = 0;
         let b = 1;
         let c = 2.;
-        let d = new __Angle__ {
+        let d = new QasmStd.Angle.Angle {
             Value = 1367130551,
             Size = 32
         };
@@ -1762,13 +1640,13 @@ fn cast_to_bool() -> miette::Result<(), Vec<Report>> {
         } else {
             true
         };
-        let s3 = if Microsoft.Quantum.Math.Truncate(c) == 0 {
+        let s3 = if Std.Math.Truncate(c) == 0 {
             false
         } else {
             true
         };
-        let s4 = __AngleAsBool__(d);
-        let s5 = __ResultAsBool__(e);
+        let s4 = QasmStd.Angle.AngleAsBool(d);
+        let s5 = QasmStd.Convert.ResultAsBool(e);
         mutable r1 = [];
         mutable r2 = [Zero];
         mutable r3 = [Zero];
@@ -1800,17 +1678,15 @@ fn cast_to_int() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = true;
         let b = 2;
         let c = 3.;
         let d = Zero;
-        let s1 = __BoolAsInt__(a);
+        let s1 = QasmStd.Convert.BoolAsInt(a);
         let s2 = b;
-        let s3 = Microsoft.Quantum.Math.Truncate(c);
-        let s4 = __ResultAsInt__(d);
+        let s3 = Std.Math.Truncate(c);
+        let s4 = QasmStd.Convert.ResultAsInt(d);
         mutable r1 = [Zero];
         mutable r2 = [Zero, Zero];
         mutable r3 = [Zero, Zero, Zero];
@@ -1841,17 +1717,15 @@ fn cast_to_uint() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = true;
         let b = 2;
         let c = 3.;
         let d = Zero;
-        let s1 = __BoolAsInt__(a);
+        let s1 = QasmStd.Convert.BoolAsInt(a);
         let s2 = b;
-        let s3 = Microsoft.Quantum.Math.Truncate(c);
-        let s4 = __ResultAsInt__(d);
+        let s3 = Std.Math.Truncate(c);
+        let s4 = QasmStd.Convert.ResultAsInt(d);
         mutable r1 = [Zero];
         mutable r2 = [Zero, Zero];
         mutable r3 = [Zero, Zero, Zero];
@@ -1879,15 +1753,13 @@ fn cast_to_float() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = true;
         let b = 2;
         let c = 3;
-        let s1 = __BoolAsDouble__(a);
-        let s2 = Microsoft.Quantum.Convert.IntAsDouble(b);
-        let s3 = Microsoft.Quantum.Convert.IntAsDouble(c);
+        let s1 = QasmStd.Convert.BoolAsDouble(a);
+        let s2 = Std.Convert.IntAsDouble(b);
+        let s3 = Std.Convert.IntAsDouble(c);
         mutable r1 = [Zero];
         mutable r2 = [Zero, Zero];
         mutable r3 = [Zero, Zero, Zero];
@@ -1915,15 +1787,13 @@ fn cast_to_angle() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a1 = 2.;
         let a2 = One;
-        let b1 = __DoubleAsAngle__(a1, 32);
-        let b2 = __ResultAsAngle__(a2);
-        let s1 = __AngleAsResult__(b1);
-        let s2 = __AngleAsResult__(b2);
+        let b1 = QasmStd.Angle.DoubleAsAngle(a1, 32);
+        let b2 = QasmStd.Angle.ResultAsAngle(a2);
+        let s1 = QasmStd.Angle.AngleAsResult(b1);
+        let s2 = QasmStd.Angle.AngleAsResult(b2);
         mutable r1 = [Zero];
         mutable r2 = [Zero];
     "#]]
@@ -1952,17 +1822,15 @@ fn cast_to_bit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let a = false;
         let b = 1;
         let c = 2;
-        let d = new __Angle__ {
+        let d = new QasmStd.Angle.Angle {
             Value = 2050695827,
             Size = 32
         };
-        let s1 = __BoolAsResult__(a);
+        let s1 = QasmStd.Convert.BoolAsResult(a);
         let s2 = if b == 0 {
             One
         } else {
@@ -1973,7 +1841,7 @@ fn cast_to_bit() -> miette::Result<(), Vec<Report>> {
         } else {
             Zero
         };
-        let s4 = __AngleAsResult__(d);
+        let s4 = QasmStd.Angle.AngleAsResult(d);
         mutable r1 = [];
         mutable r2 = [Zero];
         mutable r3 = [Zero];

--- a/compiler/qsc_qasm/src/tests/statement/end.rs
+++ b/compiler/qsc_qasm/src/tests/statement/end.rs
@@ -16,8 +16,6 @@ fn end_can_be_in_nested_scope() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable sum = 0;
         for i : Int in [1, 5, 10] {
@@ -36,8 +34,6 @@ fn end_can_be_in_global_scope() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         fail "end";
     "#]]

--- a/compiler/qsc_qasm/src/tests/statement/for_loop.rs
+++ b/compiler/qsc_qasm/src/tests/statement/for_loop.rs
@@ -16,8 +16,6 @@ fn for_loops_can_iterate_over_discrete_set() -> miette::Result<(), Vec<Report>> 
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable sum = 0;
         for i : Int in [1, 5, 10] {
@@ -38,8 +36,6 @@ fn for_loops_can_have_stmt_bodies() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable sum = 0;
         for i : Int in [1, 5, 10] {
@@ -61,8 +57,6 @@ fn for_loops_can_iterate_over_range() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable sum = 0;
         for i : Int in 0..2..20 {
@@ -84,8 +78,6 @@ fn for_loops_can_iterate_float_set() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable sum = 0.;
         for f : Double in [1.2, -3.4, 0.5, 9.8] {
@@ -136,13 +128,11 @@ fn for_loops_can_iterate_bit_register() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable sum = 0;
         let reg = [One, Zero, One, Zero, One];
         for b : Result in reg {
-            set sum += __ResultAsInt__(b);
+            set sum += QasmStd.Convert.ResultAsInt(b);
         }
     "#]]
     .assert_eq(&qsharp);

--- a/compiler/qsc_qasm/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm/src/tests/statement/gate_call.rs
@@ -15,11 +15,9 @@ fn u_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
-        U(__DoubleAsAngle__(1., 53), __DoubleAsAngle__(2., 53), __DoubleAsAngle__(3., 53), q);
+        U(QasmStd.Angle.DoubleAsAngle(1., 53), QasmStd.Angle.DoubleAsAngle(2., 53), QasmStd.Angle.DoubleAsAngle(3., 53), q);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -33,10 +31,8 @@ fn gphase_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
-        gphase(__DoubleAsAngle__(2., 53));
+        gphase(QasmStd.Angle.DoubleAsAngle(2., 53));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -59,25 +55,23 @@ fn custom_gates_can_be_called_bypassing_stdgates() -> miette::Result<(), Vec<Rep
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation h(a : Qubit) : Unit is Adj + Ctl {
-            U(__DoubleAsAngle__(3.141592653589793 / 2., 53), __DoubleAsAngle__(0., 53), __DoubleAsAngle__(3.141592653589793, 53), a);
-            gphase(__DoubleAsAngle__(-3.141592653589793 / 4., 53));
+            U(QasmStd.Angle.DoubleAsAngle(3.141592653589793 / 2., 53), QasmStd.Angle.DoubleAsAngle(0., 53), QasmStd.Angle.DoubleAsAngle(3.141592653589793, 53), a);
+            gphase(QasmStd.Angle.DoubleAsAngle(-3.141592653589793 / 4., 53));
         }
         operation x(a : Qubit) : Unit is Adj + Ctl {
-            U(__DoubleAsAngle__(3.141592653589793, 53), __DoubleAsAngle__(0., 53), __DoubleAsAngle__(3.141592653589793, 53), a);
-            gphase(__DoubleAsAngle__(-3.141592653589793 / 2., 53));
+            U(QasmStd.Angle.DoubleAsAngle(3.141592653589793, 53), QasmStd.Angle.DoubleAsAngle(0., 53), QasmStd.Angle.DoubleAsAngle(3.141592653589793, 53), a);
+            gphase(QasmStd.Angle.DoubleAsAngle(-3.141592653589793 / 2., 53));
         }
         operation cx(a : Qubit, b : Qubit) : Unit is Adj + Ctl {
             Controlled x([a], b);
         }
-        operation rz(λ : __Angle__, a : Qubit) : Unit is Adj + Ctl {
-            gphase(__DivideAngleByInt__(__NegAngle__(λ), 2));
-            U(__DoubleAsAngle__(0., 53), __DoubleAsAngle__(0., 53), λ, a);
+        operation rz(λ : QasmStd.Angle.Angle, a : Qubit) : Unit is Adj + Ctl {
+            gphase(QasmStd.Angle.DivideAngleByInt(QasmStd.Angle.NegAngle(λ), 2));
+            U(QasmStd.Angle.DoubleAsAngle(0., 53), QasmStd.Angle.DoubleAsAngle(0., 53), λ, a);
         }
-        operation rxx(theta : __Angle__, a : Qubit, b : Qubit) : Unit is Adj + Ctl {
+        operation rxx(theta : QasmStd.Angle.Angle, a : Qubit, b : Qubit) : Unit is Adj + Ctl {
             h(a);
             h(b);
             cx(a, b);
@@ -89,7 +83,7 @@ fn custom_gates_can_be_called_bypassing_stdgates() -> miette::Result<(), Vec<Rep
         let a = QIR.Runtime.__quantum__rt__qubit_allocate();
         let b = QIR.Runtime.__quantum__rt__qubit_allocate();
         x(a);
-        rxx(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), a, b);
+        rxx(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), a, b);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -105,8 +99,6 @@ fn x_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         x(q);
@@ -125,8 +117,6 @@ fn barrier_can_be_called_on_single_qubit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         __quantum__qis__barrier__body();
@@ -145,8 +135,6 @@ fn barrier_can_be_called_without_qubits() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         __quantum__qis__barrier__body();
@@ -222,8 +210,6 @@ fn barrier_can_be_called_on_two_qubit() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(2);
         __quantum__qis__barrier__body();
@@ -320,11 +306,9 @@ fn rx_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
-        rx(__DoubleAsAngle__(2., 53), q);
+        rx(QasmStd.Angle.DoubleAsAngle(2., 53), q);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -367,12 +351,10 @@ fn implicit_cast_to_angle_works() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         mutable a = 2.;
-        rx(__DoubleAsAngle__(a, 53), q);
+        rx(QasmStd.Angle.DoubleAsAngle(a, 53), q);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -393,8 +375,6 @@ fn custom_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation my_gate(q1 : Qubit, q2 : Qubit) : Unit is Adj + Ctl {
             h(q1);
@@ -422,8 +402,6 @@ fn custom_gate_can_be_called_with_inv_modifier() -> miette::Result<(), Vec<Repor
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation my_gate(q1 : Qubit, q2 : Qubit) : Unit is Adj + Ctl {
             h(q1);
@@ -452,8 +430,6 @@ fn custom_gate_can_be_called_with_ctrl_modifier() -> miette::Result<(), Vec<Repo
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation my_gate(q1 : Qubit, q2 : Qubit) : Unit is Adj + Ctl {
             h(q1);
@@ -483,8 +459,6 @@ fn custom_gate_can_be_called_with_negctrl_modifier() -> miette::Result<(), Vec<R
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation my_gate(q1 : Qubit, q2 : Qubit) : Unit is Adj + Ctl {
             h(q1);
@@ -513,15 +487,13 @@ fn custom_gate_can_be_called_with_pow_modifier() -> miette::Result<(), Vec<Repor
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         operation my_gate(q1 : Qubit, q2 : Qubit) : Unit is Adj + Ctl {
             h(q1);
             h(q2);
         }
         let q = QIR.Runtime.AllocateQubitArray(2);
-        __Pow__(2, my_gate, (q[0], q[1]));
+        ApplyOperationPowerA(2, my_gate, (q[0], q[1]));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -586,11 +558,9 @@ fn rxx_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(2);
-        rxx(__DoubleAsAngle__(2., 53), q[1], q[0]);
+        rxx(QasmStd.Angle.DoubleAsAngle(2., 53), q[1], q[0]);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -605,11 +575,9 @@ fn ryy_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(2);
-        ryy(__DoubleAsAngle__(2., 53), q[1], q[0]);
+        ryy(QasmStd.Angle.DoubleAsAngle(2., 53), q[1], q[0]);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -624,11 +592,9 @@ fn rzz_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(2);
-        rzz(__DoubleAsAngle__(2., 53), q[1], q[0]);
+        rzz(QasmStd.Angle.DoubleAsAngle(2., 53), q[1], q[0]);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -662,29 +628,27 @@ fn all_qiskit_stdgates_can_be_called_included() -> miette::Result<(), Vec<Report
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(4);
-        rxx(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), q[1], q[0]);
-        ryy(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), q[1], q[0]);
-        rzz(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), q[1], q[0]);
+        rxx(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[1], q[0]);
+        ryy(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[1], q[0]);
+        rzz(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[1], q[0]);
         dcx(q[0], q[1]);
         ecr(q[0], q[1]);
-        r(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), __DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 4., 53), q[1]);
-        rzx(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), q[1], q[0]);
+        r(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 4., 53), q[1]);
+        rzx(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[1], q[0]);
         cs(q[0], q[1]);
         csdg(q[0], q[1]);
         sxdg(q[0]);
         csx(q[0], q[1]);
-        cu1(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), q[1], q[0]);
-        cu3(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), __DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 4., 53), __DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 8., 53), q[1], q[0]);
+        cu1(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[1], q[0]);
+        cu3(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 4., 53), QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 8., 53), q[1], q[0]);
         rccx(q[0], q[1], q[2]);
         c3sqrtx(q[0], q[1], q[2], q[3]);
         c3x(q[0], q[1], q[2], q[3]);
         rc3x(q[0], q[1], q[2], q[3]);
-        xx_minus_yy(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), __DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 4., 53), q[1], q[0]);
-        xx_plus_yy(__DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 2., 53), __DoubleAsAngle__(Microsoft.Quantum.Math.PI() / 4., 53), q[1], q[0]);
+        xx_minus_yy(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 4., 53), q[1], q[0]);
+        xx_plus_yy(QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), QasmStd.Angle.DoubleAsAngle(Std.Math.PI() / 4., 53), q[1], q[0]);
         ccz(q[0], q[1], q[2]);
     "#]]
     .assert_eq(&qsharp);

--- a/compiler/qsc_qasm/src/tests/statement/if_stmt.rs
+++ b/compiler/qsc_qasm/src/tests/statement/if_stmt.rs
@@ -20,13 +20,11 @@ fn can_use_cond_with_implicit_cast_to_bool() -> miette::Result<(), Vec<Report>> 
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         h(q);
         mutable result = QIR.Intrinsic.__quantum__qis__m__body(q);
-        if __ResultAsBool__(result) {
+        if QasmStd.Convert.ResultAsBool(result) {
             Reset(q);
         };
     "#]]
@@ -49,13 +47,11 @@ fn can_use_negated_cond_with_implicit_cast_to_bool() -> miette::Result<(), Vec<R
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         h(q);
         mutable result = QIR.Intrinsic.__quantum__qis__m__body(q);
-        if not __ResultAsBool__(result) {
+        if not QasmStd.Convert.ResultAsBool(result) {
             Reset(q);
         };
     "#]]
@@ -78,8 +74,6 @@ fn then_branch_can_be_stmt() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         if 0 == 1 {
@@ -101,8 +95,6 @@ fn else_branch_can_be_stmt() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         if 0 == 1 {
@@ -126,8 +118,6 @@ fn then_and_else_branch_can_be_stmt() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         if 0 == 1 {

--- a/compiler/qsc_qasm/src/tests/statement/implicit_modified_gate_call.rs
+++ b/compiler/qsc_qasm/src/tests/statement/implicit_modified_gate_call.rs
@@ -16,8 +16,6 @@ fn cy_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
@@ -38,8 +36,6 @@ fn cz_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
@@ -60,8 +56,6 @@ fn ch_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
@@ -81,8 +75,6 @@ fn sdg_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         Adjoint s(q);
@@ -101,8 +93,6 @@ fn tdg_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         Adjoint t(q);
@@ -122,12 +112,10 @@ fn crx_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled rx([ctl], (__DoubleAsAngle__(0.5, 53), target));
+        Controlled rx([ctl], (QasmStd.Angle.DoubleAsAngle(0.5, 53), target));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -144,12 +132,10 @@ fn cry_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled ry([ctl], (__DoubleAsAngle__(0.5, 53), target));
+        Controlled ry([ctl], (QasmStd.Angle.DoubleAsAngle(0.5, 53), target));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -166,12 +152,10 @@ fn crz_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled rz([ctl], (__DoubleAsAngle__(0.5, 53), target));
+        Controlled rz([ctl], (QasmStd.Angle.DoubleAsAngle(0.5, 53), target));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -188,8 +172,6 @@ fn cswap_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let q = QIR.Runtime.AllocateQubitArray(2);
@@ -210,8 +192,6 @@ fn legacy_cx_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
@@ -232,12 +212,10 @@ fn legacy_cphase_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled phase([ctl], (__DoubleAsAngle__(1., 53), target));
+        Controlled phase([ctl], (QasmStd.Angle.DoubleAsAngle(1., 53), target));
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/statement/include.rs
+++ b/compiler/qsc_qasm/src/tests/statement/include.rs
@@ -40,8 +40,6 @@ fn programs_with_includes_can_be_parsed() -> miette::Result<(), Vec<Report>> {
     let qsharp = qsharp_from_qasm_compilation(r)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : Result[] {
@@ -53,7 +51,7 @@ fn programs_with_includes_can_be_parsed() -> miette::Result<(), Vec<Report>> {
                 let q = QIR.Runtime.AllocateQubitArray(1);
                 my_gate(q[0]);
                 set c w/= 0 <- QIR.Intrinsic.__quantum__qis__m__body(q[0]);
-                Microsoft.Quantum.Arrays.Reversed(c)
+                Std.Arrays.Reversed(c)
             }
         }"#]]
     .assert_eq(&qsharp);
@@ -85,8 +83,6 @@ fn programs_with_includes_with_includes_can_be_compiled() -> miette::Result<(), 
     let qsharp = qsharp_from_qasm_compilation(r)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : Unit {

--- a/compiler/qsc_qasm/src/tests/statement/measure.rs
+++ b/compiler/qsc_qasm/src/tests/statement/measure.rs
@@ -16,8 +16,6 @@ fn single_qubit_can_be_measured_into_single_bit() -> miette::Result<(), Vec<Repo
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable c = Zero;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
@@ -37,8 +35,6 @@ fn single_qubit_can_be_arrow_measured_into_single_bit() -> miette::Result<(), Ve
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable c = Zero;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
@@ -59,8 +55,6 @@ fn indexed_single_qubit_can_be_measured_into_indexed_bit_register(
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable c = [Zero];
         let q = QIR.Runtime.AllocateQubitArray(1);
@@ -81,8 +75,6 @@ fn indexed_single_qubit_can_be_measured_into_single_bit_register() -> miette::Re
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable c = Zero;
         let q = QIR.Runtime.AllocateQubitArray(1);
@@ -133,8 +125,6 @@ fn value_from_measurement_can_be_dropped() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         QIR.Intrinsic.__quantum__qis__m__body(q);

--- a/compiler/qsc_qasm/src/tests/statement/modified_gate_call.rs
+++ b/compiler/qsc_qasm/src/tests/statement/modified_gate_call.rs
@@ -15,8 +15,6 @@ fn adj_x_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         Adjoint x(q);
@@ -35,8 +33,6 @@ fn adj_adj_x_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         Adjoint Adjoint x(q);
@@ -56,8 +52,6 @@ fn multiple_controls_on_x_gate_can_be_called() -> miette::Result<(), Vec<Report>
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(3);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
@@ -79,8 +73,6 @@ fn repeated_multi_controls_on_x_gate_can_be_called() -> miette::Result<(), Vec<R
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(2);
         let r = QIR.Runtime.AllocateQubitArray(3);
@@ -103,8 +95,6 @@ fn repeated_multi_controls_on_x_gate_can_be_mixed_with_inv() -> miette::Result<(
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(2);
         let r = QIR.Runtime.AllocateQubitArray(3);
@@ -126,8 +116,6 @@ fn multiple_controls_on_cx_gate_can_be_called() -> miette::Result<(), Vec<Report
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(4);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
@@ -148,12 +136,10 @@ fn multiple_controls_on_crx_gate_can_be_called() -> miette::Result<(), Vec<Repor
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(4);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled Adjoint Controlled rx([q[1], q[0], q[2]], ([f], (__DoubleAsAngle__(0.5, 53), q[3])));
+        Controlled Adjoint Controlled rx([q[1], q[0], q[2]], ([f], (QasmStd.Angle.DoubleAsAngle(0.5, 53), q[3])));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -170,12 +156,10 @@ fn neg_ctrl_can_be_applied_and_wrapped_in_another_modifier() -> miette::Result<(
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(4);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Adjoint ApplyControlledOnInt(0, Adjoint Controlled rx, [q[1], q[0], q[2]], ([f], (__DoubleAsAngle__(0.5, 53), q[3])));
+        Adjoint ApplyControlledOnInt(0, Adjoint Controlled rx, [q[1], q[0], q[2]], ([f], (QasmStd.Angle.DoubleAsAngle(0.5, 53), q[3])));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -192,12 +176,10 @@ fn neg_ctrl_can_wrap_another_neg_crtl_modifier() -> miette::Result<(), Vec<Repor
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(6);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
-        ApplyControlledOnInt(0, ApplyControlledOnInt, [q[1], q[0], q[2]], (0, Controlled rx, [q[3], q[4]], ([f], (__DoubleAsAngle__(0.5, 53), q[5]))));
+        ApplyControlledOnInt(0, ApplyControlledOnInt, [q[1], q[0], q[2]], (0, Controlled rx, [q[3], q[4]], ([f], (QasmStd.Angle.DoubleAsAngle(0.5, 53), q[5]))));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -214,12 +196,10 @@ fn modifiers_can_be_repeated_many_times() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(6);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
-        __Pow__(1, __Pow__, (1, __Pow__, (1, Controlled rx, ([f], (__DoubleAsAngle__(0.5, 53), q[5])))));
+        ApplyOperationPowerA(1, ApplyOperationPowerA, (1, ApplyOperationPowerA, (1, Controlled rx, ([f], (QasmStd.Angle.DoubleAsAngle(0.5, 53), q[5])))));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -235,11 +215,9 @@ fn pow_can_be_applied_on_a_simple_gate() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
-        __Pow__(2, x, (f));
+        ApplyOperationPowerA(2, x, (f));
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/statement/reset.rs
+++ b/compiler/qsc_qasm/src/tests/statement/reset.rs
@@ -35,8 +35,6 @@ fn reset_calls_are_generated_from_qasm() -> miette::Result<(), Vec<Report>> {
     let qsharp = gen_qsharp(&unit.package);
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : Result[] {
@@ -45,7 +43,7 @@ fn reset_calls_are_generated_from_qasm() -> miette::Result<(), Vec<Report>> {
                 Reset(q[0]);
                 h(q[0]);
                 set meas w/= 0 <- QIR.Intrinsic.__quantum__qis__m__body(q[0]);
-                Microsoft.Quantum.Arrays.Reversed(meas)
+                Std.Arrays.Reversed(meas)
             }
         }"#]]
     .assert_eq(&qsharp);

--- a/compiler/qsc_qasm/src/tests/statement/switch.rs
+++ b/compiler/qsc_qasm/src/tests/statement/switch.rs
@@ -19,8 +19,6 @@ fn default_is_optional() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         mutable i = 15;
         if i == 1 {
@@ -95,8 +93,6 @@ fn spec_case_1() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         mutable i = 15;
@@ -143,8 +139,6 @@ fn spec_case_2() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         let A = 0;
@@ -191,20 +185,18 @@ fn spec_case_3() -> miette::Result<(), Vec<Report>> {
     let qsharp = compile_qasm_to_qsharp_file(source)?;
     expect![[r#"
         namespace qasm_import {
-            import QasmStd.Angle.*;
-            import QasmStd.Convert.*;
             import QasmStd.Intrinsic.*;
             @EntryPoint()
             operation Test() : Result[] {
                 let q = QIR.Runtime.__quantum__rt__qubit_allocate();
                 mutable b = [Zero, Zero];
-                if __ResultArrayAsIntBE__(b) == 0 {
+                if QasmStd.Convert.ResultArrayAsIntBE(b) == 0 {
                     h(q);
-                } elif __ResultArrayAsIntBE__(b) == 1 {
+                } elif QasmStd.Convert.ResultArrayAsIntBE(b) == 1 {
                     x(q);
-                } elif __ResultArrayAsIntBE__(b) == 2 {
+                } elif QasmStd.Convert.ResultArrayAsIntBE(b) == 2 {
                     y(q);
-                } elif __ResultArrayAsIntBE__(b) == 3 {
+                } elif QasmStd.Convert.ResultArrayAsIntBE(b) == 3 {
                     z(q);
                 };
                 b
@@ -250,8 +242,6 @@ fn spec_case_4() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         mutable b = [Zero, Zero];
@@ -264,9 +254,9 @@ fn spec_case_4() -> miette::Result<(), Vec<Report>> {
         mutable c1 = Zero;
         let q0 = QIR.Runtime.AllocateQubitArray(8);
         if i == 1 {
-            set j = k + __ResultAsInt__(foo(k, q0));
+            set j = k + QasmStd.Convert.ResultAsInt(foo(k, q0));
         } elif i == 2 {
-            mutable d = Microsoft.Quantum.Convert.IntAsDouble(j / k);
+            mutable d = Std.Convert.IntAsDouble(j / k);
         } elif i == 3 {} else {};
     "#]]
     .assert_eq(&qsharp);
@@ -300,8 +290,6 @@ fn spec_case_5() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(8);
         mutable j = 30;

--- a/compiler/qsc_qasm/src/tests/statement/while_loop.rs
+++ b/compiler/qsc_qasm/src/tests/statement/while_loop.rs
@@ -24,8 +24,6 @@ fn can_iterate_over_mutable_var_cmp_expr() -> miette::Result<(), Vec<Report>> {
 
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
-        import QasmStd.Angle.*;
-        import QasmStd.Convert.*;
         import QasmStd.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
         mutable result = Zero;
@@ -33,7 +31,7 @@ fn can_iterate_over_mutable_var_cmp_expr() -> miette::Result<(), Vec<Report>> {
         while i < 10 {
             h(q);
             set result = QIR.Intrinsic.__quantum__qis__m__body(q);
-            if __ResultAsBool__(result) {
+            if QasmStd.Convert.ResultAsBool(result) {
                 set i += 1;
             };
         }

--- a/pip/tests-integration/interop_qiskit/test_qsharp.py
+++ b/pip/tests-integration/interop_qiskit/test_qsharp.py
@@ -28,7 +28,7 @@ def test_qsharp_smoke() -> None:
     assert res is not None
     assert "qasm_import" in res
     assert "operation smoke() : Result[]" in res
-    assert "Microsoft.Quantum.Arrays.Reversed" in res
+    assert "Std.Arrays.Reversed" in res
 
 
 @pytest.mark.skipif(not QISKIT_AVAILABLE, reason=SKIP_REASON)
@@ -56,4 +56,4 @@ def test_qsharp_openqasm_output_semantics() -> None:
     output_semantics = OutputSemantics.OpenQasm
 
     res = backend._qsharp(circuit, output_semantics=output_semantics)
-    assert "Microsoft.Quantum.Arrays.Reversed" not in res
+    assert "Std.Arrays.Reversed" not in res


### PR DESCRIPTION
- Renaming functions in qasm std lib to no longer use underscores
- Adding defensive assertions in some lib calls
- Using new import names from Std
- FQN's for conversion and angle types/functions
- Bug fix in Angle negation in Rust and Q#