### PR TITLE
Annotations should now be parsed correctly

### DIFF
--- a/source/compiler/qsc_qasm/src/ast_builder.rs
+++ b/source/compiler/qsc_qasm/src/ast_builder.rs
@@ -1568,9 +1568,10 @@ fn build_idents(idents: &[&str]) -> Option<Box<[Ident]>> {
     }
 }
 
-pub(crate) fn build_attr<S>(name: S, value: Option<S>, span: Span) -> Attr
+pub(crate) fn build_attr<S, T>(name: S, value: Option<T>, span: Span) -> Attr
 where
     S: AsRef<str>,
+    T: AsRef<str>,
 {
     let name = Box::new(Ident {
         span,

--- a/source/compiler/qsc_qasm/src/parser/ast.rs
+++ b/source/compiler/qsc_qasm/src/parser/ast.rs
@@ -57,17 +57,18 @@ impl Display for Stmt {
 #[derive(Clone, Debug)]
 pub struct Annotation {
     pub span: Span,
-    pub identifier: Rc<str>,
+    pub identifier: PathKind,
     pub value: Option<Rc<str>>,
+    pub value_span: Option<Span>,
 }
 
 impl Display for Annotation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let identifier = format!("\"{}\"", self.identifier);
         let value = self.value.as_ref().map(|val| format!("\"{val}\""));
         writeln_header(f, "Annotation", self.span)?;
-        writeln_field(f, "identifier", &identifier)?;
-        write_opt_field(f, "value", value.as_ref())
+        writeln_field(f, "identifier", &self.identifier.as_string())?;
+        writeln_opt_field(f, "value", value.as_ref())?;
+        write_opt_field(f, "value_span", self.value_span.as_ref())
     }
 }
 
@@ -134,7 +135,7 @@ impl PathKind {
             PathKind::Ok(path) => match &path.segments {
                 Some(segments) => {
                     if segments.is_empty() {
-                        return path.name.to_string();
+                        return path.name.name.to_string();
                     }
                     let mut value = String::new();
                     for segment in segments {
@@ -147,7 +148,7 @@ impl PathKind {
                     value.push_str(&path.name.name);
                     value
                 }
-                None => path.name.to_string(),
+                None => path.name.name.to_string(),
             },
             PathKind::Err(Some(path)) => {
                 let mut value = String::new();

--- a/source/compiler/qsc_qasm/src/parser/scan.rs
+++ b/source/compiler/qsc_qasm/src/parser/scan.rs
@@ -15,7 +15,7 @@ pub(super) struct NoBarrierError;
 
 pub(crate) struct ParserContext<'a> {
     scanner: Scanner<'a>,
-    word_collector: Option<&'a mut ValidWordCollector>,
+    pub(super) word_collector: Option<&'a mut ValidWordCollector>,
 }
 
 /// Scans over the token stream. Notably enforces LL(1) parser behavior via

--- a/source/compiler/qsc_qasm/src/parser/stmt.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt.rs
@@ -380,7 +380,12 @@ pub fn parse_annotation(s: &mut ParserContext) -> Result<Annotation> {
     // This will tokenize the rest of the line which should be the identifier
     // and the value, if any.
 
-    let mut c = ParserContext::new(annotation_content);
+    let mut c = match s.word_collector {
+        Some(ref mut collector) => {
+            ParserContext::with_word_collector(annotation_content, collector)
+        }
+        None => ParserContext::new(annotation_content),
+    };
 
     // parse the dotted path identifier
     let Ok(mut path) = recovering_path(&mut c, WordKinds::PathExpr) else {
@@ -499,7 +504,11 @@ fn parse_pragma(s: &mut ParserContext) -> Result<Pragma> {
     // This will tokenize the rest of the line which should be the identifier
     // and the value, if any.
 
-    let mut c = ParserContext::new(pragma_content);
+    let mut c = match s.word_collector {
+        Some(ref mut collector) => ParserContext::with_word_collector(pragma_content, collector),
+        None => ParserContext::new(pragma_content),
+    };
+
     let content_lo = c.skip_trivia().hi;
     // parse the dotted path identifier
     let Ok(mut path) = recovering_path(&mut c, WordKinds::PathExpr) else {

--- a/source/compiler/qsc_qasm/src/parser/stmt.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt.rs
@@ -357,13 +357,13 @@ pub fn parse_annotation(s: &mut ParserContext) -> Result<Annotation> {
 
     // annotation_line_content:
     // @ a.b.c "some value" more value \nmore content
-    // |.      |     |                |
-    // |.      |     |                |
-    // |.      |     ^------ value ---|
-    // |.      ^-- ident_lo           ^-- stmt_hi
+    // |.      |                      |
+    // |.      |                      |
+    // |.      ^-------- value -------|
+    // | ^-- ident_lo                 ^-- stmt_hi
     // |       |                      |
     // |       ^- annotation_content -^
-    // |      ^-- annotation_kw_offset
+    // |^-- annotation_kw_offset
     // ^-- stmt_lo
 
     let from_start = annotation_kw_offset.try_into().expect("valid size");

--- a/source/compiler/qsc_qasm/src/parser/stmt.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt.rs
@@ -179,7 +179,7 @@ pub(super) fn parse(s: &mut ParserContext) -> Result<Stmt> {
 
     Ok(Stmt {
         span: s.span(lo),
-        annotations: attrs.into_boxed_slice(),
+        annotations: list_from_iter(attrs),
         kind: Box::new(kind),
     })
 }
@@ -335,55 +335,95 @@ fn default(span: Span) -> Stmt {
 }
 
 /// Grammar: `AnnotationKeyword RemainingLineContent?`.
-pub fn parse_annotation(s: &mut ParserContext) -> Result<Box<Annotation>> {
-    let lo = s.peek().span.lo;
+pub fn parse_annotation(s: &mut ParserContext) -> Result<Annotation> {
+    let token = s.peek();
+    let stmt_lo = token.span.lo;
     s.expect(WordKinds::Annotation);
 
-    let token = s.peek();
-    let pat = &['\t', ' '];
-    let parts: Vec<&str> = if token.kind == TokenKind::Annotation {
-        let lexeme = s.read();
-        s.advance();
-        // remove @
-        // split lexeme at first space/tab collecting each side
-        shorten(1, 0, lexeme).splitn(2, pat).collect()
-    } else {
+    if token.kind != TokenKind::Annotation {
         return Err(Error::new(ErrorKind::Rule(
             "annotation",
             token.kind,
             token.span,
         )));
-    };
+    }
 
-    let identifier = parts.first().map_or_else(
-        || {
-            Err(Error::new(ErrorKind::Rule(
-                "annotation",
-                token.kind,
-                token.span,
-            )))
-        },
-        |s| Ok(Into::<Rc<str>>::into(*s)),
-    )?;
+    // read the annotation lexeme, which is the whole line
+    // including the `@` and the rest of the line content.
+    let annotation_line_content = s.read();
+    let annotation_kw_offset = 1; // length of "@"
+    let ident_lo = token.span.lo + annotation_kw_offset;
+    let stmt_hi = token.span.hi;
 
-    if identifier.is_empty() {
-        s.push_error(Error::new(ErrorKind::Rule(
+    // annotation_line_content:
+    // @ a.b.c "some value" more value \nmore content
+    // |.      |     |                |
+    // |.      |     |                |
+    // |.      |     ^------ value ---|
+    // |.      ^-- ident_lo           ^-- stmt_hi
+    // |       |                      |
+    // |       ^- annotation_content -^
+    // |      ^-- annotation_kw_offset
+    // ^-- stmt_lo
+
+    let from_start = annotation_kw_offset.try_into().expect("valid size");
+    let annotation_content = shorten(from_start, 0, annotation_line_content);
+
+    // annotation_content
+    // a.b.c "some value" more value
+    //       ^-- value_lo
+
+    // advance the parser to the next token for the next token in the program
+    s.advance();
+
+    // create a sub-parser context just for the line content
+    // This will tokenize the rest of the line which should be the identifier
+    // and the value, if any.
+
+    let mut c = ParserContext::new(annotation_content);
+
+    // parse the dotted path identifier
+    let Ok(mut path) = recovering_path(&mut c, WordKinds::PathExpr) else {
+        // We only fail if no parts were parsed, which means
+        // there was no valid identifier found.
+        // annotations must have an identifier.
+
+        return Err(Error::new(ErrorKind::Rule(
             "annotation missing identifier",
             token.kind,
             token.span,
         )));
-    }
+    };
 
-    // remove any leading whitespace from the value side
-    let value = parts
-        .get(1)
-        .map(|s| Into::<Rc<str>>::into(s.trim_start_matches(pat)));
+    // update the path span based on the original lo
+    path.offset(ident_lo);
 
-    Ok(Box::new(Annotation {
-        span: s.span(lo),
-        identifier,
+    // Unlike pragmas, annotations don't need a path segment.
+    // A single identifier is sufficient.
+
+    // we need to get to the first non-whitespace token
+    // after the identifier, which should be the value.
+
+    // This value_lo offset is the start of the value in the annotation line content.
+    let value_lo = c.skip_trivia().hi;
+    let value = trim_front_safely(value_lo.try_into().expect("valid size"), annotation_content);
+    let value = if value.is_empty() {
+        None
+    } else {
+        Some(Rc::from(value))
+    };
+
+    let value_span = value.as_ref().map(|_| Span {
+        lo: value_lo + ident_lo,
+        hi: stmt_hi,
+    });
+
+    Ok(Annotation {
+        span: s.span(stmt_lo),
+        identifier: path,
         value,
-    }))
+        value_span,
+    })
 }
 
 /// Grammar: `INCLUDE StringLiteral SEMICOLON`.

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/annotation.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/annotation.rs
@@ -12,8 +12,9 @@ fn annotation() {
         "@a.b.d 23",
         &expect![[r#"
             Annotation [0-9]:
-                identifier: "a.b.d"
-                value: "23""#]],
+                identifier: a.b.d
+                value: "23"
+                value_span: [7-9]"#]],
     );
 }
 
@@ -24,8 +25,9 @@ fn annotation_ident_only() {
         "@a.b.d",
         &expect![[r#"
             Annotation [0-6]:
-                identifier: "a.b.d"
-                value: <none>"#]],
+                identifier: a.b.d
+                value: <none>
+                value_span: <none>"#]],
     );
 }
 
@@ -35,21 +37,16 @@ fn annotation_missing_ident() {
         parse_annotation,
         "@",
         &expect![[r#"
-            Annotation [0-1]:
-                identifier: ""
-                value: <none>
-
-            [
-                Error(
-                    Rule(
-                        "annotation missing identifier",
-                        Annotation,
-                        Span {
-                            lo: 0,
-                            hi: 1,
-                        },
-                    ),
+            Error(
+                Rule(
+                    "annotation missing identifier",
+                    Annotation,
+                    Span {
+                        lo: 0,
+                        hi: 1,
+                    },
                 ),
-            ]"#]],
+            )
+        "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/extern_decl.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/extern_decl.rs
@@ -201,8 +201,9 @@ fn annotation() {
             Stmt [0-47]:
                 annotations:
                     Annotation [0-16]:
-                        identifier: "test.annotation"
+                        identifier: test.annotation
                         value: <none>
+                        value_span: <none>
                 kind: ExternDecl [25-47]:
                     ident: Ident [32-33] "x"
                     parameters:

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/for_loops.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/for_loops.rs
@@ -348,11 +348,13 @@ fn annotations_in_single_stmt_for_stmt() {
                     body: Stmt [29-61]:
                         annotations:
                             Annotation [29-33]:
-                                identifier: "foo"
+                                identifier: foo
                                 value: <none>
+                                value_span: <none>
                             Annotation [42-46]:
-                                identifier: "bar"
+                                identifier: bar
                                 value: <none>
+                                value_span: <none>
                         kind: AssignStmt [55-61]:
                             lhs: Ident [55-56] "x"
                             rhs: Expr [59-60]: Lit: Int(5)"#]],

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/if_stmt.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/if_stmt.rs
@@ -194,11 +194,13 @@ fn annotations_in_single_stmt_if_stmt() {
                     if_body: Stmt [20-52]:
                         annotations:
                             Annotation [20-24]:
-                                identifier: "foo"
+                                identifier: foo
                                 value: <none>
+                                value_span: <none>
                             Annotation [33-37]:
-                                identifier: "bar"
+                                identifier: bar
                                 value: <none>
+                                value_span: <none>
                         kind: AssignStmt [46-52]:
                             lhs: Ident [46-47] "x"
                             rhs: Expr [50-51]: Lit: Int(5)

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/quantum_decl.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/quantum_decl.rs
@@ -33,8 +33,9 @@ fn annotated_quantum_decl() {
             Stmt [9-36]:
                 annotations:
                     Annotation [9-19]:
-                        identifier: "a.b.c"
+                        identifier: a.b.c
                         value: "123"
+                        value_span: [16-19]
                 kind: QubitDeclaration [28-36]:
                     ty: QubitType [28-33]:
                         size: <none>
@@ -55,14 +56,17 @@ fn multi_annotated_quantum_decl() {
             Stmt [9-108]:
                 annotations:
                     Annotation [9-57]:
-                        identifier: "g.h"
+                        identifier: g.h
                         value: "dolor sit amet, consectetur adipiscing elit"
+                        value_span: [14-57]
                     Annotation [66-72]:
-                        identifier: "d.e.f"
+                        identifier: d.e.f
                         value: <none>
+                        value_span: <none>
                     Annotation [81-91]:
-                        identifier: "a.b.c"
+                        identifier: a.b.c
                         value: "123"
+                        value_span: [88-91]
                 kind: QubitDeclaration [100-108]:
                     ty: QubitType [100-105]:
                         size: <none>

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/while_loops.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/while_loops.rs
@@ -172,11 +172,13 @@ fn annotations_in_single_stmt_while_stmt() {
                     body: Stmt [23-55]:
                         annotations:
                             Annotation [23-27]:
-                                identifier: "foo"
+                                identifier: foo
                                 value: <none>
+                                value_span: <none>
                             Annotation [36-40]:
-                                identifier: "bar"
+                                identifier: bar
                                 value: <none>
+                                value_span: <none>
                         kind: AssignStmt [49-55]:
                             lhs: Ident [49-50] "x"
                             rhs: Expr [53-54]: Lit: Int(5)"#]],

--- a/source/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/source/compiler/qsc_qasm/src/semantic/ast.rs
@@ -57,17 +57,18 @@ impl Display for Stmt {
 #[derive(Clone, Debug)]
 pub struct Annotation {
     pub span: Span,
-    pub identifier: Rc<str>,
+    pub identifier: PathKind,
     pub value: Option<Rc<str>>,
+    pub value_span: Option<Span>,
 }
 
 impl Display for Annotation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let identifier = format!("\"{}\"", self.identifier);
         let value = self.value.as_ref().map(|val| format!("\"{val}\""));
         writeln_header(f, "Annotation", self.span)?;
-        writeln_field(f, "identifier", &identifier)?;
-        write_opt_field(f, "value", value.as_ref())
+        writeln_field(f, "identifier", &self.identifier.as_string())?;
+        writeln_opt_field(f, "value", value.as_ref())?;
+        write_opt_field(f, "value_span", self.value_span.as_ref())
     }
 }
 

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -1123,11 +1123,12 @@ impl Lowerer {
             .collect::<Vec<_>>()
     }
 
-    fn lower_annotation(annotation: &syntax::Annotation) -> semantic::Annotation {
+    fn lower_annotation(stmt: &syntax::Annotation) -> semantic::Annotation {
         semantic::Annotation {
-            span: annotation.span,
-            identifier: annotation.identifier.clone(),
-            value: annotation.value.as_ref().map(Clone::clone),
+            span: stmt.span,
+            identifier: stmt.identifier.clone(),
+            value: stmt.value.clone(),
+            value_span: stmt.value_span,
         }
     }
 

--- a/source/compiler/qsc_qasm/src/tests/expression/function_call.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/function_call.rs
@@ -345,3 +345,54 @@ fn simulatable_intrinsic_on_def_stmt_generates_correct_qir() -> miette::Result<(
     .assert_eq(&qsharp);
     Ok(())
 }
+
+#[test]
+fn qdk_qir_intrinsic_on_def_stmt_generates_correct_qir() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+
+        @qdk.qir.intrinsic
+        def my_gate(qubit q) {
+            x q;
+        }
+
+        qubit q;
+        my_gate(q);
+        bit result = measure q;
+    "#;
+
+    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    expect![[r#"
+        %Result = type opaque
+        %Qubit = type opaque
+
+        define void @ENTRYPOINT__main() #0 {
+        block_0:
+          call void @my_gate(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__rt__tuple_record_output(i64 0, i8* null)
+          ret void
+        }
+
+        declare void @my_gate(%Qubit*)
+
+        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__tuple_record_output(i64, i8*)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 1, !"int_computations", !"i64"}
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}

--- a/source/compiler/qsc_qasm/src/tests/output.rs
+++ b/source/compiler/qsc_qasm/src/tests/output.rs
@@ -377,3 +377,68 @@ fn qir_generation_for_box_with_simulatable_intrinsic() -> miette::Result<(), Vec
 
     Ok(())
 }
+
+#[test]
+fn qir_generation_for_box_with_qdk_qir_intrinsic() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    #pragma qdk.box.open box_begin
+    #pragma qdk.box.close box_end
+
+    @qdk.qir.intrinsic
+    def box_begin() {}
+
+    @qdk.qir.intrinsic
+    def box_end() {}
+
+    qubit q;
+    box {
+        x q;
+    }
+    output bit c;
+    c = measure q;
+    "#;
+
+    let qir = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    expect![[r#"
+        %Result = type opaque
+        %Qubit = type opaque
+
+        define void @ENTRYPOINT__main() #0 {
+        block_0:
+          call void @box_begin()
+          call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @box_end()
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__rt__tuple_record_output(i64 0, i8* null)
+          ret void
+        }
+
+        declare void @box_begin()
+
+        declare void @__quantum__qis__x__body(%Qubit*)
+
+        declare void @box_end()
+
+        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__tuple_record_output(i64, i8*)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 1, !"int_computations", !"i64"}
+    "#]]
+    .assert_eq(&qir);
+
+    Ok(())
+}

--- a/source/compiler/qsc_qasm/src/tests/statement/annotation.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/annotation.rs
@@ -28,10 +28,54 @@ fn simulatable_intrinsic_can_be_applied_to_gate() -> miette::Result<(), Vec<Repo
 }
 
 #[test]
+fn qdk_qir_intrinsic_can_be_applied_to_gate() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        @qdk.qir.intrinsic
+        gate my_h q {
+            h q;
+        }
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        @SimulatableIntrinsic()
+        operation my_h(q : Qubit) : Unit {
+            h(q);
+        }
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
 fn simulatable_intrinsic_can_be_applied_to_def() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
         @SimulatableIntrinsic
+        def my_h(qubit q) {
+            h q;
+        }
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        @SimulatableIntrinsic()
+        operation my_h(q : Qubit) : Unit {
+            h(q);
+        }
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qdk_qir_intrinsic_can_be_applied_to_def() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        @qdk.qir.intrinsic
         def my_h(qubit q) {
             h q;
         }
@@ -72,10 +116,54 @@ fn config_can_be_applied_to_gate() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
+fn qdk_qir_profile_can_be_applied_to_gate() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        @qdk.qir.profile Base
+        gate my_h q {
+            h q;
+        }
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        @Config(Base)
+        operation my_h(q : Qubit) : Unit is Adj + Ctl {
+            h(q);
+        }
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
 fn config_can_be_applied_to_def() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
         @Config Base
+        def my_h(qubit q) {
+            h q;
+        }
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        @Config(Base)
+        operation my_h(q : Qubit) : Unit {
+            h(q);
+        }
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn qdk_qir_profile_can_be_applied_to_def() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        @qdk.qir.profile Base
         def my_h(qubit q) {
             h q;
         }
@@ -124,6 +212,34 @@ fn annotation_without_target_in_global_scope_raises_error() {
 
 #[test]
 fn annotation_without_target_in_block_scope_raises_error() {
+    let source = r#"
+        int i;
+        if (0 == 1) {
+            @SimulatableIntrinsic
+        }
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected an error");
+    };
+    expect![r#"Annotation missing target statement."#].assert_eq(&errors[0].to_string());
+}
+
+#[test]
+fn unknown_annotation_without_target_in_global_scope_raises_error() {
+    let source = r#"
+        int i;
+        @SimulatableIntrinsic
+    "#;
+
+    let Err(errors) = compile_qasm_to_qsharp(source) else {
+        panic!("Expected an error");
+    };
+    expect![r#"Annotation missing target statement."#].assert_eq(&errors[0].to_string());
+}
+
+#[test]
+fn unknown_annotation_without_target_in_block_scope_raises_error() {
     let source = r#"
         int i;
         if (0 == 1) {

--- a/source/pip/tests-integration/interop_qiskit/resources/custom_intrinsics.inc
+++ b/source/pip/tests-integration/interop_qiskit/resources/custom_intrinsics.inc
@@ -1,5 +1,5 @@
 
-@SimulatableIntrinsic
+@qdk.qir.intrinsic
 gate my_gate q {
     x q;
 }


### PR DESCRIPTION
This PR fixes annotation parsing and renames existing annotations to comply better with namespaced intent from the spec. The old annotation names have been preserved for backwards compatibility but should be removed in the future.
- `@SimulatableIntrinsic` is now `@qdk.qir.intrinsic`
- `@Config` is now `@qdk.qir.profile`