### PR TITLE
OpenQASM VSCode Spec Mode

### DIFF
--- a/source/language_service/src/code_lens.rs
+++ b/source/language_service/src/code_lens.rs
@@ -25,6 +25,16 @@ pub(crate) fn get_code_lenses(
         return vec![]; // entrypoint actions don't work in notebooks
     }
 
+    if matches!(
+        compilation.kind,
+        CompilationKind::OpenQASM {
+            spec_mode: true,
+            ..
+        }
+    ) {
+        return vec![]; // entrypoint actions don't work with OpenQASM in spec mode
+    }
+
     if !compilation.project_errors.is_empty()
         || compilation
             .compile_errors

--- a/source/language_service/src/completion/tests/openqasm.rs
+++ b/source/language_service/src/completion/tests/openqasm.rs
@@ -22,6 +22,7 @@ fn compile_project_with_markers_cursor_optional(
         Compilation::new_qasm(
             PackageType::Lib,
             qsc::target::Profile::Unrestricted,
+            false,
             sources,
             vec![],
             &Arc::from("test project"),

--- a/source/language_service/src/protocol.rs
+++ b/source/language_service/src/protocol.rs
@@ -16,6 +16,7 @@ pub struct WorkspaceConfigurationUpdate {
     pub package_type: Option<PackageType>,
     pub language_features: Option<LanguageFeatures>,
     pub lints_config: Option<Vec<LintOrGroupConfig>>,
+    pub openqasm_spec_mode: Option<bool>,
     pub dev_diagnostics: Option<bool>,
 }
 

--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -15,7 +15,10 @@
   },
   "categories": [
     "Programming Languages",
-    "Notebooks"
+    "Notebooks",
+    "Debuggers",
+    "Formatters",
+    "Linters"
   ],
   "browser": "./out/extension.js",
   "virtualWorkspaces": true,
@@ -161,6 +164,11 @@
           "type": "boolean",
           "default": false,
           "description": "Suppress notifications about new QDK updates. If true, you will not be prompted about new features after updates."
+        },
+        "qdk.openqasm.enableSpecMode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Only show OpenQASM syntax and semantic errors. This will disable the Q#-specific integration diagnostics and features."
         }
       }
     },
@@ -168,27 +176,27 @@
       "editor/title/run": [
         {
           "command": "qsharp-vscode.runProgram",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm || resourceLangId == qsharpcircuit",
+          "when": "(resourceLangId == qsharp || resourceLangId == qsharpcircuit) || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)",
           "group": "navigation@1"
         },
         {
           "command": "qsharp-vscode.debugProgram",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm || resourceLangId == qsharpcircuit",
+          "when": "(resourceLangId == qsharp || resourceLangId == qsharpcircuit) || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)",
           "group": "navigation@2"
         }
       ],
       "commandPalette": [
         {
           "command": "qsharp-vscode.runProgram",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm || resourceLangId == qsharpcircuit"
+          "when": "(resourceLangId == qsharp || resourceLangId == qsharpcircuit) || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)"
         },
         {
           "command": "qsharp-vscode.debugProgram",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm || resourceLangId == qsharpcircuit"
+          "when": "(resourceLangId == qsharp || resourceLangId == qsharpcircuit) || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)"
         },
         {
           "command": "qsharp-vscode.runEditorContentsWithCircuit",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm"
+          "when": "(resourceLangId == qsharp || resourceLangId == qsharpcircuit) || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)"
         },
         {
           "command": "qsharp-vscode.targetSubmit",
@@ -212,15 +220,15 @@
         },
         {
           "command": "qsharp-vscode.getQir",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm"
+          "when": "(resourceLangId == qsharp || resourceLangId == qsharpcircuit) || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)"
         },
         {
           "command": "qsharp-vscode.showHistogram",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm"
+          "when": "(resourceLangId == qsharp || resourceLangId == qsharpcircuit) || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)"
         },
         {
           "command": "qsharp-vscode.showRe",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm"
+          "when": "(resourceLangId == qsharp || resourceLangId == qsharpcircuit) || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)"
         },
         {
           "command": "qsharp-vscode.showHelp",
@@ -228,7 +236,7 @@
         },
         {
           "command": "qsharp-vscode.showCircuit",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm"
+          "when": "(resourceLangId == qsharp || resourceLangId == qsharpcircuit) || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)"
         },
         {
           "command": "qsharp-vscode.showDocumentation",
@@ -236,7 +244,7 @@
         },
         {
           "command": "qsharp-vscode.setTargetProfile",
-          "when": "resourceLangId == qsharp || resourceLangId == openqasm"
+          "when": "resourceLangId == qsharp || (resourceLangId == openqasm && !config.qdk.openqasm.enableSpecMode)"
         },
         {
           "command": "qsharp-vscode.webOpener",

--- a/source/vscode/src/config.ts
+++ b/source/vscode/src/config.ts
@@ -69,3 +69,9 @@ export function getShowDevDiagnostics(): boolean {
     .getConfiguration("Q#")
     .get<boolean>("dev.showDevDiagnostics", false);
 }
+
+export function getOpenQasmEnableSpecMode(): boolean {
+  return vscode.workspace
+    .getConfiguration("qdk")
+    .get<boolean>("openqasm.enableSpecMode", false);
+}

--- a/source/vscode/src/language-service/activate.ts
+++ b/source/vscode/src/language-service/activate.ts
@@ -14,7 +14,11 @@ import {
   openqasmLanguageId,
   qsharpLanguageId,
 } from "../common.js";
-import { getTarget, getShowDevDiagnostics } from "../config.js";
+import {
+  getTarget,
+  getShowDevDiagnostics,
+  getOpenQasmEnableSpecMode,
+} from "../config.js";
 import {
   fetchGithubRaw,
   findManifestDirectory,
@@ -317,7 +321,8 @@ function registerConfigurationChangeHandlers(
   return vscode.workspace.onDidChangeConfiguration((event) => {
     if (
       event.affectsConfiguration("Q#.qir.targetProfile") ||
-      event.affectsConfiguration("Q#.dev.showDevDiagnostics")
+      event.affectsConfiguration("Q#.dev.showDevDiagnostics") ||
+      event.affectsConfiguration("qdk.openqasm.enableSpecMode")
     ) {
       updateLanguageServiceConfiguration(languageService);
     }
@@ -329,6 +334,7 @@ async function updateLanguageServiceConfiguration(
 ) {
   const targetProfile = getTarget();
   const showDevDiagnostics = getShowDevDiagnostics();
+  const openqasmSpecMode = getOpenQasmEnableSpecMode();
 
   switch (targetProfile) {
     case "base":
@@ -341,11 +347,13 @@ async function updateLanguageServiceConfiguration(
   }
   log.debug("Target profile set to: " + targetProfile);
   log.debug("Show dev diagnostics set to: " + showDevDiagnostics);
+  log.debug("OpenQASM spec mode set to: " + openqasmSpecMode);
 
   // Update all configuration settings
   languageService.updateConfiguration({
     targetProfile: targetProfile,
     devDiagnostics: showDevDiagnostics,
+    openqasmSpecMode: openqasmSpecMode,
     lints: [{ lint: "needlessOperation", level: "warn" }],
   });
 }

--- a/source/wasm/src/language_service.rs
+++ b/source/wasm/src/language_service.rs
@@ -124,6 +124,7 @@ impl LanguageService {
                     .languageFeatures
                     .map(|features| features.iter().collect::<LanguageFeatures>()),
                 lints_config: config.lints,
+                openqasm_spec_mode: config.openqasmSpecMode,
                 dev_diagnostics: config.devDiagnostics,
             });
     }
@@ -382,6 +383,7 @@ serializable_type! {
         pub languageFeatures: Option<Vec<String>>,
         pub lints: Option<Vec<LintOrGroupConfig>>,
         pub devDiagnostics: Option<bool>,
+        pub openqasmSpecMode: Option<bool>,
     },
     r#"export interface IWorkspaceConfiguration {
         targetProfile?: TargetProfile;
@@ -389,6 +391,7 @@ serializable_type! {
         languageFeatures?: LanguageFeatures[];
         lints?: ({ lint: string; level: string } | { group: string; level: string })[];
         devDiagnostics?: boolean;
+        openqasmSpecMode?: boolean;
     }"#,
     IWorkspaceConfiguration
 }


### PR DESCRIPTION
This PR adds a new configuration setting allowing the user to disconnect the Q# integration features of the language service (such as code lenses, debugging, execution, etc). The use still get syntax and semantic errors. 