### PR TITLE
Clarified search goal in the Grover sample comments

### DIFF
--- a/samples/algorithms/Grover.qs
+++ b/samples/algorithms/Grover.qs
@@ -22,15 +22,16 @@ operation Main() : Result[] {
     // Grover's algorithm relies on performing a "Grover iteration" an
     // optimal number of times to maximize the probability of finding the
     // value we are searching for.
-    // You can set the number iterations to a value lower than optimal to
-    // intentionally reduce precision.
-    let iterations = CalculateOptimalIterations(nQubits);
-    Message($"Number of iterations: {iterations}");
+    // You can intentionally set the number iterations to a value lower
+    // than optimal. In this case, the algorithm will find the marked state
+    // with lower probability.
+    let nIterations = IterationsToMarked(nQubits);
+    Message($"Number of iterations: {nIterations}");
 
     // Use Grover's algorithm to find a particular marked state. The marked state
     // we are looking for in this sample is |01010⟩, which is represented
     // by the operation ReflectAboutMarked.
-    let results = GroverSearch(nQubits, iterations, ReflectAboutMarked);
+    let results = GroverSearch(nQubits, nIterations, ReflectAboutMarked);
 
     // Expected result is [Zero, One, Zero, One, Zero] with very high probability.
     return results;
@@ -63,8 +64,9 @@ operation GroverSearch(
 
 /// # Summary
 /// Returns the optimal number of Grover iterations needed to find a marked
-/// item, given the number of qubits in a register.
-function CalculateOptimalIterations(nQubits : Int) : Int {
+/// item, given the number of qubits in a register. Setting the number of
+/// itertions to a different number may undershoot or overshoot the marked state.
+function IterationsToMarked(nQubits : Int) : Int {
     if nQubits > 126 {
         fail "This sample supports at most 126 qubits.";
     }

--- a/samples/algorithms/Grover.qs
+++ b/samples/algorithms/Grover.qs
@@ -65,7 +65,7 @@ operation GroverSearch(
 /// # Summary
 /// Returns the optimal number of Grover iterations needed to find a marked
 /// item, given the number of qubits in a register. Setting the number of
-/// itertions to a different number may undershoot or overshoot the marked state.
+/// iterations to a different number may undershoot or overshoot the marked state.
 function IterationsToMarked(nQubits : Int) : Int {
     if nQubits > 126 {
         fail "This sample supports at most 126 qubits.";

--- a/samples/algorithms/Grover.qs
+++ b/samples/algorithms/Grover.qs
@@ -6,7 +6,10 @@
 /// probability the unique input to a black box function that produces a
 /// particular output value.
 ///
-/// This Q# program implements the Grover's search algorithm.
+/// This Q# program implements the Grover's search algorithm and applies it
+/// to a specific problem: finding a marked state in a register of qubits.
+/// The marked state selected for this sample is |01010⟩.
+
 import Std.Convert.*;
 import Std.Math.*;
 import Std.Arrays.*;
@@ -24,8 +27,12 @@ operation Main() : Result[] {
     let iterations = CalculateOptimalIterations(nQubits);
     Message($"Number of iterations: {iterations}");
 
-    // Use Grover's algorithm to find a particular marked state.
+    // Use Grover's algorithm to find a particular marked state. The marked state
+    // we are looking for in this sample is |01010⟩, which is represented
+    // by the operation ReflectAboutMarked.
     let results = GroverSearch(nQubits, iterations, ReflectAboutMarked);
+
+    // Expected result is [Zero, One, Zero, One, Zero] with very high probability.
     return results;
 }
 


### PR DESCRIPTION
Updated comments in the Grover search sample to clarify what we are searching for. In this particular case we are looking for the marked state |01010⟩. I still think we should keep this sample simple by looking for a specific state represented by a hard-coded operation rather than somehow providing arbitrary marked state as a parameter.