### PR TITLE
Fix panic due to missing `Unit` value from assignment

### DIFF
--- a/compiler/qsc_eval/src/tests.rs
+++ b/compiler/qsc_eval/src/tests.rs
@@ -238,6 +238,61 @@ fn block_let_bind_tuple_expr() {
 }
 
 #[test]
+fn block_let_bind_assign_expr_is_unit() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable a = 0;
+            let b = a = 1;
+            (a, b)
+        }"},
+        &expect!["(1, ())"],
+    );
+}
+
+#[test]
+fn block_let_bind_assign_field_expr_is_unit() {
+    check_expr(
+        "",
+        indoc! {"{
+            struct S {
+                inner : Int,
+            }
+            mutable a = new S { inner = 0 };
+            let b = a w/= inner <- 1;
+            (a.inner, b)
+        }"},
+        &expect!["(1, ())"],
+    );
+}
+
+#[test]
+fn block_let_bind_assign_index_expr_is_unit() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable a = [0];
+            let b = a[0] = 1;
+            (a, b)
+        }"},
+        &expect!["([1], ())"],
+    );
+}
+
+#[test]
+fn block_let_bind_assign_op_expr_is_unit() {
+    check_expr(
+        "",
+        indoc! {"{
+            mutable a = 0;
+            let b = a += 1;
+            (a, b)
+        }"},
+        &expect!["(1, ())"],
+    );
+}
+
+#[test]
 fn block_mutable_expr() {
     check_expr(
         "",

--- a/compiler/qsc_lowerer/src/lib.rs
+++ b/compiler/qsc_lowerer/src/lib.rs
@@ -728,6 +728,18 @@ impl Lowerer {
             _ => self.exec_graph.push(ExecGraphNode::Expr(id)),
         }
 
+        if matches!(
+            kind,
+            fir::ExprKind::Assign(..)
+                | fir::ExprKind::AssignField(..)
+                | fir::ExprKind::AssignIndex(..)
+                | fir::ExprKind::AssignOp(..)
+        ) {
+            // The result of an assignment is always Unit,
+            // so add an explicit Unit to the execution graph.
+            self.exec_graph.push(ExecGraphNode::Unit);
+        }
+
         let expr = fir::Expr {
             id,
             span: expr.span,


### PR DESCRIPTION
Assignments are expressions that should result in unit, but they don't push unit into the exec graph, which can cause problems if those expressions have their results bound to some other variable or expression.