### PR TITLE
Generic resource estimation using Python models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,7 @@ dependencies = [
  "qsc",
  "resource_estimator",
  "rustc-hash",
+ "serde",
  "serde_json",
 ]
 

--- a/pip/Cargo.toml
+++ b/pip/Cargo.toml
@@ -17,6 +17,7 @@ qsc = { path = "../compiler/qsc" }
 resource_estimator = { path = "../resource_estimator" }
 miette = { workspace = true, features = ["fancy"] }
 rustc-hash = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [lints]

--- a/pip/qsharp/__init__.py
+++ b/pip/qsharp/__init__.py
@@ -23,7 +23,7 @@ from ._qsharp import (
 
 telemetry_events.on_import()
 
-from ._native import Result, Pauli, QSharpError, TargetProfile
+from ._native import Result, Pauli, QSharpError, TargetProfile, estimate_generic
 
 # IPython notebook specific features
 try:
@@ -47,6 +47,7 @@ __all__ = [
     "compile",
     "circuit",
     "estimate",
+    "estimate_generic",
     "Result",
     "Pauli",
     "QSharpError",

--- a/pip/src/generic_estimator.rs
+++ b/pip/src/generic_estimator.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::{rc::Rc, time::Instant};
+
+use pyo3::{prelude::*, types::PyDict};
+use resource_estimator::estimates::{ErrorBudget, ErrorBudgetStrategy, PhysicalResourceEstimation};
+use serde_json::json;
+
+use crate::generic_estimator::{
+    code::PythonQEC,
+    counts::PythonCounts,
+    factory::{PythonFactoryBuilder, PythonFactoryBuilderDispatch},
+    utils::json_map_to_python_dict,
+};
+
+mod code;
+mod counts;
+mod factory;
+mod utils;
+
+#[cfg(test)]
+mod tests;
+
+pub(crate) fn register_generic_estimator_submodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(estimate_generic, m)?)?;
+    Ok(())
+}
+
+/// Estimates quantum resources for a given algorithm, qubit, and code.
+///
+/// Args:
+///     algorithm: Python object representing the algorithm.
+///     qubit: The qubit properties as a dictionary.
+///     qec: Python object representing the quantum error correction code.
+///     factories (list, optional): List of python objects representing factories. Default: [].
+///     error_budget (float, optional): The total error budget, which is uniformly distributed. Default: 0.01.
+///     max_factories (int, optional): Constrains the number of factories. Default: None.
+///     logical_depth_factor (float, optional): Extends algorithmic logical depth by a factor >= 1. Default: None.
+///     max_physical_qubits (int, optional): Forces estimator to not exceed provided number of physical qubits, may fail. Default: None.
+///     max_duration (int, optional): Allows estimator to run for given runtime in nanoseconds, may fail. Default: None.
+///     error_budget_pruning (bool, optional): Will try to prune the error budget to increase magic state error budget. Default: False.
+///
+/// Returns:
+///     dict: A dictionary with resource estimation results.
+#[allow(clippy::too_many_arguments)]
+#[pyfunction]
+#[pyo3(signature = (algorithm, qubit, qec, factories = vec![], *, error_budget = 0.01, max_factories = None, logical_depth_factor = None, max_physical_qubits = None, max_duration = None, error_budget_pruning = false))]
+fn estimate_generic<'py>(
+    algorithm: Bound<'py, PyAny>,
+    qubit: Bound<'py, PyDict>,
+    qec: Bound<'py, PyAny>,
+    factories: Vec<Bound<'py, PyAny>>,
+    error_budget: f64,
+    max_factories: Option<u64>,
+    logical_depth_factor: Option<f64>,
+    max_physical_qubits: Option<u64>,
+    max_duration: Option<u64>,
+    error_budget_pruning: bool,
+) -> PyResult<Bound<'py, PyDict>> {
+    let error_budget = ErrorBudget::new(error_budget / 3.0, error_budget / 3.0, error_budget / 3.0);
+
+    // evaluate algorithm to compute post-mapping logical resource counts
+    let time_algorithm = Instant::now();
+    let algorithm_overhead = Rc::new(PythonCounts::from_bound(algorithm)?);
+    let time_algorithm = time_algorithm.elapsed().as_nanos();
+
+    // prepare estimation input
+    let qubit = Rc::new(qubit);
+    let code = PythonQEC::from_bound(qec)?;
+
+    // load factories from Python
+    let factories = factories
+        .into_iter()
+        .map(PythonFactoryBuilder::from_bound)
+        .collect::<PyResult<Vec<_>>>()?;
+
+    // create resource estimator
+    let mut estimation = PhysicalResourceEstimation::new(
+        code,
+        qubit.clone(),
+        PythonFactoryBuilderDispatch(factories),
+        algorithm_overhead.clone(),
+    );
+    if let Some(max_factories) = max_factories {
+        estimation.set_max_factories(max_factories);
+    }
+    if let Some(logical_depth_factor) = logical_depth_factor {
+        estimation.set_logical_depth_factor(logical_depth_factor);
+    }
+    if let Some(max_physical_qubits) = max_physical_qubits {
+        estimation.set_max_physical_qubits(max_physical_qubits);
+    }
+    if let Some(max_duration) = max_duration {
+        estimation.set_max_duration(max_duration);
+    }
+    if error_budget_pruning {
+        estimation.set_error_budget_strategy(ErrorBudgetStrategy::PruneLogicalAndRotations);
+    }
+
+    // perform estimation
+    let time_estimation = Instant::now();
+    let result = estimation
+        .estimate(&error_budget)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
+    let time_estimation = time_estimation.elapsed().as_nanos();
+
+    // we first serialize the result to JSON, then convert it to a Python
+    // dictionary.  The alternative would be to convert the result to a Python
+    // dictionary directly, but that would either:
+    // - require to ensure that all fields are consistently added to the result
+    //   dictionary,
+    // - require to implement a custom serializer for a Python dictionary
+    let json = json!(&result);
+
+    // serialize the result to a Python dictionary and add some other fields
+    let dict = json_map_to_python_dict(
+        qubit.as_ref().py(),
+        json.as_object().expect("result is a JSON object"),
+    )?;
+
+    dict.set_item("qubit", qubit.as_ref())?;
+
+    if let Some(value) = algorithm_overhead.algorithm_overhead(&error_budget)? {
+        dict.set_item("algorithmOverhead", value)?;
+    }
+
+    let execution_stats = PyDict::new(qubit.as_ref().py());
+    execution_stats.set_item("timeAlgorithm", time_algorithm)?;
+    execution_stats.set_item("timeEstimation", time_estimation)?;
+    dict.set_item("executionStats", execution_stats)?;
+
+    Ok(dict)
+}

--- a/pip/src/generic_estimator/code.rs
+++ b/pip/src/generic_estimator/code.rs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use pyo3::{
+    types::{PyAnyMethods, PyDict},
+    Bound, PyAny, PyResult,
+};
+use resource_estimator::estimates::ErrorCorrection;
+
+use super::utils::{extract_and_check_method, maybe_extract_and_check_method, SerializableBound};
+
+/// A wrapper around a Python instance to compute quantum error correction
+/// properties in generic resource estimation.
+///
+/// The code parameter (e.g., distance) is generic and the possible code
+/// parameter values are returned via the `code_parameter_range` method and
+/// compared (for sorting) via the `code_parameter_cmp` method:
+///
+/// ```python
+///     def code_parameter_range(self):
+///         # e.g., return [7, 9, 11]
+///         ...
+///
+///     def code_parameter_cmp(self, qubit, p1, p2):
+///         # qubit properties (via qubit) may be considered for comparison
+///         #
+///         # must return -1 if p1 < p2, 0 if p1 == p2, and 1 if p1 > p2
+///         ...
+/// ```
+///
+/// The number of physical and logical qubits for one code patch depends on the
+/// code parameter and is computed with the methods `physical_qubits` and
+/// `logical_qubits`, respectively:
+///
+/// ```python
+///     def physical_qubits(self, param):
+///         # must return an int
+///         ...
+///
+///     def logical_qubits(self, param):
+///         # must return an int
+///         ...
+/// ```
+///
+/// Finally, the logical cycle time and logical error rate depend on qubit
+/// properties and the code parameter.  They are computed using the methods
+/// `logical_cycle_time` and `logical_error_rate`, respectively, in which the
+/// qubit is a Python dictionary.
+///
+/// ```python
+///     def logical_cycle_time(self, qubit, param):
+///         # returns logical cycle time in nano seconds (int)
+///         ...
+///
+///     def logical_error_rate(self, qubit, param):
+///         # must return a float
+///         ...
+/// ```
+pub struct PythonQEC<'py> {
+    qec: Bound<'py, PyAny>,
+    physical_qubits_method: Bound<'py, PyAny>,
+    logical_qubits_method: Bound<'py, PyAny>,
+    logical_cycle_time_method: Bound<'py, PyAny>,
+    logical_error_rate_method: Bound<'py, PyAny>,
+    code_parameter_cmp_method: Bound<'py, PyAny>,
+    adjust_code_parameter_method: Option<Bound<'py, PyAny>>,
+    params: Vec<SerializableBound<'py>>,
+}
+
+impl<'py> PythonQEC<'py> {
+    pub fn from_bound(qec: Bound<'py, PyAny>) -> PyResult<Self> {
+        let physical_qubits_method = extract_and_check_method(&qec, "physical_qubits")?;
+        let logical_qubits_method = extract_and_check_method(&qec, "logical_qubits")?;
+        let logical_cycle_time_method = extract_and_check_method(&qec, "logical_cycle_time")?;
+        let logical_error_rate_method = extract_and_check_method(&qec, "logical_error_rate")?;
+        let code_parameter_range_method = extract_and_check_method(&qec, "code_parameter_range")?;
+        let code_parameter_cmp_method = extract_and_check_method(&qec, "code_parameter_cmp")?;
+
+        let adjust_code_parameter_method =
+            maybe_extract_and_check_method(&qec, "adjust_code_parameter")?;
+
+        let params0: Vec<Bound<'py, PyAny>> = code_parameter_range_method.call0()?.extract()?;
+
+        let params: Vec<_> = params0.into_iter().map(SerializableBound).collect();
+        Ok(Self {
+            qec,
+            physical_qubits_method,
+            logical_qubits_method,
+            logical_cycle_time_method,
+            logical_error_rate_method,
+            code_parameter_cmp_method,
+            adjust_code_parameter_method,
+            params,
+        })
+    }
+
+    pub fn bound(&self) -> &Bound<'py, PyAny> {
+        &self.qec
+    }
+}
+
+impl<'py> ErrorCorrection for PythonQEC<'py> {
+    type Qubit = Bound<'py, PyDict>;
+
+    type Parameter = SerializableBound<'py>;
+
+    fn physical_qubits(&self, code_parameter: &Self::Parameter) -> Result<u64, String> {
+        let result = self
+            .physical_qubits_method
+            .call1((&**code_parameter,))
+            .map_err(|e| e.to_string())?;
+
+        result.extract().map_err(|e| e.to_string())
+    }
+
+    fn logical_qubits(&self, code_parameter: &Self::Parameter) -> Result<u64, String> {
+        let result = self
+            .logical_qubits_method
+            .call1((&**code_parameter,))
+            .map_err(|e| e.to_string())?;
+
+        result.extract().map_err(|e| e.to_string())
+    }
+
+    fn logical_cycle_time(
+        &self,
+        qubit: &Self::Qubit,
+        code_parameter: &Self::Parameter,
+    ) -> Result<u64, String> {
+        let result = self
+            .logical_cycle_time_method
+            .call1((qubit, &**code_parameter))
+            .map_err(|e| e.to_string())?;
+
+        result.extract().map_err(|e| e.to_string())
+    }
+
+    fn logical_error_rate(
+        &self,
+        qubit: &Self::Qubit,
+        code_parameter: &Self::Parameter,
+    ) -> Result<f64, String> {
+        let result = self
+            .logical_error_rate_method
+            .call1((qubit, &**code_parameter))
+            .map_err(|e| e.to_string())?;
+
+        result.extract().map_err(|e| e.to_string())
+    }
+
+    fn code_parameter_range(
+        &self,
+        _lower_bound: Option<&Self::Parameter>,
+    ) -> impl Iterator<Item = Self::Parameter> {
+        self.params.iter().cloned()
+    }
+
+    fn code_parameter_cmp(
+        &self,
+        qubit: &Self::Qubit,
+        p1: &Self::Parameter,
+        p2: &Self::Parameter,
+    ) -> std::cmp::Ordering {
+        let result: i32 = self
+            .code_parameter_cmp_method
+            .call1((qubit, &**p1, &**p2))
+            .expect("can call code_parameter_cmp method")
+            .extract()
+            .expect("can convert code_parameter_cmp return value into i32");
+
+        result.cmp(&0)
+    }
+
+    fn adjust_code_parameter(&self, parameter: Self::Parameter) -> Result<Self::Parameter, String> {
+        if let Some(method) = &self.adjust_code_parameter_method {
+            let result = method.call1((&*parameter,)).map_err(|e| e.to_string())?;
+            result
+                .extract()
+                .map(SerializableBound)
+                .map_err(|e| e.to_string())
+        } else {
+            Ok(parameter)
+        }
+    }
+}

--- a/pip/src/generic_estimator/counts.rs
+++ b/pip/src/generic_estimator/counts.rs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use pyo3::{
+    types::{PyAnyMethods, PyDict},
+    Bound, PyAny, PyResult,
+};
+use resource_estimator::estimates::{ErrorBudget, Overhead};
+
+use super::utils::extract_and_check_method;
+
+/// A wrapper around a Python instance to compute post-layout logical overhead
+/// for generic resource estimation.
+///
+/// The Python instance must implement three methods to compute the number of
+/// logical qubits, the logical depth, and the number of magic states.  For the
+/// last two methods, the method receives a parameter `budget`, which is a
+/// dictionary with access to the chosen error budget for logical errors
+/// (`"logical"`), rotation synthesis budget (`"rotations"`), and magic state
+/// budget (`"magic_states"`):
+///
+/// ```python
+///     def logical_qubits(self):
+///         # must return an int
+///         ...
+///
+///     def logical_depth(self, budget):
+///         # must return an int
+///         #
+///         # budget is a dictionary of the form
+///         # {"logical": ..., "rotations": ..., "magic_states": ...}
+///         ...
+///
+///     def num_magic_states(self, budget, index):
+///         # must return an int
+///         #
+///         # here index is the type of magic state; normally this number is 0,
+///         # as there is only one magic state, but if there are multiple, this
+///         # is some number starting from 0.
+///         ...
+/// ```
+///
+/// It's important to note that the number of factory builders provided in the
+/// `estimate_generic` function determine how many magic states are being
+/// requested from the logical counts model.  If only one factory is provided,
+/// then the `num_magic_states` method is only requested for the index `0` and
+/// not for any other indices.
+///
+/// Optionally, the instance may implement a method called `algorithm_overhead`,
+/// which also takes the error budget parameter `parameter` and returns a Python
+/// dictionary that is serialized into the estimation result, accessible via the
+/// key `"algorithmOverhead"`.  This can contain layout-specific variables that
+/// are interesting statistics to expose.
+///
+/// ```python
+///     def algorithm_overhead(self, budget):
+///         # returns a serializable Python dictionary
+///         ...
+/// ```
+pub struct PythonCounts<'py> {
+    counts: Bound<'py, PyAny>,
+    logical_qubits_method: Bound<'py, PyAny>,
+    logical_depth_method: Bound<'py, PyAny>,
+    num_magic_states_method: Bound<'py, PyAny>,
+}
+
+impl<'py> PythonCounts<'py> {
+    pub fn from_bound(counts: Bound<'py, PyAny>) -> PyResult<Self> {
+        let logical_qubits_method = extract_and_check_method(&counts, "logical_qubits")?;
+        let logical_depth_method = extract_and_check_method(&counts, "logical_depth")?;
+        let num_magic_states_method = extract_and_check_method(&counts, "num_magic_states")?;
+
+        Ok(Self {
+            counts,
+            logical_qubits_method,
+            logical_depth_method,
+            num_magic_states_method,
+        })
+    }
+
+    fn convert_budget(&self, budget: &ErrorBudget) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(self.counts.py());
+
+        dict.set_item("logical", budget.logical())?;
+        dict.set_item("rotations", budget.rotations())?;
+        dict.set_item("magic_states", budget.magic_states())?;
+
+        Ok(dict)
+    }
+
+    pub fn algorithm_overhead(
+        &self,
+        error_budget: &ErrorBudget,
+    ) -> PyResult<Option<Bound<'py, PyAny>>> {
+        if let Ok(result) = self
+            .counts
+            .getattr("algorithm_overhead")
+            .and_then(|f| f.call1((self.convert_budget(error_budget)?,)))
+        {
+            Ok(Some(result))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl Overhead for PythonCounts<'_> {
+    fn logical_qubits(&self) -> Result<u64, String> {
+        let result = self
+            .logical_qubits_method
+            .call0()
+            .map_err(|e| e.to_string())?;
+        result.extract().map_err(|e| e.to_string())
+    }
+
+    fn logical_depth(&self, budget: &ErrorBudget) -> Result<u64, String> {
+        let budget = self.convert_budget(budget).map_err(|e| e.to_string())?;
+
+        let result = self
+            .logical_depth_method
+            .call1((budget,))
+            .map_err(|e| e.to_string())?;
+
+        result.extract().map_err(|e| e.to_string())
+    }
+
+    fn num_magic_states(&self, budget: &ErrorBudget, index: usize) -> Result<u64, String> {
+        let budget = self.convert_budget(budget).map_err(|e| e.to_string())?;
+        let result = self
+            .num_magic_states_method
+            .call1((budget, index))
+            .map_err(|e| e.to_string())?;
+
+        result.extract().map_err(|e| e.to_string())
+    }
+}

--- a/pip/src/generic_estimator/factory.rs
+++ b/pip/src/generic_estimator/factory.rs
@@ -1,0 +1,354 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::{borrow::Cow, marker::PhantomData};
+
+use pyo3::{
+    exceptions::PyLookupError,
+    types::{PyAnyMethods, PyDict, PyList},
+    Bound, PyAny, PyResult,
+};
+use resource_estimator::estimates::{
+    Factory, FactoryBuilder, PhysicalQubitCalculation, RoundBasedFactory,
+};
+use round_based::{ordered_bfs, OrderedBFSControl};
+use serde::Serialize;
+use serde_json::{json, Map, Value};
+
+use super::{
+    code::PythonQEC,
+    utils::{python_dict_to_json_map, SerializableBound},
+};
+
+mod dispatch;
+pub use dispatch::PythonFactoryBuilderDispatch;
+pub(crate) mod round_based;
+pub use round_based::PythonDistillationUnit;
+
+enum FactoryImplementation<'py> {
+    Generic(Bound<'py, PyAny>),
+    RoundBased(Bound<'py, PyAny>),
+}
+
+/// A wrapper around a Python instance to compute magic state factories.
+///
+/// There are two ways to model magic state factories: 1) create factories
+/// explicitly, which are modeled by means of their size, runtime, and number of
+/// output states, or 2) return distillation units which can then be composed in
+/// multiple rounds to create a factory.
+///
+/// ## Explicitly creating factories
+///
+/// To create magic state factories explicitly, the class must implement the
+/// function `find_factories`, which takes as input the code that is used for
+/// algorithm qubits (it must not be used by the factory builder, and other
+/// codes could be constructed), the qubit parameters specified by the user, and
+/// the target error rate required for magic states in the current estimation.
+/// The function either returns `None`, if, e.g., no factories can be found that
+/// satisfy the target error rate, or it returns a list of factory objects.
+///
+/// ```python
+///     def find_factories(self, code, qubit, target_error_rate):
+///         # e.g., return [
+///         #   {
+///         #     "physical_qubits": 42,
+///         #     "duration": 655321,  # in ns
+///         #     "num_output_states": 1
+///         #   }
+///         # ]
+///         ...
+/// ```
+///
+/// A factory object is simply a Phython dictionary, which _must_ contain
+/// entries for `"physical_qubits"` and `"duration"` (in nano seconds).  It may
+/// also contain `"num_output_states"`, which defaults to 1 if not specified. It
+/// may contain other entries, which will be included in the serialized resource
+/// estimates.
+///
+/// ## Creating factories based on multiple rounds of distillation
+///
+/// To create factories based on mulitple rounds of distillation, the class must
+/// implement the function `distillation_units`, which returns a list of
+/// distillation unit objects (described below). Further, such a class may
+/// provide local variables `gate_error`, `max_rounds` and `max_extra_rounds`
+/// (by default set to `"gate_error"`, 3 and 5, respectively). The variable
+/// `gate_error` is a string that is used to index the `qubit` parameter for the
+/// magic gate error rate.  The variable `max_rounds` controls how many rounds
+/// of distillation should always be explored (even, if a factory is found with
+/// fewer than `max_rounds` rounds). And the variable `max_extra_rounds`
+/// controls by how many extra rounds the search should be extended, if no
+/// factory can be found within `max_rounds` rounds.
+///
+/// ```python
+///     def distillation_units(self, code, qubit, max_code_parameter):
+///         # e.g., return [
+///         #   {
+///         #     "name": "unit",
+///         #     "code_parameter": 5,  # must be same type as max_code_parameter
+///         #     "num_input_states": 42,
+///         #     "num_output_states": 2,
+///         #     "physical_qubits": lambda round: 100,  # round is 0-based index to when unit is used in factory
+///         #     "duration": lambda round: 30,  # duration in ns, and round is as above
+///         #     "output_error_rate": lambda input_error_rate: ...,  # some formula to compute output_error_rate
+///         #     "failure_probability": lambda input_error_rate: ...  # some formula to compute failure_probability
+///         #   }
+///         # ]
+/// ```
+///
+/// A distillation unit object is simply a Python dictionary, which _must_
+/// contain entries for `"num_input_states"`, `"physical_qubits"`, `"duration"`,
+/// `"output_error_rate"`, and `"failure_probability"`.  The fields `"name"`,
+/// `"code_parameter"`, and `"num_output_states"` are optional and default to
+/// `"distillation-unit"`, `None`, and `1`.  The fields for `"physical_qubits"`
+/// and `"runtime"` must be callable (e.g., using a Python lambda) with the
+/// 0-based round index as only paramter.  The fields for `"output_error_rate"`
+/// and `"failure_probability"` also must be callable with the input error rate
+/// (of the previous round or initial gate error rate) as the only parameter.
+pub struct PythonFactoryBuilder<'py> {
+    builder: Bound<'py, PyAny>,
+    implementation: FactoryImplementation<'py>,
+    num_magic_state_types: usize,
+}
+
+impl<'py> PythonFactoryBuilder<'py> {
+    pub fn from_bound(builder: Bound<'py, PyAny>) -> PyResult<Self> {
+        let implementation = if let Ok(method) = builder.getattr("find_factories") {
+            FactoryImplementation::Generic(method)
+        } else if let Ok(method) = builder.getattr("distillation_units") {
+            FactoryImplementation::RoundBased(method)
+        } else {
+            return Err(PyLookupError::new_err(
+                "FactoryBuilder must have either find_factories or distillation_units method",
+            ));
+        };
+
+        let num_magic_state_types = if let Ok(method) = builder.getattr("num_magic_state_types") {
+            method.call0()?.extract()?
+        } else {
+            1
+        };
+
+        Ok(Self {
+            builder,
+            implementation,
+            num_magic_state_types,
+        })
+    }
+}
+
+impl<'py> FactoryBuilder<PythonQEC<'py>> for PythonFactoryBuilder<'py> {
+    type Factory = PythonFactory<'py>;
+
+    fn find_factories(
+        &self,
+        code: &PythonQEC<'py>,
+        qubit: &std::rc::Rc<Bound<'py, PyDict>>,
+        _magic_state_type: usize,
+        output_error_rate: f64,
+        max_code_parameter: &SerializableBound<'py>,
+    ) -> Result<Vec<std::borrow::Cow<Self::Factory>>, String> {
+        match &self.implementation {
+            FactoryImplementation::Generic(method) => {
+                let result = method
+                    .call1((code.bound(), qubit.as_ref(), output_error_rate))
+                    .map_err(|e| e.to_string())?;
+
+                if result.is_none() {
+                    Ok(vec![])
+                } else {
+                    let factories = result.downcast::<PyList>().map_err(|e| e.to_string())?;
+                    let mut converted = vec![];
+
+                    for element in factories {
+                        let dict = element.downcast::<PyDict>().map_err(|e| e.to_string())?;
+                        let factory = PythonFactory::from_py_dict(dict).ok_or(format!(
+                            "Failed to convert factory from Python dict: {dict:?}, does the dictionary contain entries for 'physical_qubits' and 'duration'?",
+
+                        ))?;
+                        converted.push(Cow::Owned(factory));
+                    }
+
+                    Ok(converted)
+                }
+            }
+            FactoryImplementation::RoundBased(method) => {
+                // input error rate
+                let qubit_key = self
+                    .builder
+                    .getattr("gate_error")
+                    .and_then(|a| a.extract())
+                    .unwrap_or(String::from("gate_error"));
+                let initial_input_error_rate = qubit
+                    .get_item(&qubit_key)
+                    .map_err(|e| e.to_string())?
+                    .extract()
+                    .map_err(|e| e.to_string())?;
+                let use_max_qubits_per_round = self
+                    .builder
+                    .getattr("use_max_qubits_per_round")
+                    .and_then(|a| a.extract())
+                    .unwrap_or(false);
+                let max_rounds = self
+                    .builder
+                    .getattr("max_rounds")
+                    .and_then(|a| a.extract())
+                    .unwrap_or(3);
+                let max_extra_rounds = self
+                    .builder
+                    .getattr("max_extra_rounds")
+                    .and_then(|a| a.extract())
+                    .unwrap_or(5);
+
+                let return_value = method
+                    .call1((code.bound(), qubit.as_ref(), &**max_code_parameter))
+                    .map_err(|e| e.to_string())?;
+
+                let units: Vec<_> = return_value
+                    .try_iter()
+                    .map_err(|e| {
+                        format!("{e} (check the return value of the 'distillation_units' method)",)
+                    })?
+                    .map(|bound| PythonDistillationUnit::new(bound?.downcast_into::<PyDict>()?))
+                    .collect::<Result<_, _>>()
+                    .map_err(|e| e.to_string())?;
+
+                let mut factories: Vec<Cow<PythonFactory>> = vec![];
+
+                ordered_bfs(&units, max_extra_rounds, |selected_units| {
+                    if selected_units.len() > max_rounds && !factories.is_empty() {
+                        return Ok(OrderedBFSControl::Terminate);
+                    }
+
+                    if let Ok(mut factory) =
+                        RoundBasedFactory::build(&selected_units, initial_input_error_rate, 0.01)
+                    {
+                        if factory.output_error_rate() <= output_error_rate {
+                            factory.set_physical_qubit_calculation(if use_max_qubits_per_round {
+                                PhysicalQubitCalculation::Max
+                            } else {
+                                PhysicalQubitCalculation::Sum
+                            });
+                            factories.push(Cow::Owned(PythonFactory::try_from(factory)?));
+
+                            if selected_units.len() > max_rounds {
+                                return Ok(OrderedBFSControl::Terminate);
+                            }
+                        }
+                    }
+
+                    Ok(OrderedBFSControl::Continue)
+                })?;
+
+                if factories.is_empty() {
+                    return Err(format!(
+                        "No factories found for output error rate: {output_error_rate}, try increasing the 'max_rounds' parameter."
+                    ));
+                }
+
+                factories.sort_unstable_by(|f1, f2| {
+                    f1.normalized_qubits()
+                        .total_cmp(&f2.normalized_qubits())
+                        .then(f1.duration().cmp(&f2.duration()))
+                });
+
+                Ok(factories)
+            }
+        }
+    }
+
+    fn num_magic_state_types(&self) -> usize {
+        self.num_magic_state_types
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub struct PythonFactory<'py> {
+    #[serde(flatten)]
+    values: Map<String, Value>,
+    #[serde(skip)]
+    physical_qubits: u64,
+    #[serde(skip)]
+    duration: u64,
+    #[serde(skip)]
+    num_output_states: u64,
+    #[serde(skip)]
+    phantom: PhantomData<&'py ()>,
+}
+
+impl<'py> PythonFactory<'py> {
+    fn new(values: Map<String, Value>) -> Option<Self> {
+        let physical_qubits = values
+            .get("physical_qubits")
+            .and_then(serde_json::Value::as_u64)?;
+        let duration = values.get("duration").and_then(serde_json::Value::as_u64)?;
+        let num_output_states = values
+            .get("num_output_states")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(1);
+
+        Some(Self {
+            values,
+            physical_qubits,
+            duration,
+            num_output_states,
+            phantom: PhantomData,
+        })
+    }
+
+    fn from_py_dict(dict: &Bound<'py, PyDict>) -> Option<Self> {
+        Self::new(python_dict_to_json_map(dict)?)
+    }
+
+    #[allow(clippy::cast_precision_loss)] // Relevant numbers in arithmetic are small enough
+    pub fn normalized_qubits(&self) -> f64 {
+        self.physical_qubits() as f64 / self.num_output_states() as f64
+    }
+}
+
+impl<'py> TryFrom<RoundBasedFactory<SerializableBound<'py>>> for PythonFactory<'py> {
+    type Error = String;
+
+    fn try_from(value: RoundBasedFactory<SerializableBound<'py>>) -> Result<Self, Self::Error> {
+        let values = json! {{
+            "physical_qubits": value.physical_qubits(),
+            "duration": value.duration(),
+            "num_rounds": value.num_rounds(),
+            "num_output_states": value.num_output_states(),
+            "num_units_per_round": value.num_units_per_round(),
+            "num_input_states": value.num_input_states(),
+            "physical_qubits_per_round": value.physical_qubits_per_round(),
+            "duration_per_round": value.duration_per_round(),
+            "unit_name_per_round": value.unit_names(),
+            "code_parameter_per_round": value
+                .code_parameter_per_round()
+                .iter()
+                .map(|p| p.map_or(Value::Null, |p| json!(p)))
+                .collect::<Vec<_>>(),
+            "logical_error_rate": value.output_error_rate()
+        }};
+
+        Self::new(values.as_object().expect("values is a JSON object").clone()).ok_or(String::from(
+            "Failed to construct factory instance from round-based factory information",
+        ))
+    }
+}
+
+impl<'py> Factory for PythonFactory<'py> {
+    type Parameter = SerializableBound<'py>;
+
+    fn physical_qubits(&self) -> u64 {
+        self.physical_qubits
+    }
+
+    fn duration(&self) -> u64 {
+        self.duration
+    }
+
+    fn num_output_states(&self) -> u64 {
+        self.num_output_states
+    }
+
+    fn max_code_parameter(&self) -> Option<Cow<Self::Parameter>> {
+        None
+    }
+}

--- a/pip/src/generic_estimator/factory/dispatch.rs
+++ b/pip/src/generic_estimator/factory/dispatch.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::{borrow::Cow, ops::Deref, rc::Rc};
+
+use pyo3::{types::PyDict, Bound};
+use resource_estimator::estimates::FactoryBuilder;
+
+use super::super::{code::PythonQEC, utils::SerializableBound};
+
+use super::{PythonFactory, PythonFactoryBuilder};
+
+/// A generic factory dispatcher to support declaring multiple factory builders
+/// as input to generic resource estimation.
+pub struct PythonFactoryBuilderDispatch<'py>(pub Vec<PythonFactoryBuilder<'py>>);
+
+impl<'py> Deref for PythonFactoryBuilderDispatch<'py> {
+    type Target = Vec<PythonFactoryBuilder<'py>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'py> FactoryBuilder<PythonQEC<'py>> for PythonFactoryBuilderDispatch<'py> {
+    type Factory = PythonFactory<'py>;
+
+    fn find_factories(
+        &self,
+        ftp: &PythonQEC<'py>,
+        qubit: &Rc<Bound<'py, PyDict>>,
+        magic_state_type: usize,
+        output_error_rate: f64,
+        max_code_parameter: &SerializableBound<'py>,
+    ) -> Result<Vec<Cow<Self::Factory>>, String> {
+        self[magic_state_type].find_factories(
+            ftp,
+            qubit,
+            magic_state_type,
+            output_error_rate,
+            max_code_parameter,
+        )
+    }
+
+    fn num_magic_state_types(&self) -> usize {
+        self.len()
+    }
+}

--- a/pip/src/generic_estimator/factory/round_based.rs
+++ b/pip/src/generic_estimator/factory/round_based.rs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::cmp::Ordering;
+
+use pyo3::{
+    types::{PyAnyMethods, PyDict},
+    Bound, PyResult,
+};
+use resource_estimator::estimates::DistillationUnit;
+
+use super::super::utils::SerializableBound;
+
+/// A wrapper to model a distillation unit for round-based factory builders.
+pub struct PythonDistillationUnit<'py> {
+    dict: Bound<'py, PyDict>,
+    name: String,
+    code_parameter: Option<SerializableBound<'py>>,
+}
+
+impl<'py> PythonDistillationUnit<'py> {
+    pub fn new(dict: Bound<'py, PyDict>) -> PyResult<Self> {
+        let name = dict.get_item("name").map_or_else(
+            |_| Ok(String::from("distillation-unit")),
+            |field| -> PyResult<String> { Ok(field.to_string()) },
+        )?;
+
+        let code_parameter = dict.get_item("code_parameter").map_or(
+            Ok(None),
+            |field| -> PyResult<Option<SerializableBound<'py>>> {
+                if field.is_none() {
+                    Ok(None)
+                } else {
+                    Ok(Some(SerializableBound(field)))
+                }
+            },
+        )?;
+
+        Ok(Self {
+            dict,
+            name,
+            code_parameter,
+        })
+    }
+}
+
+impl<'py> DistillationUnit<SerializableBound<'py>> for PythonDistillationUnit<'py> {
+    fn num_output_states(&self) -> u64 {
+        let Ok(field) = self.dict.get_item("num_output_states") else {
+            return 1;
+        };
+
+        field
+            .extract()
+            .expect("can extract u64 value from field num_output_states")
+    }
+
+    fn num_input_states(&self) -> u64 {
+        self.dict
+            .get_item("num_input_states")
+            .expect("has field num_input_states")
+            .extract()
+            .expect("can extract u64 value from field num_input_states")
+    }
+
+    fn duration(&self, position: usize) -> u64 {
+        self.dict
+            .get_item("duration")
+            .expect("has field duration")
+            .call1((position,))
+            .expect("can call lambda duration")
+            .extract()
+            .expect("can extract u64 value from lambda duration")
+    }
+
+    fn physical_qubits(&self, position: usize) -> u64 {
+        self.dict
+            .get_item("physical_qubits")
+            .expect("has field physical_qubits")
+            .call1((position,))
+            .expect("can call lambda physical_qubits")
+            .extract()
+            .expect("can extract u64 value from lambda physical_qubits")
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn code_parameter(&self) -> Option<&SerializableBound<'py>> {
+        self.code_parameter.as_ref()
+    }
+
+    fn output_error_rate(&self, input_error_rate: f64) -> f64 {
+        self.dict
+            .get_item("output_error_rate")
+            .expect("has field output_error_rate")
+            .call1((input_error_rate,))
+            .expect("can call lambda output_error_rate")
+            .extract()
+            .expect("can extract u64 value from lambda output_error_rate")
+    }
+
+    fn failure_probability(&self, input_error_rate: f64) -> f64 {
+        self.dict
+            .get_item("failure_probability")
+            .expect("has field failure_probability")
+            .call1((input_error_rate,))
+            .expect("can call lambda failure_probability")
+            .extract()
+            .expect("can extract u64 value from lambda failure_probability")
+    }
+}
+
+impl PartialEq for PythonDistillationUnit<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.code_parameter(), other.code_parameter()) {
+            (Some(lhs), Some(rhs)) => {
+                let Ok(eq_fun) = lhs.getattr("__eq__") else {
+                    return false;
+                };
+                let Ok(eq_result) = eq_fun.call1((&**rhs,)) else {
+                    return false;
+                };
+
+                eq_result.extract().unwrap_or(false)
+            }
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl PartialOrd for PythonDistillationUnit<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let lhs = self.code_parameter()?;
+        let rhs = other.code_parameter()?;
+
+        let eq_fun = lhs.getattr("__eq__").ok()?;
+        if eq_fun.call1((&**rhs,)).ok()?.extract().ok()? {
+            return Some(Ordering::Equal);
+        }
+
+        let lt_fun = lhs.getattr("__lt__").ok()?;
+        if lt_fun.call1((&**rhs,)).ok()?.extract().ok()? {
+            Some(Ordering::Less)
+        } else {
+            Some(Ordering::Greater)
+        }
+    }
+}
+
+pub enum OrderedBFSControl {
+    Continue,
+    #[allow(dead_code)]
+    Cutoff,
+    Terminate,
+}
+
+/// Performs a breadth-first search (BFS) over the elements with up to
+/// `max_depth` repetitions.  It is guaranteed that the elements remain in the
+/// same order as initially provided.  The function `visit` is called on each
+/// tuple.
+pub fn ordered_bfs<T: PartialOrd>(
+    elements: &[T],
+    max_depth: usize,
+    mut visit: impl FnMut(Vec<&T>) -> Result<OrderedBFSControl, String>,
+) -> Result<(), String> {
+    let mut prev_prefixes = vec![vec![]];
+
+    for _ in 1..=max_depth {
+        let mut prefixes = vec![];
+
+        for stem in &prev_prefixes {
+            for (idx, element) in elements.iter().enumerate() {
+                if stem.last().is_some_and(|last| *element < elements[*last]) {
+                    continue;
+                }
+
+                let mut new_tuple = stem.clone();
+                new_tuple.push(idx);
+
+                match visit(new_tuple.iter().copied().map(|i| &elements[i]).collect())? {
+                    OrderedBFSControl::Continue => {
+                        prefixes.push(new_tuple);
+                    }
+                    OrderedBFSControl::Cutoff => {}
+                    OrderedBFSControl::Terminate => {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        prev_prefixes = prefixes;
+    }
+
+    Ok(())
+}

--- a/pip/src/generic_estimator/tests.rs
+++ b/pip/src/generic_estimator/tests.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::factory::round_based::{ordered_bfs, OrderedBFSControl};
+
+#[test]
+fn test_ordered_bfs() {
+    let mut total_sum = 0;
+    let mut total_visits = 0;
+
+    let elements = vec![2, 4, 6, 8, 10];
+    ordered_bfs(&elements, 5, |v| {
+        let sum = v.iter().copied().sum::<i32>();
+        if sum <= 10 {
+            total_sum += sum;
+            total_visits += 1;
+            if v.len() > 3 {
+                Ok(OrderedBFSControl::Terminate)
+            } else {
+                Ok(OrderedBFSControl::Continue)
+            }
+        } else {
+            Ok(OrderedBFSControl::Cutoff)
+        }
+    })
+    .expect("BFS should complete successfully");
+
+    assert_eq!(total_sum, 118);
+    assert_eq!(total_visits, 16);
+}

--- a/pip/src/generic_estimator/utils.rs
+++ b/pip/src/generic_estimator/utils.rs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::ops::Deref;
+
+use pyo3::{
+    exceptions::PyTypeError,
+    types::{
+        PyAnyMethods, PyBool, PyDict, PyDictMethods, PyFloat, PyInt, PyList, PyListMethods, PyNone,
+        PyString, PyTypeMethods,
+    },
+    Bound, IntoPyObject, PyAny, PyErr, PyResult, Python,
+};
+use serde::{ser::SerializeMap, Serialize};
+use serde_json::{json, Map, Value};
+
+/// Converts a JSON value to a Python object, handling various types such as
+/// `null`, `number`, `string`, `boolean`, `array`, and `object`.
+fn json_value_to_python_object<'py>(py: Python<'py>, value: &Value) -> PyResult<Bound<'py, PyAny>> {
+    match value {
+        Value::Null => Ok(PyNone::get(py).to_owned().into_any()),
+        Value::Number(n) => {
+            if let Some(int) = n.as_i64() {
+                Ok(int.into_pyobject(py)?.into_any())
+            } else if let Some(float) = n.as_f64() {
+                Ok(float.into_pyobject(py)?.into_any())
+            } else {
+                Err(PyErr::new::<PyTypeError, _>(format!("cannot convert {n}")))
+            }
+        }
+        Value::String(s) => Ok(PyString::new(py, s).into_any()),
+        &Value::Bool(b) => Ok(b.into_pyobject(py)?.to_owned().into_any()),
+        Value::Array(elements) => {
+            let list = PyList::empty(py);
+
+            for element in elements {
+                list.append(json_value_to_python_object(py, element)?)?;
+            }
+
+            Ok(list.into_any())
+        }
+        Value::Object(map) => Ok(json_map_to_python_dict(py, map)?.into_any()),
+    }
+}
+
+/// Converts a JSON map to a Python dictionary.
+pub(crate) fn json_map_to_python_dict<'py>(
+    py: Python<'py>,
+    map: &Map<String, Value>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    for (key, value) in map {
+        dict.set_item(key, json_value_to_python_object(py, value)?)?;
+    }
+    Ok(dict)
+}
+
+/// Converts a Python object to a JSON value, handling various types such as
+/// `None`, `int`, `float`, `bool`, `str`, `list`, and `dict`.
+pub(crate) fn python_object_to_json_value(value: &Bound<'_, PyAny>) -> Option<Value> {
+    if value.is_none() {
+        Some(Value::Null)
+    } else if let Ok(n) = value.downcast_exact::<PyInt>() {
+        Some(json!(n.extract::<i64>().expect("n is PyInt")))
+    } else if let Ok(n) = value.downcast_exact::<PyFloat>() {
+        Some(json!(n.extract::<f64>().expect("n is PyFloat")))
+    } else if let Ok(b) = value.downcast_exact::<PyBool>() {
+        Some(json!(b.extract::<bool>().expect("b is PyBool")))
+    } else if let Ok(s) = value.downcast_exact::<PyString>() {
+        Some(json!(s.extract::<String>().expect("s is PyString")))
+    } else if let Ok(l) = value.downcast_exact::<PyList>() {
+        let values: Vec<_> = l
+            .iter()
+            .map(|v| python_object_to_json_value(&v))
+            .collect::<Option<_>>()?;
+        Some(Value::Array(values))
+    } else if let Ok(d) = value.downcast_exact::<PyDict>() {
+        Some(Value::Object(python_dict_to_json_map(d)?))
+    } else {
+        None
+    }
+}
+
+/// Converts a Python dictionary to a JSON map.
+pub fn python_dict_to_json_map(value: &Bound<'_, PyDict>) -> Option<Map<String, Value>> {
+    let mut map: Map<String, Value> = Map::new();
+    for (key, value) in value.iter() {
+        map.insert(
+            key.extract::<String>().ok()?,
+            python_object_to_json_value(&value)?,
+        );
+    }
+    Some(map)
+}
+
+/// A wrapper around a Python instance that can be serialized in order to embed
+/// its value into thre returned resource estimates.
+#[derive(Clone, Debug)]
+pub struct SerializableBound<'py>(pub Bound<'py, PyAny>);
+
+impl<'py> Deref for SerializableBound<'py> {
+    type Target = Bound<'py, PyAny>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Serialize for SerializableBound<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if let Ok(dict) = self.downcast::<PyDict>() {
+            let mut map = serializer.serialize_map(Some(dict.len()))?;
+            for (key, value) in dict.iter() {
+                map.serialize_key(&SerializableBound(key))?;
+                map.serialize_value(&SerializableBound(value))?;
+            }
+            map.end()
+        } else if let Ok(number) = self.downcast::<PyInt>() {
+            serializer.serialize_i64(number.extract().expect("number is PyInt"))
+        } else {
+            serializer.serialize_str(&self.to_string())
+        }
+    }
+}
+
+/// Extracts a method from a Python instance and checks if it is callable
+pub fn extract_and_check_method<'py>(
+    instance: &Bound<'py, PyAny>,
+    method_name: &str,
+) -> PyResult<Bound<'py, PyAny>> {
+    let member = instance.getattr(method_name)?;
+    if !member.is_callable() {
+        return Err(PyTypeError::new_err(format!(
+            "Method '{}' is not callable on the instance of type '{}'",
+            method_name,
+            instance.get_type().name()?
+        )));
+    }
+    Ok(member)
+}
+
+/// Attempts to extract a method from a Python instance and checks if it is
+/// callable
+pub fn maybe_extract_and_check_method<'py>(
+    instance: &Bound<'py, PyAny>,
+    method_name: &str,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    if !instance.hasattr(method_name)? {
+        return Ok(None);
+    }
+
+    let member = instance.getattr(method_name)?;
+    if !member.is_callable() {
+        return Err(PyTypeError::new_err(format!(
+            "Method '{}' is not callable on the instance of type '{}'",
+            method_name,
+            instance.get_type().name()?
+        )));
+    }
+    Ok(Some(member))
+}

--- a/pip/src/interpreter.rs
+++ b/pip/src/interpreter.rs
@@ -4,6 +4,7 @@
 use crate::{
     displayable_output::{DisplayableMatrix, DisplayableOutput, DisplayableState},
     fs::file_system,
+    generic_estimator::register_generic_estimator_submodule,
     interop::{
         circuit_qasm_program, compile_qasm_program_to_qir, compile_qasm_to_qsharp,
         create_filesystem_from_py, get_operation_name, get_output_semantics, get_program_type,
@@ -82,6 +83,7 @@ fn _native<'a>(py: Python<'a>, m: &Bound<'a, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(physical_estimates, m)?)?;
     m.add("QSharpError", py.get_type::<QSharpError>())?;
     register_noisy_simulator_submodule(py, m)?;
+    register_generic_estimator_submodule(m)?;
     // QASM interop
     m.add("QasmError", py.get_type::<QasmError>())?;
     m.add_function(wrap_pyfunction!(resource_estimate_qasm_program, m)?)?;

--- a/pip/src/lib.rs
+++ b/pip/src/lib.rs
@@ -5,6 +5,7 @@ allocator::assign_global!();
 
 mod displayable_output;
 mod fs;
+mod generic_estimator;
 mod interop;
 mod interpreter;
 mod noisy_simulator;

--- a/pip/tests/test_generic_estimator.py
+++ b/pip/tests/test_generic_estimator.py
@@ -1,0 +1,197 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pytest
+import qsharp
+
+
+class SampleAlgorithm:
+    def __init__(self, *, qubits=10, depth=20, magic_states=[100]):
+        self.qubits = qubits
+        self.depth = depth
+        self.magic_states = magic_states
+
+    def logical_qubits(self):
+        return self.qubits
+
+    def logical_depth(self, budget):
+        return self.depth
+
+    def num_magic_states(self, budget, index):
+        return self.magic_states[index]
+
+
+class SampleCode:
+    def physical_qubits(self, param):
+        return 2 * param**2
+
+    def logical_qubits(self, param):
+        return 1
+
+    def logical_cycle_time(self, qubit, param):
+        return 6 * qubit["gate_time"] * param
+
+    def logical_error_rate(self, qubit, param):
+        return 0.03 * (qubit["error_rate"] / 0.01) ** ((param + 1) // 2)
+
+    def code_parameter_range(self):
+        return [1, 2, 3]
+
+    def code_parameter_cmp(self, qubit, p1, p2):
+        return -1 if p1 < p2 else (1 if p1 > p2 else 0)
+
+
+class SampleFactory:
+    def find_factories(self, code, qubit, target_error_rate):
+        assert isinstance(code, SampleCode)
+        assert isinstance(qubit, dict)
+        assert qubit == sample_qubit()
+
+        return [{"physical_qubits": 100, "duration": 1000}]
+
+
+class SampleFactoryBuilder:
+    def __init__(self):
+        # Key to index into magic gate error rate in qubit
+        self.gate_error = "error_rate"
+        self.max_rounds = 3
+
+    def distillation_units(self, code, qubit, max_code_parameter):
+        return [
+            {
+                "num_input_states": 15,
+                "physical_qubits": lambda _: 50,
+                "duration": lambda _: 500,
+                "output_error_rate": lambda input_error_rate: 35 * input_error_rate**3,
+                "failure_probability": lambda input_error_rate: 15 * input_error_rate,
+            }
+        ]
+
+
+def sample_qubit():
+    return {"gate_time": 50, "error_rate": 1e-4}
+
+
+def test_wrong_input():
+    pytest.raises(
+        AttributeError, qsharp.estimate_generic, 42, sample_qubit(), SampleCode()
+    )
+
+    # Catches missing methods in SampleAlgorithm
+    for method_name in ["logical_qubits", "logical_depth", "num_magic_states"]:
+        method = getattr(SampleAlgorithm, method_name)
+        delattr(SampleAlgorithm, method_name)
+        pytest.raises(
+            AttributeError,
+            qsharp.estimate_generic,
+            SampleAlgorithm(),
+            sample_qubit(),
+            SampleCode(),
+        )
+        setattr(SampleAlgorithm, method_name, method)
+
+    # Catches missing methods in SampleCode
+    for method_name in [
+        "physical_qubits",
+        "logical_qubits",
+        "logical_cycle_time",
+        "logical_error_rate",
+        "code_parameter_range",
+        "code_parameter_cmp",
+    ]:
+        method = getattr(SampleCode, method_name)
+        delattr(SampleCode, method_name)
+        pytest.raises(
+            AttributeError,
+            qsharp.estimate_generic,
+            SampleAlgorithm(),
+            sample_qubit(),
+            SampleCode(),
+        )
+        setattr(SampleCode, method_name, method)
+
+    # Catches wrong type for method
+    method = SampleAlgorithm.logical_qubits
+    SampleAlgorithm.logical_qubits = "not a method"
+    pytest.raises(
+        TypeError,
+        qsharp.estimate_generic,
+        SampleAlgorithm(),
+        sample_qubit(),
+        SampleCode(),
+    )
+    SampleAlgorithm.logical_qubits = method
+
+    # Catches wrong signature for method
+    method = SampleAlgorithm.logical_depth
+    SampleAlgorithm.logical_depth = lambda self, budget, extra: 20
+    pytest.raises(
+        RuntimeError,
+        qsharp.estimate_generic,
+        SampleAlgorithm(),
+        sample_qubit(),
+        SampleCode(),
+    )
+    SampleAlgorithm.logical_depth = lambda self: 20
+    pytest.raises(
+        RuntimeError,
+        qsharp.estimate_generic,
+        SampleAlgorithm(),
+        sample_qubit(),
+        SampleCode(),
+    )
+    SampleAlgorithm.logical_depth = method
+
+
+def test_estimate_without_factories():
+    result = qsharp.estimate_generic(SampleAlgorithm(), sample_qubit(), SampleCode())
+
+    assert len(result["factoryParts"]) == 0
+    assert len(result["layoutOverhead"]["numMagicStates"]) == 0
+    assert result["runtime"] == 18000
+    assert result["physicalQubits"] == 180
+
+    assert "executionStats" in result
+    assert "timeAlgorithm" in result["executionStats"]
+    assert "timeEstimation" in result["executionStats"]
+
+
+def test_with_single_factory():
+    result = qsharp.estimate_generic(
+        SampleAlgorithm(), sample_qubit(), SampleCode(), [SampleFactory()]
+    )
+    assert len(result["factoryParts"]) == 1
+    assert len(result["layoutOverhead"]["numMagicStates"]) == 1
+
+    assert "physical_qubits" in result["factoryParts"][0]["factory"]
+    assert "duration" in result["factoryParts"][0]["factory"]
+
+
+def test_with_multiple_factories():
+    result = qsharp.estimate_generic(
+        SampleAlgorithm(magic_states=[50, 100, 200]),
+        sample_qubit(),
+        SampleCode(),
+        [SampleFactory()] * 3,
+    )
+    assert len(result["factoryParts"]) == 3
+    assert len(result["layoutOverhead"]["numMagicStates"]) == 3
+
+    for factory_part in result["factoryParts"]:
+        assert "physical_qubits" in factory_part["factory"]
+        assert "duration" in factory_part["factory"]
+
+
+def test_with_factory_builder():
+    result = qsharp.estimate_generic(
+        SampleAlgorithm(),
+        sample_qubit(),
+        SampleCode(),
+        [SampleFactoryBuilder()],
+    )
+
+    assert len(result["factoryParts"]) == 1
+    assert len(result["layoutOverhead"]["numMagicStates"]) == 1
+
+    assert "physical_qubits" in result["factoryParts"][0]["factory"]
+    assert "duration" in result["factoryParts"][0]["factory"]


### PR DESCRIPTION
This adds a new Python function `estimate_generic` to the Q# Python package. It performs resource estimation on generic input models for logical application and layout overhead, quantum error correction, qubits, and magic state factories. Application, QEC, and factory overhead are modeled by means of Python classes, where as qubits are Python dictionaries to hold their properties.
