### PR TITLE
Don't use the start of the target as the provider id

### DIFF
--- a/vscode/src/azure/commands.ts
+++ b/vscode/src/azure/commands.ts
@@ -121,8 +121,6 @@ export async function initAzureWorkspaces(context: vscode.ExtensionContext) {
 
         const target = treeItem.itemData as Target;
 
-        const providerId = target.id.split(".")?.[0];
-
         const supports_adaptive = supportsAdaptive(target.id);
 
         let qir = "";
@@ -149,7 +147,7 @@ export async function initAzureWorkspaces(context: vscode.ExtensionContext) {
             token,
             quantumUris,
             qir,
-            providerId,
+            target.providerId,
             target.id,
           );
           if (jobId) {

--- a/vscode/src/azure/networkRequests.ts
+++ b/vscode/src/azure/networkRequests.ts
@@ -25,6 +25,7 @@ export async function azureRequest(
 
   try {
     log.debug(`Fetching ${uri} with method ${method}`);
+    log.trace("Request headers & body: ", headers, body);
     const response = await fetch(uri, {
       headers,
       method,

--- a/vscode/src/azure/treeView.ts
+++ b/vscode/src/azure/treeView.ts
@@ -115,6 +115,7 @@ export type Provider = {
 
 export type Target = {
   id: string;
+  providerId: string;
   currentAvailability: "Available" | "Degraded" | "Unavailable";
   averageQueueTime: number; // minutes
 };

--- a/vscode/src/azure/workspaceActions.ts
+++ b/vscode/src/azure/workspaceActions.ts
@@ -389,9 +389,9 @@ export async function queryWorkspace(workspace: WorkspaceConnection) {
     return {
       providerId: provider.id,
       currentAvailability: provider.currentAvailability,
-      targets: provider.targets.filter(
-        (target) => !shouldExcludeTarget(target.id),
-      ),
+      targets: provider.targets
+        .map((target) => ({ ...target, providerId: provider.id }))
+        .filter((target) => !shouldExcludeTarget(target.id)),
     };
   });
 

--- a/vscode/src/copilot/azqTools.ts
+++ b/vscode/src/copilot/azqTools.ts
@@ -431,8 +431,6 @@ export async function submitToTarget(
 
   const workspace = await getConversationWorkspace(toolState);
 
-  const providerId = target.id.split(".")?.[0];
-
   let qir = "";
   try {
     qir = await getQirForVisibleSource(supportsAdaptive(target.id));
@@ -466,7 +464,7 @@ export async function submitToTarget(
       token,
       quantumUris,
       qir,
-      providerId,
+      target.providerId,
       target.id,
       jobName,
       numberOfShots,

--- a/vscode/src/gh-copilot/tools.ts
+++ b/vscode/src/gh-copilot/tools.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import * as azqTools from "../copilot/azqTools";
 import { ToolState } from "../copilot/tools";
 import { log } from "qsharp-lang";
+import { Target } from "../azure/treeView";
 
 const toolDefinitions: {
   name: string;
@@ -85,7 +86,9 @@ async function getProviders(): Promise<any> {
   return (await azqTools.getProviders(workspaceState)).result;
 }
 
-async function getTarget(input: { target_id: string }): Promise<any> {
+async function getTarget(input: {
+  target_id: string;
+}): Promise<Target | undefined> {
   return (await azqTools.getTarget(workspaceState, input)).result;
 }
 


### PR DESCRIPTION
For targets coming online, the providerId is not necessarily the first part of the target string up to the first ".". Thus, saving the providerId along with the target (which is easier than having each child node store a reference to it's parent also)