### PR TITLE
Added OpenQASM samples into the VSCode Playground

### DIFF
--- a/vscode/src/memfs.ts
+++ b/vscode/src/memfs.ts
@@ -70,7 +70,7 @@ function populateSamplesFolder(
     const sanitized_file_name = sample.title.replace(/\W/g, ""); // Remove non-word characters
     vfs.writeFile(
       playgroundRootUri.with({
-        path: `/${folder}/${sanitized_file_name}.${extension}`,
+        path: `/${folder}/${sanitized_file_name}${extension}`,
       }),
       encoder.encode(sample.code),
       { create: true, overwrite: true },

--- a/vscode/src/memfs.ts
+++ b/vscode/src/memfs.ts
@@ -18,8 +18,8 @@ const playgroundReadme = `
 Welcome to the Azure Quantum Development Kit playground! An online environment to
 safely learn and explore quantum computing with the Q# language.
 
-The samples_qsharp folder contains a set of common quantum algorithms written in Q#.
-The samples_openqasm folder contains several quantum programs written in OpenQASM.
+The 'Samples (Q#)' folder contains a set of common quantum algorithms written in Q#.
+The 'Samples (OpenQASM)' folder contains several quantum programs written in OpenQASM.
 You can run these samples by clicking the "Run" button in the top right corner
 of the editor when you have the file open. You can also set breakpoints and
 step through the code using the Debug button at the same location to see how the

--- a/vscode/src/memfs.ts
+++ b/vscode/src/memfs.ts
@@ -43,11 +43,11 @@ function populateSamples(vfs: MemFS) {
   vfs.addAuthority(playgroundAuthority);
 
   const encoder = new TextEncoder();
-  populateSamplesFolder(vfs, encoder, "samples_qsharp", samples, ".qs");
+  populateSamplesFolder(vfs, encoder, "Samples (Q#)", samples, ".qs");
   populateSamplesFolder(
     vfs,
     encoder,
-    "samples_openqasm",
+    "Samples (OpenQASM)",
     openqasm_samples,
     ".qasm",
   );

--- a/vscode/src/memfs.ts
+++ b/vscode/src/memfs.ts
@@ -18,7 +18,8 @@ const playgroundReadme = `
 Welcome to the Azure Quantum Development Kit playground! An online environment to
 safely learn and explore quantum computing with the Q# language.
 
-The samples folder contains a set of common quantum algorithms written in Q#.
+The samples_qsharp folder contains a set of common quantum algorithms written in Q#.
+The samples_openqasm folder contains several quantum programs written in OpenQASM.
 You can run these samples by clicking the "Run" button in the top right corner
 of the editor when you have the file open. You can also set breakpoints and
 step through the code using the Debug button at the same location to see how the

--- a/vscode/src/memfs.ts
+++ b/vscode/src/memfs.ts
@@ -34,7 +34,7 @@ visit <https://aka.ms/AQ/Documentation>.
 `;
 
 // Type of a generated sample entry.
-type SampleTy = typeof samples[number];
+type SampleTy = (typeof samples)[number];
 
 function populateSamples(vfs: MemFS) {
   // Put the playground in its own 'authority', so we can keep the default space clean.
@@ -43,7 +43,13 @@ function populateSamples(vfs: MemFS) {
 
   const encoder = new TextEncoder();
   populateSamplesFolder(vfs, encoder, "samples_qsharp", samples, ".qs");
-  populateSamplesFolder(vfs, encoder, "samples_openqasm", openqasm_samples, ".qasm");
+  populateSamplesFolder(
+    vfs,
+    encoder,
+    "samples_openqasm",
+    openqasm_samples,
+    ".qasm",
+  );
 
   vfs.writeFile(
     playgroundRootUri.with({ path: "/README.md" }),
@@ -57,15 +63,17 @@ function populateSamplesFolder(
   encoder: TextEncoder,
   folder: string,
   samples: SampleTy[],
-  extension: string) {
-
+  extension: string,
+) {
   vfs.createDirectory(playgroundRootUri.with({ path: `/${folder}` }));
   samples.forEach((sample) => {
     const sanitized_file_name = sample.title.replace(/\W/g, ""); // Remove non-word characters
     vfs.writeFile(
-      playgroundRootUri.with({ path: `/${folder}/${sanitized_file_name}.${extension}` }),
+      playgroundRootUri.with({
+        path: `/${folder}/${sanitized_file_name}.${extension}`,
+      }),
       encoder.encode(sample.code),
-      { create: true, overwrite: true }
+      { create: true, overwrite: true },
     );
   });
 }


### PR DESCRIPTION
Added OpenQASM samples into the VSCode Playground
- OpenQASM samples added to "Samples (OpenQASM)" folder
- Existing folder with Q# samples is renamed to "Samples (Q#)"

![image](https://github.com/user-attachments/assets/32edfe7a-d2cd-4be5-a412-42a92ff386ea)

