### PR TITLE
 Fix completions for import and exports

### DIFF
--- a/source/compiler/qsc/src/lib.rs
+++ b/source/compiler/qsc/src/lib.rs
@@ -15,7 +15,7 @@ pub use qsc_frontend::compile::{CompileUnit, PackageStore, SourceContents, Sourc
 
 pub mod resolve {
     pub use qsc_frontend::resolve::{
-        Local, LocalKind, Locals, Res, iter_valid_items, path_as_field_accessor,
+        GlobalScope, Local, Locals, NameKind, Res, iter_valid_items, path_as_field_accessor,
     };
 }
 

--- a/source/compiler/qsc_frontend/src/incremental.rs
+++ b/source/compiler/qsc_frontend/src/incremental.rs
@@ -190,6 +190,7 @@ impl Compiler {
                 package: ast,
                 names: self.resolver.names().clone(),
                 locals: self.resolver.locals().clone(),
+                globals: self.resolver.globals().clone(),
                 tys: self.checker.table().clone(),
             },
             hir,
@@ -229,6 +230,7 @@ impl Compiler {
                 package: ast,
                 names: self.resolver.names().clone(),
                 locals: self.resolver.locals().clone(),
+                globals: self.resolver.globals().clone(),
                 tys: self.checker.table().clone(),
             },
             hir,
@@ -245,6 +247,7 @@ impl Compiler {
         unit.ast.names = new.ast.names;
         unit.ast.tys = new.ast.tys;
         unit.ast.locals = new.ast.locals;
+        unit.ast.globals = new.ast.globals;
 
         // Update the HIR
         extend_hir(&mut unit.package, new.hir);

--- a/source/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/source/compiler/qsc_frontend/src/resolve/tests.rs
@@ -3336,6 +3336,29 @@ fn get_locals_block_scope_boundary_begin() {
 }
 
 #[test]
+fn get_locals_namespace_imports() {
+    check_locals(
+        indoc! {"
+            namespace Bar {}
+            namespace Foo {
+                import Bar;
+                import Bar as Baz;
+                import Bar.*;
+                function A() : Int {
+                    ↘
+                }
+            }
+        "},
+        &expect![[r#"
+            namespace 4
+            namespace 3
+            Bar (namespace 3)
+            Baz (namespace 3)
+        "#]],
+    );
+}
+
+#[test]
 fn use_after_scope() {
     check(
         indoc! {"

--- a/source/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/source/compiler/qsc_frontend/src/resolve/tests.rs
@@ -3336,6 +3336,29 @@ fn get_locals_block_scope_boundary_begin() {
 }
 
 #[test]
+fn get_locals_item_imports() {
+    check_locals(
+        indoc! {"
+            namespace Bar {
+                function A() : Unit {}
+            }
+            namespace Foo {
+                import Bar.A;
+                import Bar.A as B;
+                function C() : Int {
+                    ↘
+                }
+            }
+        "},
+        &expect![[r#"
+            A (Item 1)
+            B (Item 1)
+            namespace 4
+        "#]],
+    );
+}
+
+#[test]
 fn get_locals_namespace_imports() {
     check_locals(
         indoc! {"

--- a/source/compiler/qsc_frontend/src/resolve/tests.rs
+++ b/source/compiler/qsc_frontend/src/resolve/tests.rs
@@ -4,7 +4,7 @@
 use super::{Error, Locals, Names, Res};
 use crate::{
     compile,
-    resolve::{Importable, LocalKind, Resolver, imports::iter_valid_items},
+    resolve::{Importable, Local, Resolver, imports::iter_valid_items},
 };
 use expect_test::{Expect, expect};
 use indoc::indoc;
@@ -3029,16 +3029,17 @@ fn check_locals(input: &str, expect: &Expect) {
 
     let locals = locals.get_all_at_offset(cursor_offset);
     let actual = locals.iter().fold(String::new(), |mut output, l| {
-        let _ = writeln!(
-            output,
-            "{} ({})",
-            l.name,
-            match l.kind {
-                LocalKind::Item(item_id) => item_id.to_string(),
-                LocalKind::TyParam(param_id) => format!("ty_param {param_id}"),
-                LocalKind::Var(node_id) => format!("var {node_id}"),
+        let _ = match l {
+            Local::Item(item_id, name) => writeln!(output, "{name} ({item_id})"),
+            Local::TyParam(param_id, name) => writeln!(output, "{name} (ty_param {param_id})"),
+            Local::Var(node_id, name) => writeln!(output, "{name} (var {node_id})"),
+            Local::NamespaceImport(namespace_id, Some(alias)) => {
+                writeln!(output, "{alias} (namespace {})", usize::from(namespace_id))
             }
-        );
+            Local::NamespaceImport(namespace_id, None) => {
+                writeln!(output, "namespace {}", usize::from(namespace_id))
+            }
+        };
         output
     });
 
@@ -3059,6 +3060,7 @@ fn get_locals_vars() {
         "},
         &expect![[r#"
             x (var 13)
+            namespace 3
         "#]],
     );
 }
@@ -3077,6 +3079,7 @@ fn get_locals_vars_shadowing_same_scope() {
         "#},
         &expect![[r#"
             x (var 17)
+            namespace 3
         "#]],
     );
 }
@@ -3098,6 +3101,7 @@ fn get_locals_vars_parent_scope() {
         &expect![[r#"
             y (var 20)
             x (var 13)
+            namespace 3
         "#]],
     );
 }
@@ -3114,6 +3118,7 @@ fn get_locals_params() {
         "#},
         &expect![[r#"
             x (var 8)
+            namespace 3
         "#]],
     );
 }
@@ -3133,6 +3138,7 @@ fn get_locals_spec_params() {
         &expect![[r#"
             cs (var 23)
             q (var 8)
+            namespace 3
         "#]],
     );
 }
@@ -3150,6 +3156,7 @@ fn get_locals_before_binding() {
         "},
         &expect![[r#"
             y (var 13)
+            namespace 3
         "#]],
     );
 }
@@ -3168,6 +3175,7 @@ fn get_locals_lambda_params() {
         &expect![[r#"
             x (var 20)
             y (var 13)
+            namespace 3
         "#]],
     );
 }
@@ -3186,6 +3194,7 @@ fn get_locals_for_loop() {
         "},
         &expect![[r#"
             x (var 14)
+            namespace 3
         "#]],
     );
 }
@@ -3201,7 +3210,9 @@ fn get_locals_for_loop_before_binding() {
                 }
             }
         "},
-        &expect![""],
+        &expect![[r#"
+            namespace 3
+        "#]],
     );
 }
 
@@ -3220,6 +3231,7 @@ fn get_locals_items() {
         &expect![[r#"
             Bar (Item 3)
             B (Item 2)
+            namespace 3
         "#]],
     );
 }
@@ -3241,6 +3253,7 @@ fn get_locals_local_item_hide_parent_scope_variables() {
         &expect![[r#"
             y (var 26)
             B (Item 2)
+            namespace 3
         "#]],
     );
 }
@@ -3261,6 +3274,7 @@ fn get_locals_shadow_parent_scope() {
         "#},
         &expect![[r#"
             x (var 20)
+            namespace 3
         "#]],
     );
 }
@@ -3280,6 +3294,7 @@ fn get_locals_type_params() {
         &expect![[r#"
             t (var 9)
             'T (ty_param 0)
+            namespace 3
         "#]],
     );
 }
@@ -3296,7 +3311,9 @@ fn get_locals_block_scope_boundary() {
                 }
             }
         "},
-        &expect![""],
+        &expect![[r#"
+            namespace 3
+        "#]],
     );
 }
 
@@ -3312,7 +3329,9 @@ fn get_locals_block_scope_boundary_begin() {
                 }
             }
         "},
-        &expect![""],
+        &expect![[r#"
+            namespace 3
+        "#]],
     );
 }
 

--- a/source/language_service/src/completion.rs
+++ b/source/language_service/src/completion.rs
@@ -141,14 +141,7 @@ fn collect_path_segments(
             }
         }
         PathKind::Ty | PathKind::Struct => globals.type_names_in(&qualifier),
-        PathKind::Import => [
-            globals.expr_names_in(&qualifier),
-            globals.type_names_in(&qualifier),
-            globals.namespaces_in(&qualifier),
-        ]
-        .into_iter()
-        .flatten()
-        .collect(),
+        PathKind::Import => globals.importable_names_in(&qualifier),
     }
 }
 

--- a/source/language_service/src/completion/global_items.rs
+++ b/source/language_service/src/completion/global_items.rs
@@ -7,46 +7,46 @@ use crate::{
     protocol::{CompletionItemKind, TextEdit},
 };
 use qsc::{
-    PRELUDE,
-    ast::{
-        Idents as _, ImportKind, Package as AstPackage, PathKind,
-        visit::{Visitor, walk_block, walk_callable_decl, walk_item, walk_namespace},
-    },
-    display::CodeDisplay,
-    hir::{CallableDecl, Idents, ItemKind, Package, PackageId, Visibility, ty::Udt},
-    resolve::iter_valid_items,
+    NamespaceId, PRELUDE,
+    display::{CodeDisplay, Lookup},
+    hir::{CallableDecl, ItemId, ItemKind, ty::Udt},
+    resolve::{Local, NameKind},
 };
-use std::{iter::once, rc::Rc};
+use rustc_hash::FxHashSet;
+use std::{cmp::Ordering, mem::take, rc::Rc};
 
 /// Provides the globals that are visible or importable at the cursor offset.
 pub(super) struct Globals<'a> {
     compilation: &'a Compilation,
-    imports: Vec<ImportItem>,
+    locals: Vec<Local>,
 }
 
 impl<'a> Globals<'a> {
     pub fn init(offset: u32, compilation: &'a Compilation) -> Self {
-        let import_finder = ImportFinder::init(offset, &compilation.user_unit().ast.package);
+        let global_scope = &compilation.user_unit().ast.globals;
+        let mut locals = compilation.user_unit().ast.locals.get_all_at_offset(offset);
+
+        // Always include the prelude as an imported namespace as well
+        locals.extend(PRELUDE.iter().filter_map(|ns| {
+            let namespace_id = global_scope.find_namespace(ns.iter().copied(), None);
+            namespace_id.map(|namespace_id| Local::NamespaceImport(namespace_id, None))
+        }));
 
         Self {
             compilation,
-            imports: import_finder.imports,
+            locals,
         }
     }
 
-    /// Returns all names that are valid in an expression context,
-    /// and available at the current offset,
-    /// taking into account any imports that are in scope.
+    /// Returns all terms, and any namespaces that may lead to terms, that
+    /// are available at the current offset.
     ///
-    /// If the item name is not in scope,
-    /// includes the item with text edits (auto-imports, etc.) to bring it into scope.
+    /// If an item's name is not in scope, includes the item with any
+    /// text edits (auto-imports, etc.) to bring it into scope.
     pub fn expr_names(&self, edit_range: &TextEditRange) -> Vec<Vec<Completion>> {
-        // let mut completions = Vec::new();
-
         // include UDTs as well since they can be constructors
         let mut completions = self.items(
-            true,  // include_callables
-            true,  // include_udts
+            NameKind::Term,
             false, // in_scope_only
             Some(edit_range),
         );
@@ -56,38 +56,33 @@ impl<'a> Globals<'a> {
         completions
     }
 
-    /// Returns all names that are valid in a type context,
-    /// and available at the current offset,
-    /// taking into account any imports that are in scope.
+    /// Returns all types, and any namespaces that may lead to types, that
+    /// are available at the current offset.
     ///
-    /// If the item name is not in scope, and `in_scope_only` is false,
-    /// includes the item with text edits (auto-imports, etc.) to bring it into scope.
+    /// If an item's name is not in scope, includes the item with any
+    /// text edits (auto-imports, etc.) to bring it into scope.
     pub fn type_names(&self, edit_range: &TextEditRange) -> Vec<Vec<Completion>> {
-        let mut completions = Vec::new();
-
-        completions.extend(self.items(
-            false, // include_callables
-            true,  // include_udts
+        let mut completions = self.items(
+            NameKind::Ty,
             false, // in_scope_only
             Some(edit_range),
-        ));
+        );
+
         completions.push(self.namespaces());
 
         completions
     }
 
-    /// Returns all names that are valid in an expression context,
-    /// and available at the current offset,
-    /// taking into account any imports that are in scope.
+    /// Returns all importables, and any namespaces that may lead to importables,
+    /// that are available at the current offset.
     ///
-    /// Does not
-    pub fn expr_names_in_scope_only(&self) -> Vec<Vec<Completion>> {
-        // let mut completions = Vec::new();
-
+    /// If an item's name is not in scope, the item is *not* included,
+    /// as it wouldn't quite make sense, for an `import` completion to
+    /// bring in text edits that auto-import other items.
+    pub fn importable_names(&self) -> Vec<Vec<Completion>> {
         // include UDTs as well since they can be constructors
         let mut completions = self.items(
-            true, // include_callables
-            true, // include_udts
+            NameKind::Importable,
             true, // in_scope_only
             None,
         );
@@ -97,92 +92,55 @@ impl<'a> Globals<'a> {
         completions
     }
 
-    /// Returns all names that are valid in a type context,
-    /// and available at the current offset,
-    /// taking into account any imports that are in scope.
-    ///
-    /// If the item name is not in scope, and `in_scope_only` is false,
-    /// includes the item with text edits (auto-imports, etc.) to bring the item into scope.
-    pub fn type_names_in_scope_only(&self) -> Vec<Vec<Completion>> {
-        let mut completions = Vec::new();
-
-        completions.extend(self.items(
-            false, // include_callables
-            true,  // include_udts
-            true,  // in_scope_only
-            None,
-        ));
-        completions.push(self.namespaces());
-
-        completions
-    }
-
-    /// Returns all namespaces in the compilation.
+    /// Returns all namespaces that are available at the current offset.
     pub fn namespaces(&self) -> Vec<Completion> {
-        let mut completions = Vec::new();
-
-        // Add all package aliases, and all top-level
-        // namespaces where the package does not have an alias
-        for (is_user_package, package_alias, package) in self.iter_all_packages() {
-            if let Some(package_alias) = package_alias {
-                completions.push(Completion::new(
-                    (*package_alias).into(),
-                    CompletionItemKind::Module,
-                ));
-            } else {
-                completions.extend(Self::namespaces_in_namespace(package, &[], is_user_package));
-            }
-        }
-        completions
+        self.namespaces_in(&[]).into_iter().flatten().collect()
     }
 
-    /// Returns all namespaces that are valid completions at the current offset,
-    /// for the given qualifier.
-    pub fn namespaces_in(&self, qualifier: &[Rc<str>]) -> Vec<Vec<Completion>> {
-        let namespaces_in_packages = self.matching_namespaces_in_packages(qualifier);
-
-        let mut groups = Vec::new();
-        for (package, is_user_package, namespaces) in &namespaces_in_packages {
-            let mut completions = Vec::new();
-
-            for namespace in namespaces {
-                completions.extend(Self::namespaces_in_namespace(
-                    package,
-                    namespace,
-                    *is_user_package,
-                ));
-            }
-
-            groups.push(completions);
-        }
-
-        groups
-    }
-
-    /// Returns all names that are valid completions at the current offset,
-    /// in an expression context, for the given qualifier,
-    /// taking into account any imports that are in scope.
+    /// Returns all terms, and any namespaces that may lead to terms, that
+    /// match the given qualifier prefix.
     pub fn expr_names_in(&self, qualifier: &[Rc<str>]) -> Vec<Vec<Completion>> {
-        let mut groups = self.items_in(
-            qualifier, true, // include_callables
-            true, // include_udts
-        );
+        let mut groups = self.items_in(qualifier, NameKind::Term);
 
         groups.extend(self.namespaces_in(qualifier));
         groups
     }
 
-    /// Returns all names that are valid completions at the current offset,
-    /// in a type context, for the given qualifier,
-    /// taking into account any imports that are in scope.
+    /// Returns all types, and any namespaces that may lead to types, that
+    /// match the given qualifier prefix.
     pub fn type_names_in(&self, qualifier: &[Rc<str>]) -> Vec<Vec<Completion>> {
-        let mut groups = self.items_in(
-            qualifier, false, // include_callables
-            true,  // include_udts
-        );
+        let mut groups = self.items_in(qualifier, NameKind::Ty);
 
         groups.extend(self.namespaces_in(qualifier));
         groups
+    }
+
+    /// Returns all importables, and any namespaces that may lead to importables, that
+    /// match the given qualifier prefix.
+    pub fn importable_names_in(&self, qualifier: &[Rc<str>]) -> Vec<Vec<Completion>> {
+        let mut groups = self.items_in(qualifier, NameKind::Importable);
+
+        groups.extend(self.namespaces_in(qualifier));
+        groups
+    }
+
+    /// Returns all namespaces that match the given qualifier prefix.
+    pub fn namespaces_in(&self, qualifier: &[Rc<str>]) -> Vec<Vec<Completion>> {
+        let namespaces_matching_qualifier = self.namespaces_matching_qualifier(qualifier);
+
+        let mut children = namespaces_matching_qualifier
+            .flat_map(|namespace| self.global_scope().namespace_children(namespace))
+            .collect::<Vec<_>>();
+
+        children.sort();
+        children.dedup();
+
+        vec![
+            children
+                .into_iter()
+                .map(|name| Completion::new(name.to_string(), CompletionItemKind::Module))
+                .collect(),
+        ]
     }
 
     /// Returns all item names that are available at the current offset,
@@ -190,408 +148,272 @@ impl<'a> Globals<'a> {
     ///
     /// If the item name is not in scope, and `in_scope_only` is false,
     /// includes the item with text edits (auto-imports, etc.) to bring the item into scope.
+    ///
+    /// e.g. if the following imports are in scope:
+    /// `import A.*;`
+    /// `import B as C;`
+    ///
+    /// Then, if `in_scope_only` is false:
+    ///     - Items from namespace `A` will be included without any edits
+    ///     - Items from `B` will be included as `C.<item_name>`
+    ///     - Items will any other namespace will include an auto-import edit,
+    ///         `import D.<item_name>;` to bring the item into scope.
+    ///
+    /// If `in_scope_only` is true, then only items from `A` will be included.
     fn items(
         &self,
-        include_callables: bool,
-        include_udts: bool,
+        name_kind: NameKind,
         in_scope_only: bool,
         edit_range: Option<&TextEditRange>,
     ) -> Vec<Vec<Completion>> {
-        let mut groups = Vec::new();
-
-        for (is_user_package, package_alias, package) in self.iter_all_packages() {
-            // Given the package, get all completion items by iterating over its items
-            // and converting any that would be valid as completions into completions
-            let completions = package
-                .items
-                .values()
-                .filter_map(|item| {
-                    Self::is_item_relevant(
-                        package,
-                        item,
-                        include_callables,
-                        include_udts,
-                        is_user_package,
-                    )
-                })
-                .filter_map(|item| {
-                    let import_info = self.import_info(&item, package_alias);
-                    if in_scope_only && !matches!(import_info, ImportInfo::InScope) {
-                        return None;
-                    }
-                    Some(self.to_completion(&item, import_info, edit_range))
-                })
-                .collect();
-            groups.push(completions);
-        }
-        groups
+        let namespaces = self.namespaces_to_search(name_kind, in_scope_only);
+        self.items_in_namespaces(namespaces, name_kind, edit_range)
     }
 
-    /// Returns all item names that are valid completions at the current offset,
-    /// for the given qualifier, taking into account any imports that are in scope.
-    fn items_in(
-        &'a self,
-        qualifier: &[Rc<str>],
-        include_callables: bool,
-        include_udts: bool,
-    ) -> Vec<Vec<Completion>> {
-        let namespaces_in_packages = self.matching_namespaces_in_packages(qualifier);
-
-        let mut groups = Vec::new();
-        for (package, is_user_package, namespaces) in &namespaces_in_packages {
-            let mut completions = Vec::new();
-
-            for namespace in namespaces {
-                completions.extend(
-                    Self::items_in_namespace(
-                        package,
-                        namespace,
-                        include_callables,
-                        include_udts,
-                        *is_user_package,
-                    )
-                    .into_iter()
-                    .map(|item| self.to_completion(&item, ImportInfo::InScope, None)),
-                );
-            }
-
-            groups.push(completions);
-        }
-
-        groups
-    }
-
-    /// For a given package, returns all namespace names that are direct
-    /// children of the given namespace prefix.
+    /// Returns all items that match the given qualifier prefix.
     ///
-    /// E.g. if the package contains `Foo.Bar.Baz` and `Foo.Qux` , and
-    /// the given prefix is `Foo` , this will return `Bar` and `Qux`.
-    fn namespaces_in_namespace(
-        package: &Package,
-        ns_prefix: &[Rc<str>],
-        is_user_package: bool,
-    ) -> Vec<Completion> {
-        package
-            .items
-            .values()
-            .filter_map(move |i| match &i.kind {
-                ItemKind::Namespace(namespace, _) => {
-                    let candidate_ns: Vec<Rc<str>> = namespace.into();
+    /// The qualifier is resolved taking into account any imports that are in scope.
+    /// e.g. `A.` will return items in:
+    ///     - namespace `A`
+    ///     - namespace `B` if an `import B as A;` is in scope
+    ///     - namespace `C.A` if an `import C.*` is in scope
+    fn items_in(&'a self, qualifier: &[Rc<str>], name_kind: NameKind) -> Vec<Vec<Completion>> {
+        let namespaces = self
+            .namespaces_matching_qualifier(qualifier)
+            .map(|namespace_id| (namespace_id, Availability::Qualified));
 
-                    // Skip the `Main` namespace from dependency packages.
-                    if !is_user_package && candidate_ns == ["Main".into()] {
-                        return None;
-                    }
-                    // filter out QASM namespaces
-                    if !is_user_package
-                        && namespace.name().to_lowercase().starts_with("std.openqasm")
-                    {
-                        return None;
-                    }
+        self.items_in_namespaces(namespaces, name_kind, None)
+    }
 
-                    let prefix_stripped = candidate_ns.strip_prefix(ns_prefix);
-                    if let Some(end) = prefix_stripped {
-                        if let Some(first) = end.first() {
-                            return Some(Completion::new(
-                                first.to_string(),
-                                CompletionItemKind::Module,
-                            ));
-                        }
+    /// Gathers all namespaces and their availability information, i.e. whether
+    /// they are already open in the current scope or need a text edit to bring them into scope.
+    fn namespaces_to_search(
+        &self,
+        name_kind: NameKind,
+        in_scope_only: bool,
+    ) -> impl Iterator<Item = (NamespaceId, Availability)> {
+        let open_namespaces = self.namespaces_matching_qualifier(&[]).collect::<Vec<_>>();
+
+        let namespaces: FxHashSet<NamespaceId> = if in_scope_only {
+            // Only include already open namespaces
+            open_namespaces.iter().copied().collect()
+        } else {
+            // Include all known namespaces
+            self.global_scope()
+                .table(name_kind)
+                .iter()
+                .map(|(namespace_id, _)| namespace_id)
+                .collect()
+        };
+
+        namespaces.into_iter().filter_map(move |namespace| {
+            if open_namespaces.contains(&namespace) {
+                // Namespace already in open in the current scope
+                Some((namespace, Availability::InScope))
+            } else if let Some(alias) = self.locals.iter().find_map(|local| {
+                if let Local::NamespaceImport(imported, Some(alias)) = local {
+                    if namespace == *imported {
+                        return Some(alias.clone());
                     }
-                    None
+                }
+                None
+            }) {
+                // Namespace is imported with an alias
+                Some((namespace, Availability::InAliasedNamespace(alias)))
+            } else if self
+                .global_scope()
+                .format_namespace_name(namespace)
+                .starts_with("Std.OpenQASM")
+            {
+                // Don't suggest auto-imports for OpenQASM namespaces
+                None
+            } else {
+                // If there are no existing exact or glob imports of the item,
+                // no open aliases for the namespace it's in,
+                // and we are not in the same namespace as the item,
+                // we need to add an import for it.
+                Some((namespace, Availability::NeedImport(namespace)))
+            }
+        })
+    }
+
+    /// Returns all namespaces that match the given qualifier prefix.
+    /// The qualifier can be empty, in which case only top-level and open namespaces
+    /// are returned.
+    ///
+    /// The qualifier is resolved taking into account any imports that are in scope.
+    /// e.g.:
+    ///
+    /// namespace A.B {}
+    /// namespace C.D {}
+    /// namespace E.A.G {}
+    /// namespace H { import C as A; import E.*; }
+    ///
+    /// `A.` inside of the namespace `H` will return `B`, `D` and `G`.
+    fn namespaces_matching_qualifier(
+        &self,
+        qualifier: &[Rc<str>],
+    ) -> impl Iterator<Item = NamespaceId> {
+        let global_scope = &self.compilation.user_unit().ast.globals;
+        self.locals
+            .iter()
+            .filter_map(|local| match local {
+                Local::NamespaceImport(namespace_id, None) => global_scope
+                    .find_namespace(qualifier.iter().map(AsRef::as_ref), Some(*namespace_id)),
+                Local::NamespaceImport(namespace_id, Some(alias))
+                    if Some(alias) == qualifier.first() =>
+                {
+                    global_scope.find_namespace(
+                        qualifier[1..].iter().map(AsRef::as_ref),
+                        Some(*namespace_id),
+                    )
                 }
                 _ => None,
             })
-            .collect()
+            .chain(global_scope.find_namespace(qualifier.iter().map(AsRef::as_ref), None))
     }
 
-    /// For a given package, returns all items that are in the given namespace.
-    fn items_in_namespace(
-        package: &'a Package,
-        namespace: &[Rc<str>],
-        include_callables: bool,
-        include_udts: bool,
-        is_user_package: bool,
-    ) -> Vec<RelevantItem<'a>> {
-        let ns_items = package.items.values().find_map(move |i| {
-            if let ItemKind::Namespace(candidate_ns, items) = &i.kind {
-                let candidate_ns: Vec<Rc<str>> = candidate_ns.into();
-
-                // If the namespace matches exactly, include the items.
-                if candidate_ns == namespace {
-                    return Some(items);
-                }
-
-                // If we're being asked for the the top-level namespace in a dependency package,
-                // include items from the `Main` namespace.
-                if namespace.is_empty() && candidate_ns == ["Main".into()] && !is_user_package {
-                    return Some(items);
-                }
-            }
-            None
-        });
-
-        ns_items
-            .into_iter()
-            .flatten()
-            .filter_map(|item_id| {
-                let item = package
-                    .items
-                    .get(*item_id)
-                    .expect("item id should exist in package");
-
-                Self::is_item_relevant(
-                    package,
-                    item,
-                    include_callables,
-                    include_udts,
-                    is_user_package,
-                )
-            })
-            .collect()
-    }
-
-    /// Given a qualifier, and any imports that are in scope,
-    /// produces a list of `(package, is_user_package, namespaces)`
-    /// tuples that this qualifier could match.
-    #[allow(clippy::type_complexity)]
-    fn matching_namespaces_in_packages(
+    /// Collects all matching items in the given namespaces and returns
+    /// them as completions.
+    fn items_in_namespaces(
         &self,
-        qualifier: &[Rc<str>],
-    ) -> Vec<(&Package, bool, Vec<Vec<Rc<str>>>)> {
-        let namespaces = self.matching_namespaces(qualifier);
+        namespaces: impl IntoIterator<Item = (NamespaceId, Availability)>,
+        name_kind: NameKind,
+        edit_range: Option<&TextEditRange>,
+    ) -> Vec<Vec<Completion>> {
+        let mut candidates = Vec::new();
+        let global_scope = self.global_scope();
+        let names_table = global_scope.table(name_kind);
 
-        let mut packages_and_namespaces = Vec::new();
+        for (namespace_id, namespace_availability) in namespaces {
+            if let Some(names) = names_table.get(namespace_id) {
+                for (name, res) in names {
+                    if let Some(item_id) = res.item_id() {
+                        let (item, _, _) = self
+                            .compilation
+                            .resolve_item_relative_to_user_package(&item_id);
+                        let decl = match &item.kind {
+                            ItemKind::Callable(callable_decl) => {
+                                ItemDecl::Callable(callable_decl.as_ref())
+                            }
+                            ItemKind::Ty(_ident, udt) => ItemDecl::Udt(udt),
+                            ItemKind::Export(..) | ItemKind::Namespace(..) => continue,
+                        };
 
-        for (is_user_package, package_alias, package) in self.iter_all_packages() {
-            let mut namespaces_for_package = Vec::new();
-            for namespace in &namespaces {
-                if let Some(package_alias) = package_alias {
-                    // Only include the namespace if it starts with this package's alias
-                    if !namespace.is_empty() && *namespace[0] == *package_alias {
-                        namespaces_for_package.push(namespace[1..].to_vec());
+                        let availability = if namespace_availability != Availability::Qualified
+                            && self.locals.iter().any(|local| {
+                                if let Local::Item(import_item_id, ..) = local {
+                                    if *import_item_id == item_id {
+                                        return true;
+                                    }
+                                }
+                                false
+                            }) {
+                            // Item is available in the local scope through a direct import.
+                            Availability::Local
+                        } else {
+                            namespace_availability.clone()
+                        };
+
+                        let item = ItemInfo {
+                            item_id,
+                            namespace_id,
+                            name: name.clone(),
+                            decl,
+                            availability,
+                        };
+                        candidates.push(item);
                     }
-                } else {
-                    // No package alias, always include the namespace
-                    namespaces_for_package.push(namespace.clone());
                 }
             }
-            packages_and_namespaces.push((package, is_user_package, namespaces_for_package));
         }
 
-        packages_and_namespaces
-    }
+        // Remove duplicate paths to the same item. The same item may be available
+        // by multiple names by way of imports/exports.
+        // e.g.
+        // `namespace A { function B() : Unit {}; export B; export B as C; }`
+        // `namespace D { export A.B; }`
+        // `namespace E { open A; import A.B as X }`
+        // Makes the same item available as `A.B`, `A.C`, `D.B`, `B` and `X`
+        // when in `namespace E`.
 
-    /// Given a qualifier, and any imports that are in scope,
-    /// produces a list of potential namespaces this qualifier could match.
-    fn matching_namespaces(&self, qualifier: &[Rc<str>]) -> Vec<Vec<Rc<str>>> {
-        let mut namespaces: Vec<Vec<Rc<str>>> = Vec::new();
-        // Add the qualifier as is
-        namespaces.push(qualifier.to_vec());
+        // Sort by availability so that direct imports and in-scope names
+        // are preferred when de-duping.
 
-        // Add qualifier prefixed with all opened namespaces
-        let opened_namespaces = self
-            .imports
-            .iter()
-            .filter_map(|import_item| {
-                if import_item.is_glob {
-                    Some(import_item.path.clone())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        for open_namespace in &opened_namespaces {
-            namespaces.push([open_namespace, qualifier].concat());
-        }
-
-        // Does `qualifier` start with a namespace alias?
-        let full_qualifier_for_aliased_ns = self
-            .imports
-            .iter()
-            .find_map(|import_item| {
-                if !qualifier.is_empty()
-                    && import_item
-                        .alias
-                        .as_ref()
-                        .is_some_and(|s| **s == *qualifier[0])
-                {
-                    Some(&import_item.path)
-                } else {
-                    None
-                }
-            })
-            .map(|full_ns_for_alias| {
-                let rest = &qualifier[1..];
-                [full_ns_for_alias, rest].concat()
-            });
-
-        // Add any aliased namespaces with an alias that matches the qualifier
-        if let Some(full_qualifier_for_aliased_ns) = &full_qualifier_for_aliased_ns {
-            namespaces.push(full_qualifier_for_aliased_ns.clone());
-        }
-        namespaces
-    }
-
-    /// Returns the core package, then the dependencies in reverse order,
-    /// then finally the user package.
-    ///
-    /// Iterating in this order ensures that the user package items appear
-    /// first, and indirect dependencies are lower on the completion list.
-    ///
-    /// Returns the tuple of `(is_user_package, alias, package)`
-    fn iter_all_packages(&self) -> impl Iterator<Item = (bool, Option<&'a str>, &'a Package)> + 'a {
-        let packages = self
-            .compilation
-            .package_store
-            .iter()
-            .rev()
-            .filter_map(|(id, unit)| {
-                if self.compilation.user_package_id == id {
-                    return Some((true, None, &unit.package));
-                }
-                self.compilation
-                    .dependencies
-                    .get(&id)
-                    .map(|alias| (false, alias.as_ref().map(AsRef::as_ref), &unit.package))
-            });
-        once((
-            false,
-            None,
-            &self
-                .compilation
-                .package_store
-                .get(PackageId::CORE)
-                .expect("core package must exist")
-                .package,
-        ))
-        .chain(packages)
-    }
-
-    /// Whether an exact import exists for the given path, along with its alias if one exists.
-    fn exact_import_exists(&self, path: &[Rc<str>]) -> (bool, Option<Rc<str>>) {
-        let exact_import = self.imports.iter().find_map(|import_item| {
-            if import_item.is_glob {
-                return None;
-            }
-
-            if import_item.path == path {
-                Some(import_item.alias.clone())
-            } else {
-                None
-            }
+        // When tied, prefer the smaller namespace ID, assuming that that's the "original" namespace,
+        // but really that's just a heuristic when we don't have much else to go on.
+        candidates.sort_by(|a, b| match a.item_id.cmp(&b.item_id) {
+            Ordering::Equal => match a.availability.cmp(&b.availability) {
+                Ordering::Equal => a.namespace_id.cmp(&b.namespace_id),
+                other => other,
+            },
+            other => other,
         });
-        (exact_import.is_some(), exact_import.unwrap_or_default())
+
+        candidates.dedup_by_key(|i| i.item_id);
+
+        // Drop any items that were direct local imports, since the locals completion module
+        // would have already included them in the ultimate completion list
+        candidates.retain(|item| !matches!(item.availability, Availability::Local));
+
+        self.to_completions(candidates, edit_range)
     }
 
-    /// An item is "relevant" if it's a callable or UDT that's visible to the user package.
-    fn is_item_relevant(
-        package: &'a qsc::hir::Package,
-        item: &'a qsc::hir::Item,
-        include_callables: bool,
-        include_udts: bool,
-        is_user_package: bool,
-    ) -> Option<RelevantItem<'a>> {
-        // We only want items whose parents are namespaces
-        if let Some(item_id) = item.parent {
-            if let Some(parent) = package.items.get(item_id) {
-                if let ItemKind::Namespace(namespace, _) = &parent.kind {
-                    // filter out internal packages that are not from the user's
-                    // compilation
-                    if matches!(item.visibility, Visibility::Internal) && !is_user_package {
-                        return None; // ignore item if not in the user's package
-                    }
-                    if !is_user_package
-                        && namespace.name().to_lowercase().starts_with("std.openqasm")
-                    {
-                        return None; // ignore item if in a QASM namespace
-                    }
-                    return match &item.kind {
-                        ItemKind::Callable(callable_decl) if include_callables => {
-                            Some(RelevantItem {
-                                name: callable_decl.name.name.clone(),
-                                namespace,
-                                kind: RelevantItemKind::Callable(callable_decl),
-                            })
-                        }
-                        ItemKind::Ty(_, udt) if include_udts => Some(RelevantItem {
-                            name: udt.name.clone(),
-                            namespace,
-                            kind: RelevantItemKind::Udt(udt),
-                        }),
-                        _ => None,
-                    };
+    /// Turns the final list of items into completion items, filling in
+    /// details and including any text edits if requested.
+    ///
+    /// Items are sorted by package, with the user package (`None`)
+    /// coming first, with the dependencies in reverse order, so
+    /// that the "closer" dependencies are listed first in the completion list.
+    fn to_completions(
+        &self,
+        mut items: Vec<ItemInfo<'_>>,
+        edit_range: Option<&TextEditRange>,
+    ) -> Vec<Vec<Completion>> {
+        items.sort_by(|a, b| match (a.item_id.package, b.item_id.package) {
+            (None, Some(_)) => Ordering::Greater,
+            (Some(_), None) => Ordering::Less,
+            (a, b) => a.cmp(&b),
+        });
+        items.reverse();
+
+        let mut groups = Vec::new();
+        let mut group = Vec::new();
+        let mut last_package_id = items.first().and_then(|item| item.item_id.package);
+
+        for item in items {
+            let curr_package_id = item.item_id.package;
+            if curr_package_id != last_package_id {
+                // push the group to the groups
+                if !group.is_empty() {
+                    groups.push(take(&mut group));
                 }
             }
-        }
-        None
-    }
+            let completion = self.to_completion(&item, edit_range);
 
-    /// For a given item, produces any auto-imports, prefixes or aliases that would
-    /// make that item a valid completion in the current scope.
-    fn import_info(&self, item: &RelevantItem<'a>, package_alias: Option<&str>) -> ImportInfo {
-        let namespace_without_pkg_alias = Into::<Vec<_>>::into(item.namespace);
-        let mut namespace = namespace_without_pkg_alias.clone();
-        if let Some(package_alias) = package_alias {
-            namespace.insert(0, package_alias.into());
+            group.push(completion);
+            last_package_id = curr_package_id;
         }
 
-        // Is there a glob import for the namespace, i.e. is the name already in scope?
-        let glob_import = self
-            .imports
-            .iter()
-            .any(|import_item| import_item.path == namespace && import_item.is_glob);
-
-        if glob_import {
-            return ImportInfo::InScope;
+        if !group.is_empty() {
+            groups.push(take(&mut group));
         }
 
-        // An exact import is an import that matches the namespace and item name exactly
-        let (exact_import, item_alias) =
-            self.exact_import_exists(&[namespace.as_slice(), &[item.name.clone()]].concat());
-
-        if exact_import {
-            if let Some(alias) = item_alias {
-                return ImportInfo::Alias(alias);
-            }
-            return ImportInfo::InScope;
-        }
-
-        // Does an alias for the namespace exist?
-        let namespace_alias = self.exact_import_exists(&namespace).1;
-
-        if let Some(namespace_alias) = namespace_alias {
-            return ImportInfo::InAliasNamespace(namespace_alias);
-        }
-
-        // If there are no existing exact or glob imports of the item,
-        // no open aliases for the namespace it's in,
-        // and we are not in the same namespace as the item,
-        // we need to add an import for it.
-        ImportInfo::NeedAutoImport(fully_qualify_name(
-            package_alias,
-            &namespace_without_pkg_alias,
-            Some(&item.name),
-        ))
+        groups
     }
 
     /// Creates a completion list entry for the given item, including
     /// any text edits that would bring the item into scope, if requested.
-    fn to_completion(
-        &self,
-        item: &RelevantItem<'a>,
-        import_info: ImportInfo,
-        text_edits: Option<&TextEditRange>,
-    ) -> Completion {
+    fn to_completion(&self, item: &ItemInfo<'a>, text_edits: Option<&TextEditRange>) -> Completion {
         let display = CodeDisplay {
             compilation: self.compilation,
         };
-        let (kind, display) = match &item.kind {
-            RelevantItemKind::Callable(callable_decl) => (
+        let (kind, display) = match &item.decl {
+            ItemDecl::Callable(callable_decl) => (
                 CompletionItemKind::Function,
                 display.hir_callable_decl(callable_decl).to_string(),
             ),
-            RelevantItemKind::Udt(udt) => (
+            ItemDecl::Udt(udt) => (
                 CompletionItemKind::Interface,
                 display.hir_udt(udt).to_string(),
             ),
@@ -600,15 +422,17 @@ impl<'a> Globals<'a> {
         // Deprioritize names starting with "__" in the completion list
         let mut sort_priority = u32::from(item.name.starts_with("__"));
 
-        match import_info {
-            ImportInfo::InScope => Completion::with_text_edits(
-                item.name.to_string(),
-                kind,
-                Some(display),
-                None,
-                sort_priority,
-            ),
-            ImportInfo::NeedAutoImport(import_path) => {
+        match &item.availability {
+            Availability::Local | Availability::InScope | Availability::Qualified => {
+                Completion::with_text_edits(
+                    item.name.to_string(),
+                    kind,
+                    Some(display),
+                    None,
+                    sort_priority,
+                )
+            }
+            Availability::NeedImport(namespace) => {
                 // Deprioritize auto-import items
                 sort_priority += 1;
 
@@ -618,7 +442,12 @@ impl<'a> Globals<'a> {
                 // if there is no place to insert an import, then we can't add an import.
                 let edits = text_edits.insert_import_at.as_ref().map(|range| {
                     vec![TextEdit {
-                        new_text: format!("import {};{}", import_path, &text_edits.indent),
+                        new_text: format!(
+                            "import {}.{};{}",
+                            self.global_scope().format_namespace_name(*namespace),
+                            item.name,
+                            &text_edits.indent
+                        ),
                         range: *range,
                     }]
                 });
@@ -631,196 +460,60 @@ impl<'a> Globals<'a> {
                     sort_priority,
                 )
             }
-            ImportInfo::InAliasNamespace(prefix) => Completion::with_text_edits(
+            Availability::InAliasedNamespace(prefix) => Completion::with_text_edits(
                 format!("{}.{}", prefix, item.name),
                 kind,
                 Some(display),
                 None,
                 sort_priority,
             ),
-            ImportInfo::Alias(alias) => Completion::with_text_edits(
-                alias.to_string(),
-                kind,
-                Some(display),
-                None,
-                sort_priority,
-            ),
         }
+    }
+
+    fn global_scope(&self) -> &qsc::resolve::GlobalScope {
+        &self.compilation.user_unit().ast.globals
     }
 }
 
-enum ImportInfo {
-    /// Item name is already in scope, no edits necessary.
-    InScope,
-    /// The path that we should add an auto-import for, if any.
-    NeedAutoImport(String),
-    /// The item name should be prefixed with the namespace alias.
-    ///
-    /// e.g. `Foo` will appear as `Bar.Foo` if it's under an open
-    /// namespace that is aliased as `Bar`.
-    InAliasNamespace(Rc<str>),
-    /// The item was imported under an alias.
-    Alias(Rc<str>),
+/// The global item that backs a completion item.
+struct ItemInfo<'a> {
+    item_id: ItemId,
+    namespace_id: NamespaceId,
+    /// Can be the original name for the decl,
+    /// or the alias if this item is found through an import.
+    name: Rc<str>,
+    decl: ItemDecl<'a>,
+    availability: Availability,
 }
 
-/// A callable or UDT that's visible to the user package.
-enum RelevantItemKind<'a> {
+/// The declaration, used to format completion item details.
+#[derive(Debug)]
+enum ItemDecl<'a> {
     Callable(&'a CallableDecl),
     Udt(&'a Udt),
 }
 
-/// A callable or UDT that's visible to the user package.
-struct RelevantItem<'a> {
-    name: Rc<str>,
-    kind: RelevantItemKind<'a>,
-    namespace: &'a Idents,
-}
-
-/// Format an external fully qualified name.
-/// This will prepend the package alias and remove `Main` if it is the first namespace.
-fn fully_qualify_name(
-    package_alias: Option<&str>,
-    namespace: &[Rc<str>],
-    name: Option<&str>,
-) -> String {
-    let mut fully_qualified_name: Vec<Rc<str>> = if let Some(alias) = package_alias {
-        vec![Rc::from(alias)]
-    } else {
-        vec![]
-    };
-
-    // if this comes from an external project's Main, then the path does not include Main
-    let item_comes_from_main_of_external_project = package_alias.is_some()
-        && namespace.len() == 1
-        && namespace.first() == Some(&"Main".into());
-
-    // So, if it is _not_ from an external project's `Main`, we include the namespace in the fully
-    // qualified name.
-    if !(item_comes_from_main_of_external_project) {
-        fully_qualified_name.append(&mut namespace.to_vec());
-    }
-
-    if let Some(name) = name {
-        fully_qualified_name.push(name.into());
-    }
-
-    fully_qualified_name.join(".")
-}
-
-#[derive(Default)]
-struct ImportFinder {
-    offset: u32,
-    // The available imports at the current location
-    imports: Vec<ImportItem>,
-}
-
-impl ImportFinder {
-    fn init(offset: u32, package: &AstPackage) -> Self {
-        let mut context = Self {
-            offset,
-            ..Self::default()
-        };
-        context.visit_package(package);
-
-        let mut prelude_ns_ids: Vec<ImportItem> = PRELUDE
-            .iter()
-            .map(|ns| ImportItem {
-                path: ns.iter().map(|x| Rc::from(*x)).collect(),
-                alias: None,
-                is_glob: true,
-            })
-            .collect();
-
-        // The PRELUDE namespaces are always implicitly opened.
-        context.imports.append(&mut prelude_ns_ids);
-
-        context
-    }
-}
-
-impl<'a> Visitor<'a> for ImportFinder {
-    fn visit_namespace(&mut self, namespace: &'a qsc::ast::Namespace) {
-        if namespace.span.contains(self.offset) {
-            // the current namespace is implicitly opened.
-            self.imports = vec![ImportItem {
-                path: namespace.name.rc_str_iter().cloned().collect(),
-                alias: None,
-                is_glob: true,
-            }];
-            walk_namespace(self, namespace);
-        }
-    }
-
-    fn visit_item(&mut self, item: &'a qsc::ast::Item) {
-        match &*item.kind {
-            qsc::ast::ItemKind::Open(PathKind::Ok(name), alias) => {
-                let open_as_import = ImportItem {
-                    path: name.rc_str_iter().cloned().collect(),
-                    alias: alias.as_ref().map(|x| x.name.clone()),
-                    is_glob: alias.is_none(),
-                };
-                self.imports.push(open_as_import);
-            }
-            qsc::ast::ItemKind::ImportOrExport(decl) => {
-                // if this is an import, populate self.imports
-                if decl.is_import() {
-                    self.imports
-                        .append(&mut ImportItem::from_import_or_export_item(decl));
-                }
-            }
-            _ => (),
-        }
-
-        if item.span.contains(self.offset) {
-            walk_item(self, item);
-        }
-    }
-
-    fn visit_callable_decl(&mut self, decl: &'a qsc::ast::CallableDecl) {
-        if decl.span.contains(self.offset) {
-            // This span covers the body too, but the
-            // context will get overwritten by visit_block
-            // if the offset is inside the actual body
-            walk_callable_decl(self, decl);
-        }
-    }
-
-    fn visit_block(&mut self, block: &'a qsc::ast::Block) {
-        if block.span.contains(self.offset) {
-            walk_block(self, block);
-        }
-    }
-}
-
-#[derive(Debug)]
-/// Used to represent pre-existing imports in the completion context
-struct ImportItem {
-    path: Vec<Rc<str>>,
-    alias: Option<Rc<str>>,
-    is_glob: bool,
-}
-
-impl ImportItem {
-    fn from_import_or_export_item(decl: &qsc::ast::ImportOrExportDecl) -> Vec<Self> {
-        if decl.is_export() {
-            return vec![];
-        }
-        let mut buf = Vec::with_capacity(decl.items.len());
-        for item in iter_valid_items(decl) {
-            let alias = if let ImportKind::Direct { alias } = &item.kind {
-                alias.as_ref().map(|x| x.name.clone())
-            } else {
-                None
-            };
-
-            let is_glob = matches!(item.kind, ImportKind::Wildcard);
-
-            buf.push(ImportItem {
-                path: item.path.rc_str_iter().cloned().collect(),
-                alias,
-                is_glob,
-            });
-        }
-        buf
-    }
+/// How the item name is available in the current scope.
+///
+/// The order here is important, as it's used when de-duping.
+/// We prefer the first kind of import if there are multiple
+/// paths leading to the same item.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+enum Availability {
+    /// Available through a direct local import.
+    Local,
+    /// In scope because of open namespaces.
+    /// Safe to include without any additional edits.
+    InScope,
+    /// In scope because of preceding qualifier.
+    /// Safe to include without any additional edits.
+    Qualified,
+    /// In a namespace that is open with a local alias.
+    /// The name should be prefixed with the namespace alias.
+    ///
+    /// e.g. `Foo` will appear as `Bar.Foo` if it's under an open
+    /// namespace that is aliased as `Bar`.
+    InAliasedNamespace(Rc<str>),
+    /// Not in scope at all. Needs an auto-import entry.
+    NeedImport(NamespaceId),
 }

--- a/source/language_service/src/completion/qsharp.rs
+++ b/source/language_service/src/completion/qsharp.rs
@@ -290,9 +290,7 @@ fn collect_paths(
             global_names.extend(globals.type_names(text_edit_range));
         }
         PathKind::Import => {
-            global_names.extend(globals.expr_names_in_scope_only());
-            global_names.extend(globals.type_names_in_scope_only());
-            global_names.push(globals.namespaces());
+            global_names.extend(globals.importable_names());
         }
         PathKind::Struct => {
             global_names.extend(globals.type_names(text_edit_range));

--- a/source/language_service/src/completion/tests.rs
+++ b/source/language_service/src/completion/tests.rs
@@ -1724,7 +1724,7 @@ fn package_alias_members() {
         namespace Other { export OtherFunc; function OtherFunc() : Unit {} }
         namespace Other.Sub { export OtherFunc; function OtherFunc() : Unit {} }
         ",
-        &["Main", "Other", "MainFunc", "Other.Sub", "Sub"],
+        &["Main", "Other", "MainFunc", "Other.Sub", "Sub", "Std"],
         &expect![[r#"
             found, sorted:
               "MainFunc" (Function)
@@ -1735,6 +1735,7 @@ fn package_alias_members() {
               "Main"
               "Other.Sub"
               "Sub"
+              "Std"
         "#]],
     );
 }
@@ -2377,5 +2378,170 @@ fn in_trailing_comment() {
         "namespace Test {
             import Foo; // Hello there ↘
         }",
+    );
+}
+
+#[test]
+fn export_from_dependency_in_scope() {
+    check_with_dependency(
+        r"
+        namespace Test {
+            open MyDep;
+            operation Foo() : Unit {
+                ↘
+            }
+        }
+        ",
+        "MyDep",
+        "
+        namespace Bar {
+            operation Baz() : Unit {}
+            export Baz;
+        }
+        namespace Main {
+            operation Qux() : Unit {}
+            export Qux, Bar.Baz;
+        }
+        ",
+        &["Qux", "Baz", "Bar"],
+        &expect![[r#"
+            found, sorted:
+              "Baz" (Function)
+                detail: "operation Baz() : Unit"
+              "Qux" (Function)
+                detail: "operation Qux() : Unit"
+              "Bar" (Module)
+        "#]],
+    );
+}
+
+#[test]
+fn aliased_export_from_dependency_in_scope() {
+    check_with_dependency(
+        r"
+        namespace Test {
+            open MyDep;
+            operation Foo() : Unit {
+                ↘
+            }
+        }
+        ",
+        "MyDep",
+        "
+        namespace Bar {
+            operation Baz() : Unit {}
+            export Baz;
+        }
+        namespace Main {
+            export Bar.Baz as BazAlias;
+        }
+        ",
+        &["BazAlias"],
+        &expect![[r#"
+            found, sorted:
+              "BazAlias" (Function)
+                detail: "operation Baz() : Unit"
+        "#]],
+    );
+}
+
+#[test]
+fn namespace_export_from_dependency_qualified() {
+    check_with_dependency(
+        r"
+        namespace Test {
+            open MyDep.Baz.↘
+        }",
+        "MyDep",
+        "namespace Foo.Bar {
+            operation Qux() : Unit {}
+            export Qux
+         }
+         namespace Baz {
+            export Foo.Bar;
+         }",
+        &["Bar"],
+        &expect![[r#"
+            found, sorted:
+              "Bar" (Module)
+        "#]],
+    );
+}
+
+#[test]
+fn export_from_dependency_qualified() {
+    check_with_dependency(
+        r"
+            namespace Test {
+                operation Test() : Unit {
+                    MyDep.↘
+                }
+            }",
+        "MyDep",
+        "namespace Foo {
+                operation Baz() : Unit {}
+                export Baz;
+             }
+             namespace Main {
+                operation Qux() : Unit {}
+                export Qux, Foo.Baz;
+             }",
+        &["Qux", "Baz"],
+        &expect![[r#"
+            found, sorted:
+              "Baz" (Function)
+                detail: "operation Baz() : Unit"
+              "Qux" (Function)
+                detail: "operation Qux() : Unit"
+        "#]],
+    );
+}
+
+#[test]
+fn reexport_namespace_from_dependency_members() {
+    check_with_dependency(
+        r"
+        namespace Test {
+            operation Main() : Unit {
+                MyDep.Baz.Bar.↘
+            }
+        }",
+        "MyDep",
+        "namespace Foo.Bar {
+            operation Zud() : Unit {}
+            export Zud
+         }
+         namespace Baz {
+            operation Qux() : Unit {}
+            export Qux, Foo.Bar;
+         }",
+        &["Zud"],
+        &expect![[r#"
+            found, sorted:
+              "Zud" (Function)
+                detail: "operation Zud() : Unit"
+        "#]],
+    );
+}
+
+#[test]
+fn import_in_local_scope() {
+    check_single_file(
+        r"
+        namespace Foo {
+            operation Bar() : Unit {}
+        }
+        namespace A {
+            operation Main() : Unit {
+                import Foo.Bar;
+                ↘
+            }
+        }",
+        &["Bar"],
+        &expect![[r#"
+            found, sorted:
+              "Bar" (Function)
+                detail: "operation Bar() : Unit"
+        "#]],
     );
 }

--- a/source/language_service/src/completion/tests.rs
+++ b/source/language_service/src/completion/tests.rs
@@ -2433,12 +2433,14 @@ fn aliased_export_from_dependency_in_scope() {
             export Baz;
         }
         namespace Main {
-            export Bar.Baz as BazAlias;
+            export Bar.Baz, Bar.Baz as BazAlias;
         }
         ",
-        &["BazAlias"],
+        &["BazAlias", "Baz"],
         &expect![[r#"
             found, sorted:
+              "Baz" (Function)
+                detail: "operation Baz() : Unit"
               "BazAlias" (Function)
                 detail: "operation Baz() : Unit"
         "#]],

--- a/source/language_service/src/test_utils.rs
+++ b/source/language_service/src/test_utils.rs
@@ -260,15 +260,13 @@ where
 {
     let (std_id, package_store) = compile_fake_stdlib();
 
-    let mut dependencies = vec![(std_id, None)];
-
     let mut compiler = Compiler::new(
         SourceMap::default(),
         PackageType::Lib,
         Profile::Unrestricted.into(),
         LanguageFeatures::default(),
         package_store,
-        &dependencies,
+        &[(std_id, None)],
     )
     .expect("expected incremental compiler creation to succeed");
 
@@ -284,10 +282,7 @@ where
         compiler.update(increment);
     }
 
-    let source_package_id = compiler.source_package_id();
     let (package_store, package_id) = compiler.into_package_store();
-
-    dependencies.push((source_package_id, None));
 
     Compilation {
         package_store,

--- a/source/language_service/src/test_utils.rs
+++ b/source/language_service/src/test_utils.rs
@@ -236,7 +236,6 @@ fn compile_project_with_markers_cursor_optional(
             },
             compile_errors: errors,
             project_errors: Vec::new(),
-            dependencies: dependencies.into_iter().collect(),
             test_cases,
         },
         cursor_location,
@@ -259,19 +258,17 @@ pub(crate) fn compile_notebook_with_fake_stdlib<'a, I>(cells: I) -> Compilation
 where
     I: Iterator<Item = (&'a str, &'a str)>,
 {
-    let std_source_map = SourceMap::new(
-        [(FAKE_STDLIB_NAME.into(), FAKE_STDLIB_CONTENTS.into())],
-        None,
-    );
+    let (std_id, package_store) = compile_fake_stdlib();
 
-    let store = qsc::PackageStore::new(qsc::compile::core());
+    let mut dependencies = vec![(std_id, None)];
+
     let mut compiler = Compiler::new(
-        std_source_map,
+        SourceMap::default(),
         PackageType::Lib,
         Profile::Unrestricted.into(),
         LanguageFeatures::default(),
-        store,
-        &[],
+        package_store,
+        &dependencies,
     )
     .expect("expected incremental compiler creation to succeed");
 
@@ -290,13 +287,14 @@ where
     let source_package_id = compiler.source_package_id();
     let (package_store, package_id) = compiler.into_package_store();
 
+    dependencies.push((source_package_id, None));
+
     Compilation {
         package_store,
         user_package_id: package_id,
         compile_errors: errors,
         kind: CompilationKind::Notebook { project: None },
         project_errors: Vec::new(),
-        dependencies: [(source_package_id, None)].into_iter().collect(),
         test_cases: Default::default(),
     }
 }


### PR DESCRIPTION
This pull request refactors the completion logic for imports and exports to be more robust and accurate.

The completion provider in the language service (`global_items.rs`) has been rewritten to leverage the `GlobalScope` and `Locals` structs already available from the resolver. This allows completions to use the same "view" as the name resolution code, rather than trying to recreate it by manually analyzing imports, enumerating items, etc. All of that work has already been done by the resolver.


The previous implementation for completions had difficulty handling more complex import and export scenarios, such as items re-exported from dependencies or items under aliased namespaces. This could lead to incomplete or incorrect suggestions. The new approach provides a more solid foundation, giving the language service a complete and accurate view of all available symbols.

Fixes #2142
