### PR TITLE
Add EC trait function to adjust code parameter after selection

### DIFF
--- a/resource_estimator/src/estimates/error_correction.rs
+++ b/resource_estimator/src/estimates/error_correction.rs
@@ -156,6 +156,21 @@ pub trait ErrorCorrection {
             .ok_or_else(|| format!("No code parameter achieves required logical error rate {required_logical_error_rate:.3e}"))
     }
 
+    /// Adjusts code parameter after computing it
+    ///
+    /// This function is called after the initial code parameter has been
+    /// computed.  The initial code parameter will fit the required logical
+    /// error rate, but it's possible to further refine it, if necessary.
+    ///
+    /// Note, that when implementing this function wrong, it may return a code
+    /// parameter that will not fit the required logical error rate any longer.
+    ///
+    /// The default implementation does not update the code parameter.
+    fn adjust_code_parameter(&self, parameter: Self::Parameter) -> Result<Self::Parameter, String> {
+        // Default implementation does not update the code parameter
+        Ok(parameter)
+    }
+
     /// Returns an iterator of all possible code parameters
     ///
     /// Implementors of this method should sort the code parameters such that

--- a/resource_estimator/src/estimates/error_correction.rs
+++ b/resource_estimator/src/estimates/error_correction.rs
@@ -162,8 +162,9 @@ pub trait ErrorCorrection {
     /// computed.  The initial code parameter will fit the required logical
     /// error rate, but it's possible to further refine it, if necessary.
     ///
-    /// Note, that when implementing this function wrong, it may return a code
-    /// parameter that will not fit the required logical error rate any longer.
+    /// Note, that when implementing the ErrorCorrection trait and providing a
+    /// custom implementation for this function, it may return a code parameter
+    /// that will not fit the required logical error rate any longer.
     ///
     /// The default implementation does not update the code parameter.
     fn adjust_code_parameter(&self, parameter: Self::Parameter) -> Result<Self::Parameter, String> {

--- a/resource_estimator/src/estimates/error_correction.rs
+++ b/resource_estimator/src/estimates/error_correction.rs
@@ -162,7 +162,7 @@ pub trait ErrorCorrection {
     /// computed.  The initial code parameter will fit the required logical
     /// error rate, but it's possible to further refine it, if necessary.
     ///
-    /// Note, that when implementing the ErrorCorrection trait and providing a
+    /// Note, that when implementing the `ErrorCorrection` trait and providing a
     /// custom implementation for this function, it may return a code parameter
     /// that will not fit the required logical error rate any longer.
     ///

--- a/resource_estimator/src/estimates/physical_estimation.rs
+++ b/resource_estimator/src/estimates/physical_estimation.rs
@@ -558,8 +558,13 @@ impl<
 
     /// Computes the code parameter for the required logical error rate
     fn compute_code_parameter(&self, error_rate: f64) -> Result<E::Parameter, Error> {
-        self.ftp
+        let parameter = self
+            .ftp
             .compute_code_parameter(&self.qubit, error_rate)
+            .map_err(Error::CodeParameterComputationFailed)?;
+
+        self.ftp
+            .adjust_code_parameter(parameter)
             .map_err(Error::CodeParameterComputationFailed)
     }
 


### PR DESCRIPTION
This adds an EC trait function to provide the possibility to adjust the code parameter after it has been computed. This is required for special EC functionality through the extensibility API. The default implementation of the trait function returns the original code parameter and the EC implementation inside the QDK does not change that function.