### PR TITLE
Updates some of the CSS colors for Circuits

### DIFF
--- a/npm/qsharp/ux/qsharp-circuit.css
+++ b/npm/qsharp/ux/qsharp-circuit.css
@@ -83,16 +83,16 @@
 
   /* Edit mode style for arg-button (hyperlink appearance) */
   .arg-button.edit-mode {
-    fill: var(--vscode-textLink-foreground, #0066cc);
+    /* fill: var(--vscode-textLink-foreground, #0066cc); */
     text-decoration: underline;
     cursor: pointer;
     pointer-events: all;
   }
 
   /* Hover style for arg-button in edit mode */
-  .arg-button.edit-mode:hover {
-    fill: var(--vscode-textLink-activeForeground, #004499); /* Hover color */
-  }
+  /* .arg-button.edit-mode:hover {
+    fill: var(--vscode-textLink-activeForeground, #004499);
+  } */
 
   /* Dot and line for controlled gates */
   .gate > line,
@@ -409,7 +409,7 @@
   margin: 0 5px;
   background: var(--vscode-button-background, #007acc);
   color: var(--vscode-button-foreground, #ffffff);
-  border: 1px solid var(--vscode-button-border, #005a9e);
+  border: 1px solid var(--vscode-button-border, transparent);
   cursor: pointer;
   border-radius: 4px;
 }
@@ -419,9 +419,7 @@
 }
 
 .prompt-button:disabled {
-  background: var(--vscode-button-secondaryBackground, #d4d4d4);
-  color: var(--vscode-disabledForeground, #a1a1a1);
-  border: 1px solid var(--vscode-button-secondaryBackground, #d4d4d4);
+  opacity: 0.4;
   cursor: not-allowed;
 }
 

--- a/npm/qsharp/ux/qsharp-circuit.css
+++ b/npm/qsharp/ux/qsharp-circuit.css
@@ -83,16 +83,10 @@
 
   /* Edit mode style for arg-button (hyperlink appearance) */
   .arg-button.edit-mode {
-    /* fill: var(--vscode-textLink-foreground, #0066cc); */
     text-decoration: underline;
     cursor: pointer;
     pointer-events: all;
   }
-
-  /* Hover style for arg-button in edit mode */
-  /* .arg-button.edit-mode:hover {
-    fill: var(--vscode-textLink-activeForeground, #004499);
-  } */
 
   /* Dot and line for controlled gates */
   .gate > line,


### PR DESCRIPTION
Made some suggested changes to the color schemes of some of the details in the Circuit Editor:
 - The disabled "OK" button now uses the same colors as other buttons and just uses an opacity to indicate its unavailability.
![image](https://github.com/user-attachments/assets/e2cc2fc8-59a5-42cd-9fbb-56bccc37b30b)
 - The default color for button boarders is now transparent so if a theme doesn't define a border color, boarders do not appear.
 - The argument on gates will remain underlined and have the "clickable" cursor on hover, but the color will not be hyperlink blue as that did not mesh well with certain themes. The color is now the same as the regular text color.
![image](https://github.com/user-attachments/assets/54cb6d26-eba7-45c7-82fe-34ff55a626e5)