### PR TITLE
Set to .qasm is code link includes the OPENQASM version

### DIFF
--- a/vscode/src/memfs.ts
+++ b/vscode/src/memfs.ts
@@ -131,7 +131,11 @@ export async function initFileSystem(context: vscode.ExtensionContext) {
             log.debug("code from query: " + code);
             try {
               linkedCode = await compressedBase64ToCode(code);
-              const codeFile = vscode.Uri.parse(`${scheme}:/code.qs`);
+              const isQasm = /^OPENQASM [\d.]+;$/gm.test(linkedCode);
+
+              const codeFile = vscode.Uri.parse(
+                `${scheme}:/code.${isQasm ? "qasm" : "qs"}`,
+              );
 
               const encoder = new TextEncoder();
               vfs.writeFile(codeFile, encoder.encode(linkedCode), {


### PR DESCRIPTION
If a code share link to the playground includes the OPENQASM version line, give it a .qasm extension instead of .qs.