### PR TITLE
Skip errors on files with `review` URI scheme

### DIFF
--- a/source/vscode/src/common.ts
+++ b/source/vscode/src/common.ts
@@ -34,7 +34,12 @@ function isQdkSupportedLanguage(document: TextDocument): boolean {
 }
 
 function isUnsupportedScheme(scheme: string): boolean {
-  return scheme === "git" || scheme === "pr" || scheme.startsWith("chat");
+  return (
+    scheme === "git" ||
+    scheme === "pr" ||
+    scheme === "review" ||
+    scheme.startsWith("chat")
+  );
 }
 
 // Returns true for all Q# documents, including unsaved files, notebook cells, circuit files, etc.


### PR DESCRIPTION
Following in the footsteps of #1754 and #1867, this ignores files with the `review` scheme to avoid spurious language service errors on the left-hand side of a diff when reviewing a PR locally checked out with the GitHub Pull Requests extension.