### PR TITLE
Implement builtin functions

### DIFF
--- a/compiler/qsc_qasm/src/compiler.rs
+++ b/compiler/qsc_qasm/src/compiler.rs
@@ -47,6 +47,7 @@ use crate::{
         symbols::{IOKind, Symbol, SymbolId, SymbolTable},
         types::{promote_types, Type},
     },
+    stdlib::complex::Complex,
     CompilerConfig, OperationSignature, OutputSemantics, ProgramType, QasmCompileUnit,
     QubitSemantics,
 };
@@ -1395,7 +1396,7 @@ impl QasmCompiler {
                 self.compile_duration_literal(*value, *time_unit, span)
             }
             LiteralKind::Float(value) => Self::compile_float_literal(*value, span),
-            LiteralKind::Complex(real, imag) => Self::compile_complex_literal(*real, *imag, span),
+            LiteralKind::Complex(value) => Self::compile_complex_literal(*value, span),
             LiteralKind::Int(value) => Self::compile_int_literal(*value, span),
             LiteralKind::BigInt(value) => Self::compile_bigint_literal(value, span),
             LiteralKind::String(value) => self.compile_string_literal(value, span),
@@ -1585,8 +1586,8 @@ impl QasmCompiler {
         build_lit_result_array_expr(values, span)
     }
 
-    fn compile_complex_literal(real: f64, imag: f64, span: Span) -> qsast::Expr {
-        build_lit_complex_expr(crate::types::Complex::new(real, imag), span)
+    fn compile_complex_literal(value: Complex, span: Span) -> qsast::Expr {
+        build_lit_complex_expr(crate::types::Complex::new(value.real, value.imag), span)
     }
 
     fn compile_float_literal(value: f64, span: Span) -> qsast::Expr {

--- a/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/compiler/qsc_qasm/src/semantic/ast.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     parser::ast::List,
     semantic::symbols::SymbolId,
-    stdlib::angle::Angle,
+    stdlib::{angle::Angle, complex::Complex},
 };
 
 use crate::parser::ast as syntax;
@@ -1246,7 +1246,7 @@ pub enum LiteralKind {
     Bool(bool),
     Duration(f64, TimeUnit),
     Float(f64),
-    Complex(f64, f64),
+    Complex(Complex),
     Int(i64),
     BigInt(BigInt),
     String(Rc<str>),
@@ -1264,7 +1264,7 @@ impl Display for LiteralKind {
             LiteralKind::Angle(a) => write!(f, "Angle({a})"),
             LiteralKind::Bit(b) => write!(f, "Bit({:?})", u8::from(*b)),
             LiteralKind::Bool(b) => write!(f, "Bool({b:?})"),
-            LiteralKind::Complex(real, imag) => write!(f, "Complex({real:?}, {imag:?})"),
+            LiteralKind::Complex(value) => write!(f, "Complex({value})"),
             LiteralKind::Duration(value, unit) => {
                 write!(f, "Duration({value:?}, {unit:?})")
             }

--- a/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -26,6 +26,9 @@ pub enum ConstEvalError {
     #[error("division by zero error during const evaluation")]
     #[diagnostic(code("Qasm.Lowerer.DivisionByZero"))]
     DivisionByZero(#[label] Span),
+    #[error("{0}")]
+    #[diagnostic(code("Qasm.Lowerer.DomainError"))]
+    DomainError(String, #[label] Span),
     #[error("expression must be const")]
     #[diagnostic(code("Qasm.Lowerer.ExprMustBeConst"))]
     ExprMustBeConst(#[label] Span),

--- a/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions.rs
+++ b/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions.rs
@@ -244,6 +244,724 @@ fn nested_builtin_call_succeeds() {
     );
 }
 
+// ----------------------------------
+// arccos
+
+#[test]
+fn arccos() {
+    let source = "
+        arccos(0.5);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-21]:
+            expr: Expr [9-20]:
+                ty: const float
+                const_value: Float(1.0471975511965979)
+                kind: BuiltinFunctionCall [9-20]:
+                    fn_name_span: [9-15]
+                    name: arccos
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [16-19]:
+                            ty: const float
+                            const_value: Float(0.5)
+                            kind: Lit: Float(0.5)
+    "#]],
+    );
+}
+
+#[test]
+fn arccos_negative_domain_edge_case() {
+    let source = "
+        arccos(-1.);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-21]:
+            expr: Expr [9-20]:
+                ty: const float
+                const_value: Float(3.141592653589793)
+                kind: BuiltinFunctionCall [9-20]:
+                    fn_name_span: [9-15]
+                    name: arccos
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [17-19]:
+                            ty: const float
+                            const_value: Float(-1.0)
+                            kind: UnaryOpExpr [17-19]:
+                                op: Neg
+                                expr: Expr [17-19]:
+                                    ty: const float
+                                    kind: Lit: Float(1.0)
+    "#]],
+    );
+}
+
+#[test]
+fn arccos_positive_domain_edge_case() {
+    let source = "
+        arccos(1.);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-20]:
+            expr: Expr [9-19]:
+                ty: const float
+                const_value: Float(0.0)
+                kind: BuiltinFunctionCall [9-19]:
+                    fn_name_span: [9-15]
+                    name: arccos
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [16-18]:
+                            ty: const float
+                            const_value: Float(1.0)
+                            kind: Lit: Float(1.0)
+    "#]],
+    );
+}
+
+#[test]
+fn arccos_negative_domain_error() {
+    let source = "
+        arccos(-1.01);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-23]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.DomainError
+
+          x arccos input should be in the range [-1.0, 1.0]
+           ,-[test:2:9]
+         1 | 
+         2 |         arccos(-1.01);
+           :         ^^^^^^^^^^^^^
+         3 |     
+           `----
+        ]"#]],
+    );
+}
+
+#[test]
+fn arccos_positive_domain_error() {
+    let source = "
+        arccos(1.01);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-22]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.DomainError
+
+          x arccos input should be in the range [-1.0, 1.0]
+           ,-[test:2:9]
+         1 | 
+         2 |         arccos(1.01);
+           :         ^^^^^^^^^^^^
+         3 |     
+           `----
+        ]"#]],
+    );
+}
+
+// ----------------------------------
+// arcsin
+
+#[test]
+fn arcsin() {
+    let source = "
+        arcsin(0.5);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-21]:
+            expr: Expr [9-20]:
+                ty: const float
+                const_value: Float(0.5235987755982989)
+                kind: BuiltinFunctionCall [9-20]:
+                    fn_name_span: [9-15]
+                    name: arcsin
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [16-19]:
+                            ty: const float
+                            const_value: Float(0.5)
+                            kind: Lit: Float(0.5)
+    "#]],
+    );
+}
+
+#[test]
+fn arcsin_negative_domain_edge_case() {
+    let source = "
+        arcsin(-1.);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-21]:
+            expr: Expr [9-20]:
+                ty: const float
+                const_value: Float(-1.5707963267948966)
+                kind: BuiltinFunctionCall [9-20]:
+                    fn_name_span: [9-15]
+                    name: arcsin
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [17-19]:
+                            ty: const float
+                            const_value: Float(-1.0)
+                            kind: UnaryOpExpr [17-19]:
+                                op: Neg
+                                expr: Expr [17-19]:
+                                    ty: const float
+                                    kind: Lit: Float(1.0)
+    "#]],
+    );
+}
+
+#[test]
+fn arcsin_positive_domain_edge_case() {
+    let source = "
+        arcsin(1.);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-20]:
+            expr: Expr [9-19]:
+                ty: const float
+                const_value: Float(1.5707963267948966)
+                kind: BuiltinFunctionCall [9-19]:
+                    fn_name_span: [9-15]
+                    name: arcsin
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [16-18]:
+                            ty: const float
+                            const_value: Float(1.0)
+                            kind: Lit: Float(1.0)
+    "#]],
+    );
+}
+
+#[test]
+fn arcsin_negative_domain_error() {
+    let source = "
+        arcsin(-1.01);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-23]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.DomainError
+
+          x arcsin input should be in the range [-1.0, 1.0]
+           ,-[test:2:9]
+         1 | 
+         2 |         arcsin(-1.01);
+           :         ^^^^^^^^^^^^^
+         3 |     
+           `----
+        ]"#]],
+    );
+}
+
+#[test]
+fn arcsin_positive_domain_error() {
+    let source = "
+        arcsin(1.01);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-22]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.DomainError
+
+          x arcsin input should be in the range [-1.0, 1.0]
+           ,-[test:2:9]
+         1 | 
+         2 |         arcsin(1.01);
+           :         ^^^^^^^^^^^^
+         3 |     
+           `----
+        ]"#]],
+    );
+}
+
+// ----------------------------------
+// arctan
+
+#[test]
+fn arctan() {
+    let source = "
+        arctan(0.5);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-21]:
+            expr: Expr [9-20]:
+                ty: const float
+                const_value: Float(0.4636476090008061)
+                kind: BuiltinFunctionCall [9-20]:
+                    fn_name_span: [9-15]
+                    name: arctan
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [16-19]:
+                            ty: const float
+                            const_value: Float(0.5)
+                            kind: Lit: Float(0.5)
+    "#]],
+    );
+}
+
+// ----------------------------------
+// ceiling
+
+#[test]
+fn ceiling_positive() {
+    let source = "
+        ceiling(0.5);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-22]:
+            expr: Expr [9-21]:
+                ty: const float
+                const_value: Float(1.0)
+                kind: BuiltinFunctionCall [9-21]:
+                    fn_name_span: [9-16]
+                    name: ceiling
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [17-20]:
+                            ty: const float
+                            const_value: Float(0.5)
+                            kind: Lit: Float(0.5)
+    "#]],
+    );
+}
+
+#[test]
+fn ceiling_positive_edge_case() {
+    let source = "
+        ceiling(1.0);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-22]:
+            expr: Expr [9-21]:
+                ty: const float
+                const_value: Float(1.0)
+                kind: BuiltinFunctionCall [9-21]:
+                    fn_name_span: [9-16]
+                    name: ceiling
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [17-20]:
+                            ty: const float
+                            const_value: Float(1.0)
+                            kind: Lit: Float(1.0)
+    "#]],
+    );
+}
+
+#[test]
+fn ceiling_negative() {
+    let source = "
+        ceiling(-0.5);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-23]:
+            expr: Expr [9-22]:
+                ty: const float
+                const_value: Float(-0.0)
+                kind: BuiltinFunctionCall [9-22]:
+                    fn_name_span: [9-16]
+                    name: ceiling
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [18-21]:
+                            ty: const float
+                            const_value: Float(-0.5)
+                            kind: UnaryOpExpr [18-21]:
+                                op: Neg
+                                expr: Expr [18-21]:
+                                    ty: const float
+                                    kind: Lit: Float(0.5)
+    "#]],
+    );
+}
+
+#[test]
+fn ceiling_negative_edge_case() {
+    let source = "
+        ceiling(-1.0);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-23]:
+            expr: Expr [9-22]:
+                ty: const float
+                const_value: Float(-1.0)
+                kind: BuiltinFunctionCall [9-22]:
+                    fn_name_span: [9-16]
+                    name: ceiling
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [18-21]:
+                            ty: const float
+                            const_value: Float(-1.0)
+                            kind: UnaryOpExpr [18-21]:
+                                op: Neg
+                                expr: Expr [18-21]:
+                                    ty: const float
+                                    kind: Lit: Float(1.0)
+    "#]],
+    );
+}
+
+// ----------------------------------
+// cos
+
+#[test]
+fn cos_float() {
+    let source = "
+        cos(pi);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-17]:
+            expr: Expr [9-16]:
+                ty: const float
+                const_value: Float(-1.0)
+                kind: BuiltinFunctionCall [9-16]:
+                    fn_name_span: [9-12]
+                    name: cos
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [13-15]:
+                            ty: const float
+                            const_value: Float(3.141592653589793)
+                            kind: SymbolId(2)
+    "#]],
+    );
+}
+
+#[test]
+fn cos_angle() {
+    let source = "
+        const angle a = pi;
+        cos(a);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-28]:
+            symbol_id: 8
+            ty_span: [15-20]
+            init_expr: Expr [25-27]:
+                ty: const angle
+                const_value: Angle(3.141592653589793)
+                kind: Cast [0-0]:
+                    ty: const angle
+                    expr: Expr [25-27]:
+                        ty: const float
+                        kind: SymbolId(2)
+        ExprStmt [37-44]:
+            expr: Expr [37-43]:
+                ty: const float
+                const_value: Float(-1.0)
+                kind: BuiltinFunctionCall [37-43]:
+                    fn_name_span: [37-40]
+                    name: cos
+                    function_ty: def (const angle) -> const float
+                    args:
+                        Expr [41-42]:
+                            ty: const angle
+                            const_value: Angle(3.141592653589793)
+                            kind: SymbolId(8)
+    "#]],
+    );
+}
+
+// ----------------------------------
+// exp
+
+#[test]
+fn exp_float() {
+    let source = "
+        exp(2.);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-17]:
+            expr: Expr [9-16]:
+                ty: const float
+                const_value: Float(7.38905609893065)
+                kind: BuiltinFunctionCall [9-16]:
+                    fn_name_span: [9-12]
+                    name: exp
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [13-15]:
+                            ty: const float
+                            const_value: Float(2.0)
+                            kind: Lit: Float(2.0)
+    "#]],
+    );
+}
+
+#[test]
+fn exp_complex() {
+    let source = "
+        const complex a = 2 + 3 im;
+        exp(a);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-36]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [9-36]:
+                            symbol_id: 8
+                            ty_span: [15-22]
+                            init_expr: Expr [27-35]:
+                                ty: const complex[float]
+                                kind: BinaryOpExpr:
+                                    op: Add
+                                    lhs: Expr [27-28]:
+                                        ty: const complex[float]
+                                        kind: Lit: Complex(2.0, 0.0)
+                                    rhs: Expr [31-35]:
+                                        ty: const complex[float]
+                                        kind: Lit: Complex(0.0, 3.0)
+                    Stmt [45-52]:
+                        annotations: <empty>
+                        kind: Err
+
+            [Qasm.Lowerer.ExprMustBeConst
+
+              x expression must be const
+               ,-[test:3:13]
+             2 |         const complex a = 2 + 3 im;
+             3 |         exp(a);
+               :             ^
+             4 |     
+               `----
+            ]"#]],
+    );
+}
+
+// ----------------------------------
+// floor
+
+#[test]
+fn floor_positive() {
+    let source = "
+        floor(0.5);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-20]:
+            expr: Expr [9-19]:
+                ty: const float
+                const_value: Float(0.0)
+                kind: BuiltinFunctionCall [9-19]:
+                    fn_name_span: [9-14]
+                    name: floor
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [15-18]:
+                            ty: const float
+                            const_value: Float(0.5)
+                            kind: Lit: Float(0.5)
+    "#]],
+    );
+}
+
+#[test]
+fn floor_positive_edge_case() {
+    let source = "
+        floor(1.0);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-20]:
+            expr: Expr [9-19]:
+                ty: const float
+                const_value: Float(1.0)
+                kind: BuiltinFunctionCall [9-19]:
+                    fn_name_span: [9-14]
+                    name: floor
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [15-18]:
+                            ty: const float
+                            const_value: Float(1.0)
+                            kind: Lit: Float(1.0)
+    "#]],
+    );
+}
+
+#[test]
+fn floor_negative() {
+    let source = "
+        floor(-0.5);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-21]:
+            expr: Expr [9-20]:
+                ty: const float
+                const_value: Float(-1.0)
+                kind: BuiltinFunctionCall [9-20]:
+                    fn_name_span: [9-14]
+                    name: floor
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [16-19]:
+                            ty: const float
+                            const_value: Float(-0.5)
+                            kind: UnaryOpExpr [16-19]:
+                                op: Neg
+                                expr: Expr [16-19]:
+                                    ty: const float
+                                    kind: Lit: Float(0.5)
+    "#]],
+    );
+}
+
+#[test]
+fn floor_negative_edge_case() {
+    let source = "
+        floor(-1.0);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-21]:
+            expr: Expr [9-20]:
+                ty: const float
+                const_value: Float(-1.0)
+                kind: BuiltinFunctionCall [9-20]:
+                    fn_name_span: [9-14]
+                    name: floor
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [16-19]:
+                            ty: const float
+                            const_value: Float(-1.0)
+                            kind: UnaryOpExpr [16-19]:
+                                op: Neg
+                                expr: Expr [16-19]:
+                                    ty: const float
+                                    kind: Lit: Float(1.0)
+    "#]],
+    );
+}
+
+// ----------------------------------
+// log
+
+#[test]
+fn log() {
+    let source = "
+        log(2.);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-17]:
+            expr: Expr [9-16]:
+                ty: const float
+                const_value: Float(0.6931471805599453)
+                kind: BuiltinFunctionCall [9-16]:
+                    fn_name_span: [9-12]
+                    name: log
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [13-15]:
+                            ty: const float
+                            const_value: Float(2.0)
+                            kind: Lit: Float(2.0)
+    "#]],
+    );
+}
+
+// ----------------------------------
+// mod
+
 #[test]
 fn mod_int() {
     let source = "
@@ -359,5 +1077,909 @@ fn mod_float_divide_by_zero_error() {
              3 |     
                `----
             ]"#]],
+    );
+}
+
+// ----------------------------------
+// popcount
+
+#[test]
+fn popcount() {
+    let source = r#"
+        const bit[5] a = "10101";
+        popcount(a);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-34]:
+                symbol_id: 8
+                ty_span: [15-21]
+                init_expr: Expr [26-33]:
+                    ty: const bit[5]
+                    const_value: Bitstring("10101")
+                    kind: Lit: Bitstring("10101")
+            ExprStmt [43-55]:
+                expr: Expr [43-54]:
+                    ty: const uint
+                    const_value: Int(3)
+                    kind: BuiltinFunctionCall [43-54]:
+                        fn_name_span: [43-51]
+                        name: popcount
+                        function_ty: def (const bit[5]) -> const uint
+                        args:
+                            Expr [52-53]:
+                                ty: const bit[5]
+                                const_value: Bitstring("10101")
+                                kind: SymbolId(8)
+        "#]],
+    );
+}
+
+#[test]
+fn popcount_literal() {
+    let source = r#"
+        popcount("10101");
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ExprStmt [9-27]:
+                expr: Expr [9-26]:
+                    ty: const uint
+                    const_value: Int(3)
+                    kind: BuiltinFunctionCall [9-26]:
+                        fn_name_span: [9-17]
+                        name: popcount
+                        function_ty: def (const bit[5]) -> const uint
+                        args:
+                            Expr [18-25]:
+                                ty: const bit[5]
+                                const_value: Bitstring("10101")
+                                kind: Lit: Bitstring("10101")
+        "#]],
+    );
+}
+
+#[test]
+fn popcount_unsized_type_error() {
+    let source = r#"
+        popcount(2);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-21]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+          x There is no valid overload of `popcount` for inputs: (const int)
+          | Overloads available are:
+          |     fn (bit[n]) -> uint
+           ,-[test:2:9]
+         1 | 
+         2 |         popcount(2);
+           :         ^^^^^^^^^^^
+         3 |     
+           `----
+        ]"#]],
+    );
+}
+
+// ----------------------------------
+// pow
+
+#[test]
+#[ignore = "pow builtin collides with the pow gate modifier"]
+fn pow_int() {
+    let source = r"
+        pow(2, 3);
+    ";
+
+    check_stmt_kinds(source, &expect![[r#""#]]);
+}
+
+#[test]
+#[ignore = "pow builtin collides with pow gate modifier"]
+fn pow_float() {
+    let source = r"
+        pow(2., 3.);
+    ";
+
+    check_stmt_kinds(source, &expect![[r#""#]]);
+}
+
+#[test]
+#[ignore = "pow builtin collides with pow gate modifier"]
+fn pow_complex() {
+    let source = r"
+        pow(2 im, 3);
+    ";
+
+    check_stmt_kinds(source, &expect![[r#""#]]);
+}
+
+// ----------------------------------
+// rotl
+
+#[test]
+fn rotl_bitarray() {
+    let source = r#"
+        const bit[5] a = "10001";
+        rotl(a, 1);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-34]:
+                symbol_id: 8
+                ty_span: [15-21]
+                init_expr: Expr [26-33]:
+                    ty: const bit[5]
+                    const_value: Bitstring("10001")
+                    kind: Lit: Bitstring("10001")
+            ExprStmt [43-54]:
+                expr: Expr [43-53]:
+                    ty: const bit[5]
+                    const_value: Bitstring("00011")
+                    kind: BuiltinFunctionCall [43-53]:
+                        fn_name_span: [43-47]
+                        name: rotl
+                        function_ty: def (const bit[5], const int) -> const bit[5]
+                        args:
+                            Expr [48-49]:
+                                ty: const bit[5]
+                                const_value: Bitstring("10001")
+                                kind: SymbolId(8)
+                            Expr [51-52]:
+                                ty: const int
+                                const_value: Int(1)
+                                kind: Lit: Int(1)
+        "#]],
+    );
+}
+
+#[test]
+fn rotl_bitarray_negative_distance() {
+    let source = r#"
+        const bit[5] a = "10001";
+        rotl(a, -1);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-34]:
+                symbol_id: 8
+                ty_span: [15-21]
+                init_expr: Expr [26-33]:
+                    ty: const bit[5]
+                    const_value: Bitstring("10001")
+                    kind: Lit: Bitstring("10001")
+            ExprStmt [43-55]:
+                expr: Expr [43-54]:
+                    ty: const bit[5]
+                    const_value: Bitstring("11000")
+                    kind: BuiltinFunctionCall [43-54]:
+                        fn_name_span: [43-47]
+                        name: rotl
+                        function_ty: def (const bit[5], const int) -> const bit[5]
+                        args:
+                            Expr [48-49]:
+                                ty: const bit[5]
+                                const_value: Bitstring("10001")
+                                kind: SymbolId(8)
+                            Expr [52-53]:
+                                ty: const int
+                                const_value: Int(-1)
+                                kind: UnaryOpExpr [52-53]:
+                                    op: Neg
+                                    expr: Expr [52-53]:
+                                        ty: const int
+                                        kind: Lit: Int(1)
+        "#]],
+    );
+}
+
+#[test]
+fn rotl_bitarray_zero_edge_case() {
+    let source = r#"
+        const bit[5] a = "10001";
+        rotl(a, 0);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-34]:
+            symbol_id: 8
+            ty_span: [15-21]
+            init_expr: Expr [26-33]:
+                ty: const bit[5]
+                const_value: Bitstring("10001")
+                kind: Lit: Bitstring("10001")
+        ExprStmt [43-54]:
+            expr: Expr [43-53]:
+                ty: const bit[5]
+                const_value: Bitstring("10001")
+                kind: BuiltinFunctionCall [43-53]:
+                    fn_name_span: [43-47]
+                    name: rotl
+                    function_ty: def (const bit[5], const int) -> const bit[5]
+                    args:
+                        Expr [48-49]:
+                            ty: const bit[5]
+                            const_value: Bitstring("10001")
+                            kind: SymbolId(8)
+                        Expr [51-52]:
+                            ty: const int
+                            const_value: Int(0)
+                            kind: Lit: Int(0)
+    "#]],
+    );
+}
+
+#[test]
+fn rotl_uint() {
+    let source = r#"
+        const uint[5] a = 17;
+        rotl(a, 1);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-30]:
+                symbol_id: 8
+                ty_span: [15-22]
+                init_expr: Expr [27-29]:
+                    ty: const uint[5]
+                    const_value: Int(17)
+                    kind: Lit: Int(17)
+            ExprStmt [39-50]:
+                expr: Expr [39-49]:
+                    ty: const bit[5]
+                    const_value: Bitstring("00011")
+                    kind: BuiltinFunctionCall [39-49]:
+                        fn_name_span: [39-43]
+                        name: rotl
+                        function_ty: def (const bit[5], const int) -> const bit[5]
+                        args:
+                            Expr [44-45]:
+                                ty: const uint[5]
+                                const_value: Int(17)
+                                kind: SymbolId(8)
+                            Expr [47-48]:
+                                ty: const int
+                                const_value: Int(1)
+                                kind: Lit: Int(1)
+        "#]],
+    );
+}
+
+#[test]
+fn rotl_uint_negative_distance() {
+    let source = r#"
+        const uint[5] a = 17;
+        rotl(a, -1);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-30]:
+                symbol_id: 8
+                ty_span: [15-22]
+                init_expr: Expr [27-29]:
+                    ty: const uint[5]
+                    const_value: Int(17)
+                    kind: Lit: Int(17)
+            ExprStmt [39-51]:
+                expr: Expr [39-50]:
+                    ty: const bit[5]
+                    const_value: Bitstring("11000")
+                    kind: BuiltinFunctionCall [39-50]:
+                        fn_name_span: [39-43]
+                        name: rotl
+                        function_ty: def (const bit[5], const int) -> const bit[5]
+                        args:
+                            Expr [44-45]:
+                                ty: const uint[5]
+                                const_value: Int(17)
+                                kind: SymbolId(8)
+                            Expr [48-49]:
+                                ty: const int
+                                const_value: Int(-1)
+                                kind: UnaryOpExpr [48-49]:
+                                    op: Neg
+                                    expr: Expr [48-49]:
+                                        ty: const int
+                                        kind: Lit: Int(1)
+        "#]],
+    );
+}
+
+#[test]
+fn rotl_uint_zero_edge_case() {
+    let source = r#"
+        const uint[5] a = 17;
+        rotl(a, 0);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-30]:
+            symbol_id: 8
+            ty_span: [15-22]
+            init_expr: Expr [27-29]:
+                ty: const uint[5]
+                const_value: Int(17)
+                kind: Lit: Int(17)
+        ExprStmt [39-50]:
+            expr: Expr [39-49]:
+                ty: const bit[5]
+                const_value: Bitstring("10001")
+                kind: BuiltinFunctionCall [39-49]:
+                    fn_name_span: [39-43]
+                    name: rotl
+                    function_ty: def (const bit[5], const int) -> const bit[5]
+                    args:
+                        Expr [44-45]:
+                            ty: const uint[5]
+                            const_value: Int(17)
+                            kind: SymbolId(8)
+                        Expr [47-48]:
+                            ty: const int
+                            const_value: Int(0)
+                            kind: Lit: Int(0)
+    "#]],
+    );
+}
+
+#[test]
+fn rotl_unsized_type_error() {
+    let source = r#"
+        rotl(17, 2);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-21]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+          x There is no valid overload of `rotl` for inputs: (const int, const int)
+          | Overloads available are:
+          |     fn (bit[n], int) -> bit[n]
+          |     fn (uint[n], int) -> uint[n]
+           ,-[test:2:9]
+         1 | 
+         2 |         rotl(17, 2);
+           :         ^^^^^^^^^^^
+         3 |     
+           `----
+        ]"#]],
+    );
+}
+
+// ----------------------------------
+// rotr
+
+#[test]
+fn rotr_bitarray() {
+    let source = r#"
+        const bit[5] a = "10001";
+        rotr(a, 1);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-34]:
+            symbol_id: 8
+            ty_span: [15-21]
+            init_expr: Expr [26-33]:
+                ty: const bit[5]
+                const_value: Bitstring("10001")
+                kind: Lit: Bitstring("10001")
+        ExprStmt [43-54]:
+            expr: Expr [43-53]:
+                ty: const bit[5]
+                const_value: Bitstring("11000")
+                kind: BuiltinFunctionCall [43-53]:
+                    fn_name_span: [43-47]
+                    name: rotr
+                    function_ty: def (const bit[5], const int) -> const bit[5]
+                    args:
+                        Expr [48-49]:
+                            ty: const bit[5]
+                            const_value: Bitstring("10001")
+                            kind: SymbolId(8)
+                        Expr [51-52]:
+                            ty: const int
+                            const_value: Int(1)
+                            kind: Lit: Int(1)
+    "#]],
+    );
+}
+
+#[test]
+fn rotr_bitarray_negative_distance() {
+    let source = r#"
+        const bit[5] a = "10001";
+        rotr(a, -1);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-34]:
+                symbol_id: 8
+                ty_span: [15-21]
+                init_expr: Expr [26-33]:
+                    ty: const bit[5]
+                    const_value: Bitstring("10001")
+                    kind: Lit: Bitstring("10001")
+            ExprStmt [43-55]:
+                expr: Expr [43-54]:
+                    ty: const bit[5]
+                    const_value: Bitstring("00011")
+                    kind: BuiltinFunctionCall [43-54]:
+                        fn_name_span: [43-47]
+                        name: rotr
+                        function_ty: def (const bit[5], const int) -> const bit[5]
+                        args:
+                            Expr [48-49]:
+                                ty: const bit[5]
+                                const_value: Bitstring("10001")
+                                kind: SymbolId(8)
+                            Expr [52-53]:
+                                ty: const int
+                                const_value: Int(-1)
+                                kind: UnaryOpExpr [52-53]:
+                                    op: Neg
+                                    expr: Expr [52-53]:
+                                        ty: const int
+                                        kind: Lit: Int(1)
+        "#]],
+    );
+}
+
+#[test]
+fn rotr_bitarray_zero_edge_case() {
+    let source = r#"
+        const bit[5] a = "10001";
+        rotr(a, 0);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-34]:
+            symbol_id: 8
+            ty_span: [15-21]
+            init_expr: Expr [26-33]:
+                ty: const bit[5]
+                const_value: Bitstring("10001")
+                kind: Lit: Bitstring("10001")
+        ExprStmt [43-54]:
+            expr: Expr [43-53]:
+                ty: const bit[5]
+                const_value: Bitstring("10001")
+                kind: BuiltinFunctionCall [43-53]:
+                    fn_name_span: [43-47]
+                    name: rotr
+                    function_ty: def (const bit[5], const int) -> const bit[5]
+                    args:
+                        Expr [48-49]:
+                            ty: const bit[5]
+                            const_value: Bitstring("10001")
+                            kind: SymbolId(8)
+                        Expr [51-52]:
+                            ty: const int
+                            const_value: Int(0)
+                            kind: Lit: Int(0)
+    "#]],
+    );
+}
+
+#[test]
+fn rotr_uint() {
+    let source = r#"
+        const uint[5] a = 17;
+        rotr(a, 1);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-30]:
+            symbol_id: 8
+            ty_span: [15-22]
+            init_expr: Expr [27-29]:
+                ty: const uint[5]
+                const_value: Int(17)
+                kind: Lit: Int(17)
+        ExprStmt [39-50]:
+            expr: Expr [39-49]:
+                ty: const bit[5]
+                const_value: Bitstring("11000")
+                kind: BuiltinFunctionCall [39-49]:
+                    fn_name_span: [39-43]
+                    name: rotr
+                    function_ty: def (const bit[5], const int) -> const bit[5]
+                    args:
+                        Expr [44-45]:
+                            ty: const uint[5]
+                            const_value: Int(17)
+                            kind: SymbolId(8)
+                        Expr [47-48]:
+                            ty: const int
+                            const_value: Int(1)
+                            kind: Lit: Int(1)
+    "#]],
+    );
+}
+
+#[test]
+fn rotr_uint_negative_distance() {
+    let source = r#"
+        const uint[5] a = 17;
+        rotr(a, -1);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+            ClassicalDeclarationStmt [9-30]:
+                symbol_id: 8
+                ty_span: [15-22]
+                init_expr: Expr [27-29]:
+                    ty: const uint[5]
+                    const_value: Int(17)
+                    kind: Lit: Int(17)
+            ExprStmt [39-51]:
+                expr: Expr [39-50]:
+                    ty: const bit[5]
+                    const_value: Bitstring("00011")
+                    kind: BuiltinFunctionCall [39-50]:
+                        fn_name_span: [39-43]
+                        name: rotr
+                        function_ty: def (const bit[5], const int) -> const bit[5]
+                        args:
+                            Expr [44-45]:
+                                ty: const uint[5]
+                                const_value: Int(17)
+                                kind: SymbolId(8)
+                            Expr [48-49]:
+                                ty: const int
+                                const_value: Int(-1)
+                                kind: UnaryOpExpr [48-49]:
+                                    op: Neg
+                                    expr: Expr [48-49]:
+                                        ty: const int
+                                        kind: Lit: Int(1)
+        "#]],
+    );
+}
+
+#[test]
+fn rotr_uint_zero_edge_case() {
+    let source = r#"
+        const uint[5] a = 17;
+        rotr(a, 0);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-30]:
+            symbol_id: 8
+            ty_span: [15-22]
+            init_expr: Expr [27-29]:
+                ty: const uint[5]
+                const_value: Int(17)
+                kind: Lit: Int(17)
+        ExprStmt [39-50]:
+            expr: Expr [39-49]:
+                ty: const bit[5]
+                const_value: Bitstring("10001")
+                kind: BuiltinFunctionCall [39-49]:
+                    fn_name_span: [39-43]
+                    name: rotr
+                    function_ty: def (const bit[5], const int) -> const bit[5]
+                    args:
+                        Expr [44-45]:
+                            ty: const uint[5]
+                            const_value: Int(17)
+                            kind: SymbolId(8)
+                        Expr [47-48]:
+                            ty: const int
+                            const_value: Int(0)
+                            kind: Lit: Int(0)
+    "#]],
+    );
+}
+
+#[test]
+fn rotr_unsized_type_error() {
+    let source = r#"
+        rotl(17, 2);
+    "#;
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-21]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+          x There is no valid overload of `rotl` for inputs: (const int, const int)
+          | Overloads available are:
+          |     fn (bit[n], int) -> bit[n]
+          |     fn (uint[n], int) -> uint[n]
+           ,-[test:2:9]
+         1 | 
+         2 |         rotl(17, 2);
+           :         ^^^^^^^^^^^
+         3 |     
+           `----
+        ]"#]],
+    );
+}
+
+// ----------------------------------
+// sin
+
+#[test]
+fn sin_float() {
+    let source = "
+        sin(pi);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-17]:
+            expr: Expr [9-16]:
+                ty: const float
+                const_value: Float(1.2246467991473532e-16)
+                kind: BuiltinFunctionCall [9-16]:
+                    fn_name_span: [9-12]
+                    name: sin
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [13-15]:
+                            ty: const float
+                            const_value: Float(3.141592653589793)
+                            kind: SymbolId(2)
+    "#]],
+    );
+}
+
+#[test]
+fn sin_angle() {
+    let source = "
+        const angle a = pi;
+        sin(a);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-28]:
+            symbol_id: 8
+            ty_span: [15-20]
+            init_expr: Expr [25-27]:
+                ty: const angle
+                const_value: Angle(3.141592653589793)
+                kind: Cast [0-0]:
+                    ty: const angle
+                    expr: Expr [25-27]:
+                        ty: const float
+                        kind: SymbolId(2)
+        ExprStmt [37-44]:
+            expr: Expr [37-43]:
+                ty: const float
+                const_value: Float(1.2246467991473532e-16)
+                kind: BuiltinFunctionCall [37-43]:
+                    fn_name_span: [37-40]
+                    name: sin
+                    function_ty: def (const angle) -> const float
+                    args:
+                        Expr [41-42]:
+                            ty: const angle
+                            const_value: Angle(3.141592653589793)
+                            kind: SymbolId(8)
+    "#]],
+    );
+}
+
+// ----------------------------------
+// sqrt
+
+#[test]
+fn sqrt_float() {
+    let source = "
+        sqrt(4.);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-18]:
+            expr: Expr [9-17]:
+                ty: const float
+                const_value: Float(2.0)
+                kind: BuiltinFunctionCall [9-17]:
+                    fn_name_span: [9-13]
+                    name: exp
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [14-16]:
+                            ty: const float
+                            const_value: Float(4.0)
+                            kind: Lit: Float(4.0)
+    "#]],
+    );
+}
+
+#[test]
+fn sqrt_float_domain_error() {
+    let source = "
+        sqrt(-4.);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-19]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.DomainError
+
+          x cannot compute square root of negative floats
+           ,-[test:2:9]
+         1 | 
+         2 |         sqrt(-4.);
+           :         ^^^^^^^^^
+         3 |     
+           `----
+        ]"#]],
+    );
+}
+
+#[test]
+fn sqrt_complex() {
+    let source = "
+        sqrt(-5 + 12 im);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-26]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.ExprMustBeConst
+
+          x expression must be const
+           ,-[test:2:14]
+         1 | 
+         2 |         sqrt(-5 + 12 im);
+           :              ^^^^^^^^^^
+         3 |     
+           `----
+        ]"#]],
+    );
+}
+
+// ----------------------------------
+// tan
+
+#[test]
+fn tan_float() {
+    let source = "
+        tan(pi / 4.);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ExprStmt [9-22]:
+            expr: Expr [9-21]:
+                ty: const float
+                const_value: Float(0.9999999999999999)
+                kind: BuiltinFunctionCall [9-21]:
+                    fn_name_span: [9-12]
+                    name: tan
+                    function_ty: def (const float) -> const float
+                    args:
+                        Expr [13-20]:
+                            ty: const float
+                            const_value: Float(0.7853981633974483)
+                            kind: BinaryOpExpr:
+                                op: Div
+                                lhs: Expr [13-15]:
+                                    ty: const float
+                                    kind: SymbolId(2)
+                                rhs: Expr [18-20]:
+                                    ty: const float
+                                    kind: Lit: Float(4.0)
+    "#]],
+    );
+}
+
+#[test]
+fn tan_angle() {
+    let source = "
+        const angle a = pi / 4.;
+        tan(a);
+    ";
+
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-33]:
+            symbol_id: 8
+            ty_span: [15-20]
+            init_expr: Expr [25-32]:
+                ty: const angle
+                const_value: Angle(0.7853981633974483)
+                kind: Cast [0-0]:
+                    ty: const angle
+                    expr: Expr [25-32]:
+                        ty: const float
+                        kind: BinaryOpExpr:
+                            op: Div
+                            lhs: Expr [25-27]:
+                                ty: const float
+                                kind: SymbolId(2)
+                            rhs: Expr [30-32]:
+                                ty: const float
+                                kind: Lit: Float(4.0)
+        ExprStmt [42-49]:
+            expr: Expr [42-48]:
+                ty: const float
+                const_value: Float(0.9999999999999999)
+                kind: BuiltinFunctionCall [42-48]:
+                    fn_name_span: [42-45]
+                    name: tan
+                    function_ty: def (const angle) -> const float
+                    args:
+                        Expr [46-47]:
+                            ty: const angle
+                            const_value: Angle(0.7853981633974483)
+                            kind: SymbolId(8)
+    "#]],
     );
 }

--- a/compiler/qsc_qasm/src/stdlib.rs
+++ b/compiler/qsc_qasm/src/stdlib.rs
@@ -3,3 +3,4 @@
 
 pub(crate) mod angle;
 pub(crate) mod builtin_functions;
+pub(crate) mod complex;

--- a/compiler/qsc_qasm/src/stdlib/complex.rs
+++ b/compiler/qsc_qasm/src/stdlib/complex.rs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use core::f64;
+use std::{
+    fmt::{self, Display, Formatter},
+    ops::{Add, Div, Mul, Neg, Sub},
+};
+
+use crate::semantic::ast::LiteralKind;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Complex {
+    pub real: f64,
+    pub imag: f64,
+}
+
+impl Complex {
+    pub fn new(real_value: f64, imaginary_value: f64) -> Self {
+        Self {
+            real: real_value,
+            imag: imaginary_value,
+        }
+    }
+
+    pub fn real(real: f64) -> Self {
+        Self { real, imag: 0. }
+    }
+
+    pub fn imag(imag: f64) -> Self {
+        Self { real: 0., imag }
+    }
+}
+
+impl Display for Complex {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}, {:?}", self.real, self.imag)
+    }
+}
+
+impl Neg for Complex {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self {
+            real: -self.real,
+            imag: -self.imag,
+        }
+    }
+}
+
+impl PartialEq for Complex {
+    fn eq(&self, other: &Self) -> bool {
+        self.real == other.real && self.imag == other.imag
+    }
+}
+
+impl Add for Complex {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let real_value = self.real + rhs.real;
+        let imaginary_value = self.imag + rhs.imag;
+        Self {
+            real: real_value,
+            imag: imaginary_value,
+        }
+    }
+}
+
+impl Sub for Complex {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let real_value = self.real - rhs.real;
+        let imaginary_value = self.imag - rhs.imag;
+        Self {
+            real: real_value,
+            imag: imaginary_value,
+        }
+    }
+}
+
+impl Mul for Complex {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let a = self;
+        let b = rhs;
+        let real_value = a.real * b.real - a.imag * b.imag;
+        let imaginary_value = a.real * b.imag + a.imag * b.real;
+
+        Self {
+            real: real_value,
+            imag: imaginary_value,
+        }
+    }
+}
+
+impl Div for Complex {
+    type Output = Self;
+
+    /// This mimics Q#'s implementation.
+    /// ```qsharp
+    /// function DividedByC(a : Complex, b : Complex) : Complex {
+    ///     let sqNorm = b.Real * b.Real + b.Imag * b.Imag;
+    ///     Complex(
+    ///         (a.Real * b.Real + a.Imag * b.Imag) / sqNorm,
+    ///         (a.Imag * b.Real - a.Real * b.Imag) / sqNorm
+    ///     )
+    /// }
+    /// ```
+    fn div(self, rhs: Self) -> Self::Output {
+        let a = self;
+        let b = rhs;
+        let sq_norm = b.real * b.real + b.imag * b.imag;
+        let real_value = (a.real * b.real + a.imag * b.imag) / sq_norm;
+        let imaginary_value = (a.imag * b.real - a.real * b.imag) / sq_norm;
+
+        Self {
+            real: real_value,
+            imag: imaginary_value,
+        }
+    }
+}
+
+impl Complex {
+    /// This mimics Q#'s `PowC` implementation.
+    pub fn pow(self, rhs: Self) -> Self {
+        let (a, b) = (self.real, self.imag);
+        let (c, d) = (rhs.real, rhs.imag);
+
+        let base_sq_norm = a * a + b * b;
+        let base_norm = base_sq_norm.sqrt();
+        let base_arg = b.atan2(a);
+
+        let magnitude = base_norm.powf(c) / f64::consts::E.powf(d * base_arg);
+        let angle = d * base_norm.ln() + c * base_arg;
+
+        Self {
+            real: magnitude * angle.cos(),
+            imag: magnitude * angle.sin(),
+        }
+    }
+}
+
+impl From<Complex> for LiteralKind {
+    fn from(value: Complex) -> Self {
+        LiteralKind::Complex(value)
+    }
+}


### PR DESCRIPTION
Add builtin functions to OpenQASM.

Note: This PR is a follow up of #2508, which added the necessary infrastructure to support builtin functions.