### PR TITLE
Allow to catch and propagate errors in all resource estimation models

### DIFF
--- a/resource_estimator/src/estimates/error.rs
+++ b/resource_estimator/src/estimates/error.rs
@@ -16,21 +16,21 @@ pub enum Error {
     /// The number of algorithmic logical qubits cannot be computed.
     ///
     /// ✅ This does not contain user data and can be logged
-    /// 🧑‍💻 This indicates a user error
+    /// ✅ This error cannot be triggered by the system.
     #[error("Cannot compute the number of algorithmic logical qubits: {0}")]
     #[diagnostic(code("Qsc.Estimates.AlgorithmicLogicalQubitsComputationFailed"))]
     AlgorithmicLogicalQubitsComputationFailed(String),
     /// The algorithmic logical depth cannot be computed.
     ///
     /// ✅ This does not contain user data and can be logged
-    /// 🧑‍💻 This indicates a user error
+    /// ✅ This error cannot be triggered by the system.
     #[error("Cannot compute the algorithmic logical depth: {0}")]
     #[diagnostic(code("Qsc.Estimates.AlgorithmicLogicalDepthComputationFailed"))]
     AlgorithmicLogicalDepthComputationFailed(String),
     /// The number of required magic states cannot be computed.
     ///
     /// ✅ This does not contain user data and can be logged
-    /// 🧑‍💻 This indicates a user error
+    /// ✅ This error cannot be triggered by the system.
     #[error("Cannot compute the required number of magic states: {0}")]
     #[diagnostic(code("Qsc.Estimates.NumberOfMagicStatesComputationFailed"))]
     NumberOfMagicStatesComputationFailed(String),
@@ -64,6 +64,12 @@ pub enum Error {
     #[error("Resource estimation configuration can never produce T states, required magic state output error rate was {0:.3e}")]
     #[diagnostic(code("Qsc.Estimates.CannotComputeMagicStates"))]
     CannotComputeMagicStates(f64),
+    /// Resource estimation failed to find factories
+    ///
+    /// ✅ This error cannot be triggered by the system.
+    #[error("Resource estimation failed to find factories: {0}")]
+    #[diagnostic(code("Qsc.Estimates.FactorySearchFailed"))]
+    FactorySearchFailed(String),
     /// Constraint-based search only supports one magic state type.
     ///
     /// ✅ This error cannot be triggered by the system, since only one magic

--- a/resource_estimator/src/estimates/error.rs
+++ b/resource_estimator/src/estimates/error.rs
@@ -13,6 +13,27 @@ pub enum Error {
     #[error("Algorithm requires at least one magic state or measurement to estimate resources")]
     #[diagnostic(code("Qsc.Estimates.AlgorithmHasNoResources"))]
     AlgorithmHasNoResources,
+    /// The number of algorithmic logical qubits cannot be computed.
+    ///
+    /// ✅ This does not contain user data and can be logged
+    /// 🧑‍💻 This indicates a user error
+    #[error("Cannot compute the number of algorithmic logical qubits: {0}")]
+    #[diagnostic(code("Qsc.Estimates.AlgorithmicLogicalQubitsComputationFailed"))]
+    AlgorithmicLogicalQubitsComputationFailed(String),
+    /// The algorithmic logical depth cannot be computed.
+    ///
+    /// ✅ This does not contain user data and can be logged
+    /// 🧑‍💻 This indicates a user error
+    #[error("Cannot compute the algorithmic logical depth: {0}")]
+    #[diagnostic(code("Qsc.Estimates.AlgorithmicLogicalDepthComputationFailed"))]
+    AlgorithmicLogicalDepthComputationFailed(String),
+    /// The number of required magic states cannot be computed.
+    ///
+    /// ✅ This does not contain user data and can be logged
+    /// 🧑‍💻 This indicates a user error
+    #[error("Cannot compute the required number of magic states: {0}")]
+    #[diagnostic(code("Qsc.Estimates.NumberOfMagicStatesComputationFailed"))]
+    NumberOfMagicStatesComputationFailed(String),
     /// Both constraints for maximal time and
     /// maximal number of qubits are provided
     ///

--- a/resource_estimator/src/estimates/error.rs
+++ b/resource_estimator/src/estimates/error.rs
@@ -58,12 +58,6 @@ pub enum Error {
     #[error("No solution found for the provided maximum number of physical qubits.")]
     #[diagnostic(code("Qsc.Estimates.MaxPhysicalQubitsTooSmall"))]
     MaxPhysicalQubitsTooSmall,
-    /// Resource estimation configuration can never produce T states
-    ///
-    /// ✅ This error cannot be triggered by the system.
-    #[error("Resource estimation configuration can never produce T states, required magic state output error rate was {0:.3e}")]
-    #[diagnostic(code("Qsc.Estimates.CannotComputeMagicStates"))]
-    CannotComputeMagicStates(f64),
     /// Resource estimation failed to find factories
     ///
     /// ✅ This error cannot be triggered by the system.

--- a/resource_estimator/src/estimates/error_correction.rs
+++ b/resource_estimator/src/estimates/error_correction.rs
@@ -82,13 +82,11 @@ pub trait ErrorCorrection {
         required_logical_error_rate: f64,
     ) -> Result<Self::Parameter, String> {
         for parameter in self.code_parameter_range(None) {
-            if let (Ok(probability), Ok(logical_qubits)) = (
-                self.logical_error_rate(qubit, &parameter),
-                self.logical_qubits(&parameter),
-            ) {
-                if probability / (logical_qubits as f64) <= required_logical_error_rate {
-                    return Ok(parameter);
-                }
+            let probability = self.logical_error_rate(qubit, &parameter)?;
+            let logical_qubits = self.logical_qubits(&parameter)?;
+
+            if probability / (logical_qubits as f64) <= required_logical_error_rate {
+                return Ok(parameter);
             }
         }
 
@@ -110,20 +108,17 @@ pub trait ErrorCorrection {
         let mut best: Option<(Self::Parameter, f64)> = None;
 
         for parameter in self.code_parameter_range(None) {
-            if let (Ok(probability), Ok(logical_qubits), Ok(physical_qubits)) = (
-                self.logical_error_rate(qubit, &parameter),
-                self.logical_qubits(&parameter),
-                self.physical_qubits(&parameter),
-            ) {
-                let physical_qubits_per_logical_qubits =
-                    physical_qubits as f64 / logical_qubits as f64;
-                if (probability / (logical_qubits as f64) <= required_logical_error_rate)
-                    && best
-                        .as_ref()
-                        .is_none_or(|&(_, pq)| physical_qubits_per_logical_qubits < pq)
-                {
-                    best = Some((parameter, physical_qubits_per_logical_qubits));
-                }
+            let probability = self.logical_error_rate(qubit, &parameter)?;
+            let logical_qubits = self.logical_qubits(&parameter)?;
+            let physical_qubits = self.physical_qubits(&parameter)?;
+
+            let physical_qubits_per_logical_qubits = physical_qubits as f64 / logical_qubits as f64;
+            if (probability / (logical_qubits as f64) <= required_logical_error_rate)
+                && best
+                    .as_ref()
+                    .is_none_or(|&(_, pq)| physical_qubits_per_logical_qubits < pq)
+            {
+                best = Some((parameter, physical_qubits_per_logical_qubits));
             }
         }
 
@@ -146,16 +141,14 @@ pub trait ErrorCorrection {
         let mut best: Option<(Self::Parameter, u64)> = None;
 
         for parameter in self.code_parameter_range(None) {
-            if let (Ok(probability), Ok(logical_qubits), Ok(logical_cycle_time)) = (
-                self.logical_error_rate(qubit, &parameter),
-                self.logical_qubits(&parameter),
-                self.logical_cycle_time(qubit, &parameter),
-            ) {
-                if (probability / (logical_qubits as f64) <= required_logical_error_rate)
-                    && best.as_ref().is_none_or(|&(_, t)| logical_cycle_time < t)
-                {
-                    best = Some((parameter, logical_cycle_time));
-                }
+            let probability = self.logical_error_rate(qubit, &parameter)?;
+            let logical_qubits = self.logical_qubits(&parameter)?;
+            let logical_cycle_time = self.logical_cycle_time(qubit, &parameter)?;
+
+            if (probability / (logical_qubits as f64) <= required_logical_error_rate)
+                && best.as_ref().is_none_or(|&(_, t)| logical_cycle_time < t)
+            {
+                best = Some((parameter, logical_cycle_time));
             }
         }
 

--- a/resource_estimator/src/estimates/factory.rs
+++ b/resource_estimator/src/estimates/factory.rs
@@ -33,7 +33,7 @@ where
         magic_state_type: usize,
         output_error_rate: f64,
         max_code_parameter: &E::Parameter,
-    ) -> Option<Vec<Cow<Self::Factory>>>;
+    ) -> Result<Vec<Cow<Self::Factory>>, String>;
 
     fn num_magic_state_types(&self) -> usize {
         1

--- a/resource_estimator/src/estimates/factory/dispatch.rs
+++ b/resource_estimator/src/estimates/factory/dispatch.rs
@@ -76,7 +76,7 @@ impl<E: ErrorCorrection, Builder1: FactoryBuilder<E>, Builder2: FactoryBuilder<E
         magic_state_type: usize,
         output_error_rate: f64,
         max_code_parameter: &E::Parameter,
-    ) -> Option<Vec<Cow<Self::Factory>>> {
+    ) -> Result<Vec<Cow<Self::Factory>>, String> {
         match magic_state_type {
             0 => self
                 .builder1

--- a/resource_estimator/src/estimates/factory/empty.rs
+++ b/resource_estimator/src/estimates/factory/empty.rs
@@ -32,7 +32,7 @@ impl<E: ErrorCorrection<Parameter = impl Clone>> FactoryBuilder<E> for NoFactori
         _magic_state_type: usize,
         _output_error_rate: f64,
         _max_code_parameter: &<E as ErrorCorrection>::Parameter,
-    ) -> Option<Vec<std::borrow::Cow<Self::Factory>>> {
+    ) -> Result<Vec<std::borrow::Cow<Self::Factory>>, String> {
         unreachable!()
     }
 

--- a/resource_estimator/src/estimates/factory/round_based.rs
+++ b/resource_estimator/src/estimates/factory/round_based.rs
@@ -83,7 +83,7 @@ impl<P: Clone> DistillationRound<P> {
         let mut upper = self.num_units;
         let mut lower = self.num_units / 2;
         while lower < upper {
-            self.num_units = (lower + upper) / 2;
+            self.num_units = u64::midpoint(lower, upper);
             let num_output_ts = self.compute_num_output_states(failure_probability);
             if num_output_ts >= output_states_needed_next {
                 upper = self.num_units;

--- a/resource_estimator/src/estimates/physical_estimation.rs
+++ b/resource_estimator/src/estimates/physical_estimation.rs
@@ -131,12 +131,15 @@ impl<
         // error budget for magic states by the number of magic states required
         // for the algorithm.
         let required_logical_magic_state_error_rate = error_budget.magic_states()
-            / (self.layout_overhead.num_magic_states(error_budget, 0) as f64);
+            / (self
+                .layout_overhead
+                .num_magic_states(error_budget, 0)
+                .map_err(Error::NumberOfMagicStatesComputationFailed)? as f64);
 
         let required_logical_error_rate = self.required_logical_error_rate(
             error_budget.logical(),
             num_cycles_required_by_layout_overhead,
-        );
+        )?;
 
         let min_code_parameter = self.compute_code_parameter(required_logical_error_rate)?;
 
@@ -165,7 +168,10 @@ impl<
             required_logical_magic_state_error_rate,
         } = self.compute_initial_optimization_values(error_budget)?;
 
-        let num_magic_states = self.layout_overhead.num_magic_states(error_budget, 0);
+        let num_magic_states = self
+            .layout_overhead
+            .num_magic_states(error_budget, 0)
+            .map_err(Error::NumberOfMagicStatesComputationFailed)?;
         if num_magic_states == 0 {
             let logical_patch =
                 LogicalPatch::new(&self.ftp, min_code_parameter, self.qubit.clone())?;
@@ -173,13 +179,13 @@ impl<
             if num_cycles_required_by_layout_overhead * logical_patch.logical_cycle_time()
                 <= max_duration_in_nanoseconds
             {
-                return Ok(PhysicalResourceEstimationResult::without_factories(
+                return PhysicalResourceEstimationResult::without_factories(
                     self,
                     logical_patch,
                     error_budget,
                     num_cycles_required_by_layout_overhead,
                     required_logical_error_rate,
-                ));
+                );
             }
             return Err(Error::MaxDurationTooSmall);
         }
@@ -254,7 +260,7 @@ impl<
                     &factory,
                     error_budget,
                     max_num_cycles_allowed,
-                );
+                )?;
 
                 let num_cycles_required_for_magic_states = self
                     .compute_num_cycles_required_for_magic_states(
@@ -263,7 +269,7 @@ impl<
                         &factory,
                         &logical_patch,
                         error_budget,
-                    );
+                    )?;
 
                 // This num_cycles could be larger than num_cycles_required_by_layout_overhead
                 // but must still not exceed the maximum number of cycles allowed by the
@@ -289,7 +295,7 @@ impl<
                         required_logical_magic_state_error_rate,
                     ))],
                     required_logical_error_rate,
-                );
+                )?;
 
                 if best_estimation_result
                     .as_ref()
@@ -320,18 +326,21 @@ impl<
             required_logical_magic_state_error_rate,
         } = self.compute_initial_optimization_values(error_budget)?;
 
-        let num_magic_states = self.layout_overhead.num_magic_states(error_budget, 0);
+        let num_magic_states = self
+            .layout_overhead
+            .num_magic_states(error_budget, 0)
+            .map_err(Error::NumberOfMagicStatesComputationFailed)?;
         if num_magic_states == 0 {
             let logical_patch =
                 LogicalPatch::new(&self.ftp, min_code_parameter, self.qubit.clone())?;
-            if self.num_algorithmic_physical_qubits(&logical_patch) <= max_num_qubits {
-                return Ok(PhysicalResourceEstimationResult::without_factories(
+            if self.num_algorithmic_physical_qubits(&logical_patch)? <= max_num_qubits {
+                return PhysicalResourceEstimationResult::without_factories(
                     self,
                     logical_patch,
                     error_budget,
                     num_cycles_required_by_layout_overhead,
                     required_logical_error_rate,
-                ));
+                );
             }
             return Err(Error::MaxPhysicalQubitsTooSmall);
         }
@@ -354,7 +363,7 @@ impl<
                 LogicalPatch::new(&self.ftp, code_parameter.clone(), self.qubit.clone())?;
 
             let physical_qubits_for_algorithm =
-                self.num_algorithmic_physical_qubits(&logical_patch);
+                self.num_algorithmic_physical_qubits(&logical_patch)?;
             if max_num_qubits <= physical_qubits_for_algorithm {
                 continue;
             }
@@ -412,7 +421,7 @@ impl<
                         &factory,
                         &logical_patch,
                         error_budget,
-                    );
+                    )?;
 
                 let num_cycles = num_cycles_required_for_magic_states
                     .max(num_cycles_required_by_layout_overhead);
@@ -439,7 +448,7 @@ impl<
                         required_logical_magic_state_error_rate,
                     ))],
                     required_logical_error_rate,
-                );
+                )?;
 
                 if best_estimation_result
                     .as_ref()
@@ -463,16 +472,17 @@ impl<
         factory: &Builder::Factory,
         logical_patch: &LogicalPatch<E>,
         error_budget: &ErrorBudget,
-    ) -> u64 {
+    ) -> Result<u64, Error> {
         let magic_states_per_run = num_factories * factory.num_output_states();
 
         let required_runs = self
             .layout_overhead
             .num_magic_states(error_budget, magic_state_index)
+            .map_err(Error::NumberOfMagicStatesComputationFailed)?
             .div_ceil(magic_states_per_run);
 
         let required_duration = required_runs * factory.duration();
-        required_duration.div_ceil(logical_patch.logical_cycle_time())
+        Ok(required_duration.div_ceil(logical_patch.logical_cycle_time()))
     }
 
     fn try_pick_factory_below_or_equal_num_qubits<'a>(
@@ -516,19 +526,24 @@ impl<
 
     /// Computes the number of algorithmic physical qubits given the layout
     /// overhead and a logical patch
-    fn num_algorithmic_physical_qubits(&self, patch: &LogicalPatch<E>) -> u64 {
+    fn num_algorithmic_physical_qubits(&self, patch: &LogicalPatch<E>) -> Result<u64, Error> {
         // the number of logical patches required for the algorithm given
         // a logical patch
         let num_logical_patches = self
             .layout_overhead
             .logical_qubits()
+            .map_err(Error::AlgorithmicLogicalQubitsComputationFailed)?
             .div_ceil(patch.logical_qubits());
 
-        num_logical_patches * patch.physical_qubits()
+        Ok(num_logical_patches * patch.physical_qubits())
     }
 
-    fn volume(&self, num_cycles: u64) -> u64 {
-        self.layout_overhead.logical_qubits() * num_cycles
+    fn volume(&self, num_cycles: u64) -> Result<u64, Error> {
+        Ok(self
+            .layout_overhead
+            .logical_qubits()
+            .map_err(Error::AlgorithmicLogicalQubitsComputationFailed)?
+            * num_cycles)
     }
 
     /// Computes required logical error rate for a logical operation one one
@@ -537,8 +552,12 @@ impl<
     /// The logical volume is the number of logical qubits times the number of
     /// cycles.  We obtain the required logical error rate by dividing the error
     /// budget for logical operations by the volume.
-    fn required_logical_error_rate(&self, logical_error_budget: f64, num_cycles: u64) -> f64 {
-        logical_error_budget / self.volume(num_cycles) as f64
+    fn required_logical_error_rate(
+        &self,
+        logical_error_budget: f64,
+        num_cycles: u64,
+    ) -> Result<f64, Error> {
+        Ok(logical_error_budget / self.volume(num_cycles)? as f64)
     }
 
     /// Computes the code parameter for the required logical error rate
@@ -560,16 +579,22 @@ impl<
             .logical_error_rate(&self.qubit, code_parameter)
             .map_err(Error::LogicalErrorRateComputationFailed)?;
 
-        Ok(
-            (logical_error_budget / (self.layout_overhead.logical_qubits() as f64 * error_rate))
-                .floor() as u64,
-        )
+        Ok((logical_error_budget
+            / (self
+                .layout_overhead
+                .logical_qubits()
+                .map_err(Error::AlgorithmicLogicalQubitsComputationFailed)? as f64
+                * error_rate))
+            .floor() as u64)
     }
 
     // Possibly adjusts number of cycles C from initial starting point C_min
     fn compute_num_cycles(&self, error_budget: &ErrorBudget) -> Result<u64, Error> {
         // Start loop with C = C_min
-        let mut num_cycles = self.layout_overhead.logical_depth(error_budget);
+        let mut num_cycles = self
+            .layout_overhead
+            .logical_depth(error_budget)
+            .map_err(Error::AlgorithmicLogicalDepthComputationFailed)?;
 
         // Perform logical depth scaling if given by constraint
         if let Some(logical_depth_scaling) = self.logical_depth_factor {
@@ -578,10 +603,17 @@ impl<
         }
 
         // We cannot perform resource estimation when there are neither magic states nor cycles
-        if num_cycles == 0
-            && (0..self.factory_builder.num_magic_state_types())
-                .all(|index| self.layout_overhead.num_magic_states(error_budget, index) == 0)
-        {
+        if num_cycles == 0 {
+            for index in 0..self.factory_builder.num_magic_state_types() {
+                if self
+                    .layout_overhead
+                    .num_magic_states(error_budget, index)
+                    .map_err(Error::NumberOfMagicStatesComputationFailed)?
+                    > 0
+                {
+                    return Ok(num_cycles);
+                }
+            }
             return Err(Error::AlgorithmHasNoResources);
         }
 
@@ -598,26 +630,29 @@ impl<
         factory: &Builder::Factory,
         error_budget: &ErrorBudget,
         num_cycles: u64,
-    ) -> u64 {
+    ) -> Result<u64, Error> {
         // first, try with the exact calculation; if that does not work, use
         // floating-point arithmetic, which may cause numeric imprecision
         if let Some(total_duration) = num_cycles.checked_mul(logical_patch.logical_cycle_time()) {
             // number of magic states that one factory can compute in num_cycles
             let num_states_per_run =
                 (total_duration / factory.duration()) * factory.num_output_states();
-            self.layout_overhead
+            Ok(self
+                .layout_overhead
                 .num_magic_states(error_budget, magic_state_index)
-                .div_ceil(num_states_per_run)
+                .map_err(Error::NumberOfMagicStatesComputationFailed)?
+                .div_ceil(num_states_per_run))
         } else {
             let magic_states_per_cycles =
                 self.layout_overhead
-                    .num_magic_states(error_budget, magic_state_index) as f64
+                    .num_magic_states(error_budget, magic_state_index)
+                    .map_err(Error::NumberOfMagicStatesComputationFailed)? as f64
                     / (factory.num_output_states() * num_cycles) as f64;
 
             let factory_duration_fraction =
                 factory.duration() as f64 / logical_patch.logical_cycle_time() as f64;
 
-            (magic_states_per_cycles * factory_duration_fraction).ceil() as _
+            Ok((magic_states_per_cycles * factory_duration_fraction).ceil() as _)
         }
     }
 }

--- a/resource_estimator/src/estimates/physical_estimation.rs
+++ b/resource_estimator/src/estimates/physical_estimation.rs
@@ -242,9 +242,7 @@ impl<
                         required_logical_magic_state_error_rate,
                         &code_parameter,
                     )
-                    .ok_or(Error::CannotComputeMagicStates(
-                        required_logical_magic_state_error_rate,
-                    ))?;
+                    .map_err(Error::FactorySearchFailed)?;
 
                 last_code_parameter = self.find_highest_code_parameter(&last_factories);
             }
@@ -395,9 +393,7 @@ impl<
                         required_logical_magic_state_error_rate,
                         &code_parameter,
                     )
-                    .ok_or(Error::CannotComputeMagicStates(
-                        required_logical_magic_state_error_rate,
-                    ))?;
+                    .map_err(Error::FactorySearchFailed)?;
 
                 last_code_parameter = self.find_highest_code_parameter(&last_factories);
             }

--- a/resource_estimator/src/estimates/physical_estimation/estimate_frontier.rs
+++ b/resource_estimator/src/estimates/physical_estimation/estimate_frontier.rs
@@ -34,15 +34,18 @@ impl<
             let min_cycles = estimator.compute_num_cycles(error_budget)?;
 
             let required_logical_error_rate =
-                estimator.required_logical_error_rate(error_budget.logical(), min_cycles);
+                estimator.required_logical_error_rate(error_budget.logical(), min_cycles)?;
+
+            let num_magic_states = estimator
+                .layout_overhead
+                .num_magic_states(error_budget, 0)
+                .map_err(Error::NumberOfMagicStatesComputationFailed)?;
 
             // The required magic state error rate is computed by dividing the total
             // error budget for magic states by the number of magic states required
             // for the algorithm.
-            let required_logical_magic_state_error_rate = error_budget.magic_states()
-                / estimator.layout_overhead.num_magic_states(error_budget, 0) as f64;
-
-            let num_magic_states = estimator.layout_overhead.num_magic_states(error_budget, 0);
+            let required_logical_magic_state_error_rate =
+                error_budget.magic_states() / num_magic_states as f64;
 
             Ok(Self {
                 estimator,
@@ -70,7 +73,7 @@ impl<
                 &self.error_budget,
                 self.min_cycles,
                 self.required_logical_error_rate,
-            )]);
+            )?]);
         }
 
         let mut best_estimation_results = Population::new();
@@ -166,7 +169,7 @@ impl<
                 &factory,
                 &self.error_budget,
                 max_num_cycles_allowed,
-            );
+            )?;
 
             for num_factories in min_num_factories.. {
                 let num_cycles_required_for_magic_states = self
@@ -176,7 +179,7 @@ impl<
                         factory.as_ref(),
                         &logical_patch,
                         &self.error_budget,
-                    );
+                    )?;
 
                 // This num_cycles could be larger than min_cycles but must
                 // still not exceed the maximum number of cycles allowed by the
@@ -198,7 +201,7 @@ impl<
                     num_cycles,
                     vec![Some(factory_part)],
                     self.required_logical_error_rate,
-                );
+                )?;
 
                 let physical_qubits = result.physical_qubits() as f64;
                 let runtime = result.runtime();

--- a/resource_estimator/src/estimates/physical_estimation/estimate_frontier.rs
+++ b/resource_estimator/src/estimates/physical_estimation/estimate_frontier.rs
@@ -106,9 +106,7 @@ impl<
                         self.required_logical_magic_state_error_rate,
                         &code_parameter,
                     )
-                    .ok_or(Error::CannotComputeMagicStates(
-                        self.required_logical_magic_state_error_rate,
-                    ))?;
+                    .map_err(Error::FactorySearchFailed)?;
 
                 last_code_parameter = self.find_highest_code_parameter(&last_factories);
             }

--- a/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
+++ b/resource_estimator/src/estimates/physical_estimation/estimate_without_restrictions.rs
@@ -144,9 +144,7 @@ impl<
                 required_logical_magic_state_error_rate,
                 logical_patch.code_parameter(),
             )
-            .ok_or(Error::CannotComputeMagicStates(
-                required_logical_magic_state_error_rate,
-            ))?;
+            .map_err(Error::FactorySearchFailed)?;
 
         if factories.is_empty() {
             return Ok(FactoryPartsResult::NoFactories);

--- a/resource_estimator/src/system/data/logical_counts.rs
+++ b/resource_estimator/src/system/data/logical_counts.rs
@@ -52,30 +52,32 @@ pub struct LogicalResourceCounts {
 /// gates per rotation are specified.
 impl Overhead for LogicalResourceCounts {
     // number of qubits per one logical qubit (part of Q in paper)
-    fn logical_qubits(&self) -> u64 {
+    fn logical_qubits(&self) -> Result<u64, String> {
         // number of logical qubits for padding (part of Q in paper)
         let qubit_padding = ((8 * self.num_qubits) as f64).sqrt().ceil() as u64 + 1;
 
-        2 * self.num_qubits + qubit_padding
+        Ok(2 * self.num_qubits + qubit_padding)
     }
 
-    fn logical_depth(&self, budget: &ErrorBudget) -> u64 {
-        (self.measurement_count + self.rotation_count + self.t_count) * NUM_MEASUREMENTS_PER_R
-            + (self.ccz_count + self.ccix_count) * NUM_MEASUREMENTS_PER_TOF
-            + self
-                .num_ts_per_rotation(budget.rotations())
-                .unwrap_or_default()
-                * self.rotation_depth
-                * NUM_MEASUREMENTS_PER_R
+    fn logical_depth(&self, budget: &ErrorBudget) -> Result<u64, String> {
+        Ok(
+            (self.measurement_count + self.rotation_count + self.t_count) * NUM_MEASUREMENTS_PER_R
+                + (self.ccz_count + self.ccix_count) * NUM_MEASUREMENTS_PER_TOF
+                + self
+                    .num_ts_per_rotation(budget.rotations())
+                    .unwrap_or_default()
+                    * self.rotation_depth
+                    * NUM_MEASUREMENTS_PER_R,
+        )
     }
 
-    fn num_magic_states(&self, budget: &ErrorBudget, _index: usize) -> u64 {
-        4 * (self.ccz_count + self.ccix_count)
+    fn num_magic_states(&self, budget: &ErrorBudget, _index: usize) -> Result<u64, String> {
+        Ok(4 * (self.ccz_count + self.ccix_count)
             + self.t_count
             + self
                 .num_ts_per_rotation(budget.rotations())
                 .unwrap_or_default()
-                * self.rotation_count
+                * self.rotation_count)
     }
 
     fn prune_error_budget(&self, budget: &mut ErrorBudget, strategy: ErrorBudgetStrategy) {

--- a/resource_estimator/src/system/optimization/code_distance_iterators.rs
+++ b/resource_estimator/src/system/optimization/code_distance_iterators.rs
@@ -36,7 +36,7 @@ pub fn search_for_code_distances(
             mid[cur_round - 1]
         };
         while left[cur_round] + 1 < right[cur_round] {
-            mid[cur_round] = (left[cur_round] + right[cur_round]) / 2;
+            mid[cur_round] = usize::midpoint(left[cur_round], right[cur_round]);
             if check_if_can_improve_with_increasing_code_distances(&mid) {
                 left[cur_round] = mid[cur_round] + 1;
             } else {

--- a/resource_estimator/src/system/optimization/tfactory_exhaustive.rs
+++ b/resource_estimator/src/system/optimization/tfactory_exhaustive.rs
@@ -384,8 +384,8 @@ impl FactoryBuilder<Protocol> for TFactoryBuilder {
         _magic_state_type: usize,
         output_t_error_rate: f64,
         max_code_distance: &u64,
-    ) -> Option<Vec<Cow<Self::Factory>>> {
-        Some(find_nondominated_tfactories(
+    ) -> Result<Vec<Cow<Self::Factory>>, String> {
+        Ok(find_nondominated_tfactories(
             ftp,
             qubit,
             &self.distillation_unit_templates,

--- a/resource_estimator/src/system/tests.rs
+++ b/resource_estimator/src/system/tests.rs
@@ -22,7 +22,7 @@ use crate::system::{
     modeling::GateBasedPhysicalQubit,
     modeling::{PhysicalQubit, Protocol, TFactory},
     optimization::TFactoryBuilder,
-    Result,
+    Error,
 };
 
 use std::{borrow::Cow, rc::Rc};
@@ -122,16 +122,16 @@ impl TestLayoutOverhead {
 }
 
 impl Overhead for TestLayoutOverhead {
-    fn logical_qubits(&self) -> u64 {
-        self.num_qubits
+    fn logical_qubits(&self) -> Result<u64, String> {
+        Ok(self.num_qubits)
     }
 
-    fn logical_depth(&self, _: &ErrorBudget) -> u64 {
-        self.logical_depth
+    fn logical_depth(&self, _: &ErrorBudget) -> Result<u64, String> {
+        Ok(self.logical_depth)
     }
 
-    fn num_magic_states(&self, _: &ErrorBudget, _: usize) -> u64 {
-        self.num_tstates
+    fn num_magic_states(&self, _: &ErrorBudget, _: usize) -> Result<u64, String> {
+        Ok(self.num_tstates)
     }
 }
 
@@ -154,7 +154,7 @@ pub fn test_no_tstates() {
 }
 
 #[test]
-pub fn single_tstate() -> Result<()> {
+pub fn single_tstate() -> Result<(), Error> {
     let ftp = surface_code_gate_based();
     let qubit = Rc::new(PhysicalQubit::default());
 
@@ -174,7 +174,7 @@ pub fn single_tstate() -> Result<()> {
 }
 
 #[test]
-pub fn perfect_tstate() -> Result<()> {
+pub fn perfect_tstate() -> Result<(), Error> {
     let ftp = surface_code_gate_based();
     let qubit = Rc::new(PhysicalQubit::GateBased(GateBasedPhysicalQubit {
         t_gate_error_rate: 0.5e-4,
@@ -196,7 +196,7 @@ pub fn perfect_tstate() -> Result<()> {
     Ok(())
 }
 
-fn hubbard_overhead_and_partitioning() -> Result<(LogicalResourceCounts, ErrorBudget)> {
+fn hubbard_overhead_and_partitioning() -> Result<(LogicalResourceCounts, ErrorBudget), Error> {
     let logical_counts =
         serde_json::from_str(include_str!("counts.json")).map_err(IO::CannotParseJSON)?;
     let partitioning = ErrorBudgetSpecification::Total(1e-3)
@@ -225,7 +225,7 @@ fn validate_result_invariants(result: &PhysicalResourceEstimationResult<Protocol
 
 #[allow(clippy::too_many_lines)]
 #[test]
-pub fn test_hubbard_e2e() -> Result<()> {
+pub fn test_hubbard_e2e() -> Result<(), Error> {
     let ftp = surface_code_gate_based();
     let qubit = Rc::new(PhysicalQubit::default());
     let (layout_overhead, partitioning) = hubbard_overhead_and_partitioning()?;
@@ -321,7 +321,7 @@ pub fn test_hubbard_e2e() -> Result<()> {
 
 #[allow(clippy::too_many_lines)]
 #[test]
-pub fn test_hubbard_e2e_measurement_based() -> Result<()> {
+pub fn test_hubbard_e2e_measurement_based() -> Result<(), Error> {
     let ftp = floquet_code();
     let qubit = Rc::new(PhysicalQubit::qubit_maj_ns_e6());
     let (layout_overhead, partitioning) = hubbard_overhead_and_partitioning()?;
@@ -414,7 +414,7 @@ pub fn test_hubbard_e2e_measurement_based() -> Result<()> {
 }
 
 #[test]
-pub fn test_hubbard_e2e_increasing_max_duration() -> Result<()> {
+pub fn test_hubbard_e2e_increasing_max_duration() -> Result<(), Error> {
     let ftp = floquet_code();
     let qubit = Rc::new(PhysicalQubit::qubit_maj_ns_e6());
     let (layout_overhead, partitioning) = hubbard_overhead_and_partitioning()?;
@@ -443,7 +443,7 @@ pub fn test_hubbard_e2e_increasing_max_duration() -> Result<()> {
 }
 
 #[test]
-pub fn test_hubbard_e2e_increasing_max_num_qubits() -> Result<()> {
+pub fn test_hubbard_e2e_increasing_max_num_qubits() -> Result<(), Error> {
     let ftp = floquet_code();
     let qubit = Rc::new(PhysicalQubit::qubit_maj_ns_e6());
     let (layout_overhead, partitioning) = hubbard_overhead_and_partitioning()?;
@@ -525,7 +525,7 @@ pub fn test_chemistry_small_max_num_qubits() {
 }
 
 #[test]
-pub fn test_chemistry_based_max_duration() -> Result<()> {
+pub fn test_chemistry_based_max_duration() -> Result<(), Error> {
     let max_duration_in_nanoseconds: u64 = 365 * 24 * 3600 * 1_000_000_000_u64;
 
     let (estimation, budget) = prepare_chemistry_estimation_with_expected_majorana();
@@ -582,7 +582,7 @@ pub fn test_chemistry_based_max_duration() -> Result<()> {
 }
 
 #[test]
-pub fn test_chemistry_based_max_num_qubits() -> Result<()> {
+pub fn test_chemistry_based_max_num_qubits() -> Result<(), Error> {
     let max_num_qubits: u64 = 4_923_120;
 
     let (estimation, budget) = prepare_chemistry_estimation_with_expected_majorana();
@@ -666,7 +666,7 @@ fn prepare_factorization_estimation_with_optimistic_majorana() -> (
 }
 
 #[test]
-pub fn test_factorization_2048_max_duration_matches_regular_estimate() -> Result<()> {
+pub fn test_factorization_2048_max_duration_matches_regular_estimate() -> Result<(), Error> {
     let (estimation, budget) = prepare_factorization_estimation_with_optimistic_majorana();
 
     let result_no_max_duration = estimation.estimate_without_restrictions(&budget)?;
@@ -718,7 +718,7 @@ pub fn test_factorization_2048_max_duration_matches_regular_estimate() -> Result
 }
 
 #[test]
-pub fn test_factorization_2048_max_num_qubits_matches_regular_estimate() -> Result<()> {
+pub fn test_factorization_2048_max_num_qubits_matches_regular_estimate() -> Result<(), Error> {
     let (estimation, budget) = prepare_factorization_estimation_with_optimistic_majorana();
 
     let result_no_max_num_qubits = estimation.estimate_without_restrictions(&budget)?;


### PR DESCRIPTION
This changes return types for methods in the `Overhead` and `FactoryBuilder` trait from `T` to `Result<T, resource_estimator::estimates::Error>`.

No implementation of this `Overhead` and `FactoryBuilder` trait returns an error; therefore, the behavior of RE for the default system architecture does not change. However, when implementing the traits to extend the resource estimator, the new signature allows more flexibility and allows users of the implementation to see errors.