### PR TITLE
Add sample notebooks

### DIFF
--- a/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -1670,9 +1670,21 @@ impl Lowerer {
         }
 
         //   1.3. Lower the args.
+        let carg_ty = crate::semantic::types::Type::Angle(None, false);
         let args = stmt.args.iter().map(|arg| {
             let arg = self.lower_expr(arg);
-            self.cast_expr_to_type(&crate::semantic::types::Type::Angle(None, false), &arg)
+            match &arg.kind.as_ref() {
+                semantic::ExprKind::Lit(kind) => {
+                    if can_cast_literal(&carg_ty, &arg.ty)
+                        || can_cast_literal_with_value_knowledge(&carg_ty, kind)
+                    {
+                        self.coerce_literal_expr_to_type(&carg_ty, &arg, kind)
+                    } else {
+                        self.cast_expr_to_type(&carg_ty, &arg)
+                    }
+                }
+                _ => self.cast_expr_to_type(&carg_ty, &arg),
+            }
         });
         let args = list_from_iter(args);
         //   1.4. Lower the qubits.
@@ -2899,6 +2911,21 @@ impl Lowerer {
                         ))),
                         ty: lhs_ty.as_const(),
                     });
+                }
+                None
+            }
+            (Type::Angle(width, _), Type::Int(..) | Type::UInt(..)) => {
+                // compatibility case for existing code
+                if let semantic::LiteralKind::Int(value) = kind {
+                    if *value == 0 {
+                        return Some(semantic::Expr {
+                            span,
+                            kind: Box::new(semantic::ExprKind::Lit(semantic::LiteralKind::Angle(
+                                Angle::from_u64_maybe_sized(0, *width),
+                            ))),
+                            ty: lhs_ty.as_const(),
+                        });
+                    }
                 }
                 None
             }

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -949,6 +949,14 @@ pub(crate) fn can_cast_literal_with_value_knowledge(lhs_ty: &Type, kind: &Litera
             return *value >= 0;
         }
     }
+    // Much existing OpenQASM code uses 0 as a literal for angles
+    // and Qiskit generates this code. While this is not allowed
+    // in the spec, we allow it for compatibility.
+    if matches!(lhs_ty, &Type::Angle(..)) {
+        if let LiteralKind::Int(value) = kind {
+            return *value == 0;
+        }
+    }
     false
 }
 

--- a/compiler/qsc_qasm/src/stdlib/angle.rs
+++ b/compiler/qsc_qasm/src/stdlib/angle.rs
@@ -28,6 +28,13 @@ impl Angle {
         Angle { value, size }
     }
 
+    pub fn from_u64_maybe_sized(value: u64, size: Option<u32>) -> Angle {
+        Angle {
+            value,
+            size: size.unwrap_or(f64::MANTISSA_DIGITS),
+        }
+    }
+
     pub fn from_f64_maybe_sized(val: f64, size: Option<u32>) -> Angle {
         Self::from_f64_sized(val, size.unwrap_or(f64::MANTISSA_DIGITS))
     }

--- a/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_int.rs
+++ b/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_int.rs
@@ -200,3 +200,24 @@ fn to_explicit_complex_implicitly() -> miette::Result<(), Vec<Report>> {
     .assert_eq(&qsharp);
     Ok(())
 }
+
+#[test]
+fn from_const_0_implicitly() -> miette::Result<(), Vec<Report>> {
+    let source = "
+        include \"stdgates.inc\";
+        qubit q;
+        rx(0) q;
+    ";
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.__quantum__rt__qubit_allocate();
+        rx(new Std.OpenQASM.Angle.Angle {
+            Value = 0,
+            Size = 53
+        }, q);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}

--- a/compiler/qsc_qasm/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm/src/tests/statement/gate_call.rs
@@ -17,7 +17,16 @@ fn u_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
     expect![[r#"
         import Std.OpenQASM.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
-        U(Std.OpenQASM.Angle.DoubleAsAngle(1., 53), Std.OpenQASM.Angle.DoubleAsAngle(2., 53), Std.OpenQASM.Angle.DoubleAsAngle(3., 53), q);
+        U(new Std.OpenQASM.Angle.Angle {
+            Value = 1433540284805665,
+            Size = 53
+        }, new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, new Std.OpenQASM.Angle.Angle {
+            Value = 4300620854416994,
+            Size = 53
+        }, q);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -32,7 +41,10 @@ fn gphase_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
     let qsharp = compile_qasm_to_qsharp(source)?;
     expect![[r#"
         import Std.OpenQASM.Intrinsic.*;
-        gphase(Std.OpenQASM.Angle.DoubleAsAngle(2., 53));
+        gphase(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        });
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -57,11 +69,26 @@ fn custom_gates_can_be_called_bypassing_stdgates() -> miette::Result<(), Vec<Rep
     expect![[r#"
         import Std.OpenQASM.Intrinsic.*;
         operation h(a : Qubit) : Unit is Adj + Ctl {
-            U(Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793 / 2., 53), Std.OpenQASM.Angle.DoubleAsAngle(0., 53), Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793, 53), a);
+            U(Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793 / 2., 53), new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            }, new Std.OpenQASM.Angle.Angle {
+                Value = 4503599627370496,
+                Size = 53
+            }, a);
             gphase(Std.OpenQASM.Angle.DoubleAsAngle(-3.141592653589793 / 4., 53));
         }
         operation x(a : Qubit) : Unit is Adj + Ctl {
-            U(Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793, 53), Std.OpenQASM.Angle.DoubleAsAngle(0., 53), Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793, 53), a);
+            U(new Std.OpenQASM.Angle.Angle {
+                Value = 4503599627370496,
+                Size = 53
+            }, new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            }, new Std.OpenQASM.Angle.Angle {
+                Value = 4503599627370496,
+                Size = 53
+            }, a);
             gphase(Std.OpenQASM.Angle.DoubleAsAngle(-3.141592653589793 / 2., 53));
         }
         operation cx(a : Qubit, b : Qubit) : Unit is Adj + Ctl {
@@ -69,7 +96,13 @@ fn custom_gates_can_be_called_bypassing_stdgates() -> miette::Result<(), Vec<Rep
         }
         operation rz(λ : Std.OpenQASM.Angle.Angle, a : Qubit) : Unit is Adj + Ctl {
             gphase(Std.OpenQASM.Angle.DivideAngleByInt(Std.OpenQASM.Angle.NegAngle(λ), 2));
-            U(Std.OpenQASM.Angle.DoubleAsAngle(0., 53), Std.OpenQASM.Angle.DoubleAsAngle(0., 53), λ, a);
+            U(new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            }, new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            }, λ, a);
         }
         operation rxx(theta : Std.OpenQASM.Angle.Angle, a : Qubit, b : Qubit) : Unit is Adj + Ctl {
             h(a);
@@ -308,7 +341,10 @@ fn rx_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
     expect![[r#"
         import Std.OpenQASM.Intrinsic.*;
         let q = QIR.Runtime.__quantum__rt__qubit_allocate();
-        rx(Std.OpenQASM.Angle.DoubleAsAngle(2., 53), q);
+        rx(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, q);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -560,7 +596,10 @@ fn rxx_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
     expect![[r#"
         import Std.OpenQASM.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(2);
-        rxx(Std.OpenQASM.Angle.DoubleAsAngle(2., 53), q[1], q[0]);
+        rxx(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, q[1], q[0]);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -577,7 +616,10 @@ fn ryy_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
     expect![[r#"
         import Std.OpenQASM.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(2);
-        ryy(Std.OpenQASM.Angle.DoubleAsAngle(2., 53), q[1], q[0]);
+        ryy(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, q[1], q[0]);
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -594,7 +636,10 @@ fn rzz_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
     expect![[r#"
         import Std.OpenQASM.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(2);
-        rzz(Std.OpenQASM.Angle.DoubleAsAngle(2., 53), q[1], q[0]);
+        rzz(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, q[1], q[0]);
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/statement/implicit_modified_gate_call.rs
+++ b/compiler/qsc_qasm/src/tests/statement/implicit_modified_gate_call.rs
@@ -115,7 +115,10 @@ fn crx_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
         import Std.OpenQASM.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled rx([ctl], (Std.OpenQASM.Angle.DoubleAsAngle(0.5, 53), target));
+        Controlled rx([ctl], (new Std.OpenQASM.Angle.Angle {
+            Value = 716770142402832,
+            Size = 53
+        }, target));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -135,7 +138,10 @@ fn cry_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
         import Std.OpenQASM.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled ry([ctl], (Std.OpenQASM.Angle.DoubleAsAngle(0.5, 53), target));
+        Controlled ry([ctl], (new Std.OpenQASM.Angle.Angle {
+            Value = 716770142402832,
+            Size = 53
+        }, target));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -155,7 +161,10 @@ fn crz_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
         import Std.OpenQASM.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled rz([ctl], (Std.OpenQASM.Angle.DoubleAsAngle(0.5, 53), target));
+        Controlled rz([ctl], (new Std.OpenQASM.Angle.Angle {
+            Value = 716770142402832,
+            Size = 53
+        }, target));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -215,7 +224,10 @@ fn legacy_cphase_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
         import Std.OpenQASM.Intrinsic.*;
         let ctl = QIR.Runtime.__quantum__rt__qubit_allocate();
         let target = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled phase([ctl], (Std.OpenQASM.Angle.DoubleAsAngle(1., 53), target));
+        Controlled phase([ctl], (new Std.OpenQASM.Angle.Angle {
+            Value = 1433540284805665,
+            Size = 53
+        }, target));
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/compiler/qsc_qasm/src/tests/statement/modified_gate_call.rs
+++ b/compiler/qsc_qasm/src/tests/statement/modified_gate_call.rs
@@ -139,7 +139,10 @@ fn multiple_controls_on_crx_gate_can_be_called() -> miette::Result<(), Vec<Repor
         import Std.OpenQASM.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(4);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Controlled Adjoint Controlled rx([q[1], q[0], q[2]], ([f], (Std.OpenQASM.Angle.DoubleAsAngle(0.5, 53), q[3])));
+        Controlled Adjoint Controlled rx([q[1], q[0], q[2]], ([f], (new Std.OpenQASM.Angle.Angle {
+            Value = 716770142402832,
+            Size = 53
+        }, q[3])));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -159,7 +162,10 @@ fn neg_ctrl_can_be_applied_and_wrapped_in_another_modifier() -> miette::Result<(
         import Std.OpenQASM.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(4);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
-        Adjoint ApplyControlledOnInt(0, Adjoint Controlled rx, [q[1], q[0], q[2]], ([f], (Std.OpenQASM.Angle.DoubleAsAngle(0.5, 53), q[3])));
+        Adjoint ApplyControlledOnInt(0, Adjoint Controlled rx, [q[1], q[0], q[2]], ([f], (new Std.OpenQASM.Angle.Angle {
+            Value = 716770142402832,
+            Size = 53
+        }, q[3])));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -179,7 +185,10 @@ fn neg_ctrl_can_wrap_another_neg_crtl_modifier() -> miette::Result<(), Vec<Repor
         import Std.OpenQASM.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(6);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
-        ApplyControlledOnInt(0, ApplyControlledOnInt, [q[1], q[0], q[2]], (0, Controlled rx, [q[3], q[4]], ([f], (Std.OpenQASM.Angle.DoubleAsAngle(0.5, 53), q[5]))));
+        ApplyControlledOnInt(0, ApplyControlledOnInt, [q[1], q[0], q[2]], (0, Controlled rx, [q[3], q[4]], ([f], (new Std.OpenQASM.Angle.Angle {
+            Value = 716770142402832,
+            Size = 53
+        }, q[5]))));
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -199,7 +208,10 @@ fn modifiers_can_be_repeated_many_times() -> miette::Result<(), Vec<Report>> {
         import Std.OpenQASM.Intrinsic.*;
         let q = QIR.Runtime.AllocateQubitArray(6);
         let f = QIR.Runtime.__quantum__rt__qubit_allocate();
-        ApplyOperationPowerA(1, ApplyOperationPowerA, (1, ApplyOperationPowerA, (1, Controlled rx, ([f], (Std.OpenQASM.Angle.DoubleAsAngle(0.5, 53), q[5])))));
+        ApplyOperationPowerA(1, ApplyOperationPowerA, (1, ApplyOperationPowerA, (1, Controlled rx, ([f], (new Std.OpenQASM.Angle.Angle {
+            Value = 716770142402832,
+            Size = 53
+        }, q[5])))));
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/pip/qsharp/openqasm/_run.py
+++ b/pip/qsharp/openqasm/_run.py
@@ -22,7 +22,7 @@ from ._ipython import display_or_print
 
 def run(
     source: Union[str, Callable],
-    shots: int,
+    shots: int = 1024,
     *args,
     on_result: Optional[Callable[[ShotResult], None]] = None,
     save_events: bool = False,
@@ -35,6 +35,7 @@ def run(
             DepolarizingNoise,
         ]
     ] = None,
+    as_bitstring: bool = False,
     **kwargs: Optional[Dict[str, Any]],
 ) -> List[Any]:
     """
@@ -157,5 +158,10 @@ def run(
 
     durationMs = (monotonic() - start_time) * 1000
     telemetry_events.on_run_qasm_end(durationMs, shots)
+
+    if as_bitstring:
+        from ._utils import as_bitstring as convert_to_bitstring
+
+        results = convert_to_bitstring(results)
 
     return results

--- a/pip/qsharp/openqasm/_utils.py
+++ b/pip/qsharp/openqasm/_utils.py
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from .. import Result
+
+
+def _map_qsharp_result_to_bit(v) -> str:
+    if isinstance(v, Result):
+        if v == Result.One:
+            return "1"
+        else:
+            return "0"
+    return str(v)
+
+
+def _convert_result_arrays_to_bitstrings(obj):
+    if isinstance(obj, tuple):
+        return tuple([_convert_result_arrays_to_bitstrings(term) for term in obj])
+    elif isinstance(obj, list):
+        # if all elements are Q# results, convert to bitstring
+        if all([isinstance(bit, Result) for bit in obj]):
+            return "".join([_map_qsharp_result_to_bit(bit) for bit in obj])
+        return [_convert_result_arrays_to_bitstrings(bit) for bit in obj]
+    elif isinstance(obj, Result):
+        if obj == Result.One:
+            return 1
+        else:
+            return 0
+    else:
+        return obj
+
+
+def as_bitstring(obj):
+    """
+    Convert Q# results to bitstrings.
+
+    :param obj: The object to convert.
+    :return: The converted object.
+    """
+    return _convert_result_arrays_to_bitstrings(obj)

--- a/samples/estimation/estimation-openqasm.ipynb
+++ b/samples/estimation/estimation-openqasm.ipynb
@@ -1,0 +1,609 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Getting Started with QDK Resource Estimation using OpenQASM\n",
+        "\n",
+        "👋 Welcome to the QDK Resource Estimator using OpenQASM. In this notebook we will\n",
+        "guide you how to estimate and analyze the physical resource estimates of a\n",
+        "quantum program targeted for execution based on the architecture design of a\n",
+        "fault-tolerant quantum computer. As a running example we are using a multiplier."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Implementing the algorithm"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "As a first step, we will create a sample application which will be used throughout this Resource Estimation notebook. To start, we'll import some utilities from the `qiskit` Python package eventually generating the OpenQASM program."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "tags": [
+          "parameters"
+        ]
+      },
+      "outputs": [],
+      "source": [
+        "# These are the Python imports that we use in this Qiskit-based example\n",
+        "from qiskit.circuit.library import RGQFTMultiplier"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We are creating a quantum circuit for a multiplier based on the construction presented in [arXiv:1411.5949](https://arxiv.org/abs/1411.5949) which uses the Quantum Fourier Transform to implement arithmetic. You can adjust the size of the multiplier by changing the `bitwidth` variable. The circuit generation is wrapped in a function that can be called with the bitwidth of the multiplier. The circuit will have two input registers with that bitwidth, and one output register with the size of twice the bitwidth."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def create_algorithm(bitwidth):\n",
+        "    print(f\"[INFO] Create a QFT-based multiplier with bitwidth {bitwidth}\")\n",
+        "\n",
+        "    circ = RGQFTMultiplier(num_state_qubits=bitwidth)\n",
+        "\n",
+        "    return circ"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Estimating the algorithm\n",
+        "Next we will create an instance of our algorithm using the `create_algorithm` function. You can adjust the size of the multiplier by changing the `bitwidth` variable."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qiskit.qasm3.exporter import Exporter\n",
+        "\n",
+        "bitwidth = 4\n",
+        "circ = create_algorithm(bitwidth)\n",
+        "\n",
+        "# Export the circuit to QASM vis Qiskit's QASM3 exporter\n",
+        "program = Exporter().dumps(circ)\n",
+        "print(program)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Let's now estimate the physical resources for this circuit using the default assumptions.\n",
+        "\n",
+        "The `estimate` call accepts and OpenQASM program as a string, so we can simply call it."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp.estimator import EstimatorParams\n",
+        "from qsharp.openqasm import estimate\n",
+        "\n",
+        "params = EstimatorParams()\n",
+        "result = estimate(program, params)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The simplest way to inspect the results of the job is to output them to the notebook. This will output a table with the overall physical resource counts. You can further inspect more details about the resource estimates by collapsing various groups which have more information. For example, if you collapse the *Logical qubit parameters* group, you can see that the quantum error correction (QEC) code distance is 15. In the last group you can see the physical qubit properties that were assumed for this estimation. For example, we see that the time to perform a single-qubit measurement and a single-qubit gate are assumed to be 100 ns and 50 ns, respectively."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp_widgets import EstimateDetails\n",
+        "\n",
+        "EstimateDetails(result)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The distribution of physical qubits used for the execution of the algorithm instructions and the supporting T factories can provide us valuable information to guide us in applying space and time optimizations. We can visualize this distribution to better understand the estimated space requirements for our algorithm."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp_widgets import SpaceChart\n",
+        "\n",
+        "SpaceChart(result)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We can also programmatically access all the values that can be passed to the job execution and see which default values were assumed:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "result.data()[\"jobParams\"]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We see that there are three input parameters that can be customized: `qubitParams`, `qecScheme`, and `errorBudget`.\n",
+        "\n",
+        "### Qubit parameters\n",
+        "\n",
+        "The first parameter `qubitParams` is used to specify qubit parameters.  When\n",
+        "modeling the physical qubit abstractions, we distinguish between two different\n",
+        "physical instruction sets that are used to operate the qubits.  The physical\n",
+        "instruction set can be either *gate-based* or *Majorana*.  A gate-based\n",
+        "instruction set provides single-qubit measurement, single-qubit gates (incl. T\n",
+        " gates), and two-qubit gates.  A Majorana instruction set provides a physical T\n",
+        " gate, single-qubit measurement and two-qubit joint measurement operations.\n",
+        "\n",
+        "Qubit parameters can be completely customized.  Before we show this, we show hot\n",
+        "to choose from six pre-defined qubit parameters, four of which have gate-based\n",
+        "instruction sets and two with a Majorana instruction set.  An overview of all\n",
+        "pre-defined qubit parameters is provided by the following table:\n",
+        "\n",
+        "| Pre-defined qubit parameters | Instruction set | References                                                                                                 |\n",
+        "|------------------------------|-----------------|------------------------------------------------------------------------------------------------------------|\n",
+        "| `\"qubit_gate_ns_e3\"`         | gate-based      | [arXiv:2003.00024](https://arxiv.org/abs/2003.00024), [arXiv:2111.11937](https://arxiv.org/abs/2111.11937) |\n",
+        "| `\"qubit_gate_ns_e4\"`         | gate-based      | [arXiv:2003.00024](https://arxiv.org/abs/2003.00024), [arXiv:2111.11937](https://arxiv.org/abs/2111.11937) |\n",
+        "| `\"qubit_gate_us_e3\"`         | gate-based      | [arXiv:1701.04195](https://arxiv.org/abs/1701.04195)                                                       |\n",
+        "| `\"qubit_gate_us_e4\"`         | gate-based      | [arXiv:1701.04195](https://arxiv.org/abs/1701.04195)                                                       |\n",
+        "| `\"qubit_maj_ns_e4\"`          | Majorana        | [arXiv:1610.05289](https://arxiv.org/abs/1610.05289)                                                       |\n",
+        "| `\"qubit_maj_ns_e6\"`          | Majorana        | [arXiv:1610.05289](https://arxiv.org/abs/1610.05289)                                                       |\n",
+        "\n",
+        "Pre-defined qubit parameters can be selected by specifying the `name` field in\n",
+        "the `qubitParams`.  If no value is provided, `\"qubit_gate_ns_e3\"` is chosen as\n",
+        "the default qubit parameters.\n",
+        "\n",
+        "Let's re-run resource estimation for our running example on the Majorana-based\n",
+        "qubit parameters `\"qubit_maj_ns_e6\"`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "qubitParams = {\n",
+        "    \"name\": \"qubit_maj_ns_e6\"\n",
+        "}\n",
+        "\n",
+        "result = estimate(program, qubitParams)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Let's inspect the physical counts programmatically. For example, we can show all physical resource estimates and their breakdown using the `physicalCounts` field in the result data. This will show the logical qubit error and logical T-state error rates required to match the error budget. By default runtimes are shown in nanoseconds."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "result.data()[\"physicalCounts\"]\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We can also explore details about the T factory that was created to execute this algorithm."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "result.data()[\"tfactory\"]\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Next, we are using this data to produce some explanations of how the T factories produce the required T states."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "data = result.data()\n",
+        "tfactory = data[\"tfactory\"]\n",
+        "breakdown = data[\"physicalCounts\"][\"breakdown\"]\n",
+        "producedTstates = breakdown[\"numTfactories\"] * breakdown[\"numTfactoryRuns\"] * tfactory[\"numTstates\"]\n",
+        "\n",
+        "print(f\"\"\"A single T factory produces {tfactory[\"logicalErrorRate\"]:.2e} T states with an error rate of (required T state error rate is {breakdown[\"requiredLogicalTstateErrorRate\"]:.2e}).\"\"\")\n",
+        "print(f\"\"\"{breakdown[\"numTfactories\"]} copie(s) of a T factory are executed {breakdown[\"numTfactoryRuns\"]} time(s) to produce {producedTstates} T states ({breakdown[\"numTstates\"]} are required by the algorithm).\"\"\")\n",
+        "print(f\"\"\"A single T factory is composed of {tfactory[\"numRounds\"]} rounds of distillation:\"\"\")\n",
+        "for round in range(tfactory[\"numRounds\"]):\n",
+        "    print(f\"\"\"- {tfactory[\"numUnitsPerRound\"][round]} {tfactory[\"unitNamePerRound\"][round]} unit(s)\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Custom qubit parameters must completely specify all required parameters.  These are the values that are\n",
+        "considered when the `instructionSet` is `\"GateBased\"`.\n",
+        "\n",
+        "| Field (*required)               | Description                                                          |\n",
+        "|---------------------------------|----------------------------------------------------------------------|\n",
+        "| `name`                          | Some descriptive name for the parameters                             |\n",
+        "| `oneQubitMeasurementTime`*      | Operation time for single-qubit measurement ($t_{\\rm meas}$) in ns   |\n",
+        "| `oneQubitGateTime`*             | Operation time for single-qubit Clifford gate ($t_{\\rm gate}$) in ns |\n",
+        "| `twoQubitGateTime`              | Operation time for two-qubit Clifford gate in ns                     |\n",
+        "| `tGateTime`                     | Operation time for single-qubit non-Clifford gate in ns              |\n",
+        "| `oneQubitMeasurementErrorRate`* | Error rate for single-qubit measurement                              |\n",
+        "| `oneQubitGateErrorRate`*        | Error rate for single-qubit Clifford gate ($p$)                      |\n",
+        "| `twoQubitGateErrorRate`         | Error rate for two-qubit Clifford gate                               |\n",
+        "| `tGateErrorRate`                | Error rate to prepare single-qubit non-Clifford state ($p_T$)        |\n",
+        "\n",
+        "The values for `twoQubitGateTime` and `tGateTime` default to `oneQubitGateTime`\n",
+        "when not specified; the values for `twoQubitGateErrorRate` and `tGateErrorRate`\n",
+        "default to `oneQubitGateErrorRate` when not specified.\n",
+        "\n",
+        "A minimum template for qubit parameters based on a gate-based instruction set\n",
+        "with all required values is:\n",
+        "\n",
+        "```json\n",
+        "{\n",
+        "    \"qubitParams\": {\n",
+        "        \"instructionSet\": \"GateBased\",\n",
+        "        \"oneQubitMeasurementTime\": <time string>,\n",
+        "        \"oneQubitGateTime\": <time string>,\n",
+        "        \"oneQubitMeasurementErrorRate\": <double>,\n",
+        "        \"oneQubitGateErrorRate\": <double>\n",
+        "    }\n",
+        "}\n",
+        "```\n",
+        "\n",
+        "For time units, you need to specify time strings which are double-precision\n",
+        "floating point numbers followed by a space and a unit prefix which is `ns`, `µs`\n",
+        "(alternatively `us`), `ms`, or `s`.\n",
+        "\n",
+        "These are the values that are considered when the `instructionSet` is\n",
+        "`\"Majorana\"`.\n",
+        "\n",
+        "| Field (*required)                   | Description                                                         |\n",
+        "|-------------------------------------|---------------------------------------------------------------------|\n",
+        "| `name`                              | Some descriptive name for the parameters                            |\n",
+        "| `oneQubitMeasurementTime`*          | Operation time for single-qubit measurement ($t_{\\rm meas}$) in ns  |\n",
+        "| `twoQubitJointMeasurementTime`      | Operation time for two-qubit joint measurement in ns                |\n",
+        "| `tGateTime`                         | Operation time for single-qubit non-Clifford gate in ns             |\n",
+        "| `oneQubitMeasurementErrorRate`*     | Error rate for single-qubit measurement                             |\n",
+        "| `twoQubitJointMeasurementErrorRate` | Error rate for two-qubit joint measurement                          |\n",
+        "| `tGateErrorRate`*                   | Error rate to prepare single-qubit non-Clifford state ($p_T$)       |\n",
+        "\n",
+        "The values for `twoQubitJointMeasurementTime` and `tGateTime` default to\n",
+        "`oneQubitGateTime` when not specified; the value for\n",
+        "`twoQubitJointMeasurementErrorRate` defaults to `oneQubitMeasurementErrorRate`\n",
+        "when not specified.\n",
+        "\n",
+        "A minimum template for qubit parameters based on a Majorana instruction set with\n",
+        "all required values is:\n",
+        "\n",
+        "```json\n",
+        "{\n",
+        "    \"qubitParams\": {\n",
+        "        \"instructionSet\": \"Majorana\",\n",
+        "        \"oneQubitMeasurementTime\": <time string>,\n",
+        "        \"oneQubitMeasurementErrorRate\": <double>,\n",
+        "        \"tGateErrorRate\": <double>\n",
+        "    }\n",
+        "}\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### QEC schemes"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "To execute practical-scale quantum applications, we require operations with very\n",
+        "low error rates. These error rate targets are typically beyond the capabilities\n",
+        "of raw physical qubits. To overcome this limitation, quantum error correction\n",
+        "(QEC) and fault-tolerant computation are two crucial techniques that form the\n",
+        "building blocks of large-scale quantum computers. First, QEC allows us to\n",
+        "compose multiple error-prone physical qubits and build a more reliable logical\n",
+        "qubit that preserves quantum information better than the underlying physical\n",
+        "qubits. Several QEC schemes have been developed since the last three decades,\n",
+        "including popular schemes such as the Shor-code, surface code, color codes and\n",
+        "others, and recently the [Hastings-Haah code](https://arxiv.org/abs/2107.02194).\n",
+        "These schemes vary based on the number of physical qubits they require, the\n",
+        "connectivity among qubits and other factors. By using QEC techniques, we can\n",
+        "achieve a fault-tolerant quantum computation, enabling reliable storing and\n",
+        "processing of quantum information in the presence of noise. To store information\n",
+        "reliably, we require that the QEC scheme is able to suppress errors when the\n",
+        "physical qubits meet a certain threshold error rate. To process information, we\n",
+        "require fault-tolerant operations that allow applications to perform general\n",
+        "purpose quantum computations efficiently and limit the spread of errors that\n",
+        "occur while computing with logical qubits. Schemes for fault-tolerant operations\n",
+        "include techniques such as lattice surgery and transversal operations. Together,\n",
+        "QEC and fault-tolerance techniques bridges the accuracy gap between quantum\n",
+        "hardware and algorithms.\n",
+        "\n",
+        "The error correction code distance (or just code distance in short) is a\n",
+        "parameter that controls the number of errors that can be corrected, and thus the\n",
+        "error rate of the logical qubits and the number of physical qubits required to\n",
+        "encode them.  The higher the code distance, the better the accuracy, but also\n",
+        "the higher the amount of physical qubits.  The goal is to find the minimum code\n",
+        "distance that can achieve the required error rate set for a particular\n",
+        "application.  We will explain later in this notebook how a global error budget\n",
+        "is provided as input and how it is distributed throughout the estimation,\n",
+        "including the logical error rate of logical qubits.\n",
+        "\n",
+        "We follow the standard way of modeling logical error rates using an exponential\n",
+        "model parameterized by the code distance $d$, physical error rate $p$, QEC\n",
+        "threshold $p^*$.  The physical error rate $p$ is extracted from the qubit\n",
+        "parameters above as the worst-case error rate any physical Clifford operation in\n",
+        "the device.  In particular, we set $p = {}$ `max(oneQubitMeasurementErrorRate,\n",
+        "oneQubitGateErrorRate, twoQubitGateErrorRate)` for qubit parameters with a\n",
+        "gate-based instruction set, and $p = {}$ `max(oneQubitMeasurementErrorRate,\n",
+        "twoQubitJointMeasurementErrorRate)` for qubit parameters with a Majorana\n",
+        "instruction set.  QEC schemes typically have a error rate threshold $p^*$ below\n",
+        "which error correction suppresses errors.\n",
+        "\n",
+        "Our current implementation uses the formula\n",
+        "\n",
+        "$$\n",
+        "P = a\\left(\\frac{p}{p^*}\\right)^{\\frac{d+1}{2}}\n",
+        "$$\n",
+        "\n",
+        "as the generic model.  The exact parameters for each pre-defined QEC scheme\n",
+        "(including  a crossing pre-factor $a$ which can be extracted numerically for\n",
+        "simulations) are listed below.\n",
+        "\n",
+        "In Azure Quantum Resource Estimation we can abstract the quantum error\n",
+        "correction scheme based on the above formula by providing values for the\n",
+        "crossing pre-factor $a$ and the error correction threshold $p^*$.  Further, one\n",
+        "needs to specify the logical cycle time, i.e., the time to execute a single\n",
+        "logical operation, which depends on the code distance and the  physical\n",
+        "operation time assumptions of the underlying physical qubits.  Finally, a second\n",
+        "formula computes the number of physical qubits required to encode one logical\n",
+        "qubit based on the code distance.\n",
+        "\n",
+        "As with the physical qubit parameters, one can choose from several pre-defined\n",
+        "QEC schemes, can extend pre-defined ones, and can provide custom schemes by\n",
+        "providing all parameters.  Note that QEC schemes are tightly connected to the\n",
+        "physical instruction set of the physical qubit parameters, and therefore are\n",
+        "defined specifically for one of the two instruction sets.\n",
+        "\n",
+        "We provide three pre-defined QEC schemes, two `\"surface_code\"` protocols for\n",
+        "gate-based and Majorana physical instruction sets, and the `\"floquet_code\"`\n",
+        "protocol that is so far only implemented for a Majorana physical instruction set\n",
+        "in the resource estimator.\n",
+        "\n",
+        "| QEC scheme     | Instruction set | References                                                                                                 |\n",
+        "|----------------|-----------------|------------------------------------------------------------------------------------------------------------|\n",
+        "| `surface_code` | gate-based      | [arXiv:1208.0928](https://arxiv.org/abs/1208.0928), [arXiv:1009.3686](https://arxiv.org/abs/1009.3686)     |\n",
+        "| `surface_code` | Majorana        | [arXiv:1909.03002](https://arxiv.org/abs/1909.03002), [arXiv:2007.00307](https://arxiv.org/abs/2007.00307) |\n",
+        "| `floquet_code` | Majorana        | [arXiv:2202.11829](https://arxiv.org/abs/2202.11829)                                                       |\n",
+        "\n",
+        "In case of `\"surface_code\"` the corresponding scheme is selected based on the\n",
+        "qubit type of the physical qubit parameters.  The gate-based surface code is\n",
+        "based on [[arXiv:1208.0928](https://arxiv.org/abs/1208.0928)] and\n",
+        "[[arXiv:1009.3686](https://arxiv.org/abs/1009.3686)]. The surface code for\n",
+        "Majorana qubits is based on\n",
+        "[[arXiv:1909.03002](https://arxiv.org/abs/1909.03002)] and\n",
+        "[[arXiv:2007.00307](https://arxiv.org/abs/2007.00307)] (replacing 8 steps to\n",
+        "measure a single stabilizer in the former reference by 20 steps to measure all\n",
+        "stabilizers). The floquet code, which can only be selected for Majorana qubits,\n",
+        "is based on [[arXiv:2202.11829](https://arxiv.org/abs/2202.11829)].\n",
+        "\n",
+        "Pre-defined qubit parameters can be selected by specifying the `name` field in\n",
+        "the `qecScheme` parameter.  If no value is provided, `\"surface_code\"` is used as\n",
+        "default value.\n",
+        "\n",
+        "Let's re-run resource estimation for our running example on the Majorana-based\n",
+        "qubit parameters with a Floquet code."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "params = {\n",
+        "    \"qubitParams\": {\"name\": \"qubit_maj_ns_e6\"},\n",
+        "    \"qecScheme\": {\"name\": \"floquet_code\"}\n",
+        "}\n",
+        "\n",
+        "result_maj_floquet = estimate(program, params)\n",
+        "EstimateDetails(result_maj_floquet)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "To specify a QEC scheme the user has to specify 2 values, the\n",
+        "`errorCorrectionThreshold` and the `crossingPrefactor`, as well as 2 formulas\n",
+        "for the `logicalCycleTime`, and the `physicalQubitsPerLogicalQubit`.  A template\n",
+        "for QEC schemes is as follows:\n",
+        "\n",
+        "```json\n",
+        "{\n",
+        "    \"qecScheme\": {\n",
+        "        \"crossingPrefactor\": <double>,\n",
+        "        \"errorCorrectionThreshold\": <double>,\n",
+        "        \"logicalCycleTime\": <formula string>,\n",
+        "        \"physicalQubitsPerLogicalQubit\": <formula string>\n",
+        "    }\n",
+        "}\n",
+        "```\n",
+        "\n",
+        "Inside the formulas, the user can make use of the following variables\n",
+        "\n",
+        "* `oneQubitGateTime`\n",
+        "* `twoQubitGateTime`\n",
+        "* `oneQubitMeasurementTime`\n",
+        "* `twoQubitJointMeasurementTime`\n",
+        "\n",
+        "whose value is taken from the corresponding field from the physical qubit\n",
+        "parameters (note that some variables are not available based on the qubit\n",
+        "parameters' instruction set), as well as the variable\n",
+        "\n",
+        "* `codeDistance`\n",
+        "\n",
+        "for the code distance computed for the logical qubit, based on the physical\n",
+        "qubit properties, the error correction threshold, and the crossing prefactor.\n",
+        "The time variables and `codeDistance` can be used to describe the\n",
+        "`logicalCycleTime` formula.  For the formula `physicalQubitsPerLogicalQubit`\n",
+        "only the `codeDistance` can be used."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Error budget\n",
+        "\n",
+        "The third parameter `errorBudget` models the total error budget $\\epsilon$.  It\n",
+        "sets the overall allowed error for the algorithm, i.e., the number of times it\n",
+        "is allowed to fail.  Its value must be between 0 and 1 and the default value is\n",
+        "0.001, which corresponds to 0.1%, and means that the algorithm is allowed to\n",
+        "fail once in 1000 executions.  This parameter is highly application specific.\n",
+        "For example, if one is running Shor's algorithm for factoring integers, a large\n",
+        "value for the error budget may be tolerated as one can check that the output are\n",
+        "indeed the prime factors of the input.  On the other hand, a much smaller error\n",
+        "budget may be needed for an algorithm solving a problem with a solution which\n",
+        "cannot be efficiently verified.  This budget\n",
+        "\n",
+        "$$\n",
+        "  \\epsilon = \\epsilon_{\\log} + \\epsilon_{\\rm dis} + \\epsilon_{\\rm syn}\n",
+        "$$\n",
+        "\n",
+        "is uniformly distributed and applies to errors $\\epsilon_{\\log}$ to implement\n",
+        "logical qubits, an error budget $\\epsilon_{\\rm dis}$ to produce T states through\n",
+        "distillation, and an error budget $\\epsilon_{\\rm syn}$ to synthesize rotation\n",
+        "gates with arbitrary angles.  Note that for distillation and rotation synthesis,\n",
+        "the respective error budgets $\\epsilon_{\\rm dis}$ and $\\epsilon_{\\rm syn}$ are\n",
+        "uniformly distributed among all required T states and all required rotation\n",
+        "gates, respectively. If there are no rotation gates in the input algorithm, the\n",
+        "error budget is uniformly distributed to logical errors and T state errors.\n",
+        "\n",
+        "Next, we re-run the last experiment with a an error budget of 10%."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "params = {\n",
+        "    \"errorBudget\": 0.01,\n",
+        "    \"qubitParams\": {\"name\": \"qubit_maj_ns_e6\"},\n",
+        "    \"qecScheme\": {\"name\": \"floquet_code\"},\n",
+        "}\n",
+        "result_maj_floquet_e1 = estimate(program, params)\n",
+        "EstimateDetails(result_maj_floquet_e1)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Next steps\n",
+        "\n",
+        "We hope you enjoyed this notebook and found it helpful in exploring the physical resource estimates for quantum programs. Here are some suggested next steps:\n",
+        "\n",
+        "* Try estimating the resources for a different Qiskit program.\n",
+        "* Explore how qubit parameters and QEC schemes affect the error correction code distance of the logical qubit.\n",
+        "* Visualize your and compare your results from different parameter sets with the space and time diagrams.\n",
+        "* Use the output data to derive logical qubit properties.\n",
+        "* Learn how to setup complex resource estimation experiments in the _Advanced analysis of estimates_ notebook."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernel_info": {
+      "name": "python3"
+    },
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.3"
+    },
+    "microsoft": {
+      "host": {
+        "AzureQuantum": {
+          "sourceLink": "https://raw.githubusercontent.com/microsoft/azure-quantum-python/41b21e8fdb4da00608d7473efa1c74e9aa7082b3/samples/resource-estimator/estimation-qiskit.ipynb",
+          "sourceType": "SampleGallery"
+        }
+      }
+    },
+    "nteract": {
+      "version": "nteract-front-end@1.0.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 1
+}

--- a/samples/notebooks/openqasm.ipynb
+++ b/samples/notebooks/openqasm.ipynb
@@ -1,0 +1,279 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "ae56fce0",
+      "metadata": {},
+      "source": [
+        "# Q# Interop with OpenQASM"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2b838c23",
+      "metadata": {},
+      "source": [
+        "The modern QDK provides interoperability with OpenQASM 3 programs built upon the core Q# compiler infrastructure.\n",
+        "\n",
+        "This core enables integration and local resource estimation without relying on external tools. Users are able to estimate resources for their OpenQASM programs locally (see the [resource estimation with OpenQASM sample notebook](../../estimation/estimation-openqasm.ipynb)), leveraging the Q# compiler's capabilities for analysis, transformation, code generation, and simulation. This also enables the generation of QIR from OpenQASM progams leveraging the [modern QDKs advanced code generation capabilities](https://devblogs.microsoft.com/qsharp/integrated-hybrid-support-in-the-azure-quantum-development-kit/).\n",
+        "\n",
+        "This includes support for classical instructions available in OpenQASM such as for loops, if statements, switch statements, while loops, binary expresssions, and more.\n",
+        "\n",
+        "### Simulating OpenQASM programs"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "016b3815",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp.openqasm import run\n",
+        "\n",
+        "source = \"\"\"\n",
+        "include \"stdgates.inc\";\n",
+        "bit[2] c;\n",
+        "qubit[2] q;\n",
+        "h q[0];\n",
+        "cx q[0], q[1];\n",
+        "c = measure q;\n",
+        "\"\"\"\n",
+        "\n",
+        "run(source, as_bitstring=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9fed5ba5",
+      "metadata": {},
+      "source": [
+        "Import the Q# module.\n",
+        "\n",
+        "This enables the `%%qsharp` magic and initializes a Q# interpreter singleton."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "75b8b81b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import qsharp\n",
+        "qsharp.init(target_profile=qsharp.TargetProfile.Base)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "95d82f22",
+      "metadata": {},
+      "source": [
+        "### Run OpenQASM 3 Code in interactive session\n",
+        "Interactive sessions have different semantics from program execution. We no longer have inferred output and input. Instead we treat qasm lines as code fragments and interpret them one at a time (though they are all compiled together). Due to scoping rules in qasm3, all code used in the the program must be defined in the snippet and can't use compilation state from other cells or calls.\n",
+        "\n",
+        "We can add an optional name parameter to compile the program into a callable operation in the interactive session."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "012cc902",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp.openqasm import import_openqasm\n",
+        "\n",
+        "source = \"\"\"\n",
+        "include \"stdgates.inc\";\n",
+        "bit[2] c;\n",
+        "qubit[2] q;\n",
+        "h q[0];\n",
+        "cx q[0], q[1];\n",
+        "c = measure q;\n",
+        "\"\"\"\n",
+        "\n",
+        "import_openqasm(source, name=\"bell\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b95a0c8b",
+      "metadata": {},
+      "source": [
+        "With the OpenQASM program loaded into a callable name `bell`, we can now import it via the QDK's Python bindings:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "db043bda",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp.code import bell\n",
+        "bell()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8db074dc",
+      "metadata": {},
+      "source": [
+        "Additionally, since it is defined in the session, we can run it directly from a Q# cell:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ad6d0331",
+      "metadata": {
+        "vscode": {
+          "languageId": "qsharp"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "%%qsharp\n",
+        "bell()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6578cadc",
+      "metadata": {},
+      "source": [
+        "This also unlocks all of the other `qsharp` package functionality. Like noisy simulation:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5bbd6d92",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp_widgets import Histogram\n",
+        "\n",
+        "Histogram(qsharp.run(\"bell()\", shots=1000, noise=qsharp.DepolarizingNoise(0.01)))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "85d48772",
+      "metadata": {},
+      "source": [
+        "Circuit rendering:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a0a50634",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "qsharp.circuit(qsharp.code.bell)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5865ea0c",
+      "metadata": {},
+      "source": [
+        "Circuit widget rendering:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c3fc87ae",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp_widgets import Circuit\n",
+        "Circuit(qsharp.circuit(qsharp.code.bell))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0e1a29c8",
+      "metadata": {},
+      "source": [
+        "Code generation:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ec6db1e5",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "print(qsharp.compile(bell))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "759f6a5e",
+      "metadata": {},
+      "source": [
+        "We can also define input for the compiled OpenQASM code so that we can parameterize input:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "bd179f1a",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp.openqasm import import_openqasm\n",
+        "\n",
+        "source = \"\"\"\n",
+        "include \"stdgates.inc\";\n",
+        "input float theta;\n",
+        "bit[2] c;\n",
+        "qubit[2] q;\n",
+        "rx(theta) q[0];\n",
+        "rx(-theta) q[1];\n",
+        "c = measure q;\n",
+        "\"\"\"\n",
+        "\n",
+        "import_openqasm(source, name=\"parameterized_program\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5b7a97d2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from qsharp.code import parameterized_program\n",
+        "print(qsharp.compile(parameterized_program, 1.57))"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds sample Python integration and resource estimation notebooks for OpenQASM. There is more here than just those changes as existing external issues require workarounds.

- Qiskit and existing OpenQASM code incorrectly specify 0 for angles which isn't allowed in the spec. So this PR adds the ability to cast literals to angles with a value of 0 for compatibility. This also removes some casting calls as we can now directly create the angle from the literal.
- There is a util bitstring function which allows the user to specify that they want the output of simulation to be converted into a bitstring if any of the outputs are bit registers. This matches what Qiskit output would be like. For the moment the code defaults to Q#'s typicaly output rendering.
