### PR TITLE
Support return values from custom intrinsics

### DIFF
--- a/compiler/qsc_partial_eval/src/tests/intrinsics.rs
+++ b/compiler/qsc_partial_eval/src/tests/intrinsics.rs
@@ -1153,7 +1153,6 @@ fn call_to_operation_with_codegen_intrinsic_override_should_skip_impl() {
     );
 }
 
-
 #[test]
 fn call_to_intrinsic_operation_that_returns_bool_value_should_produce_variable_usage() {
     let program = get_rir_program(indoc! {"
@@ -1266,7 +1265,9 @@ fn call_to_intrinsic_operation_that_returns_double_value_should_produce_variable
 }
 
 #[test]
-#[should_panic(expected = "partial evaluation failed: UnexpectedDynamicIntrinsicReturnType(\"Result\", PackageSpan { package: PackageId(2), span: Span { lo: 137, hi: 140 } })")]
+#[should_panic(
+    expected = "partial evaluation failed: UnexpectedDynamicIntrinsicReturnType(\"Result\", PackageSpan { package: PackageId(2), span: Span { lo: 137, hi: 140 } })"
+)]
 fn call_to_intrinsic_operation_that_returns_result_value_should_fail() {
     let _ = get_rir_program(indoc! {"
         namespace Test {
@@ -1282,7 +1283,9 @@ fn call_to_intrinsic_operation_that_returns_result_value_should_fail() {
 }
 
 #[test]
-#[should_panic(expected = "partial evaluation failed: UnexpectedDynamicIntrinsicReturnType(\"Qubit\", PackageSpan { package: PackageId(2), span: Span { lo: 142, hi: 145 } })")]
+#[should_panic(
+    expected = "partial evaluation failed: UnexpectedDynamicIntrinsicReturnType(\"Qubit\", PackageSpan { package: PackageId(2), span: Span { lo: 142, hi: 145 } })"
+)]
 fn call_to_intrinsic_operation_that_returns_qubit_value_should_fail() {
     let _ = get_rir_program(indoc! {"
         namespace Test {

--- a/compiler/qsc_partial_eval/src/tests/intrinsics.rs
+++ b/compiler/qsc_partial_eval/src/tests/intrinsics.rs
@@ -1152,3 +1152,147 @@ fn call_to_operation_with_codegen_intrinsic_override_should_skip_impl() {
             Return"#]],
     );
 }
+
+
+#[test]
+fn call_to_intrinsic_operation_that_returns_bool_value_should_produce_variable_usage() {
+    let program = get_rir_program(indoc! {"
+        namespace Test {
+            operation Op1() : Bool {
+                body intrinsic;
+            }
+            @EntryPoint()
+            operation Main() : Bool {
+                Op1()
+            }
+        }
+    "});
+
+    let op1_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        op1_callable_id,
+        &expect![[r#"
+            Callable:
+                name: Op1
+                call_type: Regular
+                input_type: <VOID>
+                output_type: Boolean
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Variable(0, Boolean) = Call id(1), args( )
+                Call id(2), args( Variable(0, Boolean), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn call_to_intrinsic_operation_that_returns_int_value_should_produce_variable_usage() {
+    let program = get_rir_program(indoc! {"
+        namespace Test {
+            operation Op1() : Int {
+                body intrinsic;
+            }
+            @EntryPoint()
+            operation Main() : Int {
+                Op1()
+            }
+        }
+    "});
+
+    let op1_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        op1_callable_id,
+        &expect![[r#"
+            Callable:
+                name: Op1
+                call_type: Regular
+                input_type: <VOID>
+                output_type: Integer
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Variable(0, Integer) = Call id(1), args( )
+                Call id(2), args( Variable(0, Integer), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+fn call_to_intrinsic_operation_that_returns_double_value_should_produce_variable_usage() {
+    let program = get_rir_program(indoc! {"
+        namespace Test {
+            operation Op1() : Double {
+                body intrinsic;
+            }
+            @EntryPoint()
+            operation Main() : Double {
+                Op1()
+            }
+        }
+    "});
+
+    let op1_callable_id = CallableId(1);
+    assert_callable(
+        &program,
+        op1_callable_id,
+        &expect![[r#"
+            Callable:
+                name: Op1
+                call_type: Regular
+                input_type: <VOID>
+                output_type: Double
+                body: <NONE>"#]],
+    );
+    assert_block_instructions(
+        &program,
+        BlockId(0),
+        &expect![[r#"
+            Block:
+                Variable(0, Double) = Call id(1), args( )
+                Call id(2), args( Variable(0, Double), Pointer, )
+                Return"#]],
+    );
+}
+
+#[test]
+#[should_panic(expected = "partial evaluation failed: UnexpectedDynamicIntrinsicReturnType(\"Result\", PackageSpan { package: PackageId(2), span: Span { lo: 137, hi: 140 } })")]
+fn call_to_intrinsic_operation_that_returns_result_value_should_fail() {
+    let _ = get_rir_program(indoc! {"
+        namespace Test {
+            operation Op1() : Result {
+                body intrinsic;
+            }
+            @EntryPoint()
+            operation Main() : Result {
+                Op1()
+            }
+        }
+    "});
+}
+
+#[test]
+#[should_panic(expected = "partial evaluation failed: UnexpectedDynamicIntrinsicReturnType(\"Qubit\", PackageSpan { package: PackageId(2), span: Span { lo: 142, hi: 145 } })")]
+fn call_to_intrinsic_operation_that_returns_qubit_value_should_fail() {
+    let _ = get_rir_program(indoc! {"
+        namespace Test {
+            operation Op1() : Qubit {
+                body intrinsic;
+            }
+            @EntryPoint()
+            operation Main() : Unit {
+                let q = Op1();
+            }
+        }
+    "});
+}


### PR DESCRIPTION
This change updates the handling for intrinsic generation such that any of the supported dynamic types for QIR generation (specifically `Bool`, `Int`, and `Double` in the matching profiles) can be returned from intrinsic callables. These were already correctly handled and analyzed from Runtime Capabilities Analysis, so all that was missing was support during partial evaluation and RIR generation.

<img width="1569" alt="image" src="https://github.com/user-attachments/assets/042ca1a6-2ca7-4363-9f75-82c4f839f5e7" />
