### PR TITLE
When an error occurs show line/col info for each frame in the stack

### DIFF
--- a/source/compiler/qsc/src/interpret/debug.rs
+++ b/source/compiler/qsc/src/interpret/debug.rs
@@ -4,6 +4,7 @@
 #[cfg(test)]
 mod tests;
 
+use qsc_data_structures::line_column::{Encoding, Position};
 use qsc_eval::debug::Frame;
 use qsc_fir::fir::{Global, PackageStoreLookup, StoreItemId};
 use qsc_frontend::compile::PackageStore;
@@ -48,8 +49,15 @@ pub(crate) fn format_call_stack(
         write!(trace, "{}", call.name.name).expect("writing to string should succeed");
 
         let name = get_item_file_name(store, frame.id);
-        write!(trace, " in {}", name.unwrap_or("<expression>".to_string()))
-            .expect("writing to string should succeed");
+        let pos = get_position(frame, store);
+        write!(
+            trace,
+            " in {}:{}:{}",
+            name.unwrap_or("<expression>".to_string()),
+            pos.line,
+            pos.column,
+        )
+        .expect("writing to string should succeed");
 
         trace.push('\n');
     }
@@ -88,4 +96,17 @@ fn get_ns_name(item: &Item) -> Option<Rc<str>> {
         return None;
     };
     Some(ns.name())
+}
+
+/// Converts the [`Span`] of [`Frame`] into a [`Position`].
+fn get_position(frame: Frame, store: &PackageStore) -> Position {
+    let filename = get_item_file_name(store, frame.id).expect("file should exist");
+    let package_id = map_fir_package_to_hir(frame.id.package);
+    let unit = store.get(package_id).expect("package should exist");
+    let source = unit
+        .sources
+        .find_by_name(&filename)
+        .expect("source should exist");
+    let contents = &source.contents;
+    Position::from_utf8_byte_offset(Encoding::Utf8, contents, frame.span.lo)
 }

--- a/source/compiler/qsc/src/interpret/debug/tests.rs
+++ b/source/compiler/qsc/src/interpret/debug/tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use expect_test::expect;
 use indoc::indoc;
 use miette::Result;
 use qsc_data_structures::{language_features::LanguageFeatures, target::TargetCapabilityFlags};
@@ -90,15 +91,15 @@ fn stack_traces_can_cross_eval_session_and_file_boundaries() {
             let stack_trace = e[0]
                 .stack_trace()
                 .expect("code should have a valid stack trace");
-            let expectation = indoc! {r#"
-                         Error: division by zero
-                         Call stack:
-                             at Adjoint Test.C in 1.qs
-                             at Adjoint Test.B in 1.qs
-                             at Adjoint Test2.A in 2.qs
-                             at Z in line_0
-                    "#};
-            assert_eq!(expectation, stack_trace);
+            expect![[r#"
+                Error: division by zero
+                Call stack:
+                    at Adjoint Test.C in 1.qs:10:12
+                    at Adjoint Test.B in 1.qs:3:12
+                    at Adjoint Test2.A in 2.qs:9:0
+                    at Z in line_0:0:34
+            "#]]
+            .assert_eq(stack_trace);
         }
     }
 }
@@ -161,14 +162,13 @@ fn stack_traces_can_cross_file_and_entry_boundaries() {
             let stack_trace = e[0]
                 .stack_trace()
                 .expect("code should have a valid stack trace");
-            let expectation = indoc! {r#"
-                         Error: division by zero
-                         Call stack:
-                             at Adjoint Test.C in 1.qs
-                             at Adjoint Test.B in 1.qs
-                             at Adjoint Test2.A in 2.qs
-                    "#};
-            assert_eq!(expectation, stack_trace);
+            expect![[r#"
+                Error: division by zero
+                Call stack:
+                    at Adjoint Test.C in 1.qs:11:8
+                    at Adjoint Test.B in 1.qs:5:0
+                    at Adjoint Test2.A in 2.qs:9:0
+            "#]].assert_eq(stack_trace);
         }
     }
 }


### PR DESCRIPTION
Fixes #2495 .

When an error occurs show line/col info for each frame in the stack.