### PR TITLE
Separate lowerer and compiler errors

### DIFF
--- a/source/compiler/qsc_qasm/src/ast_builder.rs
+++ b/source/compiler/qsc_qasm/src/ast_builder.rs
@@ -1301,7 +1301,9 @@ pub(crate) fn map_qsharp_type_to_ast_ty(output_ty: &crate::types::Type) -> Ty {
             let ty = build_angle_ty_ident();
             wrap_array_ty_by_dims(*dims, ty)
         }
-        crate::types::Type::Callable(_, _, _) => todo!(),
+        crate::types::Type::Callable(_, _, _) | crate::types::Type::Gate(_, _) => {
+            unreachable!("Unexpected callable type in AST conversion")
+        }
         crate::types::Type::Range => build_path_ident_ty("Range"),
         crate::types::Type::Tuple(tys) => {
             if tys.is_empty() {

--- a/source/compiler/qsc_qasm/src/parser/ast.rs
+++ b/source/compiler/qsc_qasm/src/parser/ast.rs
@@ -11,7 +11,6 @@ use qsc_data_structures::span::{Span, WithSpan};
 use std::{
     fmt::{self, Display, Formatter},
     hash::Hash,
-    rc::Rc,
     sync::Arc,
 };
 
@@ -58,7 +57,7 @@ impl Display for Stmt {
 pub struct Annotation {
     pub span: Span,
     pub identifier: PathKind,
-    pub value: Option<Rc<str>>,
+    pub value: Option<Arc<str>>,
     pub value_span: Option<Span>,
 }
 
@@ -385,7 +384,7 @@ impl WithSpan for GateOperandKind {
 #[derive(Clone, Debug)]
 pub struct HardwareQubit {
     pub span: Span,
-    pub name: Rc<str>,
+    pub name: Arc<str>,
 }
 
 impl Display for HardwareQubit {
@@ -498,7 +497,7 @@ impl Display for StmtKind {
 #[derive(Clone, Debug)]
 pub struct CalibrationGrammarStmt {
     pub span: Span,
-    pub name: String,
+    pub name: Arc<str>,
 }
 
 impl Display for CalibrationGrammarStmt {
@@ -511,11 +510,13 @@ impl Display for CalibrationGrammarStmt {
 #[derive(Clone, Debug)]
 pub struct DefCalStmt {
     pub span: Span,
+    pub content: Arc<str>,
 }
 
 impl Display for DefCalStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "DefCalStmt {}", self.span)
+        writeln_header(f, "DefCalStmt", self.span)?;
+        write_field(f, "content", &self.content)
     }
 }
 
@@ -617,7 +618,7 @@ impl WithSpan for IdentOrIndexedIdent {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Ident {
     pub span: Span,
-    pub name: Rc<str>,
+    pub name: Arc<str>,
 }
 
 impl Default for Ident {
@@ -1198,7 +1199,7 @@ impl Display for QuantumArgument {
 pub struct Pragma {
     pub span: Span,
     pub identifier: Option<PathKind>,
-    pub value: Option<Rc<str>>,
+    pub value: Option<Arc<str>>,
     pub value_span: Option<Span>,
 }
 
@@ -1434,26 +1435,15 @@ impl Display for ConstantDeclStmt {
 }
 
 #[derive(Clone, Debug)]
-pub struct CalibrationGrammarDeclaration {
-    span: Span,
-    name: String,
-}
-
-impl Display for CalibrationGrammarDeclaration {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln_header(f, "CalibrationGrammarDeclaration", self.span)?;
-        write_field(f, "name", &self.name)
-    }
-}
-
-#[derive(Clone, Debug)]
 pub struct CalibrationStmt {
     pub span: Span,
+    pub content: Arc<str>,
 }
 
 impl Display for CalibrationStmt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "CalibrationStmt {}", self.span)
+        writeln_header(f, "CalibrationStmt", self.span)?;
+        write_field(f, "content", &self.content)
     }
 }
 

--- a/source/compiler/qsc_qasm/src/parser/scan.rs
+++ b/source/compiler/qsc_qasm/src/parser/scan.rs
@@ -63,6 +63,10 @@ impl<'a> ParserContext<'a> {
         self.scanner.span(from)
     }
 
+    pub(super) fn read_from(&self, from: u32) -> &'a str {
+        self.scanner.read_from(from)
+    }
+
     /// Advances the scanner to start of the the next valid token.
     pub(super) fn advance(&mut self) {
         self.scanner.advance();
@@ -139,6 +143,10 @@ impl<'a> Scanner<'a> {
 
     pub(super) fn read(&self) -> &'a str {
         &self.input[self.peek.span]
+    }
+
+    pub(super) fn read_from(&self, from: u32) -> &'a str {
+        &self.input[self.span(from)]
     }
 
     pub(super) fn span(&self, from: u32) -> Span {

--- a/source/compiler/qsc_qasm/src/parser/stmt.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt.rs
@@ -5,7 +5,7 @@
 pub(crate) mod tests;
 
 use qsc_data_structures::span::Span;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     Result,
@@ -415,7 +415,7 @@ pub fn parse_annotation(s: &mut ParserContext) -> Result<Annotation> {
     let value = if value.is_empty() {
         None
     } else {
-        Some(Rc::from(value))
+        Some(Arc::from(value))
     };
 
     let value_span = value.as_ref().map(|_| Span {
@@ -532,7 +532,7 @@ fn parse_pragma(s: &mut ParserContext) -> Result<Pragma> {
         let value = if value.is_empty() {
             None
         } else {
-            Some(Rc::from(value))
+            Some(Arc::from(value))
         };
         let value_span = value.as_ref().map(|_| Span {
             lo: stmt_lo + ident_lo + content_lo,
@@ -557,7 +557,7 @@ fn parse_pragma(s: &mut ParserContext) -> Result<Pragma> {
         let value = if value.is_empty() {
             None
         } else {
-            Some(Rc::from(value))
+            Some(Arc::from(value))
         };
         let value_span = value.as_ref().map(|_| Span {
             lo: stmt_lo + ident_lo + content_lo,
@@ -580,7 +580,7 @@ fn parse_pragma(s: &mut ParserContext) -> Result<Pragma> {
     let value = if value.is_empty() {
         None
     } else {
-        Some(Rc::from(value))
+        Some(Arc::from(value))
     };
 
     let value_span = value.as_ref().map(|_| Span {
@@ -1823,7 +1823,7 @@ fn parse_calibration_grammar_stmt(s: &mut ParserContext) -> Result<CalibrationGr
         if let LiteralKind::String(name) = lit.kind {
             return Ok(CalibrationGrammarStmt {
                 span: s.span(lo),
-                name: name.to_string(),
+                name,
             });
         }
     }
@@ -1871,7 +1871,11 @@ fn parse_defcal_stmt(s: &mut ParserContext) -> Result<DefCalStmt> {
                 s.advance();
                 level -= 1;
                 if level == 0 {
-                    return Ok(DefCalStmt { span: s.span(lo) });
+                    let content = s.read_from(lo).into();
+                    return Ok(DefCalStmt {
+                        span: s.span(lo),
+                        content,
+                    });
                 }
             }
             _ => s.advance(),
@@ -1906,7 +1910,11 @@ fn parse_cal(s: &mut ParserContext) -> Result<CalibrationStmt> {
                 s.advance();
                 level -= 1;
                 if level == 0 {
-                    return Ok(CalibrationStmt { span: s.span(lo) });
+                    let content = s.read_from(lo).into();
+                    return Ok(CalibrationStmt {
+                        span: s.span(lo),
+                        content,
+                    });
                 }
             }
             _ => s.advance(),

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/cal.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/cal.rs
@@ -40,6 +40,11 @@ fn cal_block_accept_any_tokens_inside() {
         &expect![[r#"
             Stmt [5-69]:
                 annotations: <empty>
-                kind: CalibrationStmt [5-69]"#]],
+                kind: CalibrationStmt [5-69]:
+                    content: cal {
+                            faoi foaijdf a;
+                            fkfm )(
+                            .314
+                        }"#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/defcal.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/defcal.rs
@@ -40,6 +40,11 @@ fn cal_block_accept_any_tokens_inside() {
         &expect![[r#"
             Stmt [5-88]:
                 annotations: <empty>
-                kind: DefCalStmt [5-88]"#]],
+                kind: DefCalStmt [5-88]:
+                    content: defcal foo(a, b) q0 q1 {
+                            faoi foaijdf a;
+                            fkfm )(
+                            .314
+                        }"#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/parser/stmt/tests/invalid_stmts/cal.rs
+++ b/source/compiler/qsc_qasm/src/parser/stmt/tests/invalid_stmts/cal.rs
@@ -62,8 +62,9 @@ fn defcal_bad_signature() {
         parse,
         "defcal x $0 -> int[8] -> int[8] {}",
         &expect![[r#"
-        Stmt [0-34]:
-            annotations: <empty>
-            kind: DefCalStmt [0-34]"#]],
+            Stmt [0-34]:
+                annotations: <empty>
+                kind: DefCalStmt [0-34]:
+                    content: defcal x $0 -> int[8] -> int[8] {}"#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/resources/openqasm_compiler_errors_test.qasm
+++ b/source/compiler/qsc_qasm/src/semantic/resources/openqasm_compiler_errors_test.qasm
@@ -1,0 +1,81 @@
+// If there is a squiggle at the beginning of the file, it means some of the spans is incorrect.
+
+include "stdgates.inc";
+
+// Not an error. Utility qubits to be used in the rest of the file.
+qubit q;
+qubit[1] qreg_1;
+qubit[2] qreg_2;
+
+// NotSupported defcalgrammar
+defcalgrammar "openpulse";
+
+// NotSupported cal
+cal {
+   // Defined within `cal`, so it may not leak back out to the enclosing blocks scope
+   float new_freq = 5.2e9;
+   // declare global port
+   extern port d0;
+   // reference `freq` variable from enclosing blocks scope
+   frame d0f = newframe(d0, freq, 0.0);
+}
+
+// NotSupported defcal
+defcal x $0 {
+   waveform xp = gaussian(1.0, 160t, 40dt);
+   // References frame and `new_freq` declared in top-level cal block
+   play(d0f, xp);
+   set_frequency(d0f, new_freq);
+   play(d0f, xp);
+}
+
+// NotSupported
+delay [2ns] q;
+
+box [2ns] { // NotSupported box duration
+    x [2ns] q; // NotSupported duration on gate call
+}
+
+for int i in [0:2] {
+    break; // NotSupported break
+}
+
+for int i in [0:2] {
+    continue; // NotSupported continue
+}
+
+
+// NotSupported mutable array reference
+def mut_subroutine_dyn(mutable array[int[8], #dim = 1] arr_arg) {
+
+}
+
+// NotSupported mutable static sized array reference
+def mut_subroutine_static(mutable array[int[8], 2, 3] arr_arg) {
+
+}
+
+// curretly blocked by type checker
+// unimplemented
+//bit[2] creg1;
+//bit[10] creg2;
+//let concatenated_creg = creg1 ++ creg2;
+
+// curretly blocked by type checker
+// unimplemented
+//qubit[2] one;
+//qubit[10] two;
+//let concatenated = one ++ two;
+
+
+//duration dur0 = 2ns;
+//duration dur1 = 3ns;
+
+// NotSupported stretch types values
+//stretch stretch_val = dur0 - dur1;
+
+// Unimplemented
+extern extern_func(int);
+
+// NotSupported hardware qubit
+x $0;

--- a/source/compiler/qsc_qasm/src/semantic/resources/openqasm_lowerer_errors_test.qasm
+++ b/source/compiler/qsc_qasm/src/semantic/resources/openqasm_lowerer_errors_test.qasm
@@ -76,7 +76,7 @@ array[int, 1, 2, 3, 1, 2, 3, 1, 2] array_with_more_than_7_dims;
 // NotSupported stretch default values
 stretch stretch_val;
 
-box {
+box [2ns] {
     // ClassicalStmtInBox
     2;
 }
@@ -136,7 +136,7 @@ def non_void_def_should_return() -> int {
 }
 
 // Unimplemented delay
-delay [2ns] q1;
+delay [2ns] q;
 
 // ExternDeclarationInNonGlobalScope
 // Unimplemented
@@ -150,9 +150,6 @@ invalid_arity_call(2);
 
 // CannotCallNonFunction
 x(2);
-
-// NotSupported gate call duration
-x[2ns] q;
 
 // InvalidNumberOfClassicalArgs in gate call
 rx(2.0, 3.0) q;

--- a/source/compiler/qsc_qasm/src/semantic/tests.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests.rs
@@ -4,6 +4,7 @@
 use std::fmt::Write;
 
 pub mod assignment;
+pub mod compiler_errors;
 pub mod decls;
 
 pub mod expression;

--- a/source/compiler/qsc_qasm/src/semantic/tests/compiler_errors.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/compiler_errors.rs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This module contains tests for the compiler's error handling,
+// specifically focusing on errors related to unsupported features
+// and unimplemented statements in OpenQASM 3.
+
+use crate::tests::check_qasm_to_qsharp;
+use expect_test::expect;
+
+const SOURCE: &str = include_str!("../resources/openqasm_compiler_errors_test.qasm");
+
+#[allow(clippy::too_many_lines)]
+#[test]
+fn check_compiler_error_spans_are_correct() {
+    check_qasm_to_qsharp(
+        SOURCE,
+        &expect![[r#"
+            Qasm.Compiler.NotSupported
+
+              x calibration grammar statements are not supported
+                ,-[Test.qasm:11:1]
+             10 | // NotSupported defcalgrammar
+             11 | defcalgrammar "openpulse";
+                : ^^^^^^^^^^^^^^^^^^^^^^^^^^
+             12 | 
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x calibration statements are not supported
+                ,-[Test.qasm:14:1]
+             13 |     // NotSupported cal
+             14 | ,-> cal {
+             15 | |      // Defined within `cal`, so it may not leak back out to the enclosing blocks scope
+             16 | |      float new_freq = 5.2e9;
+             17 | |      // declare global port
+             18 | |      extern port d0;
+             19 | |      // reference `freq` variable from enclosing blocks scope
+             20 | |      frame d0f = newframe(d0, freq, 0.0);
+             21 | `-> }
+             22 |     
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x def cal statements are not supported
+                ,-[Test.qasm:24:1]
+             23 |     // NotSupported defcal
+             24 | ,-> defcal x $0 {
+             25 | |      waveform xp = gaussian(1.0, 160t, 40dt);
+             26 | |      // References frame and `new_freq` declared in top-level cal block
+             27 | |      play(d0f, xp);
+             28 | |      set_frequency(d0f, new_freq);
+             29 | |      play(d0f, xp);
+             30 | `-> }
+             31 |     
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x delay statements are not supported
+                ,-[Test.qasm:33:1]
+             32 | // NotSupported
+             33 | delay [2ns] q;
+                : ^^^^^^^^^^^^^^
+             34 | 
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x box with duration are not supported
+                ,-[Test.qasm:35:6]
+             34 | 
+             35 | box [2ns] { // NotSupported box duration
+                :      ^^^
+             36 |     x [2ns] q; // NotSupported duration on gate call
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x gate call duration are not supported
+                ,-[Test.qasm:36:8]
+             35 | box [2ns] { // NotSupported box duration
+             36 |     x [2ns] q; // NotSupported duration on gate call
+                :        ^^^
+             37 | }
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x break stmt are not supported
+                ,-[Test.qasm:40:5]
+             39 | for int i in [0:2] {
+             40 |     break; // NotSupported break
+                :     ^^^^^^
+             41 | }
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x continue stmt are not supported
+                ,-[Test.qasm:44:5]
+             43 | for int i in [0:2] {
+             44 |     continue; // NotSupported continue
+                :     ^^^^^^^^^
+             45 | }
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x mutable array references `mutable array[int[8], #dim = 1]` are not
+              | supported
+                ,-[Test.qasm:49:24]
+             48 | // NotSupported mutable array reference
+             49 | def mut_subroutine_dyn(mutable array[int[8], #dim = 1] arr_arg) {
+                :                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             50 | 
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x mutable array references `mutable array[int[8], 2, 3]` are not supported
+                ,-[Test.qasm:54:27]
+             53 | // NotSupported mutable static sized array reference
+             54 | def mut_subroutine_static(mutable array[int[8], 2, 3] arr_arg) {
+                :                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             55 | 
+                `----
+
+            Qasm.Compiler.Unimplemented
+
+              x this statement is not yet handled during OpenQASM 3 import: extern
+              | statements
+                ,-[Test.qasm:78:1]
+             77 | // Unimplemented
+             78 | extern extern_func(int);
+                : ^^^^^^^^^^^^^^^^^^^^^^^^
+             79 | 
+                `----
+
+            Qasm.Compiler.NotSupported
+
+              x hardware qubit operands are not supported
+                ,-[Test.qasm:81:3]
+             80 | // NotSupported hardware qubit
+             81 | x $0;
+                :   ^^
+                `----
+        "#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sizeof.rs
@@ -266,7 +266,6 @@ fn sizeof_static_array_ref() {
                 has_qubit_params: false
                 parameters:
                     10
-                return_type: void
                 return_type_span: [0-0]
                 body: Block [77-136]:
                     Stmt [91-126]:
@@ -299,7 +298,6 @@ fn sizeof_static_array_ref_omitted_dimension() {
                 has_qubit_params: false
                 parameters:
                     10
-                return_type: void
                 return_type_span: [0-0]
                 body: Block [77-133]:
                     Stmt [91-123]:
@@ -391,7 +389,6 @@ fn sizeof_static_array_ref_invalid_dimension_errors() {
                             has_qubit_params: false
                             parameters:
                                 10
-                            return_type: void
                             return_type_span: [0-0]
                             body: Block [77-136]:
                                 Stmt [91-126]:
@@ -434,7 +431,6 @@ fn sizeof_dyn_array_ref() {
                 has_qubit_params: false
                 parameters:
                     10
-                return_type: void
                 return_type_span: [0-0]
                 body: Block [81-134]:
                     Stmt [95-124]:
@@ -474,7 +470,6 @@ fn sizeof_dyn_array_ref_omitted_dimension() {
                 has_qubit_params: false
                 parameters:
                     10
-                return_type: void
                 return_type_span: [0-0]
                 body: Block [81-131]:
                     Stmt [95-121]:
@@ -516,7 +511,6 @@ fn sizeof_dyn_array_ref_invalid_dimension_lowers_correctly() {
                 has_qubit_params: false
                 parameters:
                     10
-                return_type: void
                 return_type_span: [0-0]
                 body: Block [81-134]:
                     Stmt [95-124]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
@@ -268,27 +268,6 @@ fn check_lowerer_error_spans_are_correct() {
              101 | }
                  `----
 
-            Qasm.Lowerer.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: def cal stmt
-                 ,-[Test.qasm:104:1]
-             103 | // Unimplemented defcal
-             104 | defcal {}
-                 : ^^^^^^^^^
-             105 | 
-                 `----
-
-            Qasm.Lowerer.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: calibration
-              | grammar stmt
-                 ,-[Test.qasm:107:1]
-             106 | // Unimplemented defcalgrammar
-             107 | defcalgrammar "my_grammar";
-                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             108 | 
-                 `----
-
             Qasm.Lowerer.ExprMustBeConst
 
               x const decl init expr must be a const expression
@@ -347,16 +326,6 @@ fn check_lowerer_error_spans_are_correct() {
              135 | 
                  `----
 
-            Qasm.Lowerer.Unimplemented
-
-              x this statement is not yet handled during OpenQASM 3 import: delay stmt
-                 ,-[Test.qasm:139:1]
-             138 | // Unimplemented delay
-             139 | delay [2ns] q1;
-                 : ^^^^^^^^^^^^^^^
-             140 | 
-                 `----
-
             Qasm.Lowerer.DefDeclarationInNonGlobalScope
 
               x extern declarations must be done in global scope
@@ -387,314 +356,304 @@ fn check_lowerer_error_spans_are_correct() {
              153 | 
                  `----
 
-            Qasm.Lowerer.NotSupported
-
-              x gate call duration are not supported
-                 ,-[Test.qasm:155:3]
-             154 | // NotSupported gate call duration
-             155 | x[2ns] q;
-                 :   ^^^
-             156 | 
-                 `----
-
             Qasm.Lowerer.InvalidNumberOfClassicalArgs
 
               x gate expects 1 classical arguments, but 2 were provided
-                 ,-[Test.qasm:158:1]
-             157 | // InvalidNumberOfClassicalArgs in gate call
-             158 | rx(2.0, 3.0) q;
+                 ,-[Test.qasm:155:1]
+             154 | // InvalidNumberOfClassicalArgs in gate call
+             155 | rx(2.0, 3.0) q;
                  : ^^^^^^^^^^^^^^^
-             159 | 
+             156 | 
                  `----
 
             Qasm.Lowerer.InvalidNumberOfQubitArgs
 
               x gate expects 1 qubit arguments, but 2 were provided
-                 ,-[Test.qasm:161:1]
-             160 | // InvalidNumberOfQubitArgs
-             161 | rx(2.0) q, q;
+                 ,-[Test.qasm:158:1]
+             157 | // InvalidNumberOfQubitArgs
+             158 | rx(2.0) q, q;
                  : ^^^^^^^^^^^^^
-             162 | 
+             159 | 
                  `----
 
             Qasm.Lowerer.BroadcastCallQuantumArgsDisagreeInSize
 
               x first quantum register is of type qubit[1] but found an argument of type
               | qubit[2]
-                 ,-[Test.qasm:164:18]
-             163 | // BroadcastCallQuantumArgsDisagreeInSize
-             164 | ryy(2.0) qreg_1, qreg_2;
+                 ,-[Test.qasm:161:18]
+             160 | // BroadcastCallQuantumArgsDisagreeInSize
+             161 | ryy(2.0) qreg_1, qreg_2;
                  :                  ^^^^^^
-             165 | 
+             162 | 
                  `----
 
             Qasm.Lowerer.ExprMustFitInU32
 
               x ctrl modifier argument must fit in a u32
-                 ,-[Test.qasm:172:6]
-             171 | // ExprMustFitInU32
-             172 | ctrl(5000000000) @ x q;
+                 ,-[Test.qasm:169:6]
+             168 | // ExprMustFitInU32
+             169 | ctrl(5000000000) @ x q;
                  :      ^^^^^^^^^^
-             173 | 
+             170 | 
                  `----
 
             Qasm.Lowerer.CannotCastLiteral
 
               x cannot cast literal expression of type const float to type const uint
-                 ,-[Test.qasm:179:12]
-             178 | // ArraySizeMustBeNonNegativeConstExpr
-             179 | array[int, 2.0] non_int_array_size;
+                 ,-[Test.qasm:176:12]
+             175 | // ArraySizeMustBeNonNegativeConstExpr
+             176 | array[int, 2.0] non_int_array_size;
                  :            ^^^
-             180 | 
+             177 | 
                  `----
 
             Qasm.Lowerer.ExprMustBeNonNegativeInt
 
               x array size must be a non-negative integer
-                 ,-[Test.qasm:182:12]
-             181 | // ArraySizeMustBeNonNegativeConstExpr
-             182 | array[int, -2] negative_array_size;
+                 ,-[Test.qasm:179:12]
+             178 | // ArraySizeMustBeNonNegativeConstExpr
+             179 | array[int, -2] negative_array_size;
                  :            ^^
-             183 | 
+             180 | 
                  `----
 
             Qasm.Lowerer.DesignatorTooLarge
 
               x designator is too large
-                 ,-[Test.qasm:185:12]
-             184 | // DesignatorTooLarge
-             185 | array[int, 5000000000] arr_size_too_large;
+                 ,-[Test.qasm:182:12]
+             181 | // DesignatorTooLarge
+             182 | array[int, 5000000000] arr_size_too_large;
                  :            ^^^^^^^^^^
-             186 | 
+             183 | 
                  `----
 
             Qasm.Lowerer.CannotCastLiteral
 
               x cannot cast literal expression of type const float to type const uint
+                 ,-[Test.qasm:185:5]
+             184 | // TypeWidthMustBePositiveIntConstExpr
+             185 | int[2.0] non_int_width;
+                 :     ^^^
+             186 | 
+                 `----
+
+            Qasm.Lowerer.ExprMustBePositiveInt
+
+              x type width must be a positive integer
                  ,-[Test.qasm:188:5]
              187 | // TypeWidthMustBePositiveIntConstExpr
-             188 | int[2.0] non_int_width;
-                 :     ^^^
-             189 | 
-                 `----
-
-            Qasm.Lowerer.ExprMustBePositiveInt
-
-              x type width must be a positive integer
-                 ,-[Test.qasm:191:5]
-             190 | // TypeWidthMustBePositiveIntConstExpr
-             191 | int[0] zero_width;
+             188 | int[0] zero_width;
                  :     ^
-             192 | int[-2] negative_width;
+             189 | int[-2] negative_width;
                  `----
 
             Qasm.Lowerer.ExprMustBePositiveInt
 
               x type width must be a positive integer
-                 ,-[Test.qasm:192:5]
-             191 | int[0] zero_width;
-             192 | int[-2] negative_width;
+                 ,-[Test.qasm:189:5]
+             188 | int[0] zero_width;
+             189 | int[-2] negative_width;
                  :     ^^
-             193 | 
+             190 | 
                  `----
 
             Qasm.Lowerer.DesignatorTooLarge
 
               x designator is too large
-                 ,-[Test.qasm:195:5]
-             194 | // DesignatorTooLarge
-             195 | int[5000000000] width_too_large;
+                 ,-[Test.qasm:192:5]
+             191 | // DesignatorTooLarge
+             192 | int[5000000000] width_too_large;
                  :     ^^^^^^^^^^
-             196 | 
+             193 | 
                  `----
 
             Qasm.Lowerer.TypeMaxWidthExceeded
 
               x float max width is 64 but 65 was provided
-                 ,-[Test.qasm:198:1]
-             197 | // TypeMaxWidthExceeded
-             198 | float[65] float_width_too_large;
+                 ,-[Test.qasm:195:1]
+             194 | // TypeMaxWidthExceeded
+             195 | float[65] float_width_too_large;
                  : ^^^^^^^^^
-             199 | angle[65] angle_width_too_large;
+             196 | angle[65] angle_width_too_large;
                  `----
 
             Qasm.Lowerer.TypeMaxWidthExceeded
 
               x angle max width is 64 but 65 was provided
-                 ,-[Test.qasm:199:1]
-             198 | float[65] float_width_too_large;
-             199 | angle[65] angle_width_too_large;
+                 ,-[Test.qasm:196:1]
+             195 | float[65] float_width_too_large;
+             196 | angle[65] angle_width_too_large;
                  : ^^^^^^^^^
-             200 | 
+             197 | 
                  `----
 
             Qasm.Lowerer.CannotCastLiteral
 
               x cannot cast literal expression of type const float to type int
-                 ,-[Test.qasm:202:1]
-             201 | // Invalid literal cast in cast_expr_with_target_type_or_default(...)
-             202 | int invalid_lit_cast = 2.0;
+                 ,-[Test.qasm:199:1]
+             198 | // Invalid literal cast in cast_expr_with_target_type_or_default(...)
+             199 | int invalid_lit_cast = 2.0;
                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             203 | 
+             200 | 
                  `----
 
             Qasm.Lowerer.QuantumTypesInBinaryExpression
 
               x quantum typed values cannot be used in binary expressions
-                 ,-[Test.qasm:211:5]
-             210 | // QuantumTypesInBinaryExpression
-             211 | 1 + q;
+                 ,-[Test.qasm:208:5]
+             207 | // QuantumTypesInBinaryExpression
+             208 | 1 + q;
                  :     ^
-             212 | q + 1;
+             209 | q + 1;
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type qubit to type const float
-                 ,-[Test.qasm:211:5]
-             210 | // QuantumTypesInBinaryExpression
-             211 | 1 + q;
+                 ,-[Test.qasm:208:5]
+             207 | // QuantumTypesInBinaryExpression
+             208 | 1 + q;
                  :     ^
-             212 | q + 1;
+             209 | q + 1;
                  `----
 
             Qasm.Lowerer.QuantumTypesInBinaryExpression
 
               x quantum typed values cannot be used in binary expressions
-                 ,-[Test.qasm:212:1]
-             211 | 1 + q;
-             212 | q + 1;
+                 ,-[Test.qasm:209:1]
+             208 | 1 + q;
+             209 | q + 1;
                  : ^
-             213 | 
+             210 | 
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type qubit to type const float
-                 ,-[Test.qasm:212:1]
-             211 | 1 + q;
-             212 | q + 1;
+                 ,-[Test.qasm:209:1]
+             208 | 1 + q;
+             209 | q + 1;
                  : ^
-             213 | 
+             210 | 
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type angle to type float
-                 ,-[Test.qasm:216:1]
-             215 | angle uncastable_to_int = 2.0;
-             216 | uncastable_to_int + 3;
+                 ,-[Test.qasm:213:1]
+             212 | angle uncastable_to_int = 2.0;
+             213 | uncastable_to_int + 3;
                  : ^^^^^^^^^^^^^^^^^
-             217 | 3 + uncastable_to_int;
+             214 | 3 + uncastable_to_int;
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type angle to type const float
-                 ,-[Test.qasm:217:5]
-             216 | uncastable_to_int + 3;
-             217 | 3 + uncastable_to_int;
+                 ,-[Test.qasm:214:5]
+             213 | uncastable_to_int + 3;
+             214 | 3 + uncastable_to_int;
                  :     ^^^^^^^^^^^^^^^^^
-             218 | 
+             215 | 
                  `----
 
             Qasm.Lowerer.OperatorNotAllowedForComplexValues
 
               x the operator OrB is not allowed for complex values
-                 ,-[Test.qasm:220:1]
-             219 | // OperatorNotAllowedForComplexValues
-             220 | (2 + 1im) | 3im;
+                 ,-[Test.qasm:217:1]
+             216 | // OperatorNotAllowedForComplexValues
+             217 | (2 + 1im) | 3im;
                  : ^^^^^^^^^^^^^^^
-             221 | 
+             218 | 
                  `----
 
             Qasm.Lowerer.IndexSetOnlyAllowedInAliasStmt
 
               x index sets are only allowed in alias statements
-                 ,-[Test.qasm:223:8]
-             222 | // IndexSetOnlyAllowedInAliasStmt
-             223 | qreg_2[{0, 1}];
+                 ,-[Test.qasm:220:8]
+             219 | // IndexSetOnlyAllowedInAliasStmt
+             220 | qreg_2[{0, 1}];
                  :        ^^^^^^
-             224 | 
+             221 | 
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type const angle to type const int
-                 ,-[Test.qasm:227:13]
-             226 | array[int, 5] range_error;
-             227 | range_error[const_uncastable_to_int:2.2];
+                 ,-[Test.qasm:224:13]
+             223 | array[int, 5] range_error;
+             224 | range_error[const_uncastable_to_int:2.2];
                  :             ^^^^^^^^^^^^^^^^^^^^^^^
-             228 | 
+             225 | 
                  `----
 
             Qasm.Lowerer.ZeroStepInRange
 
               x range step cannot be zero
-                 ,-[Test.qasm:230:13]
-             229 | // ZeroStepInRange
-             230 | range_error[1:0:3];
+                 ,-[Test.qasm:227:13]
+             226 | // ZeroStepInRange
+             227 | range_error[1:0:3];
                  :             ^^^^^
-             231 | 
+             228 | 
                  `----
 
             Qasm.Lowerer.ZeroSizeArrayAccess
 
               x zero size array access is not allowed
-                 ,-[Test.qasm:234:1]
-             233 | array[int, 2, 0, 3] zero_size_array;
-             234 | zero_size_array[1];
+                 ,-[Test.qasm:231:1]
+             230 | array[int, 2, 0, 3] zero_size_array;
+             231 | zero_size_array[1];
                  : ^^^^^^^^^^^^^^^^^^
-             235 | 
+             232 | 
                  `----
               help: array size must be a positive integer const expression
 
             Qasm.Lowerer.CannotIndexType
 
               x cannot index variables of type bit
-                 ,-[Test.qasm:238:15]
-             237 | bit non_indexable;
-             238 | non_indexable[1];
+                 ,-[Test.qasm:235:15]
+             234 | bit non_indexable;
+             235 | non_indexable[1];
                  :               ^
-             239 | 
+             236 | 
                  `----
 
             Qasm.Lowerer.CannotIndexType
 
               x cannot index variables of type qubit
-                 ,-[Test.qasm:241:11]
-             240 | // TooManyIndices
-             241 | qreg_1[1, 2];
+                 ,-[Test.qasm:238:11]
+             237 | // TooManyIndices
+             238 | qreg_1[1, 2];
                  :           ^
-             242 | 
+             239 | 
                  `----
 
             Qasm.Lowerer.UndefinedSymbol
 
               x undefined symbol: missing_symbol
-                 ,-[Test.qasm:244:1]
-             243 | // Missing symbol in lower_indexed_ident_expr(...)
-             244 | missing_symbol[2];
+                 ,-[Test.qasm:241:1]
+             240 | // Missing symbol in lower_indexed_ident_expr(...)
+             241 | missing_symbol[2];
                  : ^^^^^^^^^^^^^^
-             245 | 
+             242 | 
                  `----
 
             Qasm.Lowerer.CannotIndexType
 
               x cannot index variables of type unknown
-                 ,-[Test.qasm:244:16]
-             243 | // Missing symbol in lower_indexed_ident_expr(...)
-             244 | missing_symbol[2];
+                 ,-[Test.qasm:241:16]
+             240 | // Missing symbol in lower_indexed_ident_expr(...)
+             241 | missing_symbol[2];
                  :                ^
-             245 | 
+             242 | 
                  `----
 
             Qasm.Lowerer.EmptyIndexOperator
 
               x index operator must contain at least one index
-                 ,-[Test.qasm:248:13]
-             247 | bit[4] empty_index;
-             248 | empty_index[];
+                 ,-[Test.qasm:245:13]
+             244 | bit[4] empty_index;
+             245 | empty_index[];
                  :             ^
                  `----
         "#]],

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/box_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/box_stmt.rs
@@ -313,25 +313,11 @@ fn with_duration_fails() {
     check_stmt_kinds(
         "box [4us] { }",
         &expect![[r#"
-            Program:
-                version: <none>
-                pragmas: <empty>
-                statements:
-                    Stmt [0-13]:
-                        annotations: <empty>
-                        kind: BoxStmt [0-13]:
-                            duration: Expr [5-8]:
-                                ty: const duration
-                                kind: Lit: Duration(4.0, Us)
-                            body: <empty>
-
-            [Qasm.Lowerer.NotSupported
-
-              x Box with duration are not supported
-               ,-[test:1:6]
-             1 | box [4us] { }
-               :      ^^^
-               `----
-            ]"#]],
+            BoxStmt [0-13]:
+                duration: Expr [5-8]:
+                    ty: const duration
+                    kind: Lit: Duration(4.0, Us)
+                body: <empty>
+        "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/break_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/break_stmt.rs
@@ -125,7 +125,6 @@ fn intermediate_def_scope_fails() {
                                             symbol_id: 8
                                             has_qubit_params: false
                                             parameters: <empty>
-                                            return_type: void
                                             return_type_span: [0-0]
                                             body: Block [44-54]:
                                                 Stmt [46-52]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/continue_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/continue_stmt.rs
@@ -125,7 +125,6 @@ fn intermediate_def_scope_fails() {
                                             symbol_id: 8
                                             has_qubit_params: false
                                             parameters: <empty>
-                                            return_type: void
                                             return_type_span: [0-0]
                                             body: Block [44-57]:
                                                 Stmt [46-55]:

--- a/source/compiler/qsc_qasm/src/types.rs
+++ b/source/compiler/qsc_qasm/src/types.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Complex {
@@ -35,8 +38,10 @@ pub enum Type {
     AngleArray(ArrayDimensions, bool),
     QubitArray(ArrayDimensions),
     ResultArray(ArrayDimensions, bool),
-    /// Function or operation, with the number of classical parameters and qubits.
-    Callable(CallableKind, u32, u32),
+    /// # cargs, # qargs
+    Gate(u32, u32),
+    /// kind, args, return ty
+    Callable(CallableKind, Arc<[Type]>, Arc<Type>),
     #[default]
     Err,
 }
@@ -138,8 +143,11 @@ impl Display for Type {
             Type::AngleArray(dim, _) => write!(f, "Angle{dim}"),
             Type::QubitArray(dim) => write!(f, "Qubit{dim}"),
             Type::ResultArray(dim, _) => write!(f, "Result{dim}"),
-            Type::Callable(kind, num_classical, num_qubits) => {
-                write!(f, "Callable({kind}, {num_classical}, {num_qubits})")
+            Type::Callable(kind, args, return_type) => {
+                write!(f, "Callable({kind}, {args:?}, {return_type})")
+            }
+            Type::Gate(cargs, qargs) => {
+                write!(f, "Gate({cargs}, {qargs})")
             }
             Type::Err => write!(f, "Err"),
         }


### PR DESCRIPTION
This PR moves errors from the lowerer to the compiler for errors that are strictly associated with the QDK's unsupported OpenQASM features. As as side effect:
- Unified parsed string handling in `Arc`'s
- Removed dead code
- Added `cal` and `defcal` bodies to parsed and semantic ASTs
- Moved Unsupported errors from lowerer to compiler

There is one bit that is a little annoying. When fixing the function/callable/def type to track the args and return type, we now have a scenario where the symbol doesn't have the correct type information. Before, we pulled the return type from the def stmt instead of the symbol. Now, we pull the return type from the symbol ty, but in cases where this shadowing happens, we set the ty to `Err` since we don't have the correct type. We can either put the return ty back into the stmt (duplicating info or in this case providing accurate info) or leave it as is. I don't think there is a correct answer as the code is incorrect. Q# allows for shadowing and if the correct type is provided, the errors aren't correct for usages of the function.