### PR TITLE
Builtin functions in OpenQASM now error when `coerce_literal_expr_to_type` fails

### DIFF
--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -3078,7 +3078,7 @@ impl Lowerer {
     }
 
     #[allow(clippy::too_many_lines)]
-    fn try_coerce_literal_expr_to_type(
+    pub(crate) fn try_coerce_literal_expr_to_type(
         &mut self,
         ty: &Type,
         rhs: &semantic::Expr,
@@ -4294,7 +4294,12 @@ impl Lowerer {
         self.push_semantic_error(kind);
     }
 
-    fn push_invalid_literal_cast_error(&mut self, target_ty: &Type, expr_ty: &Type, span: Span) {
+    pub(crate) fn push_invalid_literal_cast_error(
+        &mut self,
+        target_ty: &Type,
+        expr_ty: &Type,
+        span: Span,
+    ) {
         if target_ty.is_err() || expr_ty.is_err() {
             // if either type is an error, we don't need to push an error
             return;

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sqrt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sqrt.rs
@@ -92,3 +92,47 @@ fn sqrt_complex() {
         "#]],
     );
 }
+
+#[test]
+fn casting_large_int_to_float_errors() {
+    let source = "sqrt(888888888888888888);";
+    check_stmt_kinds(
+        source,
+        &expect![[r#"
+        Program:
+            version: <none>
+            pragmas: <empty>
+            statements:
+                Stmt [0-25]:
+                    annotations: <empty>
+                    kind: Err
+
+        [Qasm.Lowerer.InvalidCastValueRange
+
+          x assigning const int values to const float must be in a range that be
+          | converted to const float
+           ,-[test:1:6]
+         1 | sqrt(888888888888888888);
+           :      ^^^^^^^^^^^^^^^^^^
+           `----
+        , Qasm.Lowerer.InvalidCastValueRange
+
+          x assigning int values to float must be in a range that be converted to
+          | float
+           ,-[test:1:6]
+         1 | sqrt(888888888888888888);
+           :      ^^^^^^^^^^^^^^^^^^
+           `----
+        , Qasm.Lowerer.NoValidOverloadForBuiltinFunction
+
+          x There is no valid overload of `sqrt` for inputs: (const int)
+          | Overloads available are:
+          |     def sqrt(const float) -> const float
+          |     def sqrt(const complex[float]) -> const complex[float]
+           ,-[test:1:1]
+         1 | sqrt(888888888888888888);
+           : ^^^^^^^^^^^^^^^^^^^^^^^^
+           `----
+        ]"#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/stdlib/builtin_functions.rs
+++ b/source/compiler/qsc_qasm/src/stdlib/builtin_functions.rs
@@ -140,8 +140,13 @@ fn try_implicit_cast_inputs(
             value_expr.kind = Box::new(ExprKind::Lit(
                 input.get_const_value().expect("input should be const"),
             ));
-            let coerced_input = ctx.coerce_literal_expr_to_type(ty, &value_expr, &value);
-            new_inputs.push(coerced_input.with_const_value(ctx));
+            if let Some(coerced_input) =
+                ctx.try_coerce_literal_expr_to_type(ty, &value_expr, &value)
+            {
+                new_inputs.push(coerced_input.with_const_value(ctx));
+            } else {
+                return None;
+            }
         } else {
             return None;
         }

--- a/source/compiler/qsc_qasm/src/tests/fuzz.rs
+++ b/source/compiler/qsc_qasm/src/tests/fuzz.rs
@@ -160,3 +160,9 @@ fn fuzz_2397() {
     let source = "creg a[551615";
     compile_qasm_best_effort(source, Profile::Unrestricted);
 }
+
+#[test]
+fn fuzz_2620() {
+    let source = "sqrt(888888888888888888);";
+    compile_qasm_best_effort(source, Profile::Unrestricted);
+}


### PR DESCRIPTION
This PR fixes #2620 