### PR TITLE
make the lightbulb show up for 'qdk command error'

### DIFF
--- a/vscode/src/diagnostics.ts
+++ b/vscode/src/diagnostics.ts
@@ -104,6 +104,7 @@ function startCommandDiagnostics(): vscode.Disposable[] {
         if (commandErrors.length > 0) {
           const action = new vscode.CodeAction(
             "Dismiss errors for the last run QDK command",
+            vscode.CodeActionKind.QuickFix, // makes the lightbulb reliably show up
           );
           action.diagnostics = commandErrors;
           action.command = {


### PR DESCRIPTION
Something changed in VS Code where this error is no longer dismissable by clicking the lightbulb - this fixes it.