### PR TITLE
Allow implicit cast to non-const in binary exprs.

### DIFF
--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/arithmetic_conversions.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/arithmetic_conversions.rs
@@ -339,3 +339,44 @@ fn bin_op_with_const_lhs_and_non_const_rhs() {
         "#]],
     );
 }
+
+#[test]
+fn bin_op_with_const_lhs_and_non_const_rhs_sized() {
+    let source = "
+        int[32] x = 5;
+        int[32] y = 2 * x;
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-23]:
+                symbol_id: 8
+                ty_span: [9-16]
+                init_expr: Expr [21-22]:
+                    ty: const int[32]
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [32-50]:
+                symbol_id: 9
+                ty_span: [32-39]
+                init_expr: Expr [44-49]:
+                    ty: int[32]
+                    kind: Cast [0-0]:
+                        ty: int[32]
+                        expr: Expr [44-49]:
+                            ty: int
+                            kind: BinaryOpExpr:
+                                op: Mul
+                                lhs: Expr [44-45]:
+                                    ty: const int
+                                    kind: Lit: Int(2)
+                                rhs: Expr [48-49]:
+                                    ty: int
+                                    kind: Cast [0-0]:
+                                        ty: int
+                                        expr: Expr [48-49]:
+                                            ty: int[32]
+                                            kind: SymbolId(8)
+        "#]],
+    );
+}

--- a/compiler/qsc_qasm/src/semantic/tests/expression/binary/arithmetic_conversions.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/binary/arithmetic_conversions.rs
@@ -306,3 +306,36 @@ fn left_shift_casts_rhs_to_uint() {
         "#]],
     );
 }
+
+#[test]
+fn bin_op_with_const_lhs_and_non_const_rhs() {
+    let source = "
+        int x = 5;
+        int y = 2 * x;
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-19]:
+                symbol_id: 8
+                ty_span: [9-12]
+                init_expr: Expr [17-18]:
+                    ty: int
+                    kind: Lit: Int(5)
+            ClassicalDeclarationStmt [28-42]:
+                symbol_id: 9
+                ty_span: [28-31]
+                init_expr: Expr [36-41]:
+                    ty: int
+                    kind: BinaryOpExpr:
+                        op: Mul
+                        lhs: Expr [36-37]:
+                            ty: const int
+                            kind: Lit: Int(2)
+                        rhs: Expr [40-41]:
+                            ty: int
+                            kind: SymbolId(8)
+        "#]],
+    );
+}

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -712,10 +712,10 @@ fn get_effective_width(lhs_ty: &Type, rhs_ty: &Type) -> Option<u32> {
 /// If the types are not compatible, the result is `Type::Void`.
 #[must_use]
 pub fn promote_types(lhs_ty: &Type, rhs_ty: &Type) -> Type {
+    if *lhs_ty == *rhs_ty {
+        return lhs_ty.clone();
+    }
     if types_equal_except_const(lhs_ty, rhs_ty) {
-        if lhs_ty.is_const() && rhs_ty.is_const() {
-            return lhs_ty.clone();
-        }
         // If one of the types is non-const, we return the type as non-const.
         return lhs_ty.as_non_const();
     }

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -713,7 +713,11 @@ fn get_effective_width(lhs_ty: &Type, rhs_ty: &Type) -> Option<u32> {
 #[must_use]
 pub fn promote_types(lhs_ty: &Type, rhs_ty: &Type) -> Type {
     if types_equal_except_const(lhs_ty, rhs_ty) {
-        return lhs_ty.clone();
+        if lhs_ty.is_const() && rhs_ty.is_const() {
+            return lhs_ty.clone();
+        }
+        // If one of the types is non-const, we return the type as non-const.
+        return lhs_ty.as_non_const();
     }
     let ty = promote_types_symmetric(lhs_ty, rhs_ty);
     if ty != Type::Void {

--- a/compiler/qsc_qasm/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm/src/tests/statement/const_eval.rs
@@ -1843,23 +1843,13 @@ fn binary_op_non_const_type_fails() {
     let errs: Vec<_> = errs.iter().map(|e| format!("{e:?}")).collect();
     let errs_string = errs.join("\n");
     expect![[r#"
-        Qasm.Lowerer.CannotCast
-
-          x cannot cast expression of type int to type const int
-           ,-[Test.qasm:4:17]
-         3 |         int b = 3;
-         4 |         int[a + b] x = 2;
-           :                 ^
-         5 |     
-           `----
-
         Qasm.Lowerer.ExprMustBeConst
 
           x expression must be const
-           ,-[Test.qasm:4:17]
+           ,-[Test.qasm:4:13]
          3 |         int b = 3;
          4 |         int[a + b] x = 2;
-           :                 ^
+           :             ^^^^^
          5 |     
            `----
     "#]]


### PR DESCRIPTION
This PR fixes an issue in casting where the following code was treated as an error. 
```
int x = 5;
int y = 2 * x;
```

The issue was that `2` is a constant, and the casting system wasn't allowing `x`, of type `int`, which isn't a constant to be cast to the type of `2`, which is `const int`. The fix consists in allowing the type of the binary expression as a whole to be demoted to a non-const type.