### PR TITLE
Consolidate OpenQASM project loading and include handling

### DIFF
--- a/compiler/qsc_project/Cargo.toml
+++ b/compiler/qsc_project/Cargo.toml
@@ -27,6 +27,7 @@ log = { workspace = true }
 [dev-dependencies]
 expect-test = { workspace = true }
 qsc_project = { path = ".", features = ["fs"] }
+miette = { workspace = true, features = ["fancy-no-syscall"] }
 
 [features]
 fs = []

--- a/compiler/qsc_project/src/error.rs
+++ b/compiler/qsc_project/src/error.rs
@@ -4,7 +4,6 @@
 use miette::Diagnostic;
 use thiserror::Error;
 
-#[cfg(feature = "fs")]
 #[derive(Error, Debug, Diagnostic)]
 pub enum StdFsError {
     #[error("found a qsharp.json file, but it was invalid: {0}")]

--- a/compiler/qsc_project/src/js.rs
+++ b/compiler/qsc_project/src/js.rs
@@ -67,7 +67,9 @@ where
         let res = self
             .resolve_path(&base.to_string_lossy(), &path.to_string_lossy())
             .await
-            .ok_or(Error::msg("Path could not be resolved"))?;
+            .ok_or(Error::msg(format!(
+                "Failed to resolve path ${base:?} and ${path:?}"
+            )))?;
         return Ok(PathBuf::from(res.to_string()));
     }
 

--- a/compiler/qsc_project/src/js.rs
+++ b/compiler/qsc_project/src/js.rs
@@ -3,7 +3,6 @@
 
 use crate::{DirEntry, EntryType, FileSystemAsync};
 use async_trait::async_trait;
-use miette::Error;
 use std::{convert::Infallible, path::PathBuf, sync::Arc};
 
 #[derive(Debug)]
@@ -29,7 +28,7 @@ impl DirEntry for JSFileEntry {
 pub trait JSProjectHost {
     async fn read_file(&self, uri: &str) -> miette::Result<(Arc<str>, Arc<str>)>;
     async fn list_directory(&self, dir_uri: &str) -> Vec<JSFileEntry>;
-    async fn resolve_path(&self, base: &str, path: &str) -> Option<Arc<str>>;
+    async fn resolve_path(&self, base: &str, path: &str) -> miette::Result<Arc<str>>;
     async fn fetch_github(
         &self,
         owner: &str,
@@ -67,9 +66,11 @@ where
         let res = self
             .resolve_path(&base.to_string_lossy(), &path.to_string_lossy())
             .await
-            .ok_or(Error::msg(format!(
-                "Failed to resolve path ${base:?} and ${path:?}"
-            )))?;
+            .map_err(|e| {
+                miette::Error::msg(format!(
+                    "Failed to resolve path ${base:?} and ${path:?}: ${e}"
+                ))
+            })?;
         return Ok(PathBuf::from(res.to_string()));
     }
 

--- a/compiler/qsc_project/src/lib.rs
+++ b/compiler/qsc_project/src/lib.rs
@@ -16,6 +16,7 @@ mod manifest;
 pub mod openqasm;
 mod project;
 
+#[cfg(feature = "fs")]
 pub use error::StdFsError;
 #[cfg(feature = "fs")]
 pub use fs::StdFs;

--- a/compiler/qsc_project/src/openqasm.rs
+++ b/compiler/qsc_project/src/openqasm.rs
@@ -80,23 +80,17 @@ where
         }
 
         // At this point, we have a valid include path that we need to try to load.
-        match project_host
+        // Any file read errors after the root are ignored,
+        // the parser will handle them as part of full parsing.
+        if let Ok((file, source)) = project_host
             .read_file(Path::new(resolved_path.as_ref()))
             .await
         {
-            Ok((file, source)) => {
-                let (program, _errors) = qsc_qasm::parser::parse(source.as_ref());
-                let includes = get_includes(&program, &file);
-                pending_includes.extend(includes);
-                loaded_files.insert(file.clone());
-                sources.push((file, source.clone()));
-            }
-            Err(e) => {
-                errors.push(super::project::Error::FileSystem {
-                    about_path: doc_uri.to_string(),
-                    error: e.to_string(),
-                });
-            }
+            let (program, _errors) = qsc_qasm::parser::parse(source.as_ref());
+            let includes = get_includes(&program, &file);
+            pending_includes.extend(includes);
+            loaded_files.insert(file.clone());
+            sources.push((file, source.clone()));
         }
     }
 

--- a/compiler/qsc_project/src/openqasm/integration_tests.rs
+++ b/compiler/qsc_project/src/openqasm/integration_tests.rs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use qsc_qasm::semantic::QasmSemanticParseResult;
+
+use crate::{FileSystem, ProjectType, StdFs};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn get_test_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("tests")
+        .join("openqasm_projects")
+}
+
+fn parse_file(file_name: &'static str) -> (Arc<str>, QasmSemanticParseResult) {
+    let test_dir = get_test_dir();
+    let test_file = test_dir.join(file_name);
+    let test_file: Arc<str> = test_file.display().to_string().as_str().into();
+    let fs = StdFs;
+    let project = fs.load_openqasm_project(&test_file, None);
+    let ProjectType::OpenQASM(sources) = project.project_type else {
+        panic!("Expected OpenQASM project type");
+    };
+    let result = qsc_qasm::semantic::parse_sources(&sources);
+    (test_file, result)
+}
+
+#[test]
+fn test_real_simple_qasm_file() {
+    let file_name = "simple.qasm";
+    let (test_file, result) = parse_file(file_name);
+
+    // Should succeed - QasmSource always returns, check for errors
+    let errors = result.errors();
+    assert!(errors.is_empty(), "Unexpected errors: {errors:?}");
+    assert!(!result.has_errors(), "Should not have any errors");
+
+    // Verify that simple.qasm was loaded
+    let source = result.source;
+    assert_eq!(source.path().as_ref(), test_file.as_ref());
+}
+
+#[test]
+fn test_real_file_with_includes() {
+    let file_name = "with_includes.qasm";
+    let (_, result) = parse_file(file_name);
+
+    let errors = result.errors();
+    assert!(errors.is_empty(), "Unexpected errors: {errors:?}");
+    assert!(!result.has_errors(), "Should not have any errors");
+
+    let includes = result.source.includes();
+    // Note: Only one include should be present since stdgates.inc is ignored
+    assert_eq!(
+        includes.len(),
+        1,
+        "Should have one include (stdgates.inc is ignored)"
+    );
+
+    // Check that the included file is correct
+    let included_file = &includes[0];
+    let test_dir = get_test_dir();
+    let expected_include_path = test_dir.join("included.qasm");
+    assert_eq!(
+        included_file.path().as_ref(),
+        expected_include_path.to_string_lossy()
+    );
+
+    // verify that the included file content is present
+    result
+        .symbols
+        .get_symbol_by_name("my_gate")
+        .expect("Should find my_gate in symbols");
+
+    // verify some stdgates.inc symbols are included
+    for gate in &["h", "x", "y", "z"] {
+        assert!(
+            result.symbols.get_symbol_by_name(gate).is_some(),
+            "Should find gate {gate} in symbols"
+        );
+    }
+}
+
+#[test]
+fn test_real_missing_include() {
+    let file_name = "missing_include.qasm";
+    let (_, result) = parse_file(file_name);
+
+    assert!(result.has_errors(), "Should indicate presence of errors");
+
+    let all_errors = result.all_errors();
+    assert!(
+        !all_errors.is_empty(),
+        "Should have errors for missing file"
+    );
+
+    let error_strings: Vec<_> = all_errors.iter().map(|e| format!("{e:?}\n")).collect();
+    assert!(
+        error_strings
+            .iter()
+            .any(|e| e.contains("This file includes a missing file")),
+        "Should have file system error, got: {all_errors:?}"
+    );
+}
+
+#[test]
+fn test_real_circular_includes() {
+    let file_name = "circular_a.qasm";
+    let (_, result) = parse_file(file_name);
+
+    assert!(result.has_errors(), "Should indicate presence of errors");
+
+    let all_errors = result.all_errors();
+    assert!(
+        !all_errors.is_empty(),
+        "Should have errors for circular dependency"
+    );
+
+    let error_strings: Vec<_> = all_errors.iter().map(|e| format!("{e:?}")).collect();
+    assert!(
+        error_strings.iter().any(|e| e.contains("CyclicInclude")),
+        "Should have circular dependency error, got: {all_errors:?}"
+    );
+}
+
+#[test]
+fn test_real_duplicate_includes() {
+    let file_name = "duplicate_includes.qasm";
+    let (_, result) = parse_file(file_name);
+
+    assert!(result.has_errors(), "Should indicate presence of errors");
+
+    let all_errors = result.all_errors();
+    assert!(
+        !all_errors.is_empty(),
+        "Should have errors for duplicate includes"
+    );
+
+    let error_strings: Vec<_> = all_errors.iter().map(|e| format!("{e:?}")).collect();
+    assert!(
+        error_strings.iter().any(|e| e.contains("MultipleInclude")),
+        "Should have duplicate include error, got: {all_errors:?}"
+    );
+}
+
+#[test]
+fn test_relative_path_file_includes() {
+    let file_name = "relative_files.qasm";
+    let (_, result) = parse_file(file_name);
+
+    if result.has_errors() {
+        let all_errors = result.all_errors();
+        assert!(
+            all_errors.is_empty(),
+            "Should not have errors for relative path includes, got: {all_errors:?}"
+        );
+    }
+
+    // verify that the includes were loaded correctly
+    for gate in &["gate_a", "gate_b"] {
+        assert!(
+            result.symbols.get_symbol_by_name(gate).is_some(),
+            "Should find gate {gate} in symbols"
+        );
+    }
+}

--- a/compiler/qsc_project/src/openqasm/integration_tests.rs
+++ b/compiler/qsc_project/src/openqasm/integration_tests.rs
@@ -17,14 +17,13 @@ fn get_test_dir() -> PathBuf {
 fn parse_file(file_name: &'static str) -> (Arc<str>, QasmSemanticParseResult) {
     let test_dir = get_test_dir();
     let test_file = test_dir.join(file_name);
-    let test_file: Arc<str> = test_file.display().to_string().as_str().into();
     let fs = StdFs;
     let project = fs.load_openqasm_project(&test_file, None);
     let ProjectType::OpenQASM(sources) = project.project_type else {
         panic!("Expected OpenQASM project type");
     };
     let result = qsc_qasm::semantic::parse_sources(&sources);
-    (test_file, result)
+    (test_file.display().to_string().as_str().into(), result)
 }
 
 #[test]

--- a/compiler/qsc_project/src/project.rs
+++ b/compiler/qsc_project/src/project.rs
@@ -394,7 +394,7 @@ pub trait FileSystemAsync {
     ///
     /// Any errors that didn't block project load are contained in the
     /// `errors` field of the returned `Project`.
-    async fn load_openqasm_project(&self, path: &Arc<str>, source: Option<Arc<str>>) -> Project {
+    async fn load_openqasm_project(&self, path: &Path, source: Option<Arc<str>>) -> Project {
         crate::openqasm::load_project(self, path, source).await
     }
 
@@ -860,7 +860,7 @@ pub trait FileSystem {
             .expect("load_project should never await")
     }
 
-    fn load_openqasm_project(&self, path: &Arc<str>, source: Option<Arc<str>>) -> Project {
+    fn load_openqasm_project(&self, path: &Path, source: Option<Arc<str>>) -> Project {
         // Rather than rewriting all the async code in the project loader,
         // we call the async implementation here, doing some tricks to make it
         // run synchronously.

--- a/compiler/qsc_project/src/tests/openqasm_projects/circular_a.qasm
+++ b/compiler/qsc_project/src/tests/openqasm_projects/circular_a.qasm
@@ -1,0 +1,6 @@
+OPENQASM 3.0;
+include "circular_b.qasm";
+
+// Circular dependency A -> B -> A
+qreg q[1];
+U(0, 0, 0) q[0];

--- a/compiler/qsc_project/src/tests/openqasm_projects/circular_b.qasm
+++ b/compiler/qsc_project/src/tests/openqasm_projects/circular_b.qasm
@@ -1,0 +1,6 @@
+OPENQASM 3.0;
+include "circular_a.qasm";
+
+// Circular dependency B -> A -> B
+qreg q[1];
+U(0, 0, 0) q[0];

--- a/compiler/qsc_project/src/tests/openqasm_projects/duplicate_includes.qasm
+++ b/compiler/qsc_project/src/tests/openqasm_projects/duplicate_includes.qasm
@@ -1,0 +1,7 @@
+OPENQASM 3.0;
+include "included.qasm";
+include "included.qasm"; // Duplicate include
+
+// File with duplicate includes
+qreg q[1];
+U(0, 0, 0) q[0];

--- a/compiler/qsc_project/src/tests/openqasm_projects/included.qasm
+++ b/compiler/qsc_project/src/tests/openqasm_projects/included.qasm
@@ -1,0 +1,6 @@
+OPENQASM 3.0;
+
+// Included QASM file
+gate my_gate q {
+    U(0, 0, 0) q;
+}

--- a/compiler/qsc_project/src/tests/openqasm_projects/missing_include.qasm
+++ b/compiler/qsc_project/src/tests/openqasm_projects/missing_include.qasm
@@ -1,0 +1,7 @@
+OPENQASM 3.0;
+include "stdgates.inc";
+include "nonexistent.qasm";
+
+// This file includes a missing file
+qreg q[1];
+h q[0];

--- a/compiler/qsc_project/src/tests/openqasm_projects/nested/gates.inc
+++ b/compiler/qsc_project/src/tests/openqasm_projects/nested/gates.inc
@@ -1,0 +1,7 @@
+OPENQASM 3.0;
+
+gate gate_a q {
+    U(0., 0., 0.) q;
+}
+
+include "../other_nested/gates.inc";

--- a/compiler/qsc_project/src/tests/openqasm_projects/other_nested/gates.inc
+++ b/compiler/qsc_project/src/tests/openqasm_projects/other_nested/gates.inc
@@ -1,0 +1,5 @@
+OPENQASM 3.0;
+
+gate gate_b q {
+    gate_a q;
+}

--- a/compiler/qsc_project/src/tests/openqasm_projects/relative_files.qasm
+++ b/compiler/qsc_project/src/tests/openqasm_projects/relative_files.qasm
@@ -1,0 +1,10 @@
+OPENQASM 3.0;
+include "nested/gates.inc";
+
+// Simple QASM file for testing
+qreg q[2];
+creg c[2];
+
+gate_a q[0];
+gate_b q[1];
+measure q -> c;

--- a/compiler/qsc_project/src/tests/openqasm_projects/simple.qasm
+++ b/compiler/qsc_project/src/tests/openqasm_projects/simple.qasm
@@ -1,0 +1,10 @@
+OPENQASM 3.0;
+include "stdgates.inc";
+
+// Simple QASM file for testing
+qreg q[2];
+creg c[2];
+
+h q[0];
+cx q[0], q[1];
+measure q -> c;

--- a/compiler/qsc_project/src/tests/openqasm_projects/with_includes.qasm
+++ b/compiler/qsc_project/src/tests/openqasm_projects/with_includes.qasm
@@ -1,0 +1,11 @@
+OPENQASM 3.0;
+include "stdgates.inc";
+include "included.qasm";
+
+// Main QASM file with includes
+qreg q[2];
+creg c[2];
+
+h q[0];
+cx q[0], q[1];
+measure q -> c;

--- a/compiler/qsc_qasm/benches/rgqft_multiplier.rs
+++ b/compiler/qsc_qasm/benches/rgqft_multiplier.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use qsc_qasm::{
-    compile_to_qsharp_ast_with_config, io::InMemorySourceResolver, CompilerConfig, OutputSemantics,
-    ProgramType, QasmCompileUnit, QubitSemantics,
+    compiler::parse_and_compile_to_qsharp_ast_with_config, io::InMemorySourceResolver,
+    CompilerConfig, OutputSemantics, ProgramType, QasmCompileUnit, QubitSemantics,
 };
 
 fn rgqft_multiplier<S: Into<Arc<str>>>(source: S) -> QasmCompileUnit {
@@ -17,7 +17,12 @@ fn rgqft_multiplier<S: Into<Arc<str>>>(source: S) -> QasmCompileUnit {
         Some("Test".into()),
         None,
     );
-    compile_to_qsharp_ast_with_config(source, "", None::<&mut InMemorySourceResolver>, config)
+    parse_and_compile_to_qsharp_ast_with_config(
+        source,
+        "",
+        None::<&mut InMemorySourceResolver>,
+        config,
+    )
 }
 
 pub fn rgqft_multiplier_1q(c: &mut Criterion) {

--- a/compiler/qsc_qasm/src/compiler.rs
+++ b/compiler/qsc_qasm/src/compiler.rs
@@ -46,6 +46,7 @@ use crate::{
         },
         symbols::{IOKind, Symbol, SymbolId, SymbolTable},
         types::{promote_types, Type},
+        QasmSemanticParseResult,
     },
     CompilerConfig, OperationSignature, OutputSemantics, ProgramType, QasmCompileUnit,
     QubitSemantics,
@@ -65,7 +66,7 @@ fn err_expr(span: Span) -> qsast::Expr {
 }
 
 #[must_use]
-pub fn compile_to_qsharp_ast_with_config<
+pub fn parse_and_compile_to_qsharp_ast_with_config<
     R: SourceResolver,
     S: Into<Arc<str>>,
     P: Into<Arc<str>>,
@@ -80,6 +81,14 @@ pub fn compile_to_qsharp_ast_with_config<
     } else {
         crate::semantic::parse(source, path)
     };
+    compile_to_qsharp_ast_with_config(res, config)
+}
+
+#[must_use]
+pub fn compile_to_qsharp_ast_with_config(
+    res: QasmSemanticParseResult,
+    config: CompilerConfig,
+) -> QasmCompileUnit {
     let program = res.program;
 
     let compiler = crate::compiler::QasmCompiler {
@@ -111,6 +120,7 @@ impl QasmCompiler {
     /// The main entry into compilation. This function will compile the
     /// source file and build the appropriate package based on the
     /// configuration.
+    #[must_use]
     pub fn compile(mut self, program: &crate::semantic::ast::Program) -> QasmCompileUnit {
         // in non-file mode we need the runtime imports in the body
         let program_ty = self.config.program_ty.clone();

--- a/compiler/qsc_qasm/src/io.rs
+++ b/compiler/qsc_qasm/src/io.rs
@@ -146,13 +146,6 @@ pub struct Cycle {
     pub paths: Vec<Arc<str>>,
 }
 
-impl Cycle {
-    #[must_use]
-    pub fn new(paths: Vec<Arc<str>>) -> Self {
-        Self { paths }
-    }
-}
-
 impl std::fmt::Display for Cycle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let parents = self.paths[0..(self.paths.len() - 1)].iter();

--- a/compiler/qsc_qasm/src/io.rs
+++ b/compiler/qsc_qasm/src/io.rs
@@ -17,7 +17,11 @@ use rustc_hash::FxHashMap;
 pub trait SourceResolver {
     fn ctx(&mut self) -> &mut SourceResolverContext;
 
-    fn resolve(&mut self, path: &Arc<str>) -> miette::Result<(Arc<str>, Arc<str>), Error>;
+    fn resolve(
+        &mut self,
+        path: &Arc<str>,
+        original_path: &Arc<str>,
+    ) -> miette::Result<(Arc<str>, Arc<str>), Error>;
 }
 
 pub struct IncludeGraphNode {
@@ -189,12 +193,16 @@ impl SourceResolver for InMemorySourceResolver {
         &mut self.ctx
     }
 
-    fn resolve(&mut self, path: &Arc<str>) -> miette::Result<(Arc<str>, Arc<str>), Error> {
+    fn resolve(
+        &mut self,
+        path: &Arc<str>,
+        original_path: &Arc<str>,
+    ) -> miette::Result<(Arc<str>, Arc<str>), Error> {
         match self.sources.get(path) {
             Some(source) => Ok((path.clone(), source.clone())),
             None => Err(Error(ErrorKind::NotFound(
                 Span::default(),
-                format!("Could not resolve include file: {path}"),
+                format!("Could not resolve include file: {original_path}"),
             ))),
         }
     }

--- a/compiler/qsc_qasm/src/io/error.rs
+++ b/compiler/qsc_qasm/src/io/error.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use miette::Diagnostic;
+use qsc_data_structures::span::Span;
 use thiserror::Error;
 
 use super::Cycle;
@@ -13,18 +14,46 @@ pub struct Error(pub ErrorKind);
 
 #[derive(Clone, Debug, Diagnostic, Eq, Error, PartialEq)]
 pub enum ErrorKind {
-    #[error("Not Found {0}")]
-    NotFound(String),
-    #[error("IO Error: {0}")]
-    IO(String),
-    #[error("{0} was already included in: {1}")]
-    MultipleInclude(String, String),
-    #[error("Cyclic include:{0}")]
-    CyclicInclude(Cycle),
+    #[error("Not Found: {1}")]
+    NotFound(#[label] Span, String),
+    #[error("IO Error: {1}")]
+    IO(#[label] Span, String),
+    #[error("{1} was already included in: {2}")]
+    MultipleInclude(#[label] Span, String, String),
+    #[error("Cyclic include:{1}")]
+    CyclicInclude(#[label] Span, Cycle),
 }
 
 impl From<Error> for crate::Error {
     fn from(val: Error) -> Self {
         crate::Error(crate::ErrorKind::IO(val))
+    }
+}
+
+impl Error {
+    pub(crate) fn with_offset(self, offset: u32) -> Self {
+        match self {
+            Error(ErrorKind::NotFound(span, msg)) => Error(ErrorKind::NotFound(span + offset, msg)),
+            Error(ErrorKind::IO(span, msg)) => Error(ErrorKind::IO(span + offset, msg)),
+            Error(ErrorKind::MultipleInclude(span, inc, incs)) => {
+                Error(ErrorKind::MultipleInclude(span + offset, inc, incs))
+            }
+            Error(ErrorKind::CyclicInclude(span, cycle)) => {
+                Error(ErrorKind::CyclicInclude(span + offset, cycle))
+            }
+        }
+    }
+
+    pub(crate) fn with_span(self, span: Span) -> Self {
+        match self {
+            Error(ErrorKind::NotFound(_, msg)) => Error(ErrorKind::NotFound(span, msg)),
+            Error(ErrorKind::IO(_, msg)) => Error(ErrorKind::IO(span, msg)),
+            Error(ErrorKind::MultipleInclude(_, inc, incs)) => {
+                Error(ErrorKind::MultipleInclude(span, inc, incs))
+            }
+            Error(ErrorKind::CyclicInclude(_, cycle)) => {
+                Error(ErrorKind::CyclicInclude(span, cycle))
+            }
+        }
     }
 }

--- a/compiler/qsc_qasm/src/lib.rs
+++ b/compiler/qsc_qasm/src/lib.rs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 mod ast_builder;
-mod compiler;
-mod stdlib;
-pub use compiler::compile_to_qsharp_ast_with_config;
+pub mod compiler;
 mod convert;
 pub mod display_utils;
 pub mod io;
@@ -12,6 +10,7 @@ mod keyword;
 mod lex;
 pub mod parser;
 pub mod semantic;
+mod stdlib;
 mod types;
 
 #[cfg(test)]
@@ -164,6 +163,7 @@ pub enum ProgramType {
 /// This is used to create a function signature for the
 /// operation that is created from the QASM source code.
 /// This is the human readable form of the operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OperationSignature {
     pub name: String,
     pub ns: Option<String>,
@@ -224,6 +224,7 @@ impl std::fmt::Display for OperationSignature {
 
 /// A unit of compilation for QASM source code.
 /// This is the result of parsing and compiling a QASM source file.
+#[derive(Debug, Clone)]
 pub struct QasmCompileUnit {
     /// Source map created from the accumulated source files,
     source_map: SourceMap,

--- a/compiler/qsc_qasm/src/parser.rs
+++ b/compiler/qsc_qasm/src/parser.rs
@@ -229,11 +229,26 @@ impl QasmSource {
     }
 }
 
+fn strip_scheme(path: &str) -> (Option<Arc<str>>, Arc<str>) {
+    if let Some(scheme_end) = path.find("://") {
+        let scheme = &path[..scheme_end];
+        let after_scheme = &path[scheme_end + 3..];
+
+        (Some(Arc::from(scheme)), Arc::from(after_scheme))
+    } else {
+        (None, Arc::from(path))
+    }
+}
+
 /// append a path to a base path, resolving any relative components
 /// like `.` and `..` in the process.
 /// When the base path is a URI, it will be resolved as well.
+/// Uri schemes are stripped from the path, and the resulting path
+/// is processed as a file path. The scheme is prepended back to the
+/// resulting path if it was present in the base path.
 fn resolve_path(base: &Path, path: &Path) -> miette::Result<PathBuf> {
-    let joined = base.join(path);
+    let (scheme, joined) = strip_scheme(&base.join(path).to_string_lossy());
+    let joined = PathBuf::from(joined.as_ref());
     // Adapted from https://github.com/rust-lang/cargo/blob/a879a1ca12e3997d9fdd71b70f34f1f3c866e1da/crates/cargo-util/src/paths.rs#L84
     let mut components = joined.components().peekable();
     let mut normalized = if let Some(c @ Component::Prefix(..)) = components.peek().copied() {
@@ -258,7 +273,9 @@ fn resolve_path(base: &Path, path: &Path) -> miette::Result<PathBuf> {
             }
         }
     }
-
+    if let Some(scheme) = scheme {
+        normalized = format!("{scheme}://{}", normalized.to_string_lossy()).into();
+    }
     Ok(normalized)
 }
 

--- a/compiler/qsc_qasm/src/parser.rs
+++ b/compiler/qsc_qasm/src/parser.rs
@@ -295,7 +295,7 @@ where
         .check_include_errors(&resolved_path, span)
         .map_err(|e| io_to_parse_error(span, e))?;
 
-    match resolver.resolve(&resolved_path) {
+    match resolver.resolve(&resolved_path, path) {
         Ok((path, source)) => {
             let parse_result = parse_qasm_source(source, path.clone(), resolver);
 

--- a/compiler/qsc_qasm/src/parser/error.rs
+++ b/compiler/qsc_qasm/src/parser/error.rs
@@ -163,7 +163,7 @@ impl ErrorKind {
             Self::GPhaseInvalidArguments(span) => Self::GPhaseInvalidArguments(span + offset),
             Self::InvalidGateCallDesignator(span) => Self::InvalidGateCallDesignator(span + offset),
             Self::MultipleIndexOperators(span) => Self::MultipleIndexOperators(span + offset),
-            Self::IO(error) => Self::IO(error),
+            Self::IO(error) => Self::IO(error.with_offset(offset)),
         }
     }
 }

--- a/compiler/qsc_qasm/src/parser/tests.rs
+++ b/compiler/qsc_qasm/src/parser/tests.rs
@@ -21,7 +21,9 @@ pub(crate) fn parse_all<S: Into<Arc<str>>>(
 ) -> miette::Result<QasmParseResult, Vec<Report>> {
     let path = path.into();
     let mut resolver = InMemorySourceResolver::from_iter(sources);
-    let (path, source) = resolver.resolve(&path).map_err(|e| vec![Report::new(e)])?;
+    let (path, source) = resolver
+        .resolve(&path, &path)
+        .map_err(|e| vec![Report::new(e)])?;
     let res = crate::parser::parse_source(source, path, &mut resolver);
     if res.source.has_errors() {
         let errors = res

--- a/compiler/qsc_qasm/src/semantic/symbols.rs
+++ b/compiler/qsc_qasm/src/semantic/symbols.rs
@@ -222,6 +222,7 @@ impl std::fmt::Display for IOKind {
 
 /// A scope is a collection of symbols and a kind. The kind determines semantic
 /// rules for compliation as shadowing and decl rules vary by scope kind.
+#[derive(Debug, Clone)]
 pub(crate) struct Scope {
     /// A map from symbol name to symbol ID.
     name_to_id: FxHashMap<String, SymbolId>,
@@ -276,6 +277,7 @@ impl Scope {
 }
 
 /// A symbol table is a collection of scopes and manages the symbol ids.
+#[derive(Debug, Clone)]
 pub struct SymbolTable {
     scopes: Vec<Scope>,
     symbols: IndexMap<SymbolId, Rc<Symbol>>,

--- a/compiler/qsc_qasm/src/semantic/tests.rs
+++ b/compiler/qsc_qasm/src/semantic/tests.rs
@@ -134,7 +134,7 @@ fn check_map_all<P: Into<Arc<str>>>(
     let path = path.into();
     let mut resolver = InMemorySourceResolver::from_iter(sources);
     let source = resolver
-        .resolve(&path)
+        .resolve(&path, &path)
         .map_err(|e| vec![e])
         .expect("could not load source")
         .1;

--- a/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
@@ -12,7 +12,13 @@ fn check_lowerer_error_spans_are_correct() {
     check_qasm_to_qsharp(
         SOURCE,
         &expect![[r#"
-              x Not Found Could not resolve include file: missing_file
+              x Not Found: Could not resolve include file: missing_file
+                ,-[Test.qasm:21:1]
+             20 | // lowerer, so that we can contruct the error with the right span.
+             21 | include "missing_file";
+                : ^^^^^^^^^^^^^^^^^^^^^^^
+             22 | 
+                `----
 
             Qasm.Lowerer.UnsupportedVersion
 

--- a/compiler/qsc_qasm/src/tests.rs
+++ b/compiler/qsc_qasm/src/tests.rs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::compiler::parse_and_compile_to_qsharp_ast_with_config;
 use crate::io::{InMemorySourceResolver, SourceResolver};
 use crate::semantic::{parse_source, QasmSemanticParseResult};
-use crate::{
-    compile_to_qsharp_ast_with_config, CompilerConfig, OutputSemantics, ProgramType,
-    QasmCompileUnit, QubitSemantics,
-};
+use crate::{CompilerConfig, OutputSemantics, ProgramType, QasmCompileUnit, QubitSemantics};
 use expect_test::Expect;
 use miette::Report;
 use qsc::compile::compile_ast;
@@ -197,8 +195,12 @@ fn compile_qasm_best_effort(source: &str, profile: Profile) {
         None,
     );
 
-    let unit =
-        compile_to_qsharp_ast_with_config(source, "source.qasm", Some(&mut resolver), config);
+    let unit = parse_and_compile_to_qsharp_ast_with_config(
+        source,
+        "source.qasm",
+        Some(&mut resolver),
+        config,
+    );
     let (sources, _, package, _) = unit.into_tuple();
 
     let dependencies = vec![(PackageId::CORE, None), (stdid, None)];
@@ -446,7 +448,7 @@ pub(crate) fn compare_qasm_and_qasharp_asts(source: &str) {
         None,
     );
     let mut resolver = crate::io::InMemorySourceResolver::from_iter([]);
-    let unit = crate::compile_to_qsharp_ast_with_config(
+    let unit = parse_and_compile_to_qsharp_ast_with_config(
         source,
         "source.qasm",
         Some(&mut resolver),

--- a/compiler/qsc_qasm/src/tests.rs
+++ b/compiler/qsc_qasm/src/tests.rs
@@ -252,7 +252,10 @@ pub(crate) fn parse_all<P: Into<Arc<str>>>(
 ) -> miette::Result<QasmSemanticParseResult, Vec<Report>> {
     let path = path.into();
     let mut resolver = InMemorySourceResolver::from_iter(sources);
-    let source = resolver.resolve(&path).map_err(|e| vec![Report::new(e)])?.1;
+    let source = resolver
+        .resolve(&path, &path)
+        .map_err(|e| vec![Report::new(e)])?
+        .1;
     let res = parse_source(source, path, &mut resolver);
     if res.source.has_errors() {
         let errors = res

--- a/compiler/qsc_qasm/src/tests/statement/include.rs
+++ b/compiler/qsc_qasm/src/tests/statement/include.rs
@@ -122,7 +122,7 @@ fn including_stdgates_multiple_times_causes_symbol_redifintion_errors() {
 
     let errors: Vec<_> = errors.iter().map(|e| format!("{e}")).collect();
     let errors_string = errors.join("\n");
-    expect!["Not Found Could not resolve include file: main.qasm"].assert_eq(&errors_string);
+    expect!["Not Found: Could not resolve include file: main.qasm"].assert_eq(&errors_string);
 }
 
 #[test]

--- a/fuzz/fuzz_targets/qasm.rs
+++ b/fuzz/fuzz_targets/qasm.rs
@@ -12,8 +12,8 @@ use qsc::{
     compile::{compile_ast, package_store_with_stdlib},
     hir::PackageId,
     qasm::{
-        compile_to_qsharp_ast_with_config, io::InMemorySourceResolver, CompilerConfig,
-        OutputSemantics, ProgramType, QubitSemantics,
+        compiler::parse_and_compile_to_qsharp_ast_with_config, io::InMemorySourceResolver,
+        CompilerConfig, OutputSemantics, ProgramType, QubitSemantics,
     },
     target::Profile,
     PackageStore, PackageType,
@@ -36,7 +36,7 @@ fn compile(data: &[u8]) {
                 None,
             );
 
-            let unit = compile_to_qsharp_ast_with_config(
+            let unit = parse_and_compile_to_qsharp_ast_with_config(
                 fuzzed_code,
                 "fuzz.qasm",
                 Some(&mut resolver),

--- a/language_service/src/completion/tests/openqasm.rs
+++ b/language_service/src/completion/tests/openqasm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::{cell::RefCell, path::Path, rc::Rc, sync::Arc};
 
 use super::{get_completions, CompletionItem};
 use crate::{
@@ -36,8 +36,9 @@ fn compile_project_with_markers_cursor_optional(
     let fs = Rc::new(RefCell::new(fs));
     let project_host = TestProjectHost { fs: fs.clone() };
 
-    let project = FutureExt::now_or_never(project_host.load_openqasm_project(path, None))
-        .expect("load_openqasm_project should never await");
+    let project =
+        FutureExt::now_or_never(project_host.load_openqasm_project(Path::new(path.as_ref()), None))
+            .expect("load_openqasm_project should never await");
 
     let ProjectType::OpenQASM(sources) = project.project_type else {
         panic!("expected OpenQASM project type");

--- a/language_service/src/completion/tests/openqasm.rs
+++ b/language_service/src/completion/tests/openqasm.rs
@@ -1,48 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::{cell::RefCell, path::Path, rc::Rc, sync::Arc};
+use std::sync::Arc;
 
 use super::{get_completions, CompletionItem};
-use crate::{
-    test_utils::get_sources_and_markers,
-    tests::test_fs::{dir_of_files, file, TestProjectHost},
-    Compilation, Encoding,
-};
+use crate::{test_utils::get_sources_and_markers, Compilation, Encoding};
 use expect_test::{expect, Expect};
-use futures::FutureExt;
 use indoc::indoc;
 use qsc::{
     line_column::{Position, Range},
     location::Location,
     PackageType,
 };
-use qsc_project::{FileSystemAsync, ProjectType};
 
 fn compile_project_with_markers_cursor_optional(
     sources_with_markers: &[(&str, &str)],
 ) -> (Compilation, Option<(String, Position)>, Vec<Location>) {
     let (sources, cursor_location, target_spans) = get_sources_and_markers(sources_with_markers);
-    let path = &sources
-        .first()
-        .expect("There must be a file to compile")
-        .0
-        .clone();
-    let files = sources
-        .into_iter()
-        .map(|(name, contents)| file(&name, &contents))
-        .collect::<Vec<_>>();
-    let fs = dir_of_files(files);
-    let fs = Rc::new(RefCell::new(fs));
-    let project_host = TestProjectHost { fs: fs.clone() };
-
-    let project =
-        FutureExt::now_or_never(project_host.load_openqasm_project(Path::new(path.as_ref()), None))
-            .expect("load_openqasm_project should never await");
-
-    let ProjectType::OpenQASM(sources) = project.project_type else {
-        panic!("expected OpenQASM project type");
-    };
 
     (
         Compilation::new_qasm(

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -227,7 +227,7 @@ impl<'a> CompilationStateUpdater<'a> {
     ) -> Result<Option<Project>, Vec<project::Error>> {
         if is_openqasm_file(language_id) {
             return Ok(Some(
-                qsc_project::openqasm::load_project(&*self.project_host, doc_uri).await,
+                self.project_host.load_openqasm_project(doc_uri, None).await,
             ));
         }
         self.load_manifest(doc_uri).await

--- a/language_service/src/state.rs
+++ b/language_service/src/state.rs
@@ -18,6 +18,7 @@ use qsc_linter::LintOrGroupConfig;
 use qsc_project::{FileSystemAsync, JSProjectHost, PackageCache, Project, ProjectType};
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use std::path::Path;
 use std::{cell::RefCell, fmt::Debug, mem::take, path::PathBuf, rc::Rc, sync::Arc, vec};
 
 #[derive(Default, Debug)]
@@ -227,7 +228,9 @@ impl<'a> CompilationStateUpdater<'a> {
     ) -> Result<Option<Project>, Vec<project::Error>> {
         if is_openqasm_file(language_id) {
             return Ok(Some(
-                self.project_host.load_openqasm_project(doc_uri, None).await,
+                self.project_host
+                    .load_openqasm_project(Path::new(doc_uri.as_ref()), None)
+                    .await,
             ));
         }
         self.load_manifest(doc_uri).await

--- a/language_service/src/tests/test_fs.rs
+++ b/language_service/src/tests/test_fs.rs
@@ -190,6 +190,10 @@ pub(crate) fn dir<const COUNT: usize>(
     (name.into(), FsNode::Dir(contents.into_iter().collect()))
 }
 
+pub(crate) fn dir_of_files(contents: Vec<(Arc<str>, FsNode)>) -> FsNode {
+    FsNode::Dir(contents.into_iter().collect::<FxHashMap<_, _>>())
+}
+
 pub(crate) fn file(name: &str, contents: &str) -> (Arc<str>, FsNode) {
     (name.into(), FsNode::File(Arc::from(contents)))
 }

--- a/language_service/src/tests/test_fs.rs
+++ b/language_service/src/tests/test_fs.rs
@@ -208,12 +208,11 @@ impl JSProjectHost for TestProjectHost {
         self.fs.borrow().list_directory(uri.to_string())
     }
 
-    async fn resolve_path(&self, base: &str, path: &str) -> Option<Arc<str>> {
+    async fn resolve_path(&self, base: &str, path: &str) -> miette::Result<Arc<str>> {
         self.fs
             .borrow()
             .resolve_path(PathBuf::from(base).as_path(), PathBuf::from(path).as_path())
             .map(|p| p.to_string_lossy().into())
-            .ok()
     }
 
     async fn find_manifest_directory(&self, doc_uri: &str) -> Option<Arc<str>> {

--- a/language_service/src/tests/test_fs.rs
+++ b/language_service/src/tests/test_fs.rs
@@ -190,10 +190,6 @@ pub(crate) fn dir<const COUNT: usize>(
     (name.into(), FsNode::Dir(contents.into_iter().collect()))
 }
 
-pub(crate) fn dir_of_files(contents: Vec<(Arc<str>, FsNode)>) -> FsNode {
-    FsNode::Dir(contents.into_iter().collect::<FxHashMap<_, _>>())
-}
-
 pub(crate) fn file(name: &str, contents: &str) -> (Arc<str>, FsNode) {
     (name.into(), FsNode::File(Arc::from(contents)))
 }

--- a/pip/src/interop.rs
+++ b/pip/src/interop.rs
@@ -92,10 +92,7 @@ pub(crate) fn run_qasm_program(
     let file_path = PathBuf::from_str(&search_path)
         .expect("from_str is infallible")
         .join("program.qasm");
-    let project = fs.load_openqasm_project(
-        &Arc::<str>::from(file_path.display().to_string()),
-        Some(Arc::<str>::from(source)),
-    );
+    let project = fs.load_openqasm_project(&file_path, Some(Arc::<str>::from(source)));
     let ProjectType::OpenQASM(sources) = project.project_type else {
         return Err(QasmError::new_err(
             "Expected OpenQASM project, but got a different type".to_string(),
@@ -202,10 +199,7 @@ pub(crate) fn resource_estimate_qasm_program(
     let file_path = PathBuf::from_str(&search_path)
         .expect("from_str is infallible")
         .join("program.qasm");
-    let project = fs.load_openqasm_project(
-        &Arc::<str>::from(file_path.display().to_string()),
-        Some(Arc::<str>::from(source)),
-    );
+    let project = fs.load_openqasm_project(&file_path, Some(Arc::<str>::from(source)));
     let ProjectType::OpenQASM(sources) = project.project_type else {
         return Err(QasmError::new_err(
             "Expected OpenQASM project, but got a different type".to_string(),
@@ -294,10 +288,7 @@ pub(crate) fn compile_qasm_program_to_qir(
     let file_path = PathBuf::from_str(&search_path)
         .expect("from_str is infallible")
         .join("program.qasm");
-    let project = fs.load_openqasm_project(
-        &Arc::<str>::from(file_path.display().to_string()),
-        Some(Arc::<str>::from(source)),
-    );
+    let project = fs.load_openqasm_project(&file_path, Some(Arc::<str>::from(source)));
     let ProjectType::OpenQASM(sources) = project.project_type else {
         return Err(QasmError::new_err(
             "Expected OpenQASM project, but got a different type".to_string(),
@@ -396,10 +387,7 @@ pub(crate) fn compile_qasm_to_qsharp(
     let file_path = PathBuf::from_str(&search_path)
         .expect("from_str is infallible")
         .join("program.qasm");
-    let project = fs.load_openqasm_project(
-        &Arc::<str>::from(file_path.display().to_string()),
-        Some(Arc::<str>::from(source)),
-    );
+    let project = fs.load_openqasm_project(&file_path, Some(Arc::<str>::from(source)));
     let ProjectType::OpenQASM(sources) = project.project_type else {
         return Err(QasmError::new_err(
             "Expected OpenQASM project, but got a different type".to_string(),
@@ -563,10 +551,7 @@ pub(crate) fn circuit_qasm_program(
     let file_path = PathBuf::from_str(&search_path)
         .expect("from_str is infallible")
         .join("program.qasm");
-    let project = fs.load_openqasm_project(
-        &Arc::<str>::from(file_path.display().to_string()),
-        Some(Arc::<str>::from(source)),
-    );
+    let project = fs.load_openqasm_project(&file_path, Some(Arc::<str>::from(source)));
     let ProjectType::OpenQASM(sources) = project.project_type else {
         return Err(QasmError::new_err(
             "Expected OpenQASM project, but got a different type".to_string(),

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -484,10 +484,7 @@ impl Interpreter {
         let file_path = PathBuf::from_str(&search_path)
             .expect("from_str is infallible")
             .join("program.qasm");
-        let project = fs.load_openqasm_project(
-            &Arc::<str>::from(file_path.display().to_string()),
-            Some(Arc::<str>::from(input)),
-        );
+        let project = fs.load_openqasm_project(&file_path, Some(Arc::<str>::from(input)));
         let ProjectType::OpenQASM(sources) = project.project_type else {
             return Err(QasmError::new_err(
                 "Expected OpenQASM project, but got a different type".to_string(),

--- a/samples_test/src/tests.rs
+++ b/samples_test/src/tests.rs
@@ -25,7 +25,10 @@ use qsc::{
     hir::PackageId,
     interpret::{GenericReceiver, Interpreter},
     packages::BuildableProgram,
-    qasm::{io::InMemorySourceResolver, OutputSemantics, ProgramType, QubitSemantics},
+    qasm::{
+        compiler::parse_and_compile_to_qsharp_ast_with_config, io::InMemorySourceResolver,
+        OutputSemantics, ProgramType, QubitSemantics,
+    },
     LanguageFeatures, PackageType, SourceMap, TargetCapabilityFlags,
 };
 use qsc_project::{FileSystem, ProjectType, StdFs};
@@ -102,7 +105,7 @@ fn compile_and_run_qasm_internal(source: &str, debug: bool) -> String {
         None,
         None,
     );
-    let unit = qsc::qasm::compile_to_qsharp_ast_with_config(
+    let unit = parse_and_compile_to_qsharp_ast_with_config(
         source,
         "",
         Option::<&mut InMemorySourceResolver>::None,

--- a/vscode/src/projectSystem.ts
+++ b/vscode/src/projectSystem.ts
@@ -250,7 +250,9 @@ export function resolvePath(base: string, relative: string): string | null {
   try {
     return Utils.resolvePath(URI.parse(base, true), relative).toString();
   } catch (e) {
-    log.warn(`Failed to resolve path ${base} and ${relative}: ${e}`);
+    log.trace(`Failed to resolve path ${base} and ${relative}: ${e}`);
+    // `string | null` gets mapped to `JSValue` then `Option<String>` in Rust where it is mapped
+    // to a result type, so we return `null` here if the path cannot be resolved.
     return null;
   }
 }

--- a/vscode/src/projectSystem.ts
+++ b/vscode/src/projectSystem.ts
@@ -247,14 +247,7 @@ async function singleFileProject(
 }
 
 export function resolvePath(base: string, relative: string): string | null {
-  try {
-    return Utils.resolvePath(URI.parse(base, true), relative).toString();
-  } catch (e) {
-    log.trace(`Failed to resolve path ${base} and ${relative}: ${e}`);
-    // `string | null` gets mapped to `JSValue` then `Option<String>` in Rust where it is mapped
-    // to a result type, so we return `null` here if the path cannot be resolved.
-    return null;
-  }
+  return Utils.resolvePath(URI.parse(base, true), relative).toString();
 }
 
 let githubEndpoint = "https://raw.githubusercontent.com";

--- a/vscode/test/suites/debugger/openqasm.test.ts
+++ b/vscode/test/suites/debugger/openqasm.test.ts
@@ -21,8 +21,6 @@ suite("OpenQASM Debugger Tests", function suite() {
     workspaceFolder.uri,
     selfContainedName,
   );
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const multifileUri = vscode.Uri.joinPath(workspaceFolder.uri, multifileName);
   const multifileIncludeUri = vscode.Uri.joinPath(
     workspaceFolder.uri,
     multifileIncludeName,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -678,7 +678,7 @@ fn get_configured_interpreter_from_openqasm(
     let mut resolver = sources.iter().cloned().collect::<InMemorySourceResolver>();
 
     let CompileRawQasmResult(store, source_package_id, dependencies, sig, errors) =
-        qsc::qasm::compile_raw_qasm(
+        qsc::qasm::parse_and_compile_raw_qasm(
             source.clone(),
             file.clone(),
             Some(&mut resolver),

--- a/wasm/src/project_system.rs
+++ b/wasm/src/project_system.rs
@@ -8,7 +8,7 @@ use qsc::{linter::LintOrGroupConfig, packages::BuildableProgram, LanguageFeature
 use qsc_project::{EntryType, FileSystemAsync, JSFileEntry, JSProjectHost, PackageCache};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::{cell::RefCell, iter::FromIterator, rc::Rc, str::FromStr, sync::Arc};
+use std::{cell::RefCell, iter::FromIterator, path::Path, rc::Rc, str::FromStr, sync::Arc};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -189,7 +189,7 @@ impl ProjectLoader {
     ) -> Result<IProjectConfig, String> {
         let package_cache = PACKAGE_CACHE.with(Clone::clone);
 
-        let dir_path = std::path::Path::new(&directory);
+        let dir_path = Path::new(&directory);
         let project_config = match self.0.load_project(dir_path, Some(&package_cache)).await {
             Ok(loaded_project) => loaded_project,
             Err(errs) => return Err(project_errors_into_qsharp_errors_json(&directory, &errs)),
@@ -206,7 +206,7 @@ impl ProjectLoader {
     ) -> Result<IProjectConfig, String> {
         let project_config = self
             .0
-            .load_openqasm_project(&file_path.clone().into(), source.map(Arc::<str>::from))
+            .load_openqasm_project(Path::new(&file_path), source.map(Arc::<str>::from))
             .await;
         // Will return error if project has errors
         project_config.try_into()


### PR DESCRIPTION
Replaces #2444
 
- **Unified project loading**: Consolidated OpenQASM project loading across all components (compiler, language service, Python pip, WASM) to use a single `load_openqasm_project` method instead of multiple inconsistent approaches
- **Improved error handling**: Enhanced include file error propagation by properly associating errors with their source spans and include statements in the parent file
- **Better error reporting**: Include file errors now display with proper source location information, showing the problematic include statement in context instead of generic "Not Found" messages
- **API simplification**:
  - Removed custom `ImportResolver` from Python interop in favor of unified project loading
  - Replaced multiple `compile_to_qsharp_ast_with_config` calls with `parse_and_compile_to_qsharp_ast_with_config`. With parsing, compilation, and project loading being separated, trying to clear up intent and purpose.
  - Added `parse_sources` utility function for handling multiple source files
- **Enhanced debugging support**: Added test coverage for setting breakpoints in multi-file OpenQASM programs with included files
- **Code structure improvements**:
  - Added `Debug` and `Clone` derives to semantic analysis types for better tooling support
  - Consolidated error handling logic into reusable helper functions
  - Improved span tracking for IO errors through the compilation pipeline

The changes ensure consistent OpenQASM project handling across VS Code extension, Python package, WASM builds, and language service while providing better error messages and debugging capabilities for multi-file projects.