### PR TITLE
Add step-point to block exit when debugging

### DIFF
--- a/source/compiler/qsc_eval/src/lib.rs
+++ b/source/compiler/qsc_eval/src/lib.rs
@@ -37,7 +37,7 @@ use num_bigint::BigInt;
 use output::Receiver;
 use qsc_data_structures::{functors::FunctorApp, index_map::IndexMap, span::Span};
 use qsc_fir::fir::{
-    self, BinOp, CallableImpl, ExecGraph, ExecGraphNode, Expr, ExprId, ExprKind, Field,
+    self, BinOp, BlockId, CallableImpl, ExecGraph, ExecGraphNode, Expr, ExprId, ExprKind, Field,
     FieldAssign, Global, Lit, LocalItemId, LocalVarId, PackageId, PackageStoreLookup, PatId,
     PatKind, PrimField, Res, StmtId, StoreItemId, StringComponent, UnOp,
 };
@@ -808,6 +808,16 @@ impl State {
                     self.idx += 1;
                     continue;
                 }
+                Some(ExecGraphNode::BlockEnd(id)) => {
+                    self.idx += 1;
+                    match self.check_for_block_exit_break(globals, *id, step, current_frame) {
+                        Some((result, span)) => {
+                            self.current_span = span;
+                            return Ok(result);
+                        }
+                        None => continue,
+                    }
+                }
                 None => {
                     // We have reached the end of the current graph without reaching an explicit return node,
                     // usually indicating the partial execution of a single sub-expression.
@@ -864,6 +874,25 @@ impl State {
                 }
             },
         )
+    }
+
+    fn check_for_block_exit_break(
+        &self,
+        globals: &impl PackageStoreLookup,
+        block: BlockId,
+        step: StepAction,
+        current_frame: usize,
+    ) -> Option<(StepResult, Span)> {
+        if step == StepAction::Next && current_frame >= self.call_stack.len() {
+            let block = globals.get_block((self.package, block).into());
+            let span = Span {
+                lo: block.span.hi - 1,
+                hi: block.span.hi,
+            };
+            Some((StepResult::Next, span))
+        } else {
+            None
+        }
     }
 
     pub fn get_result(&mut self) -> Value {

--- a/source/compiler/qsc_fir/src/fir.rs
+++ b/source/compiler/qsc_fir/src/fir.rs
@@ -929,6 +929,9 @@ pub enum ExecGraphNode {
     PushScope,
     /// A pop of the current scope, used when tracking variables for debugging.
     PopScope,
+    /// The end of a block, used in debugging to have a step point after all statements in a block have been executed,
+    /// but before the block is exited.
+    BlockEnd(BlockId),
 }
 
 /// A sequenced block of statements.

--- a/source/compiler/qsc_lowerer/src/lib.rs
+++ b/source/compiler/qsc_lowerer/src/lib.rs
@@ -371,6 +371,7 @@ impl Lowerer {
             self.exec_graph.push(ExecGraphNode::Unit);
         }
         if self.enable_debug {
+            self.exec_graph.push(ExecGraphNode::BlockEnd(id));
             self.exec_graph.push(ExecGraphNode::PopScope);
         }
         self.blocks.insert(id, block);


### PR DESCRIPTION
This change adds a new step-point during debugging so that the debugger can stop on each scope exit and see the final values of any variables local to that scope. Like similar debugging features, these new nodes are not added to the graph during non-debug execution, such as evaluating Q# code from Python.