### PR TITLE
Remove wasm-pack dependency

### DIFF
--- a/prereqs.py
+++ b/prereqs.py
@@ -4,7 +4,6 @@
 # Licensed under the MIT License.
 
 import os
-import urllib.request
 import platform
 import re
 import sys
@@ -13,14 +12,15 @@ import tempfile
 import functools
 
 python_ver = (3, 11)  # Python support for Windows on ARM64 requires v3.11 or later
-rust_ver = (1, 88)  # Ensure Rust version 1.88 or later is installed
-node_ver = (
-    20,
-    18,
-)
-wasmpack_ver = (0, 12, 1)  # Latest tested wasm-pack version
+rust_ver = (1, 88, 0)  # Ensure Rust version 1.88 or later is installed
+node_ver = (20, 18, 0)
 rust_fmt_ver = (1, 8, 0)  # Current version when Rust 1.88 shipped
 clippy_ver = (0, 1, 88)
+wasm_bindgen_ver = (0, 2, 100)
+binaryen_ver = 123
+
+platform_sys = platform.system().lower()  # 'windows', 'darwin', or 'linux'
+platform_arch = "arm64" if platform.machine().lower() in ["aarch64", "arm64"] else "x64"
 
 # Disable buffered output so that the log statements and subprocess output get interleaved in proper order
 print = functools.partial(print, flush=True)
@@ -33,6 +33,18 @@ def get_installed_rust_targets() -> str:
     except subprocess.CalledProcessError as e:
         message = f"Unable to determine installed rust targets: {str(e)}"
         raise Exception(message)
+
+
+def get_wasm_env() -> dict[str, str]:
+    # Add the default wasm utility directories to the end of the PATH
+    wasm_bindgen_path = os.path.expanduser("~/wasm-bindgen")
+    binaryen_path = os.path.expanduser("~/binaryen/bin")
+
+    env = os.environ.copy()
+    env["PATH"] = (
+        env["PATH"] + os.pathsep + wasm_bindgen_path + os.pathsep + binaryen_path
+    )
+    return env
 
 
 def check_prereqs(install=False, skip_wasm=False):
@@ -54,15 +66,12 @@ def check_prereqs(install=False, skip_wasm=False):
         print("Node.js not found. Please install from https://nodejs.org/")
         exit(1)
 
-    version_match = re.search(r"v(\d+)\.(\d+)\.\d+", node_version.decode())
-    if version_match:
-        node_major = int(version_match.group(1))
-        node_minor = int(version_match.group(2))
-        if node_major < node_ver[0] or (
-            node_major == node_ver[0] and node_minor < node_ver[1]
-        ):
+    ver_match = re.search(r"v(\d+)\.(\d+)\.(\d+)", node_version.decode())
+    if ver_match:
+        found_ver = tuple(int(g) for g in ver_match.groups())
+        if found_ver < node_ver:
             print(
-                f"Node.js v{node_ver[0]}.{node_ver[1]} or later is required. Please update."
+                f"Node.js v{node_ver[0]}.{node_ver[1]}.{node_ver[2]} or later is required. Please update."
             )
             exit(1)
     else:
@@ -76,13 +85,10 @@ def check_prereqs(install=False, skip_wasm=False):
         print("Rust compiler not found. Install from https://rustup.rs/")
         exit(1)
 
-    version_match = re.search(r"rustc (\d+)\.(\d+).\d+", rust_version.decode())
-    if version_match:
-        rust_major = int(version_match.group(1))
-        rust_minor = int(version_match.group(2))
-        if rust_major < rust_ver[0] or (
-            rust_major == rust_ver[0] and rust_minor < rust_ver[1]
-        ):
+    ver_match = re.search(r"rustc (\d+)\.(\d+)\.(\d+)", rust_version.decode())
+    if ver_match:
+        found_ver = tuple(int(g) for g in ver_match.groups())
+        if found_ver < rust_ver:
             print(
                 f'Rust v{rust_ver[0]}.{rust_ver[1]} or later is required. Please update with "rustup update"'
             )
@@ -98,15 +104,12 @@ def check_prereqs(install=False, skip_wasm=False):
         print("cargo fmt not found. Install via rustup component add rustfmt")
         exit(1)
 
-    version_match = re.search(r"rustfmt (\d+)\.(\d+)\.(\d+)", rust_fmt_version.decode())
-    if version_match:
-        rustfmt_major = int(version_match.group(1))
-        rustfmt_minor = int(version_match.group(2))
-        if rustfmt_major < rust_fmt_ver[0] or (
-            rustfmt_major == rust_fmt_ver[0] and rustfmt_minor < rust_fmt_ver[1]
-        ):
+    ver_match = re.search(r"rustfmt (\d+)\.(\d+)\.(\d+)", rust_fmt_version.decode())
+    if ver_match:
+        found_ver = tuple(int(g) for g in ver_match.groups())
+        if found_ver < rust_fmt_ver:
             print(
-                f"cargo fmt v{rust_fmt_ver[0]}.{rust_fmt_ver[1]} or later is required. Please update"
+                f"cargo fmt v{rust_fmt_ver[0]}.{rust_fmt_ver[1]}.{rust_fmt_ver[2]} or later is required. Please update"
             )
             exit(1)
     else:
@@ -120,22 +123,12 @@ def check_prereqs(install=False, skip_wasm=False):
         print("cargo clippy not found. Install via rustup component add clippy")
         exit(1)
 
-    version_match = re.search(r"clippy (\d+)\.(\d+)\.(\d+)", clippy_version.decode())
-    if version_match:
-        clippy_major = int(version_match.group(1))
-        clippy_minor = int(version_match.group(2))
-        clippy_patch = int(version_match.group(3))
-        if (
-            clippy_major < clippy_ver[0]
-            or (clippy_major == clippy_ver[0] and clippy_minor < clippy_ver[1])
-            or (
-                clippy_major == clippy_ver[0]
-                and clippy_minor == clippy_ver[1]
-                and clippy_patch < clippy_ver[2]
-            )
-        ):
+    ver_match = re.search(r"clippy (\d+)\.(\d+)\.(\d+)", clippy_version.decode())
+    if ver_match:
+        found_ver = tuple(int(g) for g in ver_match.groups())
+        if found_ver < clippy_ver:
             print(
-                f"clippy v{clippy_ver[0]}.{clippy_ver[1]}.{clippy_ver[2]} or later is required. Please update"
+                f"clippy v{clippy_ver[0]}.{clippy_ver[1]}.{clippy_ver[2]} or later is required. Please update with 'rustup component add clippy'"
             )
             exit(1)
     else:
@@ -144,7 +137,7 @@ def check_prereqs(install=False, skip_wasm=False):
     installed_rust_targets = get_installed_rust_targets()
 
     # On MacOS, ensure the required targets are installed
-    if platform.system() == "Darwin":
+    if platform_sys == "darwin":
         targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
         if not all(target in installed_rust_targets for target in targets):
             print("One or both rust targets are not installed.")
@@ -157,60 +150,132 @@ def check_prereqs(install=False, skip_wasm=False):
 
 
 def wasm_checks(install, installed_rust_targets):
-    ### Check the wasm_pack version ###
+    env = get_wasm_env()
+    ### Check the wasm-bindgen version ###
     try:
-        wasm_pack_version = subprocess.check_output(["wasm-pack", "--version"])
-        print(f"Detected wasm-pack version {wasm_pack_version.decode()}")
+        wasm_bindgen_version = subprocess.check_output(
+            ["wasm-bindgen", "--version"], env=env
+        )
+        print(f"Detected wasm-bindgen version: {wasm_bindgen_version.decode()}")
     except FileNotFoundError:
         if install == True:
-            if platform.system() == "Windows":
-                ver_str = f"v{wasmpack_ver[0]}.{wasmpack_ver[1]}.{wasmpack_ver[2]}"
-                with urllib.request.urlopen(
-                    f"https://github.com/rustwasm/wasm-pack/releases/download/{ver_str}/wasm-pack-init.exe"
-                ) as wasm_exe:
-                    exe_bytes = wasm_exe.read()
-                    tmp_dir = os.getenv("RUNNER_TEMP", default=tempfile.gettempdir())
-                    file_name = os.path.join(tmp_dir, "wasm-pack-init.exe")
-                    with open(file_name, "wb") as exe_file:
-                        exe_file.write(exe_bytes)
-                    print("Attempting to install wasm-pack")
-                    subprocess.run([file_name, "/q"], check=True)
-            else:
-                with urllib.request.urlopen(
-                    "https://rustwasm.github.io/wasm-pack/installer/init.sh"
-                ) as wasm_script:
-                    sh_text = wasm_script.read().decode("utf-8")
-                    tmp_dir = os.getenv("RUNNER_TEMP", default=tempfile.gettempdir())
-                    file_name = os.path.join(tmp_dir, "wasm_install.sh")
-                    with open(file_name, "w") as file:
-                        file.write(sh_text)
-                    print("Attempting to install wasm-pack")
-                    subprocess.run(["sh", file_name], check=True)
-
-            wasm_pack_version = subprocess.check_output(["wasm-pack", "--version"])
+            print("wasm-bindgen not found. Attempting to install...")
+            install_wasm_bindgen()
+            wasm_bindgen_version = subprocess.check_output(
+                ["wasm-bindgen", "--version"], env=env
+            )
         else:
             print(
-                "wasm-pack not found. Please install from https://rustwasm.github.io/wasm-pack/installer/"
+                "wasm-bindgen not found. Install via 'python ./prereqs.py --install' or see https://github.com/rustwasm/wasm-bindgen"
             )
             exit(1)
-
-    version_match = re.search(r"wasm-pack (\d+)\.(\d+).\d+", wasm_pack_version.decode())
+    version_match = re.search(
+        r"wasm-bindgen (\d+)\.(\d+)\.(\d+)", wasm_bindgen_version.decode()
+    )
     if version_match:
-        wasm_major = int(version_match.group(1))
-        wasm_minor = int(version_match.group(2))
-        if wasm_major != wasmpack_ver[0] or wasm_minor < wasmpack_ver[1]:
+        found_ver = tuple(int(g) for g in version_match.groups())
+        if found_ver < wasm_bindgen_ver:
             print(
-                f"wasm-pack version must be {wasmpack_ver[0]}.{wasmpack_ver[1]} or later. Please update."
+                f"wasm-bindgen v{wasm_bindgen_ver[0]}.{wasm_bindgen_ver[1]}.{wasm_bindgen_ver[2]} or later is required. Please update."
             )
             exit(1)
     else:
-        print("Unable to determine the wasm-pack version")
+        print("Unable to determine the wasm-bindgen version")
+
+    ### Check the binaryen version ###
+    try:
+        binaryen_version = subprocess.check_output(["wasm-opt", "--version"], env=env)
+        print(f"Detected wasm-opt version: {binaryen_version.decode()}")
+    except FileNotFoundError:
+        if install == True:
+            print("wasm-opt not found. Attempting to install...")
+            install_binaryen()
+            binaryen_version = subprocess.check_output(
+                ["wasm-opt", "--version"], env=env
+            )
+        else:
+            print(
+                "wasm-opt not found. Install via 'python ./prereqs.py --install' or see https://github.com/WebAssembly/binaryen"
+            )
+            exit(1)
+    version_match = re.search(r"wasm-opt version (\d+)", binaryen_version.decode())
+    if version_match:
+        found_ver = int(version_match.group(1))
+        if found_ver < binaryen_ver:
+            print(f"wasm-opt version must be {binaryen_ver} or later. Please update.")
+            exit(1)
+    else:
+        print("Unable to determine the wasm-opt version")
+        exit(1)
 
     # Ensure the required wasm target is installed
     if "wasm32-unknown-unknown" not in installed_rust_targets:
         print("WASM rust target is not installed.")
         print("Please install the missing target by running:")
         print("rustup target add wasm32-unknown-unknown")
+
+
+def download_and_extract(url_base, tar_file, out_dir):
+    os.makedirs(out_dir, exist_ok=True)
+    temp_file = tempfile.gettempdir() + os.sep + tar_file
+
+    # Note: Using curl and tar as subprocesses rather than Python libraries for features such as --strip-components
+    subprocess.run(["curl", "-L", "-o", temp_file, url_base + tar_file], check=True)
+    subprocess.run(
+        ["tar", "-xzf", temp_file, "--strip-components=1", "-C", out_dir], check=True
+    )
+
+    os.remove(temp_file)  # Clean up the tar file
+
+
+def install_wasm_bindgen():
+    ver_str = ".".join(str(v) for v in wasm_bindgen_ver)
+    # Maintain the below mappings as filenames are inconsistent, and we want x64 builds on Windows ARM64
+    wasm_bindgen_tar_map = {
+        "darwin": {
+            "arm64": f"wasm-bindgen-{ver_str}-aarch64-apple-darwin.tar.gz",
+            "x64": f"wasm-bindgen-{ver_str}-x86_64-apple-darwin.tar.gz",
+        },
+        "linux": {
+            "arm64": f"wasm-bindgen-{ver_str}-aarch64-unknown-linux-gnu.tar.gz",
+            "x64": f"wasm-bindgen-{ver_str}-x86_64-unknown-linux-musl.tar.gz",
+        },
+        "windows": {
+            "arm64": f"wasm-bindgen-{ver_str}-x86_64-pc-windows-msvc.tar.gz",
+            "x64": f"wasm-bindgen-{ver_str}-x86_64-pc-windows-msvc.tar.gz",
+        },
+    }
+    wasm_bindgen_base_url = (
+        f"https://github.com/rustwasm/wasm-bindgen/releases/download/{ver_str}/"
+    )
+    wasm_bindgen_filename = wasm_bindgen_tar_map[platform_sys][platform_arch]
+    out_dir = os.path.expanduser("~/wasm-bindgen")
+
+    download_and_extract(wasm_bindgen_base_url, wasm_bindgen_filename, out_dir)
+    # File of interest will be in "~/wasm-bindgen/wasm-bindgen"
+
+
+def install_binaryen():
+    binaryen_tar_map = {
+        "darwin": {
+            "arm64": f"binaryen-version_{binaryen_ver}-arm64-macos.tar.gz",
+            "x64": f"binaryen-version_{binaryen_ver}-x86_64-macos.tar.gz",
+        },
+        "linux": {
+            "arm64": f"binaryen-version_{binaryen_ver}-aarch64-linux.tar.gz",
+            "x64": f"binaryen-version_{binaryen_ver}-x86_64-linux.tar.gz",
+        },
+        "windows": {
+            "arm64": f"binaryen-version_{binaryen_ver}-x86_64-windows.tar.gz",
+            "x64": f"binaryen-version_{binaryen_ver}-x86_64-windows.tar.gz",
+        },
+    }
+    binaryen_base_url = f"https://github.com/WebAssembly/binaryen/releases/download/version_{binaryen_ver}/"
+    binaryen_filename = binaryen_tar_map[platform_sys][platform_arch]
+
+    out_dir = os.path.expanduser("~/binaryen")
+    download_and_extract(binaryen_base_url, binaryen_filename, out_dir)
+    # File of interest will be in "~/binaryen/bin/wasm-opt"
 
 
 if __name__ == "__main__":

--- a/source/npm/qsharp/generate_docs.js
+++ b/source/npm/qsharp/generate_docs.js
@@ -7,7 +7,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { generate_docs } from "./lib/node/qsc_wasm.cjs";
+import { generate_docs } from "./lib/nodejs/qsc_wasm.cjs";
 
 const scriptDirPath = dirname(fileURLToPath(import.meta.url));
 const docsDirPath = join(scriptDirPath, "docs");

--- a/source/npm/qsharp/src/main.ts
+++ b/source/npm/qsharp/src/main.ts
@@ -40,7 +40,7 @@ let wasm: Wasm | null = null;
 
 function ensureWasm() {
   if (!wasm) {
-    wasm = require("../lib/node/qsc_wasm.cjs") as Wasm;
+    wasm = require("../lib/nodejs/qsc_wasm.cjs") as Wasm;
     // Set up logging and telemetry as soon as possible after instantiating
     wasm.initLogging(log.logWithLevel, log.getLogLevel());
     log.onLevelChanged = (level) => wasm?.setLogLevel(level);

--- a/source/npm/qsharp/src/workers/node.ts
+++ b/source/npm/qsharp/src/workers/node.ts
@@ -9,7 +9,7 @@ import {
   parentPort,
   workerData,
 } from "node:worker_threads";
-import * as wasm from "../../lib/node/qsc_wasm.cjs";
+import * as wasm from "../../lib/nodejs/qsc_wasm.cjs";
 import { log } from "../log.js";
 import {
   IServiceEventMessage,


### PR DESCRIPTION
wasm-pack has been a bit of a pain, and seems largely unmaintained at this point (has several hundred issues open and hasn't had a commit in 9 months). We don't use many of its features anyway (such as testing and packaging for npm).

With this change, we use wasm-bindgen (for the .JS files) and wasm-opt (to optimize the wasm) directly, instead of via wasm-pack. All wasm-pack was doing under the covers was installing these tools from the internet and invoking them, so this just makes their usage more explicit.

With this we can:

- Directly control the versions of the wasm utilities used
- Hopefully build wasm on Windows ARM64 (haven't tried yet, but wasm-pack didn't work there)
- Avoid streaming a .sh script from the internet to install wasm-pack at build time

This requires both wasm-bindgen and wasm-opt be on the path, but 'python prereqs.py --install' will add those if needed. (They are handy to have around if working with wasm anyway).

Open to feedback. It wasn't as simple as I hoped, but should be a one-off change.