### PR TITLE
Add sizeof bultin to qasm

### DIFF
--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -98,6 +98,10 @@ pub const STD_LIB: &[(&str, &str)] = &[
         include_str!("../std/src/Std/OpenQASM/Angle.qs"),
     ),
     (
+        "qsharp-library-source:Std/OpenQASM/Builtin.qs",
+        include_str!("../std/src/Std/OpenQASM/Builtin.qs"),
+    ),
+    (
         "qsharp-library-source:Std/OpenQASM/Convert.qs",
         include_str!("../std/src/Std/OpenQASM/Convert.qs"),
     ),

--- a/library/std/qsharp.json
+++ b/library/std/qsharp.json
@@ -21,6 +21,7 @@
     "src/Std/StatePreparation.qs",
     "src/Std/TableLookup.qs",
     "src/Std/OpenQASM/Angle.qs",
+    "src/Std/OpenQASM/Builtin.qs",
     "src/Std/OpenQASM/Convert.qs",
     "src/Std/OpenQASM/Intrinsic.qs"
   ]

--- a/library/std/src/Std/OpenQASM/Builtin.qs
+++ b/library/std/src/Std/OpenQASM/Builtin.qs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// This file defines the bultin functions used in the OpenQASM runtime.
+
+/// OpenQASM only supports up to seven dimensions,
+/// therefore, we only need these seven `sizeof` functions.
+export sizeof_1, sizeof_2, sizeof_3, sizeof_4, sizeof_5, sizeof_6, sizeof_7;
+
+/// Function to handle 1-dimensional arrays passed to `sizeof` in OpenQASM.
+///
+/// It takes two arguments, an array `array` and a zero-based dimension `dim`.
+/// It returns the length of the requested dimension.
+/// Fails if the requested dimension is greater than the number of dimensions
+/// in the array.
+function sizeof_1<'T>(array : 'T[], dim: Int) : Int {
+    if dim == 0 {
+        Length(array)
+    } else {
+        fail $"sizeof error: requested dimension {dim} but the array has 1 dimension";
+    }
+}
+
+/// Function to handle 2-dimensional arrays passed to `sizeof` in OpenQASM.
+///
+/// It takes two arguments, an array `array` and a zero-based dimension `dim`.
+/// It returns the length of the requested dimension.
+/// Fails if the requested dimension is greater than the number of dimensions
+/// in the array.
+function sizeof_2<'T>(array : 'T[][], dim : Int) : Int {
+    if dim == 0 {
+        Length(array)
+    } elif dim < 2 {
+        sizeof_1(array[0], dim - 1)
+    } else {
+        fail $"sizeof error: requested dimension {dim} but the array has 2 dimensions";
+    }
+}
+
+/// Function to handle 3-dimensional arrays passed to `sizeof` in OpenQASM.
+///
+/// It takes two arguments, an array `array` and a zero-based dimension `dim`.
+/// It returns the length of the requested dimension.
+/// Fails if the requested dimension is greater than the number of dimensions
+/// in the array.
+function sizeof_3<'T>(array : 'T[][][], dim : Int) : Int {
+    if dim == 0 {
+        Length(array)
+    } elif dim < 3 {
+        sizeof_2(array[0], dim - 1)
+    } else {
+        fail $"sizeof error: requested dimension {dim} but the array has 3 dimensions";
+    }
+}
+
+/// Function to handle 4-dimensional arrays passed to `sizeof` in OpenQASM.
+///
+/// It takes two arguments, an array `array` and a zero-based dimension `dim`.
+/// It returns the length of the requested dimension.
+/// Fails if the requested dimension is greater than the number of dimensions
+/// in the array.
+function sizeof_4<'T>(array : 'T[][][][], dim : Int) : Int {
+    if dim == 0 {
+        Length(array)
+    } elif dim < 4 {
+        sizeof_3(array[0], dim - 1)
+    } else {
+        fail $"sizeof error: requested dimension {dim} but the array has 4 dimensions";
+    }
+}
+
+/// Function to handle 5-dimensional arrays passed to `sizeof` in OpenQASM.
+///
+/// It takes two arguments, an array `array` and a zero-based dimension `dim`.
+/// It returns the length of the requested dimension.
+/// Fails if the requested dimension is greater than the number of dimensions
+/// in the array.
+function sizeof_5<'T>(array : 'T[][][][][], dim : Int) : Int {
+    if dim == 0 {
+        Length(array)
+    } elif dim < 5 {
+        sizeof_4(array[0], dim - 1)
+    } else {
+        fail $"sizeof error: requested dimension {dim} but the array has 5 dimensions";
+    }
+}
+
+/// Function to handle 6-dimensional arrays passed to `sizeof` in OpenQASM.
+///
+/// It takes two arguments, an array `array` and a zero-based dimension `dim`.
+/// It returns the length of the requested dimension.
+/// Fails if the requested dimension is greater than the number of dimensions
+/// in the array.
+function sizeof_6<'T>(array : 'T[][][][][][], dim : Int) : Int {
+    if dim == 0 {
+        Length(array)
+    } elif dim < 6 {
+        sizeof_5(array[0], dim - 1)
+    } else {
+        fail $"sizeof error: requested dimension {dim} but the array has 6 dimensions";
+    }
+}
+
+/// Function to handle 7-dimensional arrays passed to `sizeof` in OpenQASM.
+///
+/// It takes two arguments, an array `array` and a zero-based dimension `dim`.
+/// It returns the length of the requested dimension.
+/// Fails if the requested dimension is greater than the number of dimensions
+/// in the array.
+function sizeof_7<'T>(array : 'T[][][][][][][], dim : Int) : Int {
+    if dim == 0 {
+        Length(array)
+    } elif dim < 7 {
+        sizeof_6(array[0], dim - 1)
+    } else {
+        fail $"sizeof error: requested dimension {dim} but the array has 7 dimensions";
+    }
+}

--- a/library/std/src/Std/OpenQASM/Builtin.qs
+++ b/library/std/src/Std/OpenQASM/Builtin.qs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 /// This file defines the bultin functions used in the OpenQASM runtime.
+/// It is an internal implementation detail for OpenQASM compilation
+/// and is not intended for use outside of this context.
 
 /// OpenQASM only supports up to seven dimensions,
 /// therefore, we only need these seven `sizeof` functions.

--- a/library/std/src/Std/OpenQASM/Builtin.qs
+++ b/library/std/src/Std/OpenQASM/Builtin.qs
@@ -13,7 +13,7 @@ export sizeof_1, sizeof_2, sizeof_3, sizeof_4, sizeof_5, sizeof_6, sizeof_7;
 /// It returns the length of the requested dimension.
 /// Fails if the requested dimension is greater than the number of dimensions
 /// in the array.
-function sizeof_1<'T>(array : 'T[], dim: Int) : Int {
+function sizeof_1<'T>(array : 'T[], dim : Int) : Int {
     if dim == 0 {
         Length(array)
     } else {

--- a/source/compiler/qsc_qasm/src/ast_builder.rs
+++ b/source/compiler/qsc_qasm/src/ast_builder.rs
@@ -1273,19 +1273,19 @@ pub(crate) fn map_qsharp_type_to_ast_ty(output_ty: &crate::types::Type) -> Ty {
         crate::types::Type::Double(_) => build_path_ident_ty("Double"),
         crate::types::Type::Complex(_) => build_complex_ty_ident(),
         crate::types::Type::Bool(_) => build_path_ident_ty("Bool"),
-        crate::types::Type::ResultArray(dims, _) => build_array_type_name("Result", dims),
-        crate::types::Type::QubitArray(dims) => build_array_type_name("Qubit", dims),
-        crate::types::Type::BigIntArray(dims, _) => build_array_type_name("BigInt", dims),
-        crate::types::Type::IntArray(dims, _) => build_array_type_name("Int", dims),
-        crate::types::Type::DoubleArray(dims) => build_array_type_name("Double", dims),
-        crate::types::Type::BoolArray(dims, _) => build_array_type_name("Bool", dims),
+        crate::types::Type::ResultArray(dims, _) => build_array_type_name("Result", *dims),
+        crate::types::Type::QubitArray(dims) => build_array_type_name("Qubit", *dims),
+        crate::types::Type::BigIntArray(dims, _) => build_array_type_name("BigInt", *dims),
+        crate::types::Type::IntArray(dims, _) => build_array_type_name("Int", *dims),
+        crate::types::Type::DoubleArray(dims) => build_array_type_name("Double", *dims),
+        crate::types::Type::BoolArray(dims, _) => build_array_type_name("Bool", *dims),
         crate::types::Type::ComplexArray(dims, _) => {
             let ty = build_complex_ty_ident();
-            wrap_array_ty_by_dims(dims, ty)
+            wrap_array_ty_by_dims(*dims, ty)
         }
         crate::types::Type::AngleArray(dims, _) => {
             let ty = build_angle_ty_ident();
-            wrap_array_ty_by_dims(dims, ty)
+            wrap_array_ty_by_dims(*dims, ty)
         }
         crate::types::Type::Callable(_, _, _) => todo!(),
         crate::types::Type::Range => build_path_ident_ty("Range"),
@@ -1308,33 +1308,21 @@ pub(crate) fn map_qsharp_type_to_ast_ty(output_ty: &crate::types::Type) -> Ty {
         crate::types::Type::TupleArray(dims, tys) => {
             assert!(!tys.is_empty());
             let ty = map_qsharp_type_to_ast_ty(&crate::types::Type::Tuple(tys.clone()));
-            wrap_array_ty_by_dims(dims, ty)
+            wrap_array_ty_by_dims(*dims, ty)
         }
         crate::types::Type::Err => Ty::default(),
     }
 }
 
-fn wrap_array_ty_by_dims(dims: &ArrayDimensions, ty: Ty) -> Ty {
-    match dims {
-        ArrayDimensions::One(..) => wrap_ty_in_array(ty),
-        ArrayDimensions::Two(..) => wrap_ty_in_array(wrap_ty_in_array(ty)),
-        ArrayDimensions::Three(..) => wrap_ty_in_array(wrap_ty_in_array(wrap_ty_in_array(ty))),
-        ArrayDimensions::Four(..) => {
-            wrap_ty_in_array(wrap_ty_in_array(wrap_ty_in_array(wrap_ty_in_array(ty))))
-        }
-        ArrayDimensions::Five(..) => wrap_ty_in_array(wrap_ty_in_array(wrap_ty_in_array(
-            wrap_ty_in_array(wrap_ty_in_array(ty)),
-        ))),
-        ArrayDimensions::Six(..) => wrap_ty_in_array(wrap_ty_in_array(wrap_ty_in_array(
-            wrap_ty_in_array(wrap_ty_in_array(wrap_ty_in_array(ty))),
-        ))),
-        ArrayDimensions::Seven(..) => wrap_ty_in_array(wrap_ty_in_array(wrap_ty_in_array(
-            wrap_ty_in_array(wrap_ty_in_array(wrap_ty_in_array(wrap_ty_in_array(ty)))),
-        ))),
+fn wrap_array_ty_by_dims(dims: impl Into<u32>, mut ty: Ty) -> Ty {
+    let dims: u32 = dims.into();
+    for _ in 0..dims {
+        ty = wrap_ty_in_array(ty);
     }
+    ty
 }
 
-fn build_array_type_name<S: AsRef<str>>(name: S, dims: &ArrayDimensions) -> Ty {
+fn build_array_type_name<S: AsRef<str>>(name: S, dims: ArrayDimensions) -> Ty {
     let name = name.as_ref();
     let ty = build_path_ident_ty(name);
     wrap_array_ty_by_dims(dims, ty)

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -791,7 +791,13 @@ impl QasmCompiler {
         let array_dims = expr.array_dims;
         assert!((1..=7).contains(&array_dims));
         let fn_name = format!("sizeof_{array_dims}");
-        build_call_with_params(&fn_name, &[], operands, name_span, span)
+        build_call_with_params(
+            &fn_name,
+            &["Std", "OpenQASM", "Builtin"],
+            operands,
+            name_span,
+            span,
+        )
     }
 
     fn compile_gate_call_stmt(&mut self, stmt: &semast::GateCall) -> Option<qsast::Stmt> {

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -789,7 +789,10 @@ impl QasmCompiler {
         let dim = self.compile_expr(&expr.dim);
         let operands = vec![array, dim];
         let array_dims = expr.array_dims;
-        assert!((1..=7).contains(&array_dims), "array dimension should be between 1 and 7");
+        assert!(
+            (1..=7).contains(&array_dims),
+            "array dimension should be between 1 and 7"
+        );
         let fn_name = format!("sizeof_{array_dims}");
         build_call_with_params(
             &fn_name,

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -789,7 +789,7 @@ impl QasmCompiler {
         let dim = self.compile_expr(&expr.dim);
         let operands = vec![array, dim];
         let array_dims = expr.array_dims;
-        assert!((1..=7).contains(&array_dims));
+        assert!((1..=7).contains(&array_dims), "array dimension should be between 1 and 7");
         let fn_name = format!("sizeof_{array_dims}");
         build_call_with_params(
             &fn_name,

--- a/source/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/source/compiler/qsc_qasm/src/semantic/ast.rs
@@ -1173,7 +1173,8 @@ pub struct SizeofCallExpr {
     pub span: Span,
     pub fn_name_span: Span,
     pub array: Expr,
-    pub dim: u32,
+    pub array_dims: u32,
+    pub dim: Expr,
 }
 
 impl Display for SizeofCallExpr {
@@ -1181,6 +1182,7 @@ impl Display for SizeofCallExpr {
         writeln_header(f, "SizeofCallExpr", self.span)?;
         writeln_field(f, "fn_name_span", &self.fn_name_span)?;
         writeln_field(f, "array", &self.array)?;
+        writeln_field(f, "array_dims", &self.array_dims)?;
         write_field(f, "dim", &self.dim)
     }
 }

--- a/source/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/source/compiler/qsc_qasm/src/semantic/ast.rs
@@ -1056,6 +1056,7 @@ pub enum ExprKind {
     IndexedExpr(IndexedExpr),
     Paren(Expr),
     Measure(MeasureExpr),
+    SizeofCall(SizeofCallExpr),
 }
 
 impl Display for ExprKind {
@@ -1072,6 +1073,7 @@ impl Display for ExprKind {
             ExprKind::IndexedExpr(expr) => write!(f, "{expr}"),
             ExprKind::Paren(expr) => write!(f, "Paren {expr}"),
             ExprKind::Measure(expr) => write!(f, "{expr}"),
+            ExprKind::SizeofCall(call) => write!(f, "{call}"),
         }
     }
 }
@@ -1162,6 +1164,24 @@ impl Display for FunctionCall {
         writeln_field(f, "fn_name_span", &self.fn_name_span)?;
         writeln_field(f, "symbol_id", &self.symbol_id)?;
         write_list_field(f, "args", &self.args)
+    }
+}
+
+#[derive(Clone, Debug)]
+
+pub struct SizeofCallExpr {
+    pub span: Span,
+    pub fn_name_span: Span,
+    pub array: Expr,
+    pub dim: u32,
+}
+
+impl Display for SizeofCallExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln_header(f, "SizeofCallExpr", self.span)?;
+        writeln_field(f, "fn_name_span", &self.fn_name_span)?;
+        writeln_field(f, "array", &self.array)?;
+        write_field(f, "dim", &self.dim)
     }
 }
 

--- a/source/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/source/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -44,6 +44,12 @@ pub enum ConstEvalError {
     #[error("{0}")]
     #[diagnostic(code("Qasm.Lowerer.NoValidOverloadForBuiltinFunction"))]
     NoValidOverloadForBuiltinFunction(String, #[label] Span),
+
+    #[error("requested dimension {0} but array has {1} dimensions")]
+    #[help("dimensions are zero-based")]
+    #[diagnostic(code("Qasm.Lowerer.SizeofInvalidDimension"))]
+    SizeofInvalidDimension(usize, usize, #[label] Span),
+
     #[error("too many indices provided")]
     #[diagnostic(code("Qasm.Lowerer.TooManyIndices"))]
     TooManyIndices(#[label] Span),
@@ -104,8 +110,17 @@ impl Expr {
             ExprKind::Cast(cast) => cast.const_eval(ctx),
             ExprKind::IndexedExpr(index_expr) => index_expr.const_eval(ctx, ty),
             ExprKind::Paren(expr) => expr.const_eval(ctx),
-            // Measurements are non-const, so we don't need to implement them.
-            ExprKind::Measure(_) | ExprKind::Err => None,
+            ExprKind::Measure(_) => {
+                // Measurements are non-const, so we don't need to implement them.
+                None
+            }
+            ExprKind::SizeofCall(_) => {
+                // We only lower SizeofCall expressions that should be evaluated
+                // at runtime. The ones that can be const evaluated are hanlded
+                // in [`Lowerer::lower_sizeof_call_expr`].
+                None
+            }
+            ExprKind::Err => None,
         }
     }
 }

--- a/source/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/source/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -44,12 +44,10 @@ pub enum ConstEvalError {
     #[error("{0}")]
     #[diagnostic(code("Qasm.Lowerer.NoValidOverloadForBuiltinFunction"))]
     NoValidOverloadForBuiltinFunction(String, #[label] Span),
-
     #[error("requested dimension {0} but array has {1} dimensions")]
     #[help("dimensions are zero-based")]
     #[diagnostic(code("Qasm.Lowerer.SizeofInvalidDimension"))]
     SizeofInvalidDimension(usize, usize, #[label] Span),
-
     #[error("too many indices provided")]
     #[diagnostic(code("Qasm.Lowerer.TooManyIndices"))]
     TooManyIndices(#[label] Span),

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -4441,7 +4441,7 @@ fn sizeof_invalid_args_error(call_span: Span, inputs: &[Expr]) -> ConstEvalError
     let mut error_msg = String::new();
     write!(
         error_msg,
-        "There is no valid overload of `popcount` for inputs: "
+        "There is no valid overload of `sizeof` for inputs: "
     )
     .expect("write should succeed");
 

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 
 use super::const_eval::ConstEvalError;
 use super::symbols::ScopeKind;
-use super::types::Type;
 use super::types::binop_requires_asymmetric_angle_op;
 use super::types::binop_requires_int_conversion_for_type;
 use super::types::binop_requires_symmetric_uint_conversion;
@@ -21,6 +20,7 @@ use super::types::requires_symmetric_conversion;
 use super::types::try_promote_with_casting;
 use super::types::types_equal_except_const;
 use super::types::unary_op_can_be_applied_to_type;
+use super::types::{ArrayBaseType, Type};
 use num_bigint::BigInt;
 use num_traits::FromPrimitive;
 use num_traits::Num;
@@ -1099,10 +1099,9 @@ impl Lowerer {
     }
 
     fn make_qsharp_array_ty(
-        base_ty: &crate::semantic::types::ArrayBaseType,
+        base_ty: &ArrayBaseType,
         dims: crate::types::ArrayDimensions,
     ) -> crate::types::Type {
-        use crate::semantic::types::ArrayBaseType;
         match base_ty {
             ArrayBaseType::Duration => unreachable!(),
             ArrayBaseType::Bool => crate::types::Type::BoolArray(dims, false),
@@ -1128,8 +1127,6 @@ impl Lowerer {
         ty: &super::types::Type,
         span: Span,
     ) -> crate::types::Type {
-        use crate::semantic::types::ArrayBaseType;
-
         if ty.is_array() && matches!(ty.array_dims(), Some(super::types::ArrayDimensions::Err)) {
             self.push_unsupported_error_message("arrays with more than 7 dimensions", span);
             return crate::types::Type::Err;

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -3003,6 +3003,8 @@ impl Lowerer {
                     self.get_semantic_type_from_array_base_ty(&ref_ty.base_type, ref_ty.span);
                 let Some(num_dims) = self.const_eval_array_size_designator_expr(&ref_ty.dimensions)
                 else {
+                    // `Self::const_eval_array_size_designator_expr` already pushed
+                    // the relevant error message. So we just return `Type::Err` here.
                     return Type::Err;
                 };
 

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -1830,7 +1830,7 @@ impl Lowerer {
 
         // Check that we have 1 or 2 arguments for sizeof.
         if inputs.is_empty() || inputs.len() > 2 {
-            sizeof_invalid_args_error(expr.span, &inputs);
+            self.push_const_eval_error(sizeof_invalid_args_error(expr.span, &inputs));
             return err_expr!(Type::Err, expr.span);
         }
 
@@ -1844,7 +1844,7 @@ impl Lowerer {
 
         // Check that the 2nd argument is a const expr.
         let Some(second_arg) = second_arg.with_const_value(self).get_const_u32() else {
-            sizeof_invalid_args_error(expr.span, &inputs);
+            self.push_const_eval_error(sizeof_invalid_args_error(expr.span, &inputs));
             return err_expr!(Type::Err, expr.span);
         };
 
@@ -1894,7 +1894,7 @@ impl Lowerer {
                 Expr::new(expr.span, kind, Type::UInt(None, false))
             }
             _ => {
-                sizeof_invalid_args_error(expr.span, &inputs);
+                self.push_const_eval_error(sizeof_invalid_args_error(expr.span, &inputs));
                 err_expr!(Type::Err, expr.span)
             }
         }

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -3458,6 +3458,7 @@ impl Lowerer {
                 Self::cast_int_expr_to_type(ty, expr, *width)
             }
             Type::BitArray(size, _) => Self::cast_bitarray_expr_to_type(*size, ty, expr),
+            Type::Array(..) => Self::cast_array_expr_to_type(ty, expr),
             _ => None,
         }
     }
@@ -3607,6 +3608,26 @@ impl Lowerer {
             {
                 Some(wrap_expr_in_cast_expr(ty.clone(), rhs.clone()))
             }
+            _ => None,
+        }
+    }
+
+    fn cast_array_expr_to_type(ty: &Type, expr: &semantic::Expr) -> Option<semantic::Expr> {
+        assert!(matches!(expr.ty, Type::Array(..)));
+
+        match ty {
+            Type::StaticArrayRef(ref_ty) if !ref_ty.is_mutable => Some(Expr {
+                span: expr.span,
+                kind: expr.kind.clone(),
+                const_value: expr.const_value.clone(),
+                ty: ty.clone(),
+            }),
+            Type::DynArrayRef(ref_ty) if !ref_ty.is_mutable => Some(Expr {
+                span: expr.span,
+                kind: expr.kind.clone(),
+                const_value: expr.const_value.clone(),
+                ty: ty.clone(),
+            }),
             _ => None,
         }
     }

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -4488,7 +4488,7 @@ fn sizeof_invalid_args_error(call_span: Span, inputs: &[Expr]) -> ConstEvalError
     .expect("write should succeed");
     write!(
         error_msg,
-        "\n    fn sizeof(array[_, #dim = _], const uint) -> uint"
+        "\n    fn sizeof(array[_, #dim = _], uint) -> uint"
     )
     .expect("write should succeed");
 

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -2954,6 +2954,19 @@ impl Lowerer {
             return Type::Err;
         }
 
+        if dims.is_empty() {
+            self.push_unsupported_error_message("arrays with 0 dimensions", array_ty.span);
+            return Type::Err;
+        }
+
+        if dims.len() > 7 {
+            self.push_unsupported_error_message(
+                "arrays with more than 7 dimensions",
+                array_ty.span,
+            );
+            return Type::Err;
+        }
+
         Type::make_array_ty(&dims, &base_ty)
     }
 
@@ -2972,6 +2985,19 @@ impl Lowerer {
                     return Type::Err;
                 }
 
+                if dims.is_empty() {
+                    self.push_unsupported_error_message("arrays with 0 dimensions", ref_ty.span);
+                    return Type::Err;
+                }
+
+                if dims.len() > 7 {
+                    self.push_unsupported_error_message(
+                        "arrays with more than 7 dimensions",
+                        ref_ty.span,
+                    );
+                    return Type::Err;
+                }
+
                 Type::make_static_array_ref_ty(&dims, &base_ty, is_mutable)
             }
             syntax::ArrayReferenceType::Dyn(ref_ty) => {
@@ -2986,6 +3012,19 @@ impl Lowerer {
                 let num_dims = num_dims
                     .get_const_u32()
                     .expect("we only get here if we have a valid const expr");
+
+                if num_dims == 0 {
+                    self.push_unsupported_error_message("arrays with 0 dimensions", ref_ty.span);
+                    return Type::Err;
+                }
+
+                if num_dims > 7 {
+                    self.push_unsupported_error_message(
+                        "arrays with more than 7 dimensions",
+                        ref_ty.span,
+                    );
+                    return Type::Err;
+                }
 
                 Type::make_dyn_array_ref_ty(num_dims, &base_ty, is_mutable)
             }

--- a/source/compiler/qsc_qasm/src/semantic/tests.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests.rs
@@ -77,6 +77,16 @@ pub(super) fn check_stmt_kind<S: Into<Arc<str>>>(input: S, expect: &Expect) {
     });
 }
 
+pub(super) fn check_last_stmt<S: Into<Arc<str>>>(input: S, expect: &Expect) {
+    check_map(input, expect, |p, _| {
+        p.statements
+            .last()
+            .expect("reading last statement")
+            .kind
+            .to_string()
+    });
+}
+
 pub(super) fn check_stmt_kinds<S: Into<Arc<str>>>(input: S, expect: &Expect) {
     check_map(input, expect, |p, _| {
         p.statements

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions.rs
@@ -15,6 +15,7 @@ mod pow;
 mod rotl;
 mod rotr;
 mod sin;
+mod sizeof;
 mod sqrt;
 mod tan;
 

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
@@ -13,12 +13,31 @@ fn sizeof_no_args() {
     check(
         source,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-40]:
-            symbol_id: 8
-            ty_span: [15-19]
-            init_expr: Expr [31-39]:
-                ty: unknown
-                kind: Err"#]],
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-40]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [9-40]:
+                            symbol_id: 8
+                            ty_span: [15-19]
+                            init_expr: Expr [31-39]:
+                                ty: unknown
+                                kind: Err
+
+            [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `popcount` for inputs: ()
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+               ,-[test:2:31]
+             1 | 
+             2 |         const uint arr_size = sizeof();
+               :                               ^^^^^^^^
+             3 |     
+               `----
+            ]"#]],
     );
 }
 
@@ -31,12 +50,32 @@ fn sizeof_too_many_args() {
     check(
         source,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-47]:
-            symbol_id: 8
-            ty_span: [15-19]
-            init_expr: Expr [31-46]:
-                ty: unknown
-                kind: Err"#]],
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-47]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [9-47]:
+                            symbol_id: 8
+                            ty_span: [15-19]
+                            init_expr: Expr [31-46]:
+                                ty: unknown
+                                kind: Err
+
+            [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `popcount` for inputs: (const int, const
+              | int, const int)
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+               ,-[test:2:31]
+             1 | 
+             2 |         const uint arr_size = sizeof(1, 2, 3);
+               :                               ^^^^^^^^^^^^^^^
+             3 |     
+               `----
+            ]"#]],
     );
 }
 
@@ -49,12 +88,31 @@ fn sizeof_non_array() {
     check(
         source,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-41]:
-            symbol_id: 8
-            ty_span: [15-19]
-            init_expr: Expr [31-40]:
-                ty: unknown
-                kind: Err"#]],
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-41]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [9-41]:
+                            symbol_id: 8
+                            ty_span: [15-19]
+                            init_expr: Expr [31-40]:
+                                ty: unknown
+                                kind: Err
+
+            [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `popcount` for inputs: (const int)
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+               ,-[test:2:31]
+             1 | 
+             2 |         const uint arr_size = sizeof(1);
+               :                               ^^^^^^^^^
+             3 |     
+               `----
+            ]"#]],
     );
 }
 

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
@@ -27,7 +27,7 @@ fn sizeof_no_args_errors() {
 
             [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
 
-              x There is no valid overload of `popcount` for inputs: ()
+              x There is no valid overload of `sizeof` for inputs: ()
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
               |     fn sizeof(array[_, #dim = _], const uint) -> uint
@@ -64,8 +64,8 @@ fn sizeof_too_many_args_errors() {
 
             [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
 
-              x There is no valid overload of `popcount` for inputs: (const int, const
-              | int, const int)
+              x There is no valid overload of `sizeof` for inputs: (const int, const int,
+              | const int)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
               |     fn sizeof(array[_, #dim = _], const uint) -> uint
@@ -102,7 +102,7 @@ fn sizeof_non_array_errors() {
 
             [Qasm.Lowerer.NoValidOverloadForBuiltinFunction
 
-              x There is no valid overload of `popcount` for inputs: (const int)
+              x There is no valid overload of `sizeof` for inputs: (const int)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
               |     fn sizeof(array[_, #dim = _], const uint) -> uint

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
@@ -1,0 +1,523 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::semantic::tests::check_last_stmt as check;
+use expect_test::expect;
+
+#[test]
+fn sizeof_no_args() {
+    let source = "
+        const uint arr_size = sizeof();
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-40]:
+            symbol_id: 8
+            ty_span: [15-19]
+            init_expr: Expr [31-39]:
+                ty: unknown
+                kind: Err"#]],
+    );
+}
+
+#[test]
+fn sizeof_too_many_args() {
+    let source = "
+        const uint arr_size = sizeof(1, 2, 3);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-47]:
+            symbol_id: 8
+            ty_span: [15-19]
+            init_expr: Expr [31-46]:
+                ty: unknown
+                kind: Err"#]],
+    );
+}
+
+#[test]
+fn sizeof_non_array() {
+    let source = "
+        const uint arr_size = sizeof(1);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [9-41]:
+            symbol_id: 8
+            ty_span: [15-19]
+            init_expr: Expr [31-40]:
+                ty: unknown
+                kind: Err"#]],
+    );
+}
+
+#[test]
+fn sizeof_array() {
+    let source = "
+        array[bool, 3, 4] arr;
+        const uint arr_size = sizeof(arr, 1);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [40-77]:
+            symbol_id: 9
+            ty_span: [46-50]
+            init_expr: Expr [62-76]:
+                ty: const uint
+                const_value: Int(4)
+                kind: Lit: Int(4)"#]],
+    );
+}
+
+#[test]
+fn sizeof_array_omitted_dimension() {
+    let source = "
+        array[bool, 3, 4] arr;
+        const uint arr_size = sizeof(arr);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        ClassicalDeclarationStmt [40-74]:
+            symbol_id: 9
+            ty_span: [46-50]
+            init_expr: Expr [62-73]:
+                ty: const uint
+                const_value: Int(3)
+                kind: Lit: Int(3)"#]],
+    );
+}
+
+#[test]
+fn sizeof_array_invalid_dimension_errors() {
+    let source = "
+        array[bool, 3, 4] arr;
+        const uint arr_size = sizeof(arr, 2);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-31]:
+                    annotations: <empty>
+                    kind: ClassicalDeclarationStmt [9-31]:
+                        symbol_id: 8
+                        ty_span: [9-26]
+                        init_expr: Expr [9-31]:
+                            ty: array[bool, 3, 4]
+                            kind: Lit:     array:
+                                    Expr [0-0]:
+                                        ty: array[bool, 4]
+                                        kind: Lit:     array:
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                    Expr [0-0]:
+                                        ty: array[bool, 4]
+                                        kind: Lit:     array:
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                    Expr [0-0]:
+                                        ty: array[bool, 4]
+                                        kind: Lit:     array:
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                Stmt [40-77]:
+                    annotations: <empty>
+                    kind: ClassicalDeclarationStmt [40-77]:
+                        symbol_id: 9
+                        ty_span: [46-50]
+                        init_expr: Expr [62-76]:
+                            ty: unknown
+                            kind: Err
+
+        [Qasm.Lowerer.SizeofInvalidDimension
+
+          x requested dimension 2 but array has 2 dimensions
+           ,-[test:3:31]
+         2 |         array[bool, 3, 4] arr;
+         3 |         const uint arr_size = sizeof(arr, 2);
+           :                               ^^^^^^^^^^^^^^
+         4 |     
+           `----
+        ]"#]],
+    );
+}
+
+#[test]
+fn sizeof_static_array_ref() {
+    let source = "
+        array[bool, 3, 4] arr;
+
+        def f(readonly array[bool, 3, 4] a) {
+            const uint arr_size = sizeof(a, 1);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        DefStmt [41-136]:
+            symbol_id: 9
+            has_qubit_params: false
+            parameters:
+                10
+            return_type: ()
+            body: Block [77-136]:
+                Stmt [91-126]:
+                    annotations: <empty>
+                    kind: ClassicalDeclarationStmt [91-126]:
+                        symbol_id: 11
+                        ty_span: [97-101]
+                        init_expr: Expr [113-125]:
+                            ty: const uint
+                            const_value: Int(4)
+                            kind: Lit: Int(4)"#]],
+    );
+}
+
+#[test]
+fn sizeof_static_array_ref_omitted_dimension() {
+    let source = "
+        array[bool, 3, 4] arr;
+
+        def f(readonly array[bool, 3, 4] a) {
+            const uint arr_size = sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        DefStmt [41-133]:
+            symbol_id: 9
+            has_qubit_params: false
+            parameters:
+                10
+            return_type: ()
+            body: Block [77-133]:
+                Stmt [91-123]:
+                    annotations: <empty>
+                    kind: ClassicalDeclarationStmt [91-123]:
+                        symbol_id: 11
+                        ty_span: [97-101]
+                        init_expr: Expr [113-122]:
+                            ty: const uint
+                            const_value: Int(3)
+                            kind: Lit: Int(3)"#]],
+    );
+}
+
+#[test]
+fn sizeof_static_array_ref_invalid_dimension_errors() {
+    let source = "
+        array[bool, 3, 4] arr;
+
+        def f(readonly array[bool, 3, 4] a) {
+            const uint arr_size = sizeof(a, 2);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            statements:
+                Stmt [9-31]:
+                    annotations: <empty>
+                    kind: ClassicalDeclarationStmt [9-31]:
+                        symbol_id: 8
+                        ty_span: [9-26]
+                        init_expr: Expr [9-31]:
+                            ty: array[bool, 3, 4]
+                            kind: Lit:     array:
+                                    Expr [0-0]:
+                                        ty: array[bool, 4]
+                                        kind: Lit:     array:
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                    Expr [0-0]:
+                                        ty: array[bool, 4]
+                                        kind: Lit:     array:
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                    Expr [0-0]:
+                                        ty: array[bool, 4]
+                                        kind: Lit:     array:
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                                                Expr [9-31]:
+                                                    ty: const bool
+                                                    kind: Lit: Bool(false)
+                Stmt [41-136]:
+                    annotations: <empty>
+                    kind: DefStmt [41-136]:
+                        symbol_id: 9
+                        has_qubit_params: false
+                        parameters:
+                            10
+                        return_type: ()
+                        body: Block [77-136]:
+                            Stmt [91-126]:
+                                annotations: <empty>
+                                kind: ClassicalDeclarationStmt [91-126]:
+                                    symbol_id: 11
+                                    ty_span: [97-101]
+                                    init_expr: Expr [113-125]:
+                                        ty: unknown
+                                        kind: Err
+
+        [Qasm.Lowerer.SizeofInvalidDimension
+
+          x requested dimension 2 but array has 2 dimensions
+           ,-[test:5:35]
+         4 |         def f(readonly array[bool, 3, 4] a) {
+         5 |             const uint arr_size = sizeof(a, 2);
+           :                                   ^^^^^^^^^^^^
+         6 |         }
+           `----
+        ]"#]],
+    );
+}
+
+#[test]
+fn sizeof_dyn_array_ref() {
+    let source = "
+        array[bool, 3, 4] arr;
+
+        def f(readonly array[bool, #dim = 2] a) {
+            uint arr_size = sizeof(a, 1);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        DefStmt [41-134]:
+            symbol_id: 9
+            has_qubit_params: false
+            parameters:
+                10
+            return_type: ()
+            body: Block [81-134]:
+                Stmt [95-124]:
+                    annotations: <empty>
+                    kind: ClassicalDeclarationStmt [95-124]:
+                        symbol_id: 11
+                        ty_span: [95-99]
+                        init_expr: Expr [111-123]:
+                            ty: uint
+                            kind: SizeofCallExpr [111-123]:
+                                fn_name_span: [111-117]
+                                array: Expr [118-119]:
+                                    ty: readonly array[bool, #dim = 2]
+                                    kind: SymbolId(10)
+                                dim: 1"#]],
+    );
+}
+
+#[test]
+fn sizeof_dyn_array_ref_omitted_dimension() {
+    let source = "
+        array[bool, 3, 4] arr;
+
+        def f(readonly array[bool, #dim = 2] a) {
+            uint arr_size = sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            DefStmt [41-131]:
+                symbol_id: 9
+                has_qubit_params: false
+                parameters:
+                    10
+                return_type: ()
+                body: Block [81-131]:
+                    Stmt [95-121]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [95-121]:
+                            symbol_id: 11
+                            ty_span: [95-99]
+                            init_expr: Expr [111-120]:
+                                ty: uint
+                                kind: SizeofCallExpr [111-120]:
+                                    fn_name_span: [111-117]
+                                    array: Expr [118-119]:
+                                        ty: readonly array[bool, #dim = 2]
+                                        kind: SymbolId(10)
+                                    dim: 0"#]],
+    );
+}
+
+#[test]
+fn sizeof_dyn_array_ref_invalid_dimension_errors() {
+    let source = "
+        array[bool, 3, 4] arr;
+
+        def f(readonly array[bool, #dim = 2] a) {
+            uint arr_size = sizeof(a, 2);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Program:
+                version: <none>
+                statements:
+                    Stmt [9-31]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [9-31]:
+                            symbol_id: 8
+                            ty_span: [9-26]
+                            init_expr: Expr [9-31]:
+                                ty: array[bool, 3, 4]
+                                kind: Lit:     array:
+                                        Expr [0-0]:
+                                            ty: array[bool, 4]
+                                            kind: Lit:     array:
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                        Expr [0-0]:
+                                            ty: array[bool, 4]
+                                            kind: Lit:     array:
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                        Expr [0-0]:
+                                            ty: array[bool, 4]
+                                            kind: Lit:     array:
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                                                    Expr [9-31]:
+                                                        ty: const bool
+                                                        kind: Lit: Bool(false)
+                    Stmt [41-134]:
+                        annotations: <empty>
+                        kind: DefStmt [41-134]:
+                            symbol_id: 9
+                            has_qubit_params: false
+                            parameters:
+                                10
+                            return_type: ()
+                            body: Block [81-134]:
+                                Stmt [95-124]:
+                                    annotations: <empty>
+                                    kind: ClassicalDeclarationStmt [95-124]:
+                                        symbol_id: 11
+                                        ty_span: [95-99]
+                                        init_expr: Expr [111-123]:
+                                            ty: unknown
+                                            kind: Err
+
+            [Qasm.Lowerer.SizeofInvalidDimension
+
+              x requested dimension 2 but array has 2 dimensions
+               ,-[test:5:29]
+             4 |         def f(readonly array[bool, #dim = 2] a) {
+             5 |             uint arr_size = sizeof(a, 2);
+               :                             ^^^^^^^^^^^^
+             6 |         }
+               `----
+            ]"#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
@@ -30,7 +30,7 @@ fn sizeof_no_args_errors() {
               x There is no valid overload of `sizeof` for inputs: ()
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
-              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[test:2:31]
              1 | 
              2 |         const uint arr_size = sizeof();
@@ -68,7 +68,7 @@ fn sizeof_too_many_args_errors() {
               | const int)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
-              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[test:2:31]
              1 | 
              2 |         const uint arr_size = sizeof(1, 2, 3);
@@ -105,7 +105,7 @@ fn sizeof_non_array_errors() {
               x There is no valid overload of `sizeof` for inputs: (const int)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
-              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[test:2:31]
              1 | 
              2 |         const uint arr_size = sizeof(1);

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
@@ -5,7 +5,7 @@ use crate::semantic::tests::check_last_stmt as check;
 use expect_test::expect;
 
 #[test]
-fn sizeof_no_args() {
+fn sizeof_no_args_errors() {
     let source = "
         const uint arr_size = sizeof();
     ";
@@ -42,7 +42,7 @@ fn sizeof_no_args() {
 }
 
 #[test]
-fn sizeof_too_many_args() {
+fn sizeof_too_many_args_errors() {
     let source = "
         const uint arr_size = sizeof(1, 2, 3);
     ";
@@ -80,7 +80,7 @@ fn sizeof_too_many_args() {
 }
 
 #[test]
-fn sizeof_non_array() {
+fn sizeof_non_array_errors() {
     let source = "
         const uint arr_size = sizeof(1);
     ";

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
@@ -421,26 +421,29 @@ fn sizeof_dyn_array_ref() {
     check(
         source,
         &expect![[r#"
-        DefStmt [41-134]:
-            symbol_id: 9
-            has_qubit_params: false
-            parameters:
-                10
-            return_type: ()
-            body: Block [81-134]:
-                Stmt [95-124]:
-                    annotations: <empty>
-                    kind: ClassicalDeclarationStmt [95-124]:
-                        symbol_id: 11
-                        ty_span: [95-99]
-                        init_expr: Expr [111-123]:
-                            ty: uint
-                            kind: SizeofCallExpr [111-123]:
-                                fn_name_span: [111-117]
-                                array: Expr [118-119]:
-                                    ty: readonly array[bool, #dim = 2]
-                                    kind: SymbolId(10)
-                                dim: 1"#]],
+            DefStmt [41-134]:
+                symbol_id: 9
+                has_qubit_params: false
+                parameters:
+                    10
+                return_type: ()
+                body: Block [81-134]:
+                    Stmt [95-124]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [95-124]:
+                            symbol_id: 11
+                            ty_span: [95-99]
+                            init_expr: Expr [111-123]:
+                                ty: uint
+                                kind: SizeofCallExpr [111-123]:
+                                    fn_name_span: [111-117]
+                                    array: Expr [118-119]:
+                                        ty: readonly array[bool, #dim = 2]
+                                        kind: SymbolId(10)
+                                    array_dims: 2
+                                    dim: Expr [121-122]:
+                                        ty: const int
+                                        kind: Lit: Int(1)"#]],
     );
 }
 
@@ -476,12 +479,17 @@ fn sizeof_dyn_array_ref_omitted_dimension() {
                                     array: Expr [118-119]:
                                         ty: readonly array[bool, #dim = 2]
                                         kind: SymbolId(10)
-                                    dim: 0"#]],
+                                    array_dims: 2
+                                    dim: Expr [111-120]:
+                                        ty: const uint
+                                        const_value: Int(0)
+                                        kind: Lit: Int(0)"#]],
     );
 }
 
+// This is a runtime failure, so it lowers and compiles wihtout errors.
 #[test]
-fn sizeof_dyn_array_ref_invalid_dimension_errors() {
+fn sizeof_dyn_array_ref_invalid_dimension_lowers_correctly() {
     let source = "
         array[bool, 3, 4] arr;
 
@@ -493,89 +501,28 @@ fn sizeof_dyn_array_ref_invalid_dimension_errors() {
     check(
         source,
         &expect![[r#"
-            Program:
-                version: <none>
-                statements:
-                    Stmt [9-31]:
+            DefStmt [41-134]:
+                symbol_id: 9
+                has_qubit_params: false
+                parameters:
+                    10
+                return_type: ()
+                body: Block [81-134]:
+                    Stmt [95-124]:
                         annotations: <empty>
-                        kind: ClassicalDeclarationStmt [9-31]:
-                            symbol_id: 8
-                            ty_span: [9-26]
-                            init_expr: Expr [9-31]:
-                                ty: array[bool, 3, 4]
-                                kind: Lit:     array:
-                                        Expr [0-0]:
-                                            ty: array[bool, 4]
-                                            kind: Lit:     array:
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                        Expr [0-0]:
-                                            ty: array[bool, 4]
-                                            kind: Lit:     array:
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                        Expr [0-0]:
-                                            ty: array[bool, 4]
-                                            kind: Lit:     array:
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                                                    Expr [9-31]:
-                                                        ty: const bool
-                                                        kind: Lit: Bool(false)
-                    Stmt [41-134]:
-                        annotations: <empty>
-                        kind: DefStmt [41-134]:
-                            symbol_id: 9
-                            has_qubit_params: false
-                            parameters:
-                                10
-                            return_type: ()
-                            body: Block [81-134]:
-                                Stmt [95-124]:
-                                    annotations: <empty>
-                                    kind: ClassicalDeclarationStmt [95-124]:
-                                        symbol_id: 11
-                                        ty_span: [95-99]
-                                        init_expr: Expr [111-123]:
-                                            ty: unknown
-                                            kind: Err
-
-            [Qasm.Lowerer.SizeofInvalidDimension
-
-              x requested dimension 2 but array has 2 dimensions
-               ,-[test:5:29]
-             4 |         def f(readonly array[bool, #dim = 2] a) {
-             5 |             uint arr_size = sizeof(a, 2);
-               :                             ^^^^^^^^^^^^
-             6 |         }
-               `----
-            ]"#]],
+                        kind: ClassicalDeclarationStmt [95-124]:
+                            symbol_id: 11
+                            ty_span: [95-99]
+                            init_expr: Expr [111-123]:
+                                ty: uint
+                                kind: SizeofCallExpr [111-123]:
+                                    fn_name_span: [111-117]
+                                    array: Expr [118-119]:
+                                        ty: readonly array[bool, #dim = 2]
+                                        kind: SymbolId(10)
+                                    array_dims: 2
+                                    dim: Expr [121-122]:
+                                        ty: const int
+                                        kind: Lit: Int(2)"#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/types/tests.rs
+++ b/source/compiler/qsc_qasm/src/semantic/types/tests.rs
@@ -9,6 +9,7 @@ use crate::semantic::ast::ExprKind;
 use crate::semantic::ast::Index;
 use crate::semantic::ast::LiteralKind;
 use crate::semantic::ast::Range;
+use crate::semantic::types::ArrayType;
 use expect_test::expect;
 use qsc_data_structures::span::Span;
 
@@ -23,7 +24,12 @@ fn make_int_expr(val: i64) -> Expr {
 #[test]
 fn indexed_type_has_right_dimensions() {
     let base_ty_builder = || Type::Bool(false);
-    let array_ty_builder = |dims| Type::BoolArray(dims);
+    let array_ty_builder = |dims| {
+        Type::Array(ArrayType {
+            base_ty: crate::semantic::types::ArrayBaseType::Bool,
+            dims,
+        })
+    };
     let dims = ArrayDimensions::Three(2, 3, 4);
 
     let index = Index::Expr(make_int_expr(0));
@@ -35,7 +41,12 @@ fn indexed_type_has_right_dimensions() {
 #[test]
 fn sliced_type_has_right_dimensions() {
     let base_ty_builder = || Type::Bool(false);
-    let array_ty_builder = |dims| Type::BoolArray(dims);
+    let array_ty_builder = |dims| {
+        Type::Array(ArrayType {
+            base_ty: crate::semantic::types::ArrayBaseType::Bool,
+            dims,
+        })
+    };
     let dims = ArrayDimensions::Three(5, 1, 2);
 
     let index = Index::Range(Box::new(Range {

--- a/source/compiler/qsc_qasm/src/tests/expression.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression.rs
@@ -3,6 +3,7 @@
 
 mod binary;
 mod bits;
+mod builtin_functions;
 mod explicit_cast_from_angle;
 mod explicit_cast_from_bit;
 mod explicit_cast_from_bool;

--- a/source/compiler/qsc_qasm/src/tests/expression.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression.rs
@@ -13,6 +13,7 @@ mod explicit_cast_from_int;
 mod explicit_cast_from_uint;
 mod function_call;
 mod ident;
+mod implicit_cast_from_array;
 mod implicit_cast_from_bit;
 mod implicit_cast_from_bitarray;
 mod implicit_cast_from_bool;

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+mod sizeof_array;
+mod sizeof_dyn_array_ref;
+mod sizeof_static_array_ref;

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_array.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_array.rs
@@ -217,3 +217,40 @@ fn sizeof_with_0_dimensional_array_errors() {
         "#]],
     );
 }
+
+#[test]
+fn sizeof_with_non_const_dim_errors() {
+    let source = "
+        array[int, 1] a;
+        uint d;
+        sizeof(a, d);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.ExprMustBeConst
+
+              x expression must be const
+               ,-[Test.qasm:4:19]
+             3 |         uint d;
+             4 |         sizeof(a, d);
+               :                   ^
+             5 |     
+               `----
+
+            Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `sizeof` for inputs: (array[int, 1], uint)
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
+               ,-[Test.qasm:4:9]
+             3 |         uint d;
+             4 |         sizeof(a, d);
+               :         ^^^^^^^^^^^^
+             5 |     
+               `----
+        "#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_array.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_array.rs
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::check_qasm_to_qsharp as check;
+use expect_test::expect;
+
+#[test]
+fn sizeof_with_non_existent_dimension_errors() {
+    let source = "
+        array[int, 1] a;
+        sizeof(a, 4);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.SizeofInvalidDimension
+
+              x requested dimension 4 but array has 1 dimensions
+               ,-[Test.qasm:3:9]
+             2 |         array[int, 1] a;
+             3 |         sizeof(a, 4);
+               :         ^^^^^^^^^^^^
+             4 |     
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_1_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        array[int, 1] a;
+        sizeof(a);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            mutable a = [0];
+            1;
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_2_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        array[int, 1, 2] a;
+        sizeof(a, 1);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            mutable a = [[0, 0]];
+            2;
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_3_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        array[int, 1, 1, 3] a;
+        sizeof(a, 2);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            mutable a = [[[0, 0, 0]]];
+            3;
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_4_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        array[int, 1, 1, 1, 4] a;
+        sizeof(a, 3);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            mutable a = [[[[0, 0, 0, 0]]]];
+            4;
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_5_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        array[int, 1, 1, 1, 1, 5] a;
+        sizeof(a, 4);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            mutable a = [[[[[0, 0, 0, 0, 0]]]]];
+            5;
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_6_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        array[int, 1, 1, 1, 1, 1, 6] a;
+        sizeof(a, 5);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            mutable a = [[[[[[0, 0, 0, 0, 0, 0]]]]]];
+            6;
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_7_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        array[int, 1, 1, 1, 1, 1, 1, 7] a;
+        sizeof(a, 6);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            mutable a = [[[[[[[0, 0, 0, 0, 0, 0, 0]]]]]]];
+            7;
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_8_dimensional_array_errors() {
+    let source = "
+        array[int, 1, 1, 1, 1, 1, 1, 1, 8] a;
+        sizeof(a);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.NotSupported
+
+              x arrays with more than 7 dimensions are not supported
+               ,-[Test.qasm:2:9]
+             1 | 
+             2 |         array[int, 1, 1, 1, 1, 1, 1, 1, 8] a;
+               :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             3 |         sizeof(a);
+               `----
+
+            Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `sizeof` for inputs: (unknown)
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+               ,-[Test.qasm:3:9]
+             2 |         array[int, 1, 1, 1, 1, 1, 1, 1, 8] a;
+             3 |         sizeof(a);
+               :         ^^^^^^^^^
+             4 |     
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_0_dimensional_array_errors() {
+    let source = "
+        array[int, ] a;
+        sizeof(a);
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.NotSupported
+
+              x arrays with 0 dimensions are not supported
+               ,-[Test.qasm:2:9]
+             1 | 
+             2 |         array[int, ] a;
+               :         ^^^^^^^^^^^^
+             3 |         sizeof(a);
+               `----
+
+            Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `sizeof` for inputs: (unknown)
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+               ,-[Test.qasm:3:9]
+             2 |         array[int, ] a;
+             3 |         sizeof(a);
+               :         ^^^^^^^^^
+             4 |     
+               `----
+        "#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_array.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_array.rs
@@ -171,7 +171,7 @@ fn sizeof_with_8_dimensional_array_errors() {
               x There is no valid overload of `sizeof` for inputs: (unknown)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
-              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[Test.qasm:3:9]
              2 |         array[int, 1, 1, 1, 1, 1, 1, 1, 8] a;
              3 |         sizeof(a);
@@ -207,7 +207,7 @@ fn sizeof_with_0_dimensional_array_errors() {
               x There is no valid overload of `sizeof` for inputs: (unknown)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
-              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[Test.qasm:3:9]
              2 |         array[int, ] a;
              3 |         sizeof(a);

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_dyn_array_ref.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_dyn_array_ref.rs
@@ -167,29 +167,29 @@ fn sizeof_with_8_dimensional_array_errors() {
     check(
         source,
         &expect![[r#"
-        Qasm.Lowerer.NotSupported
+            Qasm.Lowerer.NotSupported
 
-          x arrays with more than 7 dimensions are not supported
-           ,-[Test.qasm:2:15]
-         1 | 
-         2 |         def f(readonly array[int, #dim = 8] a) {
-           :               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-         3 |             sizeof(a);
-           `----
+              x arrays with more than 7 dimensions are not supported
+               ,-[Test.qasm:2:15]
+             1 | 
+             2 |         def f(readonly array[int, #dim = 8] a) {
+               :               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             3 |             sizeof(a);
+               `----
 
-        Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+            Qasm.Lowerer.NoValidOverloadForBuiltinFunction
 
-          x There is no valid overload of `sizeof` for inputs: (unknown)
-          | Overloads available are:
-          |     fn sizeof(array[_, ...], const uint) -> const uint
-          |     fn sizeof(array[_, #dim = _], const uint) -> uint
-           ,-[Test.qasm:3:13]
-         2 |         def f(readonly array[int, #dim = 8] a) {
-         3 |             sizeof(a);
-           :             ^^^^^^^^^
-         4 |         }
-           `----
-    "#]],
+              x There is no valid overload of `sizeof` for inputs: (unknown)
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
+               ,-[Test.qasm:3:13]
+             2 |         def f(readonly array[int, #dim = 8] a) {
+             3 |             sizeof(a);
+               :             ^^^^^^^^^
+             4 |         }
+               `----
+        "#]],
     );
 }
 
@@ -219,7 +219,7 @@ fn sizeof_with_0_dimensional_array_errors() {
               x There is no valid overload of `sizeof` for inputs: (unknown)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
-              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[Test.qasm:3:13]
              2 |         def f(readonly array[int, #dim = 0] a) {
              3 |             sizeof(a);

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_dyn_array_ref.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_dyn_array_ref.rs
@@ -26,141 +26,141 @@ fn sizeof_with_non_existent_dimension_generates_correct_qsharp() {
 #[test]
 fn sizeof_with_1_dimensional_array_generates_correct_qsharp() {
     let source = "
-        def f(readonly array[int, #dim = 1] a) {
-            sizeof(a);
+        def f(readonly array[int, #dim = 1] a, uint d) {
+            sizeof(a, d);
         }
     ";
 
     check(
         source,
         &expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        function f(a : Int[]) : Unit {
-            Std.OpenQASM.Builtin.sizeof_1(a, 0);
-        }
-    "#]],
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[], d : Int) : Unit {
+                Std.OpenQASM.Builtin.sizeof_1(a, d);
+            }
+        "#]],
     );
 }
 
 #[test]
 fn sizeof_with_2_dimensional_array_generates_correct_qsharp() {
     let source = "
-        def f(readonly array[int, #dim = 2] a) {
-            sizeof(a);
+        def f(readonly array[int, #dim = 2] a, uint d) {
+            sizeof(a, d);
         }
     ";
 
     check(
         source,
         &expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        function f(a : Int[][]) : Unit {
-            Std.OpenQASM.Builtin.sizeof_2(a, 0);
-        }
-    "#]],
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][], d : Int) : Unit {
+                Std.OpenQASM.Builtin.sizeof_2(a, d);
+            }
+        "#]],
     );
 }
 
 #[test]
 fn sizeof_with_3_dimensional_array_generates_correct_qsharp() {
     let source = "
-        def f(readonly array[int, #dim = 3] a) {
-            sizeof(a);
+        def f(readonly array[int, #dim = 3] a, uint d) {
+            sizeof(a, d);
         }
     ";
 
     check(
         source,
         &expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        function f(a : Int[][][]) : Unit {
-            Std.OpenQASM.Builtin.sizeof_3(a, 0);
-        }
-    "#]],
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][], d : Int) : Unit {
+                Std.OpenQASM.Builtin.sizeof_3(a, d);
+            }
+        "#]],
     );
 }
 
 #[test]
 fn sizeof_with_4_dimensional_array_generates_correct_qsharp() {
     let source = "
-        def f(readonly array[int, #dim = 4] a) {
-            sizeof(a);
+        def f(readonly array[int, #dim = 4] a, uint d) {
+            sizeof(a, d);
         }
     ";
 
     check(
         source,
         &expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        function f(a : Int[][][][]) : Unit {
-            Std.OpenQASM.Builtin.sizeof_4(a, 0);
-        }
-    "#]],
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][][], d : Int) : Unit {
+                Std.OpenQASM.Builtin.sizeof_4(a, d);
+            }
+        "#]],
     );
 }
 
 #[test]
 fn sizeof_with_5_dimensional_array_generates_correct_qsharp() {
     let source = "
-        def f(readonly array[int, #dim = 5] a) {
-            sizeof(a);
+        def f(readonly array[int, #dim = 5] a, uint d) {
+            sizeof(a, d);
         }
     ";
 
     check(
         source,
         &expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        function f(a : Int[][][][][]) : Unit {
-            Std.OpenQASM.Builtin.sizeof_5(a, 0);
-        }
-    "#]],
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][][][], d : Int) : Unit {
+                Std.OpenQASM.Builtin.sizeof_5(a, d);
+            }
+        "#]],
     );
 }
 
 #[test]
 fn sizeof_with_6_dimensional_array_generates_correct_qsharp() {
     let source = "
-        def f(readonly array[int, #dim = 6] a) {
-            sizeof(a);
+        def f(readonly array[int, #dim = 6] a, uint d) {
+            sizeof(a, d);
         }
     ";
 
     check(
         source,
         &expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        function f(a : Int[][][][][][]) : Unit {
-            Std.OpenQASM.Builtin.sizeof_6(a, 0);
-        }
-    "#]],
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][][][][], d : Int) : Unit {
+                Std.OpenQASM.Builtin.sizeof_6(a, d);
+            }
+        "#]],
     );
 }
 
 #[test]
 fn sizeof_with_7_dimensional_array_generates_correct_qsharp() {
     let source = "
-        def f(readonly array[int, #dim = 7] a) {
-            sizeof(a);
+        def f(readonly array[int, #dim = 7] a, uint d) {
+            sizeof(a, d);
         }
     ";
 
     check(
         source,
         &expect![[r#"
-        import Std.OpenQASM.Intrinsic.*;
-        function f(a : Int[][][][][][][]) : Unit {
-            Std.OpenQASM.Builtin.sizeof_7(a, 0);
-        }
-    "#]],
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][][][][][], d : Int) : Unit {
+                Std.OpenQASM.Builtin.sizeof_7(a, d);
+            }
+        "#]],
     );
 }
 
 #[test]
 fn sizeof_with_8_dimensional_array_errors() {
     let source = "
-        def f(readonly array[int, #dim = 8] a) {
-            sizeof(a);
+        def f(readonly array[int, #dim = 8] a, uint d) {
+            sizeof(a, d);
         }
     ";
 
@@ -172,21 +172,21 @@ fn sizeof_with_8_dimensional_array_errors() {
               x arrays with more than 7 dimensions are not supported
                ,-[Test.qasm:2:15]
              1 | 
-             2 |         def f(readonly array[int, #dim = 8] a) {
+             2 |         def f(readonly array[int, #dim = 8] a, uint d) {
                :               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             3 |             sizeof(a);
+             3 |             sizeof(a, d);
                `----
 
             Qasm.Lowerer.NoValidOverloadForBuiltinFunction
 
-              x There is no valid overload of `sizeof` for inputs: (unknown)
+              x There is no valid overload of `sizeof` for inputs: (unknown, uint)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
               |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[Test.qasm:3:13]
-             2 |         def f(readonly array[int, #dim = 8] a) {
-             3 |             sizeof(a);
-               :             ^^^^^^^^^
+             2 |         def f(readonly array[int, #dim = 8] a, uint d) {
+             3 |             sizeof(a, d);
+               :             ^^^^^^^^^^^^
              4 |         }
                `----
         "#]],
@@ -196,8 +196,8 @@ fn sizeof_with_8_dimensional_array_errors() {
 #[test]
 fn sizeof_with_0_dimensional_array_errors() {
     let source = "
-        def f(readonly array[int, #dim = 0] a) {
-            sizeof(a);
+        def f(readonly array[int, #dim = 0] a, uint d) {
+            sizeof(a, d);
         }
     ";
 
@@ -209,21 +209,21 @@ fn sizeof_with_0_dimensional_array_errors() {
               x arrays with 0 dimensions are not supported
                ,-[Test.qasm:2:15]
              1 | 
-             2 |         def f(readonly array[int, #dim = 0] a) {
+             2 |         def f(readonly array[int, #dim = 0] a, uint d) {
                :               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             3 |             sizeof(a);
+             3 |             sizeof(a, d);
                `----
 
             Qasm.Lowerer.NoValidOverloadForBuiltinFunction
 
-              x There is no valid overload of `sizeof` for inputs: (unknown)
+              x There is no valid overload of `sizeof` for inputs: (unknown, uint)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
               |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[Test.qasm:3:13]
-             2 |         def f(readonly array[int, #dim = 0] a) {
-             3 |             sizeof(a);
-               :             ^^^^^^^^^
+             2 |         def f(readonly array[int, #dim = 0] a, uint d) {
+             3 |             sizeof(a, d);
+               :             ^^^^^^^^^^^^
              4 |         }
                `----
         "#]],

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_dyn_array_ref.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_dyn_array_ref.rs
@@ -1,0 +1,231 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::check_qasm_to_qsharp as check;
+use expect_test::expect;
+
+#[test]
+fn sizeof_with_non_existent_dimension_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, #dim = 1] a) {
+            sizeof(a, 4);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function f(a : Int[]) : Unit {
+            Std.OpenQASM.Builtin.sizeof_1(a, 4);
+        }
+    "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_1_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, #dim = 1] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function f(a : Int[]) : Unit {
+            Std.OpenQASM.Builtin.sizeof_1(a, 0);
+        }
+    "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_2_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, #dim = 2] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function f(a : Int[][]) : Unit {
+            Std.OpenQASM.Builtin.sizeof_2(a, 0);
+        }
+    "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_3_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, #dim = 3] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function f(a : Int[][][]) : Unit {
+            Std.OpenQASM.Builtin.sizeof_3(a, 0);
+        }
+    "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_4_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, #dim = 4] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function f(a : Int[][][][]) : Unit {
+            Std.OpenQASM.Builtin.sizeof_4(a, 0);
+        }
+    "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_5_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, #dim = 5] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function f(a : Int[][][][][]) : Unit {
+            Std.OpenQASM.Builtin.sizeof_5(a, 0);
+        }
+    "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_6_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, #dim = 6] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function f(a : Int[][][][][][]) : Unit {
+            Std.OpenQASM.Builtin.sizeof_6(a, 0);
+        }
+    "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_7_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, #dim = 7] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        function f(a : Int[][][][][][][]) : Unit {
+            Std.OpenQASM.Builtin.sizeof_7(a, 0);
+        }
+    "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_8_dimensional_array_errors() {
+    let source = "
+        def f(readonly array[int, #dim = 8] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+        Qasm.Lowerer.NotSupported
+
+          x arrays with more than 7 dimensions are not supported
+           ,-[Test.qasm:2:15]
+         1 | 
+         2 |         def f(readonly array[int, #dim = 8] a) {
+           :               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+         3 |             sizeof(a);
+           `----
+
+        Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+          x There is no valid overload of `sizeof` for inputs: (unknown)
+          | Overloads available are:
+          |     fn sizeof(array[_, ...], const uint) -> const uint
+          |     fn sizeof(array[_, #dim = _], const uint) -> uint
+           ,-[Test.qasm:3:13]
+         2 |         def f(readonly array[int, #dim = 8] a) {
+         3 |             sizeof(a);
+           :             ^^^^^^^^^
+         4 |         }
+           `----
+    "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_0_dimensional_array_errors() {
+    let source = "
+        def f(readonly array[int, #dim = 0] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.NotSupported
+
+              x arrays with 0 dimensions are not supported
+               ,-[Test.qasm:2:15]
+             1 | 
+             2 |         def f(readonly array[int, #dim = 0] a) {
+               :               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             3 |             sizeof(a);
+               `----
+
+            Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `sizeof` for inputs: (unknown)
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+               ,-[Test.qasm:3:13]
+             2 |         def f(readonly array[int, #dim = 0] a) {
+             3 |             sizeof(a);
+               :             ^^^^^^^^^
+             4 |         }
+               `----
+        "#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_static_array_ref.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_static_array_ref.rs
@@ -187,7 +187,7 @@ fn sizeof_with_8_dimensional_array_errors() {
               x There is no valid overload of `sizeof` for inputs: (unknown)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
-              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[Test.qasm:3:13]
              2 |         def f(readonly array[int, 1, 1, 1, 1, 1, 1, 1, 8] a) {
              3 |             sizeof(a);
@@ -224,7 +224,7 @@ fn sizeof_with_0_dimensional_array_errors() {
               x There is no valid overload of `sizeof` for inputs: (unknown)
               | Overloads available are:
               |     fn sizeof(array[_, ...], const uint) -> const uint
-              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+              |     fn sizeof(array[_, #dim = _], uint) -> uint
                ,-[Test.qasm:3:13]
              2 |         def f(readonly array[int, ] a) {
              3 |             sizeof(a);

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_static_array_ref.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_static_array_ref.rs
@@ -146,22 +146,17 @@ fn sizeof_with_6_dimensional_array_generates_correct_qsharp() {
 fn sizeof_with_7_dimensional_array_generates_correct_qsharp() {
     let source = "
         def f(readonly array[int, 1, 1, 1, 1, 1, 1, 7] a) {
-            sizeof(a, 7);
+            sizeof(a, 6);
         }
     ";
 
     check(
         source,
         &expect![[r#"
-            Qasm.Lowerer.SizeofInvalidDimension
-
-              x requested dimension 7 but array has 7 dimensions
-               ,-[Test.qasm:3:13]
-             2 |         def f(readonly array[int, 1, 1, 1, 1, 1, 1, 7] a) {
-             3 |             sizeof(a, 7);
-               :             ^^^^^^^^^^^^
-             4 |         }
-               `----
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][][][][][]) : Unit {
+                7;
+            }
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_static_array_ref.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/builtin_functions/sizeof_static_array_ref.rs
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::check_qasm_to_qsharp as check;
+use expect_test::expect;
+
+#[test]
+fn sizeof_with_non_existent_dimension_errors() {
+    let source = "
+        def f(readonly array[int, 1] a) {
+            sizeof(a, 4);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.SizeofInvalidDimension
+
+              x requested dimension 4 but array has 1 dimensions
+               ,-[Test.qasm:3:13]
+             2 |         def f(readonly array[int, 1] a) {
+             3 |             sizeof(a, 4);
+               :             ^^^^^^^^^^^^
+             4 |         }
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_1_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, 1] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[]) : Unit {
+                1;
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_2_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, 1, 2] a) {
+            sizeof(a, 1);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][]) : Unit {
+                2;
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_3_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, 1, 1, 3] a) {
+            sizeof(a, 2);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][]) : Unit {
+                3;
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_4_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, 1, 1, 1, 4] a) {
+            sizeof(a, 3);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][][]) : Unit {
+                4;
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_5_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, 1, 1, 1, 1, 5] a) {
+            sizeof(a, 4);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][][][]) : Unit {
+                5;
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_6_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, 1, 1, 1, 1, 1, 6] a) {
+            sizeof(a, 5);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            function f(a : Int[][][][][][]) : Unit {
+                6;
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_7_dimensional_array_generates_correct_qsharp() {
+    let source = "
+        def f(readonly array[int, 1, 1, 1, 1, 1, 1, 7] a) {
+            sizeof(a, 7);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.SizeofInvalidDimension
+
+              x requested dimension 7 but array has 7 dimensions
+               ,-[Test.qasm:3:13]
+             2 |         def f(readonly array[int, 1, 1, 1, 1, 1, 1, 7] a) {
+             3 |             sizeof(a, 7);
+               :             ^^^^^^^^^^^^
+             4 |         }
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_8_dimensional_array_errors() {
+    let source = "
+        def f(readonly array[int, 1, 1, 1, 1, 1, 1, 1, 8] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.NotSupported
+
+              x arrays with more than 7 dimensions are not supported
+               ,-[Test.qasm:2:15]
+             1 | 
+             2 |         def f(readonly array[int, 1, 1, 1, 1, 1, 1, 1, 8] a) {
+               :               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             3 |             sizeof(a);
+               `----
+
+            Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `sizeof` for inputs: (unknown)
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+               ,-[Test.qasm:3:13]
+             2 |         def f(readonly array[int, 1, 1, 1, 1, 1, 1, 1, 8] a) {
+             3 |             sizeof(a);
+               :             ^^^^^^^^^
+             4 |         }
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn sizeof_with_0_dimensional_array_errors() {
+    let source = "
+        def f(readonly array[int, ] a) {
+            sizeof(a);
+        }
+    ";
+
+    check(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.NotSupported
+
+              x arrays with 0 dimensions are not supported
+               ,-[Test.qasm:2:15]
+             1 | 
+             2 |         def f(readonly array[int, ] a) {
+               :               ^^^^^^^^^^^^^^^^^^^^^
+             3 |             sizeof(a);
+               `----
+
+            Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+              x There is no valid overload of `sizeof` for inputs: (unknown)
+              | Overloads available are:
+              |     fn sizeof(array[_, ...], const uint) -> const uint
+              |     fn sizeof(array[_, #dim = _], const uint) -> uint
+               ,-[Test.qasm:3:13]
+             2 |         def f(readonly array[int, ] a) {
+             3 |             sizeof(a);
+               :             ^^^^^^^^^
+             4 |         }
+               `----
+        "#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_array.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/implicit_cast_from_array.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::check_qasm_to_qsharp;
+use expect_test::expect;
+
+#[test]
+fn to_static_array_ref() {
+    let source = "
+    array[bool, 3, 4] arr;
+    def f(readonly array[bool, 3, 4] a) {}
+    f(arr);
+    ";
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        mutable arr = [[false, false, false, false], [false, false, false, false], [false, false, false, false]];
+        function f(a : Bool[][]) : Unit {}
+        f(arr);
+    "#]],
+    );
+}
+
+#[test]
+fn to_dyn_array_ref() {
+    let source = "
+    array[bool, 3, 4] arr;
+    def f(readonly array[bool, #dim = 2] a) {}
+    f(arr);
+    ";
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        mutable arr = [[false, false, false, false], [false, false, false, false], [false, false, false, false]];
+        function f(a : Bool[][]) : Unit {}
+        f(arr);
+    "#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/types.rs
+++ b/source/compiler/qsc_qasm/src/types.rs
@@ -59,74 +59,57 @@ impl Display for CallableKind {
     }
 }
 
-/// QASM supports up to seven dimensions, but we are going to limit it to three.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// QASM supports up to seven dimensions.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ArrayDimensions {
-    One(usize),
-    Two(usize, usize),
-    Three(usize, usize, usize),
-    Four(usize, usize, usize, usize),
-    Five(usize, usize, usize, usize, usize),
-    Six(usize, usize, usize, usize, usize, usize),
-    Seven(usize, usize, usize, usize, usize, usize, usize),
+    One,
+    Two,
+    Three,
+    Four,
+    Five,
+    Six,
+    Seven,
+}
+
+impl From<ArrayDimensions> for u32 {
+    fn from(value: ArrayDimensions) -> Self {
+        match value {
+            ArrayDimensions::One => 1,
+            ArrayDimensions::Two => 2,
+            ArrayDimensions::Three => 3,
+            ArrayDimensions::Four => 4,
+            ArrayDimensions::Five => 5,
+            ArrayDimensions::Six => 6,
+            ArrayDimensions::Seven => 7,
+        }
+    }
+}
+
+impl From<u32> for ArrayDimensions {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => Self::One,
+            2 => Self::Two,
+            3 => Self::Three,
+            4 => Self::Four,
+            5 => Self::Five,
+            6 => Self::Six,
+            7 => Self::Seven,
+            _ => unreachable!("we validate that num_dims is between 1 and 7 when generating them"),
+        }
+    }
 }
 
 impl From<&crate::semantic::types::ArrayDimensions> for ArrayDimensions {
     fn from(value: &crate::semantic::types::ArrayDimensions) -> Self {
         match value {
-            crate::semantic::types::ArrayDimensions::One(dim) => {
-                ArrayDimensions::One(*dim as usize)
-            }
-            crate::semantic::types::ArrayDimensions::Two(dim1, dim2) => {
-                ArrayDimensions::Two(*dim1 as usize, *dim2 as usize)
-            }
-            crate::semantic::types::ArrayDimensions::Three(dim1, dim2, dim3) => {
-                ArrayDimensions::Three(*dim1 as usize, *dim2 as usize, *dim3 as usize)
-            }
-            crate::semantic::types::ArrayDimensions::Four(dim1, dim2, dim3, dim4) => {
-                ArrayDimensions::Four(
-                    *dim1 as usize,
-                    *dim2 as usize,
-                    *dim3 as usize,
-                    *dim4 as usize,
-                )
-            }
-            crate::semantic::types::ArrayDimensions::Five(dim1, dim2, dim3, dim4, dim5) => {
-                ArrayDimensions::Five(
-                    *dim1 as usize,
-                    *dim2 as usize,
-                    *dim3 as usize,
-                    *dim4 as usize,
-                    *dim5 as usize,
-                )
-            }
-            crate::semantic::types::ArrayDimensions::Six(dim1, dim2, dim3, dim4, dim5, dim6) => {
-                ArrayDimensions::Six(
-                    *dim1 as usize,
-                    *dim2 as usize,
-                    *dim3 as usize,
-                    *dim4 as usize,
-                    *dim5 as usize,
-                    *dim6 as usize,
-                )
-            }
-            crate::semantic::types::ArrayDimensions::Seven(
-                dim1,
-                dim2,
-                dim3,
-                dim4,
-                dim5,
-                dim6,
-                dim7,
-            ) => ArrayDimensions::Seven(
-                *dim1 as usize,
-                *dim2 as usize,
-                *dim3 as usize,
-                *dim4 as usize,
-                *dim5 as usize,
-                *dim6 as usize,
-                *dim7 as usize,
-            ),
+            crate::semantic::types::ArrayDimensions::One(..) => Self::One,
+            crate::semantic::types::ArrayDimensions::Two(..) => Self::Two,
+            crate::semantic::types::ArrayDimensions::Three(..) => Self::Three,
+            crate::semantic::types::ArrayDimensions::Four(..) => Self::Four,
+            crate::semantic::types::ArrayDimensions::Five(..) => Self::Five,
+            crate::semantic::types::ArrayDimensions::Six(..) => Self::Six,
+            crate::semantic::types::ArrayDimensions::Seven(..) => Self::Seven,
             crate::semantic::types::ArrayDimensions::Err => {
                 unimplemented!("Array dimensions greater than seven are not supported.")
             }
@@ -185,13 +168,13 @@ impl Display for Type {
 impl Display for ArrayDimensions {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ArrayDimensions::One(..) => write!(f, "[]"),
-            ArrayDimensions::Two(..) => write!(f, "[][]"),
-            ArrayDimensions::Three(..) => write!(f, "[][][]"),
-            ArrayDimensions::Four(..) => write!(f, "[][][][]"),
-            ArrayDimensions::Five(..) => write!(f, "[][][][][]"),
-            ArrayDimensions::Six(..) => write!(f, "[][][][][][]"),
-            ArrayDimensions::Seven(..) => write!(f, "[][][][][][][]"),
+            Self::One => write!(f, "[]"),
+            Self::Two => write!(f, "[][]"),
+            Self::Three => write!(f, "[][][]"),
+            Self::Four => write!(f, "[][][][]"),
+            Self::Five => write!(f, "[][][][][]"),
+            Self::Six => write!(f, "[][][][][][]"),
+            Self::Seven => write!(f, "[][][][][][][]"),
         }
     }
 }

--- a/source/compiler/qsc_qasm/src/types.rs
+++ b/source/compiler/qsc_qasm/src/types.rs
@@ -62,26 +62,18 @@ impl Display for CallableKind {
 /// QASM supports up to seven dimensions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ArrayDimensions {
-    One,
-    Two,
-    Three,
-    Four,
-    Five,
-    Six,
-    Seven,
+    One = 1,
+    Two = 2,
+    Three = 3,
+    Four = 4,
+    Five = 5,
+    Six = 6,
+    Seven = 7,
 }
 
 impl From<ArrayDimensions> for u32 {
     fn from(value: ArrayDimensions) -> Self {
-        match value {
-            ArrayDimensions::One => 1,
-            ArrayDimensions::Two => 2,
-            ArrayDimensions::Three => 3,
-            ArrayDimensions::Four => 4,
-            ArrayDimensions::Five => 5,
-            ArrayDimensions::Six => 6,
-            ArrayDimensions::Seven => 7,
-        }
+        value as u32
     }
 }
 


### PR DESCRIPTION
This PR adds support for the `sizeof` builtin to OpenQASM. As part of the necessary things to make `sizeof` work in all supported cases, it also adds support for `readonly array[_, ...]` input types in subroutines.