### PR TITLE
Switch the default reporting format to v2

### DIFF
--- a/source/vscode/src/azure/workspaceActions.ts
+++ b/source/vscode/src/azure/workspaceActions.ts
@@ -646,7 +646,7 @@ export async function submitJob(
     containerUri: sasResponse.sasUri,
     inputDataUri: `${storageAccount}/${containerName}/inputData`,
     inputDataFormat: "qir.v1",
-    outputDataFormat: "microsoft.quantum-results.v1",
+    outputDataFormat: "microsoft.quantum-results.v2",
     inputParams: {
       entryPoint: "ENTRYPOINT__main",
       arguments: [],


### PR DESCRIPTION
Switch the default job output format to v2 when submitting jobs from VS Code.

This matches the Python behavior introduced in https://github.com/microsoft/azure-quantum-python/pull/617/files#diff-48e91f4c7742aff9a2787763a2e97e5b3c56552787ca499b4bc45d6b0815d8c0
