### PR TITLE
Adding box pragma support to QASM compiler

### DIFF
--- a/source/compiler/qsc_qasm/src/ast_builder.rs
+++ b/source/compiler/qsc_qasm/src/ast_builder.rs
@@ -844,6 +844,20 @@ pub(crate) fn build_call_no_params(
     }
 }
 
+pub(crate) fn build_call_stmt_no_params(
+    name: &str,
+    idents: &[&str],
+    fn_call_span: Span,
+    fn_name_span: Span,
+) -> Stmt {
+    build_stmt_semi_from_expr(build_call_no_params(
+        name,
+        idents,
+        fn_call_span,
+        fn_name_span,
+    ))
+}
+
 pub(crate) fn build_call_with_param(
     name: &str,
     idents: &[&str],

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -41,7 +41,7 @@ use crate::{
         wrap_expr_in_parens,
     },
     io::SourceResolver,
-    parser::ast::{List, list_from_iter},
+    parser::ast::{List, PathKind, list_from_iter},
     semantic::{
         QasmSemanticParseResult,
         ast::{
@@ -123,18 +123,9 @@ impl FromStr for PragmaKind {
     }
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Default)]
 pub struct PragmaConfig {
     pub pragmas: FxHashMap<PragmaKind, Rc<str>>,
-}
-
-impl Default for PragmaConfig {
-    #[must_use]
-    fn default() -> Self {
-        Self {
-            pragmas: FxHashMap::default(),
-        }
-    }
 }
 
 impl PragmaConfig {
@@ -1029,7 +1020,10 @@ impl QasmCompiler {
             args.is_empty() && matches!(&**return_ty, crate::semantic::types::Type::Void)
         }
 
-        let name_str = stmt.identifier.as_string();
+        let name_str = stmt
+            .identifier
+            .as_ref()
+            .map_or_else(String::new, PathKind::as_string);
 
         // Check if the pragma is supported by the compiler.
         // If not, we push an error message and return.

--- a/source/compiler/qsc_qasm/src/compiler/error.rs
+++ b/source/compiler/qsc_qasm/src/compiler/error.rs
@@ -20,6 +20,13 @@ pub enum CompilerErrorKind {
     #[error("gate expects {0} qubit arguments, but {1} were provided")]
     #[diagnostic(code("Qasm.Compiler.InvalidNumberOfQubitArgs"))]
     InvalidNumberOfQubitArgs(usize, usize, #[label] Span),
+    #[error("{0} is not defined or is not a valid target for box usage")]
+    #[help("Box pragmas can only be used with functions that have no parameters and return void.")]
+    #[diagnostic(code("Qasm.Compiler.InvalidBoxPragmaTarget"))]
+    InvalidBoxPragmaTarget(String, #[label] Span),
+    #[error("Box pragma is missing target")]
+    #[diagnostic(code("Qasm.Compiler.MissingBoxPragmaTarget"))]
+    MissingBoxPragmaTarget(#[label] Span),
     #[error("{0} are not supported")]
     #[diagnostic(code("Qasm.Compiler.NotSupported"))]
     NotSupported(String, #[label] Span),

--- a/source/compiler/qsc_qasm/src/parser/ast.rs
+++ b/source/compiler/qsc_qasm/src/parser/ast.rs
@@ -99,6 +99,61 @@ impl Display for PathKind {
     }
 }
 
+impl PathKind {
+    /// Returns the span of the path, if it exists.
+    #[must_use]
+    pub fn span(&self) -> Option<Span> {
+        match self {
+            PathKind::Ok(path) => Some(path.span),
+            PathKind::Err(Some(incomplete_path)) => Some(incomplete_path.span),
+            PathKind::Err(None) => None,
+        }
+    }
+
+    pub fn offset(&mut self, offset: u32) {
+        match self {
+            PathKind::Ok(path) => path.offset(offset),
+            PathKind::Err(Some(incomplete_path)) => incomplete_path.offset(offset),
+            PathKind::Err(None) => {}
+        }
+    }
+
+    #[must_use]
+    pub fn as_string(&self) -> String {
+        match self {
+            PathKind::Ok(path) => match &path.segments {
+                Some(segments) => {
+                    if segments.is_empty() {
+                        return path.name.to_string();
+                    }
+                    let mut value = String::new();
+                    for segment in segments {
+                        if !value.is_empty() {
+                            value.push('.');
+                        }
+                        value.push_str(&segment.name);
+                    }
+                    value.push('.');
+                    value.push_str(&path.name.name);
+                    value
+                }
+                None => path.name.to_string(),
+            },
+            PathKind::Err(Some(path)) => {
+                let mut value = String::new();
+                for segment in &path.segments {
+                    if !value.is_empty() {
+                        value.push('.');
+                    }
+                    value.push_str(&segment.name);
+                }
+                value
+            }
+            PathKind::Err(None) => "Err".to_string(),
+        }
+    }
+}
+
 /// A path that was successfully parsed up to a certain `.`,
 /// but is missing its final identifier.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -112,6 +167,17 @@ pub struct IncompletePath {
     /// Whether a keyword exists after the final `.`.
     /// This keyword can be presumed to be a partially typed identifier.
     pub keyword: bool,
+}
+
+impl IncompletePath {
+    pub fn offset(&mut self, offset: u32) {
+        self.span.lo += offset;
+        self.span.hi += offset;
+        for segment in &mut self.segments {
+            segment.span.lo += offset;
+            segment.span.hi += offset;
+        }
+    }
 }
 
 /// A path to a declaration or a field access expression,
@@ -137,6 +203,17 @@ impl Display for Path {
 impl WithSpan for Path {
     fn with_span(self, span: Span) -> Self {
         Self { span, ..self }
+    }
+}
+
+impl Path {
+    pub fn offset(&mut self, offset: u32) {
+        self.span.lo += offset;
+        self.span.hi += offset;
+        for segment in self.segments.iter_mut().flatten() {
+            segment.span.lo += offset;
+            segment.span.hi += offset;
+        }
     }
 }
 
@@ -1109,17 +1186,19 @@ impl Display for QuantumArgument {
 #[derive(Clone, Debug)]
 pub struct Pragma {
     pub span: Span,
-    pub identifier: Rc<str>,
+    pub identifier: PathKind,
     pub value: Option<Rc<str>>,
+    pub value_span: Option<Span>,
 }
 
 impl Display for Pragma {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let identifier = format!("\"{}\"", self.identifier);
+        let identifier = format!("\"{}\"", self.identifier.as_string());
         let value = self.value.as_ref().map(|val| format!("\"{val}\""));
         writeln_header(f, "Pragma", self.span)?;
         writeln_field(f, "identifier", &identifier)?;
-        write_opt_field(f, "value", value.as_ref())
+        writeln_opt_field(f, "value", value.as_ref())?;
+        write_opt_field(f, "value_span", self.value_span.as_ref())
     }
 }
 

--- a/source/compiler/qsc_qasm/src/parser/scan.rs
+++ b/source/compiler/qsc_qasm/src/parser/scan.rs
@@ -74,7 +74,6 @@ impl<'a> ParserContext<'a> {
 
     /// Moves the scanner to the start of the current token,
     /// returning the span of the skipped trivia.
-    #[cfg(test)]
     pub(super) fn skip_trivia(&mut self) -> Span {
         self.scanner.skip_trivia()
     }
@@ -151,8 +150,7 @@ impl<'a> Scanner<'a> {
 
     /// Moves the scanner to the start of the current token,
     /// returning the span of the skipped trivia.
-    #[cfg(test)]
-    pub(super) fn skip_trivia(&mut self) -> Span {
+    pub(crate) fn skip_trivia(&mut self) -> Span {
         let lo = self.offset;
         self.offset = self.peek.span.lo;
         let hi = self.offset;

--- a/source/compiler/qsc_qasm/src/parser/stmt.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt.rs
@@ -20,8 +20,12 @@ use super::{
 use crate::{
     keyword::Keyword,
     lex::{Delim, TokenKind, cooked::Type},
-    parser::ast::{
-        DefParameter, DefParameterType, DynArrayReferenceType, QubitType, StaticArrayReferenceType,
+    parser::{
+        ast::{
+            DefParameter, DefParameterType, DynArrayReferenceType, QubitType,
+            StaticArrayReferenceType,
+        },
+        prim::{recovering_path, trim_front_safely},
     },
 };
 
@@ -408,49 +412,99 @@ fn parse_include(s: &mut ParserContext) -> Result<StmtKind> {
 
 /// Grammar: `PRAGMA RemainingLineContent`.
 fn parse_pragma(s: &mut ParserContext) -> Result<Pragma> {
-    let lo = s.peek().span.lo;
+    let token = s.peek();
+    let stmt_lo = token.span.lo;
     s.expect(WordKinds::Pragma);
 
-    let token = s.peek();
-
-    let parts: Vec<&str> = if token.kind == TokenKind::Pragma {
-        let lexeme = s.read();
-        s.advance();
-        // remove pragma keyword and any leading whitespace
-        // split lexeme at first space/tab collecting each side
-        let pat = &['\t', ' '];
-        shorten(6, 0, lexeme)
-            .trim_start_matches(pat)
-            .splitn(2, pat)
-            .collect()
-    } else {
+    if token.kind != TokenKind::Pragma {
         return Err(Error::new(ErrorKind::Rule(
             "pragma", token.kind, token.span,
         )));
+    }
+
+    // read the pragma lexeme, which is the whole line
+    // including the `#pragma` or `pragma` keyword
+    // and the rest of the line content.
+    let pragma_line_content = s.read();
+    let pragma_kw_offset = if pragma_line_content.starts_with('#') {
+        7 // length of "#pragma"
+    } else {
+        6 // length of "pragma"
     };
+    let ident_lo = token.span.lo + pragma_kw_offset;
+    let stmt_hi = token.span.hi;
 
-    let identifier = parts.first().map_or_else(
-        || {
-            Err(Error::new(ErrorKind::Rule(
-                "pragma", token.kind, token.span,
-            )))
-        },
-        |s| Ok(Into::<Rc<str>>::into(*s)),
-    )?;
+    // pragma_line_content:
+    // #pragma a.b.c "some value" more value \nmore content
+    // |.      |     |                      |
+    // |.      |     |                      |
+    // |.      |     ^--------- value ------|
+    // |.      ^-- ident_lo                 ^-- stmt_hi
+    // |       |                            |
+    // |       ^-- pragma_content ----------^
+    // |      ^-- pragma_kw_offset
+    // ^-- stmt_lo
 
-    if identifier.is_empty() {
+    let from_start = pragma_kw_offset.try_into().expect("valid size");
+    let pragma_content = shorten(from_start, 0, pragma_line_content);
+
+    // pragma_content
+    // a.b.c "some value" more value
+    //       ^-- value_lo
+
+    // advance the parser to the next token for the next token in the program
+    s.advance();
+
+    // create a sub-parser context just for the line content
+    // This will tokenize the rest of the line which should be the identifier
+    // and the value, if any.
+
+    let mut c = ParserContext::new(pragma_content);
+
+    // parse the dotted path identifier
+    let Ok(mut path) = recovering_path(&mut c, WordKinds::PathExpr) else {
+        // We only fail if no parts were parsed, which means
+        // the pragma line was empty or only contained whitespace.
+        // In that case, we return an error with the span of the token.
+
         s.push_error(Error::new(ErrorKind::Rule(
             "pragma missing identifier",
             token.kind,
             token.span,
         )));
-    }
-    let value = parts.get(1).map(|s| Into::<Rc<str>>::into(*s));
+        return Ok(Pragma {
+            span: token.span,
+            identifier: super::ast::PathKind::Err(None),
+            value: None,
+            value_span: None,
+        });
+    };
+
+    // update the path span based on the original lo
+    path.offset(ident_lo);
+
+    // we need to get to the first non-whitespace token
+    // after the identifier, which should be the value.
+
+    // This value_lo offset is the start of the value in the pragma line content.
+    let value_lo = c.skip_trivia().hi;
+    let value = trim_front_safely(value_lo.try_into().expect("valid size"), pragma_content);
+    let value = if value.is_empty() {
+        None
+    } else {
+        Some(Rc::from(value))
+    };
+
+    let value_span = value.as_ref().map(|_| Span {
+        lo: value_lo + ident_lo,
+        hi: stmt_hi,
+    });
 
     Ok(Pragma {
-        span: s.span(lo),
-        identifier,
+        span: s.span(stmt_lo),
+        identifier: path,
         value,
+        value_span,
     })
 }
 

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/pragma.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/pragma.rs
@@ -16,7 +16,7 @@ fn pragma_decl() {
             Stmt [0-15]:
                 annotations: <empty>
                 kind: Pragma [0-15]:
-                    identifier: "a.b.d"
+                    identifier: a.b.d
                     value: "23"
                     value_span: [13-15]"#]],
     );
@@ -31,7 +31,7 @@ fn pragma_decl_complex_value_stops_at_newline() {
             Stmt [0-51]:
                 annotations: <empty>
                 kind: Pragma [0-51]:
-                    identifier: "a.b.d"
+                    identifier: a.b.d
                     value: "23 or "value" or 'other' or // comment"
                     value_span: [13-51]"#]],
     );
@@ -46,7 +46,7 @@ fn pragma_decl_ident_only() {
             Stmt [0-12]:
                 annotations: <empty>
                 kind: Pragma [0-12]:
-                    identifier: "a.b.d"
+                    identifier: a.b.d
                     value: <none>
                     value_span: <none>"#]],
     );
@@ -61,22 +61,24 @@ fn pragma_decl_missing_ident() {
             Stmt [0-7]:
                 annotations: <empty>
                 kind: Pragma [0-7]:
-                    identifier: "Err"
+                    identifier: <none>
                     value: <none>
-                    value_span: <none>
+                    value_span: <none>"#]],
+    );
+}
 
-            [
-                Error(
-                    Rule(
-                        "pragma missing identifier",
-                        Pragma,
-                        Span {
-                            lo: 0,
-                            hi: 7,
-                        },
-                    ),
-                ),
-            ]"#]],
+#[test]
+fn pragma_decl_incomplete_ident_is_value_only() {
+    check(
+        parse,
+        "pragma name rest of line content",
+        &expect![[r#"
+            Stmt [0-32]:
+                annotations: <empty>
+                kind: Pragma [0-32]:
+                    identifier: <none>
+                    value: "name rest of line content"
+                    value_span: [7-32]"#]],
     );
 }
 
@@ -84,14 +86,14 @@ fn pragma_decl_missing_ident() {
 fn legacy_pragma_decl() {
     check(
         parse,
-        "#pragma a.b.d 23",
+        "#pragma a.b 23",
         &expect![[r#"
-            Stmt [0-16]:
+            Stmt [0-14]:
                 annotations: <empty>
-                kind: Pragma [0-16]:
-                    identifier: "a.b.d"
+                kind: Pragma [0-14]:
+                    identifier: a.b
                     value: "23"
-                    value_span: [14-16]"#]],
+                    value_span: [12-14]"#]],
     );
 }
 
@@ -104,7 +106,7 @@ fn legacy_pragma_decl_ident_only() {
             Stmt [0-13]:
                 annotations: <empty>
                 kind: Pragma [0-13]:
-                    identifier: "a.b.d"
+                    identifier: a.b.d
                     value: <none>
                     value_span: <none>"#]],
     );
@@ -119,7 +121,7 @@ fn legacy_pragma_ws_after_hash() {
             Stmt [2-14]:
                 annotations: <empty>
                 kind: Pragma [2-14]:
-                    identifier: "a.b.d"
+                    identifier: a.b.d
                     value: <none>
                     value_span: <none>
 
@@ -150,21 +152,53 @@ fn legacy_pragma_decl_missing_ident() {
             Stmt [0-8]:
                 annotations: <empty>
                 kind: Pragma [0-8]:
-                    identifier: "Err"
+                    identifier: <none>
                     value: <none>
-                    value_span: <none>
+                    value_span: <none>"#]],
+    );
+}
 
-            [
-                Error(
-                    Rule(
-                        "pragma missing identifier",
-                        Pragma,
-                        Span {
-                            lo: 0,
-                            hi: 8,
-                        },
-                    ),
-                ),
-            ]"#]],
+#[test]
+fn spec_example_1() {
+    check(
+        parse,
+        r#"pragma qiskit.simulator noise model "qpu1.noise""#,
+        &expect![[r#"
+            Stmt [0-48]:
+                annotations: <empty>
+                kind: Pragma [0-48]:
+                    identifier: qiskit.simulator
+                    value: "noise model "qpu1.noise""
+                    value_span: [24-48]"#]],
+    );
+}
+
+#[test]
+fn spec_example_2() {
+    check(
+        parse,
+        r#"pragma ibm.user alice account 12345678"#,
+        &expect![[r#"
+            Stmt [0-38]:
+                annotations: <empty>
+                kind: Pragma [0-38]:
+                    identifier: ibm.user
+                    value: "alice account 12345678"
+                    value_span: [16-38]"#]],
+    );
+}
+
+#[test]
+fn spec_example_3() {
+    check(
+        parse,
+        r#"pragma ibm.max_temp qpu 0.4"#,
+        &expect![[r#"
+            Stmt [0-27]:
+                annotations: <empty>
+                kind: Pragma [0-27]:
+                    identifier: ibm.max_temp
+                    value: "qpu 0.4"
+                    value_span: [20-27]"#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/pragma.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/pragma.rs
@@ -17,7 +17,23 @@ fn pragma_decl() {
                 annotations: <empty>
                 kind: Pragma [0-15]:
                     identifier: "a.b.d"
-                    value: "23""#]],
+                    value: "23"
+                    value_span: [13-15]"#]],
+    );
+}
+
+#[test]
+fn pragma_decl_complex_value_stops_at_newline() {
+    check(
+        parse,
+        "pragma a.b.d 23 or \"value\" or 'other' or // comment\n 42",
+        &expect![[r#"
+            Stmt [0-51]:
+                annotations: <empty>
+                kind: Pragma [0-51]:
+                    identifier: "a.b.d"
+                    value: "23 or "value" or 'other' or // comment"
+                    value_span: [13-51]"#]],
     );
 }
 
@@ -31,7 +47,8 @@ fn pragma_decl_ident_only() {
                 annotations: <empty>
                 kind: Pragma [0-12]:
                     identifier: "a.b.d"
-                    value: <none>"#]],
+                    value: <none>
+                    value_span: <none>"#]],
     );
 }
 
@@ -44,8 +61,9 @@ fn pragma_decl_missing_ident() {
             Stmt [0-7]:
                 annotations: <empty>
                 kind: Pragma [0-7]:
-                    identifier: ""
+                    identifier: "Err"
                     value: <none>
+                    value_span: <none>
 
             [
                 Error(
@@ -71,8 +89,9 @@ fn legacy_pragma_decl() {
             Stmt [0-16]:
                 annotations: <empty>
                 kind: Pragma [0-16]:
-                    identifier: "a"
-                    value: "a.b.d 23""#]],
+                    identifier: "a.b.d"
+                    value: "23"
+                    value_span: [14-16]"#]],
     );
 }
 
@@ -85,8 +104,9 @@ fn legacy_pragma_decl_ident_only() {
             Stmt [0-13]:
                 annotations: <empty>
                 kind: Pragma [0-13]:
-                    identifier: "a"
-                    value: "a.b.d""#]],
+                    identifier: "a.b.d"
+                    value: <none>
+                    value_span: <none>"#]],
     );
 }
 
@@ -101,6 +121,7 @@ fn legacy_pragma_ws_after_hash() {
                 kind: Pragma [2-14]:
                     identifier: "a.b.d"
                     value: <none>
+                    value_span: <none>
 
             [
                 Error(
@@ -129,7 +150,21 @@ fn legacy_pragma_decl_missing_ident() {
             Stmt [0-8]:
                 annotations: <empty>
                 kind: Pragma [0-8]:
-                    identifier: "a"
-                    value: """#]],
+                    identifier: "Err"
+                    value: <none>
+                    value_span: <none>
+
+            [
+                Error(
+                    Rule(
+                        "pragma missing identifier",
+                        Pragma,
+                        Span {
+                            lo: 0,
+                            hi: 8,
+                        },
+                    ),
+                ),
+            ]"#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/source/compiler/qsc_qasm/src/semantic/ast.rs
@@ -14,7 +14,7 @@ use crate::{
         write_field, write_header, write_indented_list, write_list_field, write_opt_field,
         writeln_field, writeln_header, writeln_list_field, writeln_opt_field,
     },
-    parser::ast::List,
+    parser::ast::{List, PathKind},
     semantic::symbols::SymbolId,
     stdlib::{angle::Angle, complex::Complex},
 };
@@ -25,14 +25,16 @@ use super::types::ArrayDimensions;
 
 #[derive(Clone, Debug)]
 pub struct Program {
-    pub statements: List<Stmt>,
     pub version: Option<Version>,
+    pub pragmas: List<Pragma>,
+    pub statements: List<Stmt>,
 }
 
 impl Display for Program {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(f, "Program:")?;
         writeln_opt_field(f, "version", self.version.as_ref())?;
+        writeln_list_field(f, "pragmas", &self.pragmas)?;
         write_list_field(f, "statements", &self.statements)
     }
 }
@@ -707,8 +709,9 @@ impl Display for QuantumArgument {
 #[derive(Clone, Debug)]
 pub struct Pragma {
     pub span: Span,
-    pub identifier: Rc<str>,
+    pub identifier: PathKind,
     pub value: Option<Rc<str>>,
+    pub value_span: Option<Span>,
 }
 
 impl Display for Pragma {
@@ -717,7 +720,8 @@ impl Display for Pragma {
         let value = self.value.as_ref().map(|val| format!("\"{val}\""));
         writeln_header(f, "Pragma", self.span)?;
         writeln_field(f, "identifier", &identifier)?;
-        write_opt_field(f, "value", value.as_ref())
+        writeln_opt_field(f, "value", value.as_ref())?;
+        write_opt_field(f, "value_span", self.value_span.as_ref())
     }
 }
 

--- a/source/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/source/compiler/qsc_qasm/src/semantic/ast.rs
@@ -709,17 +709,20 @@ impl Display for QuantumArgument {
 #[derive(Clone, Debug)]
 pub struct Pragma {
     pub span: Span,
-    pub identifier: PathKind,
+    pub identifier: Option<PathKind>,
     pub value: Option<Rc<str>>,
     pub value_span: Option<Span>,
 }
 
 impl Display for Pragma {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let identifier = format!("\"{}\"", self.identifier);
         let value = self.value.as_ref().map(|val| format!("\"{val}\""));
         writeln_header(f, "Pragma", self.span)?;
-        writeln_field(f, "identifier", &identifier)?;
+        writeln_opt_field(
+            f,
+            "identifier",
+            self.identifier.as_ref().map(PathKind::as_string).as_ref(),
+        )?;
         writeln_opt_field(f, "value", value.as_ref())?;
         write_opt_field(f, "value_span", self.value_span.as_ref())
     }

--- a/source/compiler/qsc_qasm/src/semantic/tests.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests.rs
@@ -196,6 +196,7 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
         &expect![[r#"
             Program:
                 version: 3.0
+                pragmas: <empty>
                 statements:
                     Stmt [196-206]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/assignment.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/assignment.rs
@@ -16,6 +16,7 @@ fn too_many_indices_in_indexed_assignment() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-80]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls.rs
@@ -59,6 +59,7 @@ fn scalar_ty_designator_must_be_positive() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-10]:
                         annotations: <empty>
@@ -87,6 +88,7 @@ fn scalar_ty_designator_must_be_castable_to_const_int() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-23]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
@@ -391,6 +391,7 @@ fn const_lit_decl_signed_int_lit_cast_neg_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-19]:
                         annotations: <empty>
@@ -424,6 +425,7 @@ fn explicit_zero_width_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-18]:
                         annotations: <empty>
@@ -452,6 +454,7 @@ fn explicit_width_over_64_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-25]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/duration.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/duration.rs
@@ -12,6 +12,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-11]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/extern_decl.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/extern_decl.rs
@@ -65,6 +65,7 @@ fn no_allowed_in_non_global_scope() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-15]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/float.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/float.rs
@@ -437,6 +437,7 @@ fn init_float_with_int_value_greater_than_safely_representable_values() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-27]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/qreg.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/qreg.rs
@@ -22,6 +22,7 @@ fn with_no_init_expr_in_non_global_scope() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-9]:
                         annotations: <empty>
@@ -64,6 +65,7 @@ fn array_with_no_init_expr_in_non_global_scope() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-12]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/qubit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/qubit.rs
@@ -22,6 +22,7 @@ fn with_no_init_expr_in_non_global_scope() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-10]:
                         annotations: <empty>
@@ -64,6 +65,7 @@ fn array_with_no_init_expr_in_non_global_scope() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-13]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/stretch.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/stretch.rs
@@ -12,6 +12,7 @@ fn with_no_init_expr_has_generated_lit_expr() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-10]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/complex.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/complex.rs
@@ -414,6 +414,7 @@ fn modulo_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-32]:
                         annotations: <empty>
@@ -458,6 +459,7 @@ fn modulo_non_complex_type_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-32]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions.rs
@@ -33,6 +33,7 @@ fn builtin_call_with_invalid_input_types_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-22]:
                         annotations: <empty>
@@ -65,6 +66,7 @@ fn builtin_call_with_zero_arguments_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -97,6 +99,7 @@ fn builtin_call_with_lower_arity_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>
@@ -129,6 +132,7 @@ fn builtin_call_with_higher_arity_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-22]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/arccos.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/arccos.rs
@@ -95,23 +95,24 @@ fn arccos_negative_domain_error() {
     check_stmt_kinds(
         source,
         &expect![[r#"
-        Program:
-            version: <none>
-            statements:
-                Stmt [9-23]:
-                    annotations: <empty>
-                    kind: Err
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [9-23]:
+                        annotations: <empty>
+                        kind: Err
 
-        [Qasm.Lowerer.DomainError
+            [Qasm.Lowerer.DomainError
 
-          x arccos input should be in the range [-1.0, 1.0]
-           ,-[test:2:9]
-         1 | 
-         2 |         arccos(-1.01);
-           :         ^^^^^^^^^^^^^
-         3 |     
-           `----
-        ]"#]],
+              x arccos input should be in the range [-1.0, 1.0]
+               ,-[test:2:9]
+             1 | 
+             2 |         arccos(-1.01);
+               :         ^^^^^^^^^^^^^
+             3 |     
+               `----
+            ]"#]],
     );
 }
 
@@ -124,22 +125,23 @@ fn arccos_positive_domain_error() {
     check_stmt_kinds(
         source,
         &expect![[r#"
-        Program:
-            version: <none>
-            statements:
-                Stmt [9-22]:
-                    annotations: <empty>
-                    kind: Err
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [9-22]:
+                        annotations: <empty>
+                        kind: Err
 
-        [Qasm.Lowerer.DomainError
+            [Qasm.Lowerer.DomainError
 
-          x arccos input should be in the range [-1.0, 1.0]
-           ,-[test:2:9]
-         1 | 
-         2 |         arccos(1.01);
-           :         ^^^^^^^^^^^^
-         3 |     
-           `----
-        ]"#]],
+              x arccos input should be in the range [-1.0, 1.0]
+               ,-[test:2:9]
+             1 | 
+             2 |         arccos(1.01);
+               :         ^^^^^^^^^^^^
+             3 |     
+               `----
+            ]"#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/arcsin.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/arcsin.rs
@@ -95,23 +95,24 @@ fn arcsin_negative_domain_error() {
     check_stmt_kinds(
         source,
         &expect![[r#"
-        Program:
-            version: <none>
-            statements:
-                Stmt [9-23]:
-                    annotations: <empty>
-                    kind: Err
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [9-23]:
+                        annotations: <empty>
+                        kind: Err
 
-        [Qasm.Lowerer.DomainError
+            [Qasm.Lowerer.DomainError
 
-          x arcsin input should be in the range [-1.0, 1.0]
-           ,-[test:2:9]
-         1 | 
-         2 |         arcsin(-1.01);
-           :         ^^^^^^^^^^^^^
-         3 |     
-           `----
-        ]"#]],
+              x arcsin input should be in the range [-1.0, 1.0]
+               ,-[test:2:9]
+             1 | 
+             2 |         arcsin(-1.01);
+               :         ^^^^^^^^^^^^^
+             3 |     
+               `----
+            ]"#]],
     );
 }
 
@@ -124,22 +125,23 @@ fn arcsin_positive_domain_error() {
     check_stmt_kinds(
         source,
         &expect![[r#"
-        Program:
-            version: <none>
-            statements:
-                Stmt [9-22]:
-                    annotations: <empty>
-                    kind: Err
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [9-22]:
+                        annotations: <empty>
+                        kind: Err
 
-        [Qasm.Lowerer.DomainError
+            [Qasm.Lowerer.DomainError
 
-          x arcsin input should be in the range [-1.0, 1.0]
-           ,-[test:2:9]
-         1 | 
-         2 |         arcsin(1.01);
-           :         ^^^^^^^^^^^^
-         3 |     
-           `----
-        ]"#]],
+              x arcsin input should be in the range [-1.0, 1.0]
+               ,-[test:2:9]
+             1 | 
+             2 |         arcsin(1.01);
+               :         ^^^^^^^^^^^^
+             3 |     
+               `----
+            ]"#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/mod_.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/mod_.rs
@@ -45,6 +45,7 @@ fn mod_int_divide_by_zero_error() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -104,6 +105,7 @@ fn mod_float_divide_by_zero_error() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/popcount.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/popcount.rs
@@ -75,6 +75,7 @@ fn popcount_unsized_type_error() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/rotl.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/rotl.rs
@@ -251,6 +251,7 @@ fn rotl_unsized_type_error() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/rotr.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/rotr.rs
@@ -251,6 +251,7 @@ fn rotr_unsized_type_error() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
@@ -15,6 +15,7 @@ fn sizeof_no_args_errors() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-40]:
                         annotations: <empty>
@@ -52,6 +53,7 @@ fn sizeof_too_many_args_errors() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-47]:
                         annotations: <empty>
@@ -90,6 +92,7 @@ fn sizeof_non_array_errors() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-41]:
                         annotations: <empty>
@@ -166,81 +169,82 @@ fn sizeof_array_invalid_dimension_errors() {
     check(
         source,
         &expect![[r#"
-        Program:
-            version: <none>
-            statements:
-                Stmt [9-31]:
-                    annotations: <empty>
-                    kind: ClassicalDeclarationStmt [9-31]:
-                        symbol_id: 8
-                        ty_span: [9-26]
-                        init_expr: Expr [9-31]:
-                            ty: array[bool, 3, 4]
-                            kind: Lit:     array:
-                                    Expr [0-0]:
-                                        ty: array[bool, 4]
-                                        kind: Lit:     array:
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                    Expr [0-0]:
-                                        ty: array[bool, 4]
-                                        kind: Lit:     array:
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                    Expr [0-0]:
-                                        ty: array[bool, 4]
-                                        kind: Lit:     array:
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                Stmt [40-77]:
-                    annotations: <empty>
-                    kind: ClassicalDeclarationStmt [40-77]:
-                        symbol_id: 9
-                        ty_span: [46-50]
-                        init_expr: Expr [62-76]:
-                            ty: unknown
-                            kind: Err
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [9-31]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [9-31]:
+                            symbol_id: 8
+                            ty_span: [9-26]
+                            init_expr: Expr [9-31]:
+                                ty: array[bool, 3, 4]
+                                kind: Lit:     array:
+                                        Expr [0-0]:
+                                            ty: array[bool, 4]
+                                            kind: Lit:     array:
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                        Expr [0-0]:
+                                            ty: array[bool, 4]
+                                            kind: Lit:     array:
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                        Expr [0-0]:
+                                            ty: array[bool, 4]
+                                            kind: Lit:     array:
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                    Stmt [40-77]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [40-77]:
+                            symbol_id: 9
+                            ty_span: [46-50]
+                            init_expr: Expr [62-76]:
+                                ty: unknown
+                                kind: Err
 
-        [Qasm.Lowerer.SizeofInvalidDimension
+            [Qasm.Lowerer.SizeofInvalidDimension
 
-          x requested dimension 2 but array has 2 dimensions
-           ,-[test:3:31]
-         2 |         array[bool, 3, 4] arr;
-         3 |         const uint arr_size = sizeof(arr, 2);
-           :                               ^^^^^^^^^^^^^^
-         4 |     
-           `----
-        ]"#]],
+              x requested dimension 2 but array has 2 dimensions
+               ,-[test:3:31]
+             2 |         array[bool, 3, 4] arr;
+             3 |         const uint arr_size = sizeof(arr, 2);
+               :                               ^^^^^^^^^^^^^^
+             4 |     
+               `----
+            ]"#]],
     );
 }
 
@@ -321,90 +325,91 @@ fn sizeof_static_array_ref_invalid_dimension_errors() {
     check(
         source,
         &expect![[r#"
-        Program:
-            version: <none>
-            statements:
-                Stmt [9-31]:
-                    annotations: <empty>
-                    kind: ClassicalDeclarationStmt [9-31]:
-                        symbol_id: 8
-                        ty_span: [9-26]
-                        init_expr: Expr [9-31]:
-                            ty: array[bool, 3, 4]
-                            kind: Lit:     array:
-                                    Expr [0-0]:
-                                        ty: array[bool, 4]
-                                        kind: Lit:     array:
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                    Expr [0-0]:
-                                        ty: array[bool, 4]
-                                        kind: Lit:     array:
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                    Expr [0-0]:
-                                        ty: array[bool, 4]
-                                        kind: Lit:     array:
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                                                Expr [9-31]:
-                                                    ty: const bool
-                                                    kind: Lit: Bool(false)
-                Stmt [41-136]:
-                    annotations: <empty>
-                    kind: DefStmt [41-136]:
-                        symbol_id: 9
-                        has_qubit_params: false
-                        parameters:
-                            10
-                        return_type: ()
-                        body: Block [77-136]:
-                            Stmt [91-126]:
-                                annotations: <empty>
-                                kind: ClassicalDeclarationStmt [91-126]:
-                                    symbol_id: 11
-                                    ty_span: [97-101]
-                                    init_expr: Expr [113-125]:
-                                        ty: unknown
-                                        kind: Err
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [9-31]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [9-31]:
+                            symbol_id: 8
+                            ty_span: [9-26]
+                            init_expr: Expr [9-31]:
+                                ty: array[bool, 3, 4]
+                                kind: Lit:     array:
+                                        Expr [0-0]:
+                                            ty: array[bool, 4]
+                                            kind: Lit:     array:
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                        Expr [0-0]:
+                                            ty: array[bool, 4]
+                                            kind: Lit:     array:
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                        Expr [0-0]:
+                                            ty: array[bool, 4]
+                                            kind: Lit:     array:
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                    Stmt [41-136]:
+                        annotations: <empty>
+                        kind: DefStmt [41-136]:
+                            symbol_id: 9
+                            has_qubit_params: false
+                            parameters:
+                                10
+                            return_type: ()
+                            body: Block [77-136]:
+                                Stmt [91-126]:
+                                    annotations: <empty>
+                                    kind: ClassicalDeclarationStmt [91-126]:
+                                        symbol_id: 11
+                                        ty_span: [97-101]
+                                        init_expr: Expr [113-125]:
+                                            ty: unknown
+                                            kind: Err
 
-        [Qasm.Lowerer.SizeofInvalidDimension
+            [Qasm.Lowerer.SizeofInvalidDimension
 
-          x requested dimension 2 but array has 2 dimensions
-           ,-[test:5:35]
-         4 |         def f(readonly array[bool, 3, 4] a) {
-         5 |             const uint arr_size = sizeof(a, 2);
-           :                                   ^^^^^^^^^^^^
-         6 |         }
-           `----
-        ]"#]],
+              x requested dimension 2 but array has 2 dimensions
+               ,-[test:5:35]
+             4 |         def f(readonly array[bool, 3, 4] a) {
+             5 |             const uint arr_size = sizeof(a, 2);
+               :                                   ^^^^^^^^^^^^
+             6 |         }
+               `----
+            ]"#]],
     );
 }
 

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sqrt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sqrt.rs
@@ -39,23 +39,24 @@ fn sqrt_float_domain_error() {
     check_stmt_kinds(
         source,
         &expect![[r#"
-        Program:
-            version: <none>
-            statements:
-                Stmt [9-19]:
-                    annotations: <empty>
-                    kind: Err
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [9-19]:
+                        annotations: <empty>
+                        kind: Err
 
-        [Qasm.Lowerer.DomainError
+            [Qasm.Lowerer.DomainError
 
-          x cannot compute square root of negative floats
-           ,-[test:2:9]
-         1 | 
-         2 |         sqrt(-4.);
-           :         ^^^^^^^^^
-         3 |     
-           `----
-        ]"#]],
+              x cannot compute square root of negative floats
+               ,-[test:2:9]
+             1 | 
+             2 |         sqrt(-4.);
+               :         ^^^^^^^^^
+             3 |     
+               `----
+            ]"#]],
     );
 }
 

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_angle.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_angle.rs
@@ -87,6 +87,7 @@ fn angle_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -127,6 +128,7 @@ fn sized_angle_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -171,6 +173,7 @@ fn angle_to_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -211,6 +214,7 @@ fn angle_to_sized_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -251,6 +255,7 @@ fn sized_angle_to_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -291,6 +296,7 @@ fn sized_angle_to_sized_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -331,6 +337,7 @@ fn sized_angle_to_sized_int_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -371,6 +378,7 @@ fn sized_angle_to_sized_int_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -415,6 +423,7 @@ fn angle_to_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -455,6 +464,7 @@ fn angle_to_sized_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -495,6 +505,7 @@ fn sized_angle_to_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -535,6 +546,7 @@ fn sized_angle_to_sized_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -575,6 +587,7 @@ fn sized_angle_to_sized_uint_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -615,6 +628,7 @@ fn sized_angle_to_sized_uint_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -659,6 +673,7 @@ fn angle_to_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -699,6 +714,7 @@ fn angle_to_sized_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -739,6 +755,7 @@ fn sized_angle_to_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -779,6 +796,7 @@ fn sized_angle_to_sized_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -819,6 +837,7 @@ fn sized_angle_to_sized_float_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -859,6 +878,7 @@ fn sized_angle_to_sized_float_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -1061,6 +1081,7 @@ fn angle_to_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -1101,6 +1122,7 @@ fn angle_to_sized_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -1141,6 +1163,7 @@ fn sized_angle_to_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -1181,6 +1204,7 @@ fn sized_angle_to_sized_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -1221,6 +1245,7 @@ fn sized_angle_to_sized_complex_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -1261,6 +1286,7 @@ fn sized_angle_to_sized_complex_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -1332,6 +1358,7 @@ fn angle_to_bitarray_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -1426,6 +1453,7 @@ fn sized_angle_to_bitarray_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -1466,6 +1494,7 @@ fn sized_angle_to_bitarray_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bit.rs
@@ -87,6 +87,7 @@ fn bit_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -127,6 +128,7 @@ fn bitarray_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -294,6 +296,7 @@ fn bitarray_to_sized_int_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -334,6 +337,7 @@ fn bitarray_to_sized_int_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -501,6 +505,7 @@ fn bitarray_to_sized_uint_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -541,6 +546,7 @@ fn bitarray_to_sized_uint_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -639,6 +645,7 @@ fn bitarray_to_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -679,6 +686,7 @@ fn bitarray_to_sized_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -719,6 +727,7 @@ fn bitarray_to_sized_float_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -759,6 +768,7 @@ fn bitarray_to_sized_float_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -803,6 +813,7 @@ fn bit_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -843,6 +854,7 @@ fn bit_to_sized_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -883,6 +895,7 @@ fn bitarray_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -950,6 +963,7 @@ fn bitarray_to_sized_angle_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -990,6 +1004,7 @@ fn bitarray_to_sized_angle_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1034,6 +1049,7 @@ fn bit_to_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -1074,6 +1090,7 @@ fn bit_to_sized_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -1114,6 +1131,7 @@ fn bitarray_to_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1154,6 +1172,7 @@ fn bitarray_to_sized_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1194,6 +1213,7 @@ fn bitarray_to_sized_complex_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1234,6 +1254,7 @@ fn bitarray_to_sized_complex_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1378,6 +1399,7 @@ fn bitarray_to_bitarray_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1418,6 +1440,7 @@ fn bitarray_to_bitarray_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bool.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bool.rs
@@ -56,6 +56,7 @@ fn bool_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>
@@ -274,6 +275,7 @@ fn bool_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>
@@ -314,6 +316,7 @@ fn bool_to_sized_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>
@@ -358,6 +361,7 @@ fn bool_to_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>
@@ -398,6 +402,7 @@ fn bool_to_sized_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_complex.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_complex.rs
@@ -29,6 +29,7 @@ fn complex_to_bool_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -69,6 +70,7 @@ fn sized_complex_to_bool_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -113,6 +115,7 @@ fn complex_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -153,6 +156,7 @@ fn sized_complex_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -197,6 +201,7 @@ fn complex_to_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -237,6 +242,7 @@ fn complex_to_sized_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -277,6 +283,7 @@ fn sized_complex_to_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -317,6 +324,7 @@ fn sized_complex_to_sized_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -357,6 +365,7 @@ fn sized_complex_to_sized_int_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -397,6 +406,7 @@ fn sized_complex_to_sized_int_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -441,6 +451,7 @@ fn complex_to_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -481,6 +492,7 @@ fn complex_to_sized_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -521,6 +533,7 @@ fn sized_complex_to_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -561,6 +574,7 @@ fn sized_complex_to_sized_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -601,6 +615,7 @@ fn sized_complex_to_sized_uint_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -641,6 +656,7 @@ fn sized_complex_to_sized_uint_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -685,6 +701,7 @@ fn complex_to_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -725,6 +742,7 @@ fn complex_to_sized_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -765,6 +783,7 @@ fn sized_complex_to_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -805,6 +824,7 @@ fn sized_complex_to_sized_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -845,6 +865,7 @@ fn sized_complex_to_sized_float_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -885,6 +906,7 @@ fn sized_complex_to_sized_float_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -929,6 +951,7 @@ fn complex_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -969,6 +992,7 @@ fn complex_to_sized_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1009,6 +1033,7 @@ fn sized_complex_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -1049,6 +1074,7 @@ fn sized_complex_to_sized_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -1089,6 +1115,7 @@ fn sized_complex_to_sized_angle_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -1129,6 +1156,7 @@ fn sized_complex_to_sized_angle_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -1327,6 +1355,7 @@ fn complex_to_bit_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1367,6 +1396,7 @@ fn complex_to_bitarray_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1407,6 +1437,7 @@ fn sized_complex_to_bit_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -1447,6 +1478,7 @@ fn sized_complex_to_bitarray_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -1487,6 +1519,7 @@ fn sized_complex_to_bitarray_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>
@@ -1527,6 +1560,7 @@ fn sized_complex_to_bitarray_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-30]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_duration.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_duration.rs
@@ -29,6 +29,7 @@ fn duration_to_bool_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -82,6 +83,7 @@ fn duration_to_duration() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -126,6 +128,7 @@ fn duration_to_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -175,6 +178,7 @@ fn duration_to_sized_int_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -228,6 +232,7 @@ fn duration_to_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -277,6 +282,7 @@ fn duration_to_sized_uint_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -330,6 +336,7 @@ fn duration_to_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -379,6 +386,7 @@ fn duration_to_sized_float_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -432,6 +440,7 @@ fn duration_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -481,6 +490,7 @@ fn duration_to_sized_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -534,6 +544,7 @@ fn duration_to_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -583,6 +594,7 @@ fn duration_to_sized_complex_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -636,6 +648,7 @@ fn duration_to_bit_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -685,6 +698,7 @@ fn duration_to_bitarray_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_float.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_float.rs
@@ -87,6 +87,7 @@ fn float_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -127,6 +128,7 @@ fn sized_float_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -1020,6 +1022,7 @@ fn float_to_bitarray_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-17]:
                         annotations: <empty>
@@ -1087,6 +1090,7 @@ fn sized_float_to_bitarray_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -1127,6 +1131,7 @@ fn sized_float_to_bitarray_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>
@@ -1167,6 +1172,7 @@ fn sized_float_to_bitarray_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-21]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_int.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_int.rs
@@ -87,6 +87,7 @@ fn int_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -127,6 +128,7 @@ fn sized_int_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -661,6 +663,7 @@ fn int_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -701,6 +704,7 @@ fn int_to_sized_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -741,6 +745,7 @@ fn sized_int_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -781,6 +786,7 @@ fn sized_int_to_sized_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -821,6 +827,7 @@ fn sized_int_to_sized_angle_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -861,6 +868,7 @@ fn sized_int_to_sized_angle_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1098,6 +1106,7 @@ fn int_to_bitarray_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-15]:
                         annotations: <empty>
@@ -1192,6 +1201,7 @@ fn sized_int_to_bitarray_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>
@@ -1232,6 +1242,7 @@ fn sized_int_to_bitarray_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-19]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_uint.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_uint.rs
@@ -87,6 +87,7 @@ fn uint_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>
@@ -127,6 +128,7 @@ fn sized_uint_to_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -661,6 +663,7 @@ fn uint_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>
@@ -701,6 +704,7 @@ fn uint_to_sized_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>
@@ -741,6 +745,7 @@ fn sized_uint_to_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -781,6 +786,7 @@ fn sized_uint_to_sized_angle_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -821,6 +827,7 @@ fn sized_uint_to_sized_angle_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -861,6 +868,7 @@ fn sized_uint_to_sized_angle_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -1098,6 +1106,7 @@ fn uint_to_bitarray_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-16]:
                         annotations: <empty>
@@ -1192,6 +1201,7 @@ fn sized_uint_to_bitarray_truncating_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -1232,6 +1242,7 @@ fn sized_uint_to_bitarray_expanding_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_angle.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_angle.rs
@@ -136,6 +136,7 @@ fn to_implicit_int_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>
@@ -179,6 +180,7 @@ fn to_explicit_int_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>
@@ -222,6 +224,7 @@ fn to_implicit_uint_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>
@@ -265,6 +268,7 @@ fn negative_lit_to_implicit_uint_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-24]:
                         annotations: <empty>
@@ -316,6 +320,7 @@ fn to_explicit_uint_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>
@@ -359,6 +364,7 @@ fn to_explicit_bigint_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>
@@ -402,6 +408,7 @@ fn to_implicit_float_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>
@@ -445,6 +452,7 @@ fn to_explicit_float_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>
@@ -488,6 +496,7 @@ fn to_implicit_complex_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>
@@ -531,6 +540,7 @@ fn to_explicit_complex_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bit.rs
@@ -17,6 +17,7 @@ fn to_angle_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [10-20]:
                         annotations: <empty>
@@ -60,6 +61,7 @@ fn to_explicit_angle_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [10-20]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bitarray.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bitarray.rs
@@ -174,6 +174,7 @@ fn to_int_with_higher_width_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-18]:
                         annotations: <empty>
@@ -225,6 +226,7 @@ fn to_int_with_higher_width_decl_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>
@@ -269,6 +271,7 @@ fn to_int_with_lower_width_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-24]:
                         annotations: <empty>
@@ -317,6 +320,7 @@ fn to_int_with_lower_width_decl_implicitly_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-20]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/indexing.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/indexing.rs
@@ -233,6 +233,7 @@ fn array_slice_with_zero_step_errors() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-23]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
@@ -30,16 +30,6 @@ fn check_lowerer_error_spans_are_correct() {
              5 | 
                `----
 
-            Qasm.Lowerer.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: pragma stmt
-               ,-[Test.qasm:7:1]
-             6 | // Unimplemented pragma
-             7 | pragma my_pragma;
-               : ^^^^^^^^^^^^^^^^^
-             8 | 
-               `----
-
             Qasm.Lowerer.IncludeNotInGlobalScope
 
               x include stdgates.inc must be declared in global scope
@@ -246,18 +236,6 @@ fn check_lowerer_error_spans_are_correct() {
              88 |     2;
                 :     ^^
              89 | }
-                `----
-
-            Qasm.Lowerer.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: box stmt
-                ,-[Test.qasm:86:1]
-             85 |     // Unimplemented box
-             86 | ,-> box {
-             87 | |       // ClassicalStmtInBox
-             88 | |       2;
-             89 | `-> }
-             90 |     
                 `----
 
             Qasm.Lowerer.InvalidScope

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/box_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/box_stmt.rs
@@ -5,6 +5,267 @@ use crate::semantic::tests::check_stmt_kinds;
 use expect_test::expect;
 
 #[test]
+fn box_can_contain_barrier() {
+    check_stmt_kinds(
+        r#"
+            qubit q;
+            box {
+              barrier q;
+            }
+        "#,
+        &expect![[r#"
+            QubitDeclaration [13-21]:
+                symbol_id: 8
+            BoxStmt [34-78]:
+                duration: <none>
+                body:
+                    Stmt [54-64]:
+                        annotations: <empty>
+                        kind: BarrierStmt [54-64]:
+                            operands:
+                                GateOperand [62-63]:
+                                    kind: Expr [62-63]:
+                                        ty: qubit
+                                        kind: SymbolId(8)
+        "#]],
+    );
+}
+
+#[test]
+#[ignore = "Duration type, stretch type, and delay are not supported yet"]
+fn box_can_contain_delay() {
+    check_stmt_kinds(
+        r#"
+            include "stdgates.inc";
+            qubit q;
+            duration a = 300ns;
+            stretch c = 2 * a;
+            box {
+              delay[a] q;
+            }
+        "#,
+        &expect![[r#"
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [49-57]:
+                        annotations: <empty>
+                        kind: QubitDeclaration [49-57]:
+                            symbol_id: 40
+                    Stmt [70-89]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [70-89]:
+                            symbol_id: 41
+                            ty_span: [70-78]
+                            init_expr: Expr [83-88]:
+                                ty: duration
+                                kind: Lit: Duration(300.0, Ns)
+                    Stmt [102-120]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [102-120]:
+                            symbol_id: 42
+                            ty_span: [102-109]
+                            init_expr: Expr [114-119]:
+                                ty: const float
+                                kind: BinaryOpExpr:
+                                    op: Mul
+                                    lhs: Expr [114-115]:
+                                        ty: const float
+                                        kind: Lit: Float(2.0)
+                                    rhs: Expr [118-119]:
+                                        ty: duration
+                                        kind: SymbolId(41)
+                    Stmt [133-178]:
+                        annotations: <empty>
+                        kind: BoxStmt [133-178]:
+                            duration: <none>
+                            body:
+                                Stmt [153-164]:
+                                    annotations: <empty>
+                                    kind: Err
+
+            [Qasm.Lowerer.NotSupported
+
+              x duration type values are not supported
+               ,-[test:4:13]
+             3 |             qubit q;
+             4 |             duration a = 300ns;
+               :             ^^^^^^^^
+             5 |             stretch c = 2 * a;
+               `----
+            , Qasm.Lowerer.NotSupported
+
+              x stretch type values are not supported
+               ,-[test:5:13]
+             4 |             duration a = 300ns;
+             5 |             stretch c = 2 * a;
+               :             ^^^^^^^
+             6 |             box {
+               `----
+            , Qasm.Lowerer.CannotCast
+
+              x cannot cast expression of type duration to type const float
+               ,-[test:5:29]
+             4 |             duration a = 300ns;
+             5 |             stretch c = 2 * a;
+               :                             ^
+             6 |             box {
+               `----
+            , Qasm.Lowerer.CannotCast
+
+              x cannot cast expression of type const float to type stretch
+               ,-[test:5:25]
+             4 |             duration a = 300ns;
+             5 |             stretch c = 2 * a;
+               :                         ^^^^^
+             6 |             box {
+               `----
+            , Qasm.Lowerer.Unimplemented
+
+              x this statement is not yet handled during OpenQASM 3 import: delay stmt
+               ,-[test:7:15]
+             6 |             box {
+             7 |               delay[a] q;
+               :               ^^^^^^^^^^^
+             8 |             }
+               `----
+            ]"#]],
+    );
+}
+
+#[test]
+fn box_can_contain_reset() {
+    check_stmt_kinds(
+        r#"
+            include "stdgates.inc";
+            qubit q;
+            box {
+              reset q;
+            }
+        "#,
+        &expect![[r#"
+            QubitDeclaration [49-57]:
+                symbol_id: 40
+            BoxStmt [70-112]:
+                duration: <none>
+                body:
+                    Stmt [90-98]:
+                        annotations: <empty>
+                        kind: ResetStmt [90-98]:
+                            reset_token_span: [90-95]
+                            operand: GateOperand [96-97]:
+                                kind: Expr [96-97]:
+                                    ty: qubit
+                                    kind: SymbolId(40)
+        "#]],
+    );
+}
+
+#[test]
+fn box_can_contain_gate_call() {
+    check_stmt_kinds(
+        r#"
+            include "stdgates.inc";
+            qubit q;
+            box {
+              x q;
+            }
+        "#,
+        &expect![[r#"
+            QubitDeclaration [49-57]:
+                symbol_id: 40
+            BoxStmt [70-108]:
+                duration: <none>
+                body:
+                    Stmt [90-94]:
+                        annotations: <empty>
+                        kind: GateCall [90-94]:
+                            modifiers: <empty>
+                            symbol_id: 9
+                            gate_name_span: [90-91]
+                            args: <empty>
+                            qubits:
+                                GateOperand [92-93]:
+                                    kind: Expr [92-93]:
+                                        ty: qubit
+                                        kind: SymbolId(40)
+                            duration: <none>
+                            classical_arity: 0
+                            quantum_arity: 1
+        "#]],
+    );
+}
+
+#[test]
+fn box_can_contain_gphase() {
+    check_stmt_kinds(
+        r#"
+            box {
+              gphase(pi);
+            }
+        "#,
+        &expect![[r#"
+            BoxStmt [13-58]:
+                duration: <none>
+                body:
+                    Stmt [33-44]:
+                        annotations: <empty>
+                        kind: GateCall [33-44]:
+                            modifiers: <empty>
+                            symbol_id: 1
+                            gate_name_span: [33-39]
+                            args:
+                                Expr [40-42]:
+                                    ty: angle
+                                    kind: Cast [0-0]:
+                                        ty: angle
+                                        expr: Expr [40-42]:
+                                            ty: const float
+                                            kind: SymbolId(2)
+                            qubits: <empty>
+                            duration: <none>
+                            classical_arity: 1
+                            quantum_arity: 0
+        "#]],
+    );
+}
+
+#[test]
+fn box_can_contain_box() {
+    check_stmt_kinds(
+        r#"
+            qubit q;
+            box {
+              box {
+                barrier q;
+              }
+            }
+        "#,
+        &expect![[r#"
+            QubitDeclaration [13-21]:
+                symbol_id: 8
+            BoxStmt [34-116]:
+                duration: <none>
+                body:
+                    Stmt [54-102]:
+                        annotations: <empty>
+                        kind: BoxStmt [54-102]:
+                            duration: <none>
+                            body:
+                                Stmt [76-86]:
+                                    annotations: <empty>
+                                    kind: BarrierStmt [76-86]:
+                                        operands:
+                                            GateOperand [84-85]:
+                                                kind: Expr [84-85]:
+                                                    ty: qubit
+                                                    kind: SymbolId(8)
+        "#]],
+    );
+}
+
+#[test]
 fn with_invalid_instruction_fails() {
     check_stmt_kinds(
         "box {
@@ -13,10 +274,26 @@ fn with_invalid_instruction_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-26]:
                         annotations: <empty>
-                        kind: Err
+                        kind: BoxStmt [0-26]:
+                            duration: <none>
+                            body:
+                                Stmt [14-20]:
+                                    annotations: <empty>
+                                    kind: ExprStmt [14-20]:
+                                        expr: Expr [14-19]:
+                                            ty: const int
+                                            kind: BinaryOpExpr:
+                                                op: Add
+                                                lhs: Expr [14-15]:
+                                                    ty: const int
+                                                    kind: Lit: Int(2)
+                                                rhs: Expr [18-19]:
+                                                    ty: const int
+                                                    kind: Lit: Int(4)
 
             [Qasm.Lowerer.ClassicalStmtInBox
 
@@ -26,14 +303,6 @@ fn with_invalid_instruction_fails() {
              2 |         2 + 4;
                :         ^^^^^^
              3 |     }
-               `----
-            , Qasm.Lowerer.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: box stmt
-               ,-[test:1:1]
-             1 | ,-> box {
-             2 | |           2 + 4;
-             3 | `->     }
                `----
             ]"#]],
     );
@@ -46,10 +315,15 @@ fn with_duration_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-13]:
                         annotations: <empty>
-                        kind: Err
+                        kind: BoxStmt [0-13]:
+                            duration: Expr [5-8]:
+                                ty: const duration
+                                kind: Lit: Duration(4.0, Us)
+                            body: <empty>
 
             [Qasm.Lowerer.NotSupported
 
@@ -57,13 +331,6 @@ fn with_duration_fails() {
                ,-[test:1:6]
              1 | box [4us] { }
                :      ^^^
-               `----
-            , Qasm.Lowerer.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: box stmt
-               ,-[test:1:1]
-             1 | box [4us] { }
-               : ^^^^^^^^^^^^^
                `----
             ]"#]],
     );

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/break_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/break_stmt.rs
@@ -80,6 +80,7 @@ fn break_in_non_loop_scope_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-6]:
                         annotations: <empty>
@@ -107,6 +108,7 @@ fn intermediate_def_scope_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-64]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/continue_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/continue_stmt.rs
@@ -80,6 +80,7 @@ fn continue_in_non_loop_scope_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-9]:
                         annotations: <empty>
@@ -107,6 +108,7 @@ fn intermediate_def_scope_fails() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [9-67]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/reset_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/reset_stmt.rs
@@ -93,6 +93,7 @@ fn on_a_zero_len_qubit_register() {
         &expect![[r#"
             Program:
                 version: <none>
+                pragmas: <empty>
                 statements:
                     Stmt [0-11]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/switch_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/switch_stmt.rs
@@ -14,6 +14,7 @@ fn not_supported_before_version_3_1() {
         &expect![[r#"
             Program:
                 version: 3.0
+                pragmas: <empty>
                 statements:
                     Stmt [23-47]:
                         annotations: <empty>

--- a/source/compiler/qsc_qasm/src/tests.rs
+++ b/source/compiler/qsc_qasm/src/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::compiler::parse_and_compile_to_qsharp_ast_with_config;
+use crate::compiler::{PragmaConfig, parse_and_compile_to_qsharp_ast_with_config};
 use crate::io::{InMemorySourceResolver, SourceResolver};
 use crate::semantic::{QasmSemanticParseResult, parse_source};
 use crate::{CompilerConfig, OutputSemantics, ProgramType, QasmCompileUnit, QubitSemantics};
@@ -100,6 +100,7 @@ fn compile_with_config<S: Into<Arc<str>>>(
         stmts: vec![],
         symbols: res.symbols,
         errors: res.errors,
+        pragma_config: PragmaConfig::default(),
     };
 
     let unit = compiler.compile(&program);
@@ -162,6 +163,7 @@ pub fn compile_all_with_config<P: Into<Arc<str>>>(
         stmts: vec![],
         symbols: res.symbols,
         errors: res.errors,
+        pragma_config: PragmaConfig::default(),
     };
 
     let unit = compiler.compile(&program);

--- a/source/compiler/qsc_qasm/src/tests/statement.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement.rs
@@ -11,6 +11,7 @@ mod implicit_modified_gate_call;
 mod include;
 mod measure;
 mod modified_gate_call;
+mod pragma;
 mod reset;
 mod switch;
 mod while_loop;

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma.rs
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+pub mod r#box;

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/box.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/box.rs
@@ -1,0 +1,255 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::compile_qasm_to_qsharp;
+use expect_test::expect;
+use miette::Report;
+
+#[test]
+fn pragma_target_can_be_defined_before_pragma() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        def sample_box_target() {}
+        pragma qdk.box.open sample_box_target
+        box {}
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function sample_box_target() : Unit {}
+        {
+            sample_box_target();
+        };
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn pragma_target_can_be_defined_after_pragma() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        pragma qdk.box.open sample_box_target
+        def sample_box_target() {}
+        box {}
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function sample_box_target() : Unit {}
+        {
+            sample_box_target();
+        };
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn pragma_target_can_be_used_by_multilple_pragmas() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        pragma qdk.box.open sample_box_target
+        pragma qdk.box.close sample_box_target
+        def sample_box_target() {}
+        box {}
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function sample_box_target() : Unit {}
+        {
+            sample_box_target();
+            sample_box_target();
+        };
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn pragmas_can_have_separate_targets() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        pragma qdk.box.open box_open
+        pragma qdk.box.close box_close
+        def box_open() {}
+        def box_close() {}
+        box {}
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function box_open() : Unit {}
+        function box_close() : Unit {}
+        {
+            box_open();
+            box_close();
+        };
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn nested_boxes_call_separately() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        pragma qdk.box.open box_open
+        pragma qdk.box.close box_close
+        def box_open() {}
+        def box_close() {}
+        box {box {}}
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function box_open() : Unit {}
+        function box_close() : Unit {}
+        {
+            box_open();
+            {
+                box_open();
+                box_close();
+            };
+            box_close();
+        };
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn last_pragma_overwrites_previous() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        pragma qdk.box.open first
+        pragma qdk.box.open second
+        pragma qdk.box.close third
+        pragma qdk.box.close fourth
+        def first() {}
+        def second() {}
+        def third() {}
+        def fourth() {}
+        box {box {}}
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function first() : Unit {}
+        function second() : Unit {}
+        function third() : Unit {}
+        function fourth() : Unit {}
+        {
+            second();
+            {
+                second();
+                fourth();
+            };
+            fourth();
+        };
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn target_with_param_raises_error() {
+    let source = r#"
+        pragma qdk.box.open sample_box_target
+        def sample_box_target(int i) {}
+        box {}
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected an error");
+    };
+    expect![[r#"
+        Qasm.Compiler.InvalidBoxPragmaTarget
+
+          x sample_box_target is not defined or is not a valid target for box usage
+           ,-[Test.qasm:2:29]
+         1 | 
+         2 |         pragma qdk.box.open sample_box_target
+           :                             ^^^^^^^^^^^^^^^^^
+         3 |         def sample_box_target(int i) {}
+           `----
+    "#]]
+    .assert_eq(&format!("{:?}", &errors[0]));
+}
+
+#[test]
+fn unknown_pragma_raises_error() {
+    let source = r#"
+        pragma qdk.box.unknown sample_box_target
+        def sample_box_target(int i) {}
+        box {}
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected an error");
+    };
+    expect![[r#"
+        Qasm.Compiler.NotSupported
+
+          x pragma statement: qdk.box.unknown are not supported
+           ,-[Test.qasm:2:9]
+         1 | 
+         2 |         pragma qdk.box.unknown sample_box_target
+           :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         3 |         def sample_box_target(int i) {}
+           `----
+    "#]]
+    .assert_eq(&format!("{:?}", &errors[0]));
+}
+
+#[test]
+fn target_with_return_value_raises_error() {
+    let source = r#"
+        pragma qdk.box.open sample_box_target
+        def sample_box_target() -> int {
+            return 42;
+        }
+        box {}
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected an error");
+    };
+    expect![[r#"
+        Qasm.Compiler.InvalidBoxPragmaTarget
+
+          x sample_box_target is not defined or is not a valid target for box usage
+           ,-[Test.qasm:2:29]
+         1 | 
+         2 |         pragma qdk.box.open sample_box_target
+           :                             ^^^^^^^^^^^^^^^^^
+         3 |         def sample_box_target() -> int {
+           `----
+    "#]]
+    .assert_eq(&format!("{:?}", &errors[0]));
+}
+
+#[test]
+fn unknown_target_with_return_value_raises_error() {
+    let source = r#"
+        pragma qdk.box.open sample_box_target
+        box {}
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected an error");
+    };
+    expect![[r#"
+        Qasm.Compiler.InvalidBoxPragmaTarget
+
+          x sample_box_target is not defined or is not a valid target for box usage
+           ,-[Test.qasm:2:29]
+         1 | 
+         2 |         pragma qdk.box.open sample_box_target
+           :                             ^^^^^^^^^^^^^^^^^
+         3 |         box {}
+           `----
+    "#]]
+    .assert_eq(&format!("{:?}", &errors[0]));
+}

--- a/source/vscode/syntaxes/openqasm.tmLanguage.json
+++ b/source/vscode/syntaxes/openqasm.tmLanguage.json
@@ -47,11 +47,11 @@
       "patterns": [
         {
           "name": "keyword.control.openqasm",
-          "match": "\\b(in|for|return|if|else|switch|while)\\b"
+          "match": "(?<!\\s*\\.\\s*)\\b(in|for|return|if|else|switch|while)\\b(?!\\s*\\.)"
         },
         {
           "name": "keyword.other.openqasm",
-          "match": "\\b(OPENQASM|include|qubit|reset|mutable|readonly|#dim|stretch|delay|barrier|box|input|output|int|float|bit|bool|uint|angle|complex|const|defcal|def|gate|array|duration|let|measure|pragma|defcalgrammar|cal|qreg|creg|extern|port|frame|waveform)\\b"
+          "match": "(?<!\\s*\\.\\s*)\\b(OPENQASM|include|qubit|reset|mutable|readonly|#dim|stretch|delay|barrier|box|input|output|int|float|bit|bool|uint|angle|complex|const|defcal|def|gate|array|duration|let|measure|pragma|defcalgrammar|cal|qreg|creg|extern|port|frame|waveform)\\b(?!\\s*\\.)"
         }
       ]
     },


### PR DESCRIPTION
Adding support for [`boxed expressions`](https://openqasm.com/language/delays.html#boxed-expressions) and pragmas for them when integrating with the Q# compiler.

When working in OpenQASM with the QDK, we can now use pragmas to denote parameterless void functions to call at the beginning and/or end of boxed expressions. They can additionally leverage simulatable intrinsic functions which will flow through to code generation.

```openqasm
OPENQASM 3.0;
include "stdgates.inc";
#pragma qdk.box.open box_begin
#pragma qdk.box.close box_end

@SimulatableIntrinsic
def box_begin() {}

@SimulatableIntrinsic
def box_end() {}

qubit q;
box {
    x q;
}
output bit c;
c = measure q;
```

```llvm
define void @ENTRYPOINT__main() #0 {
block_0:
  call void @box_begin()
  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
  call void @box_end()
  call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
  call void @__quantum__rt__tuple_record_output(i64 0, i8* null)
  ret void
}
```