### PR TITLE
Add reset broadcast

### DIFF
--- a/compiler/qsc_qasm/src/ast_builder.rs
+++ b/compiler/qsc_qasm/src/ast_builder.rs
@@ -753,6 +753,14 @@ pub(crate) fn build_reset_call(expr: ast::Expr, name_span: Span, operand_span: S
     build_global_call_with_one_param("Reset", expr, name_span, operand_span)
 }
 
+pub(crate) fn build_reset_all_call(
+    expr: ast::Expr,
+    name_span: Span,
+    operand_span: Span,
+) -> ast::Expr {
+    build_global_call_with_one_param("ResetAll", expr, name_span, operand_span)
+}
+
 pub(crate) fn build_global_call_with_one_param<S: AsRef<str>>(
     name: S,
     expr: ast::Expr,

--- a/compiler/qsc_qasm/src/semantic/tests/statements.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements.rs
@@ -6,5 +6,6 @@ mod break_stmt;
 mod continue_stmt;
 mod for_stmt;
 mod if_stmt;
+mod reset_stmt;
 mod switch_stmt;
 mod while_stmt;

--- a/compiler/qsc_qasm/src/semantic/tests/statements/reset_stmt.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements/reset_stmt.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::semantic::tests::check_stmt_kinds;
+use expect_test::expect;
+
+#[test]
+fn on_a_single_qubit() {
+    check_stmt_kinds(
+        "qubit q;
+        reset q;",
+        &expect![[r#"
+            QubitDeclaration [0-8]:
+                symbol_id: 8
+            ResetStmt [17-25]:
+                reset_token_span: [17-22]
+                operand: GateOperand [23-24]:
+                    kind: Expr [23-24]:
+                        ty: Qubit
+                        kind: SymbolId(8)
+        "#]],
+    );
+}
+
+#[test]
+fn on_an_indexed_qubit_register() {
+    check_stmt_kinds(
+        "qubit[5] q;
+        reset q[2];",
+        &expect![[r#"
+            QubitArrayDeclaration [0-11]:
+                symbol_id: 8
+                size: 5
+                size_span: [6-7]
+            ResetStmt [20-31]:
+                reset_token_span: [20-25]
+                operand: GateOperand [26-30]:
+                    kind: Expr [26-30]:
+                        ty: Qubit
+                        kind: IndexedIdent [26-30]:
+                            symbol_id: 8
+                            name_span: [26-27]
+                            index_span: [27-30]
+                            indices:
+                                Expr [28-29]:
+                                    ty: Int(None, true)
+                                    kind: Lit: Int(2)
+        "#]],
+    );
+}
+
+#[test]
+fn on_a_span_indexed_qubit_register() {
+    check_stmt_kinds(
+        "qubit[5] q;
+        reset q[1:3];",
+        &expect![[r#"
+            QubitArrayDeclaration [0-11]:
+                symbol_id: 8
+                size: 5
+                size_span: [6-7]
+            ResetStmt [20-33]:
+                reset_token_span: [20-25]
+                operand: GateOperand [26-32]:
+                    kind: Expr [26-32]:
+                        ty: QubitArray(3)
+                        kind: IndexedIdent [26-32]:
+                            symbol_id: 8
+                            name_span: [26-27]
+                            index_span: [27-32]
+                            indices:
+                                Range [28-31]:
+                                    start: Expr [28-29]:
+                                        ty: Int(None, true)
+                                        kind: Lit: Int(1)
+                                    step: <none>
+                                    end: Expr [30-31]:
+                                        ty: Int(None, true)
+                                        kind: Lit: Int(3)
+        "#]],
+    );
+}
+
+#[test]
+fn on_a_zero_len_qubit_register() {
+    check_stmt_kinds(
+        "qubit[0] q;
+        reset q;",
+        &expect![[r#"
+            QubitArrayDeclaration [0-11]:
+                symbol_id: 8
+                size: 0
+                size_span: [6-7]
+            ResetStmt [20-28]:
+                reset_token_span: [20-25]
+                operand: GateOperand [26-27]:
+                    kind: Expr [26-27]:
+                        ty: QubitArray(0)
+                        kind: SymbolId(8)
+        "#]],
+    );
+}
+
+#[test]
+fn on_an_unindexed_qubit_register() {
+    check_stmt_kinds(
+        "qubit[5] q;
+        reset q;",
+        &expect![[r#"
+            QubitArrayDeclaration [0-11]:
+                symbol_id: 8
+                size: 5
+                size_span: [6-7]
+            ResetStmt [20-28]:
+                reset_token_span: [20-25]
+                operand: GateOperand [26-27]:
+                    kind: Expr [26-27]:
+                        ty: QubitArray(5)
+                        kind: SymbolId(8)
+        "#]],
+    );
+}

--- a/compiler/qsc_qasm/src/tests/statement/reset.rs
+++ b/compiler/qsc_qasm/src/tests/statement/reset.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
-    tests::{compile_with_config, fail_on_compilation_errors, gen_qsharp},
+    tests::{compile_qasm_to_qsharp, compile_with_config, fail_on_compilation_errors, gen_qsharp},
     CompilerConfig, OutputSemantics, ProgramType, QubitSemantics,
 };
 use expect_test::expect;
@@ -158,5 +158,90 @@ fn reset_with_adaptive_ri_profile_generates_reset_qir() -> miette::Result<(), Ve
     ]
     .assert_eq(&qir);
 
+    Ok(())
+}
+
+#[test]
+fn on_a_single_qubit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        qubit q;
+        reset q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.__quantum__rt__qubit_allocate();
+        Reset(q);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn on_an_indexed_qubit_register() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        qubit[5] q;
+        reset q[2];
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(5);
+        Reset(q[2]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn on_a_span_indexed_qubit_register() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        qubit[5] q;
+        reset q[1:3];
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(5);
+        ResetAll(q[1..3]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn on_a_zero_len_qubit_register() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        qubit[0] q;
+        reset q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(0);
+        ResetAll(q);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn on_an_unindexed_qubit_register() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        qubit[5] q;
+        reset q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(5);
+        ResetAll(q);
+    "#]]
+    .assert_eq(&qsharp);
     Ok(())
 }


### PR DESCRIPTION
Implements broadcast for resetting qubits. Any qubit registers are passed to `ResetAll` so that we don't have to generate many reset calls in the AST.