### PR TITLE
Fix include error span

### DIFF
--- a/compiler/qsc_project/src/openqasm.rs
+++ b/compiler/qsc_project/src/openqasm.rs
@@ -13,7 +13,6 @@ where
 {
     let mut loaded_files = FxHashMap::default();
     let mut pending_includes = vec![];
-    let mut errors = vec![];
 
     // this is the root of the project
     // it is the only file that has a full path.
@@ -61,11 +60,10 @@ where
                     pending_includes.push(include);
                 }
             }
-            Err(e) => {
-                errors.push(super::project::Error::FileSystem {
-                    about_path: doc_uri.to_string(),
-                    error: e.to_string(),
-                });
+            Err(_e) => {
+                // If the source failed to resolve we don't push an error here.
+                // We will push an error later during lowering, so that we can
+                // construct the error with the right span.
             }
         }
     }
@@ -76,7 +74,7 @@ where
         path: doc_uri.clone(),
         name: get_file_name_from_uri(doc_uri),
         lints: Vec::default(),
-        errors,
+        errors: vec![],
         project_type: super::ProjectType::OpenQASM(sources),
     }
 }

--- a/compiler/qsc_qasm/src/parser/tests.rs
+++ b/compiler/qsc_qasm/src/parser/tests.rs
@@ -150,6 +150,13 @@ fn programs_with_includes_with_includes_can_be_parsed() -> miette::Result<(), Ve
 
     let res = parse_all("source0.qasm", all_sources)?;
     assert!(res.source.includes().len() == 1);
-    assert!(res.source.includes()[0].includes().len() == 1);
+    assert!(
+        res.source.includes()[0]
+            .as_ref()
+            .expect("file should exists")
+            .includes()
+            .len()
+            == 1
+    );
     Ok(())
 }

--- a/compiler/qsc_qasm/src/semantic/error.rs
+++ b/compiler/qsc_qasm/src/semantic/error.rs
@@ -148,6 +148,9 @@ pub enum SemanticErrorKind {
     #[error("{0} can only appear in {1} scopes")]
     #[diagnostic(code("Qasm.Lowerer.InvalidScope"))]
     InvalidScope(String, String, #[label] Span),
+    #[error("{0}")]
+    #[diagnostic(code("Qasm.Lowerer.IO"))]
+    IO(String, #[label] Span),
     #[error("measure statements must have a name")]
     #[diagnostic(code("Qasm.Lowerer.MeasureExpressionsMustHaveName"))]
     MeasureExpressionsMustHaveName(#[label] Span),

--- a/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -173,8 +173,15 @@ impl Lowerer {
                     continue;
                 }
 
-                let include = includes.next().expect("missing include");
-                self.lower_source(include);
+                match includes.next().expect("missing include") {
+                    Ok(include) => self.lower_source(include),
+                    Err(e) => {
+                        self.push_semantic_error(SemanticErrorKind::IO(
+                            e.to_string(),
+                            include.span,
+                        ));
+                    }
+                }
             } else {
                 let mut stmts = self.lower_stmt(stmt);
                 self.stmts.append(&mut stmts);

--- a/compiler/qsc_qasm/src/tests/statement/include.rs
+++ b/compiler/qsc_qasm/src/tests/statement/include.rs
@@ -304,3 +304,26 @@ fn cyclic_include_errors() {
           source3.inc includes source1.inc"#]]
     .assert_eq(&errors_string);
 }
+
+#[test]
+fn missing_include_error() {
+    let main = r#"
+        include "source1.inc";
+    "#;
+    let all_sources = [("main.qasm".into(), main.into())];
+    let config = CompilerConfig::new(
+        QubitSemantics::Qiskit,
+        OutputSemantics::Qiskit,
+        ProgramType::File,
+        Some("Test".into()),
+        None,
+    );
+
+    let Err(errors) = compile_all_with_config("main.qasm", all_sources, config) else {
+        panic!("expected errors")
+    };
+
+    let errors: Vec<_> = errors.iter().map(|e| format!("{e}")).collect();
+    let errors_string = errors.join("\n");
+    expect!["Not Found Could not resolve include file: source1.inc"].assert_eq(&errors_string);
+}


### PR DESCRIPTION
Include error spans were set to the beginning of the file, since include errors were being pushed in resolution, where there is no knowledge of spans. This PR delays pushing `IO` errors until lowering, so that we can construct the error with the correct span.