### PR TITLE
Added telemetry to changelog prompt

### DIFF
--- a/source/vscode/src/changelog.ts
+++ b/source/vscode/src/changelog.ts
@@ -48,7 +48,7 @@ export async function maybeShowChangelogPrompt(
     const associatedId = getRandomGuid();
     sendTelemetryEvent(EventType.ChangelogPromptStart, {
       associationId: associatedId,
-      qdkVersion: CHANGELOG_VERSION,
+      changelogVersion: CHANGELOG_VERSION,
     });
     const choice = await vscode.window.showInformationMessage(
       "The Azure Quantum Development Kit has been updated.",

--- a/source/vscode/src/telemetry.ts
+++ b/source/vscode/src/telemetry.ts
@@ -328,7 +328,7 @@ type EventTypes = {
   [EventType.ChangelogPromptStart]: {
     properties: {
       associationId: string;
-      qdkVersion: string;
+      changelogVersion: string;
     };
     measurements: Empty;
   };


### PR DESCRIPTION
Added two telemetry events, `ChangelogPromptStart` and `ChangelogPromptEnd` for tracking the use of the changelog prompt. `ChangelogPromptStart` will fire when we show the popup and has a `qdkVersion` field for what version of the QDK the popup is being shown for. `ChangelogPromptEnd` will fire when the user clicks one of the buttons on the changelog popup and has an `action` field with possible values `"showChangelog"` or `"suppressChangelog"` for discerning which button was pressed. Both events have and `associationId` field to correlate instances of the two.

Also removed the restriction that prevents the popup from appearing on a fresh install, as we want the popup to appear in that scenario now.