### PR TITLE
Ty names are now human readable for errors

### DIFF
--- a/compiler/qsc_qasm/src/semantic/error.rs
+++ b/compiler/qsc_qasm/src/semantic/error.rs
@@ -166,9 +166,9 @@ pub enum SemanticErrorKind {
     #[error("{0} were introduced in version {1}")]
     #[diagnostic(code("Qasm.Lowerer.NotSupportedInThisVersion"))]
     NotSupportedInThisVersion(String, String, #[label] Span),
-    #[error("the operator {0} is not valid with lhs {1} and rhs {2}")]
-    #[diagnostic(code("Qasm.Lowerer.OperatorNotSupportedForTypes"))]
-    OperatorNotSupportedForTypes(String, String, String, #[label] Span),
+    #[error("the operator {0} is not allowed for complex values")]
+    #[diagnostic(code("Qasm.Lowerer.OperatorNotAllowedForComplexValues"))]
+    OperatorNotAllowedForComplexValues(String, #[label] Span),
     #[error("pow gate modifiers must have an exponent")]
     #[diagnostic(code("Qasm.Lowerer.PowModifierMustHaveExponent"))]
     PowModifierMustHaveExponent(#[label] Span),

--- a/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -3277,15 +3277,19 @@ impl Lowerer {
             let Some(ty) = ty else {
                 let target_ty = Type::UInt(None, left_type.is_const() && right_type.is_const());
                 if lhs_uint_promotion.is_none() {
-                    let target_str: String = target_ty.to_string();
-                    let kind =
-                        SemanticErrorKind::CannotCast(left_type.to_string(), target_str, lhs.span);
+                    let kind = SemanticErrorKind::CannotCast(
+                        left_type.to_string(),
+                        target_ty.to_string(),
+                        lhs.span,
+                    );
                     self.push_semantic_error(kind);
                 }
                 if rhs_uint_promotion.is_none() {
-                    let target_str = target_ty.to_string();
-                    let kind =
-                        SemanticErrorKind::CannotCast(right_type.to_string(), target_str, rhs.span);
+                    let kind = SemanticErrorKind::CannotCast(
+                        right_type.to_string(),
+                        target_ty.to_string(),
+                        rhs.span,
+                    );
                     self.push_semantic_error(kind);
                 }
                 let bin_expr = semantic::BinaryOpExpr {

--- a/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -1034,7 +1034,7 @@ impl Lowerer {
             Type::Void => crate::types::Type::Tuple(vec![]),
             Type::Err => crate::types::Type::Err,
             _ => {
-                let msg = format!("converting {ty:?} to Q# type");
+                let msg = format!("converting `{ty}` to Q# type");
                 self.push_unimplemented_error_message(msg, span);
                 crate::types::Type::Err
             }
@@ -2746,7 +2746,7 @@ impl Lowerer {
                 )))
             }
             Type::Gate(_, _) | Type::Function(..) | Type::Range | Type::Set | Type::Void => {
-                let message = format!("default values for {ty:?}");
+                let message = format!("default values for {ty}");
                 self.push_unsupported_error_message(message, span);
                 None
             }
@@ -3277,21 +3277,15 @@ impl Lowerer {
             let Some(ty) = ty else {
                 let target_ty = Type::UInt(None, left_type.is_const() && right_type.is_const());
                 if lhs_uint_promotion.is_none() {
-                    let target_str: String = format!("{target_ty:?}");
-                    let kind = SemanticErrorKind::CannotCast(
-                        format!("{left_type:?}"),
-                        target_str,
-                        lhs.span,
-                    );
+                    let target_str: String = target_ty.to_string();
+                    let kind =
+                        SemanticErrorKind::CannotCast(left_type.to_string(), target_str, lhs.span);
                     self.push_semantic_error(kind);
                 }
                 if rhs_uint_promotion.is_none() {
-                    let target_str: String = format!("{target_ty:?}");
-                    let kind = SemanticErrorKind::CannotCast(
-                        format!("{right_type:?}"),
-                        target_str,
-                        rhs.span,
-                    );
+                    let target_str = target_ty.to_string();
+                    let kind =
+                        SemanticErrorKind::CannotCast(right_type.to_string(), target_str, rhs.span);
                     self.push_semantic_error(kind);
                 }
                 let bin_expr = semantic::BinaryOpExpr {
@@ -3437,12 +3431,8 @@ impl Lowerer {
                     ty: ty.clone(),
                 }
             } else {
-                let kind = SemanticErrorKind::OperatorNotSupportedForTypes(
-                    format!("{op:?}"),
-                    format!("{ty:?}"),
-                    format!("{ty:?}"),
-                    span,
-                );
+                let kind =
+                    SemanticErrorKind::OperatorNotAllowedForComplexValues(format!("{op:?}"), span);
                 self.push_semantic_error(kind);
                 err_expr!(ty.clone())
             }
@@ -3677,7 +3667,7 @@ impl Lowerer {
         indices: &[semantic::Index],
     ) -> super::types::Type {
         if !ty.is_array() {
-            let kind = SemanticErrorKind::CannotIndexType(format!("{ty:?}"), span);
+            let kind = SemanticErrorKind::CannotIndexType(ty.to_string(), span);
             self.push_semantic_error(kind);
             return super::types::Type::Err;
         }
@@ -3693,7 +3683,7 @@ impl Lowerer {
         } else {
             // we failed to get the indexed type, unknown error
             // we should have caught this earlier with the two checks above
-            let kind = SemanticErrorKind::CannotIndexType(format!("{ty:?}"), span);
+            let kind = SemanticErrorKind::CannotIndexType(ty.to_string(), span);
             self.push_semantic_error(kind);
             super::types::Type::Err
         }
@@ -3797,8 +3787,8 @@ impl Lowerer {
             // if either type is an error, we don't need to push an error
             return;
         }
-        let rhs_ty_name = format!("{expr_ty:?}");
-        let lhs_ty_name = format!("{target_ty:?}");
+        let rhs_ty_name = expr_ty.to_string();
+        let lhs_ty_name = target_ty.to_string();
         let kind = SemanticErrorKind::CannotCast(rhs_ty_name, lhs_ty_name, span);
         self.push_semantic_error(kind);
     }
@@ -3808,8 +3798,9 @@ impl Lowerer {
             // if either type is an error, we don't need to push an error
             return;
         }
-        let rhs_ty_name = format!("{expr_ty:?}");
-        let lhs_ty_name = format!("{target_ty:?}");
+
+        let rhs_ty_name = expr_ty.to_string();
+        let lhs_ty_name = target_ty.to_string();
         let kind = SemanticErrorKind::CannotCastLiteral(rhs_ty_name, lhs_ty_name, span);
         self.push_semantic_error(kind);
     }

--- a/compiler/qsc_qasm/src/semantic/tests.rs
+++ b/compiler/qsc_qasm/src/semantic/tests.rs
@@ -193,7 +193,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                             symbol_id: 32
                             ty_span: [196-199]
                             init_expr: Expr [204-205]:
-                                ty: Bit(true)
+                                ty: const bit
                                 kind: Lit: Bit(1)
                     Stmt [211-227]:
                         annotations: <empty>
@@ -201,18 +201,18 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                             symbol_id: 32
                             ty_span: [211-215]
                             init_expr: Expr [220-226]:
-                                ty: Bool(false)
+                                ty: bool
                                 kind: BinaryOpExpr:
                                     op: AndL
                                     lhs: Expr [220-221]:
-                                        ty: Err
+                                        ty: unknown
                                         kind: SymbolId(33)
                                     rhs: Expr [225-226]:
-                                        ty: Bool(false)
+                                        ty: bool
                                         kind: Cast [0-0]:
-                                            ty: Bool(false)
+                                            ty: bool
                                             expr: Expr [225-226]:
-                                                ty: Bit(false)
+                                                ty: bit
                                                 kind: SymbolId(32)
                     Stmt [140-154]:
                         annotations: <empty>
@@ -220,7 +220,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                             symbol_id: 34
                             ty_span: [140-145]
                             init_expr: Expr [150-153]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0.7168146928204138)
                     Stmt [159-179]:
                         annotations: <empty>
@@ -228,18 +228,18 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                             symbol_id: 35
                             ty_span: [159-164]
                             init_expr: Expr [169-178]:
-                                ty: Float(None, false)
+                                ty: float
                                 kind: BinaryOpExpr:
                                     op: Add
                                     lhs: Expr [169-170]:
-                                        ty: Angle(None, false)
+                                        ty: angle
                                         kind: SymbolId(34)
                                     rhs: Expr [173-178]:
-                                        ty: Float(None, false)
+                                        ty: float
                                         kind: Cast [0-0]:
-                                            ty: Float(None, false)
+                                            ty: float
                                             expr: Expr [173-178]:
-                                                ty: Bool(true)
+                                                ty: const bool
                                                 kind: Lit: Bool(false)
                     Stmt [74-84]:
                         annotations: <empty>
@@ -247,7 +247,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                             symbol_id: 37
                             ty_span: [74-77]
                             init_expr: Expr [82-83]:
-                                ty: Err
+                                ty: unknown
                                 kind: SymbolId(36)
 
             [Qasm.Lowerer.UndefinedSymbol
@@ -268,8 +268,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Float(None,
-              | false)
+              x cannot cast expression of type angle to type float
                ,-[source1.qasm:3:15]
              2 |     angle j = 7.0;
              3 |     float k = j + false; // invalid cast

--- a/compiler/qsc_qasm/src/semantic/tests/assignment.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/assignment.rs
@@ -29,52 +29,52 @@ fn too_many_indices_in_indexed_assignment() {
                                             ty: FloatArray(Some(32), One(2))
                                             kind: Lit:     array:
                                                     Expr [45-48]:
-                                                        ty: Float(Some(32), false)
+                                                        ty: float[32]
                                                         kind: Cast [0-0]:
-                                                            ty: Float(Some(32), false)
+                                                            ty: float[32]
                                                             expr: Expr [45-48]:
-                                                                ty: Float(None, true)
+                                                                ty: const float
                                                                 kind: Lit: Float(1.1)
                                                     Expr [50-53]:
-                                                        ty: Float(Some(32), false)
+                                                        ty: float[32]
                                                         kind: Cast [0-0]:
-                                                            ty: Float(Some(32), false)
+                                                            ty: float[32]
                                                             expr: Expr [50-53]:
-                                                                ty: Float(None, true)
+                                                                ty: const float
                                                                 kind: Lit: Float(1.2)
                                         Expr [56-66]:
                                             ty: FloatArray(Some(32), One(2))
                                             kind: Lit:     array:
                                                     Expr [57-60]:
-                                                        ty: Float(Some(32), false)
+                                                        ty: float[32]
                                                         kind: Cast [0-0]:
-                                                            ty: Float(Some(32), false)
+                                                            ty: float[32]
                                                             expr: Expr [57-60]:
-                                                                ty: Float(None, true)
+                                                                ty: const float
                                                                 kind: Lit: Float(2.1)
                                                     Expr [62-65]:
-                                                        ty: Float(Some(32), false)
+                                                        ty: float[32]
                                                         kind: Cast [0-0]:
-                                                            ty: Float(Some(32), false)
+                                                            ty: float[32]
                                                             expr: Expr [62-65]:
-                                                                ty: Float(None, true)
+                                                                ty: const float
                                                                 kind: Lit: Float(2.2)
                                         Expr [68-78]:
                                             ty: FloatArray(Some(32), One(2))
                                             kind: Lit:     array:
                                                     Expr [69-72]:
-                                                        ty: Float(Some(32), false)
+                                                        ty: float[32]
                                                         kind: Cast [0-0]:
-                                                            ty: Float(Some(32), false)
+                                                            ty: float[32]
                                                             expr: Expr [69-72]:
-                                                                ty: Float(None, true)
+                                                                ty: const float
                                                                 kind: Lit: Float(3.1)
                                                     Expr [74-77]:
-                                                        ty: Float(Some(32), false)
+                                                        ty: float[32]
                                                         kind: Cast [0-0]:
-                                                            ty: Float(Some(32), false)
+                                                            ty: float[32]
                                                             expr: Expr [74-77]:
-                                                                ty: Float(None, true)
+                                                                ty: const float
                                                                 kind: Lit: Float(3.2)
                     Stmt [89-113]:
                         annotations: <empty>
@@ -85,16 +85,16 @@ fn too_many_indices_in_indexed_assignment() {
                                 index_span: [97-106]
                                 indices:
                                     Expr [98-99]:
-                                        ty: Int(None, true)
+                                        ty: const int
                                         kind: Lit: Int(1)
                                     Expr [101-102]:
-                                        ty: Int(None, true)
+                                        ty: const int
                                         kind: Lit: Int(1)
                                     Expr [104-105]:
-                                        ty: Int(None, true)
+                                        ty: const int
                                         kind: Lit: Int(3)
                             rhs: Expr [109-112]:
-                                ty: Float(None, true)
+                                ty: const float
                                 kind: Lit: Float(2.3)
 
             [Qasm.Lowerer.TooManyIndices

--- a/compiler/qsc_qasm/src/semantic/tests/assignment.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/assignment.rs
@@ -23,10 +23,10 @@ fn too_many_indices_in_indexed_assignment() {
                             symbol_id: 8
                             ty_span: [9-31]
                             init_expr: Expr [43-79]:
-                                ty: FloatArray(Some(32), Two(3, 2))
+                                ty: array[float[32], 3, 2]
                                 kind: Lit:     array:
                                         Expr [44-54]:
-                                            ty: FloatArray(Some(32), One(2))
+                                            ty: array[float[32], 2]
                                             kind: Lit:     array:
                                                     Expr [45-48]:
                                                         ty: float[32]
@@ -43,7 +43,7 @@ fn too_many_indices_in_indexed_assignment() {
                                                                 ty: const float
                                                                 kind: Lit: Float(1.2)
                                         Expr [56-66]:
-                                            ty: FloatArray(Some(32), One(2))
+                                            ty: array[float[32], 2]
                                             kind: Lit:     array:
                                                     Expr [57-60]:
                                                         ty: float[32]
@@ -60,7 +60,7 @@ fn too_many_indices_in_indexed_assignment() {
                                                                 ty: const float
                                                                 kind: Lit: Float(2.2)
                                         Expr [68-78]:
-                                            ty: FloatArray(Some(32), One(2))
+                                            ty: array[float[32], 2]
                                             kind: Lit:     array:
                                                     Expr [69-72]:
                                                         ty: float[32]

--- a/compiler/qsc_qasm/src/semantic/tests/decls.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls.rs
@@ -66,7 +66,7 @@ fn scalar_ty_designator_must_be_positive() {
                             symbol_id: 8
                             ty_span: [0-7]
                             init_expr: Expr [0-0]:
-                                ty: Err
+                                ty: unknown
                                 kind: Err
 
             [Qasm.Lowerer.TypeWidthMustBePositiveIntConstExpr
@@ -94,7 +94,7 @@ fn scalar_ty_designator_must_be_castable_to_const_int() {
                             symbol_id: 8
                             ty_span: [6-11]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(2.0000000000000004)
                     Stmt [24-36]:
                         annotations: <empty>
@@ -102,12 +102,12 @@ fn scalar_ty_designator_must_be_castable_to_const_int() {
                             symbol_id: 9
                             ty_span: [24-33]
                             init_expr: Expr [0-0]:
-                                ty: Err
+                                ty: unknown
                                 kind: Err
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, true) to type UInt(None, true)
+              x cannot cast expression of type const angle to type const uint
                ,-[test:1:29]
              1 | const angle size = 2.0; int[size] i;
                :                             ^^^^

--- a/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
@@ -14,11 +14,11 @@ fn implicit_bitness_default() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [0-0]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(0)
             [8] Symbol [6-7]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -33,11 +33,11 @@ fn lit() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [6-7]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -52,11 +52,11 @@ fn const_lit() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-20]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [12-13]:
                 name: x
-                type: Angle(None, true)
+                type: const angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -71,11 +71,11 @@ fn lit_explicit_width() {
                 symbol_id: 8
                 ty_span: [0-9]
                 init_expr: Expr [14-18]:
-                    ty: Angle(Some(64), true)
+                    ty: const angle[64]
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [10-11]:
                 name: x
-                type: Angle(Some(64), false)
+                type: angle[64]
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -90,11 +90,11 @@ fn const_explicit_width_lit() {
                 symbol_id: 8
                 ty_span: [6-15]
                 init_expr: Expr [20-24]:
-                    ty: Angle(Some(64), true)
+                    ty: const angle[64]
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [16-17]:
                 name: x
-                type: Angle(Some(64), true)
+                type: const angle[64]
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -109,11 +109,11 @@ fn lit_decl_leading_dot() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(0.4210000000000001)
             [8] Symbol [6-7]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -128,11 +128,11 @@ fn const_lit_decl_leading_dot() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-20]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(0.4210000000000001)
             [8] Symbol [12-13]:
                 name: x
-                type: Angle(None, true)
+                type: const angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -147,11 +147,11 @@ fn const_lit_decl_leading_dot_scientific() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-22]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [12-13]:
                 name: x
-                type: Angle(None, true)
+                type: const angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -166,11 +166,11 @@ fn lit_decl_trailing_dot() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(0.02658441896772248)
             [8] Symbol [6-7]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -185,11 +185,11 @@ fn const_lit_decl_trailing_dot() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-20]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(0.02658441896772248)
             [8] Symbol [12-13]:
                 name: x
-                type: Angle(None, true)
+                type: const angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -204,11 +204,11 @@ fn lit_decl_scientific() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-16]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [6-7]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -223,11 +223,11 @@ fn const_lit_decl_scientific() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-22]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [12-13]:
                 name: x
-                type: Angle(None, true)
+                type: const angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -242,11 +242,11 @@ fn lit_decl_scientific_signed_pos() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-17]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [6-7]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -261,11 +261,11 @@ fn const_lit_decl_scientific_signed_pos() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-23]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [12-13]:
                 name: x
-                type: Angle(None, true)
+                type: const angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -280,11 +280,11 @@ fn lit_decl_scientific_cap_e() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-16]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [6-7]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -299,11 +299,11 @@ fn const_lit_decl_scientific_cap_e() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-22]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [12-13]:
                 name: x
-                type: Angle(None, true)
+                type: const angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -318,11 +318,11 @@ fn lit_decl_scientific_signed_neg() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-18]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [6-7]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -337,11 +337,11 @@ fn const_lit_decl_scientific_signed_neg() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-24]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.400888156922484)
             [8] Symbol [12-13]:
                 name: x
-                type: Angle(None, true)
+                type: const angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -356,19 +356,19 @@ fn const_lit_decl_signed_float_lit_cast_neg() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [17-19]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Cast [0-0]:
-                        ty: Angle(None, true)
+                        ty: const angle
                         expr: Expr [17-19]:
-                            ty: Float(None, true)
+                            ty: const float
                             kind: UnaryOpExpr [17-19]:
                                 op: Neg
                                 expr: Expr [17-19]:
-                                    ty: Float(None, true)
+                                    ty: const float
                                     kind: Lit: Float(7.0)
             [8] Symbol [12-13]:
                 name: x
-                type: Angle(None, true)
+                type: const angle
                 qsharp_type: Angle
                 io_kind: Default"#]],
     );
@@ -388,16 +388,16 @@ fn const_lit_decl_signed_int_lit_cast_neg_fails() {
                             symbol_id: 8
                             ty_span: [6-11]
                             init_expr: Expr [17-18]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: UnaryOpExpr [17-18]:
                                     op: Neg
                                     expr: Expr [17-18]:
-                                        ty: Int(None, true)
+                                        ty: const int
                                         kind: Lit: Int(7)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(None, true) to type Angle(None, true)
+              x cannot cast expression of type const int to type const angle
                ,-[test:1:18]
              1 | const angle x = -7;
                :                  ^
@@ -420,7 +420,7 @@ fn explicit_zero_width_fails() {
                             symbol_id: 8
                             ty_span: [0-8]
                             init_expr: Expr [13-17]:
-                                ty: Float(None, true)
+                                ty: const float
                                 kind: Lit: Float(42.1)
 
             [Qasm.Lowerer.TypeWidthMustBePositiveIntConstExpr
@@ -448,7 +448,7 @@ fn explicit_width_over_64_fails() {
                             symbol_id: 8
                             ty_span: [6-15]
                             init_expr: Expr [20-24]:
-                                ty: Float(None, true)
+                                ty: const float
                                 kind: Lit: Float(42.1)
 
             [Qasm.Lowerer.TypeMaxWidthExceeded

--- a/compiler/qsc_qasm/src/semantic/tests/decls/bit.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/bit.rs
@@ -14,11 +14,11 @@ fn with_no_init_expr_has_generated_lit_expr() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [8] Symbol [4-5]:
                 name: a
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default"#]],
     );
@@ -33,11 +33,11 @@ fn array_with_no_init_expr_has_generated_lit_expr() {
                 symbol_id: 8
                 ty_span: [0-6]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(4, true)
+                    ty: const bit[4]
                     kind: Lit: Bitstring("0000")
             [8] Symbol [7-8]:
                 name: a
-                type: BitArray(4, false)
+                type: bit[4]
                 qsharp_type: Result[]
                 io_kind: Default"#]],
     );
@@ -52,11 +52,11 @@ fn decl_with_lit_0_init_expr() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-9]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [8] Symbol [4-5]:
                 name: a
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default"#]],
     );
@@ -71,11 +71,11 @@ fn decl_with_lit_1_init_expr() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-9]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [4-5]:
                 name: a
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default"#]],
     );
@@ -90,11 +90,11 @@ fn const_decl_with_lit_0_init_expr() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-15]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [8] Symbol [10-11]:
                 name: a
-                type: Bit(true)
+                type: const bit
                 qsharp_type: Result
                 io_kind: Default"#]],
     );
@@ -109,11 +109,11 @@ fn const_decl_with_lit_1_init_expr() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-15]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [10-11]:
                 name: a
-                type: Bit(true)
+                type: const bit
                 qsharp_type: Result
                 io_kind: Default"#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/decls/bool.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/bool.rs
@@ -33,7 +33,7 @@ fn array_with_no_init_expr_has_generated_lit_expr() {
                 symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [0-0]:
-                    ty: BoolArray(One(4))
+                    ty: array[bool, 4]
                     kind: Lit:     array:
                             Expr [0-0]:
                                 ty: const bool
@@ -49,7 +49,7 @@ fn array_with_no_init_expr_has_generated_lit_expr() {
                                 kind: Lit: Bool(false)
             [8] Symbol [15-16]:
                 name: a
-                type: BoolArray(One(4))
+                type: array[bool, 4]
                 qsharp_type: bool[]
                 io_kind: Default"#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/decls/bool.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/bool.rs
@@ -14,11 +14,11 @@ fn with_no_init_expr_has_generated_lit_expr() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             [8] Symbol [5-6]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default"#]],
     );
@@ -36,16 +36,16 @@ fn array_with_no_init_expr_has_generated_lit_expr() {
                     ty: BoolArray(One(4))
                     kind: Lit:     array:
                             Expr [0-0]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(false)
                             Expr [0-0]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(false)
                             Expr [0-0]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(false)
                             Expr [0-0]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(false)
             [8] Symbol [15-16]:
                 name: a
@@ -64,11 +64,11 @@ fn decl_with_lit_false_init_expr() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-14]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(false)
             [8] Symbol [5-6]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default"#]],
     );
@@ -83,11 +83,11 @@ fn decl_with_lit_true_init_expr() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-13]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [5-6]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default"#]],
     );
@@ -102,11 +102,11 @@ fn const_decl_with_lit_false_init_expr() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-20]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             [8] Symbol [11-12]:
                 name: a
-                type: Bool(true)
+                type: const bool
                 qsharp_type: bool
                 io_kind: Default"#]],
     );
@@ -121,11 +121,11 @@ fn const_decl_with_lit_true_init_expr() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-19]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
             [8] Symbol [11-12]:
                 name: a
-                type: Bool(true)
+                type: const bool
                 qsharp_type: bool
                 io_kind: Default"#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/decls/complex.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/complex.rs
@@ -14,11 +14,11 @@ fn implicit_bitness_default() {
                 symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [0-0]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -33,11 +33,11 @@ fn explicit_bitness_default() {
                 symbol_id: 8
                 ty_span: [0-18]
                 init_expr: Expr [0-0]:
-                    ty: Complex(Some(42), true)
+                    ty: const complex[float[42]]
                     kind: Lit: Complex(0.0, 0.0)
             [8] Symbol [19-20]:
                 name: x
-                type: Complex(Some(42), false)
+                type: complex[float[42]]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -52,11 +52,11 @@ fn const_implicit_bitness_double_img_only() {
                 symbol_id: 8
                 ty_span: [6-20]
                 init_expr: Expr [25-31]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 1.01)
             [8] Symbol [21-22]:
                 name: x
-                type: Complex(None, true)
+                type: const complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -71,11 +71,11 @@ fn const_implicit_bitness_int_img_only() {
                 symbol_id: 8
                 ty_span: [6-20]
                 init_expr: Expr [25-28]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 1.0)
             [8] Symbol [21-22]:
                 name: x
-                type: Complex(None, true)
+                type: const complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -90,11 +90,11 @@ fn const_explicit_bitness_double_img_only() {
                 symbol_id: 8
                 ty_span: [6-24]
                 init_expr: Expr [29-35]:
-                    ty: Complex(Some(42), true)
+                    ty: const complex[float[42]]
                     kind: Lit: Complex(0.0, 1.01)
             [8] Symbol [25-26]:
                 name: x
-                type: Complex(Some(42), true)
+                type: const complex[float[42]]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -109,11 +109,11 @@ fn const_explicit_bitness_int_img_only() {
                 symbol_id: 8
                 ty_span: [6-24]
                 init_expr: Expr [29-32]:
-                    ty: Complex(Some(42), true)
+                    ty: const complex[float[42]]
                     kind: Lit: Complex(0.0, 1.0)
             [8] Symbol [25-26]:
                 name: x
-                type: Complex(Some(42), true)
+                type: const complex[float[42]]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -128,11 +128,11 @@ fn implicit_bitness_double_img_only() {
                 symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-25]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Lit: Complex(0.0, 1.01)
             [8] Symbol [15-16]:
                 name: x
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -147,11 +147,11 @@ fn implicit_bitness_int_img_only() {
                 symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-22]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Lit: Complex(0.0, 1.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -166,11 +166,11 @@ fn const_implicit_bitness_double_real_only() {
                 symbol_id: 8
                 ty_span: [6-20]
                 init_expr: Expr [25-29]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(1.01, 0.0)
             [8] Symbol [21-22]:
                 name: x
-                type: Complex(None, true)
+                type: const complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -185,11 +185,11 @@ fn const_implicit_bitness_int_real_only() {
                 symbol_id: 8
                 ty_span: [6-20]
                 init_expr: Expr [25-26]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(1.0, 0.0)
             [8] Symbol [21-22]:
                 name: x
-                type: Complex(None, true)
+                type: const complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -204,11 +204,11 @@ fn implicit_bitness_double_real_only() {
                 symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-23]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(1.01, 0.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -223,11 +223,11 @@ fn implicit_bitness_int_real_only() {
                 symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-20]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(1.0, 0.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -242,18 +242,18 @@ fn implicit_bitness_simple_double_pos_im() {
                 symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-30]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Add
                         lhs: Expr [19-22]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(1.1, 0.0)
                         rhs: Expr [25-30]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(0.0, 2.2)
             [8] Symbol [15-16]:
                 name: x
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -268,18 +268,18 @@ fn implicit_bitness_simple_double_neg_im() {
                 symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-30]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Sub
                         lhs: Expr [19-22]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(1.1, 0.0)
                         rhs: Expr [25-30]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(0.0, 2.2)
             [8] Symbol [15-16]:
                 name: x
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -294,18 +294,18 @@ fn const_implicit_bitness_simple_double_neg_im() {
                 symbol_id: 8
                 ty_span: [6-20]
                 init_expr: Expr [25-36]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: BinaryOpExpr:
                         op: Sub
                         lhs: Expr [25-28]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(1.1, 0.0)
                         rhs: Expr [31-36]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(0.0, 2.2)
             [8] Symbol [21-22]:
                 name: x
-                type: Complex(None, true)
+                type: const complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -320,26 +320,26 @@ fn implicit_bitness_simple_double_neg_real() {
                 symbol_id: 8
                 ty_span: [0-14]
                 init_expr: Expr [19-31]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Add
                         lhs: Expr [20-23]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Cast [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 expr: Expr [20-23]:
-                                    ty: Float(None, true)
+                                    ty: const float
                                     kind: UnaryOpExpr [20-23]:
                                         op: Neg
                                         expr: Expr [20-23]:
-                                            ty: Float(None, true)
+                                            ty: const float
                                             kind: Lit: Float(1.1)
                         rhs: Expr [26-31]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(0.0, 2.2)
             [8] Symbol [15-16]:
                 name: x
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );
@@ -354,26 +354,26 @@ fn const_implicit_bitness_simple_double_neg_real() {
                 symbol_id: 8
                 ty_span: [6-20]
                 init_expr: Expr [25-37]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: BinaryOpExpr:
                         op: Add
                         lhs: Expr [26-29]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Cast [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 expr: Expr [26-29]:
-                                    ty: Float(None, true)
+                                    ty: const float
                                     kind: UnaryOpExpr [26-29]:
                                         op: Neg
                                         expr: Expr [26-29]:
-                                            ty: Float(None, true)
+                                            ty: const float
                                             kind: Lit: Float(1.1)
                         rhs: Expr [32-37]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(0.0, 2.2)
             [8] Symbol [21-22]:
                 name: x
-                type: Complex(None, true)
+                type: const complex[float]
                 qsharp_type: Complex
                 io_kind: Default"#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/decls/creg.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/creg.rs
@@ -14,11 +14,11 @@ fn with_no_init_expr_has_generated_lit_expr() {
                 symbol_id: 8
                 ty_span: [0-7]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [8] Symbol [5-6]:
                 name: a
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default"#]],
     );
@@ -33,11 +33,11 @@ fn array_with_no_init_expr_has_generated_lit_expr() {
                 symbol_id: 8
                 ty_span: [0-10]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(4, true)
+                    ty: const bit[4]
                     kind: Lit: Bitstring("0000")
             [8] Symbol [5-6]:
                 name: a
-                type: BitArray(4, false)
+                type: bit[4]
                 qsharp_type: Result[]
                 io_kind: Default"#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/decls/duration.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/duration.rs
@@ -19,7 +19,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
                             symbol_id: 8
                             ty_span: [0-8]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
 
             [Qasm.Lowerer.NotSupported

--- a/compiler/qsc_qasm/src/semantic/tests/decls/float.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/float.rs
@@ -14,11 +14,11 @@ fn implicit_bitness_default() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             [8] Symbol [6-7]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -33,11 +33,11 @@ fn lit() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.1)
             [8] Symbol [6-7]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -52,11 +52,11 @@ fn const_lit() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-20]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(42.1)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -71,11 +71,11 @@ fn lit_explicit_width() {
                 symbol_id: 8
                 ty_span: [0-9]
                 init_expr: Expr [14-18]:
-                    ty: Float(Some(64), true)
+                    ty: const float[64]
                     kind: Lit: Float(42.1)
             [8] Symbol [10-11]:
                 name: x
-                type: Float(Some(64), false)
+                type: float[64]
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -90,11 +90,11 @@ fn const_explicit_width_lit() {
                 symbol_id: 8
                 ty_span: [6-15]
                 init_expr: Expr [20-24]:
-                    ty: Float(Some(64), true)
+                    ty: const float[64]
                     kind: Lit: Float(42.1)
             [8] Symbol [16-17]:
                 name: x
-                type: Float(Some(64), true)
+                type: const float[64]
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -109,11 +109,11 @@ fn lit_decl_leading_dot() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(0.421)
             [8] Symbol [6-7]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -128,11 +128,11 @@ fn const_lit_decl_leading_dot() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-20]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.421)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -147,11 +147,11 @@ fn const_lit_decl_leading_dot_scientific() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-22]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(42.1)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -166,11 +166,11 @@ fn lit_decl_trailing_dot() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-14]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(421.0)
             [8] Symbol [6-7]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -185,11 +185,11 @@ fn const_lit_decl_trailing_dot() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-20]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(421.0)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -204,11 +204,11 @@ fn lit_decl_scientific() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-16]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.1)
             [8] Symbol [6-7]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -223,11 +223,11 @@ fn const_lit_decl_scientific() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-22]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(42.1)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -242,11 +242,11 @@ fn lit_decl_scientific_signed_pos() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-17]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.1)
             [8] Symbol [6-7]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -261,11 +261,11 @@ fn const_lit_decl_scientific_signed_pos() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-23]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(42.1)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -280,11 +280,11 @@ fn lit_decl_scientific_cap_e() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-16]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.1)
             [8] Symbol [6-7]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -299,11 +299,11 @@ fn const_lit_decl_scientific_cap_e() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-22]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(42.1)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -318,11 +318,11 @@ fn lit_decl_scientific_signed_neg() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-18]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.1)
             [8] Symbol [6-7]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -337,11 +337,11 @@ fn const_lit_decl_scientific_signed_neg() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [16-24]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(42.1)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -356,15 +356,15 @@ fn const_lit_decl_signed_float_lit_cast_neg() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [17-19]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: UnaryOpExpr [17-19]:
                         op: Neg
                         expr: Expr [17-19]:
-                            ty: Float(None, true)
+                            ty: const float
                             kind: Lit: Float(7.0)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -379,19 +379,19 @@ fn const_lit_decl_signed_int_lit_cast_neg() {
                 symbol_id: 8
                 ty_span: [6-11]
                 init_expr: Expr [17-18]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Cast [0-0]:
-                        ty: Float(None, true)
+                        ty: const float
                         expr: Expr [17-18]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: UnaryOpExpr [17-18]:
                                 op: Neg
                                 expr: Expr [17-18]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(7)
             [8] Symbol [12-13]:
                 name: x
-                type: Float(None, true)
+                type: const float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -407,11 +407,11 @@ fn init_float_with_int_value_equal_max_safely_representable_values() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [10-26]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(9007199254740992.0)
             [8] Symbol [6-7]:
                 name: a
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );
@@ -433,21 +433,20 @@ fn init_float_with_int_value_greater_than_safely_representable_values() {
                             symbol_id: 8
                             ty_span: [0-5]
                             init_expr: Expr [10-26]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Lit: Int(9007199254740993)
 
             [Qasm.Lowerer.InvalidCastValueRange
 
-              x assigning Int(None, true) values to Float(None, false) must be in a range
-              | that be converted to Float(None, false)
+              x assigning const int values to float must be in a range that be converted
+              | to float
                ,-[test:1:11]
              1 | float a = 9007199254740993;
                :           ^^^^^^^^^^^^^^^^
                `----
             , Qasm.Lowerer.CannotCastLiteral
 
-              x cannot cast literal expression of type Int(None, true) to type Float(None,
-              | false)
+              x cannot cast literal expression of type const int to type float
                ,-[test:1:11]
              1 | float a = 9007199254740993;
                :           ^^^^^^^^^^^^^^^^
@@ -466,19 +465,19 @@ fn init_float_with_int_value_equal_min_safely_representable_values() {
                 symbol_id: 8
                 ty_span: [0-5]
                 init_expr: Expr [11-27]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [0-0]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [11-27]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: UnaryOpExpr [11-27]:
                                 op: Neg
                                 expr: Expr [11-27]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(9007199254740992)
             [8] Symbol [6-7]:
                 name: a
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default"#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/decls/int.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/int.rs
@@ -14,15 +14,15 @@ fn implicit_bitness_int_negative() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [9-11]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: UnaryOpExpr [9-11]:
                         op: Neg
                         expr: Expr [9-11]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(42)
             [8] Symbol [4-5]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -37,15 +37,15 @@ fn implicit_bitness_int_const_negative() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [15-17]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: UnaryOpExpr [15-17]:
                         op: Neg
                         expr: Expr [15-17]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(42)
             [8] Symbol [10-11]:
                 name: x
-                type: Int(None, true)
+                type: const int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -60,11 +60,11 @@ fn implicit_bitness_int_default() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             [8] Symbol [4-5]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -79,11 +79,11 @@ fn const_implicit_bitness_int_lit() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-16]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(42)
             [8] Symbol [10-11]:
                 name: x
-                type: Int(None, true)
+                type: const int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -98,11 +98,11 @@ fn implicit_bitness_int_hex_cap() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-15]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(64031)
             [8] Symbol [4-5]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -117,11 +117,11 @@ fn const_implicit_bitness_int_hex_cap() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-21]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(64031)
             [8] Symbol [10-11]:
                 name: y
-                type: Int(None, true)
+                type: const int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -136,11 +136,11 @@ fn implicit_bitness_int_octal() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-12]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(34)
             [8] Symbol [4-5]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -155,11 +155,11 @@ fn const_implicit_bitness_int_octal() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-18]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(34)
             [8] Symbol [10-11]:
                 name: x
-                type: Int(None, true)
+                type: const int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -174,11 +174,11 @@ fn const_implicit_bitness_int_octal_cap() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-18]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(34)
             [8] Symbol [10-11]:
                 name: x
-                type: Int(None, true)
+                type: const int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -193,11 +193,11 @@ fn implicit_bitness_int_binary_low() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(153)
             [8] Symbol [4-5]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -212,11 +212,11 @@ fn implicit_bitness_int_binary_cap() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(10)
             [8] Symbol [4-5]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -231,11 +231,11 @@ fn const_implicit_bitness_int_binary_low() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-25]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(153)
             [8] Symbol [10-11]:
                 name: x
-                type: Int(None, true)
+                type: const int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -250,11 +250,11 @@ fn const_implicit_bitness_int_binary_cap() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-20]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(10)
             [8] Symbol [10-11]:
                 name: x
-                type: Int(None, true)
+                type: const int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -269,11 +269,11 @@ fn implicit_bitness_int_formatted() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [8-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(2000)
             [8] Symbol [4-5]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -288,11 +288,11 @@ fn const_implicit_bitness_int_formatted() {
                 symbol_id: 8
                 ty_span: [6-9]
                 init_expr: Expr [14-20]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(2000)
             [8] Symbol [10-11]:
                 name: x
-                type: Int(None, true)
+                type: const int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -307,11 +307,11 @@ fn explicit_bitness_int_default() {
                 symbol_id: 8
                 ty_span: [0-7]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(10), true)
+                    ty: const int[10]
                     kind: Lit: Int(0)
             [8] Symbol [8-9]:
                 name: x
-                type: Int(Some(10), false)
+                type: int[10]
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -326,11 +326,11 @@ fn explicit_bitness_int() {
                 symbol_id: 8
                 ty_span: [0-7]
                 init_expr: Expr [12-14]:
-                    ty: Int(Some(10), true)
+                    ty: const int[10]
                     kind: Lit: Int(42)
             [8] Symbol [8-9]:
                 name: x
-                type: Int(Some(10), false)
+                type: int[10]
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -345,11 +345,11 @@ fn const_explicit_bitness_int() {
                 symbol_id: 8
                 ty_span: [6-13]
                 init_expr: Expr [18-20]:
-                    ty: Int(Some(10), true)
+                    ty: const int[10]
                     kind: Lit: Int(42)
             [8] Symbol [14-15]:
                 name: x
-                type: Int(Some(10), true)
+                type: const int[10]
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -364,19 +364,19 @@ fn implicit_bitness_int_negative_float_decl_is_runtime_conversion() {
                 symbol_id: 8
                 ty_span: [0-3]
                 init_expr: Expr [9-12]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [0-0]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [9-12]:
-                            ty: Float(None, true)
+                            ty: const float
                             kind: UnaryOpExpr [9-12]:
                                 op: Neg
                                 expr: Expr [9-12]:
-                                    ty: Float(None, true)
+                                    ty: const float
                                     kind: Lit: Float(42.0)
             [8] Symbol [4-5]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default"#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/decls/stretch.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/stretch.rs
@@ -19,7 +19,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
                             symbol_id: 8
                             ty_span: [0-7]
                             init_expr: Expr [0-0]:
-                                ty: Stretch(true)
+                                ty: const stretch
                                 kind: Err
 
             [Qasm.Lowerer.NotSupported

--- a/compiler/qsc_qasm/src/semantic/tests/decls/uint.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/uint.rs
@@ -14,11 +14,11 @@ fn implicit_bitness_int_default() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             [8] Symbol [5-6]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -33,11 +33,11 @@ fn const_implicit_bitness_int_lit() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-17]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(42)
             [8] Symbol [11-12]:
                 name: x
-                type: UInt(None, true)
+                type: const uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -52,11 +52,11 @@ fn implicit_bitness_int_hex_cap() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-16]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(64031)
             [8] Symbol [5-6]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -71,11 +71,11 @@ fn const_implicit_bitness_int_hex_low() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-22]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(64031)
             [8] Symbol [11-12]:
                 name: x
-                type: UInt(None, true)
+                type: const uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -90,11 +90,11 @@ fn const_implicit_bitness_int_hex_cap() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-22]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(64031)
             [8] Symbol [11-12]:
                 name: y
-                type: UInt(None, true)
+                type: const uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -109,11 +109,11 @@ fn implicit_bitness_int_octal_low() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-13]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(34)
             [8] Symbol [5-6]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -128,11 +128,11 @@ fn implicit_bitness_int_octal_cap() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-13]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(34)
             [8] Symbol [5-6]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -147,11 +147,11 @@ fn const_implicit_bitness_int_octal_low() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-19]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(34)
             [8] Symbol [11-12]:
                 name: x
-                type: UInt(None, true)
+                type: const uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -166,11 +166,11 @@ fn const_implicit_bitness_int_octal_cap() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-19]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(34)
             [8] Symbol [11-12]:
                 name: x
-                type: UInt(None, true)
+                type: const uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -185,11 +185,11 @@ fn implicit_bitness_int_binary_low() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-20]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(153)
             [8] Symbol [5-6]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -204,11 +204,11 @@ fn implicit_bitness_int_binary_cap() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-15]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(10)
             [8] Symbol [5-6]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -223,11 +223,11 @@ fn const_implicit_bitness_int_binary_low() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-26]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(153)
             [8] Symbol [11-12]:
                 name: x
-                type: UInt(None, true)
+                type: const uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -242,11 +242,11 @@ fn const_implicit_bitness_int_binary_cap() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-21]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(10)
             [8] Symbol [11-12]:
                 name: x
-                type: UInt(None, true)
+                type: const uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -261,11 +261,11 @@ fn implicit_bitness_int_formatted() {
                 symbol_id: 8
                 ty_span: [0-4]
                 init_expr: Expr [9-15]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(2000)
             [8] Symbol [5-6]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -280,11 +280,11 @@ fn const_implicit_bitness_int_formatted() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [15-21]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(2000)
             [8] Symbol [11-12]:
                 name: x
-                type: UInt(None, true)
+                type: const uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -299,11 +299,11 @@ fn const_explicit_bitness_int() {
                 symbol_id: 8
                 ty_span: [0-8]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(10), true)
+                    ty: const uint[10]
                     kind: Lit: Int(0)
             [8] Symbol [9-10]:
                 name: x
-                type: UInt(Some(10), false)
+                type: uint[10]
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -318,19 +318,19 @@ fn assigning_uint_to_negative_lit() {
                 symbol_id: 8
                 ty_span: [6-14]
                 init_expr: Expr [20-22]:
-                    ty: UInt(Some(10), true)
+                    ty: const uint[10]
                     kind: Cast [0-0]:
-                        ty: UInt(Some(10), true)
+                        ty: const uint[10]
                         expr: Expr [20-22]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: UnaryOpExpr [20-22]:
                                 op: Neg
                                 expr: Expr [20-22]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(42)
             [8] Symbol [15-16]:
                 name: x
-                type: UInt(Some(10), true)
+                type: const uint[10]
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -345,19 +345,19 @@ fn implicit_bitness_uint_const_negative_decl() {
                 symbol_id: 8
                 ty_span: [6-10]
                 init_expr: Expr [16-18]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Cast [0-0]:
-                        ty: UInt(None, true)
+                        ty: const uint
                         expr: Expr [16-18]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: UnaryOpExpr [16-18]:
                                 op: Neg
                                 expr: Expr [16-18]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(42)
             [8] Symbol [11-12]:
                 name: x
-                type: UInt(None, true)
+                type: const uint
                 qsharp_type: Int
                 io_kind: Default"#]],
     );
@@ -372,19 +372,19 @@ fn explicit_bitness_uint_const_negative_decl() {
                 symbol_id: 8
                 ty_span: [6-14]
                 init_expr: Expr [20-22]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Cast [0-0]:
-                        ty: UInt(Some(32), true)
+                        ty: const uint[32]
                         expr: Expr [20-22]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: UnaryOpExpr [20-22]:
                                 op: Neg
                                 expr: Expr [20-22]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(42)
             [8] Symbol [15-16]:
                 name: x
-                type: UInt(Some(32), true)
+                type: const uint[32]
                 qsharp_type: Int
                 io_kind: Default"#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/arithmetic_conversions.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/arithmetic_conversions.rs
@@ -20,24 +20,24 @@ fn int_idents_without_width_can_be_multiplied() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             ExprStmt [47-53]:
                 expr: Expr [47-52]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [47-48]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [51-52]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
         "#]],
     );
@@ -58,24 +58,24 @@ fn int_idents_with_same_width_can_be_multiplied() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [21-22]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [32-46]:
                 symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(3)
             ExprStmt [55-61]:
                 expr: Expr [55-60]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [55-56]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
                         rhs: Expr [59-60]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(9)
         "#]],
     );
@@ -96,28 +96,28 @@ fn int_idents_with_different_width_can_be_multiplied() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [21-22]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [32-46]:
                 symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
-                    ty: Int(Some(64), true)
+                    ty: const int[64]
                     kind: Lit: Int(3)
             ExprStmt [55-61]:
                 expr: Expr [55-60]:
-                    ty: Int(Some(64), false)
+                    ty: int[64]
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [55-56]:
-                            ty: Int(Some(64), false)
+                            ty: int[64]
                             kind: Cast [0-0]:
-                                ty: Int(Some(64), false)
+                                ty: int[64]
                                 expr: Expr [55-56]:
-                                    ty: Int(Some(32), false)
+                                    ty: int[32]
                                     kind: SymbolId(8)
                         rhs: Expr [59-60]:
-                            ty: Int(Some(64), false)
+                            ty: int[64]
                             kind: SymbolId(9)
         "#]],
     );
@@ -138,30 +138,30 @@ fn multiplying_int_idents_with_different_width_result_in_higher_width_result() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [21-22]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [32-46]:
                 symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
-                    ty: Int(Some(64), true)
+                    ty: const int[64]
                     kind: Lit: Int(3)
             ClassicalDeclarationStmt [55-73]:
                 symbol_id: 10
                 ty_span: [55-62]
                 init_expr: Expr [67-72]:
-                    ty: Int(Some(64), false)
+                    ty: int[64]
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [67-68]:
-                            ty: Int(Some(64), false)
+                            ty: int[64]
                             kind: Cast [0-0]:
-                                ty: Int(Some(64), false)
+                                ty: int[64]
                                 expr: Expr [67-68]:
-                                    ty: Int(Some(32), false)
+                                    ty: int[32]
                                     kind: SymbolId(8)
                         rhs: Expr [71-72]:
-                            ty: Int(Some(64), false)
+                            ty: int[64]
                             kind: SymbolId(9)
         "#]],
     );
@@ -182,34 +182,34 @@ fn multiplying_int_idents_with_different_width_result_in_no_width_result() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [21-22]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [32-46]:
                 symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
-                    ty: Int(Some(64), true)
+                    ty: const int[64]
                     kind: Lit: Int(3)
             ClassicalDeclarationStmt [55-69]:
                 symbol_id: 10
                 ty_span: [55-58]
                 init_expr: Expr [63-68]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [0-0]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [63-68]:
-                            ty: Int(Some(64), false)
+                            ty: int[64]
                             kind: BinaryOpExpr:
                                 op: Mul
                                 lhs: Expr [63-64]:
-                                    ty: Int(Some(64), false)
+                                    ty: int[64]
                                     kind: Cast [0-0]:
-                                        ty: Int(Some(64), false)
+                                        ty: int[64]
                                         expr: Expr [63-64]:
-                                            ty: Int(Some(32), false)
+                                            ty: int[32]
                                             kind: SymbolId(8)
                                 rhs: Expr [67-68]:
-                                    ty: Int(Some(64), false)
+                                    ty: int[64]
                                     kind: SymbolId(9)
         "#]],
     );
@@ -230,34 +230,34 @@ fn multiplying_int_idents_with_width_greater_than_64_result_in_bigint_result() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [21-22]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [32-46]:
                 symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
-                    ty: Int(Some(64), true)
+                    ty: const int[64]
                     kind: Lit: Int(3)
             ClassicalDeclarationStmt [55-73]:
                 symbol_id: 10
                 ty_span: [55-62]
                 init_expr: Expr [67-72]:
-                    ty: Int(Some(67), false)
+                    ty: int[67]
                     kind: Cast [0-0]:
-                        ty: Int(Some(67), false)
+                        ty: int[67]
                         expr: Expr [67-72]:
-                            ty: Int(Some(64), false)
+                            ty: int[64]
                             kind: BinaryOpExpr:
                                 op: Mul
                                 lhs: Expr [67-68]:
-                                    ty: Int(Some(64), false)
+                                    ty: int[64]
                                     kind: Cast [0-0]:
-                                        ty: Int(Some(64), false)
+                                        ty: int[64]
                                         expr: Expr [67-68]:
-                                            ty: Int(Some(32), false)
+                                            ty: int[32]
                                             kind: SymbolId(8)
                                 rhs: Expr [71-72]:
-                                    ty: Int(Some(64), false)
+                                    ty: int[64]
                                     kind: SymbolId(9)
         "#]],
     );
@@ -278,30 +278,30 @@ fn left_shift_casts_rhs_to_uint() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             ClassicalDeclarationStmt [47-62]:
                 symbol_id: 10
                 ty_span: [47-50]
                 init_expr: Expr [55-61]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: BinaryOpExpr:
                         op: Shl
                         lhs: Expr [55-56]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [60-61]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: Cast [0-0]:
-                                ty: UInt(None, false)
+                                ty: uint
                                 expr: Expr [60-61]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: SymbolId(9)
         "#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison.rs
@@ -33,139 +33,139 @@ fn bitarray_var_comparisons_can_be_translated() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [20-23]:
-                    ty: BitArray(1, false)
+                    ty: bit[1]
                     kind: Lit: Bitstring("1")
             ClassicalDeclarationStmt [33-48]:
                 symbol_id: 9
                 ty_span: [33-39]
                 init_expr: Expr [44-47]:
-                    ty: BitArray(1, false)
+                    ty: bit[1]
                     kind: Lit: Bitstring("0")
             ClassicalDeclarationStmt [57-72]:
                 symbol_id: 10
                 ty_span: [57-61]
                 init_expr: Expr [66-71]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gt
                         lhs: Expr [66-67]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [66-67]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [70-71]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [70-71]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(9)
             ClassicalDeclarationStmt [81-97]:
                 symbol_id: 11
                 ty_span: [81-85]
                 init_expr: Expr [90-96]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gte
                         lhs: Expr [90-91]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [90-91]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [95-96]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [95-96]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(9)
             ClassicalDeclarationStmt [106-121]:
                 symbol_id: 12
                 ty_span: [106-110]
                 init_expr: Expr [115-120]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lt
                         lhs: Expr [115-116]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [115-116]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [119-120]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [119-120]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(9)
             ClassicalDeclarationStmt [130-146]:
                 symbol_id: 13
                 ty_span: [130-134]
                 init_expr: Expr [139-145]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lte
                         lhs: Expr [139-140]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [139-140]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [144-145]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [144-145]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(9)
             ClassicalDeclarationStmt [155-171]:
                 symbol_id: 14
                 ty_span: [155-159]
                 init_expr: Expr [164-170]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Eq
                         lhs: Expr [164-165]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [164-165]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [169-170]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [169-170]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(9)
             ClassicalDeclarationStmt [180-196]:
                 symbol_id: 15
                 ty_span: [180-184]
                 init_expr: Expr [189-195]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Neq
                         lhs: Expr [189-190]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [189-190]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [194-195]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [194-195]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(9)
         "#]],
     );
@@ -198,7 +198,7 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [20-23]:
-                    ty: BitArray(1, false)
+                    ty: bit[1]
                     kind: Lit: Bitstring("1")
             InputDeclaration [33-45]:
                 symbol_id: 9
@@ -206,205 +206,205 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                 symbol_id: 10
                 ty_span: [54-58]
                 init_expr: Expr [63-68]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gt
                         lhs: Expr [63-64]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [63-64]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [67-68]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             ClassicalDeclarationStmt [78-94]:
                 symbol_id: 11
                 ty_span: [78-82]
                 init_expr: Expr [87-93]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gte
                         lhs: Expr [87-88]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [87-88]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [92-93]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             ClassicalDeclarationStmt [103-118]:
                 symbol_id: 12
                 ty_span: [103-107]
                 init_expr: Expr [112-117]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lt
                         lhs: Expr [112-113]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [112-113]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [116-117]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             ClassicalDeclarationStmt [127-143]:
                 symbol_id: 13
                 ty_span: [127-131]
                 init_expr: Expr [136-142]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lte
                         lhs: Expr [136-137]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [136-137]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [141-142]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             ClassicalDeclarationStmt [152-168]:
                 symbol_id: 14
                 ty_span: [152-156]
                 init_expr: Expr [161-167]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Eq
                         lhs: Expr [161-162]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [161-162]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [166-167]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             ClassicalDeclarationStmt [177-193]:
                 symbol_id: 15
                 ty_span: [177-181]
                 init_expr: Expr [186-192]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Neq
                         lhs: Expr [186-187]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [186-187]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
                         rhs: Expr [191-192]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             ClassicalDeclarationStmt [202-217]:
                 symbol_id: 16
                 ty_span: [202-206]
                 init_expr: Expr [211-216]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gt
                         lhs: Expr [211-212]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
                         rhs: Expr [215-216]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [215-216]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
             ClassicalDeclarationStmt [226-242]:
                 symbol_id: 17
                 ty_span: [226-230]
                 init_expr: Expr [235-241]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gte
                         lhs: Expr [235-236]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
                         rhs: Expr [240-241]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [240-241]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
             ClassicalDeclarationStmt [251-266]:
                 symbol_id: 18
                 ty_span: [251-255]
                 init_expr: Expr [260-265]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lt
                         lhs: Expr [260-261]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
                         rhs: Expr [264-265]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [264-265]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
             ClassicalDeclarationStmt [275-291]:
                 symbol_id: 19
                 ty_span: [275-279]
                 init_expr: Expr [284-290]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lte
                         lhs: Expr [284-285]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
                         rhs: Expr [289-290]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [289-290]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
             ClassicalDeclarationStmt [300-316]:
                 symbol_id: 20
                 ty_span: [300-304]
                 init_expr: Expr [309-315]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Eq
                         lhs: Expr [309-310]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
                         rhs: Expr [314-315]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [314-315]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
             ClassicalDeclarationStmt [325-341]:
                 symbol_id: 21
                 ty_span: [325-329]
                 init_expr: Expr [334-340]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Neq
                         lhs: Expr [334-335]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
                         rhs: Expr [339-340]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: Cast [0-0]:
-                                ty: Int(None, false)
+                                ty: int
                                 expr: Expr [339-340]:
-                                    ty: BitArray(1, false)
+                                    ty: bit[1]
                                     kind: SymbolId(8)
         "#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/bit_to_bit.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/bit_to_bit.rs
@@ -20,48 +20,48 @@ fn logical_and() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [9] Symbol [32-33]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: AndL
                         lhs: Expr [56-57]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: Cast [0-0]:
-                                ty: Bool(false)
+                                ty: bool
                                 expr: Expr [56-57]:
-                                    ty: Bit(false)
+                                    ty: bit
                                     kind: SymbolId(8)
                         rhs: Expr [61-62]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: Cast [0-0]:
-                                ty: Bool(false)
+                                ty: bool
                                 expr: Expr [61-62]:
-                                    ty: Bit(false)
+                                    ty: bit
                                     kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -83,48 +83,48 @@ fn logical_or() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [9] Symbol [32-33]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: OrL
                         lhs: Expr [56-57]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: Cast [0-0]:
-                                ty: Bool(false)
+                                ty: bool
                                 expr: Expr [56-57]:
-                                    ty: Bit(false)
+                                    ty: bit
                                     kind: SymbolId(8)
                         rhs: Expr [61-62]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: Cast [0-0]:
-                                ty: Bool(false)
+                                ty: bool
                                 expr: Expr [61-62]:
-                                    ty: Bit(false)
+                                    ty: bit
                                     kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -146,56 +146,56 @@ fn unop_not_logical_and_unop_not() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [9] Symbol [32-33]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-65]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-64]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: AndL
                         lhs: Expr [57-58]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [57-58]:
                                 op: NotL
                                 expr: Expr [57-58]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: Cast [0-0]:
-                                        ty: Bool(false)
+                                        ty: bool
                                         expr: Expr [57-58]:
-                                            ty: Bit(false)
+                                            ty: bit
                                             kind: SymbolId(8)
                         rhs: Expr [63-64]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [63-64]:
                                 op: NotL
                                 expr: Expr [63-64]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: Cast [0-0]:
-                                        ty: Bool(false)
+                                        ty: bool
                                         expr: Expr [63-64]:
-                                            ty: Bit(false)
+                                            ty: bit
                                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -217,56 +217,56 @@ fn unop_not_logical_or_unop_not() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [9] Symbol [32-33]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-65]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-64]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: OrL
                         lhs: Expr [57-58]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [57-58]:
                                 op: NotL
                                 expr: Expr [57-58]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: Cast [0-0]:
-                                        ty: Bool(false)
+                                        ty: bool
                                         expr: Expr [57-58]:
-                                            ty: Bit(false)
+                                            ty: bit
                                             kind: SymbolId(8)
                         rhs: Expr [63-64]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [63-64]:
                                 op: NotL
                                 expr: Expr [63-64]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: Cast [0-0]:
-                                        ty: Bool(false)
+                                        ty: bool
                                         expr: Expr [63-64]:
-                                            ty: Bit(false)
+                                            ty: bit
                                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -288,52 +288,52 @@ fn unop_not_logical_and() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [9] Symbol [32-33]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-64]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-63]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: AndL
                         lhs: Expr [57-58]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [57-58]:
                                 op: NotL
                                 expr: Expr [57-58]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: Cast [0-0]:
-                                        ty: Bool(false)
+                                        ty: bool
                                         expr: Expr [57-58]:
-                                            ty: Bit(false)
+                                            ty: bit
                                             kind: SymbolId(8)
                         rhs: Expr [62-63]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: Cast [0-0]:
-                                ty: Bool(false)
+                                ty: bool
                                 expr: Expr [62-63]:
-                                    ty: Bit(false)
+                                    ty: bit
                                     kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -355,52 +355,52 @@ fn unop_not_logical_or() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [9] Symbol [32-33]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-64]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-63]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: OrL
                         lhs: Expr [57-58]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [57-58]:
                                 op: NotL
                                 expr: Expr [57-58]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: Cast [0-0]:
-                                        ty: Bool(false)
+                                        ty: bool
                                         expr: Expr [57-58]:
-                                            ty: Bit(false)
+                                            ty: bit
                                             kind: SymbolId(8)
                         rhs: Expr [62-63]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: Cast [0-0]:
-                                ty: Bool(false)
+                                ty: bool
                                 expr: Expr [62-63]:
-                                    ty: Bit(false)
+                                    ty: bit
                                     kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -422,52 +422,52 @@ fn logical_and_unop_not() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [9] Symbol [32-33]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-64]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-63]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: AndL
                         lhs: Expr [56-57]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: Cast [0-0]:
-                                ty: Bool(false)
+                                ty: bool
                                 expr: Expr [56-57]:
-                                    ty: Bit(false)
+                                    ty: bit
                                     kind: SymbolId(8)
                         rhs: Expr [62-63]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [62-63]:
                                 op: NotL
                                 expr: Expr [62-63]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: Cast [0-0]:
-                                        ty: Bool(false)
+                                        ty: bool
                                         expr: Expr [62-63]:
-                                            ty: Bit(false)
+                                            ty: bit
                                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -489,52 +489,52 @@ fn logical_or_unop_not() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             [9] Symbol [32-33]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [47-64]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-63]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: OrL
                         lhs: Expr [56-57]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: Cast [0-0]:
-                                ty: Bool(false)
+                                ty: bool
                                 expr: Expr [56-57]:
-                                    ty: Bit(false)
+                                    ty: bit
                                     kind: SymbolId(8)
                         rhs: Expr [62-63]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [62-63]:
                                 op: NotL
                                 expr: Expr [62-63]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: Cast [0-0]:
-                                        ty: Bool(false)
+                                        ty: bool
                                         expr: Expr [62-63]:
-                                            ty: Bit(false)
+                                            ty: bit
                                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/bool_to_bool.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/bool_to_bool.rs
@@ -20,40 +20,40 @@ fn logical_and() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(false)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-72]:
                 symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-71]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: AndL
                         lhs: Expr [65-66]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
                         rhs: Expr [70-71]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(9)
             [10] Symbol [61-62]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -75,40 +75,40 @@ fn logical_or() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(false)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-72]:
                 symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-71]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: OrL
                         lhs: Expr [65-66]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
                         rhs: Expr [70-71]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(9)
             [10] Symbol [61-62]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -130,48 +130,48 @@ fn unop_not_logical_and_unop_not() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(false)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-74]:
                 symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-73]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: AndL
                         lhs: Expr [66-67]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [66-67]:
                                 op: NotL
                                 expr: Expr [66-67]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: SymbolId(8)
                         rhs: Expr [72-73]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [72-73]:
                                 op: NotL
                                 expr: Expr [72-73]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: SymbolId(9)
             [10] Symbol [61-62]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -193,48 +193,48 @@ fn unop_not_logical_or_unop_not() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(false)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-74]:
                 symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-73]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: OrL
                         lhs: Expr [66-67]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [66-67]:
                                 op: NotL
                                 expr: Expr [66-67]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: SymbolId(8)
                         rhs: Expr [72-73]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [72-73]:
                                 op: NotL
                                 expr: Expr [72-73]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: SymbolId(9)
             [10] Symbol [61-62]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -256,44 +256,44 @@ fn unop_not_logical_and() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(false)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-73]:
                 symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-72]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: AndL
                         lhs: Expr [66-67]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [66-67]:
                                 op: NotL
                                 expr: Expr [66-67]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: SymbolId(8)
                         rhs: Expr [71-72]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(9)
             [10] Symbol [61-62]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -315,44 +315,44 @@ fn unop_not_logical_or() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(false)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-73]:
                 symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-72]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: OrL
                         lhs: Expr [66-67]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [66-67]:
                                 op: NotL
                                 expr: Expr [66-67]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: SymbolId(8)
                         rhs: Expr [71-72]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(9)
             [10] Symbol [61-62]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -374,44 +374,44 @@ fn logical_and_unop_not() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(false)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-73]:
                 symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-72]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: AndL
                         lhs: Expr [65-66]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
                         rhs: Expr [71-72]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [71-72]:
                                 op: NotL
                                 expr: Expr [71-72]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: SymbolId(9)
             [10] Symbol [61-62]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -433,44 +433,44 @@ fn logical_or_unop_not() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-46]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(false)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [56-73]:
                 symbol_id: 10
                 ty_span: [56-60]
                 init_expr: Expr [65-72]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: OrL
                         lhs: Expr [65-66]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
                         rhs: Expr [71-72]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: UnaryOpExpr [71-72]:
                                 op: NotL
                                 expr: Expr [71-72]:
-                                    ty: Bool(false)
+                                    ty: bool
                                     kind: SymbolId(9)
             [10] Symbol [61-62]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/float_to_float.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/float_to_float.rs
@@ -20,40 +20,40 @@ fn greater_than() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(5.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
                 symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(3.0)
             [9] Symbol [37-38]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-68]:
                 symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-67]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gt
                         lhs: Expr [62-63]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
                         rhs: Expr [66-67]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(9)
             [10] Symbol [58-59]:
                 name: f
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -75,40 +75,40 @@ fn greater_than_equals() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(5.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
                 symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(3.0)
             [9] Symbol [37-38]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-69]:
                 symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-68]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gte
                         lhs: Expr [62-63]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
                         rhs: Expr [67-68]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(9)
             [10] Symbol [58-59]:
                 name: e
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -130,40 +130,40 @@ fn less_than() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(5.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
                 symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(3.0)
             [9] Symbol [37-38]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-68]:
                 symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-67]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lt
                         lhs: Expr [62-63]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
                         rhs: Expr [66-67]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(9)
             [10] Symbol [58-59]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -185,40 +185,40 @@ fn less_than_equals() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(5.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
                 symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(3.0)
             [9] Symbol [37-38]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-69]:
                 symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-68]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lte
                         lhs: Expr [62-63]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
                         rhs: Expr [67-68]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(9)
             [10] Symbol [58-59]:
                 name: c
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -240,40 +240,40 @@ fn equals() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(5.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
                 symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(3.0)
             [9] Symbol [37-38]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-69]:
                 symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-68]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Eq
                         lhs: Expr [62-63]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
                         rhs: Expr [67-68]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(9)
             [10] Symbol [58-59]:
                 name: b
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -295,40 +295,40 @@ fn not_equals() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-21]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(5.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [31-44]:
                 symbol_id: 9
                 ty_span: [31-36]
                 init_expr: Expr [41-43]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(3.0)
             [9] Symbol [37-38]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [53-69]:
                 symbol_id: 10
                 ty_span: [53-57]
                 init_expr: Expr [62-68]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Neq
                         lhs: Expr [62-63]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
                         rhs: Expr [67-68]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(9)
             [10] Symbol [58-59]:
                 name: d
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/int_to_int.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/int_to_int.rs
@@ -20,40 +20,40 @@ fn greater_than() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             [9] Symbol [32-33]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-62]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-61]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gt
                         lhs: Expr [56-57]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [60-61]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: f
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -75,40 +75,40 @@ fn greater_than_equals() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             [9] Symbol [32-33]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gte
                         lhs: Expr [56-57]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [61-62]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: e
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -130,40 +130,40 @@ fn less_than() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             [9] Symbol [32-33]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-62]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-61]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lt
                         lhs: Expr [56-57]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [60-61]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -185,40 +185,40 @@ fn less_than_equals() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             [9] Symbol [32-33]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lte
                         lhs: Expr [56-57]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [61-62]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: c
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -240,40 +240,40 @@ fn equals() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             [9] Symbol [32-33]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Eq
                         lhs: Expr [56-57]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [61-62]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: b
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -295,40 +295,40 @@ fn not_equals() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             [9] Symbol [32-33]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [47-63]:
                 symbol_id: 10
                 ty_span: [47-51]
                 init_expr: Expr [56-62]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Neq
                         lhs: Expr [56-57]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [61-62]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
             [10] Symbol [52-53]:
                 name: d
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/uint_to_uint.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/uint_to_uint.rs
@@ -20,40 +20,40 @@ fn greater_than() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(5)
             [8] Symbol [14-15]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
                 symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(3)
             [9] Symbol [34-35]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-64]:
                 symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-63]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gt
                         lhs: Expr [58-59]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
                         rhs: Expr [62-63]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(9)
             [10] Symbol [54-55]:
                 name: f
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -75,40 +75,40 @@ fn greater_than_equals() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(5)
             [8] Symbol [14-15]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
                 symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(3)
             [9] Symbol [34-35]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-65]:
                 symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-64]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Gte
                         lhs: Expr [58-59]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
                         rhs: Expr [63-64]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(9)
             [10] Symbol [54-55]:
                 name: e
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -130,40 +130,40 @@ fn less_than() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(5)
             [8] Symbol [14-15]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
                 symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(3)
             [9] Symbol [34-35]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-64]:
                 symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-63]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lt
                         lhs: Expr [58-59]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
                         rhs: Expr [62-63]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(9)
             [10] Symbol [54-55]:
                 name: a
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -185,40 +185,40 @@ fn less_than_equals() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(5)
             [8] Symbol [14-15]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
                 symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(3)
             [9] Symbol [34-35]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-65]:
                 symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-64]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Lte
                         lhs: Expr [58-59]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
                         rhs: Expr [63-64]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(9)
             [10] Symbol [54-55]:
                 name: c
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -240,40 +240,40 @@ fn equals() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(5)
             [8] Symbol [14-15]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
                 symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(3)
             [9] Symbol [34-35]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-65]:
                 symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-64]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Eq
                         lhs: Expr [58-59]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
                         rhs: Expr [63-64]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(9)
             [10] Symbol [54-55]:
                 name: b
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -295,40 +295,40 @@ fn not_equals() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-19]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(5)
             [8] Symbol [14-15]:
                 name: x
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
                 symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(3)
             [9] Symbol [34-35]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [49-65]:
                 symbol_id: 10
                 ty_span: [49-53]
                 init_expr: Expr [58-64]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: BinaryOpExpr:
                         op: Neq
                         lhs: Expr [58-59]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
                         rhs: Expr [63-64]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(9)
             [10] Symbol [54-55]:
                 name: d
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/complex.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/complex.rs
@@ -13,20 +13,20 @@ fn implicit_cast_from_int() {
     check_stmt_kinds(
         input,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-30]:
-            symbol_id: 8
-            ty_span: [9-16]
-            init_expr: Expr [21-29]:
-                ty: Complex(None, false)
-                kind: BinaryOpExpr:
-                    op: Add
-                    lhs: Expr [21-22]:
-                        ty: Complex(None, true)
-                        kind: Lit: Complex(2.0, 0.0)
-                    rhs: Expr [25-29]:
-                        ty: Complex(None, true)
-                        kind: Lit: Complex(0.0, 3.0)
-    "#]],
+            ClassicalDeclarationStmt [9-30]:
+                symbol_id: 8
+                ty_span: [9-16]
+                init_expr: Expr [21-29]:
+                    ty: complex[float]
+                    kind: BinaryOpExpr:
+                        op: Add
+                        lhs: Expr [21-22]:
+                            ty: const complex[float]
+                            kind: Lit: Complex(2.0, 0.0)
+                        rhs: Expr [25-29]:
+                            ty: const complex[float]
+                            kind: Lit: Complex(0.0, 3.0)
+        "#]],
     );
 }
 
@@ -43,14 +43,14 @@ fn implicit_cast_from_float() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [21-33]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Add
                         lhs: Expr [21-24]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(2.0, 0.0)
                         rhs: Expr [27-33]:
-                            ty: Complex(None, true)
+                            ty: const complex[float]
                             kind: Lit: Complex(0.0, 3.0)
         "#]],
     );
@@ -75,14 +75,14 @@ fn addition() {
                 symbol_id: 10
                 ty_span: [73-80]
                 init_expr: Expr [85-90]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Add
                         lhs: Expr [85-86]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
                         rhs: Expr [89-90]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
         "#]],
     );
@@ -105,20 +105,20 @@ fn addition_assign_op() {
                 symbol_id: 9
                 ty_span: [41-48]
                 init_expr: Expr [53-56]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             AssignStmt [66-73]:
                 symbol_id: 9
                 lhs_span: [66-67]
                 rhs: Expr [66-73]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Add
                         lhs: Expr [66-67]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
                         rhs: Expr [71-72]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
         "#]],
     );
@@ -143,14 +143,14 @@ fn subtraction() {
                 symbol_id: 10
                 ty_span: [73-80]
                 init_expr: Expr [85-90]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Sub
                         lhs: Expr [85-86]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
                         rhs: Expr [89-90]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
         "#]],
     );
@@ -173,20 +173,20 @@ fn subtraction_assign_op() {
                 symbol_id: 9
                 ty_span: [41-48]
                 init_expr: Expr [53-56]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             AssignStmt [66-73]:
                 symbol_id: 9
                 lhs_span: [66-67]
                 rhs: Expr [66-73]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Sub
                         lhs: Expr [66-67]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
                         rhs: Expr [71-72]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
         "#]],
     );
@@ -211,14 +211,14 @@ fn multiplication() {
                 symbol_id: 10
                 ty_span: [73-80]
                 init_expr: Expr [85-90]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [85-86]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
                         rhs: Expr [89-90]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
         "#]],
     );
@@ -241,20 +241,20 @@ fn multiplication_assign_op() {
                 symbol_id: 9
                 ty_span: [41-48]
                 init_expr: Expr [53-56]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             AssignStmt [66-73]:
                 symbol_id: 9
                 lhs_span: [66-67]
                 rhs: Expr [66-73]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [66-67]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
                         rhs: Expr [71-72]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
         "#]],
     );
@@ -279,14 +279,14 @@ fn division() {
                 symbol_id: 10
                 ty_span: [73-80]
                 init_expr: Expr [85-90]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Div
                         lhs: Expr [85-86]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
                         rhs: Expr [89-90]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
         "#]],
     );
@@ -309,20 +309,20 @@ fn division_assign_op() {
                 symbol_id: 9
                 ty_span: [41-48]
                 init_expr: Expr [53-56]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             AssignStmt [66-73]:
                 symbol_id: 9
                 lhs_span: [66-67]
                 rhs: Expr [66-73]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Div
                         lhs: Expr [66-67]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
                         rhs: Expr [71-72]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
         "#]],
     );
@@ -347,14 +347,14 @@ fn power() {
                 symbol_id: 10
                 ty_span: [73-80]
                 init_expr: Expr [85-91]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Exp
                         lhs: Expr [85-86]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
                         rhs: Expr [90-91]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
         "#]],
     );
@@ -377,21 +377,109 @@ fn power_assign_op() {
                 symbol_id: 9
                 ty_span: [41-48]
                 init_expr: Expr [53-56]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             AssignStmt [66-74]:
                 symbol_id: 9
                 lhs_span: [66-67]
                 rhs: Expr [66-74]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: BinaryOpExpr:
                         op: Exp
                         lhs: Expr [66-67]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(9)
                         rhs: Expr [72-73]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
         "#]],
+    );
+}
+
+#[test]
+fn modulo_fails() {
+    let input = "
+        input complex[float] a;
+        input complex[float] b;
+        complex x = a % b;
+    ";
+
+    check_stmt_kinds(
+        input,
+        &expect![[r#"
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-32]:
+                        annotations: <empty>
+                        kind: InputDeclaration [9-32]:
+                            symbol_id: 8
+                    Stmt [41-64]:
+                        annotations: <empty>
+                        kind: InputDeclaration [41-64]:
+                            symbol_id: 9
+                    Stmt [73-91]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [73-91]:
+                            symbol_id: 10
+                            ty_span: [73-80]
+                            init_expr: Expr [0-0]:
+                                ty: complex[float]
+                                kind: Err
+
+            [Qasm.Lowerer.OperatorNotAllowedForComplexValues
+
+              x the operator Mod is not allowed for complex values
+               ,-[test:4:21]
+             3 |         input complex[float] b;
+             4 |         complex x = a % b;
+               :                     ^^^^^
+             5 |     
+               `----
+            ]"#]],
+    );
+}
+
+#[test]
+fn modulo_non_complex_type_fails() {
+    let input = "
+        input complex[float] a;
+        input float b;
+        complex x = a % b;
+    ";
+
+    check_stmt_kinds(
+        input,
+        &expect![[r#"
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-32]:
+                        annotations: <empty>
+                        kind: InputDeclaration [9-32]:
+                            symbol_id: 8
+                    Stmt [41-55]:
+                        annotations: <empty>
+                        kind: InputDeclaration [41-55]:
+                            symbol_id: 9
+                    Stmt [64-82]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [64-82]:
+                            symbol_id: 10
+                            ty_span: [64-71]
+                            init_expr: Expr [0-0]:
+                                ty: complex[float]
+                                kind: Err
+
+            [Qasm.Lowerer.OperatorNotAllowedForComplexValues
+
+              x the operator Mod is not allowed for complex values
+               ,-[test:4:21]
+             3 |         input float b;
+             4 |         complex x = a % b;
+               :                     ^^^^^
+             5 |     
+               `----
+            ]"#]],
     );
 }

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/ident.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/ident.rs
@@ -19,24 +19,24 @@ fn mutable_int_idents_without_width_can_be_multiplied() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             ExprStmt [47-53]:
                 expr: Expr [47-52]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [47-48]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [51-52]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
         "#]],
     );
@@ -57,24 +57,24 @@ fn const_int_idents_without_width_can_be_multiplied() {
                 symbol_id: 8
                 ty_span: [15-18]
                 init_expr: Expr [23-24]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [34-50]:
                 symbol_id: 9
                 ty_span: [40-43]
                 init_expr: Expr [48-49]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(3)
             ExprStmt [59-65]:
                 expr: Expr [59-64]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [59-60]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: SymbolId(8)
                         rhs: Expr [63-64]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: SymbolId(9)
         "#]],
     );
@@ -95,24 +95,24 @@ fn const_and_mut_int_idents_without_width_can_be_multiplied() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [28-44]:
                 symbol_id: 9
                 ty_span: [34-37]
                 init_expr: Expr [42-43]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(3)
             ExprStmt [53-59]:
                 expr: Expr [53-58]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [53-54]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
                         rhs: Expr [57-58]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(9)
         "#]],
     );
@@ -133,28 +133,28 @@ fn const_int_idents_widthless_lhs_can_be_multiplied_by_explicit_width_int() {
                 symbol_id: 8
                 ty_span: [15-22]
                 init_expr: Expr [27-28]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(5)
             ClassicalDeclarationStmt [38-54]:
                 symbol_id: 9
                 ty_span: [44-47]
                 init_expr: Expr [52-53]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(3)
             ExprStmt [63-69]:
                 expr: Expr [63-68]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: BinaryOpExpr:
                         op: Mul
                         lhs: Expr [63-64]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Cast [0-0]:
-                                ty: Int(None, true)
+                                ty: const int
                                 expr: Expr [63-64]:
-                                    ty: Int(Some(32), true)
+                                    ty: const int[32]
                                     kind: SymbolId(8)
                         rhs: Expr [67-68]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: SymbolId(9)
         "#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_angle.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_angle.rs
@@ -31,15 +31,15 @@ fn angle_to_bool() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(0)
             ExprStmt [26-34]:
                 expr: Expr [26-33]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [26-33]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [31-32]:
-                            ty: Angle(None, false)
+                            ty: angle
                             kind: SymbolId(8)
         "#]],
     );
@@ -58,15 +58,15 @@ fn sized_angle_to_bool() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Angle(Some(32), true)
+                    ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-38]:
                 expr: Expr [30-37]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [30-37]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [35-36]:
-                            ty: Angle(Some(32), false)
+                            ty: angle[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -94,18 +94,18 @@ fn angle_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-38]:
                         annotations: <empty>
                         kind: ExprStmt [26-38]:
                             expr: Expr [26-37]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Duration(false)
+              x cannot cast expression of type angle to type duration
                ,-[test:3:9]
              2 |         angle a;
              3 |         duration(a);
@@ -134,19 +134,18 @@ fn sized_angle_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-42]:
                         annotations: <empty>
                         kind: ExprStmt [30-42]:
                             expr: Expr [30-41]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type angle[32] to type duration
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         duration(a);
@@ -179,18 +178,18 @@ fn angle_to_int_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-33]:
                         annotations: <empty>
                         kind: ExprStmt [26-33]:
                             expr: Expr [26-32]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Int(None, false)
+              x cannot cast expression of type angle to type int
                ,-[test:3:9]
              2 |         angle a;
              3 |         int(a);
@@ -219,19 +218,18 @@ fn angle_to_sized_int_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-37]:
                         annotations: <empty>
                         kind: ExprStmt [26-37]:
                             expr: Expr [26-36]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Int(Some(32),
-              | false)
+              x cannot cast expression of type angle to type int[32]
                ,-[test:3:9]
              2 |         angle a;
              3 |         int[32](a);
@@ -260,19 +258,18 @@ fn sized_angle_to_int_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-37]:
                         annotations: <empty>
                         kind: ExprStmt [30-37]:
                             expr: Expr [30-36]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type Int(None,
-              | false)
+              x cannot cast expression of type angle[32] to type int
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         int(a);
@@ -301,19 +298,18 @@ fn sized_angle_to_sized_int_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
                         annotations: <empty>
                         kind: ExprStmt [30-41]:
                             expr: Expr [30-40]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Int(Some(32), false)
+              x cannot cast expression of type angle[32] to type int[32]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         int[32](a);
@@ -342,19 +338,18 @@ fn sized_angle_to_sized_int_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
                         annotations: <empty>
                         kind: ExprStmt [30-41]:
                             expr: Expr [30-40]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Int(Some(16), false)
+              x cannot cast expression of type angle[32] to type int[16]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         int[16](a);
@@ -383,19 +378,18 @@ fn sized_angle_to_sized_int_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
                         annotations: <empty>
                         kind: ExprStmt [30-41]:
                             expr: Expr [30-40]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Int(Some(64), false)
+              x cannot cast expression of type angle[32] to type int[64]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         int[64](a);
@@ -428,19 +422,18 @@ fn angle_to_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-34]:
                         annotations: <empty>
                         kind: ExprStmt [26-34]:
                             expr: Expr [26-33]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type UInt(None,
-              | false)
+              x cannot cast expression of type angle to type uint
                ,-[test:3:9]
              2 |         angle a;
              3 |         uint(a);
@@ -469,19 +462,18 @@ fn angle_to_sized_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-38]:
                         annotations: <empty>
                         kind: ExprStmt [26-38]:
                             expr: Expr [26-37]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type UInt(Some(32),
-              | false)
+              x cannot cast expression of type angle to type uint[32]
                ,-[test:3:9]
              2 |         angle a;
              3 |         uint[32](a);
@@ -510,19 +502,18 @@ fn sized_angle_to_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-38]:
                         annotations: <empty>
                         kind: ExprStmt [30-38]:
                             expr: Expr [30-37]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type UInt(None,
-              | false)
+              x cannot cast expression of type angle[32] to type uint
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         uint(a);
@@ -551,19 +542,18 @@ fn sized_angle_to_sized_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-42]:
                         annotations: <empty>
                         kind: ExprStmt [30-42]:
                             expr: Expr [30-41]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | UInt(Some(32), false)
+              x cannot cast expression of type angle[32] to type uint[32]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         uint[32](a);
@@ -592,19 +582,18 @@ fn sized_angle_to_sized_uint_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-42]:
                         annotations: <empty>
                         kind: ExprStmt [30-42]:
                             expr: Expr [30-41]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | UInt(Some(16), false)
+              x cannot cast expression of type angle[32] to type uint[16]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         uint[16](a);
@@ -633,19 +622,18 @@ fn sized_angle_to_sized_uint_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-42]:
                         annotations: <empty>
                         kind: ExprStmt [30-42]:
                             expr: Expr [30-41]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | UInt(Some(64), false)
+              x cannot cast expression of type angle[32] to type uint[64]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         uint[64](a);
@@ -678,19 +666,18 @@ fn angle_to_float_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-35]:
                         annotations: <empty>
                         kind: ExprStmt [26-35]:
                             expr: Expr [26-34]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Float(None,
-              | false)
+              x cannot cast expression of type angle to type float
                ,-[test:3:9]
              2 |         angle a;
              3 |         float(a);
@@ -719,19 +706,18 @@ fn angle_to_sized_float_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-39]:
                         annotations: <empty>
                         kind: ExprStmt [26-39]:
                             expr: Expr [26-38]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Float(Some(32),
-              | false)
+              x cannot cast expression of type angle to type float[32]
                ,-[test:3:9]
              2 |         angle a;
              3 |         float[32](a);
@@ -760,19 +746,18 @@ fn sized_angle_to_float_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-39]:
                         annotations: <empty>
                         kind: ExprStmt [30-39]:
                             expr: Expr [30-38]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type Float(None,
-              | false)
+              x cannot cast expression of type angle[32] to type float
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         float(a);
@@ -801,19 +786,18 @@ fn sized_angle_to_sized_float_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-43]:
                         annotations: <empty>
                         kind: ExprStmt [30-43]:
                             expr: Expr [30-42]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Float(Some(32), false)
+              x cannot cast expression of type angle[32] to type float[32]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         float[32](a);
@@ -842,19 +826,18 @@ fn sized_angle_to_sized_float_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-43]:
                         annotations: <empty>
                         kind: ExprStmt [30-43]:
                             expr: Expr [30-42]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Float(Some(16), false)
+              x cannot cast expression of type angle[32] to type float[16]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         float[16](a);
@@ -883,19 +866,18 @@ fn sized_angle_to_sized_float_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-43]:
                         annotations: <empty>
                         kind: ExprStmt [30-43]:
                             expr: Expr [30-42]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Float(Some(64), false)
+              x cannot cast expression of type angle[32] to type float[64]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         float[64](a);
@@ -923,11 +905,11 @@ fn angle_to_angle() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(0)
             ExprStmt [26-35]:
                 expr: Expr [26-34]:
-                    ty: Angle(None, false)
+                    ty: angle
                     kind: SymbolId(8)
         "#]],
     );
@@ -946,15 +928,15 @@ fn angle_to_sized_angle() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(0)
             ExprStmt [26-39]:
                 expr: Expr [26-38]:
-                    ty: Angle(Some(32), false)
+                    ty: angle[32]
                     kind: Cast [26-38]:
-                        ty: Angle(Some(32), false)
+                        ty: angle[32]
                         expr: Expr [36-37]:
-                            ty: Angle(None, false)
+                            ty: angle
                             kind: SymbolId(8)
         "#]],
     );
@@ -973,15 +955,15 @@ fn sized_angle_to_angle() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Angle(Some(32), true)
+                    ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-39]:
                 expr: Expr [30-38]:
-                    ty: Angle(None, false)
+                    ty: angle
                     kind: Cast [30-38]:
-                        ty: Angle(None, false)
+                        ty: angle
                         expr: Expr [36-37]:
-                            ty: Angle(Some(32), false)
+                            ty: angle[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1000,11 +982,11 @@ fn sized_angle_to_sized_angle() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Angle(Some(32), true)
+                    ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-43]:
                 expr: Expr [30-42]:
-                    ty: Angle(Some(32), false)
+                    ty: angle[32]
                     kind: SymbolId(8)
         "#]],
     );
@@ -1023,15 +1005,15 @@ fn sized_angle_to_sized_angle_truncating() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Angle(Some(32), true)
+                    ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-43]:
                 expr: Expr [30-42]:
-                    ty: Angle(Some(16), false)
+                    ty: angle[16]
                     kind: Cast [30-42]:
-                        ty: Angle(Some(16), false)
+                        ty: angle[16]
                         expr: Expr [40-41]:
-                            ty: Angle(Some(32), false)
+                            ty: angle[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1050,15 +1032,15 @@ fn sized_angle_to_sized_angle_expanding() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Angle(Some(32), true)
+                    ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-43]:
                 expr: Expr [30-42]:
-                    ty: Angle(Some(64), false)
+                    ty: angle[64]
                     kind: Cast [30-42]:
-                        ty: Angle(Some(64), false)
+                        ty: angle[64]
                         expr: Expr [40-41]:
-                            ty: Angle(Some(32), false)
+                            ty: angle[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1086,19 +1068,18 @@ fn angle_to_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-37]:
                         annotations: <empty>
                         kind: ExprStmt [26-37]:
                             expr: Expr [26-36]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Complex(None,
-              | false)
+              x cannot cast expression of type angle to type complex[float]
                ,-[test:3:9]
              2 |         angle a;
              3 |         complex(a);
@@ -1127,19 +1108,18 @@ fn angle_to_sized_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-48]:
                         annotations: <empty>
                         kind: ExprStmt [26-48]:
                             expr: Expr [26-47]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type
-              | Complex(Some(32), false)
+              x cannot cast expression of type angle to type complex[float[32]]
                ,-[test:3:9]
              2 |         angle a;
              3 |         complex[float[32]](a);
@@ -1168,19 +1148,18 @@ fn sized_angle_to_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
                         annotations: <empty>
                         kind: ExprStmt [30-41]:
                             expr: Expr [30-40]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Complex(None, false)
+              x cannot cast expression of type angle[32] to type complex[float]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         complex(a);
@@ -1209,19 +1188,18 @@ fn sized_angle_to_sized_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-52]:
                         annotations: <empty>
                         kind: ExprStmt [30-52]:
                             expr: Expr [30-51]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Complex(Some(32), false)
+              x cannot cast expression of type angle[32] to type complex[float[32]]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         complex[float[32]](a);
@@ -1250,19 +1228,18 @@ fn sized_angle_to_sized_complex_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-52]:
                         annotations: <empty>
                         kind: ExprStmt [30-52]:
                             expr: Expr [30-51]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Complex(Some(16), false)
+              x cannot cast expression of type angle[32] to type complex[float[16]]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         complex[float[16]](a);
@@ -1291,19 +1268,18 @@ fn sized_angle_to_sized_complex_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-52]:
                         annotations: <empty>
                         kind: ExprStmt [30-52]:
                             expr: Expr [30-51]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Complex(Some(64), false)
+              x cannot cast expression of type angle[32] to type complex[float[64]]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         complex[float[64]](a);
@@ -1331,15 +1307,15 @@ fn angle_to_bit() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(0)
             ExprStmt [26-33]:
                 expr: Expr [26-32]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [26-32]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [30-31]:
-                            ty: Angle(None, false)
+                            ty: angle
                             kind: SymbolId(8)
         "#]],
     );
@@ -1363,19 +1339,18 @@ fn angle_to_bitarray_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-37]:
                         annotations: <empty>
                         kind: ExprStmt [26-37]:
                             expr: Expr [26-36]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type angle to type bit[32]
                ,-[test:3:9]
              2 |         angle a;
              3 |         bit[32](a);
@@ -1399,15 +1374,15 @@ fn sized_angle_to_bit() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Angle(Some(32), true)
+                    ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-37]:
                 expr: Expr [30-36]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [30-36]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [34-35]:
-                            ty: Angle(Some(32), false)
+                            ty: angle[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1426,15 +1401,15 @@ fn sized_angle_to_bitarray() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Angle(Some(32), true)
+                    ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-41]:
                 expr: Expr [30-40]:
-                    ty: BitArray(32, false)
+                    ty: bit[32]
                     kind: Cast [30-40]:
-                        ty: BitArray(32, false)
+                        ty: bit[32]
                         expr: Expr [38-39]:
-                            ty: Angle(Some(32), false)
+                            ty: angle[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1458,19 +1433,18 @@ fn sized_angle_to_bitarray_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
                         annotations: <empty>
                         kind: ExprStmt [30-41]:
                             expr: Expr [30-40]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type angle[32] to type bit[16]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         bit[16](a);
@@ -1499,19 +1473,18 @@ fn sized_angle_to_bitarray_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Angle(Some(32), true)
+                                ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
                         annotations: <empty>
                         kind: ExprStmt [30-41]:
                             expr: Expr [30-40]:
-                                ty: Angle(Some(32), false)
+                                ty: angle[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type angle[32] to type bit[64]
                ,-[test:3:9]
              2 |         angle[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bit.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bit.rs
@@ -31,15 +31,15 @@ fn bit_to_bool() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-32]:
                 expr: Expr [24-31]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [24-31]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [29-30]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
         "#]],
     );
@@ -58,15 +58,15 @@ fn bitarray_to_bool() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(32, true)
+                    ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-36]:
                 expr: Expr [28-35]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [28-35]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [33-34]:
-                            ty: BitArray(32, false)
+                            ty: bit[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -94,18 +94,18 @@ fn bit_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [0-0]:
-                                ty: Bit(true)
+                                ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-36]:
                         annotations: <empty>
                         kind: ExprStmt [24-36]:
                             expr: Expr [24-35]:
-                                ty: Bit(false)
+                                ty: bit
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Duration(false)
+              x cannot cast expression of type bit to type duration
                ,-[test:3:9]
              2 |         bit a;
              3 |         duration(a);
@@ -134,18 +134,18 @@ fn bitarray_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-40]:
                         annotations: <empty>
                         kind: ExprStmt [28-40]:
                             expr: Expr [28-39]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Duration(false)
+              x cannot cast expression of type bit[32] to type duration
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         duration(a);
@@ -173,15 +173,15 @@ fn bit_to_int() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-31]:
                 expr: Expr [24-30]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [24-30]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [28-29]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
         "#]],
     );
@@ -200,15 +200,15 @@ fn bit_to_sized_int() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-35]:
                 expr: Expr [24-34]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [24-34]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [32-33]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
         "#]],
     );
@@ -269,15 +269,15 @@ fn bitarray_to_sized_int() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(32, true)
+                    ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-39]:
                 expr: Expr [28-38]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [28-38]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [36-37]:
-                            ty: BitArray(32, false)
+                            ty: bit[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -301,19 +301,18 @@ fn bitarray_to_sized_int_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:
                         annotations: <empty>
                         kind: ExprStmt [28-39]:
                             expr: Expr [28-38]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Int(Some(16),
-              | false)
+              x cannot cast expression of type bit[32] to type int[16]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         int[16](a);
@@ -342,19 +341,18 @@ fn bitarray_to_sized_int_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:
                         annotations: <empty>
                         kind: ExprStmt [28-39]:
                             expr: Expr [28-38]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Int(Some(64),
-              | false)
+              x cannot cast expression of type bit[32] to type int[64]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         int[64](a);
@@ -382,15 +380,15 @@ fn bit_to_uint() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-32]:
                 expr: Expr [24-31]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [24-31]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [29-30]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
         "#]],
     );
@@ -409,15 +407,15 @@ fn bit_to_sized_uint() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-36]:
                 expr: Expr [24-35]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [24-35]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [33-34]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
         "#]],
     );
@@ -478,15 +476,15 @@ fn bitarray_to_sized_uint() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(32, true)
+                    ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-40]:
                 expr: Expr [28-39]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [28-39]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [37-38]:
-                            ty: BitArray(32, false)
+                            ty: bit[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -510,19 +508,18 @@ fn bitarray_to_sized_uint_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-40]:
                         annotations: <empty>
                         kind: ExprStmt [28-40]:
                             expr: Expr [28-39]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type UInt(Some(16),
-              | false)
+              x cannot cast expression of type bit[32] to type uint[16]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         uint[16](a);
@@ -551,19 +548,18 @@ fn bitarray_to_sized_uint_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-40]:
                         annotations: <empty>
                         kind: ExprStmt [28-40]:
                             expr: Expr [28-39]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type UInt(Some(64),
-              | false)
+              x cannot cast expression of type bit[32] to type uint[64]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         uint[64](a);
@@ -591,15 +587,15 @@ fn bit_to_float() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-33]:
                 expr: Expr [24-32]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [24-32]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [30-31]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
         "#]],
     );
@@ -618,15 +614,15 @@ fn bit_to_sized_float() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-37]:
                 expr: Expr [24-36]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [24-36]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [34-35]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
         "#]],
     );
@@ -650,19 +646,18 @@ fn bitarray_to_float_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-37]:
                         annotations: <empty>
                         kind: ExprStmt [28-37]:
                             expr: Expr [28-36]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Float(None,
-              | false)
+              x cannot cast expression of type bit[32] to type float
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         float(a);
@@ -691,19 +686,18 @@ fn bitarray_to_sized_float_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Float(Some(32),
-              | false)
+              x cannot cast expression of type bit[32] to type float[32]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         float[32](a);
@@ -732,19 +726,18 @@ fn bitarray_to_sized_float_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Float(Some(16),
-              | false)
+              x cannot cast expression of type bit[32] to type float[16]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         float[16](a);
@@ -773,19 +766,18 @@ fn bitarray_to_sized_float_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Float(Some(64),
-              | false)
+              x cannot cast expression of type bit[32] to type float[64]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         float[64](a);
@@ -818,18 +810,18 @@ fn bit_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [0-0]:
-                                ty: Bit(true)
+                                ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-33]:
                         annotations: <empty>
                         kind: ExprStmt [24-33]:
                             expr: Expr [24-32]:
-                                ty: Bit(false)
+                                ty: bit
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Angle(None, false)
+              x cannot cast expression of type bit to type angle
                ,-[test:3:9]
              2 |         bit a;
              3 |         angle(a);
@@ -858,18 +850,18 @@ fn bit_to_sized_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [0-0]:
-                                ty: Bit(true)
+                                ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-37]:
                         annotations: <empty>
                         kind: ExprStmt [24-37]:
                             expr: Expr [24-36]:
-                                ty: Bit(false)
+                                ty: bit
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Angle(Some(32), false)
+              x cannot cast expression of type bit to type angle[32]
                ,-[test:3:9]
              2 |         bit a;
              3 |         angle[32](a);
@@ -898,19 +890,18 @@ fn bitarray_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-37]:
                         annotations: <empty>
                         kind: ExprStmt [28-37]:
                             expr: Expr [28-36]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Angle(None,
-              | false)
+              x cannot cast expression of type bit[32] to type angle
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         angle(a);
@@ -934,15 +925,15 @@ fn bitarray_to_sized_angle() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(32, true)
+                    ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-41]:
                 expr: Expr [28-40]:
-                    ty: Angle(Some(32), false)
+                    ty: angle[32]
                     kind: Cast [28-40]:
-                        ty: Angle(Some(32), false)
+                        ty: angle[32]
                         expr: Expr [38-39]:
-                            ty: BitArray(32, false)
+                            ty: bit[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -966,19 +957,18 @@ fn bitarray_to_sized_angle_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Angle(Some(16),
-              | false)
+              x cannot cast expression of type bit[32] to type angle[16]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         angle[16](a);
@@ -1007,19 +997,18 @@ fn bitarray_to_sized_angle_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Angle(Some(64),
-              | false)
+              x cannot cast expression of type bit[32] to type angle[64]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         angle[64](a);
@@ -1052,18 +1041,18 @@ fn bit_to_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [0-0]:
-                                ty: Bit(true)
+                                ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-35]:
                         annotations: <empty>
                         kind: ExprStmt [24-35]:
                             expr: Expr [24-34]:
-                                ty: Bit(false)
+                                ty: bit
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Complex(None, false)
+              x cannot cast expression of type bit to type complex[float]
                ,-[test:3:9]
              2 |         bit a;
              3 |         complex(a);
@@ -1092,18 +1081,18 @@ fn bit_to_sized_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [0-0]:
-                                ty: Bit(true)
+                                ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-46]:
                         annotations: <empty>
                         kind: ExprStmt [24-46]:
                             expr: Expr [24-45]:
-                                ty: Bit(false)
+                                ty: bit
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Complex(Some(32), false)
+              x cannot cast expression of type bit to type complex[float[32]]
                ,-[test:3:9]
              2 |         bit a;
              3 |         complex[float[32]](a);
@@ -1132,19 +1121,18 @@ fn bitarray_to_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:
                         annotations: <empty>
                         kind: ExprStmt [28-39]:
                             expr: Expr [28-38]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Complex(None,
-              | false)
+              x cannot cast expression of type bit[32] to type complex[float]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         complex(a);
@@ -1173,19 +1161,18 @@ fn bitarray_to_sized_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-50]:
                         annotations: <empty>
                         kind: ExprStmt [28-50]:
                             expr: Expr [28-49]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type
-              | Complex(Some(32), false)
+              x cannot cast expression of type bit[32] to type complex[float[32]]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         complex[float[32]](a);
@@ -1214,19 +1201,18 @@ fn bitarray_to_sized_complex_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-50]:
                         annotations: <empty>
                         kind: ExprStmt [28-50]:
                             expr: Expr [28-49]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type
-              | Complex(Some(16), false)
+              x cannot cast expression of type bit[32] to type complex[float[16]]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         complex[float[16]](a);
@@ -1255,19 +1241,18 @@ fn bitarray_to_sized_complex_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-50]:
                         annotations: <empty>
                         kind: ExprStmt [28-50]:
                             expr: Expr [28-49]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type
-              | Complex(Some(64), false)
+              x cannot cast expression of type bit[32] to type complex[float[64]]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         complex[float[64]](a);
@@ -1295,11 +1280,11 @@ fn bit_to_bit() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-31]:
                 expr: Expr [24-30]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: SymbolId(8)
         "#]],
     );
@@ -1318,15 +1303,15 @@ fn bit_to_bitarray() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-35]:
                 expr: Expr [24-34]:
-                    ty: BitArray(32, false)
+                    ty: bit[32]
                     kind: Cast [24-34]:
-                        ty: BitArray(32, false)
+                        ty: bit[32]
                         expr: Expr [32-33]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
         "#]],
     );
@@ -1345,15 +1330,15 @@ fn bitarray_to_bit() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(32, true)
+                    ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-35]:
                 expr: Expr [28-34]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [28-34]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [32-33]:
-                            ty: BitArray(32, false)
+                            ty: bit[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1372,11 +1357,11 @@ fn bitarray_to_bitarray() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(32, true)
+                    ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-39]:
                 expr: Expr [28-38]:
-                    ty: BitArray(32, false)
+                    ty: bit[32]
                     kind: SymbolId(8)
         "#]],
     );
@@ -1400,19 +1385,18 @@ fn bitarray_to_bitarray_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:
                         annotations: <empty>
                         kind: ExprStmt [28-39]:
                             expr: Expr [28-38]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type bit[32] to type bit[16]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         bit[16](a);
@@ -1441,19 +1425,18 @@ fn bitarray_to_bitarray_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(32, true)
+                                ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:
                         annotations: <empty>
                         kind: ExprStmt [28-39]:
                             expr: Expr [28-38]:
-                                ty: BitArray(32, false)
+                                ty: bit[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type bit[32] to type bit[64]
                ,-[test:3:9]
              2 |         bit[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bool.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bool.rs
@@ -31,11 +31,11 @@ fn bool_to_bool() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-33]:
                 expr: Expr [25-32]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: SymbolId(8)
         "#]],
     );
@@ -63,18 +63,18 @@ fn bool_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-13]
                             init_expr: Expr [0-0]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-37]:
                         annotations: <empty>
                         kind: ExprStmt [25-37]:
                             expr: Expr [25-36]:
-                                ty: Bool(false)
+                                ty: bool
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Duration(false)
+              x cannot cast expression of type bool to type duration
                ,-[test:3:9]
              2 |         bool a;
              3 |         duration(a);
@@ -102,15 +102,15 @@ fn bool_to_int() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-32]:
                 expr: Expr [25-31]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [25-31]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [29-30]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
         "#]],
     );
@@ -129,15 +129,15 @@ fn bool_to_sized_int() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-36]:
                 expr: Expr [25-35]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [25-35]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [33-34]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
         "#]],
     );
@@ -160,15 +160,15 @@ fn bool_to_uint() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-33]:
                 expr: Expr [25-32]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [25-32]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [30-31]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
         "#]],
     );
@@ -187,15 +187,15 @@ fn bool_to_sized_uint() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-37]:
                 expr: Expr [25-36]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [25-36]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [34-35]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
         "#]],
     );
@@ -218,15 +218,15 @@ fn bool_to_float() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-34]:
                 expr: Expr [25-33]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [25-33]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [31-32]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
         "#]],
     );
@@ -245,15 +245,15 @@ fn bool_to_sized_float() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-38]:
                 expr: Expr [25-37]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [25-37]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [35-36]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
         "#]],
     );
@@ -281,18 +281,18 @@ fn bool_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-13]
                             init_expr: Expr [0-0]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-34]:
                         annotations: <empty>
                         kind: ExprStmt [25-34]:
                             expr: Expr [25-33]:
-                                ty: Bool(false)
+                                ty: bool
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Angle(None, false)
+              x cannot cast expression of type bool to type angle
                ,-[test:3:9]
              2 |         bool a;
              3 |         angle(a);
@@ -321,18 +321,18 @@ fn bool_to_sized_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-13]
                             init_expr: Expr [0-0]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-38]:
                         annotations: <empty>
                         kind: ExprStmt [25-38]:
                             expr: Expr [25-37]:
-                                ty: Bool(false)
+                                ty: bool
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Angle(Some(32), false)
+              x cannot cast expression of type bool to type angle[32]
                ,-[test:3:9]
              2 |         bool a;
              3 |         angle[32](a);
@@ -365,18 +365,18 @@ fn bool_to_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-13]
                             init_expr: Expr [0-0]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-36]:
                         annotations: <empty>
                         kind: ExprStmt [25-36]:
                             expr: Expr [25-35]:
-                                ty: Bool(false)
+                                ty: bool
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Complex(None, false)
+              x cannot cast expression of type bool to type complex[float]
                ,-[test:3:9]
              2 |         bool a;
              3 |         complex(a);
@@ -405,19 +405,18 @@ fn bool_to_sized_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-13]
                             init_expr: Expr [0-0]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-47]:
                         annotations: <empty>
                         kind: ExprStmt [25-47]:
                             expr: Expr [25-46]:
-                                ty: Bool(false)
+                                ty: bool
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Complex(Some(32),
-              | false)
+              x cannot cast expression of type bool to type complex[float[32]]
                ,-[test:3:9]
              2 |         bool a;
              3 |         complex[float[32]](a);
@@ -445,15 +444,15 @@ fn bool_to_bit() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-32]:
                 expr: Expr [25-31]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [25-31]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [29-30]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
         "#]],
     );
@@ -472,15 +471,15 @@ fn bool_to_bitarray() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-36]:
                 expr: Expr [25-35]:
-                    ty: BitArray(32, false)
+                    ty: bit[32]
                     kind: Cast [25-35]:
-                        ty: BitArray(32, false)
+                        ty: bit[32]
                         expr: Expr [33-34]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
         "#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_complex.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_complex.rs
@@ -36,18 +36,18 @@ fn complex_to_bool_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-36]:
                         annotations: <empty>
                         kind: ExprStmt [28-36]:
                             expr: Expr [28-35]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Bool(false)
+              x cannot cast expression of type complex[float] to type bool
                ,-[test:3:9]
              2 |         complex a;
              3 |         bool(a);
@@ -76,19 +76,18 @@ fn sized_complex_to_bool_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-47]:
                         annotations: <empty>
                         kind: ExprStmt [39-47]:
                             expr: Expr [39-46]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Bool(false)
+              x cannot cast expression of type complex[float[32]] to type bool
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         bool(a);
@@ -121,19 +120,18 @@ fn complex_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-40]:
                         annotations: <empty>
                         kind: ExprStmt [28-40]:
                             expr: Expr [28-39]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type
-              | Duration(false)
+              x cannot cast expression of type complex[float] to type duration
                ,-[test:3:9]
              2 |         complex a;
              3 |         duration(a);
@@ -162,19 +160,18 @@ fn sized_complex_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-51]:
                         annotations: <empty>
                         kind: ExprStmt [39-51]:
                             expr: Expr [39-50]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type complex[float[32]] to type duration
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         duration(a);
@@ -207,19 +204,18 @@ fn complex_to_int_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-35]:
                         annotations: <empty>
                         kind: ExprStmt [28-35]:
                             expr: Expr [28-34]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Int(None,
-              | false)
+              x cannot cast expression of type complex[float] to type int
                ,-[test:3:9]
              2 |         complex a;
              3 |         int(a);
@@ -248,19 +244,18 @@ fn complex_to_sized_int_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-39]:
                         annotations: <empty>
                         kind: ExprStmt [28-39]:
                             expr: Expr [28-38]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Int(Some(32),
-              | false)
+              x cannot cast expression of type complex[float] to type int[32]
                ,-[test:3:9]
              2 |         complex a;
              3 |         int[32](a);
@@ -289,19 +284,18 @@ fn sized_complex_to_int_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-46]:
                         annotations: <empty>
                         kind: ExprStmt [39-46]:
                             expr: Expr [39-45]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type Int(None,
-              | false)
+              x cannot cast expression of type complex[float[32]] to type int
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         int(a);
@@ -330,19 +324,18 @@ fn sized_complex_to_sized_int_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
                         annotations: <empty>
                         kind: ExprStmt [39-50]:
                             expr: Expr [39-49]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Int(Some(32), false)
+              x cannot cast expression of type complex[float[32]] to type int[32]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         int[32](a);
@@ -371,19 +364,18 @@ fn sized_complex_to_sized_int_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
                         annotations: <empty>
                         kind: ExprStmt [39-50]:
                             expr: Expr [39-49]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Int(Some(16), false)
+              x cannot cast expression of type complex[float[32]] to type int[16]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         int[16](a);
@@ -412,19 +404,18 @@ fn sized_complex_to_sized_int_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
                         annotations: <empty>
                         kind: ExprStmt [39-50]:
                             expr: Expr [39-49]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Int(Some(64), false)
+              x cannot cast expression of type complex[float[32]] to type int[64]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         int[64](a);
@@ -457,19 +448,18 @@ fn complex_to_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-36]:
                         annotations: <empty>
                         kind: ExprStmt [28-36]:
                             expr: Expr [28-35]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type UInt(None,
-              | false)
+              x cannot cast expression of type complex[float] to type uint
                ,-[test:3:9]
              2 |         complex a;
              3 |         uint(a);
@@ -498,19 +488,18 @@ fn complex_to_sized_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-40]:
                         annotations: <empty>
                         kind: ExprStmt [28-40]:
                             expr: Expr [28-39]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type UInt(Some(32),
-              | false)
+              x cannot cast expression of type complex[float] to type uint[32]
                ,-[test:3:9]
              2 |         complex a;
              3 |         uint[32](a);
@@ -539,19 +528,18 @@ fn sized_complex_to_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-47]:
                         annotations: <empty>
                         kind: ExprStmt [39-47]:
                             expr: Expr [39-46]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type UInt(None,
-              | false)
+              x cannot cast expression of type complex[float[32]] to type uint
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         uint(a);
@@ -580,19 +568,18 @@ fn sized_complex_to_sized_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-51]:
                         annotations: <empty>
                         kind: ExprStmt [39-51]:
                             expr: Expr [39-50]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | UInt(Some(32), false)
+              x cannot cast expression of type complex[float[32]] to type uint[32]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         uint[32](a);
@@ -621,19 +608,18 @@ fn sized_complex_to_sized_uint_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-51]:
                         annotations: <empty>
                         kind: ExprStmt [39-51]:
                             expr: Expr [39-50]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | UInt(Some(16), false)
+              x cannot cast expression of type complex[float[32]] to type uint[16]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         uint[16](a);
@@ -662,19 +648,18 @@ fn sized_complex_to_sized_uint_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-51]:
                         annotations: <empty>
                         kind: ExprStmt [39-51]:
                             expr: Expr [39-50]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | UInt(Some(64), false)
+              x cannot cast expression of type complex[float[32]] to type uint[64]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         uint[64](a);
@@ -707,19 +692,18 @@ fn complex_to_float_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-37]:
                         annotations: <empty>
                         kind: ExprStmt [28-37]:
                             expr: Expr [28-36]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Float(None,
-              | false)
+              x cannot cast expression of type complex[float] to type float
                ,-[test:3:9]
              2 |         complex a;
              3 |         float(a);
@@ -748,19 +732,18 @@ fn complex_to_sized_float_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type
-              | Float(Some(32), false)
+              x cannot cast expression of type complex[float] to type float[32]
                ,-[test:3:9]
              2 |         complex a;
              3 |         float[32](a);
@@ -789,19 +772,18 @@ fn sized_complex_to_float_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-48]:
                         annotations: <empty>
                         kind: ExprStmt [39-48]:
                             expr: Expr [39-47]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Float(None, false)
+              x cannot cast expression of type complex[float[32]] to type float
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         float(a);
@@ -830,19 +812,18 @@ fn sized_complex_to_sized_float_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
                         annotations: <empty>
                         kind: ExprStmt [39-52]:
                             expr: Expr [39-51]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Float(Some(32), false)
+              x cannot cast expression of type complex[float[32]] to type float[32]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         float[32](a);
@@ -871,19 +852,18 @@ fn sized_complex_to_sized_float_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
                         annotations: <empty>
                         kind: ExprStmt [39-52]:
                             expr: Expr [39-51]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Float(Some(16), false)
+              x cannot cast expression of type complex[float[32]] to type float[16]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         float[16](a);
@@ -912,19 +892,18 @@ fn sized_complex_to_sized_float_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
                         annotations: <empty>
                         kind: ExprStmt [39-52]:
                             expr: Expr [39-51]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Float(Some(64), false)
+              x cannot cast expression of type complex[float[32]] to type float[64]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         float[64](a);
@@ -957,19 +936,18 @@ fn complex_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-37]:
                         annotations: <empty>
                         kind: ExprStmt [28-37]:
                             expr: Expr [28-36]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Angle(None,
-              | false)
+              x cannot cast expression of type complex[float] to type angle
                ,-[test:3:9]
              2 |         complex a;
              3 |         angle(a);
@@ -998,19 +976,18 @@ fn complex_to_sized_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type
-              | Angle(Some(32), false)
+              x cannot cast expression of type complex[float] to type angle[32]
                ,-[test:3:9]
              2 |         complex a;
              3 |         angle[32](a);
@@ -1039,19 +1016,18 @@ fn sized_complex_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-48]:
                         annotations: <empty>
                         kind: ExprStmt [39-48]:
                             expr: Expr [39-47]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Angle(None, false)
+              x cannot cast expression of type complex[float[32]] to type angle
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         angle(a);
@@ -1080,19 +1056,18 @@ fn sized_complex_to_sized_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
                         annotations: <empty>
                         kind: ExprStmt [39-52]:
                             expr: Expr [39-51]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Angle(Some(32), false)
+              x cannot cast expression of type complex[float[32]] to type angle[32]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         angle[32](a);
@@ -1121,19 +1096,18 @@ fn sized_complex_to_sized_angle_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
                         annotations: <empty>
                         kind: ExprStmt [39-52]:
                             expr: Expr [39-51]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Angle(Some(16), false)
+              x cannot cast expression of type complex[float[32]] to type angle[16]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         angle[16](a);
@@ -1162,19 +1136,18 @@ fn sized_complex_to_sized_angle_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
                         annotations: <empty>
                         kind: ExprStmt [39-52]:
                             expr: Expr [39-51]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Angle(Some(64), false)
+              x cannot cast expression of type complex[float[32]] to type angle[64]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         angle[64](a);
@@ -1202,11 +1175,11 @@ fn complex_to_complex() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [28-39]:
                 expr: Expr [28-38]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: SymbolId(8)
         "#]],
     );
@@ -1225,15 +1198,15 @@ fn complex_to_sized_complex() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Complex(None, true)
+                    ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [28-50]:
                 expr: Expr [28-49]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: Cast [28-49]:
-                        ty: Complex(Some(32), false)
+                        ty: complex[float[32]]
                         expr: Expr [47-48]:
-                            ty: Complex(None, false)
+                            ty: complex[float]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1252,15 +1225,15 @@ fn sized_complex_to_complex() {
                 symbol_id: 8
                 ty_span: [9-27]
                 init_expr: Expr [0-0]:
-                    ty: Complex(Some(32), true)
+                    ty: const complex[float[32]]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [39-50]:
                 expr: Expr [39-49]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Cast [39-49]:
-                        ty: Complex(None, false)
+                        ty: complex[float]
                         expr: Expr [47-48]:
-                            ty: Complex(Some(32), false)
+                            ty: complex[float[32]]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1279,11 +1252,11 @@ fn sized_complex_to_sized_complex() {
                 symbol_id: 8
                 ty_span: [9-27]
                 init_expr: Expr [0-0]:
-                    ty: Complex(Some(32), true)
+                    ty: const complex[float[32]]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [39-61]:
                 expr: Expr [39-60]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: SymbolId(8)
         "#]],
     );
@@ -1302,11 +1275,11 @@ fn sized_complex_to_sized_complex_truncating() {
                 symbol_id: 8
                 ty_span: [9-27]
                 init_expr: Expr [0-0]:
-                    ty: Complex(Some(32), true)
+                    ty: const complex[float[32]]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [39-61]:
                 expr: Expr [39-60]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: SymbolId(8)
         "#]],
     );
@@ -1325,15 +1298,15 @@ fn sized_complex_to_sized_complex_expanding() {
                 symbol_id: 8
                 ty_span: [9-27]
                 init_expr: Expr [0-0]:
-                    ty: Complex(Some(32), true)
+                    ty: const complex[float[32]]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [39-61]:
                 expr: Expr [39-60]:
-                    ty: Complex(Some(64), false)
+                    ty: complex[float[64]]
                     kind: Cast [39-60]:
-                        ty: Complex(Some(64), false)
+                        ty: complex[float[64]]
                         expr: Expr [58-59]:
-                            ty: Complex(Some(32), false)
+                            ty: complex[float[32]]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1361,18 +1334,18 @@ fn complex_to_bit_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-35]:
                         annotations: <empty>
                         kind: ExprStmt [28-35]:
                             expr: Expr [28-34]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Bit(false)
+              x cannot cast expression of type complex[float] to type bit
                ,-[test:3:9]
              2 |         complex a;
              3 |         bit(a);
@@ -1401,19 +1374,18 @@ fn complex_to_bitarray_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Complex(None, true)
+                                ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-39]:
                         annotations: <empty>
                         kind: ExprStmt [28-39]:
                             expr: Expr [28-38]:
-                                ty: Complex(None, false)
+                                ty: complex[float]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type complex[float] to type bit[32]
                ,-[test:3:9]
              2 |         complex a;
              3 |         bit[32](a);
@@ -1442,18 +1414,18 @@ fn sized_complex_to_bit_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-46]:
                         annotations: <empty>
                         kind: ExprStmt [39-46]:
                             expr: Expr [39-45]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type Bit(false)
+              x cannot cast expression of type complex[float[32]] to type bit
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         bit(a);
@@ -1482,19 +1454,18 @@ fn sized_complex_to_bitarray_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
                         annotations: <empty>
                         kind: ExprStmt [39-50]:
                             expr: Expr [39-49]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | BitArray(32, false)
+              x cannot cast expression of type complex[float[32]] to type bit[32]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         bit[32](a);
@@ -1523,19 +1494,18 @@ fn sized_complex_to_bitarray_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
                         annotations: <empty>
                         kind: ExprStmt [39-50]:
                             expr: Expr [39-49]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | BitArray(16, false)
+              x cannot cast expression of type complex[float[32]] to type bit[16]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         bit[16](a);
@@ -1564,19 +1534,18 @@ fn sized_complex_to_bitarray_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-27]
                             init_expr: Expr [0-0]:
-                                ty: Complex(Some(32), true)
+                                ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
                         annotations: <empty>
                         kind: ExprStmt [39-50]:
                             expr: Expr [39-49]:
-                                ty: Complex(Some(32), false)
+                                ty: complex[float[32]]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | BitArray(64, false)
+              x cannot cast expression of type complex[float[32]] to type bit[64]
                ,-[test:3:9]
              2 |         complex[float[32]] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_duration.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_duration.rs
@@ -36,13 +36,13 @@ fn duration_to_bool_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-37]:
                         annotations: <empty>
                         kind: ExprStmt [29-37]:
                             expr: Expr [29-36]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -56,7 +56,7 @@ fn duration_to_bool_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Bool(false)
+              x cannot cast expression of type duration to type bool
                ,-[test:3:9]
              2 |         duration a;
              3 |         bool(a);
@@ -89,13 +89,13 @@ fn duration_to_duration() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-41]:
                         annotations: <empty>
                         kind: ExprStmt [29-41]:
                             expr: Expr [29-40]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -133,13 +133,13 @@ fn duration_to_int_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-36]:
                         annotations: <empty>
                         kind: ExprStmt [29-36]:
                             expr: Expr [29-35]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -153,7 +153,7 @@ fn duration_to_int_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Int(None, false)
+              x cannot cast expression of type duration to type int
                ,-[test:3:9]
              2 |         duration a;
              3 |         int(a);
@@ -182,13 +182,13 @@ fn duration_to_sized_int_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-40]:
                         annotations: <empty>
                         kind: ExprStmt [29-40]:
                             expr: Expr [29-39]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -202,8 +202,7 @@ fn duration_to_sized_int_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Int(Some(32),
-              | false)
+              x cannot cast expression of type duration to type int[32]
                ,-[test:3:9]
              2 |         duration a;
              3 |         int[32](a);
@@ -236,13 +235,13 @@ fn duration_to_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-37]:
                         annotations: <empty>
                         kind: ExprStmt [29-37]:
                             expr: Expr [29-36]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -256,7 +255,7 @@ fn duration_to_uint_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type UInt(None, false)
+              x cannot cast expression of type duration to type uint
                ,-[test:3:9]
              2 |         duration a;
              3 |         uint(a);
@@ -285,13 +284,13 @@ fn duration_to_sized_uint_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-41]:
                         annotations: <empty>
                         kind: ExprStmt [29-41]:
                             expr: Expr [29-40]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -305,8 +304,7 @@ fn duration_to_sized_uint_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type UInt(Some(32),
-              | false)
+              x cannot cast expression of type duration to type uint[32]
                ,-[test:3:9]
              2 |         duration a;
              3 |         uint[32](a);
@@ -339,13 +337,13 @@ fn duration_to_float_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-38]:
                         annotations: <empty>
                         kind: ExprStmt [29-38]:
                             expr: Expr [29-37]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -359,7 +357,7 @@ fn duration_to_float_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Float(None, false)
+              x cannot cast expression of type duration to type float
                ,-[test:3:9]
              2 |         duration a;
              3 |         float(a);
@@ -388,13 +386,13 @@ fn duration_to_sized_float_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-42]:
                         annotations: <empty>
                         kind: ExprStmt [29-42]:
                             expr: Expr [29-41]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -408,8 +406,7 @@ fn duration_to_sized_float_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Float(Some(32),
-              | false)
+              x cannot cast expression of type duration to type float[32]
                ,-[test:3:9]
              2 |         duration a;
              3 |         float[32](a);
@@ -442,13 +439,13 @@ fn duration_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-38]:
                         annotations: <empty>
                         kind: ExprStmt [29-38]:
                             expr: Expr [29-37]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -462,7 +459,7 @@ fn duration_to_angle_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Angle(None, false)
+              x cannot cast expression of type duration to type angle
                ,-[test:3:9]
              2 |         duration a;
              3 |         angle(a);
@@ -491,13 +488,13 @@ fn duration_to_sized_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-42]:
                         annotations: <empty>
                         kind: ExprStmt [29-42]:
                             expr: Expr [29-41]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -511,8 +508,7 @@ fn duration_to_sized_angle_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Angle(Some(32),
-              | false)
+              x cannot cast expression of type duration to type angle[32]
                ,-[test:3:9]
              2 |         duration a;
              3 |         angle[32](a);
@@ -545,13 +541,13 @@ fn duration_to_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-40]:
                         annotations: <empty>
                         kind: ExprStmt [29-40]:
                             expr: Expr [29-39]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -565,8 +561,7 @@ fn duration_to_complex_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Complex(None,
-              | false)
+              x cannot cast expression of type duration to type complex[float]
                ,-[test:3:9]
              2 |         duration a;
              3 |         complex(a);
@@ -595,13 +590,13 @@ fn duration_to_sized_complex_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-51]:
                         annotations: <empty>
                         kind: ExprStmt [29-51]:
                             expr: Expr [29-50]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -615,8 +610,7 @@ fn duration_to_sized_complex_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Complex(Some(32),
-              | false)
+              x cannot cast expression of type duration to type complex[float[32]]
                ,-[test:3:9]
              2 |         duration a;
              3 |         complex[float[32]](a);
@@ -649,13 +643,13 @@ fn duration_to_bit_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-36]:
                         annotations: <empty>
                         kind: ExprStmt [29-36]:
                             expr: Expr [29-35]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -669,7 +663,7 @@ fn duration_to_bit_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Bit(false)
+              x cannot cast expression of type duration to type bit
                ,-[test:3:9]
              2 |         duration a;
              3 |         bit(a);
@@ -698,13 +692,13 @@ fn duration_to_bitarray_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: Duration(true)
+                                ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-40]:
                         annotations: <empty>
                         kind: ExprStmt [29-40]:
                             expr: Expr [29-39]:
-                                ty: Duration(false)
+                                ty: duration
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.NotSupported
@@ -718,7 +712,7 @@ fn duration_to_bitarray_fails() {
                `----
             , Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type BitArray(32, false)
+              x cannot cast expression of type duration to type bit[32]
                ,-[test:3:9]
              2 |         duration a;
              3 |         bit[32](a);

--- a/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_float.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_float.rs
@@ -31,15 +31,15 @@ fn float_to_bool() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-34]:
                 expr: Expr [26-33]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [26-33]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [31-32]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -58,15 +58,15 @@ fn sized_float_to_bool() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-38]:
                 expr: Expr [30-37]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [30-37]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [35-36]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -94,18 +94,18 @@ fn float_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Float(None, true)
+                                ty: const float
                                 kind: Lit: Float(0.0)
                     Stmt [26-38]:
                         annotations: <empty>
                         kind: ExprStmt [26-38]:
                             expr: Expr [26-37]:
-                                ty: Float(None, false)
+                                ty: float
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(None, false) to type Duration(false)
+              x cannot cast expression of type float to type duration
                ,-[test:3:9]
              2 |         float a;
              3 |         duration(a);
@@ -134,19 +134,18 @@ fn sized_float_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Float(Some(32), true)
+                                ty: const float[32]
                                 kind: Lit: Float(0.0)
                     Stmt [30-42]:
                         annotations: <empty>
                         kind: ExprStmt [30-42]:
                             expr: Expr [30-41]:
-                                ty: Float(Some(32), false)
+                                ty: float[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type float[32] to type duration
                ,-[test:3:9]
              2 |         float[32] a;
              3 |         duration(a);
@@ -174,15 +173,15 @@ fn float_to_int() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-33]:
                 expr: Expr [26-32]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [26-32]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [30-31]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -201,15 +200,15 @@ fn float_to_sized_int() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-37]:
                 expr: Expr [26-36]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [26-36]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [34-35]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -228,15 +227,15 @@ fn sized_float_to_int() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-37]:
                 expr: Expr [30-36]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [30-36]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [34-35]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -255,15 +254,15 @@ fn sized_float_to_sized_int() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-41]:
                 expr: Expr [30-40]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [30-40]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [38-39]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -282,15 +281,15 @@ fn sized_float_to_sized_int_truncating() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-41]:
                 expr: Expr [30-40]:
-                    ty: Int(Some(16), false)
+                    ty: int[16]
                     kind: Cast [30-40]:
-                        ty: Int(Some(16), false)
+                        ty: int[16]
                         expr: Expr [38-39]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -309,15 +308,15 @@ fn sized_float_to_sized_int_expanding() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-41]:
                 expr: Expr [30-40]:
-                    ty: Int(Some(64), false)
+                    ty: int[64]
                     kind: Cast [30-40]:
-                        ty: Int(Some(64), false)
+                        ty: int[64]
                         expr: Expr [38-39]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -340,15 +339,15 @@ fn float_to_uint() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-34]:
                 expr: Expr [26-33]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [26-33]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [31-32]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -367,15 +366,15 @@ fn float_to_sized_uint() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-38]:
                 expr: Expr [26-37]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [26-37]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [35-36]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -394,15 +393,15 @@ fn sized_float_to_uint() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-38]:
                 expr: Expr [30-37]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [30-37]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [35-36]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -421,15 +420,15 @@ fn sized_float_to_sized_uint() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-42]:
                 expr: Expr [30-41]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [30-41]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [39-40]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -448,15 +447,15 @@ fn sized_float_to_sized_uint_truncating() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-42]:
                 expr: Expr [30-41]:
-                    ty: UInt(Some(16), false)
+                    ty: uint[16]
                     kind: Cast [30-41]:
-                        ty: UInt(Some(16), false)
+                        ty: uint[16]
                         expr: Expr [39-40]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -475,15 +474,15 @@ fn sized_float_to_sized_uint_expanding() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-42]:
                 expr: Expr [30-41]:
-                    ty: UInt(Some(64), false)
+                    ty: uint[64]
                     kind: Cast [30-41]:
-                        ty: UInt(Some(64), false)
+                        ty: uint[64]
                         expr: Expr [39-40]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -506,11 +505,11 @@ fn float_to_float() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-35]:
                 expr: Expr [26-34]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: SymbolId(8)
         "#]],
     );
@@ -529,15 +528,15 @@ fn float_to_sized_float() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-39]:
                 expr: Expr [26-38]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [26-38]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [36-37]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -556,15 +555,15 @@ fn sized_float_to_float() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-39]:
                 expr: Expr [30-38]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [30-38]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [36-37]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -583,11 +582,11 @@ fn sized_float_to_sized_float() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
                 expr: Expr [30-42]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: SymbolId(8)
         "#]],
     );
@@ -606,15 +605,15 @@ fn sized_float_to_sized_float_truncating() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
                 expr: Expr [30-42]:
-                    ty: Float(Some(16), false)
+                    ty: float[16]
                     kind: Cast [30-42]:
-                        ty: Float(Some(16), false)
+                        ty: float[16]
                         expr: Expr [40-41]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -633,15 +632,15 @@ fn sized_float_to_sized_float_expanding() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
                 expr: Expr [30-42]:
-                    ty: Float(Some(64), false)
+                    ty: float[64]
                     kind: Cast [30-42]:
-                        ty: Float(Some(64), false)
+                        ty: float[64]
                         expr: Expr [40-41]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -664,15 +663,15 @@ fn float_to_angle() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-35]:
                 expr: Expr [26-34]:
-                    ty: Angle(None, false)
+                    ty: angle
                     kind: Cast [26-34]:
-                        ty: Angle(None, false)
+                        ty: angle
                         expr: Expr [32-33]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -691,15 +690,15 @@ fn float_to_sized_angle() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-39]:
                 expr: Expr [26-38]:
-                    ty: Angle(Some(32), false)
+                    ty: angle[32]
                     kind: Cast [26-38]:
-                        ty: Angle(Some(32), false)
+                        ty: angle[32]
                         expr: Expr [36-37]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -718,15 +717,15 @@ fn sized_float_to_angle() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-39]:
                 expr: Expr [30-38]:
-                    ty: Angle(None, false)
+                    ty: angle
                     kind: Cast [30-38]:
-                        ty: Angle(None, false)
+                        ty: angle
                         expr: Expr [36-37]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -745,15 +744,15 @@ fn sized_float_to_sized_angle() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
                 expr: Expr [30-42]:
-                    ty: Angle(Some(32), false)
+                    ty: angle[32]
                     kind: Cast [30-42]:
-                        ty: Angle(Some(32), false)
+                        ty: angle[32]
                         expr: Expr [40-41]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -772,15 +771,15 @@ fn sized_float_to_sized_angle_truncating() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
                 expr: Expr [30-42]:
-                    ty: Angle(Some(16), false)
+                    ty: angle[16]
                     kind: Cast [30-42]:
-                        ty: Angle(Some(16), false)
+                        ty: angle[16]
                         expr: Expr [40-41]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -799,15 +798,15 @@ fn sized_float_to_sized_angle_expanding() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
                 expr: Expr [30-42]:
-                    ty: Angle(Some(64), false)
+                    ty: angle[64]
                     kind: Cast [30-42]:
-                        ty: Angle(Some(64), false)
+                        ty: angle[64]
                         expr: Expr [40-41]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -830,15 +829,15 @@ fn float_to_complex() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-37]:
                 expr: Expr [26-36]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Cast [26-36]:
-                        ty: Complex(None, false)
+                        ty: complex[float]
                         expr: Expr [34-35]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -857,15 +856,15 @@ fn float_to_sized_complex() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-48]:
                 expr: Expr [26-47]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: Cast [26-47]:
-                        ty: Complex(Some(32), false)
+                        ty: complex[float[32]]
                         expr: Expr [45-46]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -884,15 +883,15 @@ fn sized_float_to_complex() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-41]:
                 expr: Expr [30-40]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Cast [30-40]:
-                        ty: Complex(None, false)
+                        ty: complex[float]
                         expr: Expr [38-39]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -911,15 +910,15 @@ fn sized_float_to_sized_complex() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-52]:
                 expr: Expr [30-51]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: Cast [30-51]:
-                        ty: Complex(Some(32), false)
+                        ty: complex[float[32]]
                         expr: Expr [49-50]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -938,15 +937,15 @@ fn sized_float_to_sized_complex_truncating() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-52]:
                 expr: Expr [30-51]:
-                    ty: Complex(Some(16), false)
+                    ty: complex[float[16]]
                     kind: Cast [30-51]:
-                        ty: Complex(Some(16), false)
+                        ty: complex[float[16]]
                         expr: Expr [49-50]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -965,15 +964,15 @@ fn sized_float_to_sized_complex_expanding() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-52]:
                 expr: Expr [30-51]:
-                    ty: Complex(Some(64), false)
+                    ty: complex[float[64]]
                     kind: Cast [30-51]:
-                        ty: Complex(Some(64), false)
+                        ty: complex[float[64]]
                         expr: Expr [49-50]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -996,15 +995,15 @@ fn float_to_bit() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [0-0]:
-                    ty: Float(None, true)
+                    ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-33]:
                 expr: Expr [26-32]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [26-32]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [30-31]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
         "#]],
     );
@@ -1028,19 +1027,18 @@ fn float_to_bitarray_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [0-0]:
-                                ty: Float(None, true)
+                                ty: const float
                                 kind: Lit: Float(0.0)
                     Stmt [26-37]:
                         annotations: <empty>
                         kind: ExprStmt [26-37]:
                             expr: Expr [26-36]:
-                                ty: Float(None, false)
+                                ty: float
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type float to type bit[32]
                ,-[test:3:9]
              2 |         float a;
              3 |         bit[32](a);
@@ -1064,15 +1062,15 @@ fn sized_float_to_bit() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [0-0]:
-                    ty: Float(Some(32), true)
+                    ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-37]:
                 expr: Expr [30-36]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [30-36]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [34-35]:
-                            ty: Float(Some(32), false)
+                            ty: float[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1096,19 +1094,18 @@ fn sized_float_to_bitarray_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Float(Some(32), true)
+                                ty: const float[32]
                                 kind: Lit: Float(0.0)
                     Stmt [30-41]:
                         annotations: <empty>
                         kind: ExprStmt [30-41]:
                             expr: Expr [30-40]:
-                                ty: Float(Some(32), false)
+                                ty: float[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(Some(32), false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type float[32] to type bit[32]
                ,-[test:3:9]
              2 |         float[32] a;
              3 |         bit[32](a);
@@ -1137,19 +1134,18 @@ fn sized_float_to_bitarray_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Float(Some(32), true)
+                                ty: const float[32]
                                 kind: Lit: Float(0.0)
                     Stmt [30-41]:
                         annotations: <empty>
                         kind: ExprStmt [30-41]:
                             expr: Expr [30-40]:
-                                ty: Float(Some(32), false)
+                                ty: float[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(Some(32), false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type float[32] to type bit[16]
                ,-[test:3:9]
              2 |         float[32] a;
              3 |         bit[16](a);
@@ -1178,19 +1174,18 @@ fn sized_float_to_bitarray_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-18]
                             init_expr: Expr [0-0]:
-                                ty: Float(Some(32), true)
+                                ty: const float[32]
                                 kind: Lit: Float(0.0)
                     Stmt [30-41]:
                         annotations: <empty>
                         kind: ExprStmt [30-41]:
                             expr: Expr [30-40]:
-                                ty: Float(Some(32), false)
+                                ty: float[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(Some(32), false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type float[32] to type bit[64]
                ,-[test:3:9]
              2 |         float[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_int.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_int.rs
@@ -31,15 +31,15 @@ fn int_to_bool() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-32]:
                 expr: Expr [24-31]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [24-31]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [29-30]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
         "#]],
     );
@@ -58,15 +58,15 @@ fn sized_int_to_bool() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-36]:
                 expr: Expr [28-35]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [28-35]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [33-34]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -94,18 +94,18 @@ fn int_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [0-0]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Lit: Int(0)
                     Stmt [24-36]:
                         annotations: <empty>
                         kind: ExprStmt [24-36]:
                             expr: Expr [24-35]:
-                                ty: Int(None, false)
+                                ty: int
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(None, false) to type Duration(false)
+              x cannot cast expression of type int to type duration
                ,-[test:3:9]
              2 |         int a;
              3 |         duration(a);
@@ -134,19 +134,18 @@ fn sized_int_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Int(Some(32), true)
+                                ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-40]:
                         annotations: <empty>
                         kind: ExprStmt [28-40]:
                             expr: Expr [28-39]:
-                                ty: Int(Some(32), false)
+                                ty: int[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type int[32] to type duration
                ,-[test:3:9]
              2 |         int[32] a;
              3 |         duration(a);
@@ -174,11 +173,11 @@ fn int_to_int() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-31]:
                 expr: Expr [24-30]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: SymbolId(8)
         "#]],
     );
@@ -197,15 +196,15 @@ fn int_to_sized_int() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-35]:
                 expr: Expr [24-34]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [24-34]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [32-33]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
         "#]],
     );
@@ -224,15 +223,15 @@ fn sized_int_to_int() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-35]:
                 expr: Expr [28-34]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [28-34]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [32-33]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -251,11 +250,11 @@ fn sized_int_to_sized_int() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
                 expr: Expr [28-38]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: SymbolId(8)
         "#]],
     );
@@ -274,15 +273,15 @@ fn sized_int_to_sized_int_truncating() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
                 expr: Expr [28-38]:
-                    ty: Int(Some(16), false)
+                    ty: int[16]
                     kind: Cast [28-38]:
-                        ty: Int(Some(16), false)
+                        ty: int[16]
                         expr: Expr [36-37]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -301,15 +300,15 @@ fn sized_int_to_sized_int_expanding() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
                 expr: Expr [28-38]:
-                    ty: Int(Some(64), false)
+                    ty: int[64]
                     kind: Cast [28-38]:
-                        ty: Int(Some(64), false)
+                        ty: int[64]
                         expr: Expr [36-37]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -332,15 +331,15 @@ fn int_to_uint() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-32]:
                 expr: Expr [24-31]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [24-31]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [29-30]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
         "#]],
     );
@@ -359,15 +358,15 @@ fn int_to_sized_uint() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-36]:
                 expr: Expr [24-35]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [24-35]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [33-34]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
         "#]],
     );
@@ -386,15 +385,15 @@ fn sized_int_to_uint() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-36]:
                 expr: Expr [28-35]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [28-35]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [33-34]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -413,15 +412,15 @@ fn sized_int_to_sized_uint() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-40]:
                 expr: Expr [28-39]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [28-39]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [37-38]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -440,15 +439,15 @@ fn sized_int_to_sized_uint_truncating() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-40]:
                 expr: Expr [28-39]:
-                    ty: UInt(Some(16), false)
+                    ty: uint[16]
                     kind: Cast [28-39]:
-                        ty: UInt(Some(16), false)
+                        ty: uint[16]
                         expr: Expr [37-38]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -467,15 +466,15 @@ fn sized_int_to_sized_uint_expanding() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-40]:
                 expr: Expr [28-39]:
-                    ty: UInt(Some(64), false)
+                    ty: uint[64]
                     kind: Cast [28-39]:
-                        ty: UInt(Some(64), false)
+                        ty: uint[64]
                         expr: Expr [37-38]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -498,15 +497,15 @@ fn int_to_float() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-33]:
                 expr: Expr [24-32]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [24-32]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [30-31]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
         "#]],
     );
@@ -525,15 +524,15 @@ fn int_to_sized_float() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-37]:
                 expr: Expr [24-36]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [24-36]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [34-35]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
         "#]],
     );
@@ -552,15 +551,15 @@ fn sized_int_to_float() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-37]:
                 expr: Expr [28-36]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [28-36]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [34-35]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -579,15 +578,15 @@ fn sized_int_to_sized_float() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-41]:
                 expr: Expr [28-40]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [28-40]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [38-39]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -606,15 +605,15 @@ fn sized_int_to_sized_float_truncating() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-41]:
                 expr: Expr [28-40]:
-                    ty: Float(Some(16), false)
+                    ty: float[16]
                     kind: Cast [28-40]:
-                        ty: Float(Some(16), false)
+                        ty: float[16]
                         expr: Expr [38-39]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -633,15 +632,15 @@ fn sized_int_to_sized_float_expanding() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-41]:
                 expr: Expr [28-40]:
-                    ty: Float(Some(64), false)
+                    ty: float[64]
                     kind: Cast [28-40]:
-                        ty: Float(Some(64), false)
+                        ty: float[64]
                         expr: Expr [38-39]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -669,18 +668,18 @@ fn int_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [0-0]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Lit: Int(0)
                     Stmt [24-33]:
                         annotations: <empty>
                         kind: ExprStmt [24-33]:
                             expr: Expr [24-32]:
-                                ty: Int(None, false)
+                                ty: int
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(None, false) to type Angle(None, false)
+              x cannot cast expression of type int to type angle
                ,-[test:3:9]
              2 |         int a;
              3 |         angle(a);
@@ -709,19 +708,18 @@ fn int_to_sized_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [0-0]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Lit: Int(0)
                     Stmt [24-37]:
                         annotations: <empty>
                         kind: ExprStmt [24-37]:
                             expr: Expr [24-36]:
-                                ty: Int(None, false)
+                                ty: int
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(None, false) to type Angle(Some(32),
-              | false)
+              x cannot cast expression of type int to type angle[32]
                ,-[test:3:9]
              2 |         int a;
              3 |         angle[32](a);
@@ -750,19 +748,18 @@ fn sized_int_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Int(Some(32), true)
+                                ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-37]:
                         annotations: <empty>
                         kind: ExprStmt [28-37]:
                             expr: Expr [28-36]:
-                                ty: Int(Some(32), false)
+                                ty: int[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type Angle(None,
-              | false)
+              x cannot cast expression of type int[32] to type angle
                ,-[test:3:9]
              2 |         int[32] a;
              3 |         angle(a);
@@ -791,19 +788,18 @@ fn sized_int_to_sized_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Int(Some(32), true)
+                                ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: Int(Some(32), false)
+                                ty: int[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type
-              | Angle(Some(32), false)
+              x cannot cast expression of type int[32] to type angle[32]
                ,-[test:3:9]
              2 |         int[32] a;
              3 |         angle[32](a);
@@ -832,19 +828,18 @@ fn sized_int_to_sized_angle_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Int(Some(32), true)
+                                ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: Int(Some(32), false)
+                                ty: int[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type
-              | Angle(Some(16), false)
+              x cannot cast expression of type int[32] to type angle[16]
                ,-[test:3:9]
              2 |         int[32] a;
              3 |         angle[16](a);
@@ -873,19 +868,18 @@ fn sized_int_to_sized_angle_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Int(Some(32), true)
+                                ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-41]:
                         annotations: <empty>
                         kind: ExprStmt [28-41]:
                             expr: Expr [28-40]:
-                                ty: Int(Some(32), false)
+                                ty: int[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type
-              | Angle(Some(64), false)
+              x cannot cast expression of type int[32] to type angle[64]
                ,-[test:3:9]
              2 |         int[32] a;
              3 |         angle[64](a);
@@ -913,15 +907,15 @@ fn int_to_complex() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-35]:
                 expr: Expr [24-34]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Cast [24-34]:
-                        ty: Complex(None, false)
+                        ty: complex[float]
                         expr: Expr [32-33]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
         "#]],
     );
@@ -940,15 +934,15 @@ fn int_to_sized_complex() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-46]:
                 expr: Expr [24-45]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: Cast [24-45]:
-                        ty: Complex(Some(32), false)
+                        ty: complex[float[32]]
                         expr: Expr [43-44]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
         "#]],
     );
@@ -967,15 +961,15 @@ fn sized_int_to_complex() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
                 expr: Expr [28-38]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Cast [28-38]:
-                        ty: Complex(None, false)
+                        ty: complex[float]
                         expr: Expr [36-37]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -994,15 +988,15 @@ fn sized_int_to_sized_complex() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-50]:
                 expr: Expr [28-49]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: Cast [28-49]:
-                        ty: Complex(Some(32), false)
+                        ty: complex[float[32]]
                         expr: Expr [47-48]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1021,15 +1015,15 @@ fn sized_int_to_sized_complex_truncating() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-50]:
                 expr: Expr [28-49]:
-                    ty: Complex(Some(16), false)
+                    ty: complex[float[16]]
                     kind: Cast [28-49]:
-                        ty: Complex(Some(16), false)
+                        ty: complex[float[16]]
                         expr: Expr [47-48]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1048,15 +1042,15 @@ fn sized_int_to_sized_complex_expanding() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-50]:
                 expr: Expr [28-49]:
-                    ty: Complex(Some(64), false)
+                    ty: complex[float[64]]
                     kind: Cast [28-49]:
-                        ty: Complex(Some(64), false)
+                        ty: complex[float[64]]
                         expr: Expr [47-48]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1079,15 +1073,15 @@ fn int_to_bit() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-31]:
                 expr: Expr [24-30]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [24-30]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [28-29]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
         "#]],
     );
@@ -1111,19 +1105,18 @@ fn int_to_bitarray_fails() {
                             symbol_id: 8
                             ty_span: [9-12]
                             init_expr: Expr [0-0]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Lit: Int(0)
                     Stmt [24-35]:
                         annotations: <empty>
                         kind: ExprStmt [24-35]:
                             expr: Expr [24-34]:
-                                ty: Int(None, false)
+                                ty: int
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type int to type bit[32]
                ,-[test:3:9]
              2 |         int a;
              3 |         bit[32](a);
@@ -1147,15 +1140,15 @@ fn sized_int_to_bit() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-35]:
                 expr: Expr [28-34]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [28-34]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [32-33]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1174,15 +1167,15 @@ fn sized_int_to_bitarray() {
                 symbol_id: 8
                 ty_span: [9-16]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(32), true)
+                    ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
                 expr: Expr [28-38]:
-                    ty: BitArray(32, false)
+                    ty: bit[32]
                     kind: Cast [28-38]:
-                        ty: BitArray(32, false)
+                        ty: bit[32]
                         expr: Expr [36-37]:
-                            ty: Int(Some(32), false)
+                            ty: int[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1206,19 +1199,18 @@ fn sized_int_to_bitarray_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Int(Some(32), true)
+                                ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-39]:
                         annotations: <empty>
                         kind: ExprStmt [28-39]:
                             expr: Expr [28-38]:
-                                ty: Int(Some(32), false)
+                                ty: int[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type int[32] to type bit[16]
                ,-[test:3:9]
              2 |         int[32] a;
              3 |         bit[16](a);
@@ -1247,19 +1239,18 @@ fn sized_int_to_bitarray_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-16]
                             init_expr: Expr [0-0]:
-                                ty: Int(Some(32), true)
+                                ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-39]:
                         annotations: <empty>
                         kind: ExprStmt [28-39]:
                             expr: Expr [28-38]:
-                                ty: Int(Some(32), false)
+                                ty: int[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type int[32] to type bit[64]
                ,-[test:3:9]
              2 |         int[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_uint.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_uint.rs
@@ -31,15 +31,15 @@ fn uint_to_bool() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-33]:
                 expr: Expr [25-32]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [25-32]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [30-31]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
         "#]],
     );
@@ -58,15 +58,15 @@ fn sized_uint_to_bool() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-37]:
                 expr: Expr [29-36]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [29-36]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [34-35]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -94,18 +94,18 @@ fn uint_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-13]
                             init_expr: Expr [0-0]:
-                                ty: UInt(None, true)
+                                ty: const uint
                                 kind: Lit: Int(0)
                     Stmt [25-37]:
                         annotations: <empty>
                         kind: ExprStmt [25-37]:
                             expr: Expr [25-36]:
-                                ty: UInt(None, false)
+                                ty: uint
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(None, false) to type Duration(false)
+              x cannot cast expression of type uint to type duration
                ,-[test:3:9]
              2 |         uint a;
              3 |         duration(a);
@@ -134,19 +134,18 @@ fn sized_uint_to_duration_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: UInt(Some(32), true)
+                                ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-41]:
                         annotations: <empty>
                         kind: ExprStmt [29-41]:
                             expr: Expr [29-40]:
-                                ty: UInt(Some(32), false)
+                                ty: uint[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type uint[32] to type duration
                ,-[test:3:9]
              2 |         uint[32] a;
              3 |         duration(a);
@@ -174,15 +173,15 @@ fn uint_to_int() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-32]:
                 expr: Expr [25-31]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [25-31]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [29-30]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
         "#]],
     );
@@ -201,15 +200,15 @@ fn uint_to_sized_int() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-36]:
                 expr: Expr [25-35]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [25-35]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [33-34]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
         "#]],
     );
@@ -228,15 +227,15 @@ fn sized_uint_to_int() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-36]:
                 expr: Expr [29-35]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [29-35]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [33-34]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -255,15 +254,15 @@ fn sized_uint_to_sized_int() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
                 expr: Expr [29-39]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [29-39]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [37-38]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -282,15 +281,15 @@ fn sized_uint_to_sized_int_truncating() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
                 expr: Expr [29-39]:
-                    ty: Int(Some(16), false)
+                    ty: int[16]
                     kind: Cast [29-39]:
-                        ty: Int(Some(16), false)
+                        ty: int[16]
                         expr: Expr [37-38]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -309,15 +308,15 @@ fn sized_uint_to_sized_int_expanding() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
                 expr: Expr [29-39]:
-                    ty: Int(Some(64), false)
+                    ty: int[64]
                     kind: Cast [29-39]:
-                        ty: Int(Some(64), false)
+                        ty: int[64]
                         expr: Expr [37-38]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -340,11 +339,11 @@ fn uint_to_uint() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-33]:
                 expr: Expr [25-32]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: SymbolId(8)
         "#]],
     );
@@ -363,15 +362,15 @@ fn uint_to_sized_uint() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-37]:
                 expr: Expr [25-36]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [25-36]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [34-35]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
         "#]],
     );
@@ -390,15 +389,15 @@ fn sized_uint_to_uint() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-37]:
                 expr: Expr [29-36]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [29-36]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [34-35]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -417,11 +416,11 @@ fn sized_uint_to_sized_uint() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-41]:
                 expr: Expr [29-40]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: SymbolId(8)
         "#]],
     );
@@ -440,15 +439,15 @@ fn sized_uint_to_sized_uint_truncating() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-41]:
                 expr: Expr [29-40]:
-                    ty: UInt(Some(16), false)
+                    ty: uint[16]
                     kind: Cast [29-40]:
-                        ty: UInt(Some(16), false)
+                        ty: uint[16]
                         expr: Expr [38-39]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -467,15 +466,15 @@ fn sized_uint_to_sized_uint_expanding() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-41]:
                 expr: Expr [29-40]:
-                    ty: UInt(Some(64), false)
+                    ty: uint[64]
                     kind: Cast [29-40]:
-                        ty: UInt(Some(64), false)
+                        ty: uint[64]
                         expr: Expr [38-39]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -498,15 +497,15 @@ fn uint_to_float() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-34]:
                 expr: Expr [25-33]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [25-33]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [31-32]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
         "#]],
     );
@@ -525,15 +524,15 @@ fn uint_to_sized_float() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-38]:
                 expr: Expr [25-37]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [25-37]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [35-36]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
         "#]],
     );
@@ -552,15 +551,15 @@ fn sized_uint_to_float() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-38]:
                 expr: Expr [29-37]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [29-37]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [35-36]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -579,15 +578,15 @@ fn sized_uint_to_sized_float() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-42]:
                 expr: Expr [29-41]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [29-41]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [39-40]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -606,15 +605,15 @@ fn sized_uint_to_sized_float_truncating() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-42]:
                 expr: Expr [29-41]:
-                    ty: Float(Some(16), false)
+                    ty: float[16]
                     kind: Cast [29-41]:
-                        ty: Float(Some(16), false)
+                        ty: float[16]
                         expr: Expr [39-40]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -633,15 +632,15 @@ fn sized_uint_to_sized_float_expanding() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-42]:
                 expr: Expr [29-41]:
-                    ty: Float(Some(64), false)
+                    ty: float[64]
                     kind: Cast [29-41]:
-                        ty: Float(Some(64), false)
+                        ty: float[64]
                         expr: Expr [39-40]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -669,19 +668,18 @@ fn uint_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-13]
                             init_expr: Expr [0-0]:
-                                ty: UInt(None, true)
+                                ty: const uint
                                 kind: Lit: Int(0)
                     Stmt [25-34]:
                         annotations: <empty>
                         kind: ExprStmt [25-34]:
                             expr: Expr [25-33]:
-                                ty: UInt(None, false)
+                                ty: uint
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(None, false) to type Angle(None,
-              | false)
+              x cannot cast expression of type uint to type angle
                ,-[test:3:9]
              2 |         uint a;
              3 |         angle(a);
@@ -710,19 +708,18 @@ fn uint_to_sized_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-13]
                             init_expr: Expr [0-0]:
-                                ty: UInt(None, true)
+                                ty: const uint
                                 kind: Lit: Int(0)
                     Stmt [25-38]:
                         annotations: <empty>
                         kind: ExprStmt [25-38]:
                             expr: Expr [25-37]:
-                                ty: UInt(None, false)
+                                ty: uint
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(None, false) to type Angle(Some(32),
-              | false)
+              x cannot cast expression of type uint to type angle[32]
                ,-[test:3:9]
              2 |         uint a;
              3 |         angle[32](a);
@@ -751,19 +748,18 @@ fn sized_uint_to_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: UInt(Some(32), true)
+                                ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-38]:
                         annotations: <empty>
                         kind: ExprStmt [29-38]:
                             expr: Expr [29-37]:
-                                ty: UInt(Some(32), false)
+                                ty: uint[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type Angle(None,
-              | false)
+              x cannot cast expression of type uint[32] to type angle
                ,-[test:3:9]
              2 |         uint[32] a;
              3 |         angle(a);
@@ -792,19 +788,18 @@ fn sized_uint_to_sized_angle_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: UInt(Some(32), true)
+                                ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-42]:
                         annotations: <empty>
                         kind: ExprStmt [29-42]:
                             expr: Expr [29-41]:
-                                ty: UInt(Some(32), false)
+                                ty: uint[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type
-              | Angle(Some(32), false)
+              x cannot cast expression of type uint[32] to type angle[32]
                ,-[test:3:9]
              2 |         uint[32] a;
              3 |         angle[32](a);
@@ -833,19 +828,18 @@ fn sized_uint_to_sized_angle_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: UInt(Some(32), true)
+                                ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-42]:
                         annotations: <empty>
                         kind: ExprStmt [29-42]:
                             expr: Expr [29-41]:
-                                ty: UInt(Some(32), false)
+                                ty: uint[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type
-              | Angle(Some(16), false)
+              x cannot cast expression of type uint[32] to type angle[16]
                ,-[test:3:9]
              2 |         uint[32] a;
              3 |         angle[16](a);
@@ -874,19 +868,18 @@ fn sized_uint_to_sized_angle_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: UInt(Some(32), true)
+                                ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-42]:
                         annotations: <empty>
                         kind: ExprStmt [29-42]:
                             expr: Expr [29-41]:
-                                ty: UInt(Some(32), false)
+                                ty: uint[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type
-              | Angle(Some(64), false)
+              x cannot cast expression of type uint[32] to type angle[64]
                ,-[test:3:9]
              2 |         uint[32] a;
              3 |         angle[64](a);
@@ -914,15 +907,15 @@ fn uint_to_complex() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-36]:
                 expr: Expr [25-35]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Cast [25-35]:
-                        ty: Complex(None, false)
+                        ty: complex[float]
                         expr: Expr [33-34]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
         "#]],
     );
@@ -941,15 +934,15 @@ fn uint_to_sized_complex() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-47]:
                 expr: Expr [25-46]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: Cast [25-46]:
-                        ty: Complex(Some(32), false)
+                        ty: complex[float[32]]
                         expr: Expr [44-45]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
         "#]],
     );
@@ -968,15 +961,15 @@ fn sized_uint_to_complex() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
                 expr: Expr [29-39]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Cast [29-39]:
-                        ty: Complex(None, false)
+                        ty: complex[float]
                         expr: Expr [37-38]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -995,15 +988,15 @@ fn sized_uint_to_sized_complex() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-51]:
                 expr: Expr [29-50]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: Cast [29-50]:
-                        ty: Complex(Some(32), false)
+                        ty: complex[float[32]]
                         expr: Expr [48-49]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1022,15 +1015,15 @@ fn sized_uint_to_sized_complex_truncating() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-51]:
                 expr: Expr [29-50]:
-                    ty: Complex(Some(16), false)
+                    ty: complex[float[16]]
                     kind: Cast [29-50]:
-                        ty: Complex(Some(16), false)
+                        ty: complex[float[16]]
                         expr: Expr [48-49]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1049,15 +1042,15 @@ fn sized_uint_to_sized_complex_expanding() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-51]:
                 expr: Expr [29-50]:
-                    ty: Complex(Some(64), false)
+                    ty: complex[float[64]]
                     kind: Cast [29-50]:
-                        ty: Complex(Some(64), false)
+                        ty: complex[float[64]]
                         expr: Expr [48-49]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1080,15 +1073,15 @@ fn uint_to_bit() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [0-0]:
-                    ty: UInt(None, true)
+                    ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-32]:
                 expr: Expr [25-31]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [25-31]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [29-30]:
-                            ty: UInt(None, false)
+                            ty: uint
                             kind: SymbolId(8)
         "#]],
     );
@@ -1112,19 +1105,18 @@ fn uint_to_bitarray_fails() {
                             symbol_id: 8
                             ty_span: [9-13]
                             init_expr: Expr [0-0]:
-                                ty: UInt(None, true)
+                                ty: const uint
                                 kind: Lit: Int(0)
                     Stmt [25-36]:
                         annotations: <empty>
                         kind: ExprStmt [25-36]:
                             expr: Expr [25-35]:
-                                ty: UInt(None, false)
+                                ty: uint
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type uint to type bit[32]
                ,-[test:3:9]
              2 |         uint a;
              3 |         bit[32](a);
@@ -1148,15 +1140,15 @@ fn sized_uint_to_bit() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-36]:
                 expr: Expr [29-35]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [29-35]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [33-34]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1175,15 +1167,15 @@ fn sized_uint_to_bitarray() {
                 symbol_id: 8
                 ty_span: [9-17]
                 init_expr: Expr [0-0]:
-                    ty: UInt(Some(32), true)
+                    ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
                 expr: Expr [29-39]:
-                    ty: BitArray(32, false)
+                    ty: bit[32]
                     kind: Cast [29-39]:
-                        ty: BitArray(32, false)
+                        ty: bit[32]
                         expr: Expr [37-38]:
-                            ty: UInt(Some(32), false)
+                            ty: uint[32]
                             kind: SymbolId(8)
         "#]],
     );
@@ -1207,19 +1199,18 @@ fn sized_uint_to_bitarray_truncating_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: UInt(Some(32), true)
+                                ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-40]:
                         annotations: <empty>
                         kind: ExprStmt [29-40]:
                             expr: Expr [29-39]:
-                                ty: UInt(Some(32), false)
+                                ty: uint[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type uint[32] to type bit[16]
                ,-[test:3:9]
              2 |         uint[32] a;
              3 |         bit[16](a);
@@ -1248,19 +1239,18 @@ fn sized_uint_to_bitarray_expanding_fails() {
                             symbol_id: 8
                             ty_span: [9-17]
                             init_expr: Expr [0-0]:
-                                ty: UInt(Some(32), true)
+                                ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-40]:
                         annotations: <empty>
                         kind: ExprStmt [29-40]:
                             expr: Expr [29-39]:
-                                ty: UInt(Some(32), false)
+                                ty: uint[32]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type uint[32] to type bit[64]
                ,-[test:3:9]
              2 |         uint[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_angle.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_angle.rs
@@ -19,26 +19,26 @@ fn to_bit_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.300888156922483)
             [8] Symbol [15-16]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default
             ClassicalDeclarationStmt [32-42]:
                 symbol_id: 9
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [0-0]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [40-41]:
-                            ty: Angle(None, false)
+                            ty: angle
                             kind: SymbolId(8)
             [9] Symbol [36-37]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
         "#]],
@@ -59,26 +59,26 @@ fn explicit_width_to_bit_implicitly_fails() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [23-26]:
-                    ty: Angle(Some(64), true)
+                    ty: const angle[64]
                     kind: Lit: Angle(4.300888156922483)
             [8] Symbol [19-20]:
                 name: x
-                type: Angle(Some(64), false)
+                type: angle[64]
                 qsharp_type: Angle
                 io_kind: Default
             ClassicalDeclarationStmt [36-46]:
                 symbol_id: 9
                 ty_span: [36-39]
                 init_expr: Expr [44-45]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [0-0]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [44-45]:
-                            ty: Angle(Some(64), false)
+                            ty: angle[64]
                             kind: SymbolId(8)
             [9] Symbol [40-41]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
         "#]],
@@ -98,26 +98,26 @@ fn to_bool_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.300888156922483)
             [8] Symbol [15-16]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default
             ClassicalDeclarationStmt [32-43]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [0-0]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [41-42]:
-                            ty: Angle(None, false)
+                            ty: angle
                             kind: SymbolId(8)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -143,7 +143,7 @@ fn to_implicit_int_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(4.300888156922483)
                     Stmt [32-42]:
                         annotations: <empty>
@@ -151,12 +151,12 @@ fn to_implicit_int_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [32-35]
                             init_expr: Expr [40-41]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Int(None, false)
+              x cannot cast expression of type angle to type int
                ,-[test:3:17]
              2 |         angle x = 42.;
              3 |         int y = x;
@@ -186,7 +186,7 @@ fn to_explicit_int_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(4.300888156922483)
                     Stmt [32-46]:
                         annotations: <empty>
@@ -194,13 +194,12 @@ fn to_explicit_int_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [32-39]
                             init_expr: Expr [44-45]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Int(Some(32),
-              | false)
+              x cannot cast expression of type angle to type int[32]
                ,-[test:3:21]
              2 |         angle x = 42.;
              3 |         int[32] y = x;
@@ -230,7 +229,7 @@ fn to_implicit_uint_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(4.300888156922483)
                     Stmt [32-43]:
                         annotations: <empty>
@@ -238,13 +237,12 @@ fn to_implicit_uint_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [32-36]
                             init_expr: Expr [41-42]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type UInt(None,
-              | false)
+              x cannot cast expression of type angle to type uint
                ,-[test:3:18]
              2 |         angle x = 42.;
              3 |         uint y = x;
@@ -274,15 +272,15 @@ fn negative_lit_to_implicit_uint_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [20-23]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: Cast [0-0]:
-                                    ty: Angle(None, false)
+                                    ty: angle
                                     expr: Expr [20-23]:
-                                        ty: Float(None, true)
+                                        ty: const float
                                         kind: UnaryOpExpr [20-23]:
                                             op: Neg
                                             expr: Expr [20-23]:
-                                                ty: Float(None, true)
+                                                ty: const float
                                                 kind: Lit: Float(42.0)
                     Stmt [33-44]:
                         annotations: <empty>
@@ -290,13 +288,12 @@ fn negative_lit_to_implicit_uint_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [33-37]
                             init_expr: Expr [42-43]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type UInt(None,
-              | false)
+              x cannot cast expression of type angle to type uint
                ,-[test:3:18]
              2 |         angle x = -42.;
              3 |         uint y = x;
@@ -326,7 +323,7 @@ fn to_explicit_uint_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(4.300888156922483)
                     Stmt [32-47]:
                         annotations: <empty>
@@ -334,13 +331,12 @@ fn to_explicit_uint_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [32-40]
                             init_expr: Expr [45-46]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type UInt(Some(32),
-              | false)
+              x cannot cast expression of type angle to type uint[32]
                ,-[test:3:22]
              2 |         angle x = 42.;
              3 |         uint[32] y = x;
@@ -370,7 +366,7 @@ fn to_explicit_bigint_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(4.300888156922483)
                     Stmt [32-46]:
                         annotations: <empty>
@@ -378,13 +374,12 @@ fn to_explicit_bigint_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [32-39]
                             init_expr: Expr [44-45]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Int(Some(65),
-              | false)
+              x cannot cast expression of type angle to type int[65]
                ,-[test:3:21]
              2 |         angle x = 42.;
              3 |         int[65] y = x;
@@ -414,7 +409,7 @@ fn to_implicit_float_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(4.300888156922483)
                     Stmt [32-44]:
                         annotations: <empty>
@@ -422,13 +417,12 @@ fn to_implicit_float_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [32-37]
                             init_expr: Expr [42-43]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Float(None,
-              | false)
+              x cannot cast expression of type angle to type float
                ,-[test:3:19]
              2 |         angle x = 42.;
              3 |         float y = x;
@@ -458,7 +452,7 @@ fn to_explicit_float_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(4.300888156922483)
                     Stmt [32-48]:
                         annotations: <empty>
@@ -466,13 +460,12 @@ fn to_explicit_float_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [32-41]
                             init_expr: Expr [46-47]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Float(Some(32),
-              | false)
+              x cannot cast expression of type angle to type float[32]
                ,-[test:3:23]
              2 |         angle x = 42.;
              3 |         float[32] y = x;
@@ -502,7 +495,7 @@ fn to_implicit_complex_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(4.300888156922483)
                     Stmt [32-53]:
                         annotations: <empty>
@@ -510,13 +503,12 @@ fn to_implicit_complex_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [32-46]
                             init_expr: Expr [51-52]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Complex(None,
-              | false)
+              x cannot cast expression of type angle to type complex[float]
                ,-[test:3:28]
              2 |         angle x = 42.;
              3 |         complex[float] y = x;
@@ -546,7 +538,7 @@ fn to_explicit_complex_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-14]
                             init_expr: Expr [19-22]:
-                                ty: Angle(None, true)
+                                ty: const angle
                                 kind: Lit: Angle(4.300888156922483)
                     Stmt [32-57]:
                         annotations: <empty>
@@ -554,13 +546,12 @@ fn to_explicit_complex_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [32-50]
                             init_expr: Expr [55-56]:
-                                ty: Angle(None, false)
+                                ty: angle
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type
-              | Complex(Some(32), false)
+              x cannot cast expression of type angle to type complex[float[32]]
                ,-[test:3:32]
              2 |         angle x = 42.;
              3 |         complex[float[32]] y = x;
@@ -585,22 +576,22 @@ fn to_angle_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.300888156922483)
             [8] Symbol [15-16]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default
             ClassicalDeclarationStmt [32-44]:
                 symbol_id: 9
                 ty_span: [32-37]
                 init_expr: Expr [42-43]:
-                    ty: Angle(None, false)
+                    ty: angle
                     kind: SymbolId(8)
             [9] Symbol [38-39]:
                 name: y
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default
         "#]],
@@ -621,26 +612,26 @@ fn to_explicit_angle_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Angle(None, true)
+                    ty: const angle
                     kind: Lit: Angle(4.300888156922483)
             [8] Symbol [15-16]:
                 name: x
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
-                    ty: Angle(Some(4), false)
+                    ty: angle[4]
                     kind: Cast [0-0]:
-                        ty: Angle(Some(4), false)
+                        ty: angle[4]
                         expr: Expr [45-46]:
-                            ty: Angle(None, false)
+                            ty: angle
                             kind: SymbolId(8)
             [9] Symbol [41-42]:
                 name: y
-                type: Angle(Some(4), false)
+                type: angle[4]
                 qsharp_type: Angle
                 io_kind: Default
         "#]],
@@ -662,48 +653,48 @@ fn width_promotion() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [23-26]:
-                    ty: Angle(Some(32), true)
+                    ty: const angle[32]
                     kind: Lit: Angle(1.000000000619646)
             [8] Symbol [19-20]:
                 name: x
-                type: Angle(Some(32), false)
+                type: angle[32]
                 qsharp_type: Angle
                 io_kind: Default
             ClassicalDeclarationStmt [36-54]:
                 symbol_id: 9
                 ty_span: [36-45]
                 init_expr: Expr [50-53]:
-                    ty: Angle(Some(48), true)
+                    ty: const angle[48]
                     kind: Lit: Angle(1.999999999999999)
             [9] Symbol [46-47]:
                 name: y
-                type: Angle(Some(48), false)
+                type: angle[48]
                 qsharp_type: Angle
                 io_kind: Default
             ClassicalDeclarationStmt [63-77]:
                 symbol_id: 10
                 ty_span: [63-66]
                 init_expr: Expr [71-76]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [0-0]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [71-76]:
-                            ty: UInt(Some(48), false)
+                            ty: uint[48]
                             kind: BinaryOpExpr:
                                 op: Div
                                 lhs: Expr [71-72]:
-                                    ty: Angle(Some(48), false)
+                                    ty: angle[48]
                                     kind: Cast [0-0]:
-                                        ty: Angle(Some(48), false)
+                                        ty: angle[48]
                                         expr: Expr [71-72]:
-                                            ty: Angle(Some(32), false)
+                                            ty: angle[32]
                                             kind: SymbolId(8)
                                 rhs: Expr [75-76]:
-                                    ty: Angle(Some(48), false)
+                                    ty: angle[48]
                                     kind: SymbolId(9)
             [10] Symbol [67-68]:
                 name: z
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bit.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bit.rs
@@ -24,7 +24,7 @@ fn to_angle_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [10-13]
                             init_expr: Expr [18-19]:
-                                ty: Bit(true)
+                                ty: const bit
                                 kind: Lit: Bit(1)
                     Stmt [30-42]:
                         annotations: <empty>
@@ -32,12 +32,12 @@ fn to_angle_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [30-35]
                             init_expr: Expr [40-41]:
-                                ty: Bit(false)
+                                ty: bit
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Angle(None, false)
+              x cannot cast expression of type bit to type angle
                ,-[test:3:20]
              2 |          bit x = 1;
              3 |          angle y = x;
@@ -67,7 +67,7 @@ fn to_explicit_angle_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [10-13]
                             init_expr: Expr [18-19]:
-                                ty: Bit(true)
+                                ty: const bit
                                 kind: Lit: Bit(1)
                     Stmt [30-45]:
                         annotations: <empty>
@@ -75,12 +75,12 @@ fn to_explicit_angle_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [30-38]
                             init_expr: Expr [43-44]:
-                                ty: Bit(false)
+                                ty: bit
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Angle(Some(4), false)
+              x cannot cast expression of type bit to type angle[4]
                ,-[test:3:23]
              2 |          bit x = 1;
              3 |          angle[4] y = x;
@@ -105,26 +105,26 @@ fn to_bool_implicitly() {
                 symbol_id: 8
                 ty_span: [10-13]
                 init_expr: Expr [18-19]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [14-15]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [30-41]:
                 symbol_id: 9
                 ty_span: [30-34]
                 init_expr: Expr [39-40]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [0-0]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [39-40]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
             [9] Symbol [35-36]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -145,26 +145,26 @@ fn to_implicit_int_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-38]:
                 symbol_id: 9
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [0-0]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [36-37]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
             [9] Symbol [32-33]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -185,26 +185,26 @@ fn to_explicit_int_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-42]:
                 symbol_id: 9
                 ty_span: [28-35]
                 init_expr: Expr [40-41]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [0-0]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [40-41]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
             [9] Symbol [36-37]:
                 name: y
-                type: Int(Some(32), false)
+                type: int[32]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -225,26 +225,26 @@ fn to_implicit_uint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-39]:
                 symbol_id: 9
                 ty_span: [28-32]
                 init_expr: Expr [37-38]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [0-0]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [37-38]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
             [9] Symbol [33-34]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -265,26 +265,26 @@ fn to_explicit_uint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-43]:
                 symbol_id: 9
                 ty_span: [28-36]
                 init_expr: Expr [41-42]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [0-0]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [41-42]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
             [9] Symbol [37-38]:
                 name: y
-                type: UInt(Some(32), false)
+                type: uint[32]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -305,26 +305,26 @@ fn to_explicit_bigint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-42]:
                 symbol_id: 9
                 ty_span: [28-35]
                 init_expr: Expr [40-41]:
-                    ty: Int(Some(65), false)
+                    ty: int[65]
                     kind: Cast [0-0]:
-                        ty: Int(Some(65), false)
+                        ty: int[65]
                         expr: Expr [40-41]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
             [9] Symbol [36-37]:
                 name: y
-                type: Int(Some(65), false)
+                type: int[65]
                 qsharp_type: BigInt
                 io_kind: Default
         "#]],
@@ -345,26 +345,26 @@ fn to_implicit_float_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-18]:
-                    ty: Bit(true)
+                    ty: const bit
                     kind: Lit: Bit(1)
             [8] Symbol [13-14]:
                 name: x
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
             ClassicalDeclarationStmt [28-40]:
                 symbol_id: 9
                 ty_span: [28-33]
                 init_expr: Expr [38-39]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [0-0]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [38-39]:
-                            ty: Bit(false)
+                            ty: bit
                             kind: SymbolId(8)
             [9] Symbol [34-35]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bitarray.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bitarray.rs
@@ -19,26 +19,26 @@ fn to_int_decl_implicitly() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(5, true)
+                    ty: const bit[5]
                     kind: Lit: Bitstring("00000")
             [8] Symbol [16-19]:
                 name: reg
-                type: BitArray(5, false)
+                type: bit[5]
                 qsharp_type: Result[]
                 io_kind: Default
             ClassicalDeclarationStmt [29-41]:
                 symbol_id: 9
                 ty_span: [29-32]
                 init_expr: Expr [37-40]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [0-0]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [37-40]:
-                            ty: BitArray(5, false)
+                            ty: bit[5]
                             kind: SymbolId(8)
             [9] Symbol [33-34]:
                 name: b
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -60,37 +60,37 @@ fn to_int_assignment_implicitly() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(5, true)
+                    ty: const bit[5]
                     kind: Lit: Bitstring("00000")
             [8] Symbol [16-19]:
                 name: reg
-                type: BitArray(5, false)
+                type: bit[5]
                 qsharp_type: Result[]
                 io_kind: Default
             ClassicalDeclarationStmt [29-35]:
                 symbol_id: 9
                 ty_span: [29-32]
                 init_expr: Expr [0-0]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(0)
             [9] Symbol [33-34]:
                 name: a
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             AssignStmt [44-52]:
                 symbol_id: 9
                 lhs_span: [44-45]
                 rhs: Expr [48-51]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [0-0]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [48-51]:
-                            ty: BitArray(5, false)
+                            ty: bit[5]
                             kind: SymbolId(8)
             [9] Symbol [33-34]:
                 name: a
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -112,37 +112,37 @@ fn to_int_with_equal_width_in_assignment_implicitly() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(5, true)
+                    ty: const bit[5]
                     kind: Lit: Bitstring("00000")
             [8] Symbol [16-19]:
                 name: reg
-                type: BitArray(5, false)
+                type: bit[5]
                 qsharp_type: Result[]
                 io_kind: Default
             ClassicalDeclarationStmt [29-38]:
                 symbol_id: 9
                 ty_span: [29-35]
                 init_expr: Expr [0-0]:
-                    ty: Int(Some(5), true)
+                    ty: const int[5]
                     kind: Lit: Int(0)
             [9] Symbol [36-37]:
                 name: a
-                type: Int(Some(5), false)
+                type: int[5]
                 qsharp_type: Int
                 io_kind: Default
             AssignStmt [47-55]:
                 symbol_id: 9
                 lhs_span: [47-48]
                 rhs: Expr [51-54]:
-                    ty: Int(Some(5), false)
+                    ty: int[5]
                     kind: Cast [0-0]:
-                        ty: Int(Some(5), false)
+                        ty: int[5]
                         expr: Expr [51-54]:
-                            ty: BitArray(5, false)
+                            ty: bit[5]
                             kind: SymbolId(8)
             [9] Symbol [36-37]:
                 name: a
-                type: Int(Some(5), false)
+                type: int[5]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -163,26 +163,26 @@ fn to_int_with_equal_width_in_decl_implicitly() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [0-0]:
-                    ty: BitArray(5, true)
+                    ty: const bit[5]
                     kind: Lit: Bitstring("00000")
             [8] Symbol [16-19]:
                 name: reg
-                type: BitArray(5, false)
+                type: bit[5]
                 qsharp_type: Result[]
                 io_kind: Default
             ClassicalDeclarationStmt [29-44]:
                 symbol_id: 9
                 ty_span: [29-35]
                 init_expr: Expr [40-43]:
-                    ty: Int(Some(5), false)
+                    ty: int[5]
                     kind: Cast [0-0]:
-                        ty: Int(Some(5), false)
+                        ty: int[5]
                         expr: Expr [40-43]:
-                            ty: BitArray(5, false)
+                            ty: bit[5]
                             kind: SymbolId(8)
             [9] Symbol [36-37]:
                 name: a
-                type: Int(Some(5), false)
+                type: int[5]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -209,7 +209,7 @@ fn to_int_with_higher_width_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-15]
                             init_expr: Expr [0-0]:
-                                ty: Int(Some(6), true)
+                                ty: const int[6]
                                 kind: Lit: Int(0)
                     Stmt [27-38]:
                         annotations: <empty>
@@ -217,7 +217,7 @@ fn to_int_with_higher_width_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [27-33]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(5, true)
+                                ty: const bit[5]
                                 kind: Lit: Bitstring("00000")
                     Stmt [47-55]:
                         annotations: <empty>
@@ -225,13 +225,12 @@ fn to_int_with_higher_width_implicitly_fails() {
                             symbol_id: 8
                             lhs_span: [47-48]
                             rhs: Expr [51-54]:
-                                ty: BitArray(5, false)
+                                ty: bit[5]
                                 kind: SymbolId(9)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(5, false) to type Int(Some(6),
-              | false)
+              x cannot cast expression of type bit[5] to type int[6]
                ,-[test:4:13]
              3 |         bit[5] reg;
              4 |         a = reg;
@@ -260,7 +259,7 @@ fn to_int_with_higher_width_decl_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-15]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(5, true)
+                                ty: const bit[5]
                                 kind: Lit: Bitstring("00000")
                     Stmt [29-44]:
                         annotations: <empty>
@@ -268,13 +267,12 @@ fn to_int_with_higher_width_decl_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [29-35]
                             init_expr: Expr [40-43]:
-                                ty: BitArray(5, false)
+                                ty: bit[5]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(5, false) to type Int(Some(6),
-              | false)
+              x cannot cast expression of type bit[5] to type int[6]
                ,-[test:3:20]
              2 |         bit[5] reg;
              3 |         int[6] a = reg;
@@ -309,7 +307,7 @@ fn to_int_with_lower_width_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [33-39]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(5, true)
+                                ty: const bit[5]
                                 kind: Lit: Bitstring("00000")
                     Stmt [53-61]:
                         annotations: <empty>
@@ -317,13 +315,12 @@ fn to_int_with_lower_width_implicitly_fails() {
                             symbol_id: 8
                             lhs_span: [53-54]
                             rhs: Expr [57-60]:
-                                ty: BitArray(5, false)
+                                ty: bit[5]
                                 kind: SymbolId(9)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(5, false) to type Int(Some(4),
-              | false)
+              x cannot cast expression of type bit[5] to type int[4]
                ,-[test:4:13]
              3 |         bit[5] reg;
              4 |         a = reg;
@@ -353,7 +350,7 @@ fn to_int_with_lower_width_decl_implicitly_fails() {
                             symbol_id: 8
                             ty_span: [9-15]
                             init_expr: Expr [0-0]:
-                                ty: BitArray(5, true)
+                                ty: const bit[5]
                                 kind: Lit: Bitstring("00000")
                     Stmt [29-44]:
                         annotations: <empty>
@@ -361,13 +358,12 @@ fn to_int_with_lower_width_decl_implicitly_fails() {
                             symbol_id: 9
                             ty_span: [29-35]
                             init_expr: Expr [40-43]:
-                                ty: BitArray(5, false)
+                                ty: bit[5]
                                 kind: SymbolId(8)
 
             [Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(5, false) to type Int(Some(4),
-              | false)
+              x cannot cast expression of type bit[5] to type int[4]
                ,-[test:3:20]
              2 |         bit[5] reg;
              3 |         int[4] a = reg;

--- a/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bool.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bool.rs
@@ -19,26 +19,26 @@ fn to_bit_implicitly() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-42]:
                 symbol_id: 9
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [0-0]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [40-41]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
             [9] Symbol [36-37]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
         "#]],
@@ -59,26 +59,26 @@ fn to_implicit_int_implicitly() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-42]:
                 symbol_id: 9
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [0-0]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [40-41]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
             [9] Symbol [36-37]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -99,26 +99,26 @@ fn to_explicit_int_implicitly() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-46]:
                 symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [0-0]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [44-45]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
             [9] Symbol [40-41]:
                 name: y
-                type: Int(Some(32), false)
+                type: int[32]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -139,26 +139,26 @@ fn to_implicit_uint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-43]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [0-0]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [41-42]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
             [9] Symbol [37-38]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -179,26 +179,26 @@ fn to_explicit_uint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [0-0]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [45-46]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
             [9] Symbol [41-42]:
                 name: y
-                type: UInt(Some(32), false)
+                type: uint[32]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -219,26 +219,26 @@ fn to_explicit_bigint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-46]:
                 symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
-                    ty: Int(Some(65), false)
+                    ty: int[65]
                     kind: Cast [0-0]:
-                        ty: Int(Some(65), false)
+                        ty: int[65]
                         expr: Expr [44-45]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
             [9] Symbol [40-41]:
                 name: y
-                type: Int(Some(65), false)
+                type: int[65]
                 qsharp_type: BigInt
                 io_kind: Default
         "#]],
@@ -259,26 +259,26 @@ fn to_implicit_float_implicitly() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-44]:
                 symbol_id: 9
                 ty_span: [32-37]
                 init_expr: Expr [42-43]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [0-0]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [42-43]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
             [9] Symbol [38-39]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
         "#]],
@@ -299,26 +299,26 @@ fn to_explicit_float_implicitly() {
                 symbol_id: 8
                 ty_span: [9-13]
                 init_expr: Expr [18-22]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Lit: Bool(true)
             [8] Symbol [14-15]:
                 name: x
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
             ClassicalDeclarationStmt [32-48]:
                 symbol_id: 9
                 ty_span: [32-41]
                 init_expr: Expr [46-47]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [0-0]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [46-47]:
-                            ty: Bool(false)
+                            ty: bool
                             kind: SymbolId(8)
             [9] Symbol [42-43]:
                 name: y
-                type: Float(Some(32), false)
+                type: float[32]
                 qsharp_type: Double
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_float.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_float.rs
@@ -19,26 +19,26 @@ fn to_bit_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-42]:
                 symbol_id: 9
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [0-0]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [40-41]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [36-37]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
         "#]],
@@ -59,26 +59,26 @@ fn explicit_width_to_bit_implicitly() {
                 symbol_id: 8
                 ty_span: [9-18]
                 init_expr: Expr [23-26]:
-                    ty: Float(Some(64), true)
+                    ty: const float[64]
                     kind: Lit: Float(42.0)
             [8] Symbol [19-20]:
                 name: x
-                type: Float(Some(64), false)
+                type: float[64]
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [36-46]:
                 symbol_id: 9
                 ty_span: [36-39]
                 init_expr: Expr [44-45]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [0-0]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [44-45]:
-                            ty: Float(Some(64), false)
+                            ty: float[64]
                             kind: SymbolId(8)
             [9] Symbol [40-41]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
         "#]],
@@ -98,26 +98,26 @@ fn to_bool_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-43]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [0-0]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [41-42]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [37-38]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -138,26 +138,26 @@ fn to_implicit_int_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-42]:
                 symbol_id: 9
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Cast [0-0]:
-                        ty: Int(None, false)
+                        ty: int
                         expr: Expr [40-41]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [36-37]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -178,26 +178,26 @@ fn to_explicit_int_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-46]:
                 symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [0-0]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [44-45]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [40-41]:
                 name: y
-                type: Int(Some(32), false)
+                type: int[32]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -218,26 +218,26 @@ fn to_implicit_uint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-43]:
                 symbol_id: 9
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [0-0]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [41-42]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [37-38]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -258,30 +258,30 @@ fn negative_lit_to_implicit_uint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [20-23]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: UnaryOpExpr [20-23]:
                         op: Neg
                         expr: Expr [20-23]:
-                            ty: Float(None, true)
+                            ty: const float
                             kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [33-44]:
                 symbol_id: 9
                 ty_span: [33-37]
                 init_expr: Expr [42-43]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [0-0]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [42-43]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [38-39]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -302,26 +302,26 @@ fn to_explicit_uint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [0-0]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [45-46]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [41-42]:
                 name: y
-                type: UInt(Some(32), false)
+                type: uint[32]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -342,26 +342,26 @@ fn to_explicit_bigint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-46]:
                 symbol_id: 9
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
-                    ty: Int(Some(65), false)
+                    ty: int[65]
                     kind: Cast [0-0]:
-                        ty: Int(Some(65), false)
+                        ty: int[65]
                         expr: Expr [44-45]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [40-41]:
                 name: y
-                type: Int(Some(65), false)
+                type: int[65]
                 qsharp_type: BigInt
                 io_kind: Default
         "#]],
@@ -382,22 +382,22 @@ fn to_implicit_float_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-44]:
                 symbol_id: 9
                 ty_span: [32-37]
                 init_expr: Expr [42-43]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: SymbolId(8)
             [9] Symbol [38-39]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
         "#]],
@@ -418,26 +418,26 @@ fn to_explicit_float_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-48]:
                 symbol_id: 9
                 ty_span: [32-41]
                 init_expr: Expr [46-47]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [0-0]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [46-47]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [42-43]:
                 name: y
-                type: Float(Some(32), false)
+                type: float[32]
                 qsharp_type: Double
                 io_kind: Default
         "#]],
@@ -458,26 +458,26 @@ fn to_implicit_complex_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-53]:
                 symbol_id: 9
                 ty_span: [32-46]
                 init_expr: Expr [51-52]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Cast [0-0]:
-                        ty: Complex(None, false)
+                        ty: complex[float]
                         expr: Expr [51-52]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [47-48]:
                 name: y
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default
         "#]],
@@ -498,26 +498,26 @@ fn to_explicit_complex_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-57]:
                 symbol_id: 9
                 ty_span: [32-50]
                 init_expr: Expr [55-56]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: Cast [0-0]:
-                        ty: Complex(Some(32), false)
+                        ty: complex[float[32]]
                         expr: Expr [55-56]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [51-52]:
                 name: y
-                type: Complex(Some(32), false)
+                type: complex[float[32]]
                 qsharp_type: Complex
                 io_kind: Default
         "#]],
@@ -538,26 +538,26 @@ fn to_angle_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-44]:
                 symbol_id: 9
                 ty_span: [32-37]
                 init_expr: Expr [42-43]:
-                    ty: Angle(None, false)
+                    ty: angle
                     kind: Cast [0-0]:
-                        ty: Angle(None, false)
+                        ty: angle
                         expr: Expr [42-43]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [38-39]:
                 name: y
-                type: Angle(None, false)
+                type: angle
                 qsharp_type: Angle
                 io_kind: Default
         "#]],
@@ -578,26 +578,26 @@ fn to_explicit_angle_implicitly() {
                 symbol_id: 8
                 ty_span: [9-14]
                 init_expr: Expr [19-22]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Lit: Float(42.0)
             [8] Symbol [15-16]:
                 name: x
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
             ClassicalDeclarationStmt [32-47]:
                 symbol_id: 9
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
-                    ty: Angle(Some(4), false)
+                    ty: angle[4]
                     kind: Cast [0-0]:
-                        ty: Angle(Some(4), false)
+                        ty: angle[4]
                         expr: Expr [45-46]:
-                            ty: Float(None, false)
+                            ty: float
                             kind: SymbolId(8)
             [9] Symbol [41-42]:
                 name: y
-                type: Angle(Some(4), false)
+                type: angle[4]
                 qsharp_type: Angle
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_int.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_int.rs
@@ -19,26 +19,26 @@ fn to_bit_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-39]:
                 symbol_id: 9
                 ty_span: [29-32]
                 init_expr: Expr [37-38]:
-                    ty: Bit(false)
+                    ty: bit
                     kind: Cast [0-0]:
-                        ty: Bit(false)
+                        ty: bit
                         expr: Expr [37-38]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [33-34]:
                 name: y
-                type: Bit(false)
+                type: bit
                 qsharp_type: Result
                 io_kind: Default
         "#]],
@@ -59,26 +59,26 @@ fn to_bool_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
                 symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
-                    ty: Bool(false)
+                    ty: bool
                     kind: Cast [0-0]:
-                        ty: Bool(false)
+                        ty: bool
                         expr: Expr [38-39]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [34-35]:
                 name: y
-                type: Bool(false)
+                type: bool
                 qsharp_type: bool
                 io_kind: Default
         "#]],
@@ -99,22 +99,22 @@ fn to_implicit_int_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-39]:
                 symbol_id: 9
                 ty_span: [29-32]
                 init_expr: Expr [37-38]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: SymbolId(8)
             [9] Symbol [33-34]:
                 name: y
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -135,26 +135,26 @@ fn to_explicit_int_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-43]:
                 symbol_id: 9
                 ty_span: [29-36]
                 init_expr: Expr [41-42]:
-                    ty: Int(Some(32), false)
+                    ty: int[32]
                     kind: Cast [0-0]:
-                        ty: Int(Some(32), false)
+                        ty: int[32]
                         expr: Expr [41-42]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [37-38]:
                 name: y
-                type: Int(Some(32), false)
+                type: int[32]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -175,26 +175,26 @@ fn to_implicit_uint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-40]:
                 symbol_id: 9
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
-                    ty: UInt(None, false)
+                    ty: uint
                     kind: Cast [0-0]:
-                        ty: UInt(None, false)
+                        ty: uint
                         expr: Expr [38-39]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [34-35]:
                 name: y
-                type: UInt(None, false)
+                type: uint
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -215,26 +215,26 @@ fn to_explicit_uint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-44]:
                 symbol_id: 9
                 ty_span: [29-37]
                 init_expr: Expr [42-43]:
-                    ty: UInt(Some(32), false)
+                    ty: uint[32]
                     kind: Cast [0-0]:
-                        ty: UInt(Some(32), false)
+                        ty: uint[32]
                         expr: Expr [42-43]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [38-39]:
                 name: y
-                type: UInt(Some(32), false)
+                type: uint[32]
                 qsharp_type: Int
                 io_kind: Default
         "#]],
@@ -255,26 +255,26 @@ fn to_explicit_bigint_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-43]:
                 symbol_id: 9
                 ty_span: [29-36]
                 init_expr: Expr [41-42]:
-                    ty: Int(Some(65), false)
+                    ty: int[65]
                     kind: Cast [0-0]:
-                        ty: Int(Some(65), false)
+                        ty: int[65]
                         expr: Expr [41-42]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [37-38]:
                 name: y
-                type: Int(Some(65), false)
+                type: int[65]
                 qsharp_type: BigInt
                 io_kind: Default
         "#]],
@@ -295,26 +295,26 @@ fn to_implicit_float_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-41]:
                 symbol_id: 9
                 ty_span: [29-34]
                 init_expr: Expr [39-40]:
-                    ty: Float(None, false)
+                    ty: float
                     kind: Cast [0-0]:
-                        ty: Float(None, false)
+                        ty: float
                         expr: Expr [39-40]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [35-36]:
                 name: y
-                type: Float(None, false)
+                type: float
                 qsharp_type: Double
                 io_kind: Default
         "#]],
@@ -335,26 +335,26 @@ fn to_explicit_float_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-45]:
                 symbol_id: 9
                 ty_span: [29-38]
                 init_expr: Expr [43-44]:
-                    ty: Float(Some(32), false)
+                    ty: float[32]
                     kind: Cast [0-0]:
-                        ty: Float(Some(32), false)
+                        ty: float[32]
                         expr: Expr [43-44]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [39-40]:
                 name: y
-                type: Float(Some(32), false)
+                type: float[32]
                 qsharp_type: Double
                 io_kind: Default
         "#]],
@@ -375,26 +375,26 @@ fn to_implicit_complex_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-50]:
                 symbol_id: 9
                 ty_span: [29-43]
                 init_expr: Expr [48-49]:
-                    ty: Complex(None, false)
+                    ty: complex[float]
                     kind: Cast [0-0]:
-                        ty: Complex(None, false)
+                        ty: complex[float]
                         expr: Expr [48-49]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [44-45]:
                 name: y
-                type: Complex(None, false)
+                type: complex[float]
                 qsharp_type: Complex
                 io_kind: Default
         "#]],
@@ -415,26 +415,26 @@ fn to_explicit_complex_implicitly() {
                 symbol_id: 8
                 ty_span: [9-12]
                 init_expr: Expr [17-19]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(42)
             [8] Symbol [13-14]:
                 name: x
-                type: Int(None, false)
+                type: int
                 qsharp_type: Int
                 io_kind: Default
             ClassicalDeclarationStmt [29-54]:
                 symbol_id: 9
                 ty_span: [29-47]
                 init_expr: Expr [52-53]:
-                    ty: Complex(Some(32), false)
+                    ty: complex[float[32]]
                     kind: Cast [0-0]:
-                        ty: Complex(Some(32), false)
+                        ty: complex[float[32]]
                         expr: Expr [52-53]:
-                            ty: Int(None, false)
+                            ty: int
                             kind: SymbolId(8)
             [9] Symbol [48-49]:
                 name: y
-                type: Complex(Some(32), false)
+                type: complex[float[32]]
                 qsharp_type: Complex
                 io_kind: Default
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/expression/indexing.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/indexing.rs
@@ -19,23 +19,23 @@ fn simple_array_slice_has_correct_size() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [20-22]:
-                    ty: BitArray(8, true)
+                    ty: const bit[8]
                     kind: Lit: Bitstring("00010000")
             ExprStmt [32-39]:
                 expr: Expr [32-38]:
-                    ty: BitArray(3, false)
+                    ty: bit[3]
                     kind: IndexExpr [32-38]:
                         collection: Expr [32-33]:
-                            ty: BitArray(8, false)
+                            ty: bit[8]
                             kind: SymbolId(8)
                         indices:
                             Range [34-37]:
                                 start: Expr [34-35]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(1)
                                 step: <none>
                                 end: Expr [36-37]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(3)
         "#]],
     );
@@ -55,23 +55,23 @@ fn array_slice_with_negative_start_has_correct_size() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [20-22]:
-                    ty: BitArray(8, true)
+                    ty: const bit[8]
                     kind: Lit: Bitstring("00010000")
             ExprStmt [32-40]:
                 expr: Expr [32-39]:
-                    ty: BitArray(6, false)
+                    ty: bit[6]
                     kind: IndexExpr [32-39]:
                         collection: Expr [32-33]:
-                            ty: BitArray(8, false)
+                            ty: bit[8]
                             kind: SymbolId(8)
                         indices:
                             Range [34-38]:
                                 start: Expr [35-36]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(-7)
                                 step: <none>
                                 end: Expr [37-38]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(6)
         "#]],
     );
@@ -91,23 +91,23 @@ fn array_slice_with_negative_end_has_correct_size() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [20-22]:
-                    ty: BitArray(8, true)
+                    ty: const bit[8]
                     kind: Lit: Bitstring("00010000")
             ExprStmt [32-40]:
                 expr: Expr [32-39]:
-                    ty: BitArray(6, false)
+                    ty: bit[6]
                     kind: IndexExpr [32-39]:
                         collection: Expr [32-33]:
-                            ty: BitArray(8, false)
+                            ty: bit[8]
                             kind: SymbolId(8)
                         indices:
                             Range [34-38]:
                                 start: Expr [34-35]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(1)
                                 step: <none>
                                 end: Expr [37-38]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(-2)
         "#]],
     );
@@ -127,25 +127,25 @@ fn array_slice_with_non_exact_divisor_step_has_correct_size() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [20-22]:
-                    ty: BitArray(8, true)
+                    ty: const bit[8]
                     kind: Lit: Bitstring("00010000")
             ExprStmt [32-41]:
                 expr: Expr [32-40]:
-                    ty: BitArray(3, false)
+                    ty: bit[3]
                     kind: IndexExpr [32-40]:
                         collection: Expr [32-33]:
-                            ty: BitArray(8, false)
+                            ty: bit[8]
                             kind: SymbolId(8)
                         indices:
                             Range [34-39]:
                                 start: Expr [34-35]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(0)
                                 step: Expr [36-37]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(3)
                                 end: Expr [38-39]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(7)
         "#]],
     );
@@ -165,25 +165,25 @@ fn array_slice_with_exact_divisor_step_has_correct_size() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [20-22]:
-                    ty: BitArray(8, true)
+                    ty: const bit[8]
                     kind: Lit: Bitstring("00010000")
             ExprStmt [32-41]:
                 expr: Expr [32-40]:
-                    ty: BitArray(3, false)
+                    ty: bit[3]
                     kind: IndexExpr [32-40]:
                         collection: Expr [32-33]:
-                            ty: BitArray(8, false)
+                            ty: bit[8]
                             kind: SymbolId(8)
                         indices:
                             Range [34-39]:
                                 start: Expr [34-35]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(0)
                                 step: Expr [36-37]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(3)
                                 end: Expr [38-39]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(6)
         "#]],
     );
@@ -203,25 +203,25 @@ fn array_slice_with_negative_step_has_correct_size() {
                 symbol_id: 8
                 ty_span: [9-15]
                 init_expr: Expr [20-22]:
-                    ty: BitArray(8, true)
+                    ty: const bit[8]
                     kind: Lit: Bitstring("00010000")
             ExprStmt [32-42]:
                 expr: Expr [32-41]:
-                    ty: BitArray(3, false)
+                    ty: bit[3]
                     kind: IndexExpr [32-41]:
                         collection: Expr [32-33]:
-                            ty: BitArray(8, false)
+                            ty: bit[8]
                             kind: SymbolId(8)
                         indices:
                             Range [34-40]:
                                 start: Expr [34-35]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(6)
                                 step: Expr [37-38]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(-3)
                                 end: Expr [39-40]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(0)
         "#]],
     );
@@ -246,7 +246,7 @@ fn array_slice_with_zero_step_errors() {
                             symbol_id: 8
                             ty_span: [9-15]
                             init_expr: Expr [20-22]:
-                                ty: BitArray(8, true)
+                                ty: const bit[8]
                                 kind: Lit: Bitstring("00010000")
                     Stmt [32-39]:
                         annotations: <empty>

--- a/compiler/qsc_qasm/src/semantic/tests/statements/break_stmt.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements/break_stmt.rs
@@ -14,13 +14,13 @@ fn for_loop() {
                 iterable: Set [13-22]:
                     values:
                         Expr [14-15]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(1)
                         Expr [17-18]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(2)
                         Expr [20-21]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(3)
                 body: Stmt [23-29]:
                     annotations: <empty>
@@ -39,7 +39,7 @@ fn while_loop() {
         &expect![[r#"
             WhileLoop [0-19]:
                 condition: Expr [7-11]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 body: Stmt [13-19]:
                     annotations: <empty>
@@ -58,7 +58,7 @@ fn nested_scopes() {
         &expect![[r#"
             WhileLoop [0-27]:
                 condition: Expr [7-11]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 body: Stmt [13-27]:
                     annotations: <empty>
@@ -112,7 +112,7 @@ fn intermediate_def_scope_fails() {
                         annotations: <empty>
                         kind: WhileLoop [9-64]:
                             condition: Expr [16-20]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(true)
                             body: Stmt [22-64]:
                                 annotations: <empty>

--- a/compiler/qsc_qasm/src/semantic/tests/statements/continue_stmt.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements/continue_stmt.rs
@@ -14,13 +14,13 @@ fn for_loop() {
                 iterable: Set [13-22]:
                     values:
                         Expr [14-15]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(1)
                         Expr [17-18]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(2)
                         Expr [20-21]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(3)
                 body: Stmt [23-32]:
                     annotations: <empty>
@@ -39,7 +39,7 @@ fn while_loop() {
         &expect![[r#"
             WhileLoop [0-22]:
                 condition: Expr [7-11]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 body: Stmt [13-22]:
                     annotations: <empty>
@@ -58,7 +58,7 @@ fn nested_scopes() {
         &expect![[r#"
             WhileLoop [0-30]:
                 condition: Expr [7-11]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 body: Stmt [13-30]:
                     annotations: <empty>
@@ -112,7 +112,7 @@ fn intermediate_def_scope_fails() {
                         annotations: <empty>
                         kind: WhileLoop [9-67]:
                             condition: Expr [16-20]:
-                                ty: Bool(true)
+                                ty: const bool
                                 kind: Lit: Bool(true)
                             body: Stmt [22-67]:
                                 annotations: <empty>

--- a/compiler/qsc_qasm/src/semantic/tests/statements/for_stmt.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements/for_stmt.rs
@@ -25,7 +25,7 @@ fn shadowing_loop_variable_in_single_stmt_body() {
                                 symbol_id: 9
                                 ty_span: [29-32]
                                 init_expr: Expr [37-38]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(2)
         "#]],
     );
@@ -53,7 +53,7 @@ fn shadowing_loop_variable_in_block_body_succeeds() {
                                 symbol_id: 9
                                 ty_span: [31-34]
                                 init_expr: Expr [39-40]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(2)
         "#]],
     );
@@ -75,7 +75,7 @@ fn loop_creates_its_own_scope() {
                 symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(0)
             ForStmt [20-177]:
                 loop_variable: 9
@@ -90,7 +90,7 @@ fn loop_creates_its_own_scope() {
                                 symbol_id: 10
                                 ty_span: [167-170]
                                 init_expr: Expr [175-176]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(1)
         "#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/statements/if_stmt.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements/if_stmt.rs
@@ -16,11 +16,11 @@ fn if_branch_creates_its_own_scope() {
                 symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(2)
             IfStmt [20-40]:
                 condition: Expr [24-28]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 if_body: Stmt [30-40]:
                     annotations: <empty>
@@ -31,7 +31,7 @@ fn if_branch_creates_its_own_scope() {
                                 symbol_id: 9
                                 ty_span: [30-33]
                                 init_expr: Expr [38-39]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(1)
                 else_body: <none>
         "#]],
@@ -51,11 +51,11 @@ fn else_branch_creates_its_own_scope() {
                 symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(2)
             IfStmt [20-52]:
                 condition: Expr [24-28]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 if_body: Stmt [30-32]:
                     annotations: <empty>
@@ -69,7 +69,7 @@ fn else_branch_creates_its_own_scope() {
                                 symbol_id: 9
                                 ty_span: [42-45]
                                 init_expr: Expr [50-51]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(1)
         "#]],
     );
@@ -87,11 +87,11 @@ fn branch_block_creates_a_new_scope() {
                 symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(2)
             IfStmt [20-44]:
                 condition: Expr [24-28]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 if_body: Stmt [30-44]:
                     annotations: <empty>
@@ -102,7 +102,7 @@ fn branch_block_creates_a_new_scope() {
                                 symbol_id: 9
                                 ty_span: [32-35]
                                 init_expr: Expr [40-41]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(1)
                 else_body: <none>
         "#]],
@@ -122,11 +122,11 @@ fn if_scope_and_else_scope_are_different() {
                 symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(2)
             IfStmt [20-68]:
                 condition: Expr [24-28]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 if_body: Stmt [30-44]:
                     annotations: <empty>
@@ -137,7 +137,7 @@ fn if_scope_and_else_scope_are_different() {
                                 symbol_id: 9
                                 ty_span: [32-35]
                                 init_expr: Expr [40-41]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(1)
                 else_body: Stmt [54-68]:
                     annotations: <empty>
@@ -148,7 +148,7 @@ fn if_scope_and_else_scope_are_different() {
                                 symbol_id: 10
                                 ty_span: [56-59]
                                 init_expr: Expr [64-65]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(2)
         "#]],
     );
@@ -161,11 +161,11 @@ fn condition_cast() {
         &expect![[r#"
             IfStmt [0-12]:
                 condition: Expr [4-5]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Cast [0-0]:
-                        ty: Bool(true)
+                        ty: const bool
                         expr: Expr [4-5]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(1)
                 if_body: Stmt [7-12]:
                     annotations: <empty>
@@ -174,7 +174,7 @@ fn condition_cast() {
                             annotations: <empty>
                             kind: ExprStmt [7-12]:
                                 expr: Expr [7-11]:
-                                    ty: Bool(true)
+                                    ty: const bool
                                     kind: Lit: Bool(true)
                 else_body: <none>
         "#]],

--- a/compiler/qsc_qasm/src/semantic/tests/statements/reset_stmt.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements/reset_stmt.rs
@@ -16,7 +16,7 @@ fn on_a_single_qubit() {
                 reset_token_span: [17-22]
                 operand: GateOperand [23-24]:
                     kind: Expr [23-24]:
-                        ty: Qubit
+                        ty: qubit
                         kind: SymbolId(8)
         "#]],
     );
@@ -36,14 +36,14 @@ fn on_an_indexed_qubit_register() {
                 reset_token_span: [20-25]
                 operand: GateOperand [26-30]:
                     kind: Expr [26-30]:
-                        ty: Qubit
+                        ty: qubit
                         kind: IndexedIdent [26-30]:
                             symbol_id: 8
                             name_span: [26-27]
                             index_span: [27-30]
                             indices:
                                 Expr [28-29]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     kind: Lit: Int(2)
         "#]],
     );
@@ -63,7 +63,7 @@ fn on_a_span_indexed_qubit_register() {
                 reset_token_span: [20-25]
                 operand: GateOperand [26-32]:
                     kind: Expr [26-32]:
-                        ty: QubitArray(3)
+                        ty: qubit[3]
                         kind: IndexedIdent [26-32]:
                             symbol_id: 8
                             name_span: [26-27]
@@ -71,11 +71,11 @@ fn on_a_span_indexed_qubit_register() {
                             indices:
                                 Range [28-31]:
                                     start: Expr [28-29]:
-                                        ty: Int(None, true)
+                                        ty: const int
                                         kind: Lit: Int(1)
                                     step: <none>
                                     end: Expr [30-31]:
-                                        ty: Int(None, true)
+                                        ty: const int
                                         kind: Lit: Int(3)
         "#]],
     );
@@ -95,7 +95,7 @@ fn on_a_zero_len_qubit_register() {
                 reset_token_span: [20-25]
                 operand: GateOperand [26-27]:
                     kind: Expr [26-27]:
-                        ty: QubitArray(0)
+                        ty: qubit[0]
                         kind: SymbolId(8)
         "#]],
     );
@@ -115,7 +115,7 @@ fn on_an_unindexed_qubit_register() {
                 reset_token_span: [20-25]
                 operand: GateOperand [26-27]:
                     kind: Expr [26-27]:
-                        ty: QubitArray(5)
+                        ty: qubit[5]
                         kind: SymbolId(8)
         "#]],
     );

--- a/compiler/qsc_qasm/src/semantic/tests/statements/switch_stmt.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements/switch_stmt.rs
@@ -19,13 +19,13 @@ fn not_supported_before_version_3_1() {
                         annotations: <empty>
                         kind: SwitchStmt [23-47]:
                             target: Expr [31-32]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Lit: Int(1)
                             cases:
                                 SwitchCase [36-45]:
                                     labels:
                                         Expr [41-42]:
-                                            ty: Int(None, true)
+                                            ty: const int
                                             kind: Lit: Int(1)
                                     block: Block [43-45]: <empty>
                             default_case: <none>
@@ -58,17 +58,17 @@ fn cases_introduce_their_own_scope() {
                 symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             SwitchStmt [20-101]:
                 target: Expr [28-29]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Lit: Int(1)
                 cases:
                     SwitchCase [41-62]:
                         labels:
                             Expr [46-47]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Lit: Int(1)
                         block: Block [48-62]:
                             Stmt [50-60]:
@@ -77,15 +77,15 @@ fn cases_introduce_their_own_scope() {
                                     symbol_id: 9
                                     ty_span: [50-53]
                                     init_expr: Expr [58-59]:
-                                        ty: Int(None, false)
+                                        ty: int
                                         kind: Lit: Int(1)
                     SwitchCase [71-95]:
                         labels:
                             Expr [76-77]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Lit: Int(2)
                             Expr [79-80]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Lit: Int(3)
                         block: Block [81-95]:
                             Stmt [83-93]:
@@ -94,7 +94,7 @@ fn cases_introduce_their_own_scope() {
                                     symbol_id: 10
                                     ty_span: [83-86]
                                     init_expr: Expr [91-92]:
-                                        ty: Int(None, false)
+                                        ty: int
                                         kind: Lit: Int(2)
                 default_case: <none>
         "#]],
@@ -108,21 +108,21 @@ fn target_cast() {
         &expect![[r#"
             SwitchStmt [0-31]:
                 target: Expr [8-12]:
-                    ty: Int(None, true)
+                    ty: const int
                     kind: Cast [0-0]:
-                        ty: Int(None, true)
+                        ty: const int
                         expr: Expr [8-12]:
-                            ty: Bool(true)
+                            ty: const bool
                             kind: Lit: Bool(true)
                 cases:
                     SwitchCase [16-29]:
                         labels:
                             Expr [21-26]:
-                                ty: Int(None, true)
+                                ty: const int
                                 kind: Cast [0-0]:
-                                    ty: Int(None, true)
+                                    ty: const int
                                     expr: Expr [21-26]:
-                                        ty: Bool(true)
+                                        ty: const bool
                                         kind: Lit: Bool(false)
                         block: Block [27-29]: <empty>
                 default_case: <none>

--- a/compiler/qsc_qasm/src/semantic/tests/statements/while_stmt.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements/while_stmt.rs
@@ -16,11 +16,11 @@ fn single_stmt_body_creates_its_own_scope() {
                 symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             WhileLoop [20-42]:
                 condition: Expr [26-30]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 body: Stmt [32-42]:
                     annotations: <empty>
@@ -31,7 +31,7 @@ fn single_stmt_body_creates_its_own_scope() {
                                 symbol_id: 9
                                 ty_span: [32-35]
                                 init_expr: Expr [40-41]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(1)
         "#]],
     );
@@ -49,11 +49,11 @@ fn block_body_creates_its_own_scope() {
                 symbol_id: 8
                 ty_span: [5-8]
                 init_expr: Expr [13-14]:
-                    ty: Int(None, false)
+                    ty: int
                     kind: Lit: Int(3)
             WhileLoop [20-46]:
                 condition: Expr [26-30]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Lit: Bool(true)
                 body: Stmt [32-46]:
                     annotations: <empty>
@@ -64,7 +64,7 @@ fn block_body_creates_its_own_scope() {
                                 symbol_id: 9
                                 ty_span: [34-37]
                                 init_expr: Expr [42-43]:
-                                    ty: Int(None, false)
+                                    ty: int
                                     kind: Lit: Int(1)
         "#]],
     );
@@ -77,11 +77,11 @@ fn condition_cast() {
         &expect![[r#"
             WhileLoop [0-15]:
                 condition: Expr [7-8]:
-                    ty: Bool(true)
+                    ty: const bool
                     kind: Cast [0-0]:
-                        ty: Bool(true)
+                        ty: const bool
                         expr: Expr [7-8]:
-                            ty: Int(None, true)
+                            ty: const int
                             kind: Lit: Int(1)
                 body: Stmt [10-15]:
                     annotations: <empty>
@@ -90,7 +90,7 @@ fn condition_cast() {
                             annotations: <empty>
                             kind: ExprStmt [10-15]:
                                 expr: Expr [10-14]:
-                                    ty: Bool(true)
+                                    ty: const bool
                                     kind: Lit: Bool(true)
         "#]],
     );

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -51,22 +51,71 @@ pub enum Type {
     Err,
 }
 
+fn write_ty_with_const(f: &mut Formatter<'_>, is_const: bool, name: &str) -> std::fmt::Result {
+    write_ty_with_designator_and_const(f, is_const, None, name)
+}
+
+fn write_ty_with_designator(
+    f: &mut Formatter<'_>,
+    width: Option<u32>,
+    name: &str,
+) -> std::fmt::Result {
+    write_ty_with_designator_and_const(f, false, width, name)
+}
+
+fn write_ty_with_designator_and_const(
+    f: &mut Formatter<'_>,
+    is_const: bool,
+    width: Option<u32>,
+    name: &str,
+) -> std::fmt::Result {
+    if is_const {
+        write!(f, "const ")?;
+    }
+    if let Some(width) = width {
+        write!(f, "{name}[{width}]")
+    } else {
+        write!(f, "{name}")
+    }
+}
+
+fn write_complex_ty(f: &mut Formatter<'_>, is_const: bool, width: Option<u32>) -> std::fmt::Result {
+    if is_const {
+        write!(f, "const ")?;
+    }
+    if let Some(width) = width {
+        write!(f, "complex[float[{width}]]")
+    } else {
+        write!(f, "complex[float]")
+    }
+}
+
 impl Display for Type {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Type::Bit(is_const) => write!(f, "Bit({is_const})"),
-            Type::Bool(is_const) => write!(f, "Bool({is_const})"),
-            Type::Duration(is_const) => write!(f, "Duration({is_const})"),
-            Type::Stretch(is_const) => write!(f, "Stretch({is_const})"),
-            Type::Angle(width, is_const) => write!(f, "Angle({width:?}, {is_const})"),
-            Type::Complex(width, is_const) => write!(f, "Complex({width:?}, {is_const})"),
-            Type::Float(width, is_const) => write!(f, "Float({width:?}, {is_const})"),
-            Type::Int(width, is_const) => write!(f, "Int({width:?}, {is_const})"),
-            Type::UInt(width, is_const) => write!(f, "UInt({width:?}, {is_const})"),
-            Type::Qubit => write!(f, "Qubit"),
-            Type::HardwareQubit => write!(f, "HardwareQubit"),
-            Type::BitArray(dims, is_const) => write!(f, "BitArray({dims:?}, {is_const})"),
-            Type::QubitArray(dims) => write!(f, "QubitArray({dims:?})"),
+            Type::Bit(is_const) => write_ty_with_const(f, *is_const, "bit"),
+            Type::Bool(is_const) => write_ty_with_const(f, *is_const, "bool"),
+            Type::Duration(is_const) => write_ty_with_const(f, *is_const, "duration"),
+            Type::Stretch(is_const) => write_ty_with_const(f, *is_const, "stretch"),
+            Type::Angle(width, is_const) => {
+                write_ty_with_designator_and_const(f, *is_const, *width, "angle")
+            }
+            Type::Complex(width, is_const) => write_complex_ty(f, *is_const, *width),
+            Type::Float(width, is_const) => {
+                write_ty_with_designator_and_const(f, *is_const, *width, "float")
+            }
+            Type::Int(width, is_const) => {
+                write_ty_with_designator_and_const(f, *is_const, *width, "int")
+            }
+            Type::UInt(width, is_const) => {
+                write_ty_with_designator_and_const(f, *is_const, *width, "uint")
+            }
+            Type::Qubit => write!(f, "qubit"),
+            Type::HardwareQubit => write!(f, "hardware qubit"),
+            Type::BitArray(width, is_const) => {
+                write_ty_with_designator_and_const(f, *is_const, Some(*width), "bit")
+            }
+            Type::QubitArray(width) => write_ty_with_designator(f, Some(*width), "qubit"),
             Type::BoolArray(dims) => write!(f, "BoolArray({dims:?})"),
             Type::DurationArray(dims) => {
                 write!(f, "DurationArray({dims:?})")
@@ -90,10 +139,10 @@ impl Display for Type {
             Type::Function(params_ty, return_ty) => {
                 write!(f, "Function({params_ty:?}) -> {return_ty:?}")
             }
-            Type::Range => write!(f, "Range"),
-            Type::Set => write!(f, "Set"),
-            Type::Void => write!(f, "Void"),
-            Type::Err => write!(f, "Err"),
+            Type::Range => write!(f, "range"),
+            Type::Set => write!(f, "set"),
+            Type::Void => write!(f, "void"),
+            Type::Err => write!(f, "unknown"),
         }
     }
 }

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -89,6 +89,45 @@ fn write_complex_ty(f: &mut Formatter<'_>, is_const: bool, width: Option<u32>) -
         write!(f, "complex[float]")
     }
 }
+fn write_array_ty(
+    f: &mut Formatter<'_>,
+    designator: Option<u32>,
+    name: &str,
+    sub_name: Option<&str>,
+    dims: &ArrayDimensions,
+) -> std::fmt::Result {
+    write!(f, "array[{name}")?;
+
+    // sub_name is used for complex arrays
+    if let Some(sub_name) = sub_name {
+        if let Some(width) = designator {
+            write!(f, "[{sub_name}[{width}]]")?;
+        } else {
+            write!(f, "[{sub_name}]")?;
+        }
+    } else if let Some(width) = designator {
+        write!(f, "[{width}]")?;
+    }
+    write!(f, ", ")?;
+    match dims {
+        ArrayDimensions::One(one) => write!(f, "{one}")?,
+        ArrayDimensions::Two(one, two) => write!(f, "{one}, {two}")?,
+        ArrayDimensions::Three(one, two, three) => write!(f, "{one}, {two}, {three}")?,
+        ArrayDimensions::Four(one, two, three, four) => write!(f, "{one}, {two}, {three}, {four}")?,
+        ArrayDimensions::Five(one, two, three, four, five) => {
+            write!(f, "{one}, {two}, {three}, {four}, {five}")?;
+        }
+        ArrayDimensions::Six(one, two, three, four, five, six) => {
+            write!(f, "{one}, {two}, {three}, {four}, {five}, {six}")?;
+        }
+        ArrayDimensions::Seven(one, two, three, four, five, six, seven) => {
+            write!(f, "{one}, {two}, {three}, {four}, {five}, {six}, {seven}")?;
+        }
+        ArrayDimensions::Err => write!(f, "unknown")?,
+    }
+
+    write!(f, "]")
+}
 
 impl Display for Type {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -116,28 +155,18 @@ impl Display for Type {
                 write_ty_with_designator_and_const(f, *is_const, Some(*width), "bit")
             }
             Type::QubitArray(width) => write_ty_with_designator(f, Some(*width), "qubit"),
-            Type::BoolArray(dims) => write!(f, "BoolArray({dims:?})"),
-            Type::DurationArray(dims) => {
-                write!(f, "DurationArray({dims:?})")
-            }
-            Type::AngleArray(width, dims) => {
-                write!(f, "AngleArray({width:?}, {dims:?})")
-            }
+            Type::BoolArray(dims) => write_array_ty(f, None, "bool", None, dims),
+            Type::DurationArray(dims) => write_array_ty(f, None, "duration", None, dims),
+            Type::AngleArray(width, dims) => write_array_ty(f, *width, "angle", None, dims),
             Type::ComplexArray(width, dims) => {
-                write!(f, "ComplexArray({width:?}, {dims:?})")
+                write_array_ty(f, *width, "complex", Some("float"), dims)
             }
-            Type::FloatArray(width, dims) => {
-                write!(f, "FloatArray({width:?}, {dims:?})")
-            }
-            Type::IntArray(width, dims) => {
-                write!(f, "IntArray({width:?}, {dims:?})")
-            }
-            Type::UIntArray(width, dims) => {
-                write!(f, "UIntArray({width:?}, {dims:?})")
-            }
-            Type::Gate(cargs, qargs) => write!(f, "Gate({cargs}, {qargs})"),
+            Type::FloatArray(width, dims) => write_array_ty(f, *width, "float", None, dims),
+            Type::IntArray(width, dims) => write_array_ty(f, *width, "int", None, dims),
+            Type::UIntArray(width, dims) => write_array_ty(f, *width, "uint", None, dims),
+            Type::Gate(cargs, qargs) => write!(f, "gate({cargs}, {qargs})"),
             Type::Function(params_ty, return_ty) => {
-                write!(f, "Function({params_ty:?}) -> {return_ty:?}")
+                write!(f, "def({params_ty:#?}) -> {return_ty}")
             }
             Type::Range => write!(f, "range"),
             Type::Set => write!(f, "set"),

--- a/compiler/qsc_qasm/src/semantic/types/tests.rs
+++ b/compiler/qsc_qasm/src/semantic/types/tests.rs
@@ -30,7 +30,7 @@ fn indexed_type_has_right_dimensions() {
     let indices = Index::Expr(index);
     let indexed_ty = indexed_type_builder(base_ty_builder, array_ty_builder, &dims, &[indices]);
 
-    expect!["BoolArray(Two(3, 4))"].assert_eq(&format!("{indexed_ty}"));
+    expect!["array[bool, 3, 4]"].assert_eq(&format!("{indexed_ty}"));
 }
 
 #[test]
@@ -47,5 +47,5 @@ fn sliced_type_has_right_dimensions() {
     });
     let indexed_ty = indexed_type_builder(base_ty_builder, array_ty_builder, &dims, &[indices]);
 
-    expect!["BoolArray(Three(3, 1, 2))"].assert_eq(&format!("{indexed_ty}"));
+    expect!["array[bool, 3, 1, 2]"].assert_eq(&format!("{indexed_ty}"));
 }

--- a/compiler/qsc_qasm/src/tests/declaration/array.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/array.rs
@@ -510,3 +510,29 @@ fn arrays_with_8_dimensions_are_unsupported() {
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
 }
+
+#[test]
+fn casting_arrays_unsupported() {
+    let source = "
+        array[complex, 1, 2, 3] a;
+        array[angle, 1, 2, 3] b = a;
+    ";
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qasm.Lowerer.CannotCast
+
+          x cannot cast expression of type array[complex[float], 1, 2, 3] to type
+          | array[angle, 1, 2, 3]
+           ,-[Test.qasm:3:35]
+         2 |         array[complex, 1, 2, 3] a;
+         3 |         array[angle, 1, 2, 3] b = a;
+           :                                   ^
+         4 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}

--- a/compiler/qsc_qasm/src/tests/declaration/def.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/def.rs
@@ -227,7 +227,7 @@ fn capturing_non_const_evaluatable_external_variable_fails() {
     expect![[r#"
         [Qasm.Lowerer.UnsupportedBinaryOp
 
-          x Shl is not supported between types Int(None, true) and UInt(None, true)
+          x Shl is not supported between types const int and const uint
            ,-[Test.qasm:2:23]
          1 | 
          2 |         const int a = 2 << (-3);

--- a/compiler/qsc_qasm/src/tests/declaration/gate.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/gate.rs
@@ -149,7 +149,7 @@ fn capturing_non_const_evaluatable_external_variable_fails() {
     expect![[r#"
         [Qasm.Lowerer.UnsupportedBinaryOp
 
-          x Shl is not supported between types Int(None, true) and UInt(None, true)
+          x Shl is not supported between types const int and const uint
            ,-[Test.qasm:2:23]
          1 | 
          2 |         const int a = 2 << (-3);

--- a/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_angle.rs
+++ b/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_angle.rs
@@ -71,7 +71,7 @@ fn angle_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Duration(false)
+              x cannot cast expression of type angle to type duration
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         duration(a);
@@ -93,8 +93,7 @@ fn sized_angle_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type angle[32] to type duration
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         duration(a);
@@ -120,7 +119,7 @@ fn angle_to_int_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Int(None, false)
+              x cannot cast expression of type angle to type int
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         int(a);
@@ -142,8 +141,7 @@ fn angle_to_sized_int_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Int(Some(32),
-              | false)
+              x cannot cast expression of type angle to type int[32]
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         int[32](a);
@@ -165,8 +163,7 @@ fn sized_angle_to_int_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type Int(None,
-              | false)
+              x cannot cast expression of type angle[32] to type int
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         int(a);
@@ -188,8 +185,7 @@ fn sized_angle_to_sized_int_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Int(Some(32), false)
+              x cannot cast expression of type angle[32] to type int[32]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         int[32](a);
@@ -211,8 +207,7 @@ fn sized_angle_to_sized_int_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Int(Some(16), false)
+              x cannot cast expression of type angle[32] to type int[16]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         int[16](a);
@@ -234,8 +229,7 @@ fn sized_angle_to_sized_int_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Int(Some(64), false)
+              x cannot cast expression of type angle[32] to type int[64]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         int[64](a);
@@ -261,8 +255,7 @@ fn angle_to_uint_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type UInt(None,
-              | false)
+              x cannot cast expression of type angle to type uint
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         uint(a);
@@ -284,8 +277,7 @@ fn angle_to_sized_uint_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type UInt(Some(32),
-              | false)
+              x cannot cast expression of type angle to type uint[32]
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         uint[32](a);
@@ -307,8 +299,7 @@ fn sized_angle_to_uint_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type UInt(None,
-              | false)
+              x cannot cast expression of type angle[32] to type uint
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         uint(a);
@@ -330,8 +321,7 @@ fn sized_angle_to_sized_uint_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | UInt(Some(32), false)
+              x cannot cast expression of type angle[32] to type uint[32]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         uint[32](a);
@@ -353,8 +343,7 @@ fn sized_angle_to_sized_uint_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | UInt(Some(16), false)
+              x cannot cast expression of type angle[32] to type uint[16]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         uint[16](a);
@@ -376,8 +365,7 @@ fn sized_angle_to_sized_uint_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | UInt(Some(64), false)
+              x cannot cast expression of type angle[32] to type uint[64]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         uint[64](a);
@@ -403,8 +391,7 @@ fn angle_to_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Float(None,
-              | false)
+              x cannot cast expression of type angle to type float
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         float(a);
@@ -426,8 +413,7 @@ fn angle_to_sized_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Float(Some(32),
-              | false)
+              x cannot cast expression of type angle to type float[32]
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         float[32](a);
@@ -449,8 +435,7 @@ fn sized_angle_to_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type Float(None,
-              | false)
+              x cannot cast expression of type angle[32] to type float
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         float(a);
@@ -472,8 +457,7 @@ fn sized_angle_to_sized_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Float(Some(32), false)
+              x cannot cast expression of type angle[32] to type float[32]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         float[32](a);
@@ -495,8 +479,7 @@ fn sized_angle_to_sized_float_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Float(Some(16), false)
+              x cannot cast expression of type angle[32] to type float[16]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         float[16](a);
@@ -518,8 +501,7 @@ fn sized_angle_to_sized_float_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Float(Some(64), false)
+              x cannot cast expression of type angle[32] to type float[64]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         float[64](a);
@@ -663,8 +645,7 @@ fn angle_to_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type Complex(None,
-              | false)
+              x cannot cast expression of type angle to type complex[float]
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         complex(a);
@@ -686,8 +667,7 @@ fn angle_to_sized_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type
-              | Complex(Some(32), false)
+              x cannot cast expression of type angle to type complex[float[32]]
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         complex[float[32]](a);
@@ -709,8 +689,7 @@ fn sized_angle_to_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Complex(None, false)
+              x cannot cast expression of type angle[32] to type complex[float]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         complex(a);
@@ -732,8 +711,7 @@ fn sized_angle_to_sized_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Complex(Some(32), false)
+              x cannot cast expression of type angle[32] to type complex[float[32]]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         complex[float[32]](a);
@@ -755,8 +733,7 @@ fn sized_angle_to_sized_complex_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Complex(Some(16), false)
+              x cannot cast expression of type angle[32] to type complex[float[16]]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         complex[float[16]](a);
@@ -778,8 +755,7 @@ fn sized_angle_to_sized_complex_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type
-              | Complex(Some(64), false)
+              x cannot cast expression of type angle[32] to type complex[float[64]]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         complex[float[64]](a);
@@ -824,8 +800,7 @@ fn angle_to_bitarray_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type angle to type bit[32]
                ,-[Test.qasm:3:9]
              2 |         angle a;
              3 |         bit[32](a);
@@ -885,8 +860,7 @@ fn sized_angle_to_bitarray_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type angle[32] to type bit[16]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         bit[16](a);
@@ -908,8 +882,7 @@ fn sized_angle_to_bitarray_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Angle(Some(32), false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type angle[32] to type bit[64]
                ,-[Test.qasm:3:9]
              2 |         angle[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_bit.rs
+++ b/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_bit.rs
@@ -65,7 +65,7 @@ fn bit_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Duration(false)
+              x cannot cast expression of type bit to type duration
                ,-[Test.qasm:3:9]
              2 |         bit a;
              3 |         duration(a);
@@ -87,7 +87,7 @@ fn bitarray_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Duration(false)
+              x cannot cast expression of type bit[32] to type duration
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         duration(a);
@@ -185,8 +185,7 @@ fn bitarray_to_sized_int_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Int(Some(16),
-              | false)
+              x cannot cast expression of type bit[32] to type int[16]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         int[16](a);
@@ -208,8 +207,7 @@ fn bitarray_to_sized_int_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Int(Some(64),
-              | false)
+              x cannot cast expression of type bit[32] to type int[64]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         int[64](a);
@@ -307,8 +305,7 @@ fn bitarray_to_sized_uint_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type UInt(Some(16),
-              | false)
+              x cannot cast expression of type bit[32] to type uint[16]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         uint[16](a);
@@ -330,8 +327,7 @@ fn bitarray_to_sized_uint_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type UInt(Some(64),
-              | false)
+              x cannot cast expression of type bit[32] to type uint[64]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         uint[64](a);
@@ -389,8 +385,7 @@ fn bitarray_to_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Float(None,
-              | false)
+              x cannot cast expression of type bit[32] to type float
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         float(a);
@@ -412,8 +407,7 @@ fn bitarray_to_sized_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Float(Some(32),
-              | false)
+              x cannot cast expression of type bit[32] to type float[32]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         float[32](a);
@@ -435,8 +429,7 @@ fn bitarray_to_sized_float_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Float(Some(16),
-              | false)
+              x cannot cast expression of type bit[32] to type float[16]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         float[16](a);
@@ -458,8 +451,7 @@ fn bitarray_to_sized_float_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Float(Some(64),
-              | false)
+              x cannot cast expression of type bit[32] to type float[64]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         float[64](a);
@@ -485,7 +477,7 @@ fn bit_to_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Angle(None, false)
+              x cannot cast expression of type bit to type angle
                ,-[Test.qasm:3:9]
              2 |         bit a;
              3 |         angle(a);
@@ -507,7 +499,7 @@ fn bit_to_sized_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Angle(Some(32), false)
+              x cannot cast expression of type bit to type angle[32]
                ,-[Test.qasm:3:9]
              2 |         bit a;
              3 |         angle[32](a);
@@ -529,8 +521,7 @@ fn bitarray_to_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Angle(None,
-              | false)
+              x cannot cast expression of type bit[32] to type angle
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         angle(a);
@@ -568,8 +559,7 @@ fn bitarray_to_sized_angle_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Angle(Some(16),
-              | false)
+              x cannot cast expression of type bit[32] to type angle[16]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         angle[16](a);
@@ -591,8 +581,7 @@ fn bitarray_to_sized_angle_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Angle(Some(64),
-              | false)
+              x cannot cast expression of type bit[32] to type angle[64]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         angle[64](a);
@@ -618,7 +607,7 @@ fn bit_to_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Complex(None, false)
+              x cannot cast expression of type bit to type complex[float]
                ,-[Test.qasm:3:9]
              2 |         bit a;
              3 |         complex(a);
@@ -640,7 +629,7 @@ fn bit_to_sized_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bit(false) to type Complex(Some(32), false)
+              x cannot cast expression of type bit to type complex[float[32]]
                ,-[Test.qasm:3:9]
              2 |         bit a;
              3 |         complex[float[32]](a);
@@ -662,8 +651,7 @@ fn bitarray_to_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type Complex(None,
-              | false)
+              x cannot cast expression of type bit[32] to type complex[float]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         complex(a);
@@ -685,8 +673,7 @@ fn bitarray_to_sized_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type
-              | Complex(Some(32), false)
+              x cannot cast expression of type bit[32] to type complex[float[32]]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         complex[float[32]](a);
@@ -708,8 +695,7 @@ fn bitarray_to_sized_complex_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type
-              | Complex(Some(16), false)
+              x cannot cast expression of type bit[32] to type complex[float[16]]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         complex[float[16]](a);
@@ -731,8 +717,7 @@ fn bitarray_to_sized_complex_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type
-              | Complex(Some(64), false)
+              x cannot cast expression of type bit[32] to type complex[float[64]]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         complex[float[64]](a);
@@ -822,8 +807,7 @@ fn bitarray_to_bitarray_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type bit[32] to type bit[16]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         bit[16](a);
@@ -845,8 +829,7 @@ fn bitarray_to_bitarray_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type BitArray(32, false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type bit[32] to type bit[64]
                ,-[Test.qasm:3:9]
              2 |         bit[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_bool.rs
+++ b/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_bool.rs
@@ -49,7 +49,7 @@ fn bool_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Duration(false)
+              x cannot cast expression of type bool to type duration
                ,-[Test.qasm:3:9]
              2 |         bool a;
              3 |         duration(a);
@@ -183,7 +183,7 @@ fn bool_to_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Angle(None, false)
+              x cannot cast expression of type bool to type angle
                ,-[Test.qasm:3:9]
              2 |         bool a;
              3 |         angle(a);
@@ -205,7 +205,7 @@ fn bool_to_sized_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Angle(Some(32), false)
+              x cannot cast expression of type bool to type angle[32]
                ,-[Test.qasm:3:9]
              2 |         bool a;
              3 |         angle[32](a);
@@ -231,7 +231,7 @@ fn bool_to_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Complex(None, false)
+              x cannot cast expression of type bool to type complex[float]
                ,-[Test.qasm:3:9]
              2 |         bool a;
              3 |         complex(a);
@@ -253,8 +253,7 @@ fn bool_to_sized_complex_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Bool(false) to type Complex(Some(32),
-              | false)
+              x cannot cast expression of type bool to type complex[float[32]]
                ,-[Test.qasm:3:9]
              2 |         bool a;
              3 |         complex[float[32]](a);

--- a/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_complex.rs
+++ b/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_complex.rs
@@ -29,7 +29,7 @@ fn complex_to_bool_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Bool(false)
+              x cannot cast expression of type complex[float] to type bool
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         bool(a);
@@ -51,8 +51,7 @@ fn sized_complex_to_bool_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Bool(false)
+              x cannot cast expression of type complex[float[32]] to type bool
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         bool(a);
@@ -78,8 +77,7 @@ fn complex_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type
-              | Duration(false)
+              x cannot cast expression of type complex[float] to type duration
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         duration(a);
@@ -101,8 +99,7 @@ fn sized_complex_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type complex[float[32]] to type duration
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         duration(a);
@@ -128,8 +125,7 @@ fn complex_to_int_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Int(None,
-              | false)
+              x cannot cast expression of type complex[float] to type int
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         int(a);
@@ -151,8 +147,7 @@ fn complex_to_sized_int_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Int(Some(32),
-              | false)
+              x cannot cast expression of type complex[float] to type int[32]
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         int[32](a);
@@ -174,8 +169,7 @@ fn sized_complex_to_int_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type Int(None,
-              | false)
+              x cannot cast expression of type complex[float[32]] to type int
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         int(a);
@@ -197,8 +191,7 @@ fn sized_complex_to_sized_int_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Int(Some(32), false)
+              x cannot cast expression of type complex[float[32]] to type int[32]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         int[32](a);
@@ -220,8 +213,7 @@ fn sized_complex_to_sized_int_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Int(Some(16), false)
+              x cannot cast expression of type complex[float[32]] to type int[16]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         int[16](a);
@@ -243,8 +235,7 @@ fn sized_complex_to_sized_int_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Int(Some(64), false)
+              x cannot cast expression of type complex[float[32]] to type int[64]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         int[64](a);
@@ -270,8 +261,7 @@ fn complex_to_uint_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type UInt(None,
-              | false)
+              x cannot cast expression of type complex[float] to type uint
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         uint(a);
@@ -293,8 +283,7 @@ fn complex_to_sized_uint_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type UInt(Some(32),
-              | false)
+              x cannot cast expression of type complex[float] to type uint[32]
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         uint[32](a);
@@ -316,8 +305,7 @@ fn sized_complex_to_uint_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type UInt(None,
-              | false)
+              x cannot cast expression of type complex[float[32]] to type uint
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         uint(a);
@@ -339,8 +327,7 @@ fn sized_complex_to_sized_uint_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | UInt(Some(32), false)
+              x cannot cast expression of type complex[float[32]] to type uint[32]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         uint[32](a);
@@ -362,8 +349,7 @@ fn sized_complex_to_sized_uint_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | UInt(Some(16), false)
+              x cannot cast expression of type complex[float[32]] to type uint[16]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         uint[16](a);
@@ -385,8 +371,7 @@ fn sized_complex_to_sized_uint_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | UInt(Some(64), false)
+              x cannot cast expression of type complex[float[32]] to type uint[64]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         uint[64](a);
@@ -412,8 +397,7 @@ fn complex_to_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Float(None,
-              | false)
+              x cannot cast expression of type complex[float] to type float
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         float(a);
@@ -435,8 +419,7 @@ fn complex_to_sized_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type
-              | Float(Some(32), false)
+              x cannot cast expression of type complex[float] to type float[32]
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         float[32](a);
@@ -458,8 +441,7 @@ fn sized_complex_to_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Float(None, false)
+              x cannot cast expression of type complex[float[32]] to type float
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         float(a);
@@ -481,8 +463,7 @@ fn sized_complex_to_sized_float_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Float(Some(32), false)
+              x cannot cast expression of type complex[float[32]] to type float[32]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         float[32](a);
@@ -504,8 +485,7 @@ fn sized_complex_to_sized_float_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Float(Some(16), false)
+              x cannot cast expression of type complex[float[32]] to type float[16]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         float[16](a);
@@ -527,8 +507,7 @@ fn sized_complex_to_sized_float_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Float(Some(64), false)
+              x cannot cast expression of type complex[float[32]] to type float[64]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         float[64](a);
@@ -554,8 +533,7 @@ fn complex_to_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Angle(None,
-              | false)
+              x cannot cast expression of type complex[float] to type angle
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         angle(a);
@@ -577,8 +555,7 @@ fn complex_to_sized_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type
-              | Angle(Some(32), false)
+              x cannot cast expression of type complex[float] to type angle[32]
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         angle[32](a);
@@ -600,8 +577,7 @@ fn sized_complex_to_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Angle(None, false)
+              x cannot cast expression of type complex[float[32]] to type angle
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         angle(a);
@@ -623,8 +599,7 @@ fn sized_complex_to_sized_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Angle(Some(32), false)
+              x cannot cast expression of type complex[float[32]] to type angle[32]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         angle[32](a);
@@ -646,8 +621,7 @@ fn sized_complex_to_sized_angle_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Angle(Some(16), false)
+              x cannot cast expression of type complex[float[32]] to type angle[16]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         angle[16](a);
@@ -669,8 +643,7 @@ fn sized_complex_to_sized_angle_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | Angle(Some(64), false)
+              x cannot cast expression of type complex[float[32]] to type angle[64]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         angle[64](a);
@@ -723,8 +696,7 @@ fn complex_to_sized_complex() {
 
             Qasm.Compiler.NotSupported
 
-              x casting Complex(None, false) to Complex(Some(32), false) type are not
-              | supported
+              x casting complex[float] to complex[float[32]] type are not supported
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         complex[float[32]](a);
@@ -757,8 +729,7 @@ fn sized_complex_to_complex() {
 
             Qasm.Compiler.NotSupported
 
-              x casting Complex(Some(32), false) to Complex(None, false) type are not
-              | supported
+              x casting complex[float[32]] to complex[float] type are not supported
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         complex(a);
@@ -823,8 +794,7 @@ fn sized_complex_to_sized_complex_expanding() {
 
             Qasm.Compiler.NotSupported
 
-              x casting Complex(Some(32), false) to Complex(Some(64), false) type are
-              | not supported
+              x casting complex[float[32]] to complex[float[64]] type are not supported
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         complex[float[64]](a);
@@ -850,7 +820,7 @@ fn complex_to_bit_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type Bit(false)
+              x cannot cast expression of type complex[float] to type bit
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         bit(a);
@@ -872,8 +842,7 @@ fn complex_to_bitarray_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type complex[float] to type bit[32]
                ,-[Test.qasm:3:9]
              2 |         complex a;
              3 |         bit[32](a);
@@ -895,7 +864,7 @@ fn sized_complex_to_bit_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type Bit(false)
+              x cannot cast expression of type complex[float[32]] to type bit
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         bit(a);
@@ -917,8 +886,7 @@ fn sized_complex_to_bitarray_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | BitArray(32, false)
+              x cannot cast expression of type complex[float[32]] to type bit[32]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         bit[32](a);
@@ -940,8 +908,7 @@ fn sized_complex_to_bitarray_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | BitArray(16, false)
+              x cannot cast expression of type complex[float[32]] to type bit[16]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         bit[16](a);
@@ -963,8 +930,7 @@ fn sized_complex_to_bitarray_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Complex(Some(32), false) to type
-              | BitArray(64, false)
+              x cannot cast expression of type complex[float[32]] to type bit[64]
                ,-[Test.qasm:3:9]
              2 |         complex[float[32]] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_duration.rs
+++ b/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_duration.rs
@@ -39,7 +39,7 @@ fn duration_to_bool_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Bool(false)
+              x cannot cast expression of type duration to type bool
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         bool(a);
@@ -121,7 +121,7 @@ fn duration_to_int_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Int(None, false)
+              x cannot cast expression of type duration to type int
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         int(a);
@@ -163,8 +163,7 @@ fn duration_to_sized_int_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Int(Some(32),
-              | false)
+              x cannot cast expression of type duration to type int[32]
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         int[32](a);
@@ -210,7 +209,7 @@ fn duration_to_uint_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type UInt(None, false)
+              x cannot cast expression of type duration to type uint
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         uint(a);
@@ -252,8 +251,7 @@ fn duration_to_sized_uint_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type UInt(Some(32),
-              | false)
+              x cannot cast expression of type duration to type uint[32]
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         uint[32](a);
@@ -299,7 +297,7 @@ fn duration_to_float_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Float(None, false)
+              x cannot cast expression of type duration to type float
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         float(a);
@@ -341,8 +339,7 @@ fn duration_to_sized_float_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Float(Some(32),
-              | false)
+              x cannot cast expression of type duration to type float[32]
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         float[32](a);
@@ -388,7 +385,7 @@ fn duration_to_angle_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Angle(None, false)
+              x cannot cast expression of type duration to type angle
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         angle(a);
@@ -430,8 +427,7 @@ fn duration_to_sized_angle_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Angle(Some(32),
-              | false)
+              x cannot cast expression of type duration to type angle[32]
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         angle[32](a);
@@ -477,8 +473,7 @@ fn duration_to_complex_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Complex(None,
-              | false)
+              x cannot cast expression of type duration to type complex[float]
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         complex(a);
@@ -520,8 +515,7 @@ fn duration_to_sized_complex_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Complex(Some(32),
-              | false)
+              x cannot cast expression of type duration to type complex[float[32]]
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         complex[float[32]](a);
@@ -567,7 +561,7 @@ fn duration_to_bit_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type Bit(false)
+              x cannot cast expression of type duration to type bit
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         bit(a);
@@ -609,7 +603,7 @@ fn duration_to_bitarray_fails() {
 
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Duration(false) to type BitArray(32, false)
+              x cannot cast expression of type duration to type bit[32]
                ,-[Test.qasm:3:9]
              2 |         duration a;
              3 |         bit[32](a);

--- a/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_float.rs
+++ b/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_float.rs
@@ -73,7 +73,7 @@ fn float_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(None, false) to type Duration(false)
+              x cannot cast expression of type float to type duration
                ,-[Test.qasm:3:9]
              2 |         float a;
              3 |         duration(a);
@@ -95,8 +95,7 @@ fn sized_float_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type float[32] to type duration
                ,-[Test.qasm:3:9]
              2 |         float[32] a;
              3 |         duration(a);
@@ -638,8 +637,7 @@ fn float_to_bitarray_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type float to type bit[32]
                ,-[Test.qasm:3:9]
              2 |         float a;
              3 |         bit[32](a);
@@ -677,8 +675,7 @@ fn sized_float_to_bitarray_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(Some(32), false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type float[32] to type bit[32]
                ,-[Test.qasm:3:9]
              2 |         float[32] a;
              3 |         bit[32](a);
@@ -700,8 +697,7 @@ fn sized_float_to_bitarray_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(Some(32), false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type float[32] to type bit[16]
                ,-[Test.qasm:3:9]
              2 |         float[32] a;
              3 |         bit[16](a);
@@ -723,8 +719,7 @@ fn sized_float_to_bitarray_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Float(Some(32), false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type float[32] to type bit[64]
                ,-[Test.qasm:3:9]
              2 |         float[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_int.rs
+++ b/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_int.rs
@@ -73,7 +73,7 @@ fn int_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(None, false) to type Duration(false)
+              x cannot cast expression of type int to type duration
                ,-[Test.qasm:3:9]
              2 |         int a;
              3 |         duration(a);
@@ -95,8 +95,7 @@ fn sized_int_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type int[32] to type duration
                ,-[Test.qasm:3:9]
              2 |         int[32] a;
              3 |         duration(a);
@@ -422,7 +421,7 @@ fn int_to_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(None, false) to type Angle(None, false)
+              x cannot cast expression of type int to type angle
                ,-[Test.qasm:3:9]
              2 |         int a;
              3 |         angle(a);
@@ -444,8 +443,7 @@ fn int_to_sized_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(None, false) to type Angle(Some(32),
-              | false)
+              x cannot cast expression of type int to type angle[32]
                ,-[Test.qasm:3:9]
              2 |         int a;
              3 |         angle[32](a);
@@ -467,8 +465,7 @@ fn sized_int_to_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type Angle(None,
-              | false)
+              x cannot cast expression of type int[32] to type angle
                ,-[Test.qasm:3:9]
              2 |         int[32] a;
              3 |         angle(a);
@@ -490,8 +487,7 @@ fn sized_int_to_sized_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type
-              | Angle(Some(32), false)
+              x cannot cast expression of type int[32] to type angle[32]
                ,-[Test.qasm:3:9]
              2 |         int[32] a;
              3 |         angle[32](a);
@@ -513,8 +509,7 @@ fn sized_int_to_sized_angle_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type
-              | Angle(Some(16), false)
+              x cannot cast expression of type int[32] to type angle[16]
                ,-[Test.qasm:3:9]
              2 |         int[32] a;
              3 |         angle[16](a);
@@ -536,8 +531,7 @@ fn sized_int_to_sized_angle_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type
-              | Angle(Some(64), false)
+              x cannot cast expression of type int[32] to type angle[64]
                ,-[Test.qasm:3:9]
              2 |         int[32] a;
              3 |         angle[64](a);
@@ -683,8 +677,7 @@ fn int_to_bitarray_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type int to type bit[32]
                ,-[Test.qasm:3:9]
              2 |         int a;
              3 |         bit[32](a);
@@ -742,8 +735,7 @@ fn sized_int_to_bitarray_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type int[32] to type bit[16]
                ,-[Test.qasm:3:9]
              2 |         int[32] a;
              3 |         bit[16](a);
@@ -765,8 +757,7 @@ fn sized_int_to_bitarray_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type Int(Some(32), false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type int[32] to type bit[64]
                ,-[Test.qasm:3:9]
              2 |         int[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_uint.rs
+++ b/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_uint.rs
@@ -73,7 +73,7 @@ fn uint_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(None, false) to type Duration(false)
+              x cannot cast expression of type uint to type duration
                ,-[Test.qasm:3:9]
              2 |         uint a;
              3 |         duration(a);
@@ -95,8 +95,7 @@ fn sized_uint_to_duration_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type
-              | Duration(false)
+              x cannot cast expression of type uint[32] to type duration
                ,-[Test.qasm:3:9]
              2 |         uint[32] a;
              3 |         duration(a);
@@ -422,8 +421,7 @@ fn uint_to_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(None, false) to type Angle(None,
-              | false)
+              x cannot cast expression of type uint to type angle
                ,-[Test.qasm:3:9]
              2 |         uint a;
              3 |         angle(a);
@@ -445,8 +443,7 @@ fn uint_to_sized_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(None, false) to type Angle(Some(32),
-              | false)
+              x cannot cast expression of type uint to type angle[32]
                ,-[Test.qasm:3:9]
              2 |         uint a;
              3 |         angle[32](a);
@@ -468,8 +465,7 @@ fn sized_uint_to_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type Angle(None,
-              | false)
+              x cannot cast expression of type uint[32] to type angle
                ,-[Test.qasm:3:9]
              2 |         uint[32] a;
              3 |         angle(a);
@@ -491,8 +487,7 @@ fn sized_uint_to_sized_angle_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type
-              | Angle(Some(32), false)
+              x cannot cast expression of type uint[32] to type angle[32]
                ,-[Test.qasm:3:9]
              2 |         uint[32] a;
              3 |         angle[32](a);
@@ -514,8 +509,7 @@ fn sized_uint_to_sized_angle_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type
-              | Angle(Some(16), false)
+              x cannot cast expression of type uint[32] to type angle[16]
                ,-[Test.qasm:3:9]
              2 |         uint[32] a;
              3 |         angle[16](a);
@@ -537,8 +531,7 @@ fn sized_uint_to_sized_angle_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type
-              | Angle(Some(64), false)
+              x cannot cast expression of type uint[32] to type angle[64]
                ,-[Test.qasm:3:9]
              2 |         uint[32] a;
              3 |         angle[64](a);
@@ -684,8 +677,7 @@ fn uint_to_bitarray_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(None, false) to type BitArray(32,
-              | false)
+              x cannot cast expression of type uint to type bit[32]
                ,-[Test.qasm:3:9]
              2 |         uint a;
              3 |         bit[32](a);
@@ -743,8 +735,7 @@ fn sized_uint_to_bitarray_truncating_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type BitArray(16,
-              | false)
+              x cannot cast expression of type uint[32] to type bit[16]
                ,-[Test.qasm:3:9]
              2 |         uint[32] a;
              3 |         bit[16](a);
@@ -766,8 +757,7 @@ fn sized_uint_to_bitarray_expanding_fails() {
         &expect![[r#"
             Qasm.Lowerer.CannotCast
 
-              x cannot cast expression of type UInt(Some(32), false) to type BitArray(64,
-              | false)
+              x cannot cast expression of type uint[32] to type bit[64]
                ,-[Test.qasm:3:9]
              2 |         uint[32] a;
              3 |         bit[64](a);

--- a/compiler/qsc_qasm/src/tests/expression/function_call.rs
+++ b/compiler/qsc_qasm/src/tests/expression/function_call.rs
@@ -236,8 +236,7 @@ fn classical_decl_initialized_with_incompatible_funcall_errors() {
     expect![[r#"
         [Qasm.Lowerer.CannotCast
 
-          x cannot cast expression of type Angle(None, false) to type Float(None,
-          | false)
+          x cannot cast expression of type angle to type float
            ,-[Test.qasm:6:19]
          5 | 
          6 |         float a = square(2.0);
@@ -293,7 +292,7 @@ fn funcall_implicit_arg_cast_uint_to_qubit_errors() {
     expect![[r#"
         [Qasm.Lowerer.CannotCast
 
-          x cannot cast expression of type Int(None, true) to type QubitArray(2)
+          x cannot cast expression of type const int to type qubit[2]
            ,-[Test.qasm:6:24]
          5 | 
          6 |         bit p = parity(2);

--- a/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_bitarray.rs
+++ b/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_bitarray.rs
@@ -90,7 +90,7 @@ fn to_int_with_higher_width_implicitly_fails() {
         panic!("Expected error")
     };
 
-    expect!["cannot cast expression of type BitArray(5, false) to type Int(Some(6), false)"]
+    expect!["cannot cast expression of type bit[5] to type int[6]"]
         .assert_eq(&error[0].to_string());
 }
 
@@ -105,7 +105,7 @@ fn to_int_with_higher_width_decl_implicitly_fails() {
         panic!("Expected error")
     };
 
-    expect!["cannot cast expression of type BitArray(5, false) to type Int(Some(6), false)"]
+    expect!["cannot cast expression of type bit[5] to type int[6]"]
         .assert_eq(&error[0].to_string());
 }
 
@@ -121,7 +121,7 @@ fn to_int_with_lower_width_implicitly_fails() {
         panic!("Expected error")
     };
 
-    expect!["cannot cast expression of type BitArray(5, false) to type Int(Some(4), false)"]
+    expect!["cannot cast expression of type bit[5] to type int[4]"]
         .assert_eq(&error[0].to_string());
 }
 
@@ -136,6 +136,6 @@ fn to_int_with_lower_width_decl_implicitly_fails() {
         panic!("Expected error")
     };
 
-    expect!["cannot cast expression of type BitArray(5, false) to type Int(Some(4), false)"]
+    expect!["cannot cast expression of type bit[5] to type int[4]"]
         .assert_eq(&error[0].to_string());
 }

--- a/compiler/qsc_qasm/src/tests/expression/unary.rs
+++ b/compiler/qsc_qasm/src/tests/expression/unary.rs
@@ -20,7 +20,7 @@ fn bitwise_not_int_fails() {
     expect![[r#"
         [Qasm.Lowerer.TypeDoesNotSupportedUnaryNegation
 
-          x unary negation is not allowed for instances of Int(None, false)
+          x unary negation is not allowed for instances of int
            ,-[Test.qasm:3:18]
          2 |         int x = 5;
          3 |         int y = ~x;

--- a/compiler/qsc_qasm/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm/src/tests/statement/const_eval.rs
@@ -1845,7 +1845,7 @@ fn binary_op_non_const_type_fails() {
     expect![[r#"
         Qasm.Lowerer.CannotCast
 
-          x cannot cast expression of type Int(None, false) to type Int(None, true)
+          x cannot cast expression of type int to type const int
            ,-[Test.qasm:4:17]
          3 |         int b = 3;
          4 |         int[a + b] x = 2;
@@ -1924,7 +1924,7 @@ fn binary_op_with_non_supported_types_fails() {
     expect![[r#"
         Qasm.Lowerer.CannotCast
 
-          x cannot cast expression of type Duration(true) to type Float(None, true)
+          x cannot cast expression of type const duration to type const float
            ,-[Test.qasm:2:27]
          1 | 
          2 |         const int a = 2 / 0s;
@@ -1934,7 +1934,7 @@ fn binary_op_with_non_supported_types_fails() {
 
         Qasm.Lowerer.UnsupportedBinaryOp
 
-          x Div is not supported between types Float(None, true) and Duration(true)
+          x Div is not supported between types const float and const duration
            ,-[Test.qasm:2:23]
          1 | 
          2 |         const int a = 2 / 0s;

--- a/compiler/qsc_qasm/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm/src/tests/statement/gate_call.rs
@@ -800,8 +800,8 @@ fn broadcast_with_different_register_sizes_fails() {
     expect![[r#"
         [Qasm.Lowerer.BroadcastCallQuantumArgsDisagreeInSize
 
-          x first quantum register is of type QubitArray(3) but found an argument of
-          | type QubitArray(2)
+          x first quantum register is of type qubit[3] but found an argument of type
+          | qubit[2]
            ,-[Test.qasm:5:25]
          4 |         qubit[2] targets;
          5 |         ctrl @ x ctrls, targets;

--- a/compiler/qsc_qasm/src/tests/statement/if_stmt.rs
+++ b/compiler/qsc_qasm/src/tests/statement/if_stmt.rs
@@ -143,6 +143,5 @@ fn using_cond_that_cannot_implicit_cast_to_bool_fail() {
         panic!("Expected error");
     };
 
-    expect!["cannot cast expression of type Qubit to type Bool(false)"]
-        .assert_eq(&errors[0].to_string());
+    expect!["cannot cast expression of type qubit to type bool"].assert_eq(&errors[0].to_string());
 }

--- a/compiler/qsc_qasm/src/tests/statement/while_loop.rs
+++ b/compiler/qsc_qasm/src/tests/statement/while_loop.rs
@@ -53,6 +53,5 @@ fn using_cond_that_cannot_implicit_cast_to_bool_fail() {
         panic!("Expected error");
     };
 
-    expect!["cannot cast expression of type Qubit to type Bool(false)"]
-        .assert_eq(&errors[0].to_string());
+    expect!["cannot cast expression of type qubit to type bool"].assert_eq(&errors[0].to_string());
 }


### PR DESCRIPTION
The only files with manual changes are:
- `compiler/qsc_qasm/src/semantic/error.rs`
- `compiler/qsc_qasm/src/semantic/lowerer.rs`
- `compiler/qsc_qasm/src/semantic/types.rs`