### PR TITLE
Fix bit shifts with bit literals on lhs

### DIFF
--- a/compiler/qsc_qasm/src/tests/declaration/def.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/def.rs
@@ -604,13 +604,14 @@ fn capturing_non_const_evaluatable_external_variable_fails() {
     };
 
     expect![[r#"
-        [Qasm.Lowerer.UnsupportedBinaryOp
+        [Qasm.Lowerer.NegativeUIntValue
 
-          x Shl is not supported between types const int and const uint
-           ,-[Test.qasm:2:23]
+          x uint expression must evaluate to a non-negative value, but it evaluated
+          | to -3
+           ,-[Test.qasm:2:28]
          1 | 
          2 |         const int a = 2 << (-3);
-           :                       ^^^^^^^^^
+           :                            ^^^^
          3 |         def f() -> int {
            `----
         ]"#]]

--- a/compiler/qsc_qasm/src/tests/declaration/gate.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/gate.rs
@@ -147,13 +147,14 @@ fn capturing_non_const_evaluatable_external_variable_fails() {
     };
 
     expect![[r#"
-        [Qasm.Lowerer.UnsupportedBinaryOp
+        [Qasm.Lowerer.NegativeUIntValue
 
-          x Shl is not supported between types const int and const uint
-           ,-[Test.qasm:2:23]
+          x uint expression must evaluate to a non-negative value, but it evaluated
+          | to -3
+           ,-[Test.qasm:2:28]
          1 | 
          2 |         const int a = 2 << (-3);
-           :                       ^^^^^^^^^
+           :                            ^^^^
          3 |         gate my_gate q {
            `----
         ]"#]]

--- a/compiler/qsc_qasm/src/tests/statement/const_eval.rs
+++ b/compiler/qsc_qasm/src/tests/statement/const_eval.rs
@@ -369,7 +369,21 @@ fn binary_op_shl_uint() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
+fn binary_op_shl_int_literal() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        bit[1 << 3] r;
+    "#;
 
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        mutable r = [Zero, Zero, Zero, Zero, Zero, Zero, Zero, Zero];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
 fn binary_op_shl_angle() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const angle[32] a = 1.0;
@@ -504,7 +518,21 @@ fn binary_op_shr_uint() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
+fn binary_op_shr_int_literal() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        bit[1 >> 3] r;
+    "#;
 
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        mutable r = [];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
 fn binary_op_shr_angle() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         const angle[32] a = 1.0;


### PR DESCRIPTION
The following program was failing to compile because the `1` on the lhs of the `<<` expression was being lowered as an `int`, and the qasm spec does not define bit shifts for ints. The fix consists in lowering the literal as a `uint` instead, which is allowed by the spec.

```
const int a = 1 << 5;
def const_evaluation_context() {
    int b = a;
}
```