### PR TITLE
Allow unrestricted capabilities in `@Test` callables

### DIFF
--- a/library/std/src/Std/Diagnostics.qs
+++ b/library/std/src/Std/Diagnostics.qs
@@ -122,7 +122,6 @@ function DumpMatrix(qs : Qubit[]) : Unit {
 /// # Remarks
 /// This operation is useful for checking whether a qubit is in the |0⟩ state during simulation. It is not possible to check
 /// this on hardware without measuring the qubit, which could change the state.
-@Config(Unrestricted)
 operation CheckZero(qubit : Qubit) : Bool {
     body intrinsic;
 }
@@ -144,7 +143,6 @@ operation CheckZero(qubit : Qubit) : Bool {
 /// # Remarks
 /// This operation is useful for checking whether a qubit is in the |0⟩ state during simulation. It is not possible to check
 /// this on hardware without measuring the qubit, which could change the state.
-@Config(Unrestricted)
 operation CheckAllZero(qubits : Qubit[]) : Bool {
     for q in qubits {
         if not CheckZero(q) {
@@ -201,7 +199,6 @@ function Fact(actual : Bool, message : String) : Unit {
 /// Operation defining the expected behavior for the operation under test.
 /// # Output
 /// True if operations are equal, false otherwise.
-@Config(Unrestricted)
 operation CheckOperationsAreEqual(
     nQubits : Int,
     actual : (Qubit[] => Unit),

--- a/source/compiler/qsc_fir/src/fir.rs
+++ b/source/compiler/qsc_fir/src/fir.rs
@@ -1527,6 +1527,8 @@ pub enum Attr {
     Measurement,
     /// Indicates that a callable is a reset.
     Reset,
+    /// Indicates that a callable is used for unit testing.
+    Test,
 }
 
 /// A field.

--- a/source/compiler/qsc_lowerer/src/lib.rs
+++ b/source/compiler/qsc_lowerer/src/lib.rs
@@ -962,10 +962,8 @@ fn lower_attrs(attrs: &[hir::Attr]) -> Vec<fir::Attr> {
             hir::Attr::EntryPoint => Some(fir::Attr::EntryPoint),
             hir::Attr::Measurement => Some(fir::Attr::Measurement),
             hir::Attr::Reset => Some(fir::Attr::Reset),
-            hir::Attr::SimulatableIntrinsic
-            | hir::Attr::Unimplemented
-            | hir::Attr::Config
-            | hir::Attr::Test => None,
+            hir::Attr::Test => Some(fir::Attr::Test),
+            hir::Attr::SimulatableIntrinsic | hir::Attr::Unimplemented | hir::Attr::Config => None,
         })
         .collect()
 }

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -126,15 +126,12 @@ pub enum Error {
     #[error("unsupported call into test callable")]
     #[diagnostic(code("Qsc.PartialEval.UnsupportedTestCallable"))]
     #[diagnostic(help(
-        "callables with the `@Test` annotation are not supported in partial evaluation."
+        "callables with the `@Test` annotation should not be called from non-test code."
     ))]
     UnsupportedTestCallable(#[label] PackageSpan),
 
     #[error("unsupported use of simulation-only intrinsic `{0}`")]
     #[diagnostic(code("Qsc.PartialEval.UnsupportedSimulationIntrinsic"))]
-    #[diagnostic(help(
-        "intrinsic callables that require a running quantum simulator cannot be invoked in partial evaluation"
-    ))]
     UnsupportedSimulationIntrinsic(String, #[label] PackageSpan),
 }
 

--- a/source/compiler/qsc_partial_eval/src/tests/calls.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/calls.rs
@@ -1347,3 +1347,27 @@ fn call_to_unresolved_callee_with_static_arg_and_entry_return_value_succeeds() {
                 Return"#]],
     );
 }
+
+#[test]
+fn call_to_test_callable_triggers_error() {
+    let error = get_partial_evaluation_error_with_capabilities(
+        indoc! {"
+        @Test()
+        operation Op() : Unit {
+            use q = Qubit();
+            Std.Diagnostics.CheckZero(q);
+        }
+        operation Main() : Unit {
+            Op();
+        }
+        "},
+        TargetCapabilityFlags::Adaptive,
+    );
+
+    assert_error(
+        &error,
+        &expect![
+            "UnsupportedTestCallable(PackageSpan { package: PackageId(2), span: Span { lo: 120, hi: 122 } })"
+        ],
+    );
+}

--- a/source/compiler/qsc_partial_eval/src/tests/intrinsics.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/intrinsics.rs
@@ -968,7 +968,9 @@ fn use_of_noise_does_not_generate_instructions() {
 }
 
 #[test]
-#[should_panic(expected = "`CheckZero` is not a supported by partial evaluation")]
+#[should_panic(
+    expected = "partial evaluation failed: UnsupportedSimulationIntrinsic(\"CheckZero\","
+)]
 fn call_to_check_zero_panics() {
     _ = get_rir_program(indoc! {
         r#"

--- a/source/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck.rs
@@ -20,12 +20,12 @@ use qsc_data_structures::{span::Span, target::TargetCapabilityFlags};
 
 use qsc_fir::{
     fir::{
-        Block, BlockId, CallableImpl, Expr, ExprId, ExprKind, Global, Ident, Item, ItemKind,
-        LocalItemId, LocalVarId, Package, PackageLookup, Pat, PatId, PatKind, Res, SpecDecl,
-        SpecImpl, Stmt, StmtId, StmtKind,
+        Attr, Block, BlockId, CallableDecl, CallableImpl, Expr, ExprId, ExprKind, Global, Ident,
+        Item, ItemKind, LocalItemId, LocalVarId, Package, PackageLookup, Pat, PatId, PatKind, Res,
+        SpecDecl, SpecImpl, Stmt, StmtId, StmtKind,
     },
     ty::FunctorSetValue,
-    visit::Visitor,
+    visit::{Visitor, walk_callable_decl},
 };
 
 use qsc_lowerer::map_hir_package_to_fir;
@@ -129,6 +129,12 @@ impl<'a> Visitor<'a> for Checker<'a> {
         package.entry.iter().for_each(|entry_expr_id| {
             self.check_entry_expr(*entry_expr_id);
         });
+    }
+
+    fn visit_callable_decl(&mut self, decl: &'a CallableDecl) {
+        if decl.attrs.iter().all(|attr| *attr != Attr::Test) {
+            walk_callable_decl(self, decl);
+        }
     }
 
     fn visit_callable_impl(&mut self, callable_impl: &'a CallableImpl) {

--- a/source/compiler/qsc_rca/src/tests/callables.rs
+++ b/source/compiler/qsc_rca/src/tests/callables.rs
@@ -210,6 +210,37 @@ fn check_rca_for_callable_block_with_dynamic_unreachable_binding() {
 }
 
 #[test]
+fn check_rca_for_test_callable() {
+    let mut compilation_context = CompilationContext::default();
+    compilation_context.update(
+        r#"
+        @Test()
+        operation Test() : Int {
+            use q = Qubit();
+            if M(q) == Zero {
+                return 0;
+            }
+            return 1;
+        }"#,
+    );
+    check_callable_compute_properties(
+        &compilation_context.fir_store,
+        compilation_context.get_compute_properties(),
+        "Test",
+        &expect![[r#"
+            Callable: CallableComputeProperties:
+                body: ApplicationsGeneratorSet:
+                    inherent: Quantum: QuantumProperties:
+                        runtime_features: RuntimeFeatureFlags(0x0)
+                        value_kind: Element(Dynamic)
+                    dynamic_param_applications: <empty>
+                adj: <none>
+                ctl: <none>
+                ctl-adj: <none>"#]],
+    );
+}
+
+#[test]
 fn check_rca_for_unrestricted_h() {
     let compilation_context = CompilationContext::default();
     check_callable_compute_properties(


### PR DESCRIPTION
This change creates a special exception for callables annoted with `@Test` in Runtime Capabilities Analysis, making it easier to write and run unit tests with profiles other than "Unrestricted." As part of this change, the `CheckZero`, `CheckAllZero`, and `CheckOperationsAreEqual` callables are no longer marked as `@Config(Unrestricted)` so that they can be used from tests. Any calls into these will trigger updated codegen error cases. In addition, calls into `@Test` callables also trigger a new codegen-time error.

Fixes #2504