### PR TITLE
Prevent Stepping into Circuit Files during Debug

### DIFF
--- a/compiler/qsc_frontend/src/compile.rs
+++ b/compiler/qsc_frontend/src/compile.rs
@@ -387,6 +387,9 @@ pub fn compile_ast(
     cond_compile.visit_package(&mut ast_package);
     let dropped_names = cond_compile.into_names();
 
+    let mut remove_spans = preprocess::RemoveCircuitSpans::new(&sources);
+    remove_spans.visit_package(&mut ast_package);
+
     let mut ast_assigner = AstAssigner::new();
     ast_assigner.visit_package(&mut ast_package);
     AstValidator::default().visit_package(&ast_package);

--- a/compiler/qsc_frontend/src/compile/preprocess.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess.rs
@@ -3,13 +3,17 @@
 
 use core::str::FromStr;
 use qsc_ast::{
-    ast::{Attr, ExprKind, Idents, ItemKind, Namespace, PathKind, Stmt, StmtKind, UnOp},
-    mut_visit::MutVisitor,
+    ast::{
+        Attr, ExprKind, Idents, ItemKind, Namespace, Package, PathKind, Stmt, StmtKind,
+        TopLevelNode, UnOp,
+    },
+    mut_visit::{walk_stmt, MutVisitor},
 };
+use qsc_data_structures::span::Span;
 use qsc_hir::hir;
 use std::rc::Rc;
 
-use super::TargetCapabilityFlags;
+use super::{SourceMap, TargetCapabilityFlags};
 
 #[cfg(test)]
 mod tests;
@@ -192,4 +196,76 @@ fn matches_config(attrs: &[Box<Attr>], capabilities: TargetCapabilityFlags) -> b
     }
     capabilities.contains(found_capabilities)
         && (disallowed_capabilities.is_empty() || !capabilities.contains(disallowed_capabilities))
+}
+
+// Visitor to remove spans from circuit callables defined in QSC files.
+// This will remove the spans for the contents of these circuit callables,
+// but it is important for the language server that the span for the callable itself
+// is preserved, so that the user can navigate to the definition of the callable.
+pub(crate) struct RemoveCircuitSpans {
+    qsc_spans: Vec<Span>,
+    inside_stmt: bool,
+}
+
+impl RemoveCircuitSpans {
+    pub(crate) fn new(sources: &SourceMap) -> Self {
+        let qsc_spans = sources
+            .iter()
+            .filter(|source| {
+                std::path::Path::new(source.name.as_ref())
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("qsc"))
+            })
+            .map(|source| {
+                let start = source.offset;
+                let end = start
+                    + u32::try_from(source.contents.len()).expect("source length exceeds u32::MAX");
+                Span { lo: start, hi: end }
+            })
+            .collect();
+
+        Self {
+            qsc_spans,
+            inside_stmt: false,
+        }
+    }
+}
+
+impl MutVisitor for RemoveCircuitSpans {
+    fn visit_package(&mut self, package: &mut Package) {
+        // We only want to visit namespaces
+        package.nodes.iter_mut().for_each(|n| match n {
+            TopLevelNode::Namespace(ns) => self.visit_namespace(ns),
+            TopLevelNode::Stmt(_) => {}
+        });
+    }
+
+    fn visit_namespace(&mut self, namespace: &mut Namespace) {
+        // We only want to visit circuit callables
+        namespace.items.iter_mut().for_each(|item| {
+            if let ItemKind::Callable(callable) = item.kind.as_mut() {
+                // Check if the callable's span is inside a QSC file's span
+                self.qsc_spans
+                    .iter()
+                    .any(|s| s.lo <= callable.span.lo && s.hi >= callable.span.hi)
+                    .then(|| {
+                        self.visit_callable_decl(callable);
+                    });
+            }
+        });
+    }
+
+    fn visit_stmt(&mut self, stmt: &mut Stmt) {
+        self.inside_stmt = true;
+        walk_stmt(self, stmt);
+        self.inside_stmt = false;
+    }
+
+    fn visit_span(&mut self, span: &mut Span) {
+        // Clear the span if it is inside a statement
+        if self.inside_stmt {
+            span.lo = Span::default().lo;
+            span.hi = Span::default().hi;
+        }
+    }
 }

--- a/compiler/qsc_frontend/src/compile/preprocess.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess.rs
@@ -204,7 +204,6 @@ fn matches_config(attrs: &[Box<Attr>], capabilities: TargetCapabilityFlags) -> b
 // is preserved, so that the user can navigate to the definition of the callable.
 pub(crate) struct RemoveCircuitSpans {
     qsc_spans: Vec<Span>,
-    inside_stmt: bool,
 }
 
 impl RemoveCircuitSpans {
@@ -224,10 +223,7 @@ impl RemoveCircuitSpans {
             })
             .collect();
 
-        Self {
-            qsc_spans,
-            inside_stmt: false,
-        }
+        Self { qsc_spans }
     }
 }
 
@@ -256,16 +252,7 @@ impl MutVisitor for RemoveCircuitSpans {
     }
 
     fn visit_stmt(&mut self, stmt: &mut Stmt) {
-        self.inside_stmt = true;
+        stmt.span = Span::default(); // Clear the span for the statement
         walk_stmt(self, stmt);
-        self.inside_stmt = false;
-    }
-
-    fn visit_span(&mut self, span: &mut Span) {
-        // Clear the span if it is inside a statement
-        if self.inside_stmt {
-            span.lo = Span::default().lo;
-            span.hi = Span::default().hi;
-        }
     }
 }

--- a/compiler/qsc_frontend/src/compile/preprocess/tests.rs
+++ b/compiler/qsc_frontend/src/compile/preprocess/tests.rs
@@ -1,8 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use qsc_ast::ast::{Attr, Expr, ExprKind, Ident, NodeId, Path, PathKind};
+use crate::compile::preprocess::RemoveCircuitSpans;
+use crate::compile::{parse_all, SourceMap};
+use qsc_ast::ast::{
+    Attr, CallableBody, CallableDecl, Expr, ExprKind, Ident, NodeId, Path, PathKind,
+};
+use qsc_ast::ast::{ItemKind, Package, TopLevelNode};
+use qsc_ast::mut_visit::MutVisitor;
+use qsc_data_structures::language_features::LanguageFeatures;
 use qsc_data_structures::span::Span;
+use std::sync::Arc;
 
 use crate::compile::{preprocess::matches_config, TargetCapabilityFlags};
 
@@ -51,6 +59,48 @@ fn name_value_attr(name: &str, value: &str) -> Attr {
         span: Span::default(),
         id: NodeId::default(),
     }
+}
+
+fn prepare_ast_for_circuit_tests() -> Package {
+    let circuit_source = (
+        Arc::from("circuit.qsc"),
+        Arc::from("namespace CircuitTest { operation Circuit(qs : Qubit[]) : Unit { X(qs[0]); } }"),
+    );
+    let qsharp_source = (
+        Arc::from("test.qs"),
+        Arc::from("namespace Test { operation Main(qs : Qubit[]) : Unit { X(qs[0]); } }"),
+    );
+    let sources = SourceMap::new([circuit_source, qsharp_source], None);
+    let (mut package, errs) = parse_all(&sources, LanguageFeatures::default());
+    assert!(errs.is_empty(), "{errs:?}");
+    let mut visitor = RemoveCircuitSpans::new(&sources);
+    visitor.visit_package(&mut package);
+    package
+}
+
+/// Helper to find a callable declaration by name in a package AST.
+fn find_callable<'a>(package: &'a Package, name: &str) -> &'a CallableDecl {
+    package
+        .nodes
+        .iter()
+        .find_map(|node| {
+            if let TopLevelNode::Namespace(ns) = node {
+                ns.items.iter().find_map(|item| {
+                    if let ItemKind::Callable(decl) = item.kind.as_ref() {
+                        if decl.name.name.as_ref() == name {
+                            Some(decl.as_ref())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| panic!("{name} callable not found"))
 }
 
 #[test]
@@ -131,4 +181,58 @@ fn unrestricted_attrs_matches_all() {
         &[Box::new(name_value_attr("Config", "Unrestricted"))],
         TargetCapabilityFlags::all()
     ));
+}
+
+#[test]
+fn remove_circuit_spans_clears_stmt_spans_in_qsc_files() {
+    let ast = prepare_ast_for_circuit_tests();
+    let circuit_callable = find_callable(&ast, "Circuit");
+
+    // Assert the callable declaration has a non-default span
+    assert_ne!(
+        circuit_callable.span,
+        Span::default(),
+        "Callable span should not be default"
+    );
+
+    // Assert that the body is a block and all statement spans inside the callable are cleared
+    match circuit_callable.body.as_ref() {
+        CallableBody::Block(block) => {
+            for stmt in &block.stmts {
+                assert_eq!(
+                    stmt.span,
+                    Span::default(),
+                    "Statement span inside Circuit should be cleared"
+                );
+            }
+        }
+        CallableBody::Specs(_) => panic!("Expected Circuit body to be a block"),
+    }
+}
+
+#[test]
+fn remove_circuit_spans_does_not_clear_spans_outside_qsc_files() {
+    let ast = prepare_ast_for_circuit_tests();
+    let main_callable = find_callable(&ast, "Main");
+
+    // Assert the callable declaration has a non-default span
+    assert_ne!(
+        main_callable.span,
+        Span::default(),
+        "Callable span should not be default"
+    );
+
+    // Assert that the body is a block and all statement spans inside the callable are NOT cleared
+    match main_callable.body.as_ref() {
+        CallableBody::Block(block) => {
+            for stmt in &block.stmts {
+                assert_ne!(
+                    stmt.span,
+                    Span::default(),
+                    "Statement span inside Main should NOT be cleared"
+                );
+            }
+        }
+        CallableBody::Specs(_) => panic!("Expected Main body to be a block"),
+    }
 }

--- a/compiler/qsc_project/src/project.rs
+++ b/compiler/qsc_project/src/project.rs
@@ -389,7 +389,7 @@ pub trait FileSystemAsync {
         })
     }
 
-    /// Given a directory, attemps to parse a `qsharp.json` in that directory
+    /// Given a directory, attempts to parse a `qsharp.json` in that directory
     /// according to the manifest schema.
     async fn parse_manifest_in_dir(&self, directory: &Path) -> ProjectResult<Manifest> {
         let manifest_path = self


### PR DESCRIPTION
This adds a de-spanning pass to the compiler to remove the spans for the contents of operations defined via circuit files. The operation declarations themselves retain their spans to support LS features, but the statements in the body of the operations are de-spanned. This prevents the debugger from stepping into the circuit files.