### PR TITLE
Fix default value span

### DIFF
--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -2910,8 +2910,7 @@ impl Lowerer {
         use semantic::Expr;
         use semantic::ExprKind;
         use semantic::LiteralKind;
-        let from_lit_kind =
-            |kind| -> Expr { Expr::new(Span::default(), ExprKind::Lit(kind), ty.as_const()) };
+        let from_lit_kind = |kind| -> Expr { Expr::new(span, ExprKind::Lit(kind), ty.as_const()) };
         let expr = match ty {
             Type::Angle(_, _) => Some(from_lit_kind(LiteralKind::Angle(Default::default()))),
             Type::Bit(_) => Some(from_lit_kind(LiteralKind::Bit(false))),

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
@@ -13,7 +13,7 @@ fn implicit_bitness_default() {
             ClassicalDeclarationStmt [0-8]:
                 symbol_id: 8
                 ty_span: [0-5]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-8]:
                     ty: const angle
                     kind: Lit: Angle(0)
             [8] Symbol [6-7]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/bit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/bit.rs
@@ -13,7 +13,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
             ClassicalDeclarationStmt [0-6]:
                 symbol_id: 8
                 ty_span: [0-3]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-6]:
                     ty: const bit
                     kind: Lit: Bit(0)
             [8] Symbol [4-5]:
@@ -32,7 +32,7 @@ fn array_with_no_init_expr_has_generated_lit_expr() {
             ClassicalDeclarationStmt [0-9]:
                 symbol_id: 8
                 ty_span: [0-6]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-9]:
                     ty: const bit[4]
                     kind: Lit: Bitstring("0000")
             [8] Symbol [7-8]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/bool.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/bool.rs
@@ -13,7 +13,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
             ClassicalDeclarationStmt [0-7]:
                 symbol_id: 8
                 ty_span: [0-4]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-7]:
                     ty: const bool
                     kind: Lit: Bool(false)
             [8] Symbol [5-6]:
@@ -32,19 +32,19 @@ fn array_with_no_init_expr_has_generated_lit_expr() {
             ClassicalDeclarationStmt [0-17]:
                 symbol_id: 8
                 ty_span: [0-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-17]:
                     ty: array[bool, 4]
                     kind: Lit:     array:
-                            Expr [0-0]:
+                            Expr [0-17]:
                                 ty: const bool
                                 kind: Lit: Bool(false)
-                            Expr [0-0]:
+                            Expr [0-17]:
                                 ty: const bool
                                 kind: Lit: Bool(false)
-                            Expr [0-0]:
+                            Expr [0-17]:
                                 ty: const bool
                                 kind: Lit: Bool(false)
-                            Expr [0-0]:
+                            Expr [0-17]:
                                 ty: const bool
                                 kind: Lit: Bool(false)
             [8] Symbol [15-16]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/complex.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/complex.rs
@@ -13,7 +13,7 @@ fn implicit_bitness_default() {
             ClassicalDeclarationStmt [0-17]:
                 symbol_id: 8
                 ty_span: [0-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-17]:
                     ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             [8] Symbol [15-16]:
@@ -32,7 +32,7 @@ fn explicit_bitness_default() {
             ClassicalDeclarationStmt [0-21]:
                 symbol_id: 8
                 ty_span: [0-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-21]:
                     ty: const complex[float[42]]
                     kind: Lit: Complex(0.0, 0.0)
             [8] Symbol [19-20]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/creg.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/creg.rs
@@ -13,7 +13,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
             ClassicalDeclarationStmt [0-7]:
                 symbol_id: 8
                 ty_span: [0-7]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-7]:
                     ty: const bit
                     kind: Lit: Bit(0)
             [8] Symbol [5-6]:
@@ -32,7 +32,7 @@ fn array_with_no_init_expr_has_generated_lit_expr() {
             ClassicalDeclarationStmt [0-10]:
                 symbol_id: 8
                 ty_span: [0-10]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-10]:
                     ty: const bit[4]
                     kind: Lit: Bitstring("0000")
             [8] Symbol [5-6]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/duration.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/duration.rs
@@ -18,7 +18,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
                         kind: ClassicalDeclarationStmt [0-11]:
                             symbol_id: 8
                             ty_span: [0-8]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [0-11]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
 

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/float.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/float.rs
@@ -13,7 +13,7 @@ fn implicit_bitness_default() {
             ClassicalDeclarationStmt [0-8]:
                 symbol_id: 8
                 ty_span: [0-5]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-8]:
                     ty: const float
                     kind: Lit: Float(0.0)
             [8] Symbol [6-7]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/int.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/int.rs
@@ -60,7 +60,7 @@ fn implicit_bitness_int_default() {
             ClassicalDeclarationStmt [0-6]:
                 symbol_id: 8
                 ty_span: [0-3]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-6]:
                     ty: const int
                     kind: Lit: Int(0)
             [8] Symbol [4-5]:
@@ -314,7 +314,7 @@ fn explicit_bitness_int_default() {
             ClassicalDeclarationStmt [0-10]:
                 symbol_id: 8
                 ty_span: [0-7]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-10]:
                     ty: const int[10]
                     kind: Lit: Int(0)
             [8] Symbol [8-9]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/uint.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/uint.rs
@@ -13,7 +13,7 @@ fn implicit_bitness_int_default() {
             ClassicalDeclarationStmt [0-7]:
                 symbol_id: 8
                 ty_span: [0-4]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-7]:
                     ty: const uint
                     kind: Lit: Int(0)
             [8] Symbol [5-6]:
@@ -306,7 +306,7 @@ fn const_explicit_bitness_int() {
             ClassicalDeclarationStmt [0-11]:
                 symbol_id: 8
                 ty_span: [0-8]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [0-11]:
                     ty: const uint[10]
                     kind: Lit: Int(0)
             [8] Symbol [9-10]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_angle.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_angle.rs
@@ -30,7 +30,7 @@ fn angle_to_bool() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const angle
                     kind: Lit: Angle(0)
             ExprStmt [26-34]:
@@ -57,7 +57,7 @@ fn sized_angle_to_bool() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-38]:
@@ -93,7 +93,7 @@ fn angle_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-38]:
@@ -133,7 +133,7 @@ fn sized_angle_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-42]:
@@ -177,7 +177,7 @@ fn angle_to_int_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-33]:
@@ -217,7 +217,7 @@ fn angle_to_sized_int_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-37]:
@@ -257,7 +257,7 @@ fn sized_angle_to_int_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-37]:
@@ -297,7 +297,7 @@ fn sized_angle_to_sized_int_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
@@ -337,7 +337,7 @@ fn sized_angle_to_sized_int_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
@@ -377,7 +377,7 @@ fn sized_angle_to_sized_int_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
@@ -421,7 +421,7 @@ fn angle_to_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-34]:
@@ -461,7 +461,7 @@ fn angle_to_sized_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-38]:
@@ -501,7 +501,7 @@ fn sized_angle_to_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-38]:
@@ -541,7 +541,7 @@ fn sized_angle_to_sized_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-42]:
@@ -581,7 +581,7 @@ fn sized_angle_to_sized_uint_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-42]:
@@ -621,7 +621,7 @@ fn sized_angle_to_sized_uint_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-42]:
@@ -665,7 +665,7 @@ fn angle_to_float_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-35]:
@@ -705,7 +705,7 @@ fn angle_to_sized_float_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-39]:
@@ -745,7 +745,7 @@ fn sized_angle_to_float_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-39]:
@@ -785,7 +785,7 @@ fn sized_angle_to_sized_float_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-43]:
@@ -825,7 +825,7 @@ fn sized_angle_to_sized_float_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-43]:
@@ -865,7 +865,7 @@ fn sized_angle_to_sized_float_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-43]:
@@ -904,7 +904,7 @@ fn angle_to_angle() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const angle
                     kind: Lit: Angle(0)
             ExprStmt [26-35]:
@@ -927,7 +927,7 @@ fn angle_to_sized_angle() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const angle
                     kind: Lit: Angle(0)
             ExprStmt [26-39]:
@@ -954,7 +954,7 @@ fn sized_angle_to_angle() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-39]:
@@ -981,7 +981,7 @@ fn sized_angle_to_sized_angle() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-43]:
@@ -1004,7 +1004,7 @@ fn sized_angle_to_sized_angle_truncating() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-43]:
@@ -1031,7 +1031,7 @@ fn sized_angle_to_sized_angle_expanding() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-43]:
@@ -1067,7 +1067,7 @@ fn angle_to_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-37]:
@@ -1107,7 +1107,7 @@ fn angle_to_sized_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-48]:
@@ -1147,7 +1147,7 @@ fn sized_angle_to_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
@@ -1187,7 +1187,7 @@ fn sized_angle_to_sized_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-52]:
@@ -1227,7 +1227,7 @@ fn sized_angle_to_sized_complex_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-52]:
@@ -1267,7 +1267,7 @@ fn sized_angle_to_sized_complex_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-52]:
@@ -1306,7 +1306,7 @@ fn angle_to_bit() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const angle
                     kind: Lit: Angle(0)
             ExprStmt [26-33]:
@@ -1338,7 +1338,7 @@ fn angle_to_bitarray_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const angle
                                 kind: Lit: Angle(0)
                     Stmt [26-37]:
@@ -1373,7 +1373,7 @@ fn sized_angle_to_bit() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-37]:
@@ -1400,7 +1400,7 @@ fn sized_angle_to_bitarray() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const angle[32]
                     kind: Lit: Angle(0)
             ExprStmt [30-41]:
@@ -1432,7 +1432,7 @@ fn sized_angle_to_bitarray_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:
@@ -1472,7 +1472,7 @@ fn sized_angle_to_bitarray_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const angle[32]
                                 kind: Lit: Angle(0)
                     Stmt [30-41]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bit.rs
@@ -30,7 +30,7 @@ fn bit_to_bool() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-32]:
@@ -57,7 +57,7 @@ fn bitarray_to_bool() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-36]:
@@ -93,7 +93,7 @@ fn bit_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-15]:
                             symbol_id: 8
                             ty_span: [9-12]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-15]:
                                 ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-36]:
@@ -133,7 +133,7 @@ fn bitarray_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-40]:
@@ -172,7 +172,7 @@ fn bit_to_int() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-31]:
@@ -199,7 +199,7 @@ fn bit_to_sized_int() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-35]:
@@ -268,7 +268,7 @@ fn bitarray_to_sized_int() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-39]:
@@ -300,7 +300,7 @@ fn bitarray_to_sized_int_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:
@@ -340,7 +340,7 @@ fn bitarray_to_sized_int_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:
@@ -379,7 +379,7 @@ fn bit_to_uint() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-32]:
@@ -406,7 +406,7 @@ fn bit_to_sized_uint() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-36]:
@@ -475,7 +475,7 @@ fn bitarray_to_sized_uint() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-40]:
@@ -507,7 +507,7 @@ fn bitarray_to_sized_uint_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-40]:
@@ -547,7 +547,7 @@ fn bitarray_to_sized_uint_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-40]:
@@ -586,7 +586,7 @@ fn bit_to_float() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-33]:
@@ -613,7 +613,7 @@ fn bit_to_sized_float() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-37]:
@@ -645,7 +645,7 @@ fn bitarray_to_float_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-37]:
@@ -685,7 +685,7 @@ fn bitarray_to_sized_float_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
@@ -725,7 +725,7 @@ fn bitarray_to_sized_float_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
@@ -765,7 +765,7 @@ fn bitarray_to_sized_float_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
@@ -809,7 +809,7 @@ fn bit_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-15]:
                             symbol_id: 8
                             ty_span: [9-12]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-15]:
                                 ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-33]:
@@ -849,7 +849,7 @@ fn bit_to_sized_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-15]:
                             symbol_id: 8
                             ty_span: [9-12]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-15]:
                                 ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-37]:
@@ -889,7 +889,7 @@ fn bitarray_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-37]:
@@ -924,7 +924,7 @@ fn bitarray_to_sized_angle() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-41]:
@@ -956,7 +956,7 @@ fn bitarray_to_sized_angle_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
@@ -996,7 +996,7 @@ fn bitarray_to_sized_angle_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-41]:
@@ -1040,7 +1040,7 @@ fn bit_to_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-15]:
                             symbol_id: 8
                             ty_span: [9-12]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-15]:
                                 ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-35]:
@@ -1080,7 +1080,7 @@ fn bit_to_sized_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-15]:
                             symbol_id: 8
                             ty_span: [9-12]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-15]:
                                 ty: const bit
                                 kind: Lit: Bit(0)
                     Stmt [24-46]:
@@ -1120,7 +1120,7 @@ fn bitarray_to_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:
@@ -1160,7 +1160,7 @@ fn bitarray_to_sized_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-50]:
@@ -1200,7 +1200,7 @@ fn bitarray_to_sized_complex_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-50]:
@@ -1240,7 +1240,7 @@ fn bitarray_to_sized_complex_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-50]:
@@ -1279,7 +1279,7 @@ fn bit_to_bit() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-31]:
@@ -1302,7 +1302,7 @@ fn bit_to_bitarray() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const bit
                     kind: Lit: Bit(0)
             ExprStmt [24-35]:
@@ -1329,7 +1329,7 @@ fn bitarray_to_bit() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-35]:
@@ -1356,7 +1356,7 @@ fn bitarray_to_bitarray() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const bit[32]
                     kind: Lit: Bitstring("00000000000000000000000000000000")
             ExprStmt [28-39]:
@@ -1384,7 +1384,7 @@ fn bitarray_to_bitarray_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:
@@ -1424,7 +1424,7 @@ fn bitarray_to_bitarray_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const bit[32]
                                 kind: Lit: Bitstring("00000000000000000000000000000000")
                     Stmt [28-39]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bool.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bool.rs
@@ -30,7 +30,7 @@ fn bool_to_bool() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-33]:
@@ -62,7 +62,7 @@ fn bool_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-16]:
                             symbol_id: 8
                             ty_span: [9-13]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-16]:
                                 ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-37]:
@@ -101,7 +101,7 @@ fn bool_to_int() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-32]:
@@ -128,7 +128,7 @@ fn bool_to_sized_int() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-36]:
@@ -159,7 +159,7 @@ fn bool_to_uint() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-33]:
@@ -186,7 +186,7 @@ fn bool_to_sized_uint() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-37]:
@@ -217,7 +217,7 @@ fn bool_to_float() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-34]:
@@ -244,7 +244,7 @@ fn bool_to_sized_float() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-38]:
@@ -280,7 +280,7 @@ fn bool_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-16]:
                             symbol_id: 8
                             ty_span: [9-13]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-16]:
                                 ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-34]:
@@ -320,7 +320,7 @@ fn bool_to_sized_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-16]:
                             symbol_id: 8
                             ty_span: [9-13]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-16]:
                                 ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-38]:
@@ -364,7 +364,7 @@ fn bool_to_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-16]:
                             symbol_id: 8
                             ty_span: [9-13]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-16]:
                                 ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-36]:
@@ -404,7 +404,7 @@ fn bool_to_sized_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-16]:
                             symbol_id: 8
                             ty_span: [9-13]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-16]:
                                 ty: const bool
                                 kind: Lit: Bool(false)
                     Stmt [25-47]:
@@ -443,7 +443,7 @@ fn bool_to_bit() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-32]:
@@ -470,7 +470,7 @@ fn bool_to_bitarray() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const bool
                     kind: Lit: Bool(false)
             ExprStmt [25-36]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_complex.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_complex.rs
@@ -35,7 +35,7 @@ fn complex_to_bool_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-36]:
@@ -75,7 +75,7 @@ fn sized_complex_to_bool_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-47]:
@@ -119,7 +119,7 @@ fn complex_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-40]:
@@ -159,7 +159,7 @@ fn sized_complex_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-51]:
@@ -203,7 +203,7 @@ fn complex_to_int_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-35]:
@@ -243,7 +243,7 @@ fn complex_to_sized_int_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-39]:
@@ -283,7 +283,7 @@ fn sized_complex_to_int_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-46]:
@@ -323,7 +323,7 @@ fn sized_complex_to_sized_int_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
@@ -363,7 +363,7 @@ fn sized_complex_to_sized_int_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
@@ -403,7 +403,7 @@ fn sized_complex_to_sized_int_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
@@ -447,7 +447,7 @@ fn complex_to_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-36]:
@@ -487,7 +487,7 @@ fn complex_to_sized_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-40]:
@@ -527,7 +527,7 @@ fn sized_complex_to_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-47]:
@@ -567,7 +567,7 @@ fn sized_complex_to_sized_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-51]:
@@ -607,7 +607,7 @@ fn sized_complex_to_sized_uint_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-51]:
@@ -647,7 +647,7 @@ fn sized_complex_to_sized_uint_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-51]:
@@ -691,7 +691,7 @@ fn complex_to_float_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-37]:
@@ -731,7 +731,7 @@ fn complex_to_sized_float_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-41]:
@@ -771,7 +771,7 @@ fn sized_complex_to_float_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-48]:
@@ -811,7 +811,7 @@ fn sized_complex_to_sized_float_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
@@ -851,7 +851,7 @@ fn sized_complex_to_sized_float_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
@@ -891,7 +891,7 @@ fn sized_complex_to_sized_float_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
@@ -935,7 +935,7 @@ fn complex_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-37]:
@@ -975,7 +975,7 @@ fn complex_to_sized_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-41]:
@@ -1015,7 +1015,7 @@ fn sized_complex_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-48]:
@@ -1055,7 +1055,7 @@ fn sized_complex_to_sized_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
@@ -1095,7 +1095,7 @@ fn sized_complex_to_sized_angle_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
@@ -1135,7 +1135,7 @@ fn sized_complex_to_sized_angle_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-52]:
@@ -1174,7 +1174,7 @@ fn complex_to_complex() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [28-39]:
@@ -1197,7 +1197,7 @@ fn complex_to_sized_complex() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const complex[float]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [28-50]:
@@ -1224,7 +1224,7 @@ fn sized_complex_to_complex() {
             ClassicalDeclarationStmt [9-30]:
                 symbol_id: 8
                 ty_span: [9-27]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-30]:
                     ty: const complex[float[32]]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [39-50]:
@@ -1251,7 +1251,7 @@ fn sized_complex_to_sized_complex() {
             ClassicalDeclarationStmt [9-30]:
                 symbol_id: 8
                 ty_span: [9-27]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-30]:
                     ty: const complex[float[32]]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [39-61]:
@@ -1274,7 +1274,7 @@ fn sized_complex_to_sized_complex_truncating() {
             ClassicalDeclarationStmt [9-30]:
                 symbol_id: 8
                 ty_span: [9-27]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-30]:
                     ty: const complex[float[32]]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [39-61]:
@@ -1297,7 +1297,7 @@ fn sized_complex_to_sized_complex_expanding() {
             ClassicalDeclarationStmt [9-30]:
                 symbol_id: 8
                 ty_span: [9-27]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-30]:
                     ty: const complex[float[32]]
                     kind: Lit: Complex(0.0, 0.0)
             ExprStmt [39-61]:
@@ -1333,7 +1333,7 @@ fn complex_to_bit_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-35]:
@@ -1373,7 +1373,7 @@ fn complex_to_bitarray_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const complex[float]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [28-39]:
@@ -1413,7 +1413,7 @@ fn sized_complex_to_bit_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-46]:
@@ -1453,7 +1453,7 @@ fn sized_complex_to_bitarray_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
@@ -1493,7 +1493,7 @@ fn sized_complex_to_bitarray_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:
@@ -1533,7 +1533,7 @@ fn sized_complex_to_bitarray_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-30]:
                             symbol_id: 8
                             ty_span: [9-27]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-30]:
                                 ty: const complex[float[32]]
                                 kind: Lit: Complex(0.0, 0.0)
                     Stmt [39-50]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_duration.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_duration.rs
@@ -35,7 +35,7 @@ fn duration_to_bool_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-37]:
@@ -88,7 +88,7 @@ fn duration_to_duration() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-41]:
@@ -132,7 +132,7 @@ fn duration_to_int_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-36]:
@@ -181,7 +181,7 @@ fn duration_to_sized_int_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-40]:
@@ -234,7 +234,7 @@ fn duration_to_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-37]:
@@ -283,7 +283,7 @@ fn duration_to_sized_uint_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-41]:
@@ -336,7 +336,7 @@ fn duration_to_float_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-38]:
@@ -385,7 +385,7 @@ fn duration_to_sized_float_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-42]:
@@ -438,7 +438,7 @@ fn duration_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-38]:
@@ -487,7 +487,7 @@ fn duration_to_sized_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-42]:
@@ -540,7 +540,7 @@ fn duration_to_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-40]:
@@ -589,7 +589,7 @@ fn duration_to_sized_complex_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-51]:
@@ -642,7 +642,7 @@ fn duration_to_bit_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-36]:
@@ -691,7 +691,7 @@ fn duration_to_bitarray_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const duration
                                 kind: Lit: Duration(0.0, Ns)
                     Stmt [29-40]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_float.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_float.rs
@@ -30,7 +30,7 @@ fn float_to_bool() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-34]:
@@ -57,7 +57,7 @@ fn sized_float_to_bool() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-38]:
@@ -93,7 +93,7 @@ fn float_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const float
                                 kind: Lit: Float(0.0)
                     Stmt [26-38]:
@@ -133,7 +133,7 @@ fn sized_float_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const float[32]
                                 kind: Lit: Float(0.0)
                     Stmt [30-42]:
@@ -172,7 +172,7 @@ fn float_to_int() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-33]:
@@ -199,7 +199,7 @@ fn float_to_sized_int() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-37]:
@@ -226,7 +226,7 @@ fn sized_float_to_int() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-37]:
@@ -253,7 +253,7 @@ fn sized_float_to_sized_int() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-41]:
@@ -280,7 +280,7 @@ fn sized_float_to_sized_int_truncating() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-41]:
@@ -307,7 +307,7 @@ fn sized_float_to_sized_int_expanding() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-41]:
@@ -338,7 +338,7 @@ fn float_to_uint() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-34]:
@@ -365,7 +365,7 @@ fn float_to_sized_uint() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-38]:
@@ -392,7 +392,7 @@ fn sized_float_to_uint() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-38]:
@@ -419,7 +419,7 @@ fn sized_float_to_sized_uint() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-42]:
@@ -446,7 +446,7 @@ fn sized_float_to_sized_uint_truncating() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-42]:
@@ -473,7 +473,7 @@ fn sized_float_to_sized_uint_expanding() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-42]:
@@ -504,7 +504,7 @@ fn float_to_float() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-35]:
@@ -527,7 +527,7 @@ fn float_to_sized_float() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-39]:
@@ -554,7 +554,7 @@ fn sized_float_to_float() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-39]:
@@ -581,7 +581,7 @@ fn sized_float_to_sized_float() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
@@ -604,7 +604,7 @@ fn sized_float_to_sized_float_truncating() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
@@ -631,7 +631,7 @@ fn sized_float_to_sized_float_expanding() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
@@ -662,7 +662,7 @@ fn float_to_angle() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-35]:
@@ -689,7 +689,7 @@ fn float_to_sized_angle() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-39]:
@@ -716,7 +716,7 @@ fn sized_float_to_angle() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-39]:
@@ -743,7 +743,7 @@ fn sized_float_to_sized_angle() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
@@ -770,7 +770,7 @@ fn sized_float_to_sized_angle_truncating() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
@@ -797,7 +797,7 @@ fn sized_float_to_sized_angle_expanding() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-43]:
@@ -828,7 +828,7 @@ fn float_to_complex() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-37]:
@@ -855,7 +855,7 @@ fn float_to_sized_complex() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-48]:
@@ -882,7 +882,7 @@ fn sized_float_to_complex() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-41]:
@@ -909,7 +909,7 @@ fn sized_float_to_sized_complex() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-52]:
@@ -936,7 +936,7 @@ fn sized_float_to_sized_complex_truncating() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-52]:
@@ -963,7 +963,7 @@ fn sized_float_to_sized_complex_expanding() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-52]:
@@ -994,7 +994,7 @@ fn float_to_bit() {
             ClassicalDeclarationStmt [9-17]:
                 symbol_id: 8
                 ty_span: [9-14]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-17]:
                     ty: const float
                     kind: Lit: Float(0.0)
             ExprStmt [26-33]:
@@ -1026,7 +1026,7 @@ fn float_to_bitarray_fails() {
                         kind: ClassicalDeclarationStmt [9-17]:
                             symbol_id: 8
                             ty_span: [9-14]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-17]:
                                 ty: const float
                                 kind: Lit: Float(0.0)
                     Stmt [26-37]:
@@ -1061,7 +1061,7 @@ fn sized_float_to_bit() {
             ClassicalDeclarationStmt [9-21]:
                 symbol_id: 8
                 ty_span: [9-18]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-21]:
                     ty: const float[32]
                     kind: Lit: Float(0.0)
             ExprStmt [30-37]:
@@ -1093,7 +1093,7 @@ fn sized_float_to_bitarray_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const float[32]
                                 kind: Lit: Float(0.0)
                     Stmt [30-41]:
@@ -1133,7 +1133,7 @@ fn sized_float_to_bitarray_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const float[32]
                                 kind: Lit: Float(0.0)
                     Stmt [30-41]:
@@ -1173,7 +1173,7 @@ fn sized_float_to_bitarray_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-21]:
                             symbol_id: 8
                             ty_span: [9-18]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-21]:
                                 ty: const float[32]
                                 kind: Lit: Float(0.0)
                     Stmt [30-41]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_int.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_int.rs
@@ -30,7 +30,7 @@ fn int_to_bool() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-32]:
@@ -57,7 +57,7 @@ fn sized_int_to_bool() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-36]:
@@ -93,7 +93,7 @@ fn int_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-15]:
                             symbol_id: 8
                             ty_span: [9-12]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-15]:
                                 ty: const int
                                 kind: Lit: Int(0)
                     Stmt [24-36]:
@@ -133,7 +133,7 @@ fn sized_int_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-40]:
@@ -172,7 +172,7 @@ fn int_to_int() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-31]:
@@ -195,7 +195,7 @@ fn int_to_sized_int() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-35]:
@@ -222,7 +222,7 @@ fn sized_int_to_int() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-35]:
@@ -249,7 +249,7 @@ fn sized_int_to_sized_int() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
@@ -272,7 +272,7 @@ fn sized_int_to_sized_int_truncating() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
@@ -299,7 +299,7 @@ fn sized_int_to_sized_int_expanding() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
@@ -330,7 +330,7 @@ fn int_to_uint() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-32]:
@@ -357,7 +357,7 @@ fn int_to_sized_uint() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-36]:
@@ -384,7 +384,7 @@ fn sized_int_to_uint() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-36]:
@@ -411,7 +411,7 @@ fn sized_int_to_sized_uint() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-40]:
@@ -438,7 +438,7 @@ fn sized_int_to_sized_uint_truncating() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-40]:
@@ -465,7 +465,7 @@ fn sized_int_to_sized_uint_expanding() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-40]:
@@ -496,7 +496,7 @@ fn int_to_float() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-33]:
@@ -523,7 +523,7 @@ fn int_to_sized_float() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-37]:
@@ -550,7 +550,7 @@ fn sized_int_to_float() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-37]:
@@ -577,7 +577,7 @@ fn sized_int_to_sized_float() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-41]:
@@ -604,7 +604,7 @@ fn sized_int_to_sized_float_truncating() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-41]:
@@ -631,7 +631,7 @@ fn sized_int_to_sized_float_expanding() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-41]:
@@ -667,7 +667,7 @@ fn int_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-15]:
                             symbol_id: 8
                             ty_span: [9-12]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-15]:
                                 ty: const int
                                 kind: Lit: Int(0)
                     Stmt [24-33]:
@@ -707,7 +707,7 @@ fn int_to_sized_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-15]:
                             symbol_id: 8
                             ty_span: [9-12]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-15]:
                                 ty: const int
                                 kind: Lit: Int(0)
                     Stmt [24-37]:
@@ -747,7 +747,7 @@ fn sized_int_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-37]:
@@ -787,7 +787,7 @@ fn sized_int_to_sized_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-41]:
@@ -827,7 +827,7 @@ fn sized_int_to_sized_angle_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-41]:
@@ -867,7 +867,7 @@ fn sized_int_to_sized_angle_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-41]:
@@ -906,7 +906,7 @@ fn int_to_complex() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-35]:
@@ -933,7 +933,7 @@ fn int_to_sized_complex() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-46]:
@@ -960,7 +960,7 @@ fn sized_int_to_complex() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
@@ -987,7 +987,7 @@ fn sized_int_to_sized_complex() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-50]:
@@ -1014,7 +1014,7 @@ fn sized_int_to_sized_complex_truncating() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-50]:
@@ -1041,7 +1041,7 @@ fn sized_int_to_sized_complex_expanding() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-50]:
@@ -1072,7 +1072,7 @@ fn int_to_bit() {
             ClassicalDeclarationStmt [9-15]:
                 symbol_id: 8
                 ty_span: [9-12]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-15]:
                     ty: const int
                     kind: Lit: Int(0)
             ExprStmt [24-31]:
@@ -1104,7 +1104,7 @@ fn int_to_bitarray_fails() {
                         kind: ClassicalDeclarationStmt [9-15]:
                             symbol_id: 8
                             ty_span: [9-12]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-15]:
                                 ty: const int
                                 kind: Lit: Int(0)
                     Stmt [24-35]:
@@ -1139,7 +1139,7 @@ fn sized_int_to_bit() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-35]:
@@ -1166,7 +1166,7 @@ fn sized_int_to_bitarray() {
             ClassicalDeclarationStmt [9-19]:
                 symbol_id: 8
                 ty_span: [9-16]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-19]:
                     ty: const int[32]
                     kind: Lit: Int(0)
             ExprStmt [28-39]:
@@ -1198,7 +1198,7 @@ fn sized_int_to_bitarray_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-39]:
@@ -1238,7 +1238,7 @@ fn sized_int_to_bitarray_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-19]:
                             symbol_id: 8
                             ty_span: [9-16]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-19]:
                                 ty: const int[32]
                                 kind: Lit: Int(0)
                     Stmt [28-39]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_uint.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_uint.rs
@@ -30,7 +30,7 @@ fn uint_to_bool() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-33]:
@@ -57,7 +57,7 @@ fn sized_uint_to_bool() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-37]:
@@ -93,7 +93,7 @@ fn uint_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-16]:
                             symbol_id: 8
                             ty_span: [9-13]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-16]:
                                 ty: const uint
                                 kind: Lit: Int(0)
                     Stmt [25-37]:
@@ -133,7 +133,7 @@ fn sized_uint_to_duration_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-41]:
@@ -172,7 +172,7 @@ fn uint_to_int() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-32]:
@@ -199,7 +199,7 @@ fn uint_to_sized_int() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-36]:
@@ -226,7 +226,7 @@ fn sized_uint_to_int() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-36]:
@@ -253,7 +253,7 @@ fn sized_uint_to_sized_int() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
@@ -280,7 +280,7 @@ fn sized_uint_to_sized_int_truncating() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
@@ -307,7 +307,7 @@ fn sized_uint_to_sized_int_expanding() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
@@ -338,7 +338,7 @@ fn uint_to_uint() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-33]:
@@ -361,7 +361,7 @@ fn uint_to_sized_uint() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-37]:
@@ -388,7 +388,7 @@ fn sized_uint_to_uint() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-37]:
@@ -415,7 +415,7 @@ fn sized_uint_to_sized_uint() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-41]:
@@ -438,7 +438,7 @@ fn sized_uint_to_sized_uint_truncating() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-41]:
@@ -465,7 +465,7 @@ fn sized_uint_to_sized_uint_expanding() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-41]:
@@ -496,7 +496,7 @@ fn uint_to_float() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-34]:
@@ -523,7 +523,7 @@ fn uint_to_sized_float() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-38]:
@@ -550,7 +550,7 @@ fn sized_uint_to_float() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-38]:
@@ -577,7 +577,7 @@ fn sized_uint_to_sized_float() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-42]:
@@ -604,7 +604,7 @@ fn sized_uint_to_sized_float_truncating() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-42]:
@@ -631,7 +631,7 @@ fn sized_uint_to_sized_float_expanding() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-42]:
@@ -667,7 +667,7 @@ fn uint_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-16]:
                             symbol_id: 8
                             ty_span: [9-13]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-16]:
                                 ty: const uint
                                 kind: Lit: Int(0)
                     Stmt [25-34]:
@@ -707,7 +707,7 @@ fn uint_to_sized_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-16]:
                             symbol_id: 8
                             ty_span: [9-13]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-16]:
                                 ty: const uint
                                 kind: Lit: Int(0)
                     Stmt [25-38]:
@@ -747,7 +747,7 @@ fn sized_uint_to_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-38]:
@@ -787,7 +787,7 @@ fn sized_uint_to_sized_angle_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-42]:
@@ -827,7 +827,7 @@ fn sized_uint_to_sized_angle_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-42]:
@@ -867,7 +867,7 @@ fn sized_uint_to_sized_angle_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-42]:
@@ -906,7 +906,7 @@ fn uint_to_complex() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-36]:
@@ -933,7 +933,7 @@ fn uint_to_sized_complex() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-47]:
@@ -960,7 +960,7 @@ fn sized_uint_to_complex() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
@@ -987,7 +987,7 @@ fn sized_uint_to_sized_complex() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-51]:
@@ -1014,7 +1014,7 @@ fn sized_uint_to_sized_complex_truncating() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-51]:
@@ -1041,7 +1041,7 @@ fn sized_uint_to_sized_complex_expanding() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-51]:
@@ -1072,7 +1072,7 @@ fn uint_to_bit() {
             ClassicalDeclarationStmt [9-16]:
                 symbol_id: 8
                 ty_span: [9-13]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-16]:
                     ty: const uint
                     kind: Lit: Int(0)
             ExprStmt [25-32]:
@@ -1104,7 +1104,7 @@ fn uint_to_bitarray_fails() {
                         kind: ClassicalDeclarationStmt [9-16]:
                             symbol_id: 8
                             ty_span: [9-13]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-16]:
                                 ty: const uint
                                 kind: Lit: Int(0)
                     Stmt [25-36]:
@@ -1139,7 +1139,7 @@ fn sized_uint_to_bit() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-36]:
@@ -1166,7 +1166,7 @@ fn sized_uint_to_bitarray() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-17]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const uint[32]
                     kind: Lit: Int(0)
             ExprStmt [29-40]:
@@ -1198,7 +1198,7 @@ fn sized_uint_to_bitarray_truncating_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-40]:
@@ -1238,7 +1238,7 @@ fn sized_uint_to_bitarray_expanding_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-17]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const uint[32]
                                 kind: Lit: Int(0)
                     Stmt [29-40]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bitarray.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bitarray.rs
@@ -18,7 +18,7 @@ fn to_int_decl_implicitly() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-15]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const bit[5]
                     kind: Lit: Bitstring("00000")
             [8] Symbol [16-19]:
@@ -59,7 +59,7 @@ fn to_int_assignment_implicitly() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-15]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const bit[5]
                     kind: Lit: Bitstring("00000")
             [8] Symbol [16-19]:
@@ -70,7 +70,7 @@ fn to_int_assignment_implicitly() {
             ClassicalDeclarationStmt [29-35]:
                 symbol_id: 9
                 ty_span: [29-32]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [29-35]:
                     ty: const int
                     kind: Lit: Int(0)
             [9] Symbol [33-34]:
@@ -111,7 +111,7 @@ fn to_int_with_equal_width_in_assignment_implicitly() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-15]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const bit[5]
                     kind: Lit: Bitstring("00000")
             [8] Symbol [16-19]:
@@ -122,7 +122,7 @@ fn to_int_with_equal_width_in_assignment_implicitly() {
             ClassicalDeclarationStmt [29-38]:
                 symbol_id: 9
                 ty_span: [29-35]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [29-38]:
                     ty: const int[5]
                     kind: Lit: Int(0)
             [9] Symbol [36-37]:
@@ -162,7 +162,7 @@ fn to_int_with_equal_width_in_decl_implicitly() {
             ClassicalDeclarationStmt [9-20]:
                 symbol_id: 8
                 ty_span: [9-15]
-                init_expr: Expr [0-0]:
+                init_expr: Expr [9-20]:
                     ty: const bit[5]
                     kind: Lit: Bitstring("00000")
             [8] Symbol [16-19]:
@@ -208,7 +208,7 @@ fn to_int_with_higher_width_implicitly_fails() {
                         kind: ClassicalDeclarationStmt [9-18]:
                             symbol_id: 8
                             ty_span: [9-15]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-18]:
                                 ty: const int[6]
                                 kind: Lit: Int(0)
                     Stmt [27-38]:
@@ -216,7 +216,7 @@ fn to_int_with_higher_width_implicitly_fails() {
                         kind: ClassicalDeclarationStmt [27-38]:
                             symbol_id: 9
                             ty_span: [27-33]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [27-38]:
                                 ty: const bit[5]
                                 kind: Lit: Bitstring("00000")
                     Stmt [47-55]:
@@ -258,7 +258,7 @@ fn to_int_with_higher_width_decl_implicitly_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-15]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const bit[5]
                                 kind: Lit: Bitstring("00000")
                     Stmt [29-44]:
@@ -306,7 +306,7 @@ fn to_int_with_lower_width_implicitly_fails() {
                         kind: ClassicalDeclarationStmt [33-44]:
                             symbol_id: 9
                             ty_span: [33-39]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [33-44]:
                                 ty: const bit[5]
                                 kind: Lit: Bitstring("00000")
                     Stmt [53-61]:
@@ -349,7 +349,7 @@ fn to_int_with_lower_width_decl_implicitly_fails() {
                         kind: ClassicalDeclarationStmt [9-20]:
                             symbol_id: 8
                             ty_span: [9-15]
-                            init_expr: Expr [0-0]:
+                            init_expr: Expr [9-20]:
                                 ty: const bit[5]
                                 kind: Lit: Bitstring("00000")
                     Stmt [29-44]:

--- a/source/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_duration.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_duration.rs
@@ -50,10 +50,10 @@ fn duration_to_bool_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         bool(a);
                `----
         "#]],
@@ -86,10 +86,10 @@ fn duration_to_duration() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         duration(a);
                `----
         "#]],
@@ -132,10 +132,10 @@ fn duration_to_int_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         int(a);
                `----
         "#]],
@@ -174,10 +174,10 @@ fn duration_to_sized_int_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         int[32](a);
                `----
         "#]],
@@ -220,10 +220,10 @@ fn duration_to_uint_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         uint(a);
                `----
         "#]],
@@ -262,10 +262,10 @@ fn duration_to_sized_uint_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         uint[32](a);
                `----
         "#]],
@@ -308,10 +308,10 @@ fn duration_to_float_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         float(a);
                `----
         "#]],
@@ -350,10 +350,10 @@ fn duration_to_sized_float_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         float[32](a);
                `----
         "#]],
@@ -396,10 +396,10 @@ fn duration_to_angle_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         angle(a);
                `----
         "#]],
@@ -438,10 +438,10 @@ fn duration_to_sized_angle_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         angle[32](a);
                `----
         "#]],
@@ -484,10 +484,10 @@ fn duration_to_complex_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         complex(a);
                `----
         "#]],
@@ -526,10 +526,10 @@ fn duration_to_sized_complex_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         complex[float[32]](a);
                `----
         "#]],
@@ -572,10 +572,10 @@ fn duration_to_bit_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         bit(a);
                `----
         "#]],
@@ -614,10 +614,10 @@ fn duration_to_bitarray_fails() {
             Qasm.Compiler.NotSupported
 
               x timing literals are not supported
-               ,-[Test.qasm:1:1]
+               ,-[Test.qasm:2:9]
              1 | 
-               : ^
              2 |         duration a;
+               :         ^^^^^^^^^^^
              3 |         bit[32](a);
                `----
         "#]],


### PR DESCRIPTION
The span in the get_default_value() function in lowerer.rs wasn't being used. This PR fixes that.