### PR TITLE
Adding support for QASM 2.0 in the OpenQASM compiler

### DIFF
--- a/compiler/qsc_project/src/openqasm.rs
+++ b/compiler/qsc_project/src/openqasm.rs
@@ -114,7 +114,10 @@ fn get_includes(program: &Program, parent: &Arc<str>) -> Vec<(Arc<str>, Arc<str>
         .iter()
         .filter_map(|stmt| {
             if let StmtKind::Include(include) = &*stmt.kind {
-                if include.filename.to_lowercase() == "stdgates.inc" {
+                if matches!(
+                    include.filename.to_lowercase().as_ref(),
+                    "stdgates.inc" | "qelib1.inc"
+                ) {
                     return None;
                 }
                 Some((parent.clone(), include.filename.clone()))

--- a/compiler/qsc_qasm/src/parser.rs
+++ b/compiler/qsc_qasm/src/parser.rs
@@ -365,7 +365,10 @@ where
             let file_path = &include.filename;
             // Skip the standard gates include file.
             // Handling of this file is done by the compiler.
-            if file_path.to_lowercase() == "stdgates.inc" {
+            if matches!(
+                file_path.to_lowercase().as_ref(),
+                "stdgates.inc" | "qelib1.inc"
+            ) {
                 continue;
             }
             let source = match parse_qasm_file(file_path, resolver, stmt.span) {

--- a/compiler/qsc_qasm/src/semantic/error.rs
+++ b/compiler/qsc_qasm/src/semantic/error.rs
@@ -115,6 +115,9 @@ pub enum SemanticErrorKind {
     #[error("if statement missing {0} expression")]
     #[diagnostic(code("Qasm.Lowerer.IfStmtMissingExpression"))]
     IfStmtMissingExpression(String, #[label] Span),
+    #[error("include {0} must be declared in OPENQASM {1} programs")]
+    #[diagnostic(code("Qasm.Lowerer.IncludeNotInLanguageVersion"))]
+    IncludeNotInLanguageVersion(String, String, #[label] Span),
     #[error("include {0} could not be found")]
     #[diagnostic(code("Qasm.Lowerer.IncludeNotFound"))]
     IncludeNotFound(String, #[label] Span),

--- a/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -61,6 +61,18 @@ macro_rules! err_expr {
     };
 }
 
+const SWITCH_MINIMUM_SUPPORTED_VERSION: semantic::Version = semantic::Version {
+    major: 3,
+    minor: Some(1),
+    span: Span { lo: 0, hi: 0 },
+};
+
+const QASM2_VERSION: semantic::Version = semantic::Version {
+    major: 2,
+    minor: Some(0),
+    span: Span { lo: 0, hi: 0 },
+};
+
 pub(crate) struct Lowerer {
     /// The root QASM source to compile.
     pub source: QasmSource,
@@ -72,13 +84,29 @@ pub(crate) struct Lowerer {
     /// when we are done with the file.
     /// This allows us to report errors with the correct file path.
     pub symbols: SymbolTable,
+    /// The version of the QASM source. Used to determine the base gate set
+    /// and other features.
     pub version: Option<Version>,
     pub stmts: Vec<Stmt>,
 }
 
 impl Lowerer {
     pub fn new(source: QasmSource, source_map: SourceMap) -> Self {
-        let symbols = SymbolTable::default();
+        // do a quick check for the version to set up the symbol table
+        // lowering and validation come later
+        let version = source.program().version;
+        let symbols = if let Some(version) = version {
+            if version.major == 2 && version.minor == Some(0) {
+                SymbolTable::new_qasm2()
+            } else {
+                SymbolTable::default()
+            }
+        } else {
+            SymbolTable::default()
+        };
+
+        // we don't set the version here, as we need to check
+        // for allowed version during lowering
         let version = None;
         let stmts = Vec::new();
         let errors = Vec::new();
@@ -120,6 +148,9 @@ impl Lowerer {
 
     fn lower_version(&mut self, version: Option<syntax::Version>) -> Option<Version> {
         if let Some(version) = version {
+            if version.major == 2 && version.minor == Some(0) {
+                return Some(QASM2_VERSION);
+            }
             if version.major != 3 {
                 self.push_semantic_error(SemanticErrorKind::UnsupportedVersion(
                     format!("{version}"),
@@ -166,7 +197,24 @@ impl Lowerer {
                 // special case for stdgates.inc
                 // it won't be in the includes list
                 if include.filename.to_lowercase() == "stdgates.inc" {
+                    if self.version == Some(QASM2_VERSION) {
+                        self.push_semantic_error(SemanticErrorKind::IncludeNotInLanguageVersion(
+                            include.filename.to_string(),
+                            "3.0".to_string(),
+                            include.span,
+                        ));
+                    }
                     self.define_stdgates(include.span);
+                    continue;
+                } else if include.filename.to_lowercase() == "qelib1.inc" {
+                    if self.version != Some(QASM2_VERSION) {
+                        self.push_semantic_error(SemanticErrorKind::IncludeNotInLanguageVersion(
+                            include.filename.to_string(),
+                            "2.0".to_string(),
+                            include.span,
+                        ));
+                    }
+                    self.define_qelib1_gates(include.span);
                     continue;
                 }
 
@@ -269,6 +317,59 @@ impl Lowerer {
             gate_symbol("u1", 1, 1),
             gate_symbol("u2", 2, 1),
             gate_symbol("u3", 3, 1),
+        ];
+        for gate in gates {
+            let name = gate.name.clone();
+            if self.symbols.insert_symbol(gate).is_err() {
+                self.push_redefined_symbol_error(name.as_str(), span);
+            }
+        }
+    }
+
+    /// Define the standard gates in the symbol table.
+    /// The sdg, tdg, crx, cry, crz, and ch are defined
+    /// as their bare gates, and modifiers are applied
+    /// when calling them.
+    fn define_qelib1_gates(&mut self, span: Span) {
+        fn gate_symbol(name: &str, cargs: u32, qargs: u32) -> Symbol {
+            Symbol::new(
+                name,
+                Span::default(),
+                Type::Gate(cargs, qargs),
+                Default::default(),
+                Default::default(),
+            )
+        }
+
+        let gates = vec![
+            // --- QE Hardware primitives ---
+            gate_symbol("u3", 3, 1),
+            gate_symbol("u2", 2, 1),
+            gate_symbol("u1", 1, 1),
+            //gate_symbol("cx", 0, 2), // handled as a modified x
+            gate_symbol("id", 0, 1),
+            // --- QE Standard Gates ---
+            gate_symbol("x", 0, 1),
+            gate_symbol("y", 0, 1),
+            gate_symbol("z", 0, 1),
+            gate_symbol("h", 0, 1),
+            gate_symbol("s", 0, 1),
+            // sdg handled as a modified s
+            gate_symbol("t", 0, 1),
+            // tdg handled as a modified t
+
+            // --- Standard rotations ---
+            gate_symbol("rx", 1, 1),
+            gate_symbol("ry", 1, 1),
+            gate_symbol("rz", 1, 1),
+            // --- QE Standard User-Defined Gates  ---
+            //gate_symbol("cz", 0, 2), // handled as a modified z
+            //gate_symbol("cy", 0, 2), // handled as a modified y
+            // ch handled as a modified h
+            gate_symbol("ccx", 0, 3),
+            // crz handled as a modified rz
+            // cu1 handled as a modified u1
+            // cu3 handled as a modified u3
         ];
         for gate in gates {
             let name = gate.name.clone();
@@ -1793,7 +1894,7 @@ impl Lowerer {
 
         let mut name = stmt.name.name.to_string();
         if let Some((gate_name, implicit_modifier)) =
-            try_get_qsharp_name_and_implicit_modifiers(&name, stmt.name.span)
+            self.try_get_qsharp_name_and_implicit_modifiers(&name, stmt.name.span)
         {
             // Override the gate name if we mapped with modifiers.
             name = gate_name;
@@ -2402,11 +2503,6 @@ impl Lowerer {
         // We push a semantic error on switch statements if version is less than 3.1,
         // as they were introduced in 3.1.
         if let Some(ref version) = self.version {
-            const SWITCH_MINIMUM_SUPPORTED_VERSION: semantic::Version = semantic::Version {
-                major: 3,
-                minor: Some(1),
-                span: Span { lo: 0, hi: 0 },
-            };
             if version < &SWITCH_MINIMUM_SUPPORTED_VERSION {
                 self.push_unsuported_in_this_version_error_message(
                     "switch statements",
@@ -4033,6 +4129,52 @@ impl Lowerer {
         let error = crate::Error(kind);
         WithSource::from_map(&self.source_map, error)
     }
+
+    fn try_get_qsharp_name_and_implicit_modifiers<S: AsRef<str>>(
+        &self,
+        gate_name: S,
+        name_span: Span,
+    ) -> Option<(String, semantic::QuantumGateModifier)> {
+        use semantic::GateModifierKind::*;
+
+        let make_modifier = |kind| semantic::QuantumGateModifier {
+            span: name_span,
+            modifier_keyword_span: name_span,
+            kind,
+        };
+        let ctrl_expr = Expr::uint(1, Span::default());
+
+        if self.version == Some(QASM2_VERSION) {
+            match gate_name.as_ref() {
+                "cx" => Some(("x".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "sdg" => Some(("s".to_string(), make_modifier(Inv))),
+                "tdg" => Some(("t".to_string(), make_modifier(Inv))),
+                "cz" => Some(("z".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "cy" => Some(("y".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "ch" => Some(("h".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "crz" => Some(("rz".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "cu1" => Some(("u1".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "cu3" => Some(("u3".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                _ => None,
+            }
+        } else {
+            match gate_name.as_ref() {
+                "cy" => Some(("y".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "cz" => Some(("z".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "ch" => Some(("h".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "crx" => Some(("rx".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "cry" => Some(("ry".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "crz" => Some(("rz".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "cswap" => Some(("swap".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "sdg" => Some(("s".to_string(), make_modifier(Inv))),
+                "tdg" => Some(("t".to_string(), make_modifier(Inv))),
+                // Gates for OpenQASM 2 backwards compatibility
+                "CX" => Some(("x".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                "cphase" => Some(("phase".to_string(), make_modifier(Ctrl(ctrl_expr)))),
+                _ => None,
+            }
+        }
+    }
 }
 
 fn wrap_expr_in_cast_expr(ty: Type, rhs: semantic::Expr) -> semantic::Expr {
@@ -4080,37 +4222,6 @@ fn get_identifier_name(identifier: &syntax::IdentOrIndexedIdent) -> std::rc::Rc<
     match identifier {
         syntax::IdentOrIndexedIdent::Ident(ident) => ident.name.clone(),
         syntax::IdentOrIndexedIdent::IndexedIdent(ident) => ident.ident.name.clone(),
-    }
-}
-
-fn try_get_qsharp_name_and_implicit_modifiers<S: AsRef<str>>(
-    gate_name: S,
-    name_span: Span,
-) -> Option<(String, semantic::QuantumGateModifier)> {
-    use semantic::GateModifierKind::*;
-
-    let make_modifier = |kind| semantic::QuantumGateModifier {
-        span: name_span,
-        modifier_keyword_span: name_span,
-        kind,
-    };
-
-    let ctrl_expr = Expr::uint(1, Span::default());
-
-    match gate_name.as_ref() {
-        "cy" => Some(("y".to_string(), make_modifier(Ctrl(ctrl_expr)))),
-        "cz" => Some(("z".to_string(), make_modifier(Ctrl(ctrl_expr)))),
-        "ch" => Some(("h".to_string(), make_modifier(Ctrl(ctrl_expr)))),
-        "crx" => Some(("rx".to_string(), make_modifier(Ctrl(ctrl_expr)))),
-        "cry" => Some(("ry".to_string(), make_modifier(Ctrl(ctrl_expr)))),
-        "crz" => Some(("rz".to_string(), make_modifier(Ctrl(ctrl_expr)))),
-        "cswap" => Some(("swap".to_string(), make_modifier(Ctrl(ctrl_expr)))),
-        "sdg" => Some(("s".to_string(), make_modifier(Inv))),
-        "tdg" => Some(("t".to_string(), make_modifier(Inv))),
-        // Gates for OpenQASM 2 backwards compatibility
-        "CX" => Some(("x".to_string(), make_modifier(Ctrl(ctrl_expr)))),
-        "cphase" => Some(("phase".to_string(), make_modifier(Ctrl(ctrl_expr)))),
-        _ => None,
     }
 }
 

--- a/compiler/qsc_qasm/src/tests/statement/gate_call.rs
+++ b/compiler/qsc_qasm/src/tests/statement/gate_call.rs
@@ -33,6 +33,58 @@ fn u_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
+fn u_gate_can_be_called_in_broadcast_qubit_array() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        qubit[1] q;
+        U(1.0, 2.0, 3.0) q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(1);
+        U(new Std.OpenQASM.Angle.Angle {
+            Value = 1433540284805665,
+            Size = 53
+        }, new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, new Std.OpenQASM.Angle.Angle {
+            Value = 4300620854416994,
+            Size = 53
+        }, q[0]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn u_gate_can_be_called_in_broadcast_over_qreg() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        qreg q[1];
+        U(1.0, 2.0, 3.0) q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(1);
+        U(new Std.OpenQASM.Angle.Angle {
+            Value = 1433540284805665,
+            Size = 53
+        }, new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, new Std.OpenQASM.Angle.Angle {
+            Value = 4300620854416994,
+            Size = 53
+        }, q[0]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
 fn gphase_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         gphase(2.0);
@@ -852,6 +904,676 @@ fn broadcast_with_different_register_sizes_fails() {
          5 |         ctrl @ x ctrls, targets;
            :                         ^^^^^^^
          6 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}
+
+#[test]
+fn qasm2_u_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        qreg q[1];
+        U(1.0, 2.0, 3.0) q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(1);
+        U(new Std.OpenQASM.Angle.Angle {
+            Value = 1433540284805665,
+            Size = 53
+        }, new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, new Std.OpenQASM.Angle.Angle {
+            Value = 4300620854416994,
+            Size = 53
+        }, q[0]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_custom_gates_can_be_called_bypassing_stdgates() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        gate u1(lambda) q { U(0.,0.,lambda) q; }
+        gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }
+        gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }
+        gate h a { u2(0.,pi) a; }
+        gate x a { u3(pi,0.,pi) a; }
+        gate rz(phi) a { u1(phi) a; }
+        gate rxx(theta) a, b { h a; h b; CX a, b; rz(theta) b; CX a, b; h b; h a; }
+
+        qubit a;
+        qubit b;
+        x a;
+        rxx(π/2) a, b;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        operation u1(lambda : Std.OpenQASM.Angle.Angle, q : Qubit) : Unit is Adj + Ctl {
+            U(new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            }, new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            }, lambda, q);
+        }
+        operation u2(phi : Std.OpenQASM.Angle.Angle, lambda : Std.OpenQASM.Angle.Angle, q : Qubit) : Unit is Adj + Ctl {
+            U(Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793 / 2., 53), phi, lambda, q);
+        }
+        operation u3(theta : Std.OpenQASM.Angle.Angle, phi : Std.OpenQASM.Angle.Angle, lambda : Std.OpenQASM.Angle.Angle, q : Qubit) : Unit is Adj + Ctl {
+            U(theta, phi, lambda, q);
+        }
+        operation h(a : Qubit) : Unit is Adj + Ctl {
+            u2(new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            }, new Std.OpenQASM.Angle.Angle {
+                Value = 4503599627370496,
+                Size = 53
+            }, a);
+        }
+        operation x(a : Qubit) : Unit is Adj + Ctl {
+            u3(new Std.OpenQASM.Angle.Angle {
+                Value = 4503599627370496,
+                Size = 53
+            }, new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            }, new Std.OpenQASM.Angle.Angle {
+                Value = 4503599627370496,
+                Size = 53
+            }, a);
+        }
+        operation rz(phi : Std.OpenQASM.Angle.Angle, a : Qubit) : Unit is Adj + Ctl {
+            u1(phi, a);
+        }
+        operation rxx(theta : Std.OpenQASM.Angle.Angle, a : Qubit, b : Qubit) : Unit is Adj + Ctl {
+            h(a);
+            h(b);
+            CX(a, b);
+            rz(theta, b);
+            CX(a, b);
+            h(b);
+            h(a);
+        }
+        let a = QIR.Runtime.__quantum__rt__qubit_allocate();
+        let b = QIR.Runtime.__quantum__rt__qubit_allocate();
+        x(a);
+        rxx(Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), a, b);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_x_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        x q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(1);
+        x(q[0]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_barrier_can_be_called_on_single_qubit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        barrier q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(1);
+        __quantum__qis__barrier__body();
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_barrier_can_be_called_without_qubits() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        barrier;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(1);
+        __quantum__qis__barrier__body();
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_barrier_generates_qir() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        creg c[1];
+        qubit[2] q;
+        barrier q[0], q[1];
+        barrier q[0];
+        barrier;
+        barrier q[0], q[1], q[0];
+        c[0] = measure q[0];
+    "#;
+
+    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    expect![[
+        r#"
+        %Result = type opaque
+        %Qubit = type opaque
+
+        define void @ENTRYPOINT__main() #0 {
+        block_0:
+          call void @__quantum__qis__barrier__body()
+          call void @__quantum__qis__barrier__body()
+          call void @__quantum__qis__barrier__body()
+          call void @__quantum__qis__barrier__body()
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 1, i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+          ret void
+        }
+
+        declare void @__quantum__qis__barrier__body()
+
+        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__array_record_output(i64, i8*)
+
+        declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 1, !"int_computations", !"i64"}
+        "#
+    ]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_barrier_can_be_called_on_two_qubit() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[2];
+        barrier q[0], q[1];
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(2);
+        __quantum__qis__barrier__body();
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_cx_called_with_one_qubit_generates_error() {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[2];
+        CX q[0];
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qasm.Lowerer.InvalidNumberOfQubitArgs
+
+          x gate expects 2 qubit arguments, but 1 were provided
+           ,-[Test.qasm:5:9]
+         4 |         qreg q[2];
+         5 |         CX q[0];
+           :         ^^^^^^^^
+         6 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}
+
+#[test]
+fn qasm2_cx_called_with_too_many_qubits_generates_error() {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        cx q[0], q[1], q[2];
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qasm.Lowerer.InvalidNumberOfQubitArgs
+
+          x gate expects 2 qubit arguments, but 3 were provided
+           ,-[Test.qasm:5:9]
+         4 |         qreg q[3];
+         5 |         cx q[0], q[1], q[2];
+           :         ^^^^^^^^^^^^^^^^^^^^
+         6 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}
+
+#[test]
+fn qasm2_rx_gate_with_no_angles_generates_error() {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        rx q;
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qasm.Lowerer.InvalidNumberOfClassicalArgs
+
+          x gate expects 1 classical arguments, but 0 were provided
+           ,-[Test.qasm:5:9]
+         4 |         qreg q[1];
+         5 |         rx q;
+           :         ^^^^^
+         6 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}
+
+#[test]
+fn qasm2_rx_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        rx(2.0) q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(1);
+        rx(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, q[0]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_rx_gate_with_too_many_angles_generates_error() {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        rx(2.0, 3.0) q;
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qasm.Lowerer.InvalidNumberOfClassicalArgs
+
+          x gate expects 1 classical arguments, but 2 were provided
+           ,-[Test.qasm:5:9]
+         4 |         qreg q[1];
+         5 |         rx(2.0, 3.0) q;
+           :         ^^^^^^^^^^^^^^^
+         6 |     
+           `----
+        ]"#]]
+    .assert_eq(&format!("{errors:?}"));
+}
+
+#[test]
+fn qasm2_implicit_cast_to_angle_works() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        rx(2.0) q;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(1);
+        rx(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, q[0]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_custom_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        gate my_gate q1, q2 {
+            h q1;
+            h q2;
+        }
+
+        qreg q[2];
+        my_gate q[0], q[1];
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        operation my_gate(q1 : Qubit, q2 : Qubit) : Unit is Adj + Ctl {
+            h(q1);
+            h(q2);
+        }
+        let q = QIR.Runtime.AllocateQubitArray(2);
+        my_gate(q[0], q[1]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_simulatable_intrinsic_on_gate_stmt_generates_correct_qir(
+) -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+
+        @SimulatableIntrinsic
+        gate my_gate q {
+            x q;
+        }
+
+        qreg q[1];
+        my_gate q;
+        creg result[1];
+        result = measure q;
+    "#;
+
+    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    expect![[r#"
+        %Result = type opaque
+        %Qubit = type opaque
+
+        define void @ENTRYPOINT__main() #0 {
+        block_0:
+          call void @my_gate(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 1, i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+          ret void
+        }
+
+        declare void @my_gate(%Qubit*)
+
+        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__array_record_output(i64, i8*)
+
+        declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 1, !"int_computations", !"i64"}
+    "#]].assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_rxx_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[2];
+        rxx(2.0) q[1], q[0];
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(2);
+        rxx(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, q[1], q[0]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_ryy_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[2];
+        ryy(2.0) q[1], q[0];
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(2);
+        ryy(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, q[1], q[0]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_rzz_gate_with_one_angle_can_be_called() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[2];
+        rzz(2.0) q[1], q[0];
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(2);
+        rzz(new Std.OpenQASM.Angle.Angle {
+            Value = 2867080569611330,
+            Size = 53
+        }, q[1], q[0]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_all_qiskit_stdgates_can_be_called_included() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[4];
+        rxx(pi / 2.0) q[1], q[0];
+        ryy(pi / 2.0) q[1], q[0];
+        rzz(pi / 2.0) q[1], q[0];
+        dcx q[0], q[1];
+        ecr q[0], q[1];
+        r(pi / 2.0, pi / 4.0) q[1];
+        rzx(pi / 2.0) q[1], q[0];
+        cs q[0], q[1];
+        csdg q[0], q[1];
+        sxdg q[0];
+        csx q[0], q[1];
+        cu1(pi / 2.0) q[1], q[0];
+        cu3(pi / 2.0, pi / 4.0, pi / 8.0) q[1], q[0];
+        rccx q[0], q[1], q[2];
+        c3sqrtx q[0], q[1], q[2], q[3];
+        c3x q[0], q[1], q[2], q[3];
+        rc3x q[0], q[1], q[2], q[3];
+        xx_minus_yy(pi / 2.0, pi / 4.0) q[1], q[0];
+        xx_plus_yy(pi / 2.0, pi / 4.0) q[1], q[0];
+        ccz q[0], q[1], q[2];
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let q = QIR.Runtime.AllocateQubitArray(4);
+        rxx(Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[1], q[0]);
+        ryy(Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[1], q[0]);
+        rzz(Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[1], q[0]);
+        dcx(q[0], q[1]);
+        ecr(q[0], q[1]);
+        r(Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 4., 53), q[1]);
+        rzx(Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[1], q[0]);
+        cs(q[0], q[1]);
+        csdg(q[0], q[1]);
+        sxdg(q[0]);
+        csx(q[0], q[1]);
+        Controlled u1([q[1]], (Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), q[0]));
+        Controlled u3([q[1]], (Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 4., 53), Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 8., 53), q[0]));
+        rccx(q[0], q[1], q[2]);
+        c3sqrtx(q[0], q[1], q[2], q[3]);
+        c3x(q[0], q[1], q[2], q[3]);
+        rc3x(q[0], q[1], q[2], q[3]);
+        xx_minus_yy(Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 4., 53), q[1], q[0]);
+        xx_plus_yy(Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 2., 53), Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI() / 4., 53), q[1], q[0]);
+        ccz(q[0], q[1], q[2]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_broadcast_one_qubit_gate() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg qs[2];
+        h qs;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let qs = QIR.Runtime.AllocateQubitArray(2);
+        h(qs[0]);
+        h(qs[1]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_broadcast_two_qubit_gate() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg ctrls[3];
+        qreg targets[3];
+        cx ctrls, targets;
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let ctrls = QIR.Runtime.AllocateQubitArray(3);
+        let targets = QIR.Runtime.AllocateQubitArray(3);
+        Controlled x([ctrls[0]], targets[0]);
+        Controlled x([ctrls[1]], targets[1]);
+        Controlled x([ctrls[2]], targets[2]);
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qasm2_broadcast_with_different_register_sizes_fails() {
+    let source = r#"
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg ctrls[3];
+        qreg targets[2];
+        CX ctrls, targets;
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected error");
+    };
+
+    expect![[r#"
+        [Qasm.Lowerer.BroadcastCallQuantumArgsDisagreeInSize
+
+          x first quantum register is of type qubit[3] but found an argument of type
+          | qubit[2]
+           ,-[Test.qasm:6:19]
+         5 |         qreg targets[2];
+         6 |         CX ctrls, targets;
+           :                   ^^^^^^^
+         7 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));


### PR DESCRIPTION
This PR adds promotion of OpenQASM 2.0 programs into OpenQASM 3.0 with some caveats
- Global phase is not adjusted so any OpenQASM 2.0 programs will have OpenQASM 3.0 global phase
- Opaque gates are not parsed. Any OpenQASM 2.0 programs with them will have parser errors. This concept was not migrated to OpenQASM 3.0
- OpenQASM 2.0 programs can import `"qelib1.inc"` and trying to import `"stdgates.inc"` will give an error.