### PR TITLE
Restrict OpenQASM indices to range `[-N, N - 1]`.

### DIFF
--- a/source/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/source/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -164,7 +164,8 @@ impl LiteralKind {
                 };
 
                 #[allow(clippy::cast_sign_loss)]
-                let idx = super::types::wrap_index_value(idx, i64::from(size)) as u64;
+                let idx =
+                    super::types::wrap_index_value(ctx, idx, i64::from(size), index.span())? as u64;
 
                 // We need to change the endianness of the index.
                 // Our bitarrays are stored as BigInts, but indexing into OpenQASM bit registers
@@ -175,7 +176,7 @@ impl LiteralKind {
                 Some(Self::Bit((value & mask) != BigInt::ZERO))
             }
             Index::Range(range) => {
-                let (start, step, end) = compute_slice_components(range, size);
+                let (start, step, end) = compute_slice_components(ctx, range, size)?;
                 #[allow(clippy::cast_sign_loss)]
                 #[allow(clippy::cast_possible_truncation)]
                 // When changing the endianness of a range, we also need to negate the step.

--- a/source/compiler/qsc_qasm/src/semantic/error.rs
+++ b/source/compiler/qsc_qasm/src/semantic/error.rs
@@ -136,6 +136,9 @@ pub enum SemanticErrorKind {
     #[error("indexed must be a single expression")]
     #[diagnostic(code("Qasm.Lowerer.IndexMustBeSingleExpr"))]
     IndexMustBeSingleExpr(#[label] Span),
+    #[error("index must be in the range [{0}, {1}] but it was {2}")]
+    #[diagnostic(code("Qasm.Lowerer.IndexOutOfBounds"))]
+    IndexOutOfBounds(i64, i64, i64, #[label] Span),
     #[error("index sets are only allowed in alias statements")]
     #[diagnostic(code("Qasm.Lowerer.IndexSetOnlyAllowedInAliasStmt"))]
     IndexSetOnlyAllowedInAliasStmt(#[label] Span),

--- a/source/compiler/qsc_qasm/src/tests/expression/indexed.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/indexed.rs
@@ -362,3 +362,83 @@ fn index_into_array_and_then_into_int() {
         "#]],
     );
 }
+
+#[test]
+fn negative_index_edge_case_succeeds() {
+    let source = r#"
+        const bit[4] a = "1010";
+        const bit b = a[-4];
+    "#;
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            let a = [One, Zero, One, Zero];
+            let b = One;
+        "#]],
+    );
+}
+
+#[test]
+fn negative_index_out_of_bounds_errors() {
+    let source = r#"
+        const bit[4] a = "1010";
+        const bit b = a[-5];
+    "#;
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.IndexOutOfBounds
+
+              x index must be in the range [-4, 3] but it was -5
+               ,-[Test.qasm:3:26]
+             2 |         const bit[4] a = "1010";
+             3 |         const bit b = a[-5];
+               :                          ^
+             4 |     
+               `----
+        "#]],
+    );
+}
+
+#[test]
+fn positive_index_edge_case_succeeds() {
+    let source = r#"
+        const bit[4] a = "1010";
+        const bit b = a[3];
+    "#;
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            let a = [One, Zero, One, Zero];
+            let b = Zero;
+        "#]],
+    );
+}
+
+#[test]
+fn positive_index_out_of_bounds_errors() {
+    let source = r#"
+        const bit[4] a = "1010";
+        const bit b = a[4];
+    "#;
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            Qasm.Lowerer.IndexOutOfBounds
+
+              x index must be in the range [-4, 3] but it was 4
+               ,-[Test.qasm:3:25]
+             2 |         const bit[4] a = "1010";
+             3 |         const bit b = a[4];
+               :                         ^
+             4 |     
+               `----
+        "#]],
+    );
+}


### PR DESCRIPTION
We initially implemented OpenQASM indexing using arithmetic mod N, where N is the size of the array. We are now restricting indices to be in the range [-N, N - 1].