### PR TITLE
Bug bashing fixes for qasm support

### DIFF
--- a/compiler/qsc_codegen/src/qsharp.rs
+++ b/compiler/qsc_codegen/src/qsharp.rs
@@ -714,8 +714,8 @@ impl<W: Write> Visitor<'_> for QSharpGen<W> {
             ExprKind::Hole => {
                 self.write("_");
             }
-            ExprKind::Err
-            | ExprKind::Path(PathKind::Err(_))
+            ExprKind::Err => {}
+            ExprKind::Path(PathKind::Err(_))
             | ExprKind::Struct(PathKind::Err(_), ..)
             | ExprKind::Field(_, FieldAccess::Err) => {
                 unreachable!();

--- a/compiler/qsc_qasm/src/semantic/error.rs
+++ b/compiler/qsc_qasm/src/semantic/error.rs
@@ -103,6 +103,9 @@ pub enum SemanticErrorKind {
     #[error("for statements must have a body or statement")]
     #[diagnostic(code("Qasm.Lowerer.ForStatementsMustHaveABodyOrStatement"))]
     ForStatementsMustHaveABodyOrStatement(#[label] Span),
+    #[error("gate declarations must be done in global scope")]
+    #[diagnostic(code("Qasm.Lowerer.GateDeclarationInNonGlobalScope"))]
+    GateDeclarationInNonGlobalScope(#[label] Span),
     #[error("if statement missing {0} expression")]
     #[diagnostic(code("Qasm.Lowerer.IfStmtMissingExpression"))]
     IfStmtMissingExpression(String, #[label] Span),
@@ -169,9 +172,9 @@ pub enum SemanticErrorKind {
     #[error("pow gate modifiers must have an exponent")]
     #[diagnostic(code("Qasm.Lowerer.PowModifierMustHaveExponent"))]
     PowModifierMustHaveExponent(#[label] Span),
-    #[error("quantum declarations must be done in global scope")]
-    #[diagnostic(code("Qasm.Lowerer.QuantumDeclarationInNonGlobalScope"))]
-    QuantumDeclarationInNonGlobalScope(#[label] Span),
+    #[error("qubit declarations must be done in global scope")]
+    #[diagnostic(code("Qasm.Lowerer.QubitDeclarationInNonGlobalScope"))]
+    QubitDeclarationInNonGlobalScope(#[label] Span),
     #[error("quantum typed values cannot be used in binary expressions")]
     #[diagnostic(code("Qasm.Lowerer.QuantumTypesInBinaryExpression"))]
     QuantumTypesInBinaryExpression(#[label] Span),

--- a/compiler/qsc_qasm/src/semantic/tests/decls.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls.rs
@@ -11,6 +11,7 @@ mod extern_decl;
 mod float;
 mod int;
 mod qreg;
+mod qubit;
 mod stretch;
 mod uint;
 

--- a/compiler/qsc_qasm/src/semantic/tests/decls/qubit.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/qubit.rs
@@ -8,9 +8,9 @@ use crate::semantic::tests::check_stmt_kind;
 #[test]
 fn with_no_init_expr() {
     check_stmt_kind(
-        "qreg a;",
+        "qubit a;",
         &expect![[r#"
-            QubitDeclaration [0-7]:
+            QubitDeclaration [0-8]:
                 symbol_id: 8"#]],
     );
 }
@@ -18,25 +18,25 @@ fn with_no_init_expr() {
 #[test]
 fn with_no_init_expr_in_non_global_scope() {
     check_stmt_kind(
-        "{qreg a;}",
+        "{qubit a;}",
         &expect![[r#"
             Program:
                 version: <none>
                 statements:
-                    Stmt [0-9]:
+                    Stmt [0-10]:
                         annotations: <empty>
-                        kind: Block [0-9]:
-                            Stmt [1-8]:
+                        kind: Block [0-10]:
+                            Stmt [1-9]:
                                 annotations: <empty>
-                                kind: QubitDeclaration [1-8]:
+                                kind: QubitDeclaration [1-9]:
                                     symbol_id: 8
 
             [Qasm.Lowerer.QubitDeclarationInNonGlobalScope
 
               x qubit declarations must be done in global scope
                ,-[test:1:2]
-             1 | {qreg a;}
-               :  ^^^^^^^
+             1 | {qubit a;}
+               :  ^^^^^^^^
                `----
             ]"#]],
     );
@@ -45,39 +45,39 @@ fn with_no_init_expr_in_non_global_scope() {
 #[test]
 fn array_with_no_init_expr() {
     check_stmt_kind(
-        "qreg a[3];",
+        "qubit[3] a;",
         &expect![[r#"
-            QubitArrayDeclaration [0-10]:
+            QubitArrayDeclaration [0-11]:
                 symbol_id: 8
                 size: 3
-                size_span: [7-8]"#]],
+                size_span: [6-7]"#]],
     );
 }
 
 #[test]
 fn array_with_no_init_expr_in_non_global_scope() {
     check_stmt_kind(
-        "{qreg a[3];}",
+        "{qubit[3] a;}",
         &expect![[r#"
             Program:
                 version: <none>
                 statements:
-                    Stmt [0-12]:
+                    Stmt [0-13]:
                         annotations: <empty>
-                        kind: Block [0-12]:
-                            Stmt [1-11]:
+                        kind: Block [0-13]:
+                            Stmt [1-12]:
                                 annotations: <empty>
-                                kind: QubitArrayDeclaration [1-11]:
+                                kind: QubitArrayDeclaration [1-12]:
                                     symbol_id: 8
                                     size: 3
-                                    size_span: [8-9]
+                                    size_span: [7-8]
 
             [Qasm.Lowerer.QubitDeclarationInNonGlobalScope
 
               x qubit declarations must be done in global scope
                ,-[test:1:2]
-             1 | {qreg a[3];}
-               :  ^^^^^^^^^^
+             1 | {qubit[3] a;}
+               :  ^^^^^^^^^^^
                `----
             ]"#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/expression/indexing.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/indexing.rs
@@ -250,10 +250,7 @@ fn array_slice_with_zero_step_errors() {
                                 kind: Lit: Bitstring("00010000")
                     Stmt [32-39]:
                         annotations: <empty>
-                        kind: ExprStmt [32-39]:
-                            expr: Expr [32-38]:
-                                ty: Err
-                                kind: Err
+                        kind: Err
 
             [Qasm.Lowerer.ZeroStepInRange
 

--- a/compiler/qsc_qasm/src/tests.rs
+++ b/compiler/qsc_qasm/src/tests.rs
@@ -435,6 +435,7 @@ pub(crate) fn compare_qasm_and_qasharp_asts(source: &str) {
         Some(&mut resolver),
         config,
     );
+    fail_on_compilation_errors(&unit);
     let despanned_qasm_ast = AstDespanner.despan(&unit.package);
 
     // 2. Generate Q# source from the QASM ast.

--- a/compiler/qsc_qasm/src/tests/fuzz.rs
+++ b/compiler/qsc_qasm/src/tests/fuzz.rs
@@ -17,7 +17,6 @@ fn fuzz_2297_referencing_qubit_parameter() {
         q1;
     }
     "#;
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
@@ -30,7 +29,6 @@ fn fuzz_2297_referencing_angle_parameter() {
         r;
     }
     "#;
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
@@ -44,7 +42,6 @@ fn fuzz_2297_def() {
         q1;
     }
     "#;
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
@@ -60,72 +57,59 @@ fn fuzz_2297_with_trailing_comma() {
             q1;
         }
     "#;
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
 #[test]
 fn fuzz_2298() {
     let source = r#"gate y()a{gate a,b{}b"#;
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
 #[test]
 fn fuzz_2313() {
     let source = r#"ctrl(π/0s)@a"#;
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
 #[test]
 fn fuzz_2332() {
     let source = r#"ctrl(0/0)@s"#;
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
 #[test]
 fn fuzz_2348() {
     let source = r#"ctrl(0%0)@s"#;
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
 #[test]
-#[ignore = "Requires further investigation"]
 fn fuzz_2366() {
     let source = "t[:π";
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
 #[test]
 fn fuzz_2368() {
     let source = "c[:0s";
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
 #[test]
-#[ignore = "Requires further investigation"]
 fn fuzz_2379() {
     let source = "1[true:";
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
 #[test]
 fn fuzz_2391() {
     let source = "c[:0s";
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
 
 #[test]
-#[ignore = "Requires further investigation"]
 fn fuzz_2392() {
     let source = "e[π:";
-    super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }

--- a/compiler/qsc_qasm/src/tests/fuzz.rs
+++ b/compiler/qsc_qasm/src/tests/fuzz.rs
@@ -91,3 +91,41 @@ fn fuzz_2348() {
     super::compare_qasm_and_qasharp_asts(source);
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
+
+#[test]
+#[ignore = "Requires further investigation"]
+fn fuzz_2366() {
+    let source = "t[:π";
+    super::compare_qasm_and_qasharp_asts(source);
+    compile_qasm_best_effort(source, Profile::Unrestricted);
+}
+
+#[test]
+fn fuzz_2368() {
+    let source = "c[:0s";
+    super::compare_qasm_and_qasharp_asts(source);
+    compile_qasm_best_effort(source, Profile::Unrestricted);
+}
+
+#[test]
+#[ignore = "Requires further investigation"]
+fn fuzz_2379() {
+    let source = "1[true:";
+    super::compare_qasm_and_qasharp_asts(source);
+    compile_qasm_best_effort(source, Profile::Unrestricted);
+}
+
+#[test]
+fn fuzz_2391() {
+    let source = "c[:0s";
+    super::compare_qasm_and_qasharp_asts(source);
+    compile_qasm_best_effort(source, Profile::Unrestricted);
+}
+
+#[test]
+#[ignore = "Requires further investigation"]
+fn fuzz_2392() {
+    let source = "e[π:";
+    super::compare_qasm_and_qasharp_asts(source);
+    compile_qasm_best_effort(source, Profile::Unrestricted);
+}

--- a/language_service/src/compilation.rs
+++ b/language_service/src/compilation.rs
@@ -264,7 +264,7 @@ impl Compilation {
             .collect::<InMemorySourceResolver>();
         let capabilities = target_profile.into();
 
-        let CompileRawQasmResult(store, source_package_id, dependencies, _sig, compile_errors) =
+        let CompileRawQasmResult(store, source_package_id, dependencies, _sig, mut compile_errors) =
             qsc::qasm::compile_raw_qasm(
                 source.clone(),
                 path.clone(),
@@ -272,6 +272,18 @@ impl Compilation {
                 package_type,
                 capabilities,
             );
+
+        let unit = store
+            .get(source_package_id)
+            .expect("expected to find user package");
+
+        run_fir_passes(
+            &mut compile_errors,
+            target_profile,
+            &store,
+            source_package_id,
+            unit,
+        );
 
         Self {
             package_store: store,

--- a/language_service/src/state/tests.rs
+++ b/language_service/src/state/tests.rs
@@ -31,6 +31,7 @@ async fn no_error() {
             "single/foo.qs",
             1,
             "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
+            "qsharp",
         )
         .await;
 
@@ -44,7 +45,7 @@ async fn clear_error() {
     let mut updater = new_updater(&errors, &test_cases);
 
     updater
-        .update_document("single/foo.qs", 1, "namespace {")
+        .update_document("single/foo.qs", 1, "namespace {", "qsharp")
         .await;
 
     expect_errors(
@@ -63,6 +64,7 @@ async fn clear_error() {
             "single/foo.qs",
             2,
             "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
+            "qsharp",
         )
         .await;
 
@@ -86,6 +88,7 @@ async fn close_last_doc_in_project() {
             "project/src/other_file.qs",
             1,
             "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
+            "qsharp",
         )
         .await;
     updater
@@ -93,10 +96,13 @@ async fn close_last_doc_in_project() {
             "project/src/this_file.qs",
             1,
             "/* this should not show up in the final state */ we should not see compile errors",
+            "qsharp",
         )
         .await;
 
-    updater.close_document("project/src/this_file.qs").await;
+    updater
+        .close_document("project/src/this_file.qs", "qsharp")
+        .await;
     // now there should be one compilation and one open document
 
     check_state_and_errors(
@@ -127,7 +133,9 @@ async fn close_last_doc_in_project() {
               uri: "project/src/this_file.qs" version: None errors: [],
             ]"#]],
     );
-    updater.close_document("project/src/other_file.qs").await;
+    updater
+        .close_document("project/src/other_file.qs", "qsharp")
+        .await;
 
     // now there should be no file and no compilation
     check_state_and_errors(
@@ -152,6 +160,7 @@ async fn close_last_doc_in_openqasm_project() {
             "openqasm_files/self-contained.qasm",
             1,
             "include \"stdgates.inc\";\nqubit q;\nreset q;\nx q;\nh q;\nbit c = measure q;\n",
+            "openqasm",
         )
         .await;
 
@@ -176,7 +185,7 @@ async fn close_last_doc_in_openqasm_project() {
     );
 
     updater
-        .close_document("openqasm_files/self-contained.qasm")
+        .close_document("openqasm_files/self-contained.qasm", "openqasm")
         .await;
 
     // now there should be no file and no compilation
@@ -199,7 +208,7 @@ async fn clear_on_document_close() {
     let mut updater = new_updater(&errors, &test_cases);
 
     updater
-        .update_document("single/foo.qs", 1, "namespace {")
+        .update_document("single/foo.qs", 1, "namespace {", "qsharp")
         .await;
 
     expect_errors(
@@ -213,7 +222,7 @@ async fn clear_on_document_close() {
             ]"#]],
     );
 
-    updater.close_document("single/foo.qs").await;
+    updater.close_document("single/foo.qs", "qsharp").await;
 
     expect_errors(
         &errors,
@@ -231,7 +240,7 @@ async fn compile_error() {
     let mut updater = new_updater(&errors, &test_cases);
 
     updater
-        .update_document("single/foo.qs", 1, "badsyntax")
+        .update_document("single/foo.qs", 1, "badsyntax", "qsharp")
         .await;
 
     expect_errors(
@@ -259,7 +268,7 @@ async fn rca_errors_are_reported_when_compilation_succeeds() {
     });
 
     updater
-        .update_document("single/foo.qs", 1, "namespace Test { operation RcaCheck() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x } }")
+        .update_document("single/foo.qs", 1, "namespace Test { operation RcaCheck() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x } }", "qsharp")
         .await;
 
     // we expect two errors, one for `set x = 2` and one for `x`
@@ -290,7 +299,7 @@ async fn base_profile_rca_errors_are_reported_when_compilation_succeeds() {
     });
 
     updater
-        .update_document("single/foo.qs", 1, "namespace Test { operation RcaCheck() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x } }")
+        .update_document("single/foo.qs", 1, "namespace Test { operation RcaCheck() : Double { use q = Qubit(); mutable x = 1.0; if MResetZ(q) == One { set x = 2.0; } x } }", "qsharp")
         .await;
 
     // we expect two errors, one for `set x = 2.0` and one for `x`
@@ -326,6 +335,7 @@ async fn package_type_update_causes_error() {
             "single/foo.qs",
             1,
             "namespace Foo { operation Test() : Unit {} }",
+            "qsharp",
         )
         .await;
 
@@ -364,6 +374,7 @@ async fn target_profile_update_fixes_error() {
             "single/foo.qs",
             1,
             r#"namespace Foo { operation Main() : Unit { use q = Qubit(); if M(q) == Zero { Message("hi") } } }"#,
+            "qsharp",
         )
         .await;
 
@@ -409,6 +420,7 @@ async fn target_profile_update_updates_test_cases() {
             "single/foo.qs",
             1,
             r#"@Config(Base) @Test() operation BaseTest() : Unit {}"#,
+            "qsharp",
         )
         .await;
 
@@ -468,6 +480,7 @@ async fn target_profile_update_causes_error_in_stdlib() {
         "single/foo.qs",
         1,
         r#"namespace Foo { @EntryPoint() operation Main() : Unit { use q = Qubit(); let r = M(q); let b = Microsoft.Quantum.Convert.ResultAsBool(r); } }"#,
+        "qsharp",
     ).await;
 
     expect_errors(&errors, &expect!["[]"]);
@@ -851,6 +864,7 @@ async fn update_doc_updates_project() {
             "project/src/other_file.qs",
             1,
             "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
+            "qsharp",
         )
         .await;
     updater
@@ -858,6 +872,7 @@ async fn update_doc_updates_project() {
             "project/src/this_file.qs",
             1,
             "namespace Foo { we should see this in the source }",
+            "qsharp",
         )
         .await;
 
@@ -932,7 +947,12 @@ async fn file_not_in_files_list() {
 
     // Open the file that is listed in the files list
     updater
-        .update_document("project/src/explicitly_listed.qs", 1, "// CONTENTS")
+        .update_document(
+            "project/src/explicitly_listed.qs",
+            1,
+            "// CONTENTS",
+            "qsharp",
+        )
         .await;
 
     // The whole project should be loaded, which should generate
@@ -966,7 +986,7 @@ async fn file_not_in_files_list() {
 
     // Open the unlisted file as well.
     updater
-        .update_document("project/src/unlisted.qs", 1, "// CONTENTS")
+        .update_document("project/src/unlisted.qs", 1, "// CONTENTS", "qsharp")
         .await;
 
     // Documents are both open and correctly associated with the project.
@@ -1035,7 +1055,7 @@ async fn file_not_under_src() {
 
     // Open the file that is not under src.
     updater
-        .update_document("project/not_under_src.qs", 1, "// CONTENTS")
+        .update_document("project/not_under_src.qs", 1, "// CONTENTS", "qsharp")
         .await;
 
     // This document is not associated with the manifest,
@@ -1063,7 +1083,7 @@ async fn file_not_under_src() {
 
     // Open the file that's properly under the "src" directory.
     updater
-        .update_document("project/src/under_src.qs", 1, "// CONTENTS")
+        .update_document("project/src/under_src.qs", 1, "// CONTENTS", "qsharp")
         .await;
 
     // The manifest is loaded, `not_under_src.qs` is still not associated with it.
@@ -1113,6 +1133,7 @@ async fn close_doc_prioritizes_fs() {
             "project/src/other_file.qs",
             1,
             "namespace Foo { @EntryPoint() operation Main() : Unit {} }",
+            "qsharp",
         )
         .await;
     updater
@@ -1120,10 +1141,13 @@ async fn close_doc_prioritizes_fs() {
             "project/src/this_file.qs",
             1,
             "/* this should not show up in the final state */ we should not see compile errors",
+            "qsharp",
         )
         .await;
 
-    updater.close_document("project/src/this_file.qs").await;
+    updater
+        .close_document("project/src/this_file.qs", "qsharp")
+        .await;
 
     check_state_and_errors(
         &updater,
@@ -1166,6 +1190,7 @@ async fn delete_manifest() {
             "project/src/this_file.qs",
             1,
             "// DISK CONTENTS\n namespace Foo { }",
+            "qsharp",
         )
         .await;
 
@@ -1195,6 +1220,7 @@ async fn delete_manifest() {
             "project/src/this_file.qs",
             2,
             "// DISK CONTENTS\n namespace Foo { }",
+            "qsharp",
         )
         .await;
 
@@ -1228,6 +1254,7 @@ async fn delete_manifest_then_close() {
             "project/src/this_file.qs",
             1,
             "// DISK CONTENTS\n namespace Foo { }",
+            "qsharp",
         )
         .await;
 
@@ -1252,7 +1279,9 @@ async fn delete_manifest_then_close() {
 
     TEST_FS.with(|fs| fs.borrow_mut().remove("project/qsharp.json"));
 
-    updater.close_document("project/src/this_file.qs").await;
+    updater
+        .close_document("project/src/this_file.qs", "qsharp")
+        .await;
 
     check_state(
         &updater,
@@ -1270,11 +1299,21 @@ async fn doc_switches_project() {
     let mut updater = new_updater(&received_errors, &test_cases);
 
     updater
-        .update_document("nested_projects/src/subdir/src/a.qs", 1, "namespace A {}")
+        .update_document(
+            "nested_projects/src/subdir/src/a.qs",
+            1,
+            "namespace A {}",
+            "qsharp",
+        )
         .await;
 
     updater
-        .update_document("nested_projects/src/subdir/src/b.qs", 1, "namespace B {}")
+        .update_document(
+            "nested_projects/src/subdir/src/b.qs",
+            1,
+            "namespace B {}",
+            "qsharp",
+        )
         .await;
 
     check_state(
@@ -1310,11 +1349,21 @@ async fn doc_switches_project() {
     });
 
     updater
-        .update_document("nested_projects/src/subdir/src/a.qs", 2, "namespace A {}")
+        .update_document(
+            "nested_projects/src/subdir/src/a.qs",
+            2,
+            "namespace A {}",
+            "qsharp",
+        )
         .await;
 
     updater
-        .update_document("nested_projects/src/subdir/src/b.qs", 2, "namespace B {}")
+        .update_document(
+            "nested_projects/src/subdir/src/b.qs",
+            2,
+            "namespace B {}",
+            "qsharp",
+        )
         .await;
 
     // the error should now be coming from the parent qsharp.json? But the document
@@ -1351,11 +1400,21 @@ async fn doc_switches_project_on_close() {
     let mut updater = new_updater(&received_errors, &test_cases);
 
     updater
-        .update_document("nested_projects/src/subdir/src/a.qs", 1, "namespace A {}")
+        .update_document(
+            "nested_projects/src/subdir/src/a.qs",
+            1,
+            "namespace A {}",
+            "qsharp",
+        )
         .await;
 
     updater
-        .update_document("nested_projects/src/subdir/src/b.qs", 1, "namespace B {}")
+        .update_document(
+            "nested_projects/src/subdir/src/b.qs",
+            1,
+            "namespace B {}",
+            "qsharp",
+        )
         .await;
 
     check_state(
@@ -1391,11 +1450,16 @@ async fn doc_switches_project_on_close() {
     });
 
     updater
-        .close_document("nested_projects/src/subdir/src/a.qs")
+        .close_document("nested_projects/src/subdir/src/a.qs", "qsharp")
         .await;
 
     updater
-        .update_document("nested_projects/src/subdir/src/b.qs", 2, "namespace B {}")
+        .update_document(
+            "nested_projects/src/subdir/src/b.qs",
+            2,
+            "namespace B {}",
+            "qsharp",
+        )
         .await;
 
     check_state(
@@ -1508,7 +1572,7 @@ async fn lints_update_after_manifest_change() {
 
     // Trigger a document update.
     updater
-        .update_document("project/src/this_file.qs", 1, this_file_qs)
+        .update_document("project/src/this_file.qs", 1, this_file_qs, "qsharp")
         .await;
 
     // Check generated lints.
@@ -1533,7 +1597,7 @@ async fn lints_update_after_manifest_change() {
 
     // Trigger a document update
     updater
-        .update_document("project/src/this_file.qs", 1, this_file_qs)
+        .update_document("project/src/this_file.qs", 1, this_file_qs, "qsharp")
         .await;
 
     // Check lints again
@@ -1569,7 +1633,7 @@ async fn lints_prefer_workspace_over_defaults() {
 
     // Trigger a document update.
     updater
-        .update_document("project/src/this_file.qs", 1, this_file_qs)
+        .update_document("project/src/this_file.qs", 1, this_file_qs, "qsharp")
         .await;
 
     // Check generated lints.
@@ -1618,7 +1682,7 @@ async fn lints_prefer_manifest_over_workspace() {
 
     // Trigger a document update.
     updater
-        .update_document("project/src/this_file.qs", 1, this_file_qs)
+        .update_document("project/src/this_file.qs", 1, this_file_qs, "qsharp")
         .await;
 
     // No lints expected ("allow" wins over "warn")
@@ -1649,7 +1713,12 @@ async fn missing_dependency_reported() {
 
     // Trigger a document update.
     updater
-        .update_document("parent/src/main.qs", 1, "function Main() : Unit {}")
+        .update_document(
+            "parent/src/main.qs",
+            1,
+            "function Main() : Unit {}",
+            "qsharp",
+        )
         .await;
 
     expect_errors(
@@ -1696,7 +1765,12 @@ async fn error_from_dependency_reported() {
 
     // Trigger a document update.
     updater
-        .update_document("parent/src/main.qs", 1, "function Main() : Unit {}")
+        .update_document(
+            "parent/src/main.qs",
+            1,
+            "function Main() : Unit {}",
+            "qsharp",
+        )
         .await;
 
     expect_errors(
@@ -1718,11 +1792,16 @@ async fn single_github_source_no_errors() {
     let mut updater = new_updater(&received_errors, &test_cases);
 
     updater
-        .update_document("qsharp-github-source:foo/bar/Main.qs", 1, "badsyntax")
+        .update_document(
+            "qsharp-github-source:foo/bar/Main.qs",
+            1,
+            "badsyntax",
+            "qsharp",
+        )
         .await;
 
     updater
-        .update_document("/foo/bar/Main.qs", 1, "badsyntax")
+        .update_document("/foo/bar/Main.qs", 1, "badsyntax", "qsharp")
         .await;
 
     // Same error exists in both files, but the github one should not be reported
@@ -1787,6 +1866,7 @@ async fn test_case_detected() {
             "parent/src/main.qs",
             1,
             "@Test() function MyTestCase() : Unit {}",
+            "qsharp",
         )
         .await;
 
@@ -1843,7 +1923,12 @@ async fn test_case_removed() {
 
     // Trigger a document update.
     updater
-        .update_document("parent/src/main.qs", 1, "function MyTestCase() : Unit {}")
+        .update_document(
+            "parent/src/main.qs",
+            1,
+            "function MyTestCase() : Unit {}",
+            "qsharp",
+        )
         .await;
 
     expect![[r#"
@@ -1884,6 +1969,7 @@ async fn test_case_modified() {
             "parent/src/main.qs",
             1,
             "@Test() function MyTestCase() : Unit {}",
+            "qsharp",
         )
         .await;
 
@@ -1892,6 +1978,7 @@ async fn test_case_modified() {
             "parent/src/main.qs",
             2,
             "@Test() function MyTestCase2() : Unit { }",
+            "qsharp",
         )
         .await;
 
@@ -1974,11 +2061,17 @@ async fn test_annotation_removed() {
             "parent/src/main.qs",
             1,
             "@Test() function MyTestCase() : Unit {}",
+            "qsharp",
         )
         .await;
 
     updater
-        .update_document("parent/src/main.qs", 2, "function MyTestCase() : Unit {}")
+        .update_document(
+            "parent/src/main.qs",
+            2,
+            "function MyTestCase() : Unit {}",
+            "qsharp",
+        )
         .await;
 
     expect![[r#"
@@ -2044,6 +2137,7 @@ async fn multiple_tests() {
             "parent/src/main.qs",
             1,
             "@Test() function Test1() : Unit {} @Test() function Test2() : Unit {}",
+            "qsharp",
         )
         .await;
 
@@ -2125,6 +2219,7 @@ async fn test_case_in_different_files() {
             "parent/src/test1.qs",
             1,
             "@Test() function Test1() : Unit {}",
+            "qsharp",
         )
         .await;
 

--- a/language_service/src/tests.rs
+++ b/language_service/src/tests.rs
@@ -19,7 +19,7 @@ async fn single_document() {
     let mut ls = LanguageService::new(Encoding::Utf8);
     let mut worker = create_update_worker(&mut ls, &received_errors, &test_cases);
 
-    ls.update_document("foo.qs", 1, "namespace Foo { }");
+    ls.update_document("foo.qs", 1, "namespace Foo { }", "qsharp");
 
     worker.apply_pending().await;
 
@@ -54,7 +54,7 @@ async fn single_document_update() {
     let mut ls = LanguageService::new(Encoding::Utf8);
     let mut worker = create_update_worker(&mut ls, &received_errors, &test_cases);
 
-    ls.update_document("foo.qs", 1, "namespace Foo { }");
+    ls.update_document("foo.qs", 1, "namespace Foo { }", "qsharp");
 
     worker.apply_pending().await;
 
@@ -85,6 +85,7 @@ async fn single_document_update() {
         "foo.qs",
         1,
         "namespace Foo { @EntryPoint() operation Bar() : Unit {} }",
+        "qsharp",
     );
 
     worker.apply_pending().await;
@@ -120,7 +121,7 @@ async fn document_in_project() {
     let mut ls = LanguageService::new(Encoding::Utf8);
     let mut worker = create_update_worker(&mut ls, &received_errors, &test_cases);
 
-    ls.update_document("project/src/this_file.qs", 1, "namespace Foo { }");
+    ls.update_document("project/src/this_file.qs", 1, "namespace Foo { }", "qsharp");
 
     check_errors_and_no_compilation(
         &ls,
@@ -178,6 +179,7 @@ async fn completions_requested_before_document_load() {
         "foo.qs",
         1,
         "namespace Foo { open Microsoft.Quantum.Diagnostics; @EntryPoint() operation Main() : Unit { DumpMachine() } }",
+        "qsharp"
     );
 
     // we intentionally don't await work to test how LSP features function when
@@ -209,6 +211,7 @@ async fn completions_requested_after_document_load() {
         "foo.qs",
         1,
         "namespace Foo { open Microsoft.Quantum.Diagnostics; @EntryPoint() operation Main() : Unit { DumpMachine() } }",
+        "qsharp"
     );
 
     worker.apply_pending().await;

--- a/npm/qsharp/src/compiler/compiler.ts
+++ b/npm/qsharp/src/compiler/compiler.ts
@@ -144,7 +144,7 @@ export class Compiler implements ICompiler {
         findManifestDirectory: async () => null,
       },
     );
-    languageService.update_document("code", 1, code);
+    languageService.update_document("code", 1, code, "qsharp");
     // Yield to let the language service background worker handle the update
     await Promise.resolve();
     languageService.stop_background_work();

--- a/npm/qsharp/src/language-service/language-service.ts
+++ b/npm/qsharp/src/language-service/language-service.ts
@@ -55,7 +55,7 @@ export interface ILanguageService {
     uri: string,
     version: number,
     code: string,
-    languageId: string,
+    languageId?: string,
   ): Promise<void>;
   updateNotebookDocument(
     notebookUri: string,
@@ -67,7 +67,7 @@ export interface ILanguageService {
       code: string;
     }[],
   ): Promise<void>;
-  closeDocument(uri: string, languageId: string): Promise<void>;
+  closeDocument(uri: string, languageId?: string): Promise<void>;
   closeNotebookDocument(notebookUri: string): Promise<void>;
   getCodeActions(documentUri: string, range: IRange): Promise<ICodeAction[]>;
   getCompletions(
@@ -156,13 +156,13 @@ export class QSharpLanguageService implements ILanguageService {
     documentUri: string,
     version: number,
     code: string,
-    languageId: string,
+    languageId?: string,
   ): Promise<void> {
     this.languageService.update_document(
       documentUri,
       version,
       code,
-      languageId,
+      languageId || "qsharp",
     );
   }
 
@@ -175,8 +175,8 @@ export class QSharpLanguageService implements ILanguageService {
     this.languageService.update_notebook_document(notebookUri, metadata, cells);
   }
 
-  async closeDocument(documentUri: string, languageId: string): Promise<void> {
-    this.languageService.close_document(documentUri, languageId);
+  async closeDocument(documentUri: string, languageId?: string): Promise<void> {
+    this.languageService.close_document(documentUri, languageId || "qsharp");
   }
 
   async closeNotebookDocument(documentUri: string): Promise<void> {

--- a/npm/qsharp/src/language-service/language-service.ts
+++ b/npm/qsharp/src/language-service/language-service.ts
@@ -51,7 +51,12 @@ export type LanguageServiceEvent =
 // for running the compiler in the same thread the result will be synchronous (a resolved promise).
 export interface ILanguageService {
   updateConfiguration(config: IWorkspaceConfiguration): Promise<void>;
-  updateDocument(uri: string, version: number, code: string): Promise<void>;
+  updateDocument(
+    uri: string,
+    version: number,
+    code: string,
+    languageId: string,
+  ): Promise<void>;
   updateNotebookDocument(
     notebookUri: string,
     version: number,
@@ -62,7 +67,7 @@ export interface ILanguageService {
       code: string;
     }[],
   ): Promise<void>;
-  closeDocument(uri: string): Promise<void>;
+  closeDocument(uri: string, languageId: string): Promise<void>;
   closeNotebookDocument(notebookUri: string): Promise<void>;
   getCodeActions(documentUri: string, range: IRange): Promise<ICodeAction[]>;
   getCompletions(
@@ -151,8 +156,14 @@ export class QSharpLanguageService implements ILanguageService {
     documentUri: string,
     version: number,
     code: string,
+    languageId: string,
   ): Promise<void> {
-    this.languageService.update_document(documentUri, version, code);
+    this.languageService.update_document(
+      documentUri,
+      version,
+      code,
+      languageId,
+    );
   }
 
   async updateNotebookDocument(
@@ -164,8 +175,8 @@ export class QSharpLanguageService implements ILanguageService {
     this.languageService.update_notebook_document(notebookUri, metadata, cells);
   }
 
-  async closeDocument(documentUri: string): Promise<void> {
-    this.languageService.close_document(documentUri);
+  async closeDocument(documentUri: string, languageId: string): Promise<void> {
+    this.languageService.close_document(documentUri, languageId);
   }
 
   async closeNotebookDocument(documentUri: string): Promise<void> {

--- a/npm/qsharp/test/basics.js
+++ b/npm/qsharp/test/basics.js
@@ -497,6 +497,7 @@ test("language service diagnostics", async () => {
         return [m1];
     }
 }`,
+    "qsharp",
   );
 
   // dispose() will complete when the language service has processed all the updates.
@@ -533,6 +534,7 @@ test("test callable discovery", async () => {
     @Test()
     operation main() : Unit {}
 }`,
+    "qsharp",
   );
 
   // dispose() will complete when the language service has processed all the updates.
@@ -571,6 +573,7 @@ namespace Sample2 {
   }    
 }
 `,
+    "qsharp",
   );
 
   // dispose() will complete when the language service has processed all the updates.
@@ -654,6 +657,7 @@ test("diagnostics with related spans", async () => {
         DumpMachine();
       }
     }`,
+    "qsharp",
   );
 
   // dispose() will complete when the language service has processed all the updates.
@@ -684,6 +688,7 @@ test("language service diagnostics - web worker", async () => {
         return [m1];
     }
 }`,
+    "qsharp",
   );
 
   // dispose() will complete when the language service has processed all the updates.
@@ -711,6 +716,7 @@ test("language service configuration update", async () => {
     operation Test() : Unit {
     }
 }`,
+    "qsharp",
   );
 
   // Above document should have generated a missing entrypoint error.

--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -282,6 +282,7 @@ export function Editor(props: {
         srcModel.uri.toString(),
         srcModel.getVersionId(),
         srcModel.getValue(),
+        srcModel.getLanguageId(),
       );
       const measure = performance.measure(
         "update-document",
@@ -299,7 +300,10 @@ export function Editor(props: {
     return () => {
       log.info("Disposing a monaco editor");
       window.removeEventListener("resize", onResize);
-      props.languageService.closeDocument(srcModel.uri.toString());
+      props.languageService.closeDocument(
+        srcModel.uri.toString(),
+        srcModel.getLanguageId(),
+      );
       newEditor.dispose();
     };
   }, []);

--- a/playground/src/editor.tsx
+++ b/playground/src/editor.tsx
@@ -282,7 +282,6 @@ export function Editor(props: {
         srcModel.uri.toString(),
         srcModel.getVersionId(),
         srcModel.getValue(),
-        srcModel.getLanguageId(),
       );
       const measure = performance.measure(
         "update-document",
@@ -300,10 +299,7 @@ export function Editor(props: {
     return () => {
       log.info("Disposing a monaco editor");
       window.removeEventListener("resize", onResize);
-      props.languageService.closeDocument(
-        srcModel.uri.toString(),
-        srcModel.getLanguageId(),
-      );
+      props.languageService.closeDocument(srcModel.uri.toString());
       newEditor.dispose();
     };
   }, []);

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -23,9 +23,7 @@
     "onNotebook:jupyter-notebook",
     "onDebug",
     "onDebugResolve:qsharp",
-    "onDebugResolve:openqasm",
     "onDebugDynamicConfigurations:qsharp",
-    "onDebugDynamicConfigurations:openqasm",
     "onFileSystem:qsharp-vfs",
     "onWebviewPanel:qsharp-webview"
   ],

--- a/vscode/src/diagnostics.ts
+++ b/vscode/src/diagnostics.ts
@@ -98,17 +98,17 @@ function startCommandDiagnostics(): vscode.Disposable[] {
     {
       provideCodeActions(doc, range, context): vscode.CodeAction[] | undefined {
         const commandErrors = context.diagnostics.filter((d) =>
-          d.message.startsWith("Q# command error: "),
+          d.message.startsWith("QDK command error: "),
         );
 
         if (commandErrors.length > 0) {
           const action = new vscode.CodeAction(
-            "Dismiss errors for the last run Q# command",
+            "Dismiss errors for the last run QDK command",
           );
           action.diagnostics = commandErrors;
           action.command = {
             command: `${qsharpExtensionId}.dismissCommandDiagnostics`,
-            title: "Dismiss errors for the last run Q# command",
+            title: "Dismiss errors for the last run QDK command",
           };
           action.isPreferred = true;
           return [action];

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -79,13 +79,13 @@ export async function activate(
 
   context.subscriptions.push(CircuitEditorProvider.register(context));
 
-  initAzureWorkspaces(context);
+  await initAzureWorkspaces(context);
   initCodegen(context);
-  activateDebugger(context);
+  await activateDebugger(context);
   registerCreateNotebookCommand(context);
   registerWebViewCommands(context);
-  initFileSystem(context);
-  initProjectCreator(context);
+  await initFileSystem(context);
+  await initProjectCreator(context);
   registerCopilotPanel(context);
   registerLanguageModelTools(context);
   registerGhCopilotInstructionsCommand(context);

--- a/vscode/src/language-service/activate.ts
+++ b/vscode/src/language-service/activate.ts
@@ -242,7 +242,10 @@ function registerDocumentUpdateHandlers(
   subscriptions.push(
     vscode.workspace.onDidCloseTextDocument((document) => {
       if (isQdkDocument(document) && !isNotebookCell(document)) {
-        languageService.closeDocument(document.uri.toString());
+        languageService.closeDocument(
+          document.uri.toString(),
+          document.languageId,
+        );
       }
     }),
   );
@@ -292,6 +295,7 @@ function registerDocumentUpdateHandlers(
         document.uri.toString(),
         document.version,
         content,
+        document.languageId,
       );
     }
   }

--- a/vscode/src/programConfig.ts
+++ b/vscode/src/programConfig.ts
@@ -52,7 +52,7 @@ export async function getActiveProgram(): Promise<FullProgramConfigOrError> {
     };
   }
 
-  return getProgramForDocument(doc);
+  return await getProgramForDocument(doc);
 }
 
 export function getActiveQdkDocumentUri(): vscode.Uri | undefined {
@@ -75,7 +75,7 @@ export async function getVisibleProgram(): Promise<FullProgramConfigOrError> {
         "There are no visible windows that contain a document supported by the QDK",
     };
   }
-  return getProgramForDocument(doc);
+  return await getProgramForDocument(doc);
 }
 
 export function getVisibleQdkDocumentUri(): vscode.Uri | undefined {

--- a/wasm/src/language_service.rs
+++ b/wasm/src/language_service.rs
@@ -127,12 +127,12 @@ impl LanguageService {
             });
     }
 
-    pub fn update_document(&mut self, uri: &str, version: u32, text: &str) {
-        self.0.update_document(uri, version, text);
+    pub fn update_document(&mut self, uri: &str, version: u32, text: &str, language_id: &str) {
+        self.0.update_document(uri, version, text, language_id);
     }
 
-    pub fn close_document(&mut self, uri: &str) {
-        self.0.close_document(uri);
+    pub fn close_document(&mut self, uri: &str, language_id: &str) {
+        self.0.close_document(uri, language_id);
     }
 
     pub fn update_notebook_document(


### PR DESCRIPTION
Fixes:
- Qubits must be declared globally.
- No longer using file ext for type, language id is passed into LS
- Cleaning up debugger
- Adding missing `await`s in TS
- QIR profile errors now show in openqasm docs
- Clearing command errors should work again.

Fixes #2366
Fixes #2368
Fixes #2379
Fixes #2391 
Fixes #2392

