### PR TITLE
Added OpenQASM samples as templates in VSCode

### DIFF
--- a/npm/qsharp/generate_samples_content.js
+++ b/npm/qsharp/generate_samples_content.js
@@ -7,26 +7,52 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import samples from "../../samples/samples.mjs";
+import qSharpSampleList from "../../samples/samples.mjs";
+import openQasmSampleList from "../../samples/OpenQASM/samples.mjs";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
-const sampleDir = join(thisDir, "..", "..", "samples");
-const sampleGeneratedDir = join(thisDir, "src");
+const qSharpSampleDir = join(thisDir, "..", "..", "samples");
+const openQasmSampleDir = join(thisDir, "..", "..", "samples", "OpenQASM");
 
-const result = samples.map((sample) => {
-  const samplePath = join(sampleDir, sample.file);
-  const sampleText = readFileSync(samplePath, "utf8");
-  return {
-    title: sample.title,
-    shots: sample.shots,
-    code: sampleText,
-    omitFromTests: sample.omitFromTests,
-  };
-});
+const tsDir = join(thisDir, "src");
+const qSharpGeneratedTsPath = join(tsDir, "samples.generated.ts");
+const openQasmGeneratedTsPath = join(tsDir, "openqasm-samples.generated.ts");
 
-const contentPath = join(sampleGeneratedDir, "samples.generated.ts");
-writeFileSync(
-  contentPath,
-  `export default ${JSON.stringify(result, undefined, 2)}`,
-  "utf-8",
+embedSampleContentsInTsFile(
+  qSharpSampleList,
+  qSharpSampleDir,
+  qSharpGeneratedTsPath,
 );
+embedSampleContentsInTsFile(
+  openQasmSampleList,
+  openQasmSampleDir,
+  openQasmGeneratedTsPath,
+);
+
+/**
+ * @param {any[]} sampleList
+ * @param {string} sampleDir
+ * @param {import("fs").PathOrFileDescriptor} generatedJsFileName
+ */
+function embedSampleContentsInTsFile(
+  sampleList,
+  sampleDir,
+  generatedJsFileName,
+) {
+  const result = sampleList.map((sample) => {
+    const samplePath = join(sampleDir, sample.file);
+    const sampleText = readFileSync(samplePath, "utf8");
+    return {
+      title: sample.title,
+      shots: sample.shots,
+      code: sampleText,
+      omitFromTests: sample.omitFromTests,
+    };
+  });
+
+  writeFileSync(
+    generatedJsFileName,
+    `export default ${JSON.stringify(result, undefined, 2)}`,
+    "utf-8",
+  );
+}

--- a/npm/qsharp/src/browser.ts
+++ b/npm/qsharp/src/browser.ts
@@ -184,6 +184,7 @@ export type {
   LanguageServiceTestCallablesEvent,
 } from "./language-service/language-service.js";
 export { default as samples } from "./samples.generated.js";
+export { default as openqasm_samples } from "./openqasm-samples.generated.js";
 export { log, type LogLevel, type TargetProfile, type ProjectType };
 export type {
   ICompiler,

--- a/samples/OpenQASM/samples.mjs
+++ b/samples/OpenQASM/samples.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// @ts-check
+
+// This file gives the order, title, and default shots for each sample
+
+/** @type {Array<{title: string; file: string; shots: number; omitFromTests?: boolean}>} */
+export default [
+    { title: "Hello World in OpenQASM", file: "./OpenQasmHelloWorld.qasm", shots: 100 },
+    { title: "Random Number Generator", file: "./RandomNumber.qasm", shots: 1000 },
+    { title: "Bell Pair Creation", file: "./BellPair.qasm", shots: 1000 },
+    { title: "Bernstein-Vazirani Algorithm", file: "./BernsteinVazirani.qasm", shots: 10 },
+    { title: "Grover Search Algorithm", file: "./Grover.qasm", shots: 10 },
+]

--- a/vscode/src/language-service/completion.ts
+++ b/vscode/src/language-service/completion.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ILanguageService, samples } from "qsharp-lang";
+import { ILanguageService, samples, openqasm_samples } from "qsharp-lang";
 import * as vscode from "vscode";
 import { CompletionItem } from "vscode";
-import { toVsCodeRange } from "../common";
+import { isOpenQasmDocument, isQsharpDocument, toVsCodeRange } from "../common";
 import { EventType, sendTelemetryEvent } from "../telemetry";
 
 export function createCompletionItemProvider(
@@ -15,9 +15,18 @@ export function createCompletionItemProvider(
 
 class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
   private samples: vscode.CompletionItem[] = [];
+  private openqasm_samples: vscode.CompletionItem[] = [];
 
   constructor(public languageService: ILanguageService) {
     this.samples = samples.map((s) => {
+      const item = new CompletionItem(
+        s.title + " sample",
+        vscode.CompletionItemKind.Snippet,
+      );
+      item.insertText = s.code;
+      return item;
+    });
+    this.openqasm_samples = openqasm_samples.map((s) => {
       const item = new CompletionItem(
         s.title + " sample",
         vscode.CompletionItemKind.Snippet,
@@ -49,7 +58,7 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
         completionListLength: completions.items.length,
       },
     );
-    const results = completions.items.map((c) => {
+    var results = completions.items.map((c) => {
       let kind;
       switch (c.kind) {
         case "function":
@@ -89,17 +98,25 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
       return item;
     });
 
-    // Include the samples in contexts that are syntactically appropriate.
-    // The presence of the "operation" keyword in the completion list is a
-    // hint that the cursor is at a point we can insert the sample code.
-
-    const shouldIncludeSamples =
+    // In qsharp documents include the qsharp samples in contexts that are syntactically
+    // appropriate. The presence of the "operation" keyword in/ the completion list
+    // is a hint that the cursor is at a point we can insert the sample code.
+    if (
+      isQsharpDocument(document) &&
       results.findIndex(
         (i) =>
           i.kind === vscode.CompletionItemKind.Keyword &&
           i.label === "operation",
-      ) !== -1;
+      ) !== -1
+    ) {
+      results = results.concat(this.samples);
+    }
 
-    return !shouldIncludeSamples ? results : results.concat(this.samples);
+    // In OpenQASM documents always include the OpenQASM samples.
+    if (isOpenQasmDocument(document)) {
+      results = results.concat(this.openqasm_samples);
+    }
+
+    return results;
   }
 }


### PR DESCRIPTION
This adds OpenQASM samples as templates in VSCode. They are available when editing OpenQASM files in any context. This shouldn't affect Q# completions (something to check).