### PR TITLE
Remove Author Tags from the Generated Doc Metadata

### DIFF
--- a/compiler/qsc_doc_gen/src/generate_docs.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs.rs
@@ -56,8 +56,6 @@ impl Metadata {
 uid: {}
 title: {}
 description: {}
-author: {{AUTHOR}}
-ms.author: {{MS_AUTHOR}}
 ms.date: {{TIMESTAMP}}
 ms.topic: landing-page
 ---",

--- a/compiler/qsc_doc_gen/src/generate_docs/tests.rs
+++ b/compiler/qsc_doc_gen/src/generate_docs/tests.rs
@@ -148,8 +148,6 @@ fn index_file_generation() {
         uid: Qdk.Std.Core-toc
         title: Std.Core namespace
         description: Table of contents for the Q# Core namespace
-        author: {AUTHOR}
-        ms.author: {MS_AUTHOR}
         ms.date: {TIMESTAMP}
         ms.topic: landing-page
         ---
@@ -180,8 +178,6 @@ fn top_index_file_generation() {
         uid: Microsoft.Quantum.apiref-toc
         title: Q# standard libraries for the Azure Quantum Development Kit
         description: Table of contents for the Q# standard libraries for Azure Quantum Development Kit
-        author: {AUTHOR}
-        ms.author: {MS_AUTHOR}
         ms.date: {TIMESTAMP}
         ms.topic: landing-page
         ---


### PR DESCRIPTION
These tags are no longer used and should be removed from the metadata in the generated documentation.