### PR TITLE
QASM Profile Pragma

### DIFF
--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -114,7 +114,7 @@ pub fn compile_to_qsharp_ast_with_config(
 pub enum PragmaKind {
     QdkBoxOpen,
     QdkBoxClose,
-    QdkProfile,
+    QdkQirProfile,
 }
 
 impl FromStr for PragmaKind {
@@ -124,7 +124,7 @@ impl FromStr for PragmaKind {
         match s.to_lowercase().as_str() {
             "qdk.box.open" => Ok(PragmaKind::QdkBoxOpen),
             "qdk.box.close" => Ok(PragmaKind::QdkBoxClose),
-            "qdk.qir.profile" => Ok(PragmaKind::QdkProfile),
+            "qdk.qir.profile" => Ok(PragmaKind::QdkQirProfile),
             _ => Err(()),
         }
     }
@@ -190,7 +190,7 @@ impl QasmCompiler {
         let target_profile = self.pragma_config.pragmas
             .iter()
             .find_map(|(kind, value)|
-                if matches!(kind, PragmaKind::QdkProfile) {
+                if matches!(kind, PragmaKind::QdkQirProfile) {
                     Some(Profile::from_str(value).expect("Invalid profile pragma; only a valid profile should be store in pragma_config."))
                 } else {
                     None
@@ -1133,10 +1133,10 @@ impl QasmCompiler {
             (PragmaKind::QdkBoxOpen | PragmaKind::QdkBoxClose, None) => {
                 self.push_compiler_error(CompilerErrorKind::MissingBoxPragmaTarget(stmt.span));
             }
-            (PragmaKind::QdkProfile, Some(profile)) => {
+            (PragmaKind::QdkQirProfile, Some(profile)) => {
                 if Profile::from_str(profile).is_ok() {
                     self.pragma_config
-                        .insert(PragmaKind::QdkProfile, profile.clone());
+                        .insert(PragmaKind::QdkQirProfile, profile.clone());
                     return;
                 }
                 self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(
@@ -1144,7 +1144,7 @@ impl QasmCompiler {
                     stmt.value_span.unwrap_or(stmt.span),
                 ));
             }
-            (PragmaKind::QdkProfile, None) => {
+            (PragmaKind::QdkQirProfile, None) => {
                 self.push_compiler_error(CompilerErrorKind::MissingProfilePragmaTarget(stmt.span));
             }
         }

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -1145,7 +1145,10 @@ impl QasmCompiler {
                 ));
             }
             (PragmaKind::QdkQirProfile, None) => {
-                self.push_compiler_error(CompilerErrorKind::MissingProfilePragmaTarget(stmt.span));
+                self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(
+                    "<empty>".to_string(),
+                    stmt.span,
+                ));
             }
         }
     }

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -1142,20 +1142,24 @@ impl QasmCompiler {
             (PragmaKind::QdkQirProfile, Some(profile)) => {
                 // For this pragma, we only keep the first instance.
                 if Profile::from_str(profile).is_ok() {
-                    if !self
+                    if self
                         .pragma_config
                         .pragmas
                         .contains_key(&PragmaKind::QdkQirProfile)
                     {
+                        self.push_compiler_error(CompilerErrorKind::MultipleProfilePragmas(
+                            stmt.span,
+                        ));
+                    } else {
                         self.pragma_config
                             .insert(PragmaKind::QdkQirProfile, profile.clone());
                     }
-                    return;
+                } else {
+                    self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(
+                        profile.to_string(),
+                        stmt.value_span.unwrap_or(stmt.span),
+                    ));
                 }
-                self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(
-                    profile.to_string(),
-                    stmt.value_span.unwrap_or(stmt.span),
-                ));
             }
             (PragmaKind::QdkQirProfile, None) => {
                 self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -1142,24 +1142,20 @@ impl QasmCompiler {
             (PragmaKind::QdkQirProfile, Some(profile)) => {
                 // For this pragma, we only keep the first instance.
                 if Profile::from_str(profile).is_ok() {
-                    if self
+                    if !self
                         .pragma_config
                         .pragmas
                         .contains_key(&PragmaKind::QdkQirProfile)
                     {
-                        self.push_compiler_error(CompilerErrorKind::MultipleProfilePragmas(
-                            stmt.span,
-                        ));
-                    } else {
                         self.pragma_config
                             .insert(PragmaKind::QdkQirProfile, profile.clone());
                     }
-                } else {
-                    self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(
-                        profile.to_string(),
-                        stmt.value_span.unwrap_or(stmt.span),
-                    ));
+                    return;
                 }
+                self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(
+                    profile.to_string(),
+                    stmt.value_span.unwrap_or(stmt.span),
+                ));
             }
             (PragmaKind::QdkQirProfile, None) => {
                 self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -1146,7 +1146,7 @@ impl QasmCompiler {
             }
             (PragmaKind::QdkQirProfile, None) => {
                 self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(
-                    "<empty>".to_string(),
+                    String::new(),
                     stmt.span,
                 ));
             }

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -1140,9 +1140,16 @@ impl QasmCompiler {
                 self.push_compiler_error(CompilerErrorKind::MissingBoxPragmaTarget(stmt.span));
             }
             (PragmaKind::QdkQirProfile, Some(profile)) => {
+                // For this pragma, we only keep the first instance.
                 if Profile::from_str(profile).is_ok() {
-                    self.pragma_config
-                        .insert(PragmaKind::QdkQirProfile, profile.clone());
+                    if !self
+                        .pragma_config
+                        .pragmas
+                        .contains_key(&PragmaKind::QdkQirProfile)
+                    {
+                        self.pragma_config
+                            .insert(PragmaKind::QdkQirProfile, profile.clone());
+                    }
                     return;
                 }
                 self.push_compiler_error(CompilerErrorKind::InvalidProfilePragmaTarget(

--- a/source/compiler/qsc_qasm/src/compiler/error.rs
+++ b/source/compiler/qsc_qasm/src/compiler/error.rs
@@ -27,6 +27,13 @@ pub enum CompilerErrorKind {
     #[error("Box pragma is missing target")]
     #[diagnostic(code("Qasm.Compiler.MissingBoxPragmaTarget"))]
     MissingBoxPragmaTarget(#[label] Span),
+    #[error("{0} is not a supported QIR Profile")]
+    #[help("Supported profiles include `unrestricted`, `base`, `adaptive_ri`, and `adaptive_rif`.")]
+    #[diagnostic(code("Qasm.Compiler.InvalidProfilePragmaTarget"))]
+    InvalidProfilePragmaTarget(String, #[label] Span),
+    #[error("Profile pragma is missing target")]
+    #[diagnostic(code("Qasm.Compiler.MissingProfilePragmaTarget"))]
+    MissingProfilePragmaTarget(#[label] Span),
     #[error("{0} are not supported")]
     #[diagnostic(code("Qasm.Compiler.NotSupported"))]
     NotSupported(String, #[label] Span),

--- a/source/compiler/qsc_qasm/src/compiler/error.rs
+++ b/source/compiler/qsc_qasm/src/compiler/error.rs
@@ -32,6 +32,11 @@ pub enum CompilerErrorKind {
     )]
     #[diagnostic(code("Qasm.Compiler.InvalidProfilePragmaTarget"))]
     InvalidProfilePragmaTarget(String, #[label] Span),
+    #[error(
+        "Duplicate `qdk.qir.profile` pragma. Only one `qdk.qir.profile` pragma should be specified."
+    )]
+    #[diagnostic(code("Qasm.Compiler.MultipleProfilePragmas"))]
+    MultipleProfilePragmas(#[label] Span),
     #[error("{0} are not supported")]
     #[diagnostic(code("Qasm.Compiler.NotSupported"))]
     NotSupported(String, #[label] Span),

--- a/source/compiler/qsc_qasm/src/compiler/error.rs
+++ b/source/compiler/qsc_qasm/src/compiler/error.rs
@@ -32,11 +32,6 @@ pub enum CompilerErrorKind {
     )]
     #[diagnostic(code("Qasm.Compiler.InvalidProfilePragmaTarget"))]
     InvalidProfilePragmaTarget(String, #[label] Span),
-    #[error(
-        "Duplicate `qdk.qir.profile` pragma. Only one `qdk.qir.profile` pragma should be specified."
-    )]
-    #[diagnostic(code("Qasm.Compiler.MultipleProfilePragmas"))]
-    MultipleProfilePragmas(#[label] Span),
     #[error("{0} are not supported")]
     #[diagnostic(code("Qasm.Compiler.NotSupported"))]
     NotSupported(String, #[label] Span),

--- a/source/compiler/qsc_qasm/src/compiler/error.rs
+++ b/source/compiler/qsc_qasm/src/compiler/error.rs
@@ -27,13 +27,10 @@ pub enum CompilerErrorKind {
     #[error("Box pragma is missing target")]
     #[diagnostic(code("Qasm.Compiler.MissingBoxPragmaTarget"))]
     MissingBoxPragmaTarget(#[label] Span),
-    #[error("{0} is not a supported QIR Profile")]
-    #[help("Supported profiles include `unrestricted`, `base`, `adaptive_ri`, and `adaptive_rif`.")]
+    #[error("{0} is not a supported QIR Profile, please specify a valid target")]
+    #[help("Supported profiles include `Unrestricted`, `Base`, `Adaptive_RI`, and `Adaptive_RIF`.")]
     #[diagnostic(code("Qasm.Compiler.InvalidProfilePragmaTarget"))]
     InvalidProfilePragmaTarget(String, #[label] Span),
-    #[error("Profile pragma is missing target")]
-    #[diagnostic(code("Qasm.Compiler.MissingProfilePragmaTarget"))]
-    MissingProfilePragmaTarget(#[label] Span),
     #[error("{0} are not supported")]
     #[diagnostic(code("Qasm.Compiler.NotSupported"))]
     NotSupported(String, #[label] Span),

--- a/source/compiler/qsc_qasm/src/compiler/error.rs
+++ b/source/compiler/qsc_qasm/src/compiler/error.rs
@@ -27,8 +27,9 @@ pub enum CompilerErrorKind {
     #[error("Box pragma is missing target")]
     #[diagnostic(code("Qasm.Compiler.MissingBoxPragmaTarget"))]
     MissingBoxPragmaTarget(#[label] Span),
-    #[error("{0} is not a supported QIR Profile, please specify a valid target")]
-    #[help("Supported profiles include `Unrestricted`, `Base`, `Adaptive_RI`, and `Adaptive_RIF`.")]
+    #[error(
+        "Invalid or missing QIR Profile: '{0}'. Please specify one of: `Unrestricted`, `Base`, `Adaptive_RI`, `Adaptive_RIF`."
+    )]
     #[diagnostic(code("Qasm.Compiler.InvalidProfilePragmaTarget"))]
     InvalidProfilePragmaTarget(String, #[label] Span),
     #[error("{0} are not supported")]

--- a/source/compiler/qsc_qasm/src/lib.rs
+++ b/source/compiler/qsc_qasm/src/lib.rs
@@ -33,7 +33,7 @@ use std::{fmt::Write, sync::Arc};
 
 use miette::Diagnostic;
 use qsc_ast::ast::Package;
-use qsc_data_structures::span::Span;
+use qsc_data_structures::{span::Span, target::Profile};
 use qsc_frontend::{compile::SourceMap, error::WithSource};
 use thiserror::Error;
 
@@ -251,6 +251,10 @@ pub struct QasmCompileUnit {
     /// The signature of the operation created from the QASM source code.
     /// None if the program type is `ProgramType::Fragments`.
     signature: Option<OperationSignature>,
+    /// The QIR profile used for the compilation.
+    /// This is used to determine the QIR profile that the generated code
+    /// will use.
+    profile: Profile,
 }
 
 /// Represents a QASM compilation unit.
@@ -264,12 +268,14 @@ impl QasmCompileUnit {
         errors: Vec<WithSource<crate::Error>>,
         package: Package,
         signature: Option<OperationSignature>,
+        profile: Profile,
     ) -> Self {
         Self {
             source_map,
             errors,
             package,
             signature,
+            profile,
         }
     }
 
@@ -285,6 +291,12 @@ impl QasmCompileUnit {
         self.errors.clone()
     }
 
+    /// Returns the QIR target profile associated with the compilation unit.
+    #[must_use]
+    pub fn profile(&self) -> Profile {
+        self.profile
+    }
+
     /// Deconstructs the compilation unit into its owned parts.
     #[must_use]
     pub fn into_tuple(
@@ -294,8 +306,15 @@ impl QasmCompileUnit {
         Vec<WithSource<crate::Error>>,
         Package,
         Option<OperationSignature>,
+        Profile,
     ) {
-        (self.source_map, self.errors, self.package, self.signature)
+        (
+            self.source_map,
+            self.errors,
+            self.package,
+            self.signature,
+            self.profile,
+        )
     }
 }
 

--- a/source/compiler/qsc_qasm/src/tests.rs
+++ b/source/compiler/qsc_qasm/src/tests.rs
@@ -170,11 +170,11 @@ pub fn compile_all_with_config<P: Into<Arc<str>>>(
     Ok(unit)
 }
 
-fn compile_qasm_to_qir(source: &str, profile: Profile) -> Result<String, Vec<Report>> {
+fn compile_qasm_to_qir(source: &str) -> Result<String, Vec<Report>> {
     let unit = compile(source)?;
     fail_on_compilation_errors(&unit);
     let package = unit.package;
-    let qir = generate_qir_from_ast(package, unit.source_map, profile).map_err(|errors| {
+    let qir = generate_qir_from_ast(package, unit.source_map, unit.profile).map_err(|errors| {
         errors
             .iter()
             .map(|e| Report::new(e.clone()))
@@ -185,9 +185,7 @@ fn compile_qasm_to_qir(source: &str, profile: Profile) -> Result<String, Vec<Rep
 
 /// used to do full compilation with best effort of the input.
 /// This is useful for fuzz testing.
-fn compile_qasm_best_effort(source: &str, profile: Profile) {
-    let (stdid, store) = package_store_with_stdlib(profile.into());
-
+fn compile_qasm_best_effort(source: &str) {
     let mut resolver = InMemorySourceResolver::from_iter([]);
     let config = CompilerConfig::new(
         QubitSemantics::Qiskit,
@@ -203,8 +201,9 @@ fn compile_qasm_best_effort(source: &str, profile: Profile) {
         Some(&mut resolver),
         config,
     );
-    let (sources, _, package, _) = unit.into_tuple();
+    let (sources, _, package, _, profile) = unit.into_tuple();
 
+    let (stdid, store) = package_store_with_stdlib(profile.into());
     let dependencies = vec![(PackageId::CORE, None), (stdid, None)];
 
     let (mut _unit, _errors) = compile_ast(

--- a/source/compiler/qsc_qasm/src/tests/declaration.rs
+++ b/source/compiler/qsc_qasm/src/tests/declaration.rs
@@ -18,7 +18,6 @@ use crate::{
     tests::{compile_fragments, compile_with_config, fail_on_compilation_errors},
 };
 use miette::Report;
-use qsc::target::Profile;
 
 use super::compile_qasm_best_effort;
 
@@ -118,5 +117,5 @@ fn stretch() {
 #[test]
 fn gate_decl_with_missing_seq_item_doesnt_panic() {
     let source = r#"gate g1 x,,y {}"#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }

--- a/source/compiler/qsc_qasm/src/tests/expression/function_call.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/function_call.rs
@@ -130,10 +130,10 @@ fn funcall_with_too_few_arguments_generates_error() {
 
           x gate expects 1 classical arguments, but 0 were provided
            ,-[Test.qasm:6:9]
-         5 |
+         5 | 
          6 |         square();
            :         ^^^^^^^^
-         7 |
+         7 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -158,10 +158,10 @@ fn funcall_with_too_many_arguments_generates_error() {
 
           x gate expects 1 classical arguments, but 2 were provided
            ,-[Test.qasm:6:9]
-         5 |
+         5 | 
          6 |         square(2, 3);
            :         ^^^^^^^^^^^^
-         7 |
+         7 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -233,10 +233,10 @@ fn classical_decl_initialized_with_incompatible_funcall_errors() {
 
           x cannot cast expression of type angle to type float
            ,-[Test.qasm:6:19]
-         5 |
+         5 | 
          6 |         float a = square(2.0);
            :                   ^^^^^^^^^^^
-         7 |
+         7 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -285,10 +285,10 @@ fn funcall_implicit_arg_cast_uint_to_qubit_errors() {
 
           x cannot cast expression of type const int to type qubit[2]
            ,-[Test.qasm:6:24]
-         5 |
+         5 | 
          6 |         bit p = parity(2);
            :                        ^
-         7 |
+         7 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));

--- a/source/compiler/qsc_qasm/src/tests/expression/function_call.rs
+++ b/source/compiler/qsc_qasm/src/tests/expression/function_call.rs
@@ -4,7 +4,6 @@
 use crate::tests::{compile_qasm_to_qir, compile_qasm_to_qsharp};
 use expect_test::expect;
 use miette::Report;
-use qsc::target::Profile;
 
 #[test]
 fn funcall_with_no_arguments_generates_correct_qsharp() -> miette::Result<(), Vec<Report>> {
@@ -131,10 +130,10 @@ fn funcall_with_too_few_arguments_generates_error() {
 
           x gate expects 1 classical arguments, but 0 were provided
            ,-[Test.qasm:6:9]
-         5 | 
+         5 |
          6 |         square();
            :         ^^^^^^^^
-         7 |     
+         7 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -159,10 +158,10 @@ fn funcall_with_too_many_arguments_generates_error() {
 
           x gate expects 1 classical arguments, but 2 were provided
            ,-[Test.qasm:6:9]
-         5 | 
+         5 |
          6 |         square(2, 3);
            :         ^^^^^^^^^^^^
-         7 |     
+         7 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -234,10 +233,10 @@ fn classical_decl_initialized_with_incompatible_funcall_errors() {
 
           x cannot cast expression of type angle to type float
            ,-[Test.qasm:6:19]
-         5 | 
+         5 |
          6 |         float a = square(2.0);
            :                   ^^^^^^^^^^^
-         7 |     
+         7 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -286,10 +285,10 @@ fn funcall_implicit_arg_cast_uint_to_qubit_errors() {
 
           x cannot cast expression of type const int to type qubit[2]
            ,-[Test.qasm:6:24]
-         5 | 
+         5 |
          6 |         bit p = parity(2);
            :                        ^
-         7 |     
+         7 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -299,6 +298,7 @@ fn funcall_implicit_arg_cast_uint_to_qubit_errors() {
 fn simulatable_intrinsic_on_def_stmt_generates_correct_qir() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
+        #pragma qdk.qir.profile Adaptive_RI
 
         @SimulatableIntrinsic
         def my_gate(qubit q) {
@@ -310,7 +310,7 @@ fn simulatable_intrinsic_on_def_stmt_generates_correct_qir() -> miette::Result<(
         bit result = measure q;
     "#;
 
-    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qsharp = compile_qasm_to_qir(source)?;
     expect![[r#"
         %Result = type opaque
         %Qubit = type opaque
@@ -350,6 +350,7 @@ fn simulatable_intrinsic_on_def_stmt_generates_correct_qir() -> miette::Result<(
 fn qdk_qir_intrinsic_on_def_stmt_generates_correct_qir() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
+        #pragma qdk.qir.profile Adaptive_RI
 
         @qdk.qir.intrinsic
         def my_gate(qubit q) {
@@ -361,7 +362,7 @@ fn qdk_qir_intrinsic_on_def_stmt_generates_correct_qir() -> miette::Result<(), V
         bit result = measure q;
     "#;
 
-    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qsharp = compile_qasm_to_qir(source)?;
     expect![[r#"
         %Result = type opaque
         %Qubit = type opaque

--- a/source/compiler/qsc_qasm/src/tests/fuzz.rs
+++ b/source/compiler/qsc_qasm/src/tests/fuzz.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 use super::compile_qasm_best_effort;
-use qsc::target::Profile;
 
 /// We also had an issue where
 ///   1. naming a gate the same as a qubit parameter of a parent gate,
@@ -17,7 +16,7 @@ fn fuzz_2297_referencing_qubit_parameter() {
         q1;
     }
     "#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 /// The same panic happened when referencing an angle parameter.
@@ -29,7 +28,7 @@ fn fuzz_2297_referencing_angle_parameter() {
         r;
     }
     "#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 /// Subroutines didn't have this problem, even though they are also
@@ -42,7 +41,7 @@ fn fuzz_2297_def() {
         q1;
     }
     "#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 /// We also had an issue where, in the same conditions as `fuzz_2297`,
@@ -57,43 +56,43 @@ fn fuzz_2297_with_trailing_comma() {
             q1;
         }
     "#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2298() {
     let source = r#"gate y()a{gate a,b{}b"#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2313() {
     let source = r#"ctrl(π/0s)@a"#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2332() {
     let source = r#"ctrl(0/0)@s"#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2348() {
     let source = r#"ctrl(0%0)@s"#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2366() {
     let source = "t[:π";
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2368() {
     let source = "c[:0s";
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
@@ -134,29 +133,29 @@ gaoooooootoe i {adnv @ pow(0.` docume5) @ pow(0.` docume5) nta inverse of sqrt(5
 gaoooooootoe i {adnv @ pow(0.` docume5) @ pow(0.` docume5) nta inver5) @ pow(0.` docume5) nta inverse of sqrt(5) @ pow(0.` docume5) nta inverse of sqrt(S)
 gaoooooootoe i {adnv @ pow(0.` docume5) @ pow(0.` docume5) nta inverse of sqrt(S)
 gaoooooootoe tg  i {adnv @ pow(0.` docume)5@  pow(0.` docume5) ntation for full @ staildnv @ pow(0.` docume)5@  pow(0.` docume5) ntation for full @ stail."#;
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2379() {
     let source = "1[true:";
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2391() {
     let source = "c[:0s";
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2392() {
     let source = "e[π:";
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }
 
 #[test]
 fn fuzz_2397() {
     let source = "creg a[551615";
-    compile_qasm_best_effort(source, Profile::Unrestricted);
+    compile_qasm_best_effort(source);
 }

--- a/source/compiler/qsc_qasm/src/tests/output.rs
+++ b/source/compiler/qsc_qasm/src/tests/output.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use expect_test::expect;
 use miette::Report;
-use qsc::target::Profile;
 
 use super::{compile_qasm_to_qir, compile_with_config};
 
@@ -227,6 +226,7 @@ fn qir_generation_using_qiskit_semantics_multiple_bit_arrays_are_reversed_in_ord
     let source = r#"
 OPENQASM 3.0;
 include "stdgates.inc";
+#pragma qdk.qir.profile Adaptive_RI
 output bit[2] c;
 output bit[3] c2;
 qubit[5] q;
@@ -248,7 +248,7 @@ c2[1] = measure q[3];
 c2[2] = measure q[4];
     "#;
 
-    let qir = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qir = compile_qasm_to_qir(source)?;
     expect![[r#"
         %Result = type opaque
         %Qubit = type opaque
@@ -318,6 +318,7 @@ fn qir_generation_for_box_with_simulatable_intrinsic() -> miette::Result<(), Vec
     let source = r#"
     OPENQASM 3.0;
     include "stdgates.inc";
+    #pragma qdk.qir.profile Adaptive_RI
     #pragma qdk.box.open box_begin
     #pragma qdk.box.close box_end
 
@@ -335,7 +336,7 @@ fn qir_generation_for_box_with_simulatable_intrinsic() -> miette::Result<(), Vec
     c = measure q;
     "#;
 
-    let qir = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qir = compile_qasm_to_qir(source)?;
     expect![[r#"
         %Result = type opaque
         %Qubit = type opaque
@@ -383,6 +384,7 @@ fn qir_generation_for_box_with_qdk_qir_intrinsic() -> miette::Result<(), Vec<Rep
     let source = r#"
     OPENQASM 3.0;
     include "stdgates.inc";
+    #pragma qdk.qir.profile Adaptive_RI
     #pragma qdk.box.open box_begin
     #pragma qdk.box.close box_end
 
@@ -400,7 +402,7 @@ fn qir_generation_for_box_with_qdk_qir_intrinsic() -> miette::Result<(), Vec<Rep
     c = measure q;
     "#;
 
-    let qir = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qir = compile_qasm_to_qir(source)?;
     expect![[r#"
         %Result = type opaque
         %Qubit = type opaque

--- a/source/compiler/qsc_qasm/src/tests/statement/gate_call.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/gate_call.rs
@@ -4,7 +4,6 @@
 use crate::tests::{compile_qasm_to_qir, compile_qasm_to_qsharp};
 use expect_test::expect;
 use miette::Report;
-use qsc::target::Profile;
 
 #[test]
 fn u_gate_can_be_called() -> miette::Result<(), Vec<Report>> {
@@ -232,6 +231,7 @@ fn barrier_can_be_called_without_qubits() -> miette::Result<(), Vec<Report>> {
 fn barrier_generates_qir() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
+        #pragma qdk.qir.profile Adaptive_RI
         bit[1] c;
         qubit[2] q;
         barrier q[0], q[1];
@@ -241,7 +241,7 @@ fn barrier_generates_qir() -> miette::Result<(), Vec<Report>> {
         c[0] = measure q[0];
     "#;
 
-    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qsharp = compile_qasm_to_qir(source)?;
     expect![[
         r#"
         %Result = type opaque
@@ -323,7 +323,7 @@ fn cx_called_with_one_qubit_generates_error() {
          3 |         qubit[2] q;
          4 |         cx q[0];
            :         ^^^^^^^^
-         5 |     
+         5 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -349,7 +349,7 @@ fn cx_called_with_too_many_qubits_generates_error() {
          3 |         qubit[3] q;
          4 |         cx q[0], q[1], q[2];
            :         ^^^^^^^^^^^^^^^^^^^^
-         5 |     
+         5 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -375,7 +375,7 @@ fn rx_gate_with_no_angles_generates_error() {
          3 |         qubit q;
          4 |         rx q;
            :         ^^^^^
-         5 |     
+         5 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -422,7 +422,7 @@ fn rx_gate_with_too_many_angles_generates_error() {
          3 |         qubit q;
          4 |         rx(2.0, 3.0) q;
            :         ^^^^^^^^^^^^^^^
-         5 |     
+         5 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -591,6 +591,7 @@ fn custom_gate_can_be_called_with_pow_modifier() -> miette::Result<(), Vec<Repor
 fn simulatable_intrinsic_on_gate_stmt_generates_correct_qir() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
+        #pragma qdk.qir.profile Adaptive_RI
 
         @SimulatableIntrinsic
         gate my_gate q {
@@ -602,7 +603,7 @@ fn simulatable_intrinsic_on_gate_stmt_generates_correct_qir() -> miette::Result<
         bit result = measure q;
     "#;
 
-    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qsharp = compile_qasm_to_qir(source)?;
     expect![[r#"
         %Result = type opaque
         %Qubit = type opaque
@@ -641,6 +642,7 @@ fn simulatable_intrinsic_on_gate_stmt_generates_correct_qir() -> miette::Result<
 fn qdk_qir_intrinsic_on_gate_stmt_generates_correct_qir() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
+        #pragma qdk.qir.profile Adaptive_RI
 
         @qdk.qir.intrinsic
         gate my_gate q {
@@ -652,7 +654,7 @@ fn qdk_qir_intrinsic_on_gate_stmt_generates_correct_qir() -> miette::Result<(), 
         bit result = measure q;
     "#;
 
-    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qsharp = compile_qasm_to_qir(source)?;
     expect![[r#"
         %Result = type opaque
         %Qubit = type opaque
@@ -953,7 +955,7 @@ fn broadcast_with_different_register_sizes_fails() {
          4 |         qubit[2] targets;
          5 |         ctrl @ x ctrls, targets;
            :                         ^^^^^^^
-         6 |     
+         6 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1126,6 +1128,7 @@ fn qasm2_barrier_generates_qir() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         OPENQASM 2.0;
         include "qelib1.inc";
+        #pragma qdk.qir.profile Adaptive_RI
         creg c[1];
         qubit[2] q;
         barrier q[0], q[1];
@@ -1135,7 +1138,7 @@ fn qasm2_barrier_generates_qir() -> miette::Result<(), Vec<Report>> {
         c[0] = measure q[0];
     "#;
 
-    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qsharp = compile_qasm_to_qir(source)?;
     expect![[
         r#"
         %Result = type opaque
@@ -1219,7 +1222,7 @@ fn qasm2_cx_called_with_one_qubit_generates_error() {
          4 |         qreg q[2];
          5 |         CX q[0];
            :         ^^^^^^^^
-         6 |     
+         6 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1246,7 +1249,7 @@ fn qasm2_cx_called_with_too_many_qubits_generates_error() {
          4 |         qreg q[3];
          5 |         cx q[0], q[1], q[2];
            :         ^^^^^^^^^^^^^^^^^^^^
-         6 |     
+         6 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1273,7 +1276,7 @@ fn qasm2_rx_gate_with_no_angles_generates_error() {
          4 |         qreg q[1];
          5 |         rx q;
            :         ^^^^^
-         6 |     
+         6 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1322,7 +1325,7 @@ fn qasm2_rx_gate_with_too_many_angles_generates_error() {
          4 |         qreg q[1];
          5 |         rx(2.0, 3.0) q;
            :         ^^^^^^^^^^^^^^^
-         6 |     
+         6 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1384,6 +1387,7 @@ fn qasm2_simulatable_intrinsic_on_gate_stmt_generates_correct_qir()
     let source = r#"
         OPENQASM 2.0;
         include "qelib1.inc";
+        #pragma qdk.qir.profile Adaptive_RI
 
         @SimulatableIntrinsic
         gate my_gate q {
@@ -1396,7 +1400,7 @@ fn qasm2_simulatable_intrinsic_on_gate_stmt_generates_correct_qir()
         result = measure q;
     "#;
 
-    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qsharp = compile_qasm_to_qir(source)?;
     expect![[r#"
         %Result = type opaque
         %Qubit = type opaque
@@ -1439,6 +1443,7 @@ fn qasm2_qdk_qir_intrinsic_on_gate_stmt_generates_correct_qir() -> miette::Resul
     let source = r#"
         OPENQASM 2.0;
         include "qelib1.inc";
+        #pragma qdk.qir.profile Adaptive_RI
 
         @qdk.qir.intrinsic
         gate my_gate q {
@@ -1451,7 +1456,7 @@ fn qasm2_qdk_qir_intrinsic_on_gate_stmt_generates_correct_qir() -> miette::Resul
         result = measure q;
     "#;
 
-    let qsharp = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qsharp = compile_qasm_to_qir(source)?;
     expect![[r#"
         %Result = type opaque
         %Qubit = type opaque
@@ -1678,7 +1683,7 @@ fn qasm2_broadcast_with_different_register_sizes_fails() {
          5 |         qreg targets[2];
          6 |         CX ctrls, targets;
            :                   ^^^^^^^
-         7 |     
+         7 |
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));

--- a/source/compiler/qsc_qasm/src/tests/statement/gate_call.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/gate_call.rs
@@ -323,7 +323,7 @@ fn cx_called_with_one_qubit_generates_error() {
          3 |         qubit[2] q;
          4 |         cx q[0];
            :         ^^^^^^^^
-         5 |
+         5 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -349,7 +349,7 @@ fn cx_called_with_too_many_qubits_generates_error() {
          3 |         qubit[3] q;
          4 |         cx q[0], q[1], q[2];
            :         ^^^^^^^^^^^^^^^^^^^^
-         5 |
+         5 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -375,7 +375,7 @@ fn rx_gate_with_no_angles_generates_error() {
          3 |         qubit q;
          4 |         rx q;
            :         ^^^^^
-         5 |
+         5 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -422,7 +422,7 @@ fn rx_gate_with_too_many_angles_generates_error() {
          3 |         qubit q;
          4 |         rx(2.0, 3.0) q;
            :         ^^^^^^^^^^^^^^^
-         5 |
+         5 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -955,7 +955,7 @@ fn broadcast_with_different_register_sizes_fails() {
          4 |         qubit[2] targets;
          5 |         ctrl @ x ctrls, targets;
            :                         ^^^^^^^
-         6 |
+         6 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1222,7 +1222,7 @@ fn qasm2_cx_called_with_one_qubit_generates_error() {
          4 |         qreg q[2];
          5 |         CX q[0];
            :         ^^^^^^^^
-         6 |
+         6 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1249,7 +1249,7 @@ fn qasm2_cx_called_with_too_many_qubits_generates_error() {
          4 |         qreg q[3];
          5 |         cx q[0], q[1], q[2];
            :         ^^^^^^^^^^^^^^^^^^^^
-         6 |
+         6 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1276,7 +1276,7 @@ fn qasm2_rx_gate_with_no_angles_generates_error() {
          4 |         qreg q[1];
          5 |         rx q;
            :         ^^^^^
-         6 |
+         6 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1325,7 +1325,7 @@ fn qasm2_rx_gate_with_too_many_angles_generates_error() {
          4 |         qreg q[1];
          5 |         rx(2.0, 3.0) q;
            :         ^^^^^^^^^^^^^^^
-         6 |
+         6 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));
@@ -1683,7 +1683,7 @@ fn qasm2_broadcast_with_different_register_sizes_fails() {
          5 |         qreg targets[2];
          6 |         CX ctrls, targets;
            :                   ^^^^^^^
-         7 |
+         7 |     
            `----
         ]"#]]
     .assert_eq(&format!("{errors:?}"));

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma.rs
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 
 pub mod r#box;
+pub mod profile;

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/box.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/box.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use core::panic;
-
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/box.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/box.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use core::panic;
+
 use crate::tests::compile_qasm_to_qsharp;
 use expect_test::expect;
 use miette::Report;
@@ -169,7 +171,7 @@ fn target_with_param_raises_error() {
 
           x sample_box_target is not defined or is not a valid target for box usage
            ,-[Test.qasm:2:29]
-         1 | 
+         1 |
          2 |         pragma qdk.box.open sample_box_target
            :                             ^^^^^^^^^^^^^^^^^
          3 |         def sample_box_target(int i) {}
@@ -194,7 +196,7 @@ fn unknown_pragma_raises_error() {
 
           x pragma statement: qdk.box.unknown are not supported
            ,-[Test.qasm:2:9]
-         1 | 
+         1 |
          2 |         pragma qdk.box.unknown sample_box_target
            :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          3 |         def sample_box_target(int i) {}
@@ -221,7 +223,7 @@ fn target_with_return_value_raises_error() {
 
           x sample_box_target is not defined or is not a valid target for box usage
            ,-[Test.qasm:2:29]
-         1 | 
+         1 |
          2 |         pragma qdk.box.open sample_box_target
            :                             ^^^^^^^^^^^^^^^^^
          3 |         def sample_box_target() -> int {
@@ -245,7 +247,7 @@ fn unknown_target_with_return_value_raises_error() {
 
           x sample_box_target is not defined or is not a valid target for box usage
            ,-[Test.qasm:2:29]
-         1 | 
+         1 |
          2 |         pragma qdk.box.open sample_box_target
            :                             ^^^^^^^^^^^^^^^^^
          3 |         box {}

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/box.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/box.rs
@@ -171,7 +171,7 @@ fn target_with_param_raises_error() {
 
           x sample_box_target is not defined or is not a valid target for box usage
            ,-[Test.qasm:2:29]
-         1 |
+         1 | 
          2 |         pragma qdk.box.open sample_box_target
            :                             ^^^^^^^^^^^^^^^^^
          3 |         def sample_box_target(int i) {}
@@ -196,7 +196,7 @@ fn unknown_pragma_raises_error() {
 
           x pragma statement: qdk.box.unknown are not supported
            ,-[Test.qasm:2:9]
-         1 |
+         1 | 
          2 |         pragma qdk.box.unknown sample_box_target
            :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          3 |         def sample_box_target(int i) {}
@@ -223,7 +223,7 @@ fn target_with_return_value_raises_error() {
 
           x sample_box_target is not defined or is not a valid target for box usage
            ,-[Test.qasm:2:29]
-         1 |
+         1 | 
          2 |         pragma qdk.box.open sample_box_target
            :                             ^^^^^^^^^^^^^^^^^
          3 |         def sample_box_target() -> int {
@@ -247,7 +247,7 @@ fn unknown_target_with_return_value_raises_error() {
 
           x sample_box_target is not defined or is not a valid target for box usage
            ,-[Test.qasm:2:29]
-         1 |
+         1 | 
          2 |         pragma qdk.box.open sample_box_target
            :                             ^^^^^^^^^^^^^^^^^
          3 |         box {}

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
@@ -255,7 +255,7 @@ fn invalid_profile_target() -> miette::Result<(), Vec<Report>> {
 
     assert!(unit.has_errors(), "Expected compilation to fail");
 
-    expect![[r#""Foo is not a supported QIR Profile, please specify a valid target""#]]
+    expect![[r#""Invalid or missing QIR Profile: 'Foo'. Please specify one of: `Unrestricted`, `Base`, `Adaptive_RI`, `Adaptive_RIF`.""#]]
         .assert_eq(&format!("{:?}", &unit.errors[0].to_string()));
     Ok(())
 }
@@ -283,7 +283,7 @@ fn missing_profile_target() -> miette::Result<(), Vec<Report>> {
 
     assert!(unit.has_errors(), "Expected compilation to fail");
 
-    expect![[r#""<empty> is not a supported QIR Profile, please specify a valid target""#]]
+    expect![[r#""Invalid or missing QIR Profile: ''. Please specify one of: `Unrestricted`, `Base`, `Adaptive_RI`, `Adaptive_RIF`.""#]]
     .assert_eq(&format!("{:?}", &unit.errors[0].to_string()));
     Ok(())
 }

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
@@ -285,7 +285,7 @@ fn missing_profile_target() -> miette::Result<(), Vec<Report>> {
 
     assert!(unit.has_errors(), "Expected compilation to fail");
 
-    expect!["Error(Compiler(Error(MissingProfilePragmaTarget(Span { lo: 41, hi: 64 }))))"]
+    expect![[r#"Error(Compiler(Error(InvalidProfilePragmaTarget("<empty>", Span { lo: 41, hi: 64 }))))"#]]
         .assert_eq(&format!("{:?}", &unit.errors[0].error()));
     Ok(())
 }

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
@@ -6,7 +6,7 @@ use expect_test::expect;
 use miette::Report;
 
 #[test]
-fn profile_pragma_compiles_with_adaptive() -> miette::Result<(), Vec<Report>> {
+fn profile_pragma_compiles_with_adaptive_ri() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
         #pragma qdk.qir.profile Adaptive_RI
@@ -94,6 +94,101 @@ fn profile_pragma_compiles_with_adaptive() -> miette::Result<(), Vec<Report>> {
         !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
         !3 = !{i32 1, !"dynamic_result_management", i1 false}
         !4 = !{i32 1, !"int_computations", !"i64"}
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn profile_pragma_compiles_with_adaptive_rif() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        #pragma qdk.qir.profile Adaptive_RIF
+        qubit[5] qs;
+        qubit aux;
+        output bit[5] results;
+        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
+        results = measure qs;
+    "#;
+
+    let qsharp = compile_qasm_to_qir(source)?;
+    expect![[r#"
+        %Result = type opaque
+        %Qubit = type opaque
+
+        define void @ENTRYPOINT__main() #0 {
+        block_0:
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          %var_5 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 0 to %Result*))
+          br i1 %var_5, label %block_1, label %block_2
+        block_1:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          br label %block_2
+        block_2:
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          %var_8 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+          br i1 %var_8, label %block_3, label %block_4
+        block_3:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          br label %block_4
+        block_4:
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          %var_10 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
+          br i1 %var_10, label %block_5, label %block_6
+        block_5:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          br label %block_6
+        block_6:
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 5, i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 7 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 6 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 5 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* null)
+          ret void
+        }
+
+        declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__h__body(%Qubit*)
+
+        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
+
+        declare i1 @__quantum__qis__read_result__body(%Result*)
+
+        declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__array_record_output(i64, i8*)
+
+        declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="8" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 1, !"int_computations", !"i64"}
+        !5 = !{i32 1, !"float_computations", !"f64"}
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
@@ -1,0 +1,291 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::{compile, compile_qasm_to_qir};
+use expect_test::expect;
+use miette::Report;
+
+#[test]
+fn profile_pragma_compiles_with_adaptive() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        #pragma qdk.qir.profile Adaptive_RI
+        qubit[5] qs;
+        qubit aux;
+        output bit[5] results;
+        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
+        results = measure qs;
+    "#;
+
+    let qsharp = compile_qasm_to_qir(source)?;
+    expect![[r#"
+        %Result = type opaque
+        %Qubit = type opaque
+
+        define void @ENTRYPOINT__main() #0 {
+        block_0:
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          %var_5 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 0 to %Result*))
+          br i1 %var_5, label %block_1, label %block_2
+        block_1:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          br label %block_2
+        block_2:
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          %var_8 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+          br i1 %var_8, label %block_3, label %block_4
+        block_3:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          br label %block_4
+        block_4:
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          %var_10 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
+          br i1 %var_10, label %block_5, label %block_6
+        block_5:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          br label %block_6
+        block_6:
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 5, i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 7 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 6 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 5 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* null)
+          ret void
+        }
+
+        declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__h__body(%Qubit*)
+
+        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
+
+        declare i1 @__quantum__qis__read_result__body(%Result*)
+
+        declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__array_record_output(i64, i8*)
+
+        declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="8" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 1, !"int_computations", !"i64"}
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn profile_pragma_compiles_with_base() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        #pragma qdk.qir.profile Base
+        qubit[5] qs;
+        qubit aux;
+        output bit[5] results;
+        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
+        results = measure qs;
+    "#;
+
+    let qsharp = compile_qasm_to_qir(source)?;
+    expect![[r#"
+        %Result = type opaque
+        %Qubit = type opaque
+
+        define void @ENTRYPOINT__main() #0 {
+        block_0:
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 2 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 2 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 5, i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* null)
+          ret void
+        }
+
+        declare void @__quantum__qis__h__body(%Qubit*)
+
+        declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__t__body(%Qubit*)
+
+        declare void @__quantum__qis__t__adj(%Qubit*)
+
+        declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__array_record_output(i64, i8*)
+
+        declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="9" "required_num_results"="5" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn invalid_profile_target() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        #pragma qdk.qir.profile Foo
+
+        // Allocate qubits
+        qubit[5] qs;
+        qubit aux;
+
+        // The state we are looking for is returned after execution.
+        output bit[5] results;
+
+        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
+
+        // Measure the qubits
+        results = measure qs;
+    "#;
+
+    let unit = compile(source)?;
+
+    assert!(unit.has_errors(), "Expected compilation to fail");
+
+    expect![[
+        r#"Error(Compiler(Error(InvalidProfilePragmaTarget("Foo", Span { lo: 65, hi: 68 }))))"#
+    ]]
+    .assert_eq(&format!("{:?}", &unit.errors[0].error()));
+    Ok(())
+}
+
+#[test]
+fn missing_profile_target() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        #pragma qdk.qir.profile
+
+        // Allocate qubits
+        qubit[5] qs;
+        qubit aux;
+
+        // The state we are looking for is returned after execution.
+        output bit[5] results;
+
+        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
+
+        // Measure the qubits
+        results = measure qs;
+    "#;
+
+    let unit = compile(source)?;
+
+    assert!(unit.has_errors(), "Expected compilation to fail");
+
+    expect!["Error(Compiler(Error(MissingProfilePragmaTarget(Span { lo: 41, hi: 64 }))))"]
+        .assert_eq(&format!("{:?}", &unit.errors[0].error()));
+    Ok(())
+}

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
@@ -365,6 +365,102 @@ fn invalid_profile_target_errors() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
+fn profile_pragma_first_wins() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        #pragma qdk.qir.profile Adaptive_RI
+        #pragma qdk.qir.profile Base
+        qubit[5] qs;
+        qubit aux;
+        output bit[5] results;
+        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
+        results = measure qs;
+    "#;
+
+    let qsharp = compile_qasm_to_qir(source)?;
+    expect![[r#"
+        %Result = type opaque
+        %Qubit = type opaque
+
+        define void @ENTRYPOINT__main() #0 {
+        block_0:
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          %var_5 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 0 to %Result*))
+          br i1 %var_5, label %block_1, label %block_2
+        block_1:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          br label %block_2
+        block_2:
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          %var_8 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+          br i1 %var_8, label %block_3, label %block_4
+        block_3:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          br label %block_4
+        block_4:
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          %var_10 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
+          br i1 %var_10, label %block_5, label %block_6
+        block_5:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          br label %block_6
+        block_6:
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 5, i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 7 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 6 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 5 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* null)
+          ret void
+        }
+
+        declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__h__body(%Qubit*)
+
+        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
+
+        declare i1 @__quantum__qis__read_result__body(%Result*)
+
+        declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__array_record_output(i64, i8*)
+
+        declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="8" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 1, !"int_computations", !"i64"}
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
 fn missing_profile_target_errors() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
@@ -328,7 +328,45 @@ fn profile_pragma_compiles_with_base() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn duplicate_profile_pragmas_errors() -> miette::Result<(), Vec<Report>> {
+fn invalid_profile_target_errors() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        #pragma qdk.qir.profile Foo
+
+        // Allocate qubits
+        qubit[5] qs;
+        qubit aux;
+
+        // The state we are looking for is returned after execution.
+        output bit[5] results;
+
+        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
+
+        // Measure the qubits
+        results = measure qs;
+    "#;
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+        Qasm.Compiler.InvalidProfilePragmaTarget
+
+          x Invalid or missing QIR Profile: 'Foo'. Please specify one of:
+          | `Unrestricted`, `Base`, `Adaptive_RI`, `Adaptive_RIF`.
+           ,-[Test.qasm:3:33]
+         2 |         include "stdgates.inc";
+         3 |         #pragma qdk.qir.profile Foo
+           :                                 ^^^
+         4 | 
+           `----
+    "#]],
+    );
+    Ok(())
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn profile_pragma_first_wins() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
         #pragma qdk.qir.profile Adaptive_RI
@@ -340,51 +378,85 @@ fn duplicate_profile_pragmas_errors() -> miette::Result<(), Vec<Report>> {
         results = measure qs;
     "#;
 
-    check_qasm_to_qsharp(
-        source,
-        &expect![[r#"
-            Qasm.Compiler.MultipleProfilePragmas
+    let qsharp = compile_qasm_to_qir(source)?;
+    expect![[r#"
+        %Result = type opaque
+        %Qubit = type opaque
 
-              x Duplicate `qdk.qir.profile` pragma. Only one `qdk.qir.profile` pragma
-              | should be specified.
-               ,-[Test.qasm:4:9]
-             3 |         #pragma qdk.qir.profile Adaptive_RI
-             4 |         #pragma qdk.qir.profile Base
-               :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             5 |         qubit[5] qs;
-               `----
-        "#]],
-    );
-    Ok(())
-}
+        define void @ENTRYPOINT__main() #0 {
+        block_0:
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          %var_5 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 0 to %Result*))
+          br i1 %var_5, label %block_1, label %block_2
+        block_1:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          br label %block_2
+        block_2:
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          %var_8 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+          br i1 %var_8, label %block_3, label %block_4
+        block_3:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+          br label %block_4
+        block_4:
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          %var_10 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
+          br i1 %var_10, label %block_5, label %block_6
+        block_5:
+          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
+          br label %block_6
+        block_6:
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
+          call void @__quantum__rt__array_record_output(i64 5, i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 7 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 6 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 5 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* null)
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* null)
+          ret void
+        }
 
-#[test]
-fn invalid_profile_target_errors() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        include "stdgates.inc";
-        #pragma qdk.qir.profile Foo
-        qubit[5] qs;
-        qubit aux;
-        output bit[5] results;
-        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
-        results = measure qs;
-    "#;
+        declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
 
-    check_qasm_to_qsharp(
-        source,
-        &expect![[r#"
-            Qasm.Compiler.InvalidProfilePragmaTarget
+        declare void @__quantum__qis__h__body(%Qubit*)
 
-              x Invalid or missing QIR Profile: 'Foo'. Please specify one of:
-              | `Unrestricted`, `Base`, `Adaptive_RI`, `Adaptive_RIF`.
-               ,-[Test.qasm:3:33]
-             2 |         include "stdgates.inc";
-             3 |         #pragma qdk.qir.profile Foo
-               :                                 ^^^
-             4 |         qubit[5] qs;
-               `----
-        "#]],
-    );
+        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
+
+        declare i1 @__quantum__qis__read_result__body(%Result*)
+
+        declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
+
+        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+
+        declare void @__quantum__rt__array_record_output(i64, i8*)
+
+        declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="8" }
+        attributes #1 = { "irreversible" }
+
+        ; module flags
+
+        !llvm.module.flags = !{!0, !1, !2, !3, !4}
+
+        !0 = !{i32 1, !"qir_major_version", i32 1}
+        !1 = !{i32 7, !"qir_minor_version", i32 0}
+        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+        !3 = !{i32 1, !"dynamic_result_management", i1 false}
+        !4 = !{i32 1, !"int_computations", !"i64"}
+    "#]]
+    .assert_eq(&qsharp);
     Ok(())
 }
 
@@ -393,27 +465,34 @@ fn missing_profile_target_errors() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
         #pragma qdk.qir.profile
+
+        // Allocate qubits
         qubit[5] qs;
         qubit aux;
+
+        // The state we are looking for is returned after execution.
         output bit[5] results;
+
         ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
+
+        // Measure the qubits
         results = measure qs;
     "#;
 
     check_qasm_to_qsharp(
         source,
         &expect![[r#"
-            Qasm.Compiler.InvalidProfilePragmaTarget
+        Qasm.Compiler.InvalidProfilePragmaTarget
 
-              x Invalid or missing QIR Profile: ''. Please specify one of: `Unrestricted`,
-              | `Base`, `Adaptive_RI`, `Adaptive_RIF`.
-               ,-[Test.qasm:3:9]
-             2 |         include "stdgates.inc";
-             3 |         #pragma qdk.qir.profile
-               :         ^^^^^^^^^^^^^^^^^^^^^^^
-             4 |         qubit[5] qs;
-               `----
-        "#]],
+          x Invalid or missing QIR Profile: ''. Please specify one of: `Unrestricted`,
+          | `Base`, `Adaptive_RI`, `Adaptive_RIF`.
+           ,-[Test.qasm:3:9]
+         2 |         include "stdgates.inc";
+         3 |         #pragma qdk.qir.profile
+           :         ^^^^^^^^^^^^^^^^^^^^^^^
+         4 | 
+           `----
+    "#]],
     );
     Ok(())
 }

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
@@ -328,45 +328,7 @@ fn profile_pragma_compiles_with_base() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
-fn invalid_profile_target_errors() -> miette::Result<(), Vec<Report>> {
-    let source = r#"
-        include "stdgates.inc";
-        #pragma qdk.qir.profile Foo
-
-        // Allocate qubits
-        qubit[5] qs;
-        qubit aux;
-
-        // The state we are looking for is returned after execution.
-        output bit[5] results;
-
-        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
-
-        // Measure the qubits
-        results = measure qs;
-    "#;
-
-    check_qasm_to_qsharp(
-        source,
-        &expect![[r#"
-        Qasm.Compiler.InvalidProfilePragmaTarget
-
-          x Invalid or missing QIR Profile: 'Foo'. Please specify one of:
-          | `Unrestricted`, `Base`, `Adaptive_RI`, `Adaptive_RIF`.
-           ,-[Test.qasm:3:33]
-         2 |         include "stdgates.inc";
-         3 |         #pragma qdk.qir.profile Foo
-           :                                 ^^^
-         4 | 
-           `----
-    "#]],
-    );
-    Ok(())
-}
-
-#[test]
-#[allow(clippy::too_many_lines)]
-fn profile_pragma_first_wins() -> miette::Result<(), Vec<Report>> {
+fn duplicate_profile_pragmas_errors() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
         #pragma qdk.qir.profile Adaptive_RI
@@ -378,85 +340,51 @@ fn profile_pragma_first_wins() -> miette::Result<(), Vec<Report>> {
         results = measure qs;
     "#;
 
-    let qsharp = compile_qasm_to_qir(source)?;
-    expect![[r#"
-        %Result = type opaque
-        %Qubit = type opaque
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            Qasm.Compiler.MultipleProfilePragmas
 
-        define void @ENTRYPOINT__main() #0 {
-        block_0:
-          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
-          %var_5 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 0 to %Result*))
-          br i1 %var_5, label %block_1, label %block_2
-        block_1:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          br label %block_2
-        block_2:
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-          %var_8 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-          br i1 %var_8, label %block_3, label %block_4
-        block_3:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          br label %block_4
-        block_4:
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
-          %var_10 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
-          br i1 %var_10, label %block_5, label %block_6
-        block_5:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          br label %block_6
-        block_6:
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
-          call void @__quantum__rt__array_record_output(i64 5, i8* null)
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 7 to %Result*), i8* null)
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 6 to %Result*), i8* null)
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 5 to %Result*), i8* null)
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* null)
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* null)
-          ret void
-        }
+              x Duplicate `qdk.qir.profile` pragma. Only one `qdk.qir.profile` pragma
+              | should be specified.
+               ,-[Test.qasm:4:9]
+             3 |         #pragma qdk.qir.profile Adaptive_RI
+             4 |         #pragma qdk.qir.profile Base
+               :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             5 |         qubit[5] qs;
+               `----
+        "#]],
+    );
+    Ok(())
+}
 
-        declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
+#[test]
+fn invalid_profile_target_errors() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        include "stdgates.inc";
+        #pragma qdk.qir.profile Foo
+        qubit[5] qs;
+        qubit aux;
+        output bit[5] results;
+        ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
+        results = measure qs;
+    "#;
 
-        declare void @__quantum__qis__h__body(%Qubit*)
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            Qasm.Compiler.InvalidProfilePragmaTarget
 
-        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
-
-        declare i1 @__quantum__qis__read_result__body(%Result*)
-
-        declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
-
-        declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
-
-        declare void @__quantum__rt__array_record_output(i64, i8*)
-
-        declare void @__quantum__rt__result_record_output(%Result*, i8*)
-
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="8" }
-        attributes #1 = { "irreversible" }
-
-        ; module flags
-
-        !llvm.module.flags = !{!0, !1, !2, !3, !4}
-
-        !0 = !{i32 1, !"qir_major_version", i32 1}
-        !1 = !{i32 7, !"qir_minor_version", i32 0}
-        !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-        !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        !4 = !{i32 1, !"int_computations", !"i64"}
-    "#]]
-    .assert_eq(&qsharp);
+              x Invalid or missing QIR Profile: 'Foo'. Please specify one of:
+              | `Unrestricted`, `Base`, `Adaptive_RI`, `Adaptive_RIF`.
+               ,-[Test.qasm:3:33]
+             2 |         include "stdgates.inc";
+             3 |         #pragma qdk.qir.profile Foo
+               :                                 ^^^
+             4 |         qubit[5] qs;
+               `----
+        "#]],
+    );
     Ok(())
 }
 
@@ -465,34 +393,27 @@ fn missing_profile_target_errors() -> miette::Result<(), Vec<Report>> {
     let source = r#"
         include "stdgates.inc";
         #pragma qdk.qir.profile
-
-        // Allocate qubits
         qubit[5] qs;
         qubit aux;
-
-        // The state we are looking for is returned after execution.
         output bit[5] results;
-
         ctrl(5) @ x qs[0], qs[1], qs[2], qs[3], qs[4], aux;
-
-        // Measure the qubits
         results = measure qs;
     "#;
 
     check_qasm_to_qsharp(
         source,
         &expect![[r#"
-        Qasm.Compiler.InvalidProfilePragmaTarget
+            Qasm.Compiler.InvalidProfilePragmaTarget
 
-          x Invalid or missing QIR Profile: ''. Please specify one of: `Unrestricted`,
-          | `Base`, `Adaptive_RI`, `Adaptive_RIF`.
-           ,-[Test.qasm:3:9]
-         2 |         include "stdgates.inc";
-         3 |         #pragma qdk.qir.profile
-           :         ^^^^^^^^^^^^^^^^^^^^^^^
-         4 | 
-           `----
-    "#]],
+              x Invalid or missing QIR Profile: ''. Please specify one of: `Unrestricted`,
+              | `Base`, `Adaptive_RI`, `Adaptive_RIF`.
+               ,-[Test.qasm:3:9]
+             2 |         include "stdgates.inc";
+             3 |         #pragma qdk.qir.profile
+               :         ^^^^^^^^^^^^^^^^^^^^^^^
+             4 |         qubit[5] qs;
+               `----
+        "#]],
     );
     Ok(())
 }

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
@@ -255,10 +255,8 @@ fn invalid_profile_target() -> miette::Result<(), Vec<Report>> {
 
     assert!(unit.has_errors(), "Expected compilation to fail");
 
-    expect![[
-        r#"Error(Compiler(Error(InvalidProfilePragmaTarget("Foo", Span { lo: 65, hi: 68 }))))"#
-    ]]
-    .assert_eq(&format!("{:?}", &unit.errors[0].error()));
+    expect![[r#""Foo is not a supported QIR Profile, please specify a valid target""#]]
+        .assert_eq(&format!("{:?}", &unit.errors[0].to_string()));
     Ok(())
 }
 
@@ -285,7 +283,7 @@ fn missing_profile_target() -> miette::Result<(), Vec<Report>> {
 
     assert!(unit.has_errors(), "Expected compilation to fail");
 
-    expect![[r#"Error(Compiler(Error(InvalidProfilePragmaTarget("<empty>", Span { lo: 41, hi: 64 }))))"#]]
-        .assert_eq(&format!("{:?}", &unit.errors[0].error()));
+    expect![[r#""<empty> is not a supported QIR Profile, please specify a valid target""#]]
+    .assert_eq(&format!("{:?}", &unit.errors[0].to_string()));
     Ok(())
 }

--- a/source/compiler/qsc_qasm/src/tests/statement/reset.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/reset.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::tests::compile_qasm_to_qir;
 use crate::{
     CompilerConfig, OutputSemantics, ProgramType, QubitSemantics,
     tests::{
@@ -10,9 +11,6 @@ use crate::{
 };
 use expect_test::expect;
 use miette::Report;
-use qsc::target::Profile;
-
-use crate::tests::compile_qasm_to_qir;
 
 #[test]
 fn reset_calls_are_generated_from_qasm() -> miette::Result<(), Vec<Report>> {
@@ -59,6 +57,7 @@ fn reset_with_base_profile_is_rewritten_without_resets() -> miette::Result<(), V
     let source = r#"
         OPENQASM 3.0;
         include "stdgates.inc";
+        #pragma qdk.qir.profile Base
         bit[1] meas;
         qubit[1] q;
         reset q[0];
@@ -66,7 +65,7 @@ fn reset_with_base_profile_is_rewritten_without_resets() -> miette::Result<(), V
         meas[0] = measure q[0];
     "#;
 
-    let qir = compile_qasm_to_qir(source, Profile::Base)?;
+    let qir = compile_qasm_to_qir(source)?;
     expect![[
         r#"
         %Result = type opaque
@@ -112,6 +111,7 @@ fn reset_with_adaptive_ri_profile_generates_reset_qir() -> miette::Result<(), Ve
     let source = r#"
         OPENQASM 3.0;
         include "stdgates.inc";
+        #pragma qdk.qir.profile Adaptive_RI
         bit[1] meas;
         qubit[1] q;
         reset q[0];
@@ -119,7 +119,7 @@ fn reset_with_adaptive_ri_profile_generates_reset_qir() -> miette::Result<(), Ve
         meas[0] = measure q[0];
     "#;
 
-    let qir = compile_qasm_to_qir(source, Profile::AdaptiveRI)?;
+    let qir = compile_qasm_to_qir(source)?;
     expect![
         r#"
         %Result = type opaque
@@ -229,7 +229,7 @@ fn on_a_zero_len_qubit_register_fails() {
 
               x quantum register size must be a positive integer
                ,-[Test.qasm:2:15]
-             1 | 
+             1 |
              2 |         qubit[0] q;
                :               ^
              3 |         reset q;

--- a/source/compiler/qsc_qasm/src/tests/statement/reset.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/reset.rs
@@ -229,7 +229,7 @@ fn on_a_zero_len_qubit_register_fails() {
 
               x quantum register size must be a positive integer
                ,-[Test.qasm:2:15]
-             1 |
+             1 | 
              2 |         qubit[0] q;
                :               ^
              3 |         reset q;

--- a/source/fuzz/fuzz_targets/qasm.rs
+++ b/source/fuzz/fuzz_targets/qasm.rs
@@ -42,7 +42,7 @@ fn compile(data: &[u8]) {
                 Some(&mut resolver),
                 config,
             );
-            let (sources, _, package, _) = unit.into_tuple();
+            let (sources, _, package, _, profile) = unit.into_tuple();
 
             let dependencies = vec![(PackageId::CORE, None), (*stdid, None)];
 
@@ -52,7 +52,7 @@ fn compile(data: &[u8]) {
                 package,
                 sources,
                 PackageType::Lib,
-                Profile::Unrestricted.into(),
+                profile.into(),
             );
         });
     }

--- a/source/language_service/src/compilation.rs
+++ b/source/language_service/src/compilation.rs
@@ -14,7 +14,7 @@ use qsc::{
     project,
     qasm::{
         CompileRawQasmResult, CompilerConfig, OutputSemantics, ProgramType, QubitSemantics,
-        compiler::{PragmaKind, compile_to_qsharp_ast_with_config},
+        compiler::compile_to_qsharp_ast_with_config,
     },
     resolve,
     target::Profile,
@@ -22,8 +22,8 @@ use qsc::{
 use qsc_linter::{LintLevel, LintOrGroupConfig};
 use qsc_project::{PackageGraphSources, Project, ProjectType};
 use rustc_hash::FxHashMap;
+use std::sync::Arc;
 use std::{iter::once, mem::take};
-use std::{str::FromStr, sync::Arc};
 
 /// The alias that a project gives a dependency in its qsharp.json.
 /// In other words, this is the name that a given project uses to reference
@@ -266,25 +266,16 @@ impl Compilation {
             None,
         );
         let res = qsc::qasm::semantic::parse_sources(&sources);
-        // Get the first profile pragma if present, otherwise default to `Unrestricted`.
-        let target_profile = res
-            .program
-            .pragmas
-            .iter()
-            .find_map(|p| match (&p.identifier, &p.value) {
-                (Some(id), Some(value))
-                    if PragmaKind::from_str(id.as_string().as_str())
-                        == Ok(PragmaKind::QdkProfile) =>
-                {
-                    Profile::from_str(value).ok()
-                }
-                _ => None,
-            })
-            .unwrap_or(Profile::Unrestricted);
-        let capabilities = target_profile.into();
         let unit = compile_to_qsharp_ast_with_config(res, config);
-        let CompileRawQasmResult(store, source_package_id, dependencies, _sig, mut compile_errors) =
-            qsc::qasm::compile_openqasm(unit, package_type, capabilities);
+        let target_profile = unit.profile();
+        let CompileRawQasmResult(
+            store,
+            source_package_id,
+            dependencies,
+            _sig,
+            mut compile_errors,
+            _,
+        ) = qsc::qasm::compile_openqasm(unit, package_type);
 
         let compile_unit = store
             .get(source_package_id)

--- a/source/language_service/src/completion/tests/openqasm.rs
+++ b/source/language_service/src/completion/tests/openqasm.rs
@@ -20,7 +20,6 @@ fn compile_project_with_markers_cursor_optional(
     (
         Compilation::new_qasm(
             PackageType::Lib,
-            qsc::target::Profile::Unrestricted,
             sources,
             vec![],
             &Arc::from("test project"),

--- a/source/language_service/src/state.rs
+++ b/source/language_service/src/state.rs
@@ -309,7 +309,6 @@ impl<'a> CompilationStateUpdater<'a> {
             let compilation = match loaded_project.project_type {
                 ProjectType::OpenQASM(sources) => Compilation::new_qasm(
                     configuration.package_type,
-                    configuration.target_profile,
                     sources,
                     loaded_project.errors,
                     &loaded_project.name,

--- a/source/pip/src/interop.rs
+++ b/source/pip/src/interop.rs
@@ -332,7 +332,7 @@ pub(crate) fn compile_qasm_enriching_errors<S: AsRef<str>>(
 
     let unit = compile_to_qsharp_ast_with_config(semantic_parse_result, config);
 
-    let (source_map, errors, package, sig) = unit.into_tuple();
+    let (source_map, errors, package, sig, _) = unit.into_tuple();
     if !errors.is_empty() {
         return Err(QasmError::new_err(format_qasm_errors(errors)));
     }

--- a/source/pip/src/interpreter.rs
+++ b/source/pip/src/interpreter.rs
@@ -500,7 +500,7 @@ impl Interpreter {
         );
         let res = qsc::qasm::semantic::parse_sources(&sources);
         let unit = compile_to_qsharp_ast_with_config(res, config);
-        let (sources, errors, package, _) = unit.into_tuple();
+        let (sources, errors, package, _, _) = unit.into_tuple();
 
         if !errors.is_empty() {
             let errors = errors

--- a/source/samples_test/src/tests.rs
+++ b/source/samples_test/src/tests.rs
@@ -110,7 +110,7 @@ fn compile_and_run_qasm_internal(source: &str, debug: bool) -> String {
         Option::<&mut InMemorySourceResolver>::None,
         config,
     );
-    let (source_map, errors, package, sig) = unit.into_tuple();
+    let (source_map, errors, package, sig, _) = unit.into_tuple();
     assert!(errors.is_empty(), "QASM compilation failed: {errors:?}");
 
     let Some(signature) = sig else {

--- a/source/wasm/src/debug_service.rs
+++ b/source/wasm/src/debug_service.rs
@@ -4,7 +4,7 @@
 use crate::line_column::{Location, Range};
 use crate::project_system::{ProgramConfig, into_qsc_args};
 use crate::{
-    CallbackReceiver, get_debugger_from_openqasm, into_openqasm_args, is_openqasm_program,
+    CallbackReceiver, get_debugger_from_openqasm, into_openqasm_arg, is_openqasm_program,
     serializable_type,
 };
 use qsc::fir::StmtId;
@@ -31,8 +31,8 @@ impl DebugService {
     #[allow(clippy::needless_pass_by_value)] // needed for wasm_bindgen
     pub fn load_program(&mut self, program: ProgramConfig, entry: Option<String>) -> String {
         if is_openqasm_program(&program) {
-            let (sources, capabilities) = into_openqasm_args(program);
-            match get_debugger_from_openqasm(&sources, capabilities) {
+            let sources = into_openqasm_arg(program);
+            match get_debugger_from_openqasm(&sources) {
                 Ok((entry_expr, mut interpreter)) => {
                     if let Err(e) = interpreter.set_entry_expr(&entry_expr) {
                         return render_errors(e);

--- a/source/wasm/src/project_system.rs
+++ b/source/wasm/src/project_system.rs
@@ -476,18 +476,10 @@ pub(crate) fn into_qsc_args(
 
 #[allow(clippy::needless_pass_by_value)]
 #[allow(clippy::type_complexity)]
-pub(crate) fn into_openqasm_args(
-    program: ProgramConfig,
-) -> (Vec<(Arc<str>, Arc<str>)>, qsc::TargetCapabilityFlags) {
-    let capabilities = qsc::target::Profile::from_str(&program.profile())
-        .unwrap_or_else(|()| panic!("Invalid target : {}", program.profile()))
-        .into();
-
+pub(crate) fn into_openqasm_arg(program: ProgramConfig) -> Vec<(Arc<str>, Arc<str>)> {
     let pkg_graph: PackageGraphSources = program.packageGraphSources().into();
     let pkg_graph: qsc_project::PackageGraphSources = pkg_graph.into();
-    let sources = pkg_graph.root.sources;
-
-    (sources, capabilities)
+    pkg_graph.root.sources
 }
 
 pub(crate) fn is_openqasm_program(program: &ProgramConfig) -> bool {


### PR DESCRIPTION
Adds the `#pragma qdk.qir.profile` pragma to our QASM compiler. This pragma is used to specify the profile to compile the QASM file with, i.e. `#pragma qdk.qir.profile Base` to have the file compile with the `Base` profile. QASM files are always compiled with the profile specified by their source with this pragma. If no pragma is provided, the compilation will default to `Unrestricted`.

The PR is built on top of and relies on #2591