### PR TITLE
Fix source offset when printing call stack

### DIFF
--- a/source/compiler/qsc/src/interpret/debug.rs
+++ b/source/compiler/qsc/src/interpret/debug.rs
@@ -108,5 +108,5 @@ fn get_position(frame: Frame, store: &PackageStore) -> Position {
         .find_by_name(&filename)
         .expect("source should exist");
     let contents = &source.contents;
-    Position::from_utf8_byte_offset(Encoding::Utf8, contents, frame.span.lo)
+    Position::from_utf8_byte_offset(Encoding::Utf8, contents, frame.span.lo - source.offset)
 }


### PR DESCRIPTION
This PR fixes a bug when printing the call stack. We weren't substracting the file offset in the SourceMap which is necessary to convert from SourceMap offsets to file offsets.