### PR TITLE
Fix error when casting from int to bit

### DIFF
--- a/library/std/src/Std/OpenQASM/Convert.qs
+++ b/library/std/src/Std/OpenQASM/Convert.qs
@@ -120,6 +120,16 @@ function ResultArrayAsIntBE(results : Result[]) : Int {
     Std.Convert.ResultArrayAsInt(Std.Arrays.Reversed(results))
 }
 
+/// The ``IntAsResult`` function is used to implement the cast expr in QASM for float to bit.
+/// This is needed for round-trip conversion for bin ops.
+function IntAsResult(value : Int) : Result {
+    if value == 0 {
+        Zero
+    } else {
+        One
+    }
+}
+
 /// The ``DoubleAsResult`` function is used to implement the cast expr in QASM for float to bit.
 /// This is needed for round-trip conversion for bin ops.
 function DoubleAsResult(value : Double) : Result {
@@ -130,4 +140,4 @@ function DoubleAsResult(value : Double) : Result {
     }
 }
 
-export BoolAsResult, BoolAsInt, BoolAsBigInt, BoolAsDouble, ResultAsBool, ResultAsInt, ResultAsBigInt, ResultAsDouble, ResultArrayAsBool, ResultArrayAsResultBE, IntAsResultArrayBE, BoolAsResultArrayBE, ResultAsResultArrayBE, ResultArrayAsIntBE, DoubleAsResult;
+export BoolAsResult, BoolAsInt, BoolAsBigInt, BoolAsDouble, ResultAsBool, ResultAsInt, ResultAsBigInt, ResultAsDouble, ResultArrayAsBool, ResultArrayAsResultBE, IntAsResultArrayBE, BoolAsResultArrayBE, ResultAsResultArrayBE, ResultArrayAsIntBE, IntAsResult, DoubleAsResult;

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -1922,18 +1922,7 @@ impl QasmCompiler {
                     expr_span,
                 )
             }
-            Type::Bit(..) => {
-                let expr_span = expr.span;
-                let const_int_zero_expr = build_lit_int_expr(0, expr.span);
-                let qsop = qsast::BinOp::Eq;
-                let cond = build_binary_expr(false, qsop, expr, const_int_zero_expr, expr_span);
-                build_if_expr_then_expr_else_expr(
-                    cond,
-                    build_lit_result_expr(qsast::Result::One, expr_span),
-                    build_lit_result_expr(qsast::Result::Zero, expr_span),
-                    expr_span,
-                )
-            }
+            Type::Bit(..) => build_convert_call_expr(expr, "IntAsResult"),
             Type::Complex(..) => {
                 let expr = build_convert_call_expr(expr, "IntAsDouble");
                 build_complex_from_expr(expr)

--- a/source/compiler/qsc_qasm/src/tests/assignment.rs
+++ b/source/compiler/qsc_qasm/src/tests/assignment.rs
@@ -84,11 +84,7 @@ fn indexed_uint() {
             mutable a = 15;
             set a = {
                 mutable bitarray = Std.OpenQASM.Convert.IntAsResultArrayBE(a, 4);
-                set bitarray[1] = if 0 == 0 {
-                    One
-                } else {
-                    Zero
-                };
+                set bitarray[1] = Std.Convert.IntAsResult(0);
                 Std.OpenQASM.Convert.ResultArrayAsIntBE(bitarray)
             };
         "#]],
@@ -130,11 +126,7 @@ fn indexed_angle() {
             mutable a = Std.OpenQASM.Angle.DoubleAsAngle(Std.Math.PI(), 4);
             set a = {
                 mutable bitarray = Std.OpenQASM.Angle.AngleAsResultArrayBE(a);
-                set bitarray[1] = if 0 == 0 {
-                    One
-                } else {
-                    Zero
-                };
+                set bitarray[1] = Std.Convert.IntAsResult(0);
                 Std.OpenQASM.Angle.ResultArrayAsAngleBE(bitarray)
             };
         "#]],
@@ -176,11 +168,7 @@ fn index_into_array_and_then_into_int() {
             mutable a = [1, 2, 3];
             set a[1] = {
                 mutable bitarray = Std.OpenQASM.Convert.IntAsResultArrayBE(a[1], 4);
-                set bitarray[1] = if 1 == 0 {
-                    One
-                } else {
-                    Zero
-                };
+                set bitarray[1] = Std.Convert.IntAsResult(1);
                 Std.OpenQASM.Convert.ResultArrayAsIntBE(bitarray)
             };
         "#]],

--- a/source/compiler/qsc_qasm/src/tests/declaration/def.rs
+++ b/source/compiler/qsc_qasm/src/tests/declaration/def.rs
@@ -82,11 +82,7 @@ fn implicit_cast_to_function_return_type() -> miette::Result<(), Vec<Report>> {
     let qsharp = compile_qasm_stmt_to_qsharp(source)?;
     expect![[r#"
         function square(a : Int) : Result {
-            return if a == 0 {
-                One
-            } else {
-                Zero
-            };
+            return Std.Convert.IntAsResult(a);
         }
     "#]]
     .assert_eq(&qsharp);
@@ -204,17 +200,9 @@ fn return_from_if_with_else() {
             import Std.OpenQASM.Intrinsic.*;
             function square(a : Int) : Result {
                 if a == 0 {
-                    return if 0 == 0 {
-                        One
-                    } else {
-                        Zero
-                    };
+                    return Std.Convert.IntAsResult(0);
                 } else {
-                    return if 1 == 0 {
-                        One
-                    } else {
-                        Zero
-                    };
+                    return Std.Convert.IntAsResult(1);
                 };
             }
         "#]],
@@ -317,11 +305,7 @@ fn return_from_for_loop() {
             import Std.OpenQASM.Intrinsic.*;
             function square(a : Int) : Result {
                 for i : Int in [1, 2] {
-                    return if 1 == 0 {
-                        One
-                    } else {
-                        Zero
-                    };
+                    return Std.Convert.IntAsResult(1);
                 }
             }
         "#]],
@@ -368,11 +352,7 @@ fn return_from_while_loop() {
             import Std.OpenQASM.Intrinsic.*;
             function square(a : Int) : Result {
                 while true {
-                    return if 1 == 0 {
-                        One
-                    } else {
-                        Zero
-                    };
+                    return Std.Convert.IntAsResult(1);
                 }
             }
         "#]],
@@ -420,17 +400,9 @@ fn return_from_switch() {
             import Std.OpenQASM.Intrinsic.*;
             function square(a : Int) : Result {
                 if a == 0 {
-                    return if 1 == 0 {
-                        One
-                    } else {
-                        Zero
-                    };
+                    return Std.Convert.IntAsResult(1);
                 } elif a == 1 {
-                    return if 0 == 0 {
-                        One
-                    } else {
-                        Zero
-                    };
+                    return Std.Convert.IntAsResult(0);
                 };
             }
         "#]],
@@ -507,11 +479,7 @@ fn return_from_block() {
             import Std.OpenQASM.Intrinsic.*;
             function square(a : Int) : Result {
                 {
-                    return if 1 == 0 {
-                        One
-                    } else {
-                        Zero
-                    };
+                    return Std.Convert.IntAsResult(1);
                 };
             }
         "#]],

--- a/source/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_int.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_int.rs
@@ -657,11 +657,7 @@ fn int_to_bit() {
         &expect![[r#"
             import Std.OpenQASM.Intrinsic.*;
             mutable a = 0;
-            if a == 0 {
-                One
-            } else {
-                Zero
-            };
+            Std.Convert.IntAsResult(a);
         "#]],
     );
 }
@@ -699,11 +695,7 @@ fn sized_int_to_bit() {
         &expect![[r#"
             import Std.OpenQASM.Intrinsic.*;
             mutable a = 0;
-            if a == 0 {
-                One
-            } else {
-                Zero
-            };
+            Std.Convert.IntAsResult(a);
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_uint.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/explicit_cast_from_uint.rs
@@ -657,11 +657,7 @@ fn uint_to_bit() {
         &expect![[r#"
             import Std.OpenQASM.Intrinsic.*;
             mutable a = 0;
-            if a == 0 {
-                One
-            } else {
-                Zero
-            };
+            Std.Convert.IntAsResult(a);
         "#]],
     );
 }
@@ -699,11 +695,7 @@ fn sized_uint_to_bit() {
         &expect![[r#"
             import Std.OpenQASM.Intrinsic.*;
             mutable a = 0;
-            if a == 0 {
-                One
-            } else {
-                Zero
-            };
+            Std.Convert.IntAsResult(a);
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/tests/expression/function_call.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/function_call.rs
@@ -103,11 +103,7 @@ fn funcall_with_qubit_argument() -> miette::Result<(), Vec<Report>> {
         operation parity(qs : Qubit[]) : Result {
             mutable a = Std.Intrinsic.M(qs[0]);
             mutable b = Std.Intrinsic.M(qs[1]);
-            return if Std.OpenQASM.Convert.ResultAsInt(a) ^^^ Std.OpenQASM.Convert.ResultAsInt(b) == 0 {
-                One
-            } else {
-                Zero
-            };
+            return Std.Convert.IntAsResult(Std.OpenQASM.Convert.ResultAsInt(a) ^^^ Std.OpenQASM.Convert.ResultAsInt(b));
         }
         let qs = QIR.Runtime.AllocateQubitArray(2);
         mutable p = parity(qs);
@@ -262,11 +258,7 @@ fn funcall_implicit_arg_cast_uint_to_bitarray() -> miette::Result<(), Vec<Report
     expect![[r#"
         import Std.OpenQASM.Intrinsic.*;
         function parity(arr : Result[]) : Result {
-            return if 1 == 0 {
-                One
-            } else {
-                Zero
-            };
+            return Std.Convert.IntAsResult(1);
         }
         mutable x = 2;
         mutable p = parity(Std.OpenQASM.Convert.IntAsResultArrayBE(x, 2));

--- a/source/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_int.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_int.rs
@@ -17,11 +17,7 @@ fn to_bit_implicitly() -> miette::Result<(), Vec<Report>> {
     expect![[r#"
         import Std.OpenQASM.Intrinsic.*;
         mutable x = 42;
-        mutable y = if x == 0 {
-            One
-        } else {
-            Zero
-        };
+        mutable y = Std.Convert.IntAsResult(x);
     "#]]
     .assert_eq(&qsharp);
     Ok(())


### PR DESCRIPTION
There was an error in compilation when casting from `int` to `bit`. This PR adds `IntAsResult` to `Std.OpenQASM.Convert` and uses that to do the cast.