### PR TITLE
Implement error handling for invalid logical depth scaling

### DIFF
--- a/resource_estimator/src/estimates/error.rs
+++ b/resource_estimator/src/estimates/error.rs
@@ -58,6 +58,12 @@ pub enum Error {
     #[error("No solution found for the provided maximum number of physical qubits.")]
     #[diagnostic(code("Qsc.Estimates.MaxPhysicalQubitsTooSmall"))]
     MaxPhysicalQubitsTooSmall,
+    /// Logical depth scaling factor is too small
+    ///
+    /// 🧑‍💻 This indicates a user error
+    #[error("Logical depth scaling factor is too small, it must be at least 1: {0}")]
+    #[diagnostic(code("Qsc.Estimates.LogicalDepthScalingFactorTooSmall"))]
+    LogicalDepthScalingFactorTooSmall(f64),
     /// Resource estimation failed to find factories
     ///
     /// ✅ This error cannot be triggered by the system.

--- a/resource_estimator/src/estimates/physical_estimation.rs
+++ b/resource_estimator/src/estimates/physical_estimation.rs
@@ -599,7 +599,12 @@ impl<
 
         // Perform logical depth scaling if given by constraint
         if let Some(logical_depth_scaling) = self.logical_depth_factor {
-            // TODO: error handling if value is <= 1.0
+            if logical_depth_scaling < 1.0 {
+                return Err(Error::LogicalDepthScalingFactorTooSmall(
+                    logical_depth_scaling,
+                ));
+            }
+
             num_cycles = ((num_cycles as f64) * logical_depth_scaling).ceil() as u64;
         }
 


### PR DESCRIPTION
Resolves [security alert 390](https://github.com/microsoft/qsharp/security/code-scanning/390) by returning an error, when the logical depth scaling factor is less than 1.0.