### PR TITLE
Add documentType to telemetry events

### DIFF
--- a/vscode/src/circuit.ts
+++ b/vscode/src/circuit.ts
@@ -15,7 +15,12 @@ import { Uri } from "vscode";
 import { getTargetFriendlyName } from "./config";
 import { clearCommandDiagnostics } from "./diagnostics";
 import { FullProgramConfig, getActiveProgram } from "./programConfig";
-import { EventType, UserFlowStatus, sendTelemetryEvent } from "./telemetry";
+import {
+  EventType,
+  UserFlowStatus,
+  getActiveDocumentType,
+  sendTelemetryEvent,
+} from "./telemetry";
 import { getRandomGuid } from "./utils";
 import { sendMessageToPanel } from "./webviewPanel";
 
@@ -54,7 +59,11 @@ export async function showCircuitCommand(
   clearCommandDiagnostics();
 
   const associationId = getRandomGuid();
-  sendTelemetryEvent(EventType.TriggerCircuit, { associationId }, {});
+  sendTelemetryEvent(
+    EventType.TriggerCircuit,
+    { documentType: getActiveDocumentType(), associationId },
+    {},
+  );
 
   const program = await getActiveProgram();
   if (!program.success) {

--- a/vscode/src/copilot/azqTools.ts
+++ b/vscode/src/copilot/azqTools.ts
@@ -5,7 +5,6 @@ import { log } from "qsharp-lang";
 import * as vscode from "vscode";
 import { getTokenForWorkspace } from "../azure/auth.js";
 import { QuantumUris } from "../azure/networkRequests.js";
-import { supportsAdaptive } from "../azure/providerProperties.js";
 import { startRefreshCycle } from "../azure/treeRefresher.js";
 import {
   Job,
@@ -16,7 +15,6 @@ import {
 } from "../azure/treeView.js";
 import { getJobFiles, submitJob } from "../azure/workspaceActions.js";
 import { HistogramData } from "./shared.js";
-import { getQirForVisibleSource } from "../qirGeneration.js";
 import { CopilotToolError, ToolResult, ToolState } from "./tools.js";
 import { CopilotWebviewViewProvider as CopilotView } from "./webviewViewProvider.js";
 import { sendMessageToPanel } from "../webviewPanel.js";
@@ -433,7 +431,7 @@ export async function submitToTarget(
 
   let qir = "";
   try {
-    qir = await getQirForVisibleSource(supportsAdaptive(target.id));
+    qir = "";
   } catch (e: any) {
     if (e?.name === "QirGenerationError") {
       throw new CopilotToolError(e.message);

--- a/vscode/src/copilot/azqTools.ts
+++ b/vscode/src/copilot/azqTools.ts
@@ -5,6 +5,7 @@ import { log } from "qsharp-lang";
 import * as vscode from "vscode";
 import { getTokenForWorkspace } from "../azure/auth.js";
 import { QuantumUris } from "../azure/networkRequests.js";
+import { supportsAdaptive } from "../azure/providerProperties.js";
 import { startRefreshCycle } from "../azure/treeRefresher.js";
 import {
   Job,
@@ -15,6 +16,7 @@ import {
 } from "../azure/treeView.js";
 import { getJobFiles, submitJob } from "../azure/workspaceActions.js";
 import { HistogramData } from "./shared.js";
+import { getQirForVisibleSource } from "../qirGeneration.js";
 import { CopilotToolError, ToolResult, ToolState } from "./tools.js";
 import { CopilotWebviewViewProvider as CopilotView } from "./webviewViewProvider.js";
 import { sendMessageToPanel } from "../webviewPanel.js";
@@ -431,7 +433,7 @@ export async function submitToTarget(
 
   let qir = "";
   try {
-    qir = "";
+    qir = await getQirForVisibleSource(supportsAdaptive(target.id));
   } catch (e: any) {
     if (e?.name === "QirGenerationError") {
       throw new CopilotToolError(e.message);

--- a/vscode/src/estimate.ts
+++ b/vscode/src/estimate.ts
@@ -8,8 +8,10 @@ import { loadCompilerWorker } from "./common";
 import { clearCommandDiagnostics } from "./diagnostics";
 import { FullProgramConfig, getActiveProgram } from "./programConfig";
 import {
-  CommandInvocationType,
+  UserTaskInvocationType,
   EventType,
+  getActiveDocumentType,
+  QsharpDocumentType,
   sendTelemetryEvent,
 } from "./telemetry";
 import { getRandomGuid } from "./utils";
@@ -26,7 +28,11 @@ export async function resourceEstimateCommand(
   const associationId = getRandomGuid();
   sendTelemetryEvent(
     EventType.TriggerResourceEstimation,
-    { associationId, invocationType: CommandInvocationType.Command },
+    {
+      associationId,
+      documentType: getActiveDocumentType(),
+      invocationType: UserTaskInvocationType.Command,
+    },
     {},
   );
 
@@ -155,6 +161,7 @@ const qubitTypeOptions = [
 export function resourceEstimateTool(
   extensionUri: vscode.Uri,
   programConfig: FullProgramConfig,
+  telemetryDocumentType: QsharpDocumentType,
   qubitTypeLabels: string[],
   errorBudget: number,
 ): Promise<object[] | undefined> {
@@ -166,7 +173,11 @@ export function resourceEstimateTool(
   const associationId = getRandomGuid();
   sendTelemetryEvent(
     EventType.TriggerResourceEstimation,
-    { associationId, invocationType: CommandInvocationType.ChatToolCall },
+    {
+      associationId,
+      documentType: telemetryDocumentType,
+      invocationType: UserTaskInvocationType.ChatToolCall,
+    },
     {},
   );
 

--- a/vscode/src/language-service/activate.ts
+++ b/vscode/src/language-service/activate.ts
@@ -9,12 +9,8 @@ import {
 } from "qsharp-lang";
 import * as vscode from "vscode";
 import {
-  isCircuitDocument,
   isNotebookCell,
-  isOpenQasmDocument,
   isQdkDocument,
-  isQdkNotebookCell,
-  isQsharpDocument,
   openqasmLanguageId,
   qsharpLanguageId,
 } from "../common.js";
@@ -27,6 +23,7 @@ import {
   resolvePath,
 } from "../projectSystem.js";
 import {
+  determineDocumentType,
   EventType,
   QsharpDocumentType,
   sendTelemetryEvent,
@@ -301,18 +298,6 @@ function registerDocumentUpdateHandlers(
   }
 
   return subscriptions;
-}
-
-function determineDocumentType(document: vscode.TextDocument) {
-  return isQdkNotebookCell(document)
-    ? QsharpDocumentType.JupyterCell
-    : isCircuitDocument(document)
-      ? QsharpDocumentType.Circuit
-      : isQsharpDocument(document)
-        ? QsharpDocumentType.Qsharp
-        : isOpenQasmDocument(document)
-          ? QsharpDocumentType.OpenQasm
-          : QsharpDocumentType.Other;
 }
 
 function sendDocumentOpenedEvent(document: vscode.TextDocument) {

--- a/vscode/src/language-service/completion.ts
+++ b/vscode/src/language-service/completion.ts
@@ -5,7 +5,11 @@ import { ILanguageService, samples, openqasm_samples } from "qsharp-lang";
 import * as vscode from "vscode";
 import { CompletionItem } from "vscode";
 import { isOpenQasmDocument, isQsharpDocument, toVsCodeRange } from "../common";
-import { EventType, sendTelemetryEvent } from "../telemetry";
+import {
+  determineDocumentType,
+  EventType,
+  sendTelemetryEvent,
+} from "../telemetry";
 
 export function createCompletionItemProvider(
   languageService: ILanguageService,
@@ -52,7 +56,9 @@ class QSharpCompletionItemProvider implements vscode.CompletionItemProvider {
     const end = performance.now();
     sendTelemetryEvent(
       EventType.ReturnCompletionList,
-      {},
+      {
+        documentType: determineDocumentType(document),
+      },
       {
         timeToCompletionMs: end - start,
         completionListLength: completions.items.length,

--- a/vscode/src/language-service/format.ts
+++ b/vscode/src/language-service/format.ts
@@ -4,7 +4,12 @@
 import { ILanguageService } from "qsharp-lang";
 import * as vscode from "vscode";
 import { toVsCodeRange } from "../common";
-import { EventType, FormatEvent, sendTelemetryEvent } from "../telemetry";
+import {
+  determineDocumentType,
+  EventType,
+  FormatEvent,
+  sendTelemetryEvent,
+} from "../telemetry";
 import { getRandomGuid } from "../utils";
 
 export function createFormattingProvider(languageService: ILanguageService) {
@@ -27,7 +32,11 @@ class QSharpFormattingProvider
     const associationId = getRandomGuid();
     sendTelemetryEvent(
       EventType.FormatStart,
-      { associationId, event: eventKind },
+      {
+        documentType: determineDocumentType(document),
+        associationId,
+        event: eventKind,
+      },
       {},
     );
     const start = performance.now();

--- a/vscode/src/programConfig.ts
+++ b/vscode/src/programConfig.ts
@@ -82,7 +82,7 @@ export function getVisibleQdkDocumentUri(): vscode.Uri | undefined {
   return getVisibleQdkDocument()?.uri;
 }
 
-function getVisibleQdkDocument(): vscode.TextDocument | undefined {
+export function getVisibleQdkDocument(): vscode.TextDocument | undefined {
   return vscode.window.visibleTextEditors.find((editor) =>
     isQdkDocument(editor.document),
   )?.document;

--- a/vscode/src/qirGeneration.ts
+++ b/vscode/src/qirGeneration.ts
@@ -5,12 +5,12 @@ import { getCompilerWorker, log } from "qsharp-lang";
 import * as vscode from "vscode";
 import { getTarget, setTarget } from "./config";
 import { invokeAndReportCommandDiagnostics } from "./diagnostics";
+import { getActiveProgram } from "./programConfig";
 import {
-  FullProgramConfig,
-  getActiveProgram,
-  getVisibleProgram,
-} from "./programConfig";
-import { EventType, sendTelemetryEvent } from "./telemetry";
+  EventType,
+  getActiveDocumentType,
+  sendTelemetryEvent,
+} from "./telemetry";
 import { getRandomGuid } from "./utils";
 import { qsharpExtensionId } from "./common";
 
@@ -25,16 +25,6 @@ export class QirGenerationError extends Error {
   }
 }
 
-export async function getQirForVisibleSource(
-  targetSupportsAdaptive?: boolean, // should be true or false when submitting to Azure, undefined when generating QIR
-): Promise<string> {
-  const program = await getVisibleProgram();
-  if (!program.success) {
-    throw new QirGenerationError(program.errorMsg);
-  }
-  return getQirForProgram(program.programConfig, targetSupportsAdaptive);
-}
-
 export async function getQirForActiveWindow(
   targetSupportsAdaptive?: boolean, // should be true or false when submitting to Azure, undefined when generating QIR
 ): Promise<string> {
@@ -42,13 +32,7 @@ export async function getQirForActiveWindow(
   if (!program.success) {
     throw new QirGenerationError(program.errorMsg);
   }
-  return getQirForProgram(program.programConfig, targetSupportsAdaptive);
-}
-
-async function getQirForProgram(
-  config: FullProgramConfig,
-  targetSupportsAdaptive?: boolean,
-): Promise<string> {
+  const config = program.programConfig;
   let result = "";
   const isLocalQirGeneration = targetSupportsAdaptive === undefined;
   const targetProfile = config.profile;
@@ -118,7 +102,7 @@ async function getQirForProgram(
     const start = performance.now();
     sendTelemetryEvent(
       EventType.GenerateQirStart,
-      { associationId, targetProfile },
+      { documentType: getActiveDocumentType(), associationId, targetProfile },
       {},
     );
 

--- a/vscode/src/telemetry.ts
+++ b/vscode/src/telemetry.ts
@@ -6,7 +6,7 @@
 import * as vscode from "vscode";
 import TelemetryReporter from "@vscode/extension-telemetry";
 import { log } from "qsharp-lang";
-import { getActiveQdkDocument } from "./programConfig";
+import { getActiveQdkDocument, getVisibleQdkDocument } from "./programConfig";
 import {
   isCircuitDocument,
   isOpenQasmDocument,
@@ -410,6 +410,15 @@ function getBrowserRelease(): string {
 
 export function getUserAgent(): string {
   return userAgentString || navigator.userAgent;
+}
+
+export function getVisibleDocumentType(): QsharpDocumentType {
+  const doc = getVisibleQdkDocument();
+  if (!doc) {
+    return QsharpDocumentType.Unknown;
+  }
+
+  return determineDocumentType(doc);
 }
 
 export function getActiveDocumentType(): QsharpDocumentType {

--- a/vscode/src/webviewPanel.ts
+++ b/vscode/src/webviewPanel.ts
@@ -23,7 +23,11 @@ import { showCircuitCommand } from "./circuit";
 import { clearCommandDiagnostics } from "./diagnostics";
 import { showDocumentationCommand } from "./documentation";
 import { getActiveProgram } from "./programConfig";
-import { EventType, sendTelemetryEvent } from "./telemetry";
+import {
+  EventType,
+  getActiveDocumentType,
+  sendTelemetryEvent,
+} from "./telemetry";
 import { getRandomGuid } from "./utils";
 import { getPauliNoiseModel } from "./config";
 import { qsharpExtensionId } from "./common";
@@ -64,7 +68,14 @@ export function registerWebViewCommands(context: ExtensionContext) {
     clearCommandDiagnostics();
 
     const associationId = getRandomGuid();
-    sendTelemetryEvent(EventType.TriggerHistogram, { associationId }, {});
+    sendTelemetryEvent(
+      EventType.TriggerHistogram,
+      {
+        associationId,
+        documentType: getActiveDocumentType(),
+      },
+      {},
+    );
     function resultToLabel(result: string | VSDiagnostic): string {
       if (typeof result !== "string") return "ERROR";
       return result;


### PR DESCRIPTION
This adds a `documentType` property to relevant telemetry events to differentiate between the various language types we now support.