### PR TITLE
Show local variables of selected frame when debugging.

### DIFF
--- a/source/compiler/qsc/src/interpret.rs
+++ b/source/compiler/qsc/src/interpret.rs
@@ -1152,10 +1152,10 @@ impl Debugger {
     }
 
     #[must_use]
-    pub fn get_locals(&self) -> Vec<VariableInfo> {
+    pub fn get_locals(&self, frame_id: usize) -> Vec<VariableInfo> {
         self.interpreter
             .env
-            .get_variables_in_top_frame()
+            .get_variables_in_frame(frame_id)
             .into_iter()
             .filter(|v| !v.name.starts_with('@'))
             .collect()

--- a/source/compiler/qsc_eval/src/lib.rs
+++ b/source/compiler/qsc_eval/src/lib.rs
@@ -607,13 +607,9 @@ impl State {
     }
 
     fn push_scope(&mut self, env: &mut Env) {
-        // The `EntryPoint` is the first and only function called from the entry.
-        // The `EntryPoint` should have `frame_id := 0`.
         // `push_frame`, which increments the length of `self.call_stack` by 1,
         // is called before `self.push_scope`.
-        // Therefore, when assigning the `frame_id` to the `EntryPoint`,
-        // `self.call_stack.len()` is already 1, and we need to correct
-        // by substracting 1, so that the `frame_id` of the `EntryPoint` is 0.
+        // Since the first `frame_id` should be 0, we substract 1 here.
         env.push_scope(self.call_stack.len() - 1);
     }
 

--- a/source/compiler/qsc_eval/src/lib.rs
+++ b/source/compiler/qsc_eval/src/lib.rs
@@ -607,13 +607,13 @@ impl State {
     }
 
     fn push_scope(&mut self, env: &mut Env) {
-        // `Main` is the first and only function called from `entry_point`.
-        // `Main` should have `frame_id := 0`.
+        // The `EntryPoint` is the first and only function called from the entry.
+        // The `EntryPoint` should have `frame_id := 0`.
         // `push_frame`, which increments the length of `self.call_stack` by 1,
         // is called before `self.push_scope`.
-        // Therefore, when assigning the `frame_id` to `Main`,
+        // Therefore, when assigning the `frame_id` to the `EntryPoint`,
         // `self.call_stack.len()` is already 1, and we need to correct
-        // by substracting 1, so that the `frame_id` of `Main` is 0.
+        // by substracting 1, so that the `frame_id` of the `EntryPoint` is 0.
         env.push_scope(self.call_stack.len() - 1);
     }
 

--- a/source/compiler/qsc_eval/src/lib.rs
+++ b/source/compiler/qsc_eval/src/lib.rs
@@ -607,7 +607,14 @@ impl State {
     }
 
     fn push_scope(&mut self, env: &mut Env) {
-        env.push_scope(self.call_stack.len());
+        // `Main` is the first and only function called from `entry_point`.
+        // `Main` should have `frame_id := 0`.
+        // `push_frame`, which increments the length of `self.call_stack` by 1,
+        // is called before `self.push_scope`.
+        // Therefore, when assigning the `frame_id` to `Main`,
+        // `self.call_stack.len()` is already 1, and we need to correct
+        // by substracting 1, so that the `frame_id` of `Main` is 0.
+        env.push_scope(self.call_stack.len() - 1);
     }
 
     fn take_val_register(&mut self) -> Value {

--- a/source/npm/qsharp/src/debug-service/debug-service.ts
+++ b/source/npm/qsharp/src/debug-service/debug-service.ts
@@ -35,7 +35,7 @@ export interface IDebugService {
     entry: string | undefined,
   ): Promise<string>;
   getBreakpoints(path: string): Promise<IBreakpointSpan[]>;
-  getLocalVariables(): Promise<Array<IVariable>>;
+  getLocalVariables(frameID: number): Promise<Array<IVariable>>;
   captureQuantumState(): Promise<Array<IQuantumState>>;
   getCircuit(): Promise<CircuitData>;
   getStackFrames(): Promise<IStackFrame[]>;
@@ -84,8 +84,8 @@ export class QSharpDebugService implements IDebugService {
     return this.debugService.get_breakpoints(path).spans;
   }
 
-  async getLocalVariables(): Promise<Array<IVariable>> {
-    const variable_list = this.debugService.get_locals();
+  async getLocalVariables(frameID: number): Promise<Array<IVariable>> {
+    const variable_list = this.debugService.get_locals(frameID);
     return variable_list.variables;
   }
 

--- a/source/vscode/src/debugger/session.ts
+++ b/source/vscode/src/debugger/session.ts
@@ -757,12 +757,12 @@ export class QscDebugSession extends LoggingDebugSession {
         ),
         new Scope(
           "Quantum State",
-          this.variableHandles.create(["quantum", args.frameId]),
+          this.variableHandles.create(["quantum", -1]),
           true, // expensive - keeps scope collapsed in the UI by default
         ),
         new Scope(
           "Quantum Circuit",
-          this.variableHandles.create(["circuit", args.frameId]),
+          this.variableHandles.create(["circuit", -1]),
           true, // expensive - keeps scope collapsed in the UI by default
         ),
       ],

--- a/source/vscode/test/suites/debugger/openqasm.test.ts
+++ b/source/vscode/test/suites/debugger/openqasm.test.ts
@@ -55,7 +55,7 @@ suite("OpenQASM Debugger Tests", function suite() {
     // launch debugger
     await vscode.commands.executeCommand(`${qsharpExtensionId}.debugProgram`);
 
-    await waitUntilPaused([
+    await assertStackTrace([
       {
         id: 0,
         source: {
@@ -84,7 +84,7 @@ suite("OpenQASM Debugger Tests", function suite() {
       program: "${workspaceFolder}" + `${selfContainedName}`,
     });
 
-    await waitUntilPaused([
+    await assertStackTrace([
       {
         id: 0,
         source: {
@@ -114,7 +114,7 @@ suite("OpenQASM Debugger Tests", function suite() {
       program: "${file}",
     });
 
-    await waitUntilPaused([
+    await assertStackTrace([
       {
         id: 0,
         source: {
@@ -144,7 +144,7 @@ suite("OpenQASM Debugger Tests", function suite() {
     });
 
     // should hit the breakpoint we set above
-    await waitUntilPaused([
+    await assertStackTrace([
       {
         id: 0,
         source: {
@@ -191,7 +191,7 @@ suite("OpenQASM Debugger Tests", function suite() {
     });
 
     // should hit the breakpoint we set above
-    await waitUntilPaused([
+    await assertStackTrace([
       {
         id: 0,
         source: {
@@ -228,7 +228,7 @@ suite("OpenQASM Debugger Tests", function suite() {
     });
 
     // should hit the breakpoint we set above
-    await waitUntilPaused([
+    await assertStackTrace([
       {
         id: 1,
         source: {
@@ -280,7 +280,7 @@ suite("OpenQASM Debugger Tests", function suite() {
     });
 
     // should hit the breakpoint we set above
-    await waitUntilPaused([
+    await assertStackTrace([
       {
         id: 0,
         source: {
@@ -301,7 +301,7 @@ suite("OpenQASM Debugger Tests", function suite() {
     // step into call (will be a call into intrinsic.qs)
     await vscode.commands.executeCommand("workbench.action.debug.stepInto");
 
-    await waitUntilPaused([
+    await assertStackTrace([
       {
         id: 1,
         source: {
@@ -344,8 +344,8 @@ suite("OpenQASM Debugger Tests", function suite() {
    *
    * @param expectedStackTrace assert that the stack trace matches this value
    */
-  function waitUntilPaused(expectedStackTrace: DebugProtocol.StackFrame[]) {
-    return tracker!.waitUntilPaused(expectedStackTrace);
+  function assertStackTrace(expectedStackTrace: DebugProtocol.StackFrame[]) {
+    return tracker!.assertStackTrace(expectedStackTrace);
   }
 });
 

--- a/source/vscode/test/suites/debugger/openqasm.test.ts
+++ b/source/vscode/test/suites/debugger/openqasm.test.ts
@@ -365,7 +365,7 @@ suite("OpenQASM Debugger Tests", function suite() {
     // Step over to prepare the tracker to detect a new variable.
     await vscode.commands.executeCommand("workbench.action.debug.stepOver");
 
-    // Go one frame down the call stack.
+    // Request scopes for the frame with frameId 1 (g's frame).
     await vscode.debug.activeDebugSession?.customRequest("scopes", {
       frameId: 1,
     });

--- a/source/vscode/test/suites/debugger/qsharp.test.ts
+++ b/source/vscode/test/suites/debugger/qsharp.test.ts
@@ -457,7 +457,7 @@ suite("Q# Debugger Tests", function suite() {
    *
    * @param expectedVariables assert that the tracker.variables trace matches this value.
    */
-  function assertVariables(expectedVariables: any) {
+  function assertVariables(expectedVariables: DebugProtocol.Variable[]) {
     return tracker!.assertVariables(expectedVariables);
   }
 });

--- a/source/vscode/test/suites/debugger/qsharp.test.ts
+++ b/source/vscode/test/suites/debugger/qsharp.test.ts
@@ -433,12 +433,14 @@ suite("Q# Debugger Tests", function suite() {
     );
 
     // Verify that the locals variables correspond to the Main frame.
-    await assertVariables({
-      name: "a",
-      type: undefined,
-      value: "1",
-      variablesReference: 0,
-    });
+    await assertVariables([
+      {
+        name: "a",
+        type: undefined,
+        value: "1",
+        variablesReference: 0,
+      },
+    ]);
   });
 
   /**

--- a/source/vscode/test/suites/debugger/qsharp.test.ts
+++ b/source/vscode/test/suites/debugger/qsharp.test.ts
@@ -401,7 +401,7 @@ suite("Q# Debugger Tests", function suite() {
   });
 
   test("Show local variables of selected frame", async () => {
-    // Set a breakpoint on line 16 of foo.qs (7 when 0-indexed)
+    // Set a breakpoint on line 16 of foo.qs (15 when 0-indexed)
     // This will be in the function `AnotherCallFrame` after `b`
     // has been defined.
     vscode.debug.addBreakpoints([
@@ -427,7 +427,7 @@ suite("Q# Debugger Tests", function suite() {
     // Step over to prepare the tracker to detect a new variable.
     await vscode.commands.executeCommand("workbench.action.debug.stepOver");
 
-    // Go one frame down the call stack.
+    // Request scopes for the frame with frameId 0 (Foo's frame).
     await vscode.debug.activeDebugSession?.customRequest("scopes", {
       frameId: 0,
     });

--- a/source/vscode/test/suites/debugger/test-workspace/self-contained.qasm
+++ b/source/vscode/test/suites/debugger/test-workspace/self-contained.qasm
@@ -7,3 +7,16 @@ reset q;
 x q;
 h q;
 bit c = measure q;
+
+def f() {
+    int b = 3;
+    int c = 4;
+    int d = 5;
+}
+
+def g() {
+    int a = 2;
+    f();
+}
+
+g();

--- a/source/vscode/test/suites/debugger/test-workspace/src/foo.qs
+++ b/source/vscode/test/suites/debugger/test-workspace/src/foo.qs
@@ -7,5 +7,13 @@ namespace Foo {
         use q = Qubit();
         H(q);
         Reset(q);
+        let a = 2;
+        AnotherCallFrame();
+    }
+
+    function AnotherCallFrame() : Unit {
+        let b = 3;
+        let c = 4;
+        let d = 5;
     }
 }

--- a/source/vscode/test/suites/debugger/tracker.ts
+++ b/source/vscode/test/suites/debugger/tracker.ts
@@ -108,12 +108,13 @@ class Tracker implements vscode.DebugAdapterTracker {
    *
    * @param expectedVariables assert that the tracker.variables trace matches this value.
    */
-  async assertVariables(expectedVariables: any) {
+  async assertVariables(expectedVariables: DebugProtocol.Variable[]) {
     await this.waitUntilPaused();
 
     assert.deepEqual(
       this.variables,
       expectedVariables,
+      // print copy-pastable variables
       `actual variables:\n${JSON.stringify(this.variables)}\n`,
     );
 

--- a/source/vscode/test/suites/debugger/tracker.ts
+++ b/source/vscode/test/suites/debugger/tracker.ts
@@ -89,7 +89,9 @@ class Tracker implements vscode.DebugAdapterTracker {
    *
    * @param expectedStackTrace assert that the stack trace matches this value.
    */
-  async assertStackTrace(expectedStackTrace: DebugProtocol.StackFrame[]) {
+  async waitUntilPausedAndAssertStackTrace(
+    expectedStackTrace: DebugProtocol.StackFrame[],
+  ) {
     await this.waitUntilPaused();
 
     assert.deepEqual(
@@ -108,7 +110,9 @@ class Tracker implements vscode.DebugAdapterTracker {
    *
    * @param expectedVariables assert that the tracker.variables trace matches this value.
    */
-  async assertVariables(expectedVariables: DebugProtocol.Variable[]) {
+  async waitUntilPausedAndAssertVariables(
+    expectedVariables: DebugProtocol.Variable[],
+  ) {
     await this.waitUntilPaused();
 
     assert.deepEqual(

--- a/source/wasm/src/debug_service.rs
+++ b/source/wasm/src/debug_service.rs
@@ -201,8 +201,8 @@ impl DebugService {
         .into()
     }
 
-    pub fn get_locals(&self) -> IVariableList {
-        let locals = self.debugger().get_locals();
+    pub fn get_locals(&self, frame_id: usize) -> IVariableList {
+        let locals = self.debugger().get_locals(frame_id);
         let variables: Vec<_> = locals
             .into_iter()
             .map(|local| Variable {


### PR DESCRIPTION
Fixes #2494 

This PR modifies the debugger behavior to show local variables for the selected stack frame when debugging.