### PR TITLE
Log token budget and usage for Copilot tools

### DIFF
--- a/npm/qsharp/src/workers/common.ts
+++ b/npm/qsharp/src/workers/common.ts
@@ -206,7 +206,7 @@ export function createProxyInternal<
     }
     if (!curr) {
       // Nothing else queued, signal that we're now idle and exit.
-      log.debug("Proxy: Worker queue is empty");
+      log.trace("Proxy: Worker queue is empty");
       setState("idle");
       return;
     }
@@ -216,7 +216,7 @@ export function createProxyInternal<
       setState("busy");
     }
 
-    log.debug("Proxy: Posting message to worker: %o", msg);
+    log.trace("Proxy: Posting message to worker: %o", msg);
     postMessage(msg);
   }
 
@@ -227,7 +227,7 @@ export function createProxyInternal<
       | CommonEventMessage,
   ) {
     if (log.getLogLevel() >= 4)
-      log.debug("Proxy: Received message from worker: %s", JSON.stringify(msg));
+      log.trace("Proxy: Received message from worker: %s", JSON.stringify(msg));
 
     if (msg.messageType === "common-event") {
       const commonEvent = msg; // assignment is necessary here for TypeScript to narrow the type
@@ -249,7 +249,7 @@ export function createProxyInternal<
       const event = new Event(msg.type) as Event & TServiceEventMsg;
       event.detail = msg.detail;
 
-      log.debug("Proxy: Posting event: %o", msg);
+      log.trace("Proxy: Posting event: %o", msg);
       // Post to a currently attached event target if there's a "requestWithProgress"
       // in progress
       curr?.requestEventTarget?.dispatchEvent(event);
@@ -323,7 +323,7 @@ export function createProxyInternal<
     // Kill the worker without a chance to shutdown. May be needed if it is not responding.
     log.info("Proxy: Terminating the worker");
     if (curr) {
-      log.debug(
+      log.trace(
         "Proxy: Terminating running worker item of type: %s",
         curr.type,
       );
@@ -332,7 +332,7 @@ export function createProxyInternal<
     // Reject any outstanding items
     while (queue.length) {
       const item = queue.shift();
-      log.debug(
+      log.trace(
         "Proxy: Terminating outstanding work item of type: %s",
         item?.type,
       );
@@ -366,12 +366,12 @@ function createDispatcher<
   methods: MethodMap<TService>,
   eventNames: TServiceEventMsg["type"][],
 ): (req: RequestMessage<TService>) => Promise<void> {
-  log.debug("Worker: Constructing WorkerEventHandler");
+  log.trace("Worker: Constructing WorkerEventHandler");
 
   function logAndPost(
     msg: ResponseMessage<TService> | EventMessage<TServiceEventMsg>,
   ) {
-    log.debug(
+    log.trace(
       "Worker: Sending %s message from worker: %o",
       msg.messageType,
       msg,


### PR DESCRIPTION
This way we can keep an eye on how various use cases and instructions files affect the token budget for our tools.

While this number doesn't give us true visibility into the internals of Copilot, like the global token budget, it may at least act as a rough indicator of how much context we're eating up.

Some numbers I gathered to help paint a picture:

- We seem to get about ~43000 tokens in our budget for each tool call. Every message in the conversation history seems to reduce this budget, but not by much - by about 2
- When we include our Q# instructions file in the context, the token budget seems to decrease about ~500 tokens
- Claude talks more than GPT 4.1, thereby reducing our budget slightly 🙄 
- A typical short output, like the circuit from a Bell state program) takes up ~200 tokens