### PR TITLE
Add timestamp check to `generate_katas_content.js`

### DIFF
--- a/npm/qsharp/package.json
+++ b/npm/qsharp/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "build": "npm run docs && npm run generate && npm run build:tsc",
     "generate": "node generate_katas_content.js && node generate_samples_content.js",
+    "generate:force": "node generate_katas_content.js --force && node generate_samples_content.js",
     "docs": "node generate_docs.js",
     "build:tsc": "node ../../node_modules/typescript/bin/tsc -p ./src/tsconfig.json",
     "tsc:watch": "node ../../node_modules/typescript/bin/tsc -p ./src/tsconfig.json --watch --preserveWatchOutput",


### PR DESCRIPTION

This change improves the local dev loop by skipping content generation when kata files haven't changed.

* Regular builds now skip unnecessary regeneration: `./build.py` or `npm run build`
* When you need to force regeneration: `npm run generate:force`

To keep the build script simple, I chose to leave in the timestamp checks for CI builds, rather than plumbing up the `-f` flag to a bunch of places. 