### PR TITLE
Definition, References, Hover, Rename for import/export decls

### DIFF
--- a/source/language_service/src/definition.rs
+++ b/source/language_service/src/definition.rs
@@ -58,6 +58,7 @@ impl<'a> Handler<'a> for DefinitionFinder<'a> {
     fn at_callable_ref(
         &mut self,
         _: &'a ast::Path,
+        _: Option<&'a ast::Ident>,
         item_id: &hir::ItemId,
         decl: &'a hir::CallableDecl,
     ) {
@@ -107,6 +108,7 @@ impl<'a> Handler<'a> for DefinitionFinder<'a> {
     fn at_new_type_ref(
         &mut self,
         _: &'a ast::Path,
+        _: Option<&'a ast::Ident>,
         item_id: &hir::ItemId,
         type_name: &'a hir::Ident,
         _: &'a hir::ty::Udt,

--- a/source/language_service/src/definition/tests.rs
+++ b/source/language_service/src/definition/tests.rs
@@ -695,13 +695,26 @@ fn item_export() {
 }
 
 #[test]
-fn item_export_with_alias() {
+fn item_export_with_alias_on_path() {
     assert_definition(
         r#"
         namespace Test {
             operation ◉Foo◉() : Unit {
             }
             export Fo↘o as Bar;
+        }
+    "#,
+    );
+}
+
+#[test]
+fn item_export_with_alias_on_alias() {
+    assert_definition(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+            export Foo as B↘ar;
         }
     "#,
     );

--- a/source/language_service/src/definition/tests.rs
+++ b/source/language_service/src/definition/tests.rs
@@ -680,3 +680,92 @@ fn notebook_local_from_later_cell() {
         ("cell2", "let z = ↘x + 2;"),
     ]);
 }
+
+#[test]
+fn item_export() {
+    assert_definition(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+            export Fo↘o;
+        }
+    "#,
+    );
+}
+
+#[test]
+fn item_export_with_alias() {
+    assert_definition(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+            export Fo↘o as Bar;
+        }
+    "#,
+    );
+}
+
+#[test]
+fn item_import() {
+    assert_definition(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+        }
+        namespace Other {
+            import X, Test.Fo↘o;
+        }
+    "#,
+    );
+}
+
+#[test]
+fn item_import_incomplete() {
+    assert_definition(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+        }
+        namespace Other {
+            import X, Test.Foo↘
+        }
+    "#,
+    );
+}
+
+#[test]
+fn item_import_alias() {
+    assert_definition(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+        }
+        namespace Other {
+            import Test.Foo as B↘ar;
+        }
+    "#,
+    );
+}
+
+#[test]
+fn item_import_alias_usage() {
+    assert_definition(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+        }
+        namespace Other {
+            import Test.Foo as Bar;
+            operation Baz() : Unit {
+                let x = Ba↘r();
+            }
+        }
+    "#,
+    );
+}

--- a/source/language_service/src/hover.rs
+++ b/source/language_service/src/hover.rs
@@ -86,6 +86,7 @@ impl<'a> Handler<'a> for HoverGenerator<'a> {
     fn at_callable_ref(
         &mut self,
         path: &'a ast::Path,
+        _: Option<&'a ast::Ident>,
         item_id: &hir::ItemId,
         decl: &'a hir::CallableDecl,
     ) {
@@ -185,6 +186,7 @@ impl<'a> Handler<'a> for HoverGenerator<'a> {
     fn at_new_type_ref(
         &mut self,
         path: &'a ast::Path,
+        _: Option<&'a ast::Ident>,
         item_id: &hir::ItemId,
         _: &'a hir::Ident,
         udt: &'a hir::ty::Udt,

--- a/source/language_service/src/name_locator.rs
+++ b/source/language_service/src/name_locator.rs
@@ -6,7 +6,8 @@ use std::rc::Rc;
 
 use crate::compilation::Compilation;
 use qsc::ast::visit::{
-    Visitor, walk_attr, walk_expr, walk_item, walk_namespace, walk_pat, walk_ty, walk_ty_def,
+    Visitor, walk_attr, walk_expr, walk_import_or_export, walk_namespace, walk_pat, walk_ty,
+    walk_ty_def,
 };
 use qsc::ast::{FieldAccess, Idents, ImportKind, PathKind};
 use qsc::display::Lookup;
@@ -280,8 +281,8 @@ impl<'package, T: Handler<'package>> Visitor<'package> for Locator<'_, 'package,
                                 }
                             }
                         }
+                        walk_import_or_export(self, item);
                     }
-                    walk_item(self, item);
                 }
                 _ => {}
             }

--- a/source/language_service/src/name_locator.rs
+++ b/source/language_service/src/name_locator.rs
@@ -6,9 +6,9 @@ use std::rc::Rc;
 
 use crate::compilation::Compilation;
 use qsc::ast::visit::{
-    Visitor, walk_attr, walk_expr, walk_namespace, walk_pat, walk_ty, walk_ty_def,
+    Visitor, walk_attr, walk_expr, walk_item, walk_namespace, walk_pat, walk_ty, walk_ty_def,
 };
-use qsc::ast::{FieldAccess, Idents, PathKind};
+use qsc::ast::{FieldAccess, Idents, ImportKind, PathKind};
 use qsc::display::Lookup;
 use qsc::{ast, hir, resolve};
 
@@ -25,6 +25,7 @@ pub(crate) trait Handler<'package> {
     fn at_callable_ref(
         &mut self,
         path: &'package ast::Path,
+        alias: Option<&'package ast::Ident>,
         item_id: &hir::ItemId,
         decl: &'package hir::CallableDecl,
     );
@@ -61,6 +62,7 @@ pub(crate) trait Handler<'package> {
     fn at_new_type_ref(
         &mut self,
         path: &'package ast::Path,
+        alias: Option<&'package ast::Ident>,
         item_id: &hir::ItemId,
         type_name: &'package hir::Ident,
         udt: &'package hir::ty::Udt,
@@ -186,7 +188,7 @@ impl<'package, T: Handler<'package>> Visitor<'package> for Locator<'_, 'package,
 
     // Handles callable, UDT, struct, and type param definitions
     fn visit_item(&mut self, item: &'package ast::Item) {
-        if item.span.contains(self.offset) {
+        if item.span.touches(self.offset) {
             let context = replace(&mut self.context.current_item_doc, item.doc.clone());
             item.attrs.iter().for_each(|a| self.visit_attr(a));
             match &*item.kind {
@@ -266,6 +268,20 @@ impl<'package, T: Handler<'package>> Visitor<'package> for Locator<'_, 'package,
                         self.context.current_udt_id = context;
                         self.context.current_item_name = context_curr_item_name;
                     }
+                }
+                ast::ItemKind::ImportOrExport(decl) => {
+                    for item in &decl.items {
+                        if let ImportKind::Direct { alias: Some(alias) } = &item.kind {
+                            if alias.span.touches(self.offset) {
+                                // If the cursor is on the alias, go through the path.
+                                if let PathKind::Ok(path) = &item.path {
+                                    self.at_path(path, Some(alias));
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    walk_item(self, item);
                 }
                 _ => {}
             }
@@ -416,50 +432,62 @@ impl<'package, T: Handler<'package>> Visitor<'package> for Locator<'_, 'package,
     // Handles local variable, UDT, and callable references
     fn visit_path(&mut self, path: &'package ast::Path) {
         if path.span.touches(self.offset) {
-            match resolve::path_as_field_accessor(&self.compilation.user_unit().ast.names, path) {
-                // The path is a field accessor.
-                Some((node_id, parts)) => {
-                    let (first, rest) = parts
-                        .split_first()
-                        .expect("paths should have at least one part");
-                    if first.span.touches(self.offset) {
-                        if let Some(definition) = self.find_ident(node_id) {
-                            self.inner
-                                .at_local_ref(&self.context, first, node_id, definition);
-                        }
-                    } else {
-                        // Loop through the parts of the path to find the first part that touches the offset
-                        let mut last_id = first.id;
-                        for part in rest {
-                            if part.span.touches(self.offset) {
-                                if let Some(hir::ty::Ty::Udt(_, res)) =
-                                    &self.compilation.get_ty(last_id)
-                                {
-                                    if let Some((item_id, field_def)) =
-                                        self.get_field_def(res, part)
-                                    {
-                                        self.inner.at_field_ref(part, &item_id, field_def);
-                                    }
+            self.at_path(path, None);
+        }
+    }
+}
+
+impl<'package, T: Handler<'package>> Locator<'_, 'package, T> {
+    fn at_path(&mut self, path: &'package ast::Path, alias: Option<&'package ast::Ident>) {
+        match resolve::path_as_field_accessor(&self.compilation.user_unit().ast.names, path) {
+            // The path is a field accessor.
+            Some((node_id, parts)) => {
+                let (first, rest) = parts
+                    .split_first()
+                    .expect("paths should have at least one part");
+                if first.span.touches(self.offset) {
+                    if let Some(definition) = self.find_ident(node_id) {
+                        self.inner
+                            .at_local_ref(&self.context, first, node_id, definition);
+                    }
+                } else {
+                    // Loop through the parts of the path to find the first part that touches the offset
+                    let mut last_id = first.id;
+                    for part in rest {
+                        if part.span.touches(self.offset) {
+                            if let Some(hir::ty::Ty::Udt(_, res)) =
+                                &self.compilation.get_ty(last_id)
+                            {
+                                if let Some((item_id, field_def)) = self.get_field_def(res, part) {
+                                    self.inner.at_field_ref(part, &item_id, field_def);
                                 }
-                                break;
                             }
-                            last_id = part.id;
+                            break;
                         }
+                        last_id = part.id;
                     }
                 }
-                // The path is a namespace path.
-                None => match self.compilation.get_res(path.id) {
-                    Some(resolve::Res::Item(item_id, _)) => {
+            }
+            // The path is not a field accessor.
+            None => match self.compilation.get_res(path.id) {
+                Some(res @ (resolve::Res::Item(..) | resolve::Res::Importable(_))) => {
+                    if let Some(ref item_id) = res.item_id() {
                         let (item, _, resolved_item_id) = self
                             .compilation
                             .resolve_item_relative_to_user_package(item_id);
                         match &item.kind {
                             hir::ItemKind::Callable(decl) => {
-                                self.inner.at_callable_ref(path, &resolved_item_id, decl);
+                                self.inner
+                                    .at_callable_ref(path, alias, &resolved_item_id, decl);
                             }
                             hir::ItemKind::Ty(type_name, udt) => {
-                                self.inner
-                                    .at_new_type_ref(path, &resolved_item_id, type_name, udt);
+                                self.inner.at_new_type_ref(
+                                    path,
+                                    alias,
+                                    &resolved_item_id,
+                                    type_name,
+                                    udt,
+                                );
                             }
                             hir::ItemKind::Namespace(_, _) => {
                                 panic!(
@@ -472,19 +500,15 @@ impl<'package, T: Handler<'package>> Visitor<'package> for Locator<'_, 'package,
                             }
                         }
                     }
-                    Some(resolve::Res::Local(node_id)) => {
-                        if let Some(definition) = self.find_ident(*node_id) {
-                            self.inner.at_local_ref(
-                                &self.context,
-                                &path.name,
-                                *node_id,
-                                definition,
-                            );
-                        }
+                }
+                Some(resolve::Res::Local(node_id)) => {
+                    if let Some(definition) = self.find_ident(*node_id) {
+                        self.inner
+                            .at_local_ref(&self.context, &path.name, *node_id, definition);
                     }
-                    _ => {}
-                },
-            }
+                }
+                _ => {}
+            },
         }
     }
 }

--- a/source/language_service/src/references.rs
+++ b/source/language_service/src/references.rs
@@ -10,7 +10,7 @@ use crate::compilation::Compilation;
 use crate::name_locator::{Handler, Locator, LocatorContext};
 use crate::qsc_utils::into_location;
 use qsc::ast::PathKind;
-use qsc::ast::visit::{Visitor, walk_callable_decl, walk_expr, walk_ty};
+use qsc::ast::visit::{Visitor, walk_callable_decl, walk_expr, walk_item, walk_ty};
 use qsc::display::Lookup;
 use qsc::hir::ty::Ty;
 use qsc::hir::{PackageId, Res};
@@ -65,17 +65,18 @@ impl<'a> Handler<'a> for NameHandler<'a> {
         if let Some(resolve::Res::Item(item_id, _)) =
             self.reference_finder.compilation.get_res(name.id)
         {
-            self.references = self.reference_finder.for_item(item_id);
+            self.references = self.reference_finder.for_item(item_id, None);
         }
     }
 
     fn at_callable_ref(
         &mut self,
         _: &'a ast::Path,
+        _: Option<&'a ast::Ident>,
         item_id: &hir::ItemId,
         _: &'a hir::CallableDecl,
     ) {
-        self.references = self.reference_finder.for_item(item_id);
+        self.references = self.reference_finder.for_item(item_id, None);
     }
 
     fn at_type_param_def(
@@ -110,7 +111,7 @@ impl<'a> Handler<'a> for NameHandler<'a> {
         if let Some(resolve::Res::Item(item_id, _)) =
             self.reference_finder.compilation.get_res(type_name.id)
         {
-            self.references = self.reference_finder.for_item(item_id);
+            self.references = self.reference_finder.for_item(item_id, None);
         }
     }
 
@@ -123,18 +124,19 @@ impl<'a> Handler<'a> for NameHandler<'a> {
         if let Some(resolve::Res::Item(item_id, _)) =
             self.reference_finder.compilation.get_res(type_name.id)
         {
-            self.references = self.reference_finder.for_item(item_id);
+            self.references = self.reference_finder.for_item(item_id, None);
         }
     }
 
     fn at_new_type_ref(
         &mut self,
         _: &'a ast::Path,
+        _: Option<&'a ast::Ident>,
         item_id: &hir::ItemId,
         _: &'a hir::Ident,
         _: &'a hir::ty::Udt,
     ) {
-        self.references = self.reference_finder.for_item(item_id);
+        self.references = self.reference_finder.for_item(item_id, None);
     }
 
     fn at_field_def(
@@ -198,31 +200,37 @@ impl<'a> ReferenceFinder<'a> {
         }
     }
 
-    pub fn for_item(&self, item_id: &hir::ItemId) -> Vec<Location> {
+    pub fn for_item(&self, item_id: &hir::ItemId, name_filter: Option<&Rc<str>>) -> Vec<Location> {
         let mut locations = vec![];
 
         let (def, _, resolved_item_id) = self
             .compilation
             .resolve_item_relative_to_user_package(item_id);
         if self.include_declaration {
-            let def_span = match &def.kind {
-                hir::ItemKind::Callable(decl) => decl.name.span,
-                hir::ItemKind::Namespace(name, _) => name.span(),
-                hir::ItemKind::Ty(name, _) | hir::ItemKind::Export(name, _) => name.span,
+            let (decl_name, decl_span) = match &def.kind {
+                hir::ItemKind::Callable(decl) => (Some(&decl.name.name), decl.name.span),
+                hir::ItemKind::Namespace(name, _) => (None, name.span()),
+                hir::ItemKind::Ty(name, _) | hir::ItemKind::Export(name, _) => {
+                    (Some(&name.name), name.span)
+                }
             };
-            locations.push(
-                self.location(
-                    def_span,
-                    resolved_item_id
-                        .package
-                        .expect("package id should have been resolved"),
-                ),
-            );
+
+            if name_filter.is_none() || decl_name == name_filter {
+                locations.push(
+                    self.location(
+                        decl_span,
+                        resolved_item_id
+                            .package
+                            .expect("package id should have been resolved"),
+                    ),
+                );
+            }
         }
 
         let mut find_refs = FindItemRefs {
             item_id: &resolved_item_id,
             compilation: self.compilation,
+            name_filter,
             locations: vec![],
         };
 
@@ -337,30 +345,46 @@ impl<'a> ReferenceFinder<'a> {
 struct FindItemRefs<'a> {
     item_id: &'a hir::ItemId,
     compilation: &'a Compilation,
+    name_filter: Option<&'a Rc<str>>,
     locations: Vec<Span>,
 }
 
 impl Visitor<'_> for FindItemRefs<'_> {
     fn visit_path(&mut self, path: &ast::Path) {
         let res = self.compilation.get_res(path.id);
-        if let Some(resolve::Res::Item(item_id, _)) = res {
-            if self.eq(item_id) {
-                self.locations.push(path.name.span);
+        if let Some(res) = res {
+            if let Some(ref item_id) = res.item_id() {
+                if self.eq(item_id)
+                    && (self.name_filter.is_none() || Some(&path.name.name) == self.name_filter)
+                {
+                    self.locations.push(path.name.span);
+                }
             }
         }
     }
 
-    fn visit_ty(&mut self, ty: &ast::Ty) {
-        if let ast::TyKind::Path(PathKind::Ok(ty_path)) = &*ty.kind {
-            let res = self.compilation.get_res(ty_path.id);
-            if let Some(resolve::Res::Item(item_id, _)) = res {
-                if self.eq(item_id) {
-                    self.locations.push(ty_path.name.span);
+    fn visit_item(&mut self, item: &'_ ast::Item) {
+        // TODO: replace with specific visitor
+        if let ast::ItemKind::ImportOrExport(decl) = &*item.kind {
+            for item in &decl.items {
+                if let ast::ImportKind::Direct { alias: Some(alias) } = &item.kind {
+                    if let PathKind::Ok(path) = &item.path {
+                        let res = self.compilation.get_res(path.id);
+                        if let Some(res) = res {
+                            if let Some(item_id) = res.item_id() {
+                                if self.eq(&item_id)
+                                    && (self.name_filter.is_none()
+                                        || Some(&alias.name) == self.name_filter)
+                                {
+                                    self.locations.push(alias.span);
+                                }
+                            }
+                        }
+                    }
                 }
             }
-        } else {
-            walk_ty(self, ty);
         }
+        walk_item(self, item);
     }
 }
 

--- a/source/language_service/src/references/tests.rs
+++ b/source/language_service/src/references/tests.rs
@@ -930,85 +930,349 @@ fn notebook_local_reference() {
 }
 
 #[test]
-fn on_item_declaration_finds_exports_and_imports() {
-    check_include_decl(
-        r#"
-        namespace Test {
-            operation ◉Fo↘o◉() : Unit {
+fn on_item_declaration_finds_all_usages() {
+    check_include_decl(indoc! {"
+            namespace Base {
+                operation ◉b↘1◉() : Unit {}
+                export
+                    ◉b1◉,
+                    ◉b1◉ as ◉b2◉;
             }
-            export ◉Foo◉ as ◉Bar◉;
-        }
-        namespace Other {
-            import Test.◉Bar◉;
-            import Test.◉Bar◉ as ◉Baz◉;
-            operation X() : Unit {
-                ◉Bar◉();
-                ◉Baz◉();
+            namespace Intermediate {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉i1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉i2◉;
+                export
+                    Base.◉b1◉,
+                    Base.◉b2◉,
+                    ◉i1◉,
+                    ◉i2◉;
             }
-        }
-    "#,
-    );
+            namespace Usage1 {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉u1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉u2◉,
+                    Intermediate.◉b1◉ as ◉u3◉,
+                    Intermediate.◉b2◉ as ◉u4◉,
+                    Intermediate.◉i1◉,
+                    Intermediate.◉i1◉ as ◉u5◉,
+                    Intermediate.◉i2◉,
+                    Intermediate.◉i2◉ as ◉u6◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                    ◉i1◉();
+                    ◉i2◉();
+                    ◉u1◉();
+                    ◉u2◉();
+                    ◉u3◉();
+                    ◉u4◉();
+                    ◉u5◉();
+                    ◉u6◉();
+                }
+            }
+            namespace Usage2 {
+                import
+                    Intermediate.◉b1◉,
+                    Intermediate.◉b2◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                }
+            }
+            "});
 }
 
 #[test]
-fn on_export_path_finds_declaration_and_usages() {
-    check_include_decl(
-        r#"
-        namespace Test {
-            operation ◉Foo◉() : Unit {
+fn on_item_export_path_finds_all_usages() {
+    check_include_decl(indoc! {"
+            namespace Base {
+                operation ◉b1◉() : Unit {}
+                export
+                    ◉b↘1◉,
+                    ◉b1◉ as ◉b2◉;
             }
-            export ◉F↘oo◉ as ◉Bar◉;
-        }
-        namespace Other {
-            import Test.◉Bar◉;
-            import Test.◉Bar◉ as ◉Baz◉;
-            operation X() : Unit {
-                ◉Bar◉();
-                ◉Baz◉();
+            namespace Intermediate {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉i1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉i2◉;
+                export
+                    Base.◉b1◉,
+                    Base.◉b2◉,
+                    ◉i1◉,
+                    ◉i2◉;
             }
-        }
-    "#,
-    );
+            namespace Usage1 {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉u1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉u2◉,
+                    Intermediate.◉b1◉ as ◉u3◉,
+                    Intermediate.◉b2◉ as ◉u4◉,
+                    Intermediate.◉i1◉,
+                    Intermediate.◉i1◉ as ◉u5◉,
+                    Intermediate.◉i2◉,
+                    Intermediate.◉i2◉ as ◉u6◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                    ◉i1◉();
+                    ◉i2◉();
+                    ◉u1◉();
+                    ◉u2◉();
+                    ◉u3◉();
+                    ◉u4◉();
+                    ◉u5◉();
+                    ◉u6◉();
+                }
+            }
+            namespace Usage2 {
+                import
+                    Intermediate.◉b1◉,
+                    Intermediate.◉b2◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                }
+            }
+            "});
 }
 
 #[test]
-fn on_export_alias_finds_declaration_and_usages() {
-    check_include_decl(
-        r#"
-        namespace Test {
-            operation ◉Foo◉() : Unit {
+fn on_item_export_alias_finds_all_usages() {
+    check_include_decl(indoc! {"
+            namespace Base {
+                operation ◉b1◉() : Unit {}
+                export
+                    ◉b1◉,
+                    ◉b1◉ as ◉b↘2◉;
             }
-            export ◉Foo◉ as ◉Ba↘r◉;
-        }
-        namespace Other {
-            import Test.◉Bar◉;
-            import Test.◉Bar◉ as ◉Baz◉;
-            operation X() : Unit {
-                ◉Bar◉();
-                ◉Baz◉();
+            namespace Intermediate {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉i1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉i2◉;
+                export
+                    Base.◉b1◉,
+                    Base.◉b2◉,
+                    ◉i1◉,
+                    ◉i2◉;
             }
-        }
-    "#,
-    );
+            namespace Usage1 {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉u1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉u2◉,
+                    Intermediate.◉b1◉ as ◉u3◉,
+                    Intermediate.◉b2◉ as ◉u4◉,
+                    Intermediate.◉i1◉,
+                    Intermediate.◉i1◉ as ◉u5◉,
+                    Intermediate.◉i2◉,
+                    Intermediate.◉i2◉ as ◉u6◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                    ◉i1◉();
+                    ◉i2◉();
+                    ◉u1◉();
+                    ◉u2◉();
+                    ◉u3◉();
+                    ◉u4◉();
+                    ◉u5◉();
+                    ◉u6◉();
+                }
+            }
+            namespace Usage2 {
+                import
+                    Intermediate.◉b1◉,
+                    Intermediate.◉b2◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                }
+            }
+            "});
 }
 
 #[test]
-fn on_export_alias_usage_finds_declaration_and_usages() {
-    check_include_decl(
-        r#"
-        namespace Test {
-            operation ◉Foo◉() : Unit {
+fn on_item_import_finds_all_usages() {
+    check_include_decl(indoc! {"
+            namespace Base {
+                operation ◉b1◉() : Unit {}
+                export
+                    ◉b1◉,
+                    ◉b1◉ as ◉b2◉;
             }
-            export ◉Foo◉ as ◉Bar◉;
-        }
-        namespace Other {
-            import Test.◉Bar◉;
-            import Test.◉Bar◉ as ◉Ba↘z◉;
-            operation X() : Unit {
-                ◉Bar◉();
-                ◉Baz◉();
+            namespace Intermediate {
+                import
+                    Base.◉b↘1◉,
+                    Base.◉b1◉ as ◉i1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉i2◉;
+                export
+                    Base.◉b1◉,
+                    Base.◉b2◉,
+                    ◉i1◉,
+                    ◉i2◉;
             }
-        }
-    "#,
-    );
+            namespace Usage1 {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉u1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉u2◉,
+                    Intermediate.◉b1◉ as ◉u3◉,
+                    Intermediate.◉b2◉ as ◉u4◉,
+                    Intermediate.◉i1◉,
+                    Intermediate.◉i1◉ as ◉u5◉,
+                    Intermediate.◉i2◉,
+                    Intermediate.◉i2◉ as ◉u6◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                    ◉i1◉();
+                    ◉i2◉();
+                    ◉u1◉();
+                    ◉u2◉();
+                    ◉u3◉();
+                    ◉u4◉();
+                    ◉u5◉();
+                    ◉u6◉();
+                }
+            }
+            namespace Usage2 {
+                import
+                    Intermediate.◉b1◉,
+                    Intermediate.◉b2◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                }
+            }
+            "});
+}
+
+#[test]
+fn on_item_import_alias_finds_all_usages() {
+    check_include_decl(indoc! {"
+            namespace Base {
+                operation ◉b1◉() : Unit {}
+                export
+                    ◉b1◉,
+                    ◉b1◉ as ◉b2◉;
+            }
+            namespace Intermediate {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉i↘1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉i2◉;
+                export
+                    Base.◉b1◉,
+                    Base.◉b2◉,
+                    ◉i1◉,
+                    ◉i2◉;
+            }
+            namespace Usage1 {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉u1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉u2◉,
+                    Intermediate.◉b1◉ as ◉u3◉,
+                    Intermediate.◉b2◉ as ◉u4◉,
+                    Intermediate.◉i1◉,
+                    Intermediate.◉i1◉ as ◉u5◉,
+                    Intermediate.◉i2◉,
+                    Intermediate.◉i2◉ as ◉u6◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                    ◉i1◉();
+                    ◉i2◉();
+                    ◉u1◉();
+                    ◉u2◉();
+                    ◉u3◉();
+                    ◉u4◉();
+                    ◉u5◉();
+                    ◉u6◉();
+                }
+            }
+            namespace Usage2 {
+                import
+                    Intermediate.◉b1◉,
+                    Intermediate.◉b2◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                }
+            }
+            "});
+}
+
+#[test]
+fn on_item_import_usage_finds_all_usages() {
+    check_include_decl(indoc! {"
+            namespace Base {
+                operation ◉b1◉() : Unit {}
+                export
+                    ◉b1◉,
+                    ◉b1◉ as ◉b2◉;
+            }
+            namespace Intermediate {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉i1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉i2◉;
+                export
+                    Base.◉b1◉,
+                    Base.◉b2◉,
+                    ◉i1◉,
+                    ◉i2◉;
+            }
+            namespace Usage1 {
+                import
+                    Base.◉b1◉,
+                    Base.◉b1◉ as ◉u1◉,
+                    Base.◉b2◉,
+                    Base.◉b2◉ as ◉u2◉,
+                    Intermediate.◉b1◉ as ◉u3◉,
+                    Intermediate.◉b2◉ as ◉u4◉,
+                    Intermediate.◉i1◉,
+                    Intermediate.◉i1◉ as ◉u5◉,
+                    Intermediate.◉i2◉,
+                    Intermediate.◉i2◉ as ◉u6◉;
+                operation useOp() : Unit {
+                    ◉b1◉();
+                    ◉b2◉();
+                    ◉i1◉();
+                    ◉i2◉();
+                    ◉u1◉();
+                    ◉u2◉();
+                    ◉u3◉();
+                    ◉u4◉();
+                    ◉u5◉();
+                    ◉u6◉();
+                }
+            }
+            namespace Usage2 {
+                import
+                    Intermediate.◉b1◉,
+                    Intermediate.◉b2◉;
+                operation useOp() : Unit {
+                    ◉b↘1◉();
+                    ◉b2◉();
+                }
+            }
+            "});
 }

--- a/source/language_service/src/references/tests.rs
+++ b/source/language_service/src/references/tests.rs
@@ -928,3 +928,87 @@ fn notebook_local_reference() {
         ("cell2", "let z = ◉↘x◉ + 2;"),
     ]);
 }
+
+#[test]
+fn on_item_declaration_finds_exports_and_imports() {
+    check_include_decl(
+        r#"
+        namespace Test {
+            operation ◉Fo↘o◉() : Unit {
+            }
+            export ◉Foo◉ as ◉Bar◉;
+        }
+        namespace Other {
+            import Test.◉Bar◉;
+            import Test.◉Bar◉ as ◉Baz◉;
+            operation X() : Unit {
+                ◉Bar◉();
+                ◉Baz◉();
+            }
+        }
+    "#,
+    );
+}
+
+#[test]
+fn on_export_path_finds_declaration_and_usages() {
+    check_include_decl(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+            export ◉F↘oo◉ as ◉Bar◉;
+        }
+        namespace Other {
+            import Test.◉Bar◉;
+            import Test.◉Bar◉ as ◉Baz◉;
+            operation X() : Unit {
+                ◉Bar◉();
+                ◉Baz◉();
+            }
+        }
+    "#,
+    );
+}
+
+#[test]
+fn on_export_alias_finds_declaration_and_usages() {
+    check_include_decl(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+            export ◉Foo◉ as ◉Ba↘r◉;
+        }
+        namespace Other {
+            import Test.◉Bar◉;
+            import Test.◉Bar◉ as ◉Baz◉;
+            operation X() : Unit {
+                ◉Bar◉();
+                ◉Baz◉();
+            }
+        }
+    "#,
+    );
+}
+
+#[test]
+fn on_export_alias_usage_finds_declaration_and_usages() {
+    check_include_decl(
+        r#"
+        namespace Test {
+            operation ◉Foo◉() : Unit {
+            }
+            export ◉Foo◉ as ◉Bar◉;
+        }
+        namespace Other {
+            import Test.◉Bar◉;
+            import Test.◉Bar◉ as ◉Ba↘z◉;
+            operation X() : Unit {
+                ◉Bar◉();
+                ◉Baz◉();
+            }
+        }
+    "#,
+    );
+}

--- a/source/language_service/src/rename.rs
+++ b/source/language_service/src/rename.rs
@@ -92,7 +92,9 @@ impl<'a> Rename<'a> {
             if self.is_prepare {
                 self.prepare = Some((ast_name.span, ast_name.name.to_string()));
             } else {
-                self.locations = self.reference_finder.for_item(item_id);
+                self.locations = self
+                    .reference_finder
+                    .for_item(item_id, Some(&ast_name.name));
             }
         }
     }
@@ -173,10 +175,11 @@ impl<'a> Handler<'a> for Rename<'a> {
     fn at_callable_ref(
         &mut self,
         path: &'a ast::Path,
+        alias: Option<&'a ast::Ident>,
         item_id: &hir::ItemId,
         _: &'a hir::CallableDecl,
     ) {
-        self.get_spans_for_item_rename(item_id, &path.name);
+        self.get_spans_for_item_rename(item_id, alias.unwrap_or(&path.name));
     }
 
     fn at_new_type_def(
@@ -233,11 +236,12 @@ impl<'a> Handler<'a> for Rename<'a> {
     fn at_new_type_ref(
         &mut self,
         path: &'a ast::Path,
+        alias: Option<&'a ast::Ident>,
         item_id: &hir::ItemId,
         _: &'a hir::Ident,
         _: &'a hir::ty::Udt,
     ) {
-        self.get_spans_for_item_rename(item_id, &path.name);
+        self.get_spans_for_item_rename(item_id, alias.unwrap_or(&path.name));
     }
 
     fn at_field_def(

--- a/source/language_service/src/rename/tests.rs
+++ b/source/language_service/src/rename/tests.rs
@@ -664,3 +664,66 @@ fn notebook_rename_across_cells() {
         "#]],
     );
 }
+
+#[test]
+fn on_declaration_with_aliased_export_finds_only_matching_names() {
+    check(
+        r#"
+        namespace Test {
+            operation ◉F↘oo◉() : Unit {
+            }
+            export ◉Foo◉ as Bar;
+        }
+        namespace Other {
+            import Test.Bar;
+            import Test.Bar as Baz;
+            operation X() : Unit {
+                Bar();
+                Baz();
+            }
+        }
+    "#,
+    );
+}
+
+#[test]
+fn on_export_alias_finds_only_matching_names() {
+    check(
+        r#"
+        namespace Test {
+            operation Foo() : Unit {
+            }
+            export Foo as Bar;
+        }
+        namespace Other {
+            import Test.Bar;
+            import Test.Bar as ◉Ba↘z◉;
+            operation X() : Unit {
+                Bar();
+                ◉Baz◉();
+            }
+        }
+    "#,
+    );
+}
+
+#[test]
+fn on_export_alias_usage_finds_only_matching_names() {
+    check(
+        r#"
+        namespace Test {
+            operation Foo() : Unit {
+            }
+            export Foo as Bar;
+        }
+        namespace Other {
+            import Test.Bar;
+            import Test.Bar as ◉Baz◉;
+            operation X() : Unit {
+                Bar();
+                ◉B↘az◉();
+            }
+        }
+    "#,
+    );
+}


### PR DESCRIPTION
Adds Go To Definition, Hover, Go To References, Rename support for import/export declarations. Also, for References and Rename, results when these commands are invoked on any items, now include any import/export declarations.

- Go To Definition on any imports/exports, and any usages of those imports/exports, resolve back to the original item.
- Hover shows hover info of original item.
- Go To References finds references to an item including any imports, exports, and usages across packages, including any aliased usages.
- Rename renames the declaration and usages, as long as they match the alias that the cursor is on.

