### PR TITLE
Add unit tests for OpenQASM samples

### DIFF
--- a/samples_test/build.rs
+++ b/samples_test/build.rs
@@ -13,6 +13,7 @@ fn main() {
     create_tests_for_files("getting_started");
     create_tests_for_files("language");
     create_tests_for_files_compile_only("estimation");
+    create_tests_for_qasm_files("OpenQASM");
     create_tests_for_projects();
 }
 
@@ -222,4 +223,78 @@ fn collect_qsharp_project_folders(path: &Path) -> Vec<PathBuf> {
         }
     }
     projects
+}
+
+fn create_tests_for_qasm_files(folder: &str) {
+    println!("cargo::rerun-if-changed=../samples/{folder}/");
+    // Iterate through the folder and create a test for each qs file
+    let mut paths =
+        read_dir(format!("../samples/{folder}")).expect("folder should exist and be readable");
+    let out_dir = "./src/tests";
+    let dest_path = Path::new(&out_dir).join(format!("{folder}_generated.rs"));
+    let mut f = File::create(dest_path).expect("files should be creatable in ./src/tests");
+
+    writeln!(
+        f,
+        r#"
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! This build-generated module contains tests for the samples in the `/samples/{folder}` folder.
+//! DO NOT MANUALLY EDIT THIS FILE. To regenerate this file, run `cargo check` or `cargo test` in the `samples_test` directory.
+
+use super::{folder}::*;
+use super::{{compile_and_run_qasm, compile_and_run_debug_qasm}};"#,
+    )
+    .expect("writing to file should succeed");
+
+    while let Some(Ok(dir_entry)) = paths.next() {
+        let path = &dir_entry.path();
+        if Some("qasm") != path.extension().and_then(OsStr::to_str) {
+            continue;
+        }
+        let file_name = path
+            .file_name()
+            .expect("file name should be separable")
+            .to_str()
+            .expect("file name should be valid");
+        let file_stem = path
+            .file_stem()
+            .expect("file name should be separable")
+            .to_str()
+            .expect("file name should be valid");
+        assert!(
+            !file_stem.contains(' '),
+            "file name `{file_name}` should not contain spaces"
+        );
+        let file_stem_upper = file_stem.to_uppercase();
+
+        writeln!(
+            f,
+            r#"
+#[allow(non_snake_case)]
+fn {file_stem}_src() -> &'static str {{
+    include_str!("../../../samples/{folder}/{file_name}")
+}}
+
+#[allow(non_snake_case)]
+#[test]
+fn run_{file_stem}() {{
+    let output = compile_and_run_qasm({file_stem}_src());
+    // This constant must be defined in `samples_test/src/tests/{folder}.rs` and
+    // must contain the output of the sample {file_name}
+    {file_stem_upper}_EXPECT.assert_eq(&output);
+}}
+
+#[allow(non_snake_case)]
+#[test]
+fn debug_{file_stem}() {{
+    let output = compile_and_run_debug_qasm({file_stem}_src());
+    // This constant must be defined in `samples_test/src/tests/{folder}.rs` and
+    // must contain the output of the sample {file_name}
+    {file_stem_upper}_EXPECT_DEBUG.assert_eq(&output);
+}}"#
+        )
+        .expect("writing to file should succeed");
+    }
 }

--- a/samples_test/src/tests/OpenQASM.rs
+++ b/samples_test/src/tests/OpenQASM.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use expect_test::{expect, Expect};
+
+// Each file in the samples/OpenQASM folder is compiled and run as two tests and should
+// have matching expect strings in this file. If new samples are added, this file will
+// fail to compile until the new expect strings are added.
+pub const BELLPAIR_EXPECT: Expect = expect!["(One, One)"];
+pub const BELLPAIR_EXPECT_DEBUG: Expect = expect!["(One, One)"];
+pub const OPENQASMHELLOWORLD_EXPECT: Expect = expect!["Zero"];
+pub const OPENQASMHELLOWORLD_EXPECT_DEBUG: Expect = expect!["Zero"];
+pub const BERNSTEINVAZIRANI_EXPECT: Expect = expect!["[One, Zero, One, Zero, One]"];
+pub const BERNSTEINVAZIRANI_EXPECT_DEBUG: Expect = expect!["[One, Zero, One, Zero, One]"];
+pub const GROVER_EXPECT: Expect = expect!["[Zero, One, Zero, One, Zero]"];
+pub const GROVER_EXPECT_DEBUG: Expect = expect!["[Zero, One, Zero, One, Zero]"];
+pub const RANDOMNUMBER_EXPECT: Expect = expect!["9"];
+pub const RANDOMNUMBER_EXPECT_DEBUG: Expect = expect!["9"];


### PR DESCRIPTION
This change adds auto-generated Rust unit tests for executing each of the files in samples/OpenQASM/*.qasm. Like with the other sampels tests, the expect entries corresponding to newly introduced samples should be added manually while the test infra in the OpenQASM_generated.rs file is created at build time.