### PR TITLE
Add noise telemetry to `qsharp.run`

### DIFF
--- a/source/pip/qsharp/_qsharp.py
+++ b/source/pip/qsharp/_qsharp.py
@@ -490,7 +490,9 @@ def run(
     if shots < 1:
         raise ValueError("The number of shots must be greater than 0.")
 
-    telemetry_events.on_run(shots)
+    telemetry_events.on_run(
+        shots, noise=noise is not None, qubit_loss=qubit_loss is not None
+    )
     start_time = monotonic()
 
     results: List[ShotResult] = []

--- a/source/pip/qsharp/_qsharp.py
+++ b/source/pip/qsharp/_qsharp.py
@@ -491,7 +491,9 @@ def run(
         raise ValueError("The number of shots must be greater than 0.")
 
     telemetry_events.on_run(
-        shots, noise=noise is not None, qubit_loss=qubit_loss is not None
+        shots,
+        noise=(noise is not None and noise != (0.0, 0.0, 0.0)),
+        qubit_loss=(qubit_loss is not None and qubit_loss > 0.0),
     )
     start_time = monotonic()
 

--- a/source/pip/qsharp/openqasm/_run.py
+++ b/source/pip/qsharp/openqasm/_run.py
@@ -77,7 +77,9 @@ def run(
     if shots < 1:
         raise ValueError("The number of shots must be greater than 0.")
 
-    telemetry_events.on_run_qasm(shots)
+    telemetry_events.on_run_qasm(
+        shots, noise=noise is not None, qubit_loss=qubit_loss is not None
+    )
     start_time = monotonic()
 
     results: List[ShotResult] = []

--- a/source/pip/qsharp/telemetry_events.py
+++ b/source/pip/qsharp/telemetry_events.py
@@ -41,11 +41,15 @@ def on_import() -> None:
     log_telemetry("qsharp.import", 1)
 
 
-def on_run(shots: int) -> None:
+def on_run(shots: int, noise: bool, qubit_loss: bool) -> None:
     log_telemetry(
         "qsharp.run",
         1,
-        properties={"shots": get_next_power_of_ten_bucket(shots)},
+        properties={
+            "shots": get_next_power_of_ten_bucket(shots),
+            "noise": noise,
+            "qubit_loss": qubit_loss,
+        },
     )
 
 
@@ -58,11 +62,15 @@ def on_run_end(durationMs: float, shots: int) -> None:
     )
 
 
-def on_run_qasm(shots: int) -> None:
+def on_run_qasm(shots: int, noise: bool, qubit_loss: bool) -> None:
     log_telemetry(
         "qsharp.run_qasm",
         1,
-        properties={"shots": get_next_power_of_ten_bucket(shots)},
+        properties={
+            "shots": get_next_power_of_ten_bucket(shots),
+            "noise": noise,
+            "qubit_loss": qubit_loss,
+        },
     )
 
 


### PR DESCRIPTION
This adds two Booleans to show whether `qsharp.run` or `qsharp.openqasm.run` were invoked with noise and/or qubit loss. The bools show up in the custom data along with the bucketized shot count.