### PR TITLE
Add support for builtin functions

### DIFF
--- a/compiler/qsc_qasm/src/compiler.rs
+++ b/compiler/qsc_qasm/src/compiler.rs
@@ -816,17 +816,19 @@ impl QasmCompiler {
                         build_path_ident_expr("ApplyOperationPowerA", modifier.span, stmt.span);
                 }
                 semast::GateModifierKind::Ctrl(num_ctrls) => {
+                    let num_ctrls = num_ctrls.get_const_u32()?;
+
                     // remove the last n qubits from the qubit list
-                    if qubits.len() < *num_ctrls as usize {
+                    if qubits.len() < num_ctrls as usize {
                         let kind = CompilerErrorKind::InvalidNumberOfQubitArgs(
-                            *num_ctrls as usize,
+                            num_ctrls as usize,
                             qubits.len(),
                             modifier.span,
                         );
                         self.push_compiler_error(kind);
                         return None;
                     }
-                    let ctrl = qubits.split_off(qubits.len().saturating_sub(*num_ctrls as usize));
+                    let ctrl = qubits.split_off(qubits.len().saturating_sub(num_ctrls as usize));
                     let ctrls = build_expr_array_expr(ctrl, modifier.span);
                     args = build_tuple_expr(vec![ctrls, args]);
                     callee = build_unary_op_expr(
@@ -836,17 +838,19 @@ impl QasmCompiler {
                     );
                 }
                 semast::GateModifierKind::NegCtrl(num_ctrls) => {
+                    let num_ctrls = num_ctrls.get_const_u32()?;
+
                     // remove the last n qubits from the qubit list
-                    if qubits.len() < *num_ctrls as usize {
+                    if qubits.len() < num_ctrls as usize {
                         let kind = CompilerErrorKind::InvalidNumberOfQubitArgs(
-                            *num_ctrls as usize,
+                            num_ctrls as usize,
                             qubits.len(),
                             modifier.span,
                         );
                         self.push_compiler_error(kind);
                         return None;
                     }
-                    let ctrl = qubits.split_off(qubits.len().saturating_sub(*num_ctrls as usize));
+                    let ctrl = qubits.split_off(qubits.len().saturating_sub(num_ctrls as usize));
                     let ctrls = build_expr_array_expr(ctrl, modifier.span);
                     let lit_0 = build_lit_int_expr(0, Span::default());
                     args = build_tuple_expr(vec![lit_0, callee, ctrls, args]);
@@ -1024,11 +1028,12 @@ impl QasmCompiler {
 
         let stmt = match self.config.qubit_semantics {
             QubitSemantics::QSharp => {
-                managed_qubit_alloc_array(name, stmt.size, stmt.span, name_span, stmt.size_span)
+                let size = stmt.size.get_const_u32()?;
+                managed_qubit_alloc_array(name, size, stmt.span, name_span, stmt.size_span)
             }
             QubitSemantics::Qiskit => build_unmanaged_qubit_alloc_array(
                 name,
-                stmt.size,
+                stmt.size.get_const_u32()?,
                 stmt.span,
                 name_span,
                 stmt.size_span,

--- a/compiler/qsc_qasm/src/semantic.rs
+++ b/compiler/qsc_qasm/src/semantic.rs
@@ -5,7 +5,7 @@ use crate::io::InMemorySourceResolver;
 use crate::io::SourceResolver;
 use crate::parser::QasmSource;
 
-use lowerer::Lowerer;
+pub(crate) use lowerer::Lowerer;
 use qsc_frontend::compile::SourceMap;
 use qsc_frontend::error::WithSource;
 

--- a/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/compiler/qsc_qasm/src/semantic/ast.rs
@@ -501,12 +501,32 @@ impl Expr {
         }
     }
 
+    pub fn int(val: i64, span: Span) -> Self {
+        let val = LiteralKind::Int(val);
+        Expr {
+            span,
+            kind: Box::new(ExprKind::Lit(val.clone())),
+            ty: super::types::Type::Int(None, true),
+            const_value: Some(val),
+        }
+    }
+
     pub fn uint(val: i64, span: Span) -> Self {
         let val = LiteralKind::Int(val);
         Expr {
             span,
             kind: Box::new(ExprKind::Lit(val.clone())),
             ty: super::types::Type::UInt(None, true),
+            const_value: Some(val),
+        }
+    }
+
+    pub fn float(val: f64, span: Span) -> Self {
+        let val = LiteralKind::Float(val);
+        Expr {
+            span,
+            kind: Box::new(ExprKind::Lit(val.clone())),
+            ty: super::types::Type::Float(None, true),
             const_value: Some(val),
         }
     }

--- a/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/compiler/qsc_qasm/src/semantic/ast.rs
@@ -480,6 +480,7 @@ pub struct Expr {
     pub span: Span,
     pub kind: Box<ExprKind>,
     pub ty: super::types::Type,
+    pub const_value: Option<LiteralKind>,
 }
 
 impl Display for Expr {
@@ -487,6 +488,17 @@ impl Display for Expr {
         writeln_header(f, "Expr", self.span)?;
         writeln_field(f, "ty", &self.ty)?;
         write_field(f, "kind", &self.kind)
+    }
+}
+
+impl Expr {
+    pub fn new(span: Span, kind: ExprKind, ty: super::types::Type) -> Self {
+        Self {
+            span,
+            kind: kind.into(),
+            ty,
+            const_value: None,
+        }
     }
 }
 
@@ -1216,11 +1228,11 @@ impl Array {
                 data,
                 dims: (&dims[1..]).into(),
             };
-            let expr = Expr {
-                span: Default::default(),
-                kind: Box::new(ExprKind::Lit(LiteralKind::Array(array))),
-                ty: super::types::Type::make_array_ty(&dims[1..], base_ty),
-            };
+            let expr = Expr::new(
+                Default::default(),
+                ExprKind::Lit(LiteralKind::Array(array)),
+                super::types::Type::make_array_ty(&dims[1..], base_ty),
+            );
             let dim_size = dims[0] as usize;
             vec![expr; dim_size]
         }

--- a/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/compiler/qsc_qasm/src/semantic/ast.rs
@@ -500,6 +500,16 @@ impl Expr {
             const_value: None,
         }
     }
+
+    pub fn uint(val: i64, span: Span) -> Self {
+        let val = LiteralKind::Int(val);
+        Expr {
+            span,
+            kind: Box::new(ExprKind::Lit(val.clone())),
+            ty: super::types::Type::UInt(None, true),
+            const_value: Some(val),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -551,8 +561,12 @@ impl Display for QuantumGateModifier {
 pub enum GateModifierKind {
     Inv,
     Pow(Expr),
-    Ctrl(u32),
-    NegCtrl(u32),
+    /// This `Expr` is const, but we don't substitute by the `LiteralKind` yet
+    /// to be able to provide Span and Type information to the Language Service.
+    Ctrl(Expr),
+    /// This `Expr` is const, but we don't substitute by the `LiteralKind` yet
+    /// to be able to provide Span and Type information to the Language Service.
+    NegCtrl(Expr),
 }
 
 impl Display for GateModifierKind {
@@ -704,7 +718,9 @@ impl Display for QubitDeclaration {
 pub struct QubitArrayDeclaration {
     pub span: Span,
     pub symbol_id: SymbolId,
-    pub size: u32,
+    /// This `Expr` is const, but we don't substitute by the `LiteralKind` yet
+    /// to be able to provide Span and Type information to the Language Service.
+    pub size: Expr,
     pub size_span: Span,
 }
 

--- a/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -38,6 +38,11 @@ pub enum ConstEvalError {
     #[error("uint expression must evaluate to a non-negative value, but it evaluated to {0}")]
     #[diagnostic(code("Qasm.Lowerer.NegativeUIntValue"))]
     NegativeUIntValue(i64, #[label] Span),
+
+    #[error("{0}")]
+    #[diagnostic(code("Qasm.Lowerer.NoValidOverloadForBuiltinFunction"))]
+    NoValidOverloadForBuiltinFunction(String, #[label] Span),
+
     #[error("too many indices provided")]
     #[diagnostic(code("Qasm.Lowerer.TooManyIndices"))]
     TooManyIndices(#[label] Span),

--- a/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -61,6 +61,14 @@ impl Expr {
         self.const_value.clone()
     }
 
+    pub(crate) fn get_const_u32(&self) -> Option<u32> {
+        if let Some(LiteralKind::Int(val)) = self.get_const_value() {
+            u32::try_from(val).ok()
+        } else {
+            None
+        }
+    }
+
     /// Tries to evaluate the expression. It takes the current `Lowerer` as
     /// the evaluation context to resolve symbols and push errors in case
     /// of failure.

--- a/compiler/qsc_qasm/src/semantic/error.rs
+++ b/compiler/qsc_qasm/src/semantic/error.rs
@@ -30,9 +30,6 @@ pub enum SemanticErrorKind {
     #[error("array literals are only allowed in classical declarations")]
     #[diagnostic(code("Qasm.Lowerer.ArrayLiteralInNonClassicalDecl"))]
     ArrayLiteralInNonClassicalDecl(#[label] Span),
-    #[error("array size must be a non-negative integer const expression")]
-    #[diagnostic(code("Qasm.Lowerer.ArraySizeMustBeNonNegativeConstExpr"))]
-    ArraySizeMustBeNonNegativeConstExpr(#[label] Span),
     #[error("first quantum register is of type {0} but found an argument of type {1}")]
     #[diagnostic(code("Qasm.Lowerer.BroadcastCallQuantumArgsDisagreeInSize"))]
     BroadcastCallQuantumArgsDisagreeInSize(String, String, #[label] Span),
@@ -88,6 +85,15 @@ pub enum SemanticErrorKind {
     #[error("{0} must be a const expression")]
     #[diagnostic(code("Qasm.Lowerer.ExprMustBeConst"))]
     ExprMustBeConst(String, #[label] Span),
+    #[error("{0} must be an integer")]
+    #[diagnostic(code("Qasm.Lowerer.ExprMustBeInt"))]
+    ExprMustBeInt(String, #[label] Span),
+    #[error("{0} must be a non-negative integer")]
+    #[diagnostic(code("Qasm.Lowerer.ExprMustBeNonNegativeInt"))]
+    ExprMustBeNonNegativeInt(String, #[label] Span),
+    #[error("{0} must be a positive integer")]
+    #[diagnostic(code("Qasm.Lowerer.ExprMustBePositiveInt"))]
+    ExprMustBePositiveInt(String, #[label] Span),
     #[error("{0} must fit in a u32")]
     #[diagnostic(code("Qasm.Lowerer.ExprMustFitInU32"))]
     ExprMustFitInU32(String, #[label] Span),
@@ -223,9 +229,6 @@ pub enum SemanticErrorKind {
     #[error("types differ by dimensions and are incompatible")]
     #[diagnostic(code("Qasm.Lowerer.TypeRankError"))]
     TypeRankError(#[label] Span),
-    #[error("type width must be a positive integer const expression")]
-    #[diagnostic(code("Qasm.Lowerer.TypeWidthMustBePositiveIntConstExpr"))]
-    TypeWidthMustBePositiveIntConstExpr(#[label] Span),
     #[error("undefined symbol: {0}")]
     #[diagnostic(code("Qasm.Lowerer.UndefinedSymbol"))]
     UndefinedSymbol(String, #[label] Span),

--- a/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -2865,7 +2865,7 @@ impl Lowerer {
         expr
     }
 
-    fn coerce_literal_expr_to_type(
+    pub(crate) fn coerce_literal_expr_to_type(
         &mut self,
         ty: &Type,
         expr: &semantic::Expr,

--- a/compiler/qsc_qasm/src/semantic/symbols.rs
+++ b/compiler/qsc_qasm/src/semantic/symbols.rs
@@ -136,7 +136,19 @@ impl Symbol {
         }
     }
 
-    /// Returns the value of the symbol.
+    /// Returns the const evaluated value of the symbol, if any.
+    #[must_use]
+    pub fn get_const_value(&self) -> Option<LiteralKind> {
+        self.const_expr
+            .as_ref()
+            .and_then(|expr| expr.get_const_value())
+    }
+
+    /// This function is meant to be used by the Language Service
+    /// to access span and type information about the original
+    /// expression before it was const evaluated. If you need
+    /// the const evaluated value, use [`Symbol::get_const_value`]
+    /// instead.
     #[must_use]
     pub fn get_const_expr(&self) -> Option<Rc<Expr>> {
         self.const_expr.clone()
@@ -318,6 +330,7 @@ impl Default for SymbolTable {
                 span: Span::default(),
                 kind: Box::new(ExprKind::Lit(LiteralKind::Float(val))),
                 ty: ty.clone(),
+                const_value: Some(LiteralKind::Float(val)),
             };
 
             slf.insert_symbol(Symbol {

--- a/compiler/qsc_qasm/src/semantic/symbols.rs
+++ b/compiler/qsc_qasm/src/semantic/symbols.rs
@@ -124,6 +124,17 @@ impl Symbol {
         }
     }
 
+    pub(crate) fn err(name: &str, span: Span) -> Self {
+        Symbol {
+            name: name.to_string(),
+            span,
+            ty: Type::Err,
+            qsharp_ty: crate::types::Type::Err,
+            io_kind: IOKind::Default,
+            const_expr: None,
+        }
+    }
+
     #[must_use]
     pub fn with_const_expr(self, value: Rc<Expr>) -> Self {
         assert!(
@@ -378,14 +389,7 @@ impl SymbolTable {
     }
 
     fn insert_err_symbol(&mut self, name: &str, span: Span) -> (SymbolId, Rc<Symbol>) {
-        let symbol = Rc::new(Symbol {
-            name: name.to_string(),
-            span,
-            ty: Type::Err,
-            qsharp_ty: crate::types::Type::Err,
-            io_kind: IOKind::Default,
-            const_expr: None,
-        });
+        let symbol = Rc::new(Symbol::err(name, span));
         let id = self.current_id;
         self.current_id = self.current_id.successor();
         self.symbols.insert(id, symbol.clone());

--- a/compiler/qsc_qasm/src/semantic/tests/decls.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls.rs
@@ -69,9 +69,9 @@ fn scalar_ty_designator_must_be_positive() {
                                 ty: unknown
                                 kind: Err
 
-            [Qasm.Lowerer.TypeWidthMustBePositiveIntConstExpr
+            [Qasm.Lowerer.ExprMustBePositiveInt
 
-              x type width must be a positive integer const expression
+              x type width must be a positive integer
                ,-[test:1:5]
              1 | int[-5] i;
                :     ^^
@@ -112,9 +112,9 @@ fn scalar_ty_designator_must_be_castable_to_const_int() {
              1 | const angle size = 2.0; int[size] i;
                :                             ^^^^
                `----
-            , Qasm.Lowerer.TypeWidthMustBePositiveIntConstExpr
+            , Qasm.Lowerer.ExprMustBeInt
 
-              x type width must be a positive integer const expression
+              x type width must be an integer
                ,-[test:1:29]
              1 | const angle size = 2.0; int[size] i;
                :                             ^^^^

--- a/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
@@ -423,9 +423,9 @@ fn explicit_zero_width_fails() {
                                 ty: unknown
                                 kind: Err
 
-            [Qasm.Lowerer.TypeWidthMustBePositiveIntConstExpr
+            [Qasm.Lowerer.ExprMustBePositiveInt
 
-              x type width must be a positive integer const expression
+              x type width must be a positive integer
                ,-[test:1:7]
              1 | angle[0] x = 42.1;
                :       ^

--- a/compiler/qsc_qasm/src/semantic/tests/decls/qreg.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/qreg.rs
@@ -49,7 +49,9 @@ fn array_with_no_init_expr() {
         &expect![[r#"
             QubitArrayDeclaration [0-10]:
                 symbol_id: 8
-                size: 3
+                size: Expr [7-8]:
+                    ty: const uint
+                    kind: Lit: Int(3)
                 size_span: [7-8]"#]],
     );
 }
@@ -69,7 +71,9 @@ fn array_with_no_init_expr_in_non_global_scope() {
                                 annotations: <empty>
                                 kind: QubitArrayDeclaration [1-11]:
                                     symbol_id: 8
-                                    size: 3
+                                    size: Expr [8-9]:
+                                        ty: const uint
+                                        kind: Lit: Int(3)
                                     size_span: [8-9]
 
             [Qasm.Lowerer.QubitDeclarationInNonGlobalScope

--- a/compiler/qsc_qasm/src/semantic/tests/decls/qubit.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/decls/qubit.rs
@@ -49,7 +49,9 @@ fn array_with_no_init_expr() {
         &expect![[r#"
             QubitArrayDeclaration [0-11]:
                 symbol_id: 8
-                size: 3
+                size: Expr [6-7]:
+                    ty: const uint
+                    kind: Lit: Int(3)
                 size_span: [6-7]"#]],
     );
 }
@@ -69,7 +71,9 @@ fn array_with_no_init_expr_in_non_global_scope() {
                                 annotations: <empty>
                                 kind: QubitArrayDeclaration [1-12]:
                                     symbol_id: 8
-                                    size: 3
+                                    size: Expr [7-8]:
+                                        ty: const uint
+                                        kind: Lit: Int(3)
                                     size_span: [7-8]
 
             [Qasm.Lowerer.QubitDeclarationInNonGlobalScope

--- a/compiler/qsc_qasm/src/semantic/tests/expression.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 mod binary;
+mod builtin_functions;
 mod explicit_cast_from_angle;
 mod explicit_cast_from_bit;
 mod explicit_cast_from_bool;

--- a/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions.rs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::semantic::tests::check_stmt_kinds;
+use expect_test::expect;
+
+#[test]
+fn builtin_call_with_invalid_input_types_fails() {
+    let source = "
+        mod(9, true);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-22]:
+                        annotations: <empty>
+                        kind: Err
+
+            [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `mod` for inputs: (const int, const bool)
+              | Overloads available are:
+              |   def(const int, const int) -> const int
+              |   def(const float, const float) -> const float
+               ,-[test:2:9]
+             1 | 
+             2 |         mod(9, true);
+               :         ^^^^^^^^^^^^
+             3 |     
+               `----
+            ]"#]],
+    );
+}
+
+#[test]
+fn builtin_call_with_lower_arity_fails() {
+    let source = "
+        mod(9);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-16]:
+                        annotations: <empty>
+                        kind: Err
+
+            [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `mod` for inputs: (const int)
+              | Overloads available are:
+              |   def(const int, const int) -> const int
+              |   def(const float, const float) -> const float
+               ,-[test:2:9]
+             1 | 
+             2 |         mod(9);
+               :         ^^^^^^
+             3 |     
+               `----
+            ]"#]],
+    );
+}
+
+#[test]
+fn builtin_call_with_higer_arity_fails() {
+    let source = "
+        mod(9);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-16]:
+                        annotations: <empty>
+                        kind: Err
+
+            [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `mod` for inputs: (const int)
+              | Overloads available are:
+              |   def(const int, const int) -> const int
+              |   def(const float, const float) -> const float
+               ,-[test:2:9]
+             1 | 
+             2 |         mod(9);
+               :         ^^^^^^
+             3 |     
+               `----
+            ]"#]],
+    );
+}
+
+#[test]
+fn builtin_call_with_const_expr_succeeds() {
+    let source = "
+        const int a = 9;
+        const int b = 7;
+        mod(a + b, b);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-25]:
+                symbol_id: 8
+                ty_span: [15-18]
+                init_expr: Expr [23-24]:
+                    ty: const int
+                    kind: Lit: Int(9)
+            ClassicalDeclarationStmt [34-50]:
+                symbol_id: 9
+                ty_span: [40-43]
+                init_expr: Expr [48-49]:
+                    ty: const int
+                    kind: Lit: Int(7)
+            ExprStmt [59-73]:
+                expr: Expr [59-72]:
+                    ty: const int
+                    kind: Lit: Int(2)
+        "#]],
+    );
+}
+
+#[test]
+fn nested_builtin_call_succeeds() {
+    let source = "
+        const int a = 9;
+        const int b = 7;
+        mod(a, mod(a, b));
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-25]:
+                symbol_id: 8
+                ty_span: [15-18]
+                init_expr: Expr [23-24]:
+                    ty: const int
+                    kind: Lit: Int(9)
+            ClassicalDeclarationStmt [34-50]:
+                symbol_id: 9
+                ty_span: [40-43]
+                init_expr: Expr [48-49]:
+                    ty: const int
+                    kind: Lit: Int(7)
+            ExprStmt [59-77]:
+                expr: Expr [59-76]:
+                    ty: const int
+                    kind: Lit: Int(1)
+        "#]],
+    );
+}
+
+#[test]
+fn mod_int() {
+    let source = "
+        mod(9, 7);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ExprStmt [9-19]:
+                expr: Expr [9-18]:
+                    ty: const int
+                    kind: Lit: Int(2)
+        "#]],
+    );
+}
+
+#[test]
+fn mod_float() {
+    let source = "
+        mod(9, 7.0);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ExprStmt [9-21]:
+                expr: Expr [9-20]:
+                    ty: const float
+                    kind: Lit: Float(2.0)
+        "#]],
+    );
+}

--- a/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
@@ -494,9 +494,9 @@ fn check_lowerer_error_spans_are_correct() {
              187 | 
                  `----
 
-            Qasm.Lowerer.ArraySizeMustBeNonNegativeConstExpr
+            Qasm.Lowerer.ExprMustBeNonNegativeInt
 
-              x array size must be a non-negative integer const expression
+              x array size must be a non-negative integer
                  ,-[Test.qasm:189:12]
              188 | // ArraySizeMustBeNonNegativeConstExpr
              189 | array[int, -2] negative_array_size;
@@ -524,9 +524,9 @@ fn check_lowerer_error_spans_are_correct() {
              196 | 
                  `----
 
-            Qasm.Lowerer.TypeWidthMustBePositiveIntConstExpr
+            Qasm.Lowerer.ExprMustBePositiveInt
 
-              x type width must be a positive integer const expression
+              x type width must be a positive integer
                  ,-[Test.qasm:198:5]
              197 | // TypeWidthMustBePositiveIntConstExpr
              198 | int[0] zero_width;
@@ -534,9 +534,9 @@ fn check_lowerer_error_spans_are_correct() {
              199 | int[-2] negative_width;
                  `----
 
-            Qasm.Lowerer.TypeWidthMustBePositiveIntConstExpr
+            Qasm.Lowerer.ExprMustBePositiveInt
 
-              x type width must be a positive integer const expression
+              x type width must be a positive integer
                  ,-[Test.qasm:199:5]
              198 | int[0] zero_width;
              199 | int[-2] negative_width;

--- a/compiler/qsc_qasm/src/semantic/tests/statements/reset_stmt.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/statements/reset_stmt.rs
@@ -30,7 +30,9 @@ fn on_an_indexed_qubit_register() {
         &expect![[r#"
             QubitArrayDeclaration [0-11]:
                 symbol_id: 8
-                size: 5
+                size: Expr [6-7]:
+                    ty: const uint
+                    kind: Lit: Int(5)
                 size_span: [6-7]
             ResetStmt [20-31]:
                 reset_token_span: [20-25]
@@ -57,7 +59,9 @@ fn on_a_span_indexed_qubit_register() {
         &expect![[r#"
             QubitArrayDeclaration [0-11]:
                 symbol_id: 8
-                size: 5
+                size: Expr [6-7]:
+                    ty: const uint
+                    kind: Lit: Int(5)
                 size_span: [6-7]
             ResetStmt [20-33]:
                 reset_token_span: [20-25]
@@ -87,17 +91,30 @@ fn on_a_zero_len_qubit_register() {
         "qubit[0] q;
         reset q;",
         &expect![[r#"
-            QubitArrayDeclaration [0-11]:
-                symbol_id: 8
-                size: 0
-                size_span: [6-7]
-            ResetStmt [20-28]:
-                reset_token_span: [20-25]
-                operand: GateOperand [26-27]:
-                    kind: Expr [26-27]:
-                        ty: qubit[0]
-                        kind: SymbolId(8)
-        "#]],
+            Program:
+                version: <none>
+                statements:
+                    Stmt [0-11]:
+                        annotations: <empty>
+                        kind: Err
+                    Stmt [20-28]:
+                        annotations: <empty>
+                        kind: ResetStmt [20-28]:
+                            reset_token_span: [20-25]
+                            operand: GateOperand [26-27]:
+                                kind: Expr [26-27]:
+                                    ty: unknown
+                                    kind: SymbolId(8)
+
+            [Qasm.Lowerer.ExprMustBePositiveInt
+
+              x quantum register size must be a positive integer
+               ,-[test:1:7]
+             1 | qubit[0] q;
+               :       ^
+             2 |         reset q;
+               `----
+            ]"#]],
     );
 }
 
@@ -109,7 +126,9 @@ fn on_an_unindexed_qubit_register() {
         &expect![[r#"
             QubitArrayDeclaration [0-11]:
                 symbol_id: 8
-                size: 5
+                size: Expr [6-7]:
+                    ty: const uint
+                    kind: Lit: Int(5)
                 size_span: [6-7]
             ResetStmt [20-28]:
                 reset_token_span: [20-25]

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -4,8 +4,8 @@
 #[cfg(test)]
 mod tests;
 
-use super::ast::{BinOp, ExprKind, Index, LiteralKind, Range};
-use crate::{parser::ast as syntax, semantic::ast::Expr};
+use super::ast::{BinOp, Expr, ExprKind, Index, LiteralKind, Range};
+use crate::parser::ast as syntax;
 use core::fmt;
 use std::fmt::{Display, Formatter};
 use std::{cmp::max, rc::Rc};

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -166,7 +166,12 @@ impl Display for Type {
             Type::UIntArray(width, dims) => write_array_ty(f, *width, "uint", None, dims),
             Type::Gate(cargs, qargs) => write!(f, "gate({cargs}, {qargs})"),
             Type::Function(params_ty, return_ty) => {
-                write!(f, "def({params_ty:#?}) -> {return_ty}")
+                let params_ty_str = params_ty
+                    .iter()
+                    .map(std::string::ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "def({params_ty_str}) -> {return_ty}")
             }
             Type::Range => write!(f, "range"),
             Type::Set => write!(f, "set"),

--- a/compiler/qsc_qasm/src/semantic/types.rs
+++ b/compiler/qsc_qasm/src/semantic/types.rs
@@ -1167,7 +1167,10 @@ pub(crate) fn binary_op_is_supported_for_types(op: BinOp, lhs_ty: &Type, rhs_ty:
         // Arithmetic
         BinOp::Add | BinOp::Sub => {
             base_types_equal(lhs_ty, rhs_ty)
-                && matches!(lhs_ty, Int(..) | UInt(..) | Float(..) | Angle(..))
+                && matches!(
+                    lhs_ty,
+                    Int(..) | UInt(..) | Float(..) | Angle(..) | Complex(..)
+                )
         }
         BinOp::Mul => {
             let uint_angle_exception = (matches!(lhs_ty, Angle(..)) && matches!(rhs_ty, UInt(..)))

--- a/compiler/qsc_qasm/src/semantic/types/tests.rs
+++ b/compiler/qsc_qasm/src/semantic/types/tests.rs
@@ -13,11 +13,11 @@ use expect_test::expect;
 use qsc_data_structures::span::Span;
 
 fn make_int_expr(val: i64) -> Expr {
-    Expr {
-        span: Span::default(),
-        kind: Box::new(ExprKind::Lit(LiteralKind::Int(val))),
-        ty: Type::Int(None, true),
-    }
+    Expr::new(
+        Span::default(),
+        ExprKind::Lit(LiteralKind::Int(val)),
+        Type::Int(None, true),
+    )
 }
 
 #[test]

--- a/compiler/qsc_qasm/src/stdlib.rs
+++ b/compiler/qsc_qasm/src/stdlib.rs
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 
 pub(crate) mod angle;
+pub(crate) mod builtin_functions;

--- a/compiler/qsc_qasm/src/stdlib/builtin_functions.rs
+++ b/compiler/qsc_qasm/src/stdlib/builtin_functions.rs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Reference: <https://openqasm.com/versions/3.0/language/types.html#built-in-constant-expression-functions>
+//!
+//! The following are compile-time functions that take const inputs and have a const output.
+//! The normal implicit casting rules apply to the inputs of these functions.
+
+use std::fmt::Write;
+
+use crate::semantic::{
+    ast::{Expr, LiteralKind},
+    const_eval::ConstEvalError,
+    types::{can_cast_literal, can_cast_literal_with_value_knowledge, Type},
+    Lowerer,
+};
+use qsc_data_structures::span::Span;
+
+/// The output of calling a polymorphic function is a pair
+/// where the first element is the result of the computation
+/// and the second element is the type of the monomorphic
+/// function that was selected, if any.
+type PolymorphicFunctionOutput = Option<(Expr, Type)>;
+
+// A function table mapping function signatures to functions.
+// This is a vector and not a hash-map because the order of
+// iteration matters. Overloads should be tried in the order
+// they appear.
+type FnTable = Vec<(Type, Box<dyn Fn(&[Expr], Span) -> Expr>)>;
+
+fn dispatch(
+    name: &str,
+    call_span: Span,
+    inputs: &[Expr],
+    fn_table: FnTable,
+    ctx: &mut Lowerer,
+) -> PolymorphicFunctionOutput {
+    // All the builtin functions take const expressions as inputs
+    // and return a const expression as output. If any of the
+    // inputs is not const, we return an error.
+    if inputs.iter().filter_map(|e| check_const(e, ctx)).count() != inputs.len() {
+        return None;
+    }
+
+    // Reference: <https://openqasm.com/versions/3.0/language/types.html#built-in-constant-expression-functions>
+    //
+    // For each built-in function, the chosen overload is the first one to appear in Table 2 in
+    // the link above where all given operands can be implicitly cast to the valid input types.
+    // The output type is not considered when choosing an overload. It is an error if there is
+    // no valid overload for a given sequence of operands.
+    for (signature, function) in &fn_table {
+        if let Some(new_inputs) = try_implicit_cast_inputs(inputs, signature, ctx) {
+            let output = function(&new_inputs, call_span);
+            return Some((output, signature.clone()));
+        }
+    }
+
+    ctx.push_const_eval_error(no_valid_overload_error(name, call_span, inputs, fn_table));
+
+    None
+}
+
+fn check_const(expr: &Expr, ctx: &mut Lowerer) -> Option<()> {
+    if expr.ty.is_const() && expr.const_value.is_some() {
+        Some(())
+    } else {
+        ctx.push_const_eval_error(ConstEvalError::ExprMustBeConst(expr.span));
+        None
+    }
+}
+
+/// A helper macro for unwrapping the literal value of a const expression.
+macro_rules! unwarp_lit {
+    // This pattern is used for unary expressions.
+    ($const_expr:expr, $pat:pat) => {
+        #[allow(irrefutable_let_patterns)]
+        let $pat = $const_expr.get_const_value().expect("expr is const") else {
+            unreachable!("if we hit this, there is a bug in our dispatch mechanism")
+        };
+    };
+}
+
+fn try_implicit_cast_inputs(
+    inputs: &[Expr],
+    signature: &Type,
+    ctx: &mut Lowerer,
+) -> Option<Vec<Expr>> {
+    let mut new_inputs = Vec::with_capacity(inputs.len());
+    let Type::Function(input_types, _) = signature else {
+        unreachable!("if we hit this we are initializing the function table incorrectly");
+    };
+
+    for (input, ty) in inputs.iter().zip(input_types.iter()) {
+        unwarp_lit!(input, value);
+        if can_cast_literal(ty, &input.ty) || can_cast_literal_with_value_knowledge(ty, &value) {
+            let coerced_input = ctx.coerce_literal_expr_to_type(ty, input, &value);
+            new_inputs.push(coerced_input);
+        } else {
+            return None;
+        }
+    }
+
+    Some(new_inputs)
+}
+
+fn no_valid_overload_error(
+    name: &str,
+    call_span: Span,
+    inputs: &[Expr],
+    fn_table: FnTable,
+) -> ConstEvalError {
+    let mut error_msg = String::new();
+    write!(error_msg, "There is no valid overload for inputs: ").expect("write should succeed");
+
+    for input in inputs {
+        write!(error_msg, "{}", input.ty).expect("write should succeed");
+    }
+
+    write!(error_msg, "\nOverloads available are:").expect("write should succeed");
+
+    for (signature, _) in fn_table {
+        write!(error_msg, "\n  {signature}").expect("write should succeed");
+    }
+
+    ConstEvalError::NoValidOverloadForBuiltinFunction(error_msg, call_span)
+}
+
+pub fn fun(inputs: &[Type], output: Type) -> Type {
+    Type::Function(inputs.into(), output.into())
+}
+
+pub fn int() -> Type {
+    Type::Int(None, true)
+}
+
+pub fn float() -> Type {
+    Type::Float(None, true)
+}
+
+pub(crate) fn mod_(
+    a: Expr,
+    b: Expr,
+    call_span: Span,
+    ctx: &mut Lowerer,
+) -> PolymorphicFunctionOutput {
+    let fn_table: FnTable = vec![
+        (fun(&[int(), int()], int()), Box::new(mod_int)),
+        (fun(&[float(), float()], float()), Box::new(mod_float)),
+    ];
+
+    dispatch("mod", call_span, &[a, b], fn_table, ctx)
+}
+
+pub(crate) fn mod_int(inputs: &[Expr], span: Span) -> Expr {
+    unwarp_lit!(inputs[0], LiteralKind::Int(a));
+    unwarp_lit!(inputs[1], LiteralKind::Int(b));
+    Expr::int(a.rem_euclid(b), span)
+}
+
+pub(crate) fn mod_float(inputs: &[Expr], span: Span) -> Expr {
+    unwarp_lit!(inputs[0], LiteralKind::Float(a));
+    unwarp_lit!(inputs[1], LiteralKind::Float(b));
+    Expr::float(a.rem_euclid(b), span)
+}

--- a/compiler/qsc_qasm/src/tests/declaration/array/qubit.rs
+++ b/compiler/qsc_qasm/src/tests/declaration/array/qubit.rs
@@ -44,10 +44,9 @@ fn qubit_array_decl_with_qsharp_semantics() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn indexing_a_qubit_array_of_zero_size_fails() {
+fn declaring_a_qubit_array_of_zero_size_fails() {
     let source = "
         qubit[0] qs;
-        qs[0];
     ";
 
     let Err(errors) = compile_qasm_to_qsharp(source) else {
@@ -55,16 +54,15 @@ fn indexing_a_qubit_array_of_zero_size_fails() {
     };
 
     expect![[r#"
-        [Qasm.Lowerer.ZeroSizeArrayAccess
+        [Qasm.Lowerer.ExprMustBePositiveInt
 
-          x zero size array access is not allowed
-           ,-[Test.qasm:3:9]
+          x quantum register size must be a positive integer
+           ,-[Test.qasm:2:15]
+         1 | 
          2 |         qubit[0] qs;
-         3 |         qs[0];
-           :         ^^^^^
-         4 |     
+           :               ^
+         3 |     
            `----
-          help: array size must be a positive integer const expression
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
 }

--- a/compiler/qsc_qasm/src/tests/statement/measure.rs
+++ b/compiler/qsc_qasm/src/tests/statement/measure.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::tests::compile_qasm_to_qsharp;
+use crate::tests::{check_qasm_to_qsharp, compile_qasm_to_qsharp};
 use expect_test::expect;
 use miette::Report;
 use std::fmt::Write;
@@ -105,22 +105,24 @@ fn unindexed_single_qubit_can_be_measured_into_indexed_bit_register(
 }
 
 #[test]
-fn measure_zero_length_qubits_into_register() -> miette::Result<(), Vec<Report>> {
+fn measure_zero_length_qubits_into_register_fails() {
     let source = r#"
         bit[0] c;
         qubit[0] q;
         c = measure q;
     "#;
 
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        mutable c = [];
-        let q = QIR.Runtime.AllocateQubitArray(0);
-        set c = Std.Measurement.MeasureEachZ(q);
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
+    check_qasm_to_qsharp(source, &expect![[r#"
+        Qasm.Lowerer.ExprMustBePositiveInt
+
+          x quantum register size must be a positive integer
+           ,-[Test.qasm:3:15]
+         2 |         bit[0] c;
+         3 |         qubit[0] q;
+           :               ^
+         4 |         c = measure q;
+           `----
+    "#]]);
 }
 
 #[test]
@@ -252,22 +254,27 @@ fn unindexed_single_qubit_with_measure_arrow_into_indexed_bit_register(
 }
 
 #[test]
-fn measure_arrow_zero_length_qubits_into_register() -> miette::Result<(), Vec<Report>> {
+fn measure_arrow_zero_length_qubits_into_register_fails() {
     let source = r#"
         bit[0] c;
         qubit[0] q;
         measure q -> c;
     "#;
 
-    let qsharp = compile_qasm_to_qsharp(source)?;
-    expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        mutable c = [];
-        let q = QIR.Runtime.AllocateQubitArray(0);
-        set c = Std.Measurement.MeasureEachZ(q);
-    "#]]
-    .assert_eq(&qsharp);
-    Ok(())
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.ExprMustBePositiveInt
+
+              x quantum register size must be a positive integer
+               ,-[Test.qasm:3:15]
+             2 |         bit[0] c;
+             3 |         qubit[0] q;
+               :               ^
+             4 |         measure q -> c;
+               `----
+        "#]],
+    );
 }
 
 #[test]

--- a/compiler/qsc_qasm/src/tests/statement/measure.rs
+++ b/compiler/qsc_qasm/src/tests/statement/measure.rs
@@ -112,7 +112,9 @@ fn measure_zero_length_qubits_into_register_fails() {
         c = measure q;
     "#;
 
-    check_qasm_to_qsharp(source, &expect![[r#"
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
         Qasm.Lowerer.ExprMustBePositiveInt
 
           x quantum register size must be a positive integer
@@ -122,7 +124,8 @@ fn measure_zero_length_qubits_into_register_fails() {
            :               ^
          4 |         c = measure q;
            `----
-    "#]]);
+    "#]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR adds the necessary infrastructure to support for builtin functions in the lowerer and prepares the groundwork for providing language service support for const evaluated expressions. These changes are related because builtin function calls are a kind of const evaluated expression.

The PR can be understood in two areas:
 1. The part that prepares the groundwork for providing language service support for const evaluated expressions, which includes two changes: now const expressions are eagarly evaluated in the lowerer; and the `Expr` type is augmented with the result of const evaluated the expression, instead of just storing the final value in the AST, this will provide the necessary span and type information to the language service to for its hover, jump to definition, and type hint features.
 2. The part that adds the necessary infrastructure to support builtin functions in the lowerer: this changes include adding a polymorphic dispatch mechanism for QASM bultins and wiring this mechanism to the `Lowerer::lower_function_call_expr` method.