### PR TITLE
Update expect formatting in unit tests to be more readable

### DIFF
--- a/source/language_service/src/completion/tests.rs
+++ b/source/language_service/src/completion/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use super::{CompletionItem, get_completions};
+use super::{Compilation, CompletionItem, get_completions};
 use crate::{
     Encoding,
     protocol::CompletionList,
@@ -12,42 +12,68 @@ use crate::{
 };
 use expect_test::{Expect, expect};
 use indoc::indoc;
+use qsc::line_column::Position;
 
 mod class_completions;
 mod openqasm;
 
-fn check(source_with_cursor: &str, completions_to_check: &[&str], expect: &Expect) {
-    let (compilation, cursor_position, _) = compile_with_markers(source_with_cursor, true);
+fn check(
+    compilation: &Compilation,
+    cursor_uri: &str,
+    cursor_position: Position,
+    completions_to_check: &[&str],
+    expect: &Expect,
+) {
     let actual_completions =
-        get_completions(&compilation, "<source>", cursor_position, Encoding::Utf8);
-    let checked_completions: Vec<Option<&CompletionItem>> = completions_to_check
+        get_completions(compilation, cursor_uri, cursor_position, Encoding::Utf8);
+
+    let mut checked_completions: Vec<(String, Option<&CompletionItem>)> = completions_to_check
         .iter()
         .map(|comp| {
-            actual_completions
-                .items
-                .iter()
-                .find(|item| item.label == **comp)
+            (
+                (*comp).to_string(),
+                actual_completions
+                    .items
+                    .iter()
+                    .find(|item| item.label == **comp),
+            )
         })
         .collect();
 
-    expect.assert_debug_eq(&checked_completions);
+    // Sort by actual items' sort text
+    checked_completions.sort_by_key(|c| {
+        c.1.map_or(String::new(), |c| c.sort_text.clone().unwrap_or_default())
+    });
+
+    expect.assert_debug_eq(&ActualCompletions {
+        completions: checked_completions,
+    });
+
+    assert_no_duplicates(actual_completions);
+}
+
+fn check_single_file(source_with_cursor: &str, completions_to_check: &[&str], expect: &Expect) {
+    let (compilation, cursor_position, _) = compile_with_markers(source_with_cursor, true);
+
+    check(
+        &compilation,
+        "<source>",
+        cursor_position,
+        completions_to_check,
+        expect,
+    );
 }
 
 fn check_with_stdlib(source_with_cursor: &str, completions_to_check: &[&str], expect: &Expect) {
     let (compilation, cursor_position, _) = compile_with_markers(source_with_cursor, false);
-    let actual_completions =
-        get_completions(&compilation, "<source>", cursor_position, Encoding::Utf8);
-    let checked_completions: Vec<Option<&CompletionItem>> = completions_to_check
-        .iter()
-        .map(|comp| {
-            actual_completions
-                .items
-                .iter()
-                .find(|item| item.label == **comp)
-        })
-        .collect();
 
-    expect.assert_debug_eq(&checked_completions);
+    check(
+        &compilation,
+        "<source>",
+        cursor_position,
+        completions_to_check,
+        expect,
+    );
 }
 
 fn check_project(
@@ -57,20 +83,14 @@ fn check_project(
 ) {
     let (compilation, cursor_uri, cursor_position, _) =
         compile_project_with_markers(sources_with_markers, true);
-    let actual_completions =
-        get_completions(&compilation, &cursor_uri, cursor_position, Encoding::Utf8);
-    let checked_completions: Vec<Option<&CompletionItem>> = completions_to_check
-        .iter()
-        .map(|comp| {
-            actual_completions
-                .items
-                .iter()
-                .find(|item| item.label == **comp)
-        })
-        .collect();
 
-    expect.assert_debug_eq(&checked_completions);
-    assert_no_duplicates(actual_completions);
+    check(
+        &compilation,
+        &cursor_uri,
+        cursor_position,
+        completions_to_check,
+        expect,
+    );
 }
 
 fn check_notebook(
@@ -80,20 +100,14 @@ fn check_notebook(
 ) {
     let (compilation, cell_uri, cursor_position, _) =
         compile_notebook_with_markers(cells_with_markers);
-    let actual_completions =
-        get_completions(&compilation, &cell_uri, cursor_position, Encoding::Utf8);
-    let checked_completions: Vec<Option<&CompletionItem>> = completions_to_check
-        .iter()
-        .map(|comp| {
-            actual_completions
-                .items
-                .iter()
-                .find(|item| item.label == **comp)
-        })
-        .collect();
 
-    expect.assert_debug_eq(&checked_completions);
-    assert_no_duplicates(actual_completions);
+    check(
+        &compilation,
+        &cell_uri,
+        cursor_position,
+        completions_to_check,
+        expect,
+    );
 }
 
 fn check_with_dependency(
@@ -108,20 +122,14 @@ fn check_with_dependency(
         dependency_alias,
         &[("<dependency_source>", dependency_source)],
     );
-    let actual_completions =
-        get_completions(&compilation, &cursor_uri, cursor_position, Encoding::Utf8);
-    let checked_completions: Vec<Option<&CompletionItem>> = completions_to_check
-        .iter()
-        .map(|comp| {
-            actual_completions
-                .items
-                .iter()
-                .find(|item| item.label == **comp)
-        })
-        .collect();
 
-    expect.assert_debug_eq(&checked_completions);
-    assert_no_duplicates(actual_completions);
+    check(
+        &compilation,
+        &cursor_uri,
+        cursor_position,
+        completions_to_check,
+        expect,
+    );
 }
 
 fn check_no_completions(source_with_cursor: &str) {
@@ -150,36 +158,80 @@ fn assert_no_duplicates(mut actual_completions: CompletionList) {
     assert!(dups.is_empty(), "duplicate completions found: {dups:#?}");
 }
 
+struct ActualCompletions<'a> {
+    completions: Vec<(String, Option<&'a CompletionItem>)>,
+}
+
+impl std::fmt::Debug for ActualCompletions<'_> {
+    fn fmt(&self, output: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut first = true;
+
+        for (label, c) in &self.completions {
+            if let Some(c) = c {
+                if first {
+                    first = false;
+                    writeln!(output, "found, sorted:")?;
+                }
+                writeln!(output, "  {label:?} ({:?})", c.kind,)?;
+                if let Some(detail) = &c.detail {
+                    writeln!(output, "    detail: {detail:?}")?;
+                }
+
+                if let Some(edits) = &c.additional_text_edits {
+                    writeln!(output, "    additional_text_edits:")?;
+                    for edit in edits {
+                        writeln!(
+                            output,
+                            "      [{}:{}-{}:{}] {:?}",
+                            edit.range.start.line,
+                            edit.range.start.column,
+                            edit.range.end.line,
+                            edit.range.end.column,
+                            edit.new_text,
+                        )?;
+                    }
+                }
+            }
+        }
+
+        first = true;
+
+        for (label, c) in &self.completions {
+            if c.is_none() {
+                if first {
+                    first = false;
+                    writeln!(output, "\nnot found:")?;
+                }
+                writeln!(output, "  {label:?}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[test]
 fn ignore_unstable_namespace() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             open ↘
         }"#,
         &["FakeStdLib", "Microsoft.Quantum.Unstable"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "FakeStdLib",
-                        kind: Module,
-                        sort_text: Some(
-                            "0100FakeStdLib",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "FakeStdLib" (Module)
+
+            not found:
+              "Microsoft.Quantum.Unstable"
+
         "#]],
     );
 }
 
 #[test]
 fn ignore_unstable_callable() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             import Microsoft.Quantum.Unstable.*;
@@ -189,45 +241,22 @@ fn ignore_unstable_callable() {
         }"#,
         &["Fake", "UnstableFake"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Fake;\n            ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+                additional_text_edits:
+                  [2:12-2:12] "import FakeStdLib.Fake;\n            "
+
+            not found:
+              "UnstableFake"
+
         "#]],
     );
 }
 
 #[test]
 fn ignore_internal_callable() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             internal operation Foo() : Unit {}
@@ -241,71 +270,26 @@ fn ignore_internal_callable() {
         }"#,
         &["Fake", "Foo", "Baz", "Hidden"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Fake;\n            ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Foo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300Foo",
-                        ),
-                        detail: Some(
-                            "operation Foo() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Baz",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300Baz",
-                        ),
-                        detail: Some(
-                            "operation Baz() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "Baz" (Function)
+                detail: "operation Baz() : Unit"
+              "Foo" (Function)
+                detail: "operation Foo() : Unit"
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+                additional_text_edits:
+                  [2:12-2:12] "import FakeStdLib.Fake;\n            "
+
+            not found:
+              "Hidden"
+
         "#]],
     );
 }
 
 #[test]
 fn in_block_contains_std_functions_from_open_namespace() {
-    check(
+    check_single_file(
         r#"
     namespace Test {
         open FakeStdLib;
@@ -315,47 +299,14 @@ fn in_block_contains_std_functions_from_open_namespace() {
     }"#,
         &["Fake", "FakeWithParam", "FakeCtlAdj"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "FakeWithParam",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400FakeWithParam",
-                        ),
-                        detail: Some(
-                            "operation FakeWithParam(x : Int) : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "FakeCtlAdj",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400FakeCtlAdj",
-                        ),
-                        detail: Some(
-                            "operation FakeCtlAdj() : Unit is Adj + Ctl",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+              "FakeCtlAdj" (Function)
+                detail: "operation FakeCtlAdj() : Unit is Adj + Ctl"
+              "FakeWithParam" (Function)
+                detail: "operation FakeWithParam(x : Int) : Unit"
+
         "#]],
     );
 }
@@ -363,7 +314,7 @@ fn in_block_contains_std_functions_from_open_namespace() {
 #[allow(clippy::too_many_lines)]
 #[test]
 fn in_block_contains_std_functions() {
-    check(
+    check_single_file(
         indoc! {r#"
     namespace Test {
         operation Foo() : Unit {
@@ -372,102 +323,27 @@ fn in_block_contains_std_functions() {
     }"#},
         &["Fake", "FakeWithParam", "FakeCtlAdj"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Fake;\n    ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "FakeWithParam",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401FakeWithParam",
-                        ),
-                        detail: Some(
-                            "operation FakeWithParam(x : Int) : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.FakeWithParam;\n    ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "FakeCtlAdj",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401FakeCtlAdj",
-                        ),
-                        detail: Some(
-                            "operation FakeCtlAdj() : Unit is Adj + Ctl",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.FakeCtlAdj;\n    ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+                additional_text_edits:
+                  [1:4-1:4] "import FakeStdLib.Fake;\n    "
+              "FakeCtlAdj" (Function)
+                detail: "operation FakeCtlAdj() : Unit is Adj + Ctl"
+                additional_text_edits:
+                  [1:4-1:4] "import FakeStdLib.FakeCtlAdj;\n    "
+              "FakeWithParam" (Function)
+                detail: "operation FakeWithParam(x : Int) : Unit"
+                additional_text_edits:
+                  [1:4-1:4] "import FakeStdLib.FakeWithParam;\n    "
+
         "#]],
     );
 }
 
 #[test]
 fn in_block_contains_newtypes() {
-    check(
+    check_single_file(
         r#"
     namespace Test {
         newtype Custom = String;
@@ -477,57 +353,21 @@ fn in_block_contains_newtypes() {
     }"#,
         &["Custom", "Udt"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Custom",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0400Custom",
-                        ),
-                        detail: Some(
-                            "newtype Custom = String",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0501Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Udt;\n        ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 2,
-                                            column: 8,
-                                        },
-                                        end: Position {
-                                            line: 2,
-                                            column: 8,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "Custom" (Interface)
+                detail: "newtype Custom = String"
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+                additional_text_edits:
+                  [2:8-2:8] "import FakeStdLib.Udt;\n        "
+
         "#]],
     );
 }
 
 #[test]
 fn types_only_in_signature() {
-    check(
+    check_single_file(
         r#"
     namespace Test {
         operation Foo(foo: ↘) : Unit {
@@ -537,38 +377,20 @@ fn types_only_in_signature() {
     }"#,
         &["Int", "String", "Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Int",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0200Int",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "String",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0200String",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "Int" (Interface)
+              "String" (Interface)
+
+            not found:
+              "Bar"
+
         "#]],
     );
 }
 
 #[test]
 fn in_block_no_auto_open() {
-    check(
+    check_single_file(
         indoc! {r#"
     namespace Test {
         open FakeStdLib;
@@ -578,28 +400,17 @@ fn in_block_no_auto_open() {
     }"#},
         &["Fake"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+
         "#]],
     );
 }
 
 #[test]
 fn in_block_with_alias() {
-    check(
+    check_single_file(
         indoc! {r#"
     namespace Test {
         open FakeStdLib as Alias;
@@ -609,28 +420,17 @@ fn in_block_with_alias() {
     }"#},
         &["Alias.Fake"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Alias.Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400Alias.Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Alias.Fake" (Function)
+                detail: "operation Fake() : Unit"
+
         "#]],
     );
 }
 
 #[test]
 fn members_of_aliased_namespace() {
-    check(
+    check_single_file(
         indoc! {r#"
     namespace Test {
         open FakeStdLib as Alias;
@@ -640,42 +440,23 @@ fn members_of_aliased_namespace() {
     }"#},
         &["Fake", "Alias.Fake", "Library", "Alias.Library", "Foo"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Library",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600Library",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+              "Library" (Module)
+
+            not found:
+              "Alias.Fake"
+              "Alias.Library"
+              "Foo"
+
         "#]],
     );
 }
 
 #[test]
 fn aliased_exact_import() {
-    check(
+    check_single_file(
         indoc! {r#"
     namespace Test {
         import FakeStdLib.Fake as Alias;
@@ -685,23 +466,14 @@ fn aliased_exact_import() {
     }"#},
         &["Fake", "Alias.Fake", "Alias"],
         &expect![[r#"
-            [
-                None,
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Alias",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400Alias",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Alias" (Function)
+                detail: "operation Fake() : Unit"
+
+            not found:
+              "Fake"
+              "Alias.Fake"
+
         "#]],
     );
 }
@@ -720,21 +492,10 @@ fn open_from_dependency() {
         "namespace Dependency { operation Baz() : Unit {} export Baz; }",
         &["Baz"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Baz",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400Baz",
-                        ),
-                        detail: Some(
-                            "operation Baz() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Baz" (Function)
+                detail: "operation Baz() : Unit"
+
         "#]],
     );
 }
@@ -755,36 +516,16 @@ fn open_with_alias_from_dependency() {
         "namespace Dependency { operation Baz() : Unit {} export Baz; }",
         &["Alias.Baz", "Baz", "Alias1.Bar", "Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Alias.Baz",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400Alias.Baz",
-                        ),
-                        detail: Some(
-                            "operation Baz() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Alias1.Bar",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300Alias1.Bar",
-                        ),
-                        detail: Some(
-                            "operation Bar() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "Alias1.Bar" (Function)
+                detail: "operation Bar() : Unit"
+              "Alias.Baz" (Function)
+                detail: "operation Baz() : Unit"
+
+            not found:
+              "Baz"
+              "Bar"
+
         "#]],
     );
 }
@@ -805,36 +546,16 @@ fn import_ns_with_alias_from_dependency() {
         "namespace Dependency { operation Baz() : Unit {} export Baz; }",
         &["Alias.Baz", "Baz", "Alias1.Bar", "Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Alias.Baz",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400Alias.Baz",
-                        ),
-                        detail: Some(
-                            "operation Baz() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Alias1.Bar",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300Alias1.Bar",
-                        ),
-                        detail: Some(
-                            "operation Bar() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "Alias1.Bar" (Function)
+                detail: "operation Bar() : Unit"
+              "Alias.Baz" (Function)
+                detail: "operation Baz() : Unit"
+
+            not found:
+              "Baz"
+              "Bar"
+
         "#]],
     );
 }
@@ -853,28 +574,17 @@ fn exact_import_from_dependency() {
         "namespace Dependency { operation Baz() : Unit {} export Baz; }",
         &["Baz"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Baz",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400Baz",
-                        ),
-                        detail: Some(
-                            "operation Baz() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Baz" (Function)
+                detail: "operation Baz() : Unit"
+
         "#]],
     );
 }
 
 #[test]
 fn in_block_from_other_namespace() {
-    check(
+    check_single_file(
         indoc! {r#"
     namespace Test {
         operation Bar() : Unit {
@@ -888,37 +598,12 @@ fn in_block_from_other_namespace() {
     }"#},
         &["Foo"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Foo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0301Foo",
-                        ),
-                        detail: Some(
-                            "operation Foo() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import Other.Foo;\n    ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "Foo" (Function)
+                detail: "operation Foo() : Unit"
+                additional_text_edits:
+                  [1:4-1:4] "import Other.Foo;\n    "
+
         "#]],
     );
 }
@@ -940,44 +625,19 @@ fn auto_open_multiple_files() {
         ],
         &["FooOperation"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "FooOperation",
-                        kind: Function,
-                        sort_text: Some(
-                            "0301FooOperation",
-                        ),
-                        detail: Some(
-                            "operation FooOperation() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import Foo.FooOperation;\n ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 0,
-                                            column: 16,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 16,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "FooOperation" (Function)
+                detail: "operation FooOperation() : Unit"
+                additional_text_edits:
+                  [0:16-0:16] "import Foo.FooOperation;\n "
+
         "#]],
     );
 }
 
 #[test]
 fn in_block_nested_op() {
-    check(
+    check_single_file(
         indoc! {r#"
     namespace Test {
         operation Bar() : Unit {
@@ -987,28 +647,17 @@ fn in_block_nested_op() {
     }"#},
         &["Foo"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Foo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0100Foo",
-                        ),
-                        detail: Some(
-                            "operation Foo() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Foo" (Function)
+                detail: "operation Foo() : Unit"
+
         "#]],
     );
 }
 
 #[test]
 fn in_block_hidden_nested_op() {
-    check(
+    check_single_file(
         indoc! {r#"
     namespace Test {
         operation Baz() : Unit {
@@ -1020,16 +669,17 @@ fn in_block_hidden_nested_op() {
     }"#},
         &["Bar"],
         &expect![[r#"
-            [
-                None,
-            ]
+
+            not found:
+              "Bar"
+
         "#]],
     );
 }
 
 #[test]
 fn in_namespace_contains_open() {
-    check(
+    check_single_file(
         indoc! {r#"
     namespace Test {
         ↘
@@ -1038,52 +688,32 @@ fn in_namespace_contains_open() {
     }"#},
         &["open"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "open",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000open",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "open" (Keyword)
+
         "#]],
     );
 }
 
 #[test]
 fn top_level_contains_namespace() {
-    check(
+    check_single_file(
         indoc! {r#"
         namespace Test {}
         ↘
         "#},
         &["namespace"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "namespace",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000namespace",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "namespace" (Keyword)
+
         "#]],
     );
 }
 
 #[test]
 fn attributes() {
-    check(
+    check_single_file(
         indoc! {r#"
         namespace Test {
             @↘
@@ -1091,26 +721,16 @@ fn attributes() {
         "#},
         &["EntryPoint"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "EntryPoint",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0000EntryPoint",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "EntryPoint" (Interface)
+
         "#]],
     );
 }
 
 #[test]
 fn stdlib_udt() {
-    check(
+    check_single_file(
         indoc! {r#"
         namespace Test {
             operation Foo() : Unit {
@@ -1119,37 +739,12 @@ fn stdlib_udt() {
         "#},
         &["TakesUdt"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "TakesUdt",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401TakesUdt",
-                        ),
-                        detail: Some(
-                            "function TakesUdt(input : Udt) : Udt",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.TakesUdt;\n    ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 4,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "TakesUdt" (Function)
+                detail: "function TakesUdt(input : Udt) : Udt"
+                additional_text_edits:
+                  [1:4-1:4] "import FakeStdLib.TakesUdt;\n    "
+
         "#]],
     );
 }
@@ -1165,70 +760,15 @@ fn notebook_top_level() {
         )],
         &["operation", "namespace", "let", "Fake"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "operation",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000operation",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "namespace",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000namespace",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "let",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000let",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Fake;\n",
-                                    range: Range {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "let" (Keyword)
+              "namespace" (Keyword)
+              "operation" (Keyword)
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+                additional_text_edits:
+                  [0:0-0:0] "import FakeStdLib.Fake;\n"
+
         "#]],
     );
 }
@@ -1244,37 +784,12 @@ fn notebook_top_level_global() {
         )],
         &["Fake"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Fake;\n",
-                                    range: Range {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+                additional_text_edits:
+                  [0:0-0:0] "import FakeStdLib.Fake;\n"
+
         "#]],
     );
 }
@@ -1292,21 +807,10 @@ fn notebook_top_level_namespace_already_open_for_global() {
         )],
         &["Fake"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+
         "#]],
     );
 }
@@ -1323,48 +827,13 @@ fn notebook_block() {
         )],
         &["Fake", "let"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Fake;\n",
-                                    range: Range {
-                                        start: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 0,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "let",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000let",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "let" (Keyword)
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+                additional_text_edits:
+                  [0:0-0:0] "import FakeStdLib.Fake;\n"
+
         "#]],
     );
 }
@@ -1390,37 +859,12 @@ fn notebook_auto_open_start_of_cell_empty() {
         ],
         &["Fake"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Fake;\n",
-                                    range: Range {
-                                        start: Position {
-                                            line: 1,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 0,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+                additional_text_edits:
+                  [1:0-1:0] "import FakeStdLib.Fake;\n"
+
         "#]],
     );
 }
@@ -1447,37 +891,12 @@ fn notebook_auto_open_start_of_cell() {
         ],
         &["Fake"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Fake;\n",
-                                    range: Range {
-                                        start: Position {
-                                            line: 1,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 0,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+                additional_text_edits:
+                  [1:0-1:0] "import FakeStdLib.Fake;\n"
+
         "#]],
     );
 }
@@ -1495,57 +914,21 @@ fn notebook_last_expr() {
         )],
         &["Foo", "Fake"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Foo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0100Foo",
-                        ),
-                        detail: Some(
-                            "function Foo() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Fake;\n",
-                                    range: Range {
-                                        start: Position {
-                                            line: 1,
-                                            column: 0,
-                                        },
-                                        end: Position {
-                                            line: 1,
-                                            column: 0,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "Foo" (Function)
+                detail: "function Foo() : Unit"
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+                additional_text_edits:
+                  [1:0-1:0] "import FakeStdLib.Fake;\n"
+
         "#]],
     );
 }
 
 #[test]
 fn local_vars() {
-    check(
+    check_single_file(
         r#"
     namespace Test {
         operation Foo() : Unit {
@@ -1556,29 +939,20 @@ fn local_vars() {
     }"#,
         &["foo", "bar"],
         &expect![[r#"
-            [
-                None,
-                Some(
-                    CompletionItem {
-                        label: "bar",
-                        kind: Variable,
-                        sort_text: Some(
-                            "0100bar",
-                        ),
-                        detail: Some(
-                            "bar : Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "bar" (Variable)
+                detail: "bar : Int"
+
+            not found:
+              "foo"
+
         "#]],
     );
 }
 
 #[test]
 fn local_items() {
-    check(
+    check_single_file(
         r#"
     namespace Test {
         operation Baz() : Unit {
@@ -1590,54 +964,21 @@ fn local_items() {
     }"#,
         &["Foo", "Bar", "Custom"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Foo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0100Foo",
-                        ),
-                        detail: Some(
-                            "operation Foo() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Bar",
-                        kind: Function,
-                        sort_text: Some(
-                            "0100Bar",
-                        ),
-                        detail: Some(
-                            "operation Bar() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Custom",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0100Custom",
-                        ),
-                        detail: Some(
-                            "newtype Custom = String",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Bar" (Function)
+                detail: "operation Bar() : Unit"
+              "Custom" (Interface)
+                detail: "newtype Custom = String"
+              "Foo" (Function)
+                detail: "operation Foo() : Unit"
+
         "#]],
     );
 }
 
 #[test]
 fn type_params() {
-    check(
+    check_single_file(
         r#"
     namespace Test {
         operation Foo<'T>() : Unit {
@@ -1646,27 +987,19 @@ fn type_params() {
     }"#,
         &["'T", "Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "'T",
-                        kind: TypeParameter,
-                        sort_text: Some(
-                            "0100'T",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "'T" (TypeParameter)
+
+            not found:
+              "Bar"
+
         "#]],
     );
 }
 
 #[test]
 fn scoped_local_vars() {
-    check(
+    check_single_file(
         r#"
     namespace Test {
         operation Foo() : Unit {
@@ -1678,16 +1011,17 @@ fn scoped_local_vars() {
     }"#,
         &["foo"],
         &expect![[r#"
-            [
-                None,
-            ]
+
+            not found:
+              "foo"
+
         "#]],
     );
 }
 
 #[test]
 fn callable_params() {
-    check(
+    check_single_file(
         r#"
     namespace Test {
         newtype Custom = String;
@@ -1699,41 +1033,19 @@ fn callable_params() {
     }"#,
         &["foo", "bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "foo",
-                        kind: Variable,
-                        sort_text: Some(
-                            "0100foo",
-                        ),
-                        detail: Some(
-                            "foo : Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "bar",
-                        kind: Variable,
-                        sort_text: Some(
-                            "0100bar",
-                        ),
-                        detail: Some(
-                            "bar : Custom",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "bar" (Variable)
+                detail: "bar : Custom"
+              "foo" (Variable)
+                detail: "foo : Int"
+
         "#]],
     );
 }
 
 #[test]
 fn local_var_in_callable_parent_scope() {
-    check(
+    check_single_file(
         r#"
     namespace Test {
         operation Foo(foo: Int) : Unit {
@@ -1746,23 +1058,14 @@ fn local_var_in_callable_parent_scope() {
     }"#,
         &["foo", "bar", "baz"],
         &expect![[r#"
-            [
-                None,
-                None,
-                Some(
-                    CompletionItem {
-                        label: "baz",
-                        kind: Variable,
-                        sort_text: Some(
-                            "0100baz",
-                        ),
-                        detail: Some(
-                            "baz : Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "baz" (Variable)
+                detail: "baz : Int"
+
+            not found:
+              "foo"
+              "bar"
+
         "#]],
     );
 }
@@ -1770,7 +1073,7 @@ fn local_var_in_callable_parent_scope() {
 #[test]
 #[ignore = "completion list ignores shadowing rules for open statements"]
 fn local_var_and_open_shadowing_rules() {
-    check(
+    check_single_file(
         r#"
         namespace Foo {
             operation Bar() : Unit {
@@ -1814,7 +1117,7 @@ fn local_var_and_open_shadowing_rules() {
 // no additional text edits for Foo or Bar because FooNs is already glob imported
 #[test]
 fn dont_import_if_already_glob_imported() {
-    check(
+    check_single_file(
         r#"
         namespace FooNs {
             operation Foo() : Unit {
@@ -1830,34 +1133,12 @@ fn dont_import_if_already_glob_imported() {
         }"#,
         &["Foo", "Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Foo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300Foo",
-                        ),
-                        detail: Some(
-                            "operation Foo() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Bar",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300Bar",
-                        ),
-                        detail: Some(
-                            "operation Bar() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Bar" (Function)
+                detail: "operation Bar() : Unit"
+              "Foo" (Function)
+                detail: "operation Foo() : Unit"
+
         "#]],
     );
 }
@@ -1865,7 +1146,7 @@ fn dont_import_if_already_glob_imported() {
 // expect an auto-import for `Foo.Bar`, separate from the preexisting glob import `Foo.Bar.*`
 #[test]
 fn glob_import_item_with_same_name() {
-    check(
+    check_single_file(
         r#"
         namespace Foo {
             operation Bar() : Unit {
@@ -1883,37 +1164,12 @@ fn glob_import_item_with_same_name() {
         }"#,
         &["Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Bar",
-                        kind: Function,
-                        sort_text: Some(
-                            "0301Bar",
-                        ),
-                        detail: Some(
-                            "operation Bar() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import Foo.Bar;\n            ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 10,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 10,
-                                            column: 12,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "Bar" (Function)
+                detail: "operation Bar() : Unit"
+                additional_text_edits:
+                  [10:12-10:12] "import Foo.Bar;\n            "
+
         "#]],
     );
 }
@@ -1922,7 +1178,7 @@ fn glob_import_item_with_same_name() {
 // but additional text edits for Bar because Bar is not directly imported
 #[test]
 fn dont_import_if_already_directly_imported() {
-    check(
+    check_single_file(
         r#"
         namespace FooNs {
             operation Foo() : Unit { }
@@ -1937,50 +1193,14 @@ fn dont_import_if_already_directly_imported() {
         }"#,
         &["Foo", "Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Foo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300Foo",
-                        ),
-                        detail: Some(
-                            "operation Foo() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Bar",
-                        kind: Function,
-                        sort_text: Some(
-                            "0301Bar",
-                        ),
-                        detail: Some(
-                            "operation Bar() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FooNs.Bar;\n            ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 7,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 7,
-                                            column: 12,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "Foo" (Function)
+                detail: "operation Foo() : Unit"
+              "Bar" (Function)
+                detail: "operation Bar() : Unit"
+                additional_text_edits:
+                  [7:12-7:12] "import FooNs.Bar;\n            "
+
         "#]],
     );
 }
@@ -1996,37 +1216,12 @@ fn auto_import_from_qir_runtime() {
         }"#,
         &["AllocateQubitArray"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "AllocateQubitArray",
-                        kind: Function,
-                        sort_text: Some(
-                            "0201AllocateQubitArray",
-                        ),
-                        detail: Some(
-                            "operation AllocateQubitArray(size : Int) : Qubit[]",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import QIR.Runtime.AllocateQubitArray;\n            ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "AllocateQubitArray" (Function)
+                detail: "operation AllocateQubitArray(size : Int) : Qubit[]"
+                additional_text_edits:
+                  [2:12-2:12] "import QIR.Runtime.AllocateQubitArray;\n            "
+
         "#]],
     );
 }
@@ -2043,21 +1238,10 @@ fn dont_generate_import_for_core_prelude() {
         &["Length"],
         // additional text edits should be None because Length is in the core prelude
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Length",
-                        kind: Function,
-                        sort_text: Some(
-                            "0200Length",
-                        ),
-                        detail: Some(
-                            "function Length<'T>(a : 'T[]) : Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Length" (Function)
+                detail: "function Length<'T>(a : 'T[]) : Int"
+
         "#]],
     );
 }
@@ -2075,28 +1259,17 @@ fn dont_generate_import_for_stdlib_prelude() {
         // additional text edits should be None because MResetZ is in Std.Measurement, which
         // is in the prelude.
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "MResetZ",
-                        kind: Function,
-                        sort_text: Some(
-                            "0400MResetZ",
-                        ),
-                        detail: Some(
-                            "operation MResetZ(target : Qubit) : Result",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "MResetZ" (Function)
+                detail: "operation MResetZ(target : Qubit) : Result"
+
         "#]],
     );
 }
 
 #[test]
 fn callable_from_same_file() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             function MyCallable() : Unit {}
@@ -2106,28 +1279,17 @@ fn callable_from_same_file() {
         }"#,
         &["MyCallable"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "MyCallable",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300MyCallable",
-                        ),
-                        detail: Some(
-                            "function MyCallable() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "MyCallable" (Function)
+                detail: "function MyCallable() : Unit"
+
         "#]],
     );
 }
 
 #[test]
 fn member_completion() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             function MyCallable() : Unit {}
@@ -2142,28 +1304,17 @@ fn member_completion() {
         "#,
         &["MyCallable"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "MyCallable",
-                        kind: Function,
-                        sort_text: Some(
-                            "0200MyCallable",
-                        ),
-                        detail: Some(
-                            "function MyCallable() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "MyCallable" (Function)
+                detail: "function MyCallable() : Unit"
+
         "#]],
     );
 }
 
 #[test]
 fn member_completion_in_imported_namespace() {
-    check(
+    check_single_file(
         r#"
         namespace Test.Foo {
             function MyCallable() : Unit {}
@@ -2183,39 +1334,18 @@ fn member_completion_in_imported_namespace() {
         "#,
         &["MyCallable", "Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "MyCallable",
-                        kind: Function,
-                        sort_text: Some(
-                            "0200MyCallable",
-                        ),
-                        detail: Some(
-                            "function MyCallable() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Bar",
-                        kind: Module,
-                        sort_text: Some(
-                            "0500Bar",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "MyCallable" (Function)
+                detail: "function MyCallable() : Unit"
+              "Bar" (Module)
+
         "#]],
     );
 }
 
 #[test]
 fn namespace_completion() {
-    check(
+    check_single_file(
         r#"
         namespace Test.Foo {
             function MyCallable() : Unit {}
@@ -2230,26 +1360,16 @@ fn namespace_completion() {
         "#,
         &["Foo"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Foo",
-                        kind: Module,
-                        sort_text: Some(
-                            "0500Foo",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Foo" (Module)
+
         "#]],
     );
 }
 
 #[test]
 fn nested_namespace() {
-    check(
+    check_single_file(
         r#"
         namespace Test.Foo {
             function MyCallable() : Unit {}
@@ -2262,29 +1382,20 @@ fn nested_namespace() {
         }"#,
         &["MyCallable", "MyCallable2"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "MyCallable",
-                        kind: Function,
-                        sort_text: Some(
-                            "0200MyCallable",
-                        ),
-                        detail: Some(
-                            "function MyCallable() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "MyCallable" (Function)
+                detail: "function MyCallable() : Unit"
+
+            not found:
+              "MyCallable2"
+
         "#]],
     );
 }
 
 #[test]
 fn std_member() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             function MyCallable2() : Unit {
@@ -2293,93 +1404,56 @@ fn std_member() {
         }"#,
         &["Fake", "Library"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Fake",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300Fake",
-                        ),
-                        detail: Some(
-                            "operation Fake() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Library",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600Library",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Fake" (Function)
+                detail: "operation Fake() : Unit"
+              "Library" (Module)
+
         "#]],
     );
 }
 
 #[test]
 fn open_namespace() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             open FakeStdLib.↘;
         }"#,
         &["Fake", "Library"],
         &expect![[r#"
-            [
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Library",
-                        kind: Module,
-                        sort_text: Some(
-                            "0300Library",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Library" (Module)
+
+            not found:
+              "Fake"
+
         "#]],
     );
 }
 
 #[test]
 fn open_namespace_no_semi() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             open FakeStdLib.↘
         }"#,
         &["Fake", "Library"],
         &expect![[r#"
-            [
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Library",
-                        kind: Module,
-                        sort_text: Some(
-                            "0300Library",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Library" (Module)
+
+            not found:
+              "Fake"
+
         "#]],
     );
 }
 
 #[test]
 fn open_namespace_no_semi_followed_by_decl() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             open FakeStdLib.↘
@@ -2387,27 +1461,19 @@ fn open_namespace_no_semi_followed_by_decl() {
         }"#,
         &["Fake", "Library"],
         &expect![[r#"
-            [
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Library",
-                        kind: Module,
-                        sort_text: Some(
-                            "0300Library",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Library" (Module)
+
+            not found:
+              "Fake"
+
         "#]],
     );
 }
 
 #[test]
 fn open_namespace_partial_path_part() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             open FakeStdLib.↘F
@@ -2415,27 +1481,19 @@ fn open_namespace_partial_path_part() {
         }"#,
         &["Fake", "Library"],
         &expect![[r#"
-            [
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Library",
-                        kind: Module,
-                        sort_text: Some(
-                            "0300Library",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Library" (Module)
+
+            not found:
+              "Fake"
+
         "#]],
     );
 }
 
 #[test]
 fn let_stmt_type() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             function Main() : Unit {
@@ -2444,68 +1502,25 @@ fn let_stmt_type() {
         }"#,
         &["Udt", "Qubit", "Int", "Main", "FakeWithParam"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0501Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Udt;\n            ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Qubit",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0200Qubit",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Int",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0200Int",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-            ]
+            found, sorted:
+              "Int" (Interface)
+              "Qubit" (Interface)
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+                additional_text_edits:
+                  [2:12-2:12] "import FakeStdLib.Udt;\n            "
+
+            not found:
+              "Main"
+              "FakeWithParam"
+
         "#]],
     );
 }
 
 #[test]
 fn let_stmt_type_before_next_stmt() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             function Main() : Unit {
@@ -2516,68 +1531,25 @@ fn let_stmt_type_before_next_stmt() {
         }"#,
         &["Udt", "Qubit", "Int", "Main", "FakeWithParam"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0501Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Udt;\n            ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Qubit",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0200Qubit",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Int",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0200Int",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-            ]
+            found, sorted:
+              "Int" (Interface)
+              "Qubit" (Interface)
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+                additional_text_edits:
+                  [2:12-2:12] "import FakeStdLib.Udt;\n            "
+
+            not found:
+              "Main"
+              "FakeWithParam"
+
         "#]],
     );
 }
 
 #[test]
 fn type_position_namespace() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             function Main() : Unit {
@@ -2586,62 +1558,44 @@ fn type_position_namespace() {
         }"#,
         &["Udt", "Qubit", "Int", "Main", "FakeWithParam"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-                None,
-                None,
-            ]
+            found, sorted:
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+
+            not found:
+              "Qubit"
+              "Int"
+              "Main"
+              "FakeWithParam"
+
         "#]],
     );
 }
 
 #[test]
 fn udt_base_type_part() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             newtype Foo = FakeStdLib.↘
         }"#,
         &["Udt", "Qubit", "FakeWithParam"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-            ]
+            found, sorted:
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+
+            not found:
+              "Qubit"
+              "FakeWithParam"
+
         "#]],
     );
 }
 
 #[test]
 fn struct_init() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             function Main() : Unit {
@@ -2650,48 +1604,25 @@ fn struct_init() {
         }"#,
         &["Udt", "Qubit", "Int", "Main", "FakeWithParam"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0301Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import FakeStdLib.Udt;\n            ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                        end: Position {
-                                            line: 2,
-                                            column: 12,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-                None,
-                None,
-                None,
-                None,
-            ]
+            found, sorted:
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+                additional_text_edits:
+                  [2:12-2:12] "import FakeStdLib.Udt;\n            "
+
+            not found:
+              "Qubit"
+              "Int"
+              "Main"
+              "FakeWithParam"
+
         "#]],
     );
 }
 
 #[test]
 fn struct_init_path_part() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             function Main() : Unit {
@@ -2700,32 +1631,23 @@ fn struct_init_path_part() {
         }"#,
         &["Udt", "Qubit", "Int", "Main", "FakeWithParam"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-                None,
-                None,
-            ]
+            found, sorted:
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+
+            not found:
+              "Qubit"
+              "Int"
+              "Main"
+              "FakeWithParam"
+
         "#]],
     );
 }
 
 #[test]
 fn struct_init_path_part_in_field_assigment() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             function Main() : Unit {
@@ -2734,42 +1656,22 @@ fn struct_init_path_part_in_field_assigment() {
         }"#,
         &["Udt", "Qubit", "FakeWithParam"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                Some(
-                    CompletionItem {
-                        label: "FakeWithParam",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300FakeWithParam",
-                        ),
-                        detail: Some(
-                            "operation FakeWithParam(x : Int) : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "FakeWithParam" (Function)
+                detail: "operation FakeWithParam(x : Int) : Unit"
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+
+            not found:
+              "Qubit"
+
         "#]],
     );
 }
 
 #[test]
 fn export_path() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             export ↘ ;
@@ -2778,43 +1680,24 @@ fn export_path() {
         }"#,
         &["Udt", "Qubit", "Int", "Main", "FakeWithParam", "FakeStdLib"],
         &expect![[r#"
-            [
-                None,
-                None,
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Main",
-                        kind: Function,
-                        sort_text: Some(
-                            "0200Main",
-                        ),
-                        detail: Some(
-                            "function Main() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                Some(
-                    CompletionItem {
-                        label: "FakeStdLib",
-                        kind: Module,
-                        sort_text: Some(
-                            "0400FakeStdLib",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Main" (Function)
+                detail: "function Main() : Unit"
+              "FakeStdLib" (Module)
+
+            not found:
+              "Udt"
+              "Qubit"
+              "Int"
+              "FakeWithParam"
+
         "#]],
     );
 }
 
 #[test]
 fn export_path_part() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             export FakeStdLib.↘ ;
@@ -2823,45 +1706,25 @@ fn export_path_part() {
         }"#,
         &["Udt", "Qubit", "Int", "Main", "FakeWithParam", "FakeStdLib"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-                None,
-                Some(
-                    CompletionItem {
-                        label: "FakeWithParam",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300FakeWithParam",
-                        ),
-                        detail: Some(
-                            "operation FakeWithParam(x : Int) : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "FakeWithParam" (Function)
+                detail: "operation FakeWithParam(x : Int) : Unit"
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+
+            not found:
+              "Qubit"
+              "Int"
+              "Main"
+              "FakeStdLib"
+
         "#]],
     );
 }
 
 #[test]
 fn partially_typed_name() {
-    check(
+    check_single_file(
         r#"
         namespace Test {
             export Fo↘
@@ -2870,21 +1733,10 @@ fn partially_typed_name() {
         }"#,
         &["Foo"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Foo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0200Foo",
-                        ),
-                        detail: Some(
-                            "function Foo() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Foo" (Function)
+                detail: "function Foo() : Unit"
+
         "#]],
     );
 }
@@ -2899,66 +1751,16 @@ fn from_dependency_main() {
         ",
         &["MainFunc", "OtherFunc"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "MainFunc",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401MainFunc",
-                        ),
-                        detail: Some(
-                            "function MainFunc() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import MyDep.MainFunc;\n ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 0,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 17,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "OtherFunc",
-                        kind: Function,
-                        sort_text: Some(
-                            "0401OtherFunc",
-                        ),
-                        detail: Some(
-                            "function OtherFunc() : Unit",
-                        ),
-                        additional_text_edits: Some(
-                            [
-                                TextEdit {
-                                    new_text: "import MyDep.Other.OtherFunc;\n ",
-                                    range: Range {
-                                        start: Position {
-                                            line: 0,
-                                            column: 17,
-                                        },
-                                        end: Position {
-                                            line: 0,
-                                            column: 17,
-                                        },
-                                    },
-                                },
-                            ],
-                        ),
-                    },
-                ),
-            ]
+            found, sorted:
+              "MainFunc" (Function)
+                detail: "function MainFunc() : Unit"
+                additional_text_edits:
+                  [0:17-0:17] "import MyDep.MainFunc;\n "
+              "OtherFunc" (Function)
+                detail: "function OtherFunc() : Unit"
+                additional_text_edits:
+                  [0:17-0:17] "import MyDep.Other.OtherFunc;\n "
+
         "#]],
     );
 }
@@ -2971,20 +1773,12 @@ fn package_aliases() {
         "namespace Main { export MainFunc; function MainFunc() : Unit {} }",
         &["MyDep", "Main"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "MyDep",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600MyDep",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "MyDep" (Module)
+
+            not found:
+              "Main"
+
         "#]],
     );
 }
@@ -3000,35 +1794,16 @@ fn package_alias_members() {
         ",
         &["Main", "Other", "MainFunc", "Other.Sub", "Sub"],
         &expect![[r#"
-            [
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Other",
-                        kind: Module,
-                        sort_text: Some(
-                            "0700Other",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "MainFunc",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300MainFunc",
-                        ),
-                        detail: Some(
-                            "function MainFunc() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-            ]
+            found, sorted:
+              "MainFunc" (Function)
+                detail: "function MainFunc() : Unit"
+              "Other" (Module)
+
+            not found:
+              "Main"
+              "Other.Sub"
+              "Sub"
+
         "#]],
     );
 }
@@ -3044,36 +1819,17 @@ fn dependency_namespace_members() {
         ",
         &["Main", "Other", "MainFunc", "Other.Sub", "Sub", "OtherFunc"],
         &expect![[r#"
-            [
-                None,
-                None,
-                None,
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Sub",
-                        kind: Module,
-                        sort_text: Some(
-                            "0700Sub",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "OtherFunc",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300OtherFunc",
-                        ),
-                        detail: Some(
-                            "function OtherFunc() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "OtherFunc" (Function)
+                detail: "function OtherFunc() : Unit"
+              "Sub" (Module)
+
+            not found:
+              "Main"
+              "Other"
+              "MainFunc"
+              "Other.Sub"
+
         "#]],
     );
 }
@@ -3089,23 +1845,15 @@ fn package_alias_members_in_open() {
         ",
         &["Main", "Other", "MainFunc", "Other.Sub", "Sub"],
         &expect![[r#"
-            [
-                None,
-                Some(
-                    CompletionItem {
-                        label: "Other",
-                        kind: Module,
-                        sort_text: Some(
-                            "0300Other",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-                None,
-            ]
+            found, sorted:
+              "Other" (Module)
+
+            not found:
+              "Main"
+              "MainFunc"
+              "Other.Sub"
+              "Sub"
+
         "#]],
     );
 }
@@ -3133,32 +1881,11 @@ fn member_completion_in_imported_namespace_from_dependency() {
         ",
         &["CallableInFoo", "Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "CallableInFoo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300CallableInFoo",
-                        ),
-                        detail: Some(
-                            "function CallableInFoo() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Bar",
-                        kind: Module,
-                        sort_text: Some(
-                            "0700Bar",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "CallableInFoo" (Function)
+                detail: "function CallableInFoo() : Unit"
+              "Bar" (Module)
+
         "#]],
     );
 }
@@ -3186,32 +1913,11 @@ fn aliased_namespace_in_dependency() {
         ",
         &["CallableInFoo", "Bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "CallableInFoo",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300CallableInFoo",
-                        ),
-                        detail: Some(
-                            "function CallableInFoo() : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Bar",
-                        kind: Module,
-                        sort_text: Some(
-                            "0700Bar",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "CallableInFoo" (Function)
+                detail: "function CallableInFoo() : Unit"
+              "Bar" (Module)
+
         "#]],
     );
 }
@@ -3239,17 +1945,18 @@ fn open_does_not_match_pkg_alias() {
         ",
         &["CallableInFoo", "Bar"],
         &expect![[r#"
-            [
-                None,
-                None,
-            ]
+
+            not found:
+              "CallableInFoo"
+              "Bar"
+
         "#]],
     );
 }
 
 #[test]
 fn field_access_expr() {
-    check(
+    check_single_file(
         "namespace Test {
         struct Foo {
             bar : Int,
@@ -3261,57 +1968,25 @@ fn field_access_expr() {
     }",
         &["bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "bar",
-                        kind: Field,
-                        sort_text: Some(
-                            "0100bar",
-                        ),
-                        detail: Some(
-                            "Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "bar" (Field)
+                detail: "Int"
+
         "#]],
     );
 }
 
 #[test]
 fn input_type_missing() {
-    check(
+    check_single_file(
         "namespace Test { function Foo(x : FakeStdLib.↘ ) : Unit { body intrinsic; } }",
         &["Udt", "Library"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Library",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600Library",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+              "Library" (Module)
+
         "#]],
     );
 }
@@ -3327,53 +2002,23 @@ fn notebook_top_level_path_part() {
         )],
         &["Udt", "Library", "FakeStdLib", "FakeWithParam"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Library",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600Library",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                Some(
-                    CompletionItem {
-                        label: "FakeWithParam",
-                        kind: Function,
-                        sort_text: Some(
-                            "0300FakeWithParam",
-                        ),
-                        detail: Some(
-                            "operation FakeWithParam(x : Int) : Unit",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "FakeWithParam" (Function)
+                detail: "operation FakeWithParam(x : Int) : Unit"
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+              "Library" (Module)
+
+            not found:
+              "FakeStdLib"
+
         "#]],
     );
 }
 
 #[test]
 fn field_access_path() {
-    check(
+    check_single_file(
         "namespace Test {
         struct Foo {
             bar : Int,
@@ -3386,21 +2031,10 @@ fn field_access_path() {
     }",
         &["bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "bar",
-                        kind: Field,
-                        sort_text: Some(
-                            "0100bar",
-                        ),
-                        detail: Some(
-                            "Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "bar" (Field)
+                detail: "Int"
+
         "#]],
     );
 }
@@ -3416,153 +2050,77 @@ fn notebook_top_level_path_part_in_type() {
         )],
         &["Udt", "Library", "FakeStdLib", "FakeWithParam"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Library",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600Library",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-                None,
-            ]
+            found, sorted:
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+              "Library" (Module)
+
+            not found:
+              "FakeStdLib"
+              "FakeWithParam"
+
         "#]],
     );
 }
 
 #[test]
 fn prefix_ops() {
-    check(
+    check_single_file(
         "namespace Test { function Main() : Unit { let x = ↘ ; } }",
         &["and", "or", "not", "Adjoint"],
         &expect![[r#"
-            [
-                None,
-                None,
-                Some(
-                    CompletionItem {
-                        label: "not",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000not",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Adjoint",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000Adjoint",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Adjoint" (Keyword)
+              "not" (Keyword)
+
+            not found:
+              "and"
+              "or"
+
         "#]],
     );
 }
 
 #[test]
 fn binary_ops() {
-    check(
+    check_single_file(
         "namespace Test { function Main() : Unit { let x = 1 ↘ ; } }",
         &["and", "or", "not"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "and",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000and",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "or",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000or",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "and" (Keyword)
+              "or" (Keyword)
+
+            not found:
+              "not"
+
         "#]],
     );
 }
 
 #[test]
 fn array_size() {
-    check(
+    check_single_file(
         "namespace Test { function Main() : Unit { let x = [0, ↘] ; } }",
         &["size"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "size",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000size",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "size" (Keyword)
+
         "#]],
     );
 }
 
 #[test]
 fn path_segment_partial_ident_is_keyword() {
-    check(
+    check_single_file(
         "namespace Test { import FakeStdLib.struct↘ }",
         &["StructFn"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "StructFn",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300StructFn",
-                        ),
-                        detail: Some(
-                            "struct StructFn { inner : (Int -> Int) }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "StructFn" (Interface)
+                detail: "struct StructFn { inner : (Int -> Int) }"
+
         "#]],
     );
 }
@@ -3572,13 +2130,14 @@ fn path_segment_followed_by_wslash() {
     // `w/` is a single token, so it gets tricky
     // to separate out the `w` and treat it as an identifier.
     // We're just not going to worry about doing anything clever here.
-    check(
+    check_single_file(
         "namespace Test { import FakeStdLib.w↘/ }",
         &["StructFn"],
         &expect![[r#"
-            [
-                None,
-            ]
+
+            not found:
+              "StructFn"
+
         "#]],
     );
 }
@@ -3587,70 +2146,49 @@ fn path_segment_followed_by_wslash() {
 fn path_segment_followed_by_op_token() {
     // Invoking in the middle of a multi-character op token
     // shouldn't break anything.
-    check(
+    check_single_file(
         "namespace Test { import FakeStdLib.<↘<< }",
         &["StructFn"],
         &expect![[r#"
-            [
-                None,
-            ]
+
+            not found:
+              "StructFn"
+
         "#]],
     );
 }
 
 #[test]
 fn path_segment_before_glob() {
-    check(
+    check_single_file(
         "namespace Test { import FakeStdLib.↘* }",
         &["StructFn"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "StructFn",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300StructFn",
-                        ),
-                        detail: Some(
-                            "struct StructFn { inner : (Int -> Int) }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "StructFn" (Interface)
+                detail: "struct StructFn { inner : (Int -> Int) }"
+
         "#]],
     );
 }
 
 #[test]
 fn path_segment_before_glob_with_alias() {
-    check(
+    check_single_file(
         "namespace Test { import FakeStdLib.↘* as Alias }",
         &["StructFn"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "StructFn",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300StructFn",
-                        ),
-                        detail: Some(
-                            "struct StructFn { inner : (Int -> Int) }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "StructFn" (Interface)
+                detail: "struct StructFn { inner : (Int -> Int) }"
+
         "#]],
     );
 }
 
 #[test]
 fn field_in_initializer() {
-    check(
+    check_single_file(
         "namespace Test {
         struct Foo {
             bar : Int,
@@ -3662,28 +2200,17 @@ fn field_in_initializer() {
     }",
         &["bar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "bar",
-                        kind: Field,
-                        sort_text: Some(
-                            "0100bar",
-                        ),
-                        detail: Some(
-                            "Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "bar" (Field)
+                detail: "Int"
+
         "#]],
     );
 }
 
 #[test]
 fn stdlib_struct_field_init() {
-    check(
+    check_single_file(
         "namespace Test {
             import FakeStdLib.FakeStruct as StructAlias;
             function Main() : Unit {
@@ -3692,28 +2219,17 @@ fn stdlib_struct_field_init() {
         }",
         &["x"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "x",
-                        kind: Field,
-                        sort_text: Some(
-                            "0100x",
-                        ),
-                        detail: Some(
-                            "Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "x" (Field)
+                detail: "Int"
+
         "#]],
     );
 }
 
 #[test]
 fn newtype_named_field() {
-    check(
+    check_single_file(
         "namespace Test {
             newtype Foo = (field : Int);
             function Main() : Unit {
@@ -3722,28 +2238,17 @@ fn newtype_named_field() {
         }",
         &["field"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "field",
-                        kind: Field,
-                        sort_text: Some(
-                            "0100field",
-                        ),
-                        detail: Some(
-                            "Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "field" (Field)
+                detail: "Int"
+
         "#]],
     );
 }
 
 #[test]
 fn field_access_path_chained() {
-    check(
+    check_single_file(
         "namespace Test {
             newtype Foo = ( fieldFoo : Int );
             struct Bar { fieldBar : Foo );
@@ -3754,29 +2259,20 @@ fn field_access_path_chained() {
         }",
         &["fieldFoo", "fieldBar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "fieldFoo",
-                        kind: Field,
-                        sort_text: Some(
-                            "0100fieldFoo",
-                        ),
-                        detail: Some(
-                            "Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "fieldFoo" (Field)
+                detail: "Int"
+
+            not found:
+              "fieldBar"
+
         "#]],
     );
 }
 
 #[test]
 fn field_access_expr_chained() {
-    check(
+    check_single_file(
         "namespace Test {
             newtype Foo = ( fieldFoo : Int );
             struct Bar { fieldBar : Foo );
@@ -3786,29 +2282,20 @@ fn field_access_expr_chained() {
         }",
         &["fieldFoo", "fieldBar"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "fieldFoo",
-                        kind: Field,
-                        sort_text: Some(
-                            "0100fieldFoo",
-                        ),
-                        detail: Some(
-                            "Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "fieldFoo" (Field)
+                detail: "Int"
+
+            not found:
+              "fieldBar"
+
         "#]],
     );
 }
 
 #[test]
 fn field_assignment_rhs() {
-    check(
+    check_single_file(
         "namespace Test {
         struct Foo {
             bar : Int,
@@ -3821,29 +2308,20 @@ fn field_assignment_rhs() {
     }",
         &["bar", "var"],
         &expect![[r#"
-            [
-                None,
-                Some(
-                    CompletionItem {
-                        label: "var",
-                        kind: Variable,
-                        sort_text: Some(
-                            "0100var",
-                        ),
-                        detail: Some(
-                            "var : Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "var" (Variable)
+                detail: "var : Int"
+
+            not found:
+              "bar"
+
         "#]],
     );
 }
 
 #[test]
 fn field_access_local_shadows_global() {
-    check(
+    check_single_file(
         "namespace Test {
         struct Foo {
             bar : Int,
@@ -3856,229 +2334,109 @@ fn field_access_local_shadows_global() {
     }",
         &["Fake", "bar"],
         &expect![[r#"
-            [
-                None,
-                Some(
-                    CompletionItem {
-                        label: "bar",
-                        kind: Field,
-                        sort_text: Some(
-                            "0100bar",
-                        ),
-                        detail: Some(
-                            "Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "bar" (Field)
+                detail: "Int"
+
+            not found:
+              "Fake"
+
         "#]],
     );
 }
 
 #[test]
 fn ty_param_in_signature() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test<'T>(x: ↘) : Unit {}
         }",
         &["'T", "FakeStdLib"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "'T",
-                        kind: TypeParameter,
-                        sort_text: Some(
-                            "0100'T",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "FakeStdLib",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600FakeStdLib",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "'T" (TypeParameter)
+              "FakeStdLib" (Module)
+
         "#]],
     );
 }
 
 #[test]
 fn ty_param_in_return_type() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test<'T>(x: 'T) : ↘ {}
         }",
         &["'T", "FakeStdLib"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "'T",
-                        kind: TypeParameter,
-                        sort_text: Some(
-                            "0100'T",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "FakeStdLib",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600FakeStdLib",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "'T" (TypeParameter)
+              "FakeStdLib" (Module)
+
         "#]],
     );
 }
 
 #[test]
 fn path_segment_in_return_type() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test(x: 'T) : FakeStdLib.↘ {}
         }",
         &["Udt"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Udt",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0300Udt",
-                        ),
-                        detail: Some(
-                            "struct Udt { x : Int, y : Int }",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Udt" (Interface)
+                detail: "struct Udt { x : Int, y : Int }"
+
         "#]],
     );
 }
 
 #[test]
 fn return_type_in_partial_callable_signature() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test<'T>() : ↘
         }",
         &["'T", "FakeStdLib"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "'T",
-                        kind: TypeParameter,
-                        sort_text: Some(
-                            "0100'T",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "FakeStdLib",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600FakeStdLib",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "'T" (TypeParameter)
+              "FakeStdLib" (Module)
+
         "#]],
     );
 }
 
 #[test]
 fn arg_type_in_partial_callable_signature() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test<'T>(x: ↘)
         }",
         &["'T", "FakeStdLib"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "'T",
-                        kind: TypeParameter,
-                        sort_text: Some(
-                            "0100'T",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "FakeStdLib",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600FakeStdLib",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "'T" (TypeParameter)
+              "FakeStdLib" (Module)
+
         "#]],
     );
 }
 
 #[test]
 fn incomplete_return_type_in_partial_callable_signature() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test<'T>() : () => ↘
         }",
         &["'T", "FakeStdLib"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "'T",
-                        kind: TypeParameter,
-                        sort_text: Some(
-                            "0100'T",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "FakeStdLib",
-                        kind: Module,
-                        sort_text: Some(
-                            "0600FakeStdLib",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "'T" (TypeParameter)
+              "FakeStdLib" (Module)
+
         "#]],
     );
 }

--- a/source/language_service/src/completion/tests/class_completions.rs
+++ b/source/language_service/src/completion/tests/class_completions.rs
@@ -3,21 +3,22 @@
 
 #![allow(clippy::too_many_lines)]
 
-use super::check;
+use super::check_single_file;
 use expect_test::expect;
 
 // the `Iterable` class should not be in completions until we support it
 #[test]
 fn iterable_not_included_in_completions() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test<'T: ↘
         }",
         &["Iterable"],
         &expect![[r#"
-            [
-                None,
-            ]
+
+            not found:
+              "Iterable"
+
         "#]],
     );
 }
@@ -25,22 +26,23 @@ fn iterable_not_included_in_completions() {
 // the `Num` class should not be in completions since it was dropped
 #[test]
 fn num_not_included_in_completions() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test<'T: ↘
         }",
         &["Num"],
         &expect![[r#"
-            [
-                None,
-            ]
+
+            not found:
+              "Num"
+
         "#]],
     );
 }
 
 #[test]
 fn all_prim_classes_in_completions() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test<'T: ↘
         }",
@@ -48,138 +50,27 @@ fn all_prim_classes_in_completions() {
             "Eq", "Add", "Exp", "Integral", "Mod", "Mul", "Sub", "Div", "Signed", "Ord", "Show",
         ],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Eq",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Eq",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Add",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Add",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Exp",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Exp",
-                        ),
-                        detail: Some(
-                            "Exp['Power]",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Integral",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Integral",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Mod",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Mod",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Mul",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Mul",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Sub",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Sub",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Div",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Div",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Signed",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Signed",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Ord",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Ord",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Show",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Show",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Add" (Class)
+              "Div" (Class)
+              "Eq" (Class)
+              "Exp" (Class)
+                detail: "Exp['Power]"
+              "Integral" (Class)
+              "Mod" (Class)
+              "Mul" (Class)
+              "Ord" (Class)
+              "Show" (Class)
+              "Signed" (Class)
+              "Sub" (Class)
+
         "#]],
     );
 }
 
 #[test]
 fn classes_appear_after_plus_too() {
-    check(
+    check_single_file(
         r"namespace Test {
             operation Test<'T: Add + ↘
         }",
@@ -187,131 +78,20 @@ fn classes_appear_after_plus_too() {
             "Eq", "Add", "Exp", "Integral", "Mod", "Mul", "Sub", "Div", "Signed", "Ord", "Show",
         ],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "Eq",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Eq",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Add",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Add",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Exp",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Exp",
-                        ),
-                        detail: Some(
-                            "Exp['Power]",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Integral",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Integral",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Mod",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Mod",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Mul",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Mul",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Sub",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Sub",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Div",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Div",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Signed",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Signed",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Ord",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Ord",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "Show",
-                        kind: Class,
-                        sort_text: Some(
-                            "0100Show",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "Add" (Class)
+              "Div" (Class)
+              "Eq" (Class)
+              "Exp" (Class)
+                detail: "Exp['Power]"
+              "Integral" (Class)
+              "Mod" (Class)
+              "Mul" (Class)
+              "Ord" (Class)
+              "Show" (Class)
+              "Signed" (Class)
+              "Sub" (Class)
+
         "#]],
     );
 }

--- a/source/language_service/src/completion/tests/class_completions.rs
+++ b/source/language_service/src/completion/tests/class_completions.rs
@@ -15,10 +15,8 @@ fn iterable_not_included_in_completions() {
         }",
         &["Iterable"],
         &expect![[r#"
-
             not found:
               "Iterable"
-
         "#]],
     );
 }
@@ -32,10 +30,8 @@ fn num_not_included_in_completions() {
         }",
         &["Num"],
         &expect![[r#"
-
             not found:
               "Num"
-
         "#]],
     );
 }
@@ -63,7 +59,6 @@ fn all_prim_classes_in_completions() {
               "Show" (Class)
               "Signed" (Class)
               "Sub" (Class)
-
         "#]],
     );
 }
@@ -91,7 +86,6 @@ fn classes_appear_after_plus_too() {
               "Show" (Class)
               "Signed" (Class)
               "Sub" (Class)
-
         "#]],
     );
 }

--- a/source/language_service/src/completion/tests/openqasm.rs
+++ b/source/language_service/src/completion/tests/openqasm.rs
@@ -3,8 +3,7 @@
 
 use std::sync::Arc;
 
-use super::{CompletionItem, get_completions};
-use crate::{Compilation, Encoding, test_utils::get_sources_and_markers};
+use crate::{Compilation, completion::tests::check, test_utils::get_sources_and_markers};
 use expect_test::{Expect, expect};
 use indoc::indoc;
 use qsc::{
@@ -53,136 +52,71 @@ pub fn compile_with_markers(source_with_markers: &str) -> (Compilation, Position
     )
 }
 
-fn check(source_with_cursor: &str, completions_to_check: &[&str], expect: &Expect) {
+fn check_single_file(source_with_cursor: &str, completions_to_check: &[&str], expect: &Expect) {
     let (compilation, cursor_position, _) = compile_with_markers(source_with_cursor);
-    let actual_completions =
-        get_completions(&compilation, "<source>", cursor_position, Encoding::Utf8);
-    let checked_completions: Vec<Option<&CompletionItem>> = completions_to_check
-        .iter()
-        .map(|comp| {
-            actual_completions
-                .items
-                .iter()
-                .find(|item| item.label == **comp)
-        })
-        .collect();
 
-    expect.assert_debug_eq(&checked_completions);
+    check(
+        &compilation,
+        "<source>",
+        cursor_position,
+        completions_to_check,
+        expect,
+    );
 }
 
 #[test]
 fn in_empty_file_contains_openqasm() {
-    check(
+    check_single_file(
         indoc! {r#"
         ↘
     }"#},
         &["OPENQASM"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "OPENQASM",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000OPENQASM",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "OPENQASM" (Keyword)
+
         "#]],
     );
 }
 
 #[test]
 fn in_file_after_openqasm_contains_keywords_containing_i() {
-    check(
+    check_single_file(
         indoc! {r#"
         OPENQASM 3.0;
         i↘
     }"#},
         &["if", "include", "input", "inv"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "if",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000if",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "include",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000include",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "input",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000input",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "inv",
-                        kind: Keyword,
-                        sort_text: Some(
-                            "0000inv",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "if" (Keyword)
+              "include" (Keyword)
+              "input" (Keyword)
+              "inv" (Keyword)
+
         "#]],
     );
 }
 
 #[test]
 fn in_file_after_openqasm_contains_annotations_containing_i() {
-    check(
+    check_single_file(
         indoc! {r#"
         OPENQASM 3.0;
         i↘
     }"#},
         &["SimulatableIntrinsic"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "SimulatableIntrinsic",
-                        kind: Interface,
-                        sort_text: Some(
-                            "0000SimulatableIntrinsic",
-                        ),
-                        detail: None,
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "SimulatableIntrinsic" (Interface)
+
         "#]],
     );
 }
 
 #[test]
 fn local_vars() {
-    check(
+    check_single_file(
         indoc! {r#"
         OPENQASM 3.0;
         input int num_samples;
@@ -191,41 +125,19 @@ fn local_vars() {
     }"#},
         &["num_samples", "angle_value"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "num_samples",
-                        kind: Variable,
-                        sort_text: Some(
-                            "0100num_samples",
-                        ),
-                        detail: Some(
-                            "num_samples : Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                Some(
-                    CompletionItem {
-                        label: "angle_value",
-                        kind: Variable,
-                        sort_text: Some(
-                            "0100angle_value",
-                        ),
-                        detail: Some(
-                            "angle_value : Double",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-            ]
+            found, sorted:
+              "angle_value" (Variable)
+                detail: "angle_value : Double"
+              "num_samples" (Variable)
+                detail: "num_samples : Int"
+
         "#]],
     );
 }
 
 #[test]
 fn local_vars_doesnt_pick_up_variables_declared_after_cursor() {
-    check(
+    check_single_file(
         indoc! {r#"
         OPENQASM 3.0;
         input int num_samples;
@@ -234,22 +146,13 @@ fn local_vars_doesnt_pick_up_variables_declared_after_cursor() {
     }"#},
         &["num_samples", "angle_value"],
         &expect![[r#"
-            [
-                Some(
-                    CompletionItem {
-                        label: "num_samples",
-                        kind: Variable,
-                        sort_text: Some(
-                            "0100num_samples",
-                        ),
-                        detail: Some(
-                            "num_samples : Int",
-                        ),
-                        additional_text_edits: None,
-                    },
-                ),
-                None,
-            ]
+            found, sorted:
+              "num_samples" (Variable)
+                detail: "num_samples : Int"
+
+            not found:
+              "angle_value"
+
         "#]],
     );
 }

--- a/source/language_service/src/completion/tests/openqasm.rs
+++ b/source/language_service/src/completion/tests/openqasm.rs
@@ -74,7 +74,6 @@ fn in_empty_file_contains_openqasm() {
         &expect![[r#"
             found, sorted:
               "OPENQASM" (Keyword)
-
         "#]],
     );
 }
@@ -93,7 +92,6 @@ fn in_file_after_openqasm_contains_keywords_containing_i() {
               "include" (Keyword)
               "input" (Keyword)
               "inv" (Keyword)
-
         "#]],
     );
 }
@@ -109,7 +107,6 @@ fn in_file_after_openqasm_contains_annotations_containing_i() {
         &expect![[r#"
             found, sorted:
               "SimulatableIntrinsic" (Interface)
-
         "#]],
     );
 }
@@ -130,7 +127,6 @@ fn local_vars() {
                 detail: "angle_value : Double"
               "num_samples" (Variable)
                 detail: "num_samples : Int"
-
         "#]],
     );
 }
@@ -152,7 +148,6 @@ fn local_vars_doesnt_pick_up_variables_declared_after_cursor() {
 
             not found:
               "angle_value"
-
         "#]],
     );
 }


### PR DESCRIPTION
In anticipation of some bugfixes I'm making in this area, I wanted to clean up the unit tests a bit, so that the upcoming PR is less headache-inducing.

Changing how we format the expected output in completions tests. This way:

- They're more readable

- There's less churn when sort texts change due to unrelated changes, (e.g. [this PR](https://github.com/microsoft/qsharp/pull/2345/files#diff-474255c7ce3b4fd2763734186079ae268564b2bc4f9377c266de1ed6e8f9df65)). _Relative_ order is still validated, but the exact sort text (e.g. "`0300DumpMachine`") is not.
