### PR TITLE
Restore fancy error reporting in Python

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ indoc = "2.0"
 js-sys = "0.3"
 libfuzzer-sys = "0.4"
 log = "0.4"
-miette = { version = "7.2", features = ["fancy-no-syscall"] }
+miette = { version = "7.2" }
 thiserror = "1.0"
 nalgebra = { version = "0.33" }
 ndarray = "0.15.4"

--- a/compiler/qsc/Cargo.toml
+++ b/compiler/qsc/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 clap = { workspace = true, features = ["derive", "cargo"] }
 env_logger = { workspace = true }
 log = { workspace = true }
-miette = { workspace = true, features = ["fancy-no-syscall"] }
+miette = { workspace = true }
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
 qsc_codegen = { path = "../qsc_codegen" }

--- a/pip/Cargo.toml
+++ b/pip/Cargo.toml
@@ -15,7 +15,7 @@ num-bigint = { workspace = true }
 num-complex = { workspace = true }
 qsc = { path = "../compiler/qsc" }
 resource_estimator = { path = "../resource_estimator" }
-miette = { workspace = true, features = ["fancy-no-syscall"] }
+miette = { workspace = true, features = ["fancy"] }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -891,7 +891,8 @@ pub(crate) fn format_errors(errors: Vec<interpret::Error>) -> String {
     errors
         .into_iter()
         .map(|e| format_error(&e))
-        .collect::<String>()
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 pub(crate) fn format_error(e: &interpret::Error) -> String {

--- a/resource_estimator/Cargo.toml
+++ b/resource_estimator/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 [dependencies]
 qsc = { path = "../compiler/qsc" }
 thiserror = { workspace = true }
-miette = { workspace = true, features = ["fancy-no-syscall"] }
+miette = { workspace = true }
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
 rand = { workspace = true }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = { workspace = true }
 js-sys = { workspace = true }
 katas = { path = "../katas"}
 log = { workspace = true }
-miette = { workspace = true }
+miette = { workspace = true, features = ["fancy-no-syscall"] }
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
 qsls = { path = "../language_service" }


### PR DESCRIPTION
This change updates the way we pull features for miette such that the wasm crate preserves the ASCII-based "fancy-no-syscall" behavior needed for broader extension/web compatibility, while allowing the native pip crate to use full "fancy" and have colors and symbols for improved readability.

Before:
![image](https://github.com/user-attachments/assets/1168b51d-0604-49e5-b112-ad1b51eacd9c)

After:
![image](https://github.com/user-attachments/assets/cfc16f59-6ac3-491a-a6fe-a4958e1453c1)

Existing behavior (and reduced dependencies) preserved in VS Code:
![image](https://github.com/user-attachments/assets/4ce04b02-84b6-4bb8-8ce8-cc2ae3aa9f13)


Fixes #1898