### PR TITLE
Remove scheduled fuzzer runs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -11,8 +11,6 @@ env:
   SEEDS_RDPATH: fuzz/seed_inputs              # Fuzzing seed inputs rel dir path.
   SEEDS_FNAME: list.txt                       # Fuzzing seed inputs list file name.
 on:
-  schedule:                                   # Production runs against default branch.
-    - cron: '24 11 * * 0'                     # Run after 11:24 UTC (4:24am PDT/3:24am PST) on Sun.
   workflow_dispatch:                          # Manual runs.
   push:
     branches:


### PR DESCRIPTION
Now that the fuzzer consistently runs on any merge to main that edits the compiler (#498), we don't really need the scheduled runs.