### PR TITLE
Playground Profile Selection

### DIFF
--- a/source/npm/qsharp/src/browser.ts
+++ b/source/npm/qsharp/src/browser.ts
@@ -22,6 +22,7 @@ import {
   QSharpDebugService,
   debugServiceProtocol,
 } from "./debug-service/debug-service.js";
+import { callAndTransformExceptions } from "./diagnostics.js";
 import {
   ILanguageService,
   ILanguageServiceWorker,
@@ -156,6 +157,19 @@ export function getLanguageServiceWorker(
   return createProxy(worker, wasmModule, languageServiceProtocol);
 }
 
+export async function getTargetProfileFromEntryPoint(
+  fileName: string,
+  source: string,
+): Promise<wasm.TargetProfile | undefined> {
+  await instantiateWasm();
+  return callAndTransformExceptions(
+    async () =>
+      wasm.get_target_profile_from_entry_point(fileName, source) as
+        | wasm.TargetProfile
+        | undefined,
+  );
+}
+
 export { StepResultId } from "../lib/web/qsc_wasm.js";
 export type {
   IBreakpointSpan,
@@ -186,7 +200,6 @@ export type {
 } from "./language-service/language-service.js";
 export { default as openqasm_samples } from "./openqasm-samples.generated.js";
 export type { ProjectLoader } from "./project.js";
-export { getTargetProfileFromEntryPoint } from "./project.js";
 export { default as samples } from "./samples.generated.js";
 export type { CircuitGroup as CircuitData } from "./data-structures/circuit.js";
 export * as utils from "./utils.js";

--- a/source/npm/qsharp/src/browser.ts
+++ b/source/npm/qsharp/src/browser.ts
@@ -157,6 +157,10 @@ export function getLanguageServiceWorker(
   return createProxy(worker, wasmModule, languageServiceProtocol);
 }
 
+/// Extracts the target profile from a Q# source file's entry point.
+/// Scans the provided source code for an EntryPoint argument specifying
+/// a profile and returns the corresponding TargetProfile value, if found.
+/// Returns undefined if no profile is specified or if the profile is not recognized.
 export async function getTargetProfileFromEntryPoint(
   fileName: string,
   source: string,

--- a/source/npm/qsharp/src/compiler/compiler.ts
+++ b/source/npm/qsharp/src/compiler/compiler.ts
@@ -156,10 +156,7 @@ export class Compiler implements ICompiler {
   }
 
   async getRir(program: ProgramConfig): Promise<string[]> {
-    const config = toWasmProgramConfig(
-      program,
-      program.profile || "adaptive_ri",
-    );
+    const config = toWasmProgramConfig(program, "adaptive_rif");
     return callAndTransformExceptions(async () => this.wasm.get_rir(config));
   }
 

--- a/source/npm/qsharp/src/compiler/compiler.ts
+++ b/source/npm/qsharp/src/compiler/compiler.ts
@@ -204,7 +204,7 @@ export class Compiler implements ICompiler {
 
   async getQir(program: ProgramConfig): Promise<string> {
     return callAndTransformExceptions(async () =>
-      this.wasm.get_qir(toWasmProgramConfig(program, "base")),
+      this.wasm.get_qir(toWasmProgramConfig(program, "adaptive_rif")),
     );
   }
 

--- a/source/npm/qsharp/src/compiler/compiler.ts
+++ b/source/npm/qsharp/src/compiler/compiler.ts
@@ -156,7 +156,7 @@ export class Compiler implements ICompiler {
   }
 
   async getRir(program: ProgramConfig): Promise<string[]> {
-    const config = toWasmProgramConfig(program, "adaptive_rif");
+    const config = toWasmProgramConfig(program, "adaptive_ri");
     return callAndTransformExceptions(async () => this.wasm.get_rir(config));
   }
 
@@ -201,7 +201,7 @@ export class Compiler implements ICompiler {
 
   async getQir(program: ProgramConfig): Promise<string> {
     return callAndTransformExceptions(async () =>
-      this.wasm.get_qir(toWasmProgramConfig(program, "adaptive_rif")),
+      this.wasm.get_qir(toWasmProgramConfig(program, "base")),
     );
   }
 

--- a/source/npm/qsharp/src/project.ts
+++ b/source/npm/qsharp/src/project.ts
@@ -29,15 +29,3 @@ export class ProjectLoader {
     );
   }
 }
-
-export async function getTargetProfileFromEntryPoint(
-  fileName: string,
-  source: string,
-): Promise<wasm.TargetProfile | undefined> {
-  return callAndTransformExceptions(
-    async () =>
-      wasm.get_target_profile_from_entry_point(fileName, source) as
-        | wasm.TargetProfile
-        | undefined,
-  );
-}

--- a/source/playground/src/editor.tsx
+++ b/source/playground/src/editor.tsx
@@ -13,6 +13,7 @@ import {
   log,
   ProgramConfig,
   LanguageServiceDiagnosticEvent,
+  getTargetProfileFromEntryPoint,
 } from "qsharp-lang";
 import { Exercise, getExerciseSources } from "qsharp-lang/katas-md";
 import { codeToCompressedBase64, lsRangeToMonacoRange } from "./utils.js";
@@ -128,6 +129,7 @@ export function Editor(props: {
     const config = {
       sources: [["code", code]] as [string, string][],
       languageFeatures: [],
+      profile: await getTargetProfileFromEntryPoint("main.qs", code),
     };
 
     if (props.activeTab === "ast-tab") {
@@ -182,6 +184,7 @@ export function Editor(props: {
     const config = {
       sources: [["code", code]],
       languageFeatures: [],
+      profile: await getTargetProfileFromEntryPoint("main.qs", code),
     } as ProgramConfig;
 
     try {

--- a/source/playground/src/editor.tsx
+++ b/source/playground/src/editor.tsx
@@ -129,7 +129,9 @@ export function Editor(props: {
     const config = {
       sources: [["code", code]] as [string, string][],
       languageFeatures: [],
-      profile: await getTargetProfileFromEntryPoint("main.qs", code),
+      profile:
+        (await getTargetProfileFromEntryPoint("main.qs", code)) ||
+        "adaptive_rif", // Default to adaptive_rif for qir and rir generation
     };
 
     if (props.activeTab === "ast-tab") {


### PR DESCRIPTION
Profile selection in the playground will now default to adaptive_rif for qir gen.
It will also properly search the user code for a profile specification via the EntryPoint argument.