### PR TITLE
Fix lowering of OpenQASM assign-op statements

### DIFF
--- a/source/compiler/qsc_qasm/src/tests/assignment.rs
+++ b/source/compiler/qsc_qasm/src/tests/assignment.rs
@@ -174,3 +174,43 @@ fn index_into_array_and_then_into_int() {
         "#]],
     );
 }
+
+#[test]
+fn angle_shl_assign() {
+    let source = "
+        angle[8] a;
+        a <<= 1;
+    ";
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            mutable a = new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            };
+            set a = Std.OpenQASM.Angle.__AngleShl__(a, 1);
+        "#]],
+    );
+}
+
+#[test]
+fn angle_shr_assign() {
+    let source = "
+        angle[8] a;
+        a >>= 1;
+    ";
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            import Std.OpenQASM.Intrinsic.*;
+            mutable a = new Std.OpenQASM.Angle.Angle {
+                Value = 0,
+                Size = 53
+            };
+            set a = Std.OpenQASM.Angle.AngleShr(a, 1);
+        "#]],
+    );
+}


### PR DESCRIPTION
There was casting bug when trying to do

```
angle[8] a;
a <<= 1;
```

The issue was that assign-op expressions like `a <<= 1;` should be lowered as

```a = cast_to_type_of_lhs(a << 1);```

But they were being lowered as
```a = a << cast_to_type_of_lhs(1);```