### PR TITLE
Fix panic in QIR generation when conditional branches use early return

### DIFF
--- a/compiler/qsc_partial_eval/src/evaluation_context.rs
+++ b/compiler/qsc_partial_eval/src/evaluation_context.rs
@@ -262,14 +262,6 @@ impl Arg {
     }
 }
 
-/// Represents the possible control flow options that can result from a branch.
-pub enum BranchControlFlow {
-    /// The block ID corresponding to a branch.
-    Block(BlockId),
-    /// The return value resulting from a branch.
-    Return(Value),
-}
-
 /// Represents the possible control flow options that an evaluation can have.
 pub enum EvalControlFlow {
     Continue(Value),

--- a/compiler/qsc_partial_eval/src/tests/returns.rs
+++ b/compiler/qsc_partial_eval/src/tests/returns.rs
@@ -365,7 +365,7 @@ fn non_classical_entry_point_with_classical_early_return_within_non_classical_br
     assert_error(
         &error,
         &expect![[
-            r#"Unimplemented("early return", PackageSpan { package: PackageId(2), span: Span { lo: 163, hi: 213 } })"#
+            r#"Unimplemented("early return", PackageSpan { package: PackageId(2), span: Span { lo: 176, hi: 213 } })"#
         ]],
     );
 }
@@ -389,7 +389,7 @@ fn non_classical_entry_point_with_non_classical_early_return_within_non_classica
     assert_error(
         &error,
         &expect![[
-            r#"Unimplemented("early return", PackageSpan { package: PackageId(2), span: Span { lo: 185, hi: 278 } })"#
+            r#"Unimplemented("early return", PackageSpan { package: PackageId(2), span: Span { lo: 199, hi: 278 } })"#
         ]],
     );
 }

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -579,11 +579,18 @@ fn use_of_dynamic_rhs_exp_binop_yields_errors() {
 }
 
 #[test]
-fn return_within_dynamic_scope_yields_no_errors() {
+fn return_within_dynamic_scope_yields_errors() {
     check_profile(
         RETURN_WITHIN_DYNAMIC_SCOPE,
         &expect![[r#"
-            []
+            [
+                ReturnWithinDynamicScope(
+                    Span {
+                        lo: 128,
+                        hi: 136,
+                    },
+                ),
+            ]
         "#]],
     );
 }

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers.rs
@@ -455,11 +455,18 @@ fn use_of_dynamic_rhs_exp_binop_yields_errors() {
 }
 
 #[test]
-fn return_within_dynamic_scope_yields_no_errors() {
+fn return_within_dynamic_scope_yields_errors() {
     check_profile(
         RETURN_WITHIN_DYNAMIC_SCOPE,
         &expect![[r#"
-            []
+            [
+                ReturnWithinDynamicScope(
+                    Span {
+                        lo: 128,
+                        hi: 136,
+                    },
+                ),
+            ]
         "#]],
     );
 }

--- a/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers_and_floats.rs
+++ b/compiler/qsc_passes/src/capabilitiesck/tests_adaptive_plus_integers_and_floats.rs
@@ -440,11 +440,18 @@ fn use_of_dynamic_rhs_exp_binop_yields_errors() {
 }
 
 #[test]
-fn return_within_dynamic_scope_yields_no_errors() {
+fn return_within_dynamic_scope_yields_errors() {
     check_profile(
         RETURN_WITHIN_DYNAMIC_SCOPE,
         &expect![[r#"
-            []
+            [
+                ReturnWithinDynamicScope(
+                    Span {
+                        lo: 128,
+                        hi: 136,
+                    },
+                ),
+            ]
         "#]],
     );
 }

--- a/compiler/qsc_rca/src/lib.rs
+++ b/compiler/qsc_rca/src/lib.rs
@@ -890,7 +890,7 @@ impl RuntimeFeatureFlags {
             capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::ReturnWithinDynamicScope) {
-            capabilities |= TargetCapabilityFlags::Adaptive;
+            capabilities |= TargetCapabilityFlags::HigherLevelConstructs;
         }
         if self.contains(RuntimeFeatureFlags::LoopWithDynamicCondition) {
             capabilities |= TargetCapabilityFlags::BackwardsBranching;


### PR DESCRIPTION
This change avoids the panic in early returns by blocking them in RCA and providing the user with compile-time feedback before failing during QIR generation. It also includes updates to partial evaluation to ensure that the panicking case is now treated as a unimplemented graceful failure, since we don't have proper support for it.

Since QIR generation for programs with early return have never properly been handled, this doesn't take any functionality away but rather ensures earlier indication of the unsupported patterns at compile time. I filed #2387 to cover the additional work needed to fully support dynamic explicit returns.

Fixes #2290