### PR TITLE
Fix parsing of OPENQASM version statement

### DIFF
--- a/source/compiler/qsc_qasm/src/parser/prgm.rs
+++ b/source/compiler/qsc_qasm/src/parser/prgm.rs
@@ -42,15 +42,9 @@ pub(super) fn parse(s: &mut ParserContext) -> Program {
 fn parse_version(s: &mut ParserContext<'_>) -> Result<Version> {
     s.expect(WordKinds::OpenQASM);
     token(s, TokenKind::Keyword(crate::keyword::Keyword::OpenQASM))?;
-    let next = s.peek();
-    if let Ok(version) = expr::version(s) {
-        recovering_semi(s);
-        Ok(version)
-    } else {
-        Err(crate::parser::error::Error::new(
-            crate::parser::error::ErrorKind::Lit("version", next.span),
-        ))
-    }
+    let version = expr::version(s)?;
+    recovering_semi(s);
+    Ok(version)
 }
 
 pub(super) fn parse_top_level_nodes(s: &mut ParserContext) -> Result<Vec<Stmt>> {

--- a/source/compiler/qsc_qasm/src/parser/prgm.rs
+++ b/source/compiler/qsc_qasm/src/parser/prgm.rs
@@ -18,7 +18,13 @@ use super::ParserContext;
 /// Grammar: `version? statementOrScope* EOF`.
 pub(super) fn parse(s: &mut ParserContext) -> Program {
     let lo = s.peek().span.lo;
-    let version = opt(s, parse_version).unwrap_or_default();
+    let version = match opt(s, parse_version) {
+        Ok(version) => version,
+        Err(err) => {
+            s.push_error(err);
+            None
+        }
+    };
     let stmts = parse_top_level_nodes(s).unwrap_or_default();
 
     Program {
@@ -37,7 +43,7 @@ fn parse_version(s: &mut ParserContext<'_>) -> Result<Version> {
     s.expect(WordKinds::OpenQASM);
     token(s, TokenKind::Keyword(crate::keyword::Keyword::OpenQASM))?;
     let next = s.peek();
-    if let Some(version) = expr::version(s)? {
+    if let Ok(version) = expr::version(s) {
         recovering_semi(s);
         Ok(version)
     } else {

--- a/source/compiler/qsc_qasm/src/tests/statement.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement.rs
@@ -14,4 +14,5 @@ mod modified_gate_call;
 mod pragma;
 mod reset;
 mod switch;
+mod version;
 mod while_loop;

--- a/source/compiler/qsc_qasm/src/tests/statement/version.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/version.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::tests::check_qasm_to_qsharp;
+use expect_test::expect;
+
+#[test]
+fn missing_version_number() {
+    let source = "OPENQASM;";
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+        Qasm.Parser.Literal
+
+          x invalid version literal
+           ,-[Test.qasm:1:9]
+         1 | OPENQASM;
+           :         ^
+           `----
+
+        Qasm.Parser.EmptyStatement
+
+          x Empty statements are not supported
+           ,-[Test.qasm:1:9]
+         1 | OPENQASM;
+           :         ^
+           `----
+    "#]],
+    );
+}
+
+#[test]
+fn major() {
+    let source = "OPENQASM 3;";
+
+    check_qasm_to_qsharp(source, &expect!["import Std.OpenQASM.Intrinsic.*;"]);
+}
+
+#[test]
+fn major_minor() {
+    let source = "OPENQASM 3.1;";
+
+    check_qasm_to_qsharp(source, &expect!["import Std.OpenQASM.Intrinsic.*;"]);
+}
+
+#[test]
+fn non_existing_version_errors() {
+    let source = "OPENQASM 1.5;";
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+        Qasm.Lowerer.UnsupportedVersion
+
+          x unsupported version: '1.5'
+           ,-[Test.qasm:1:10]
+         1 | OPENQASM 1.5;
+           :          ^^^
+           `----
+    "#]],
+    );
+}
+
+#[test]
+fn other_expressions_error() {
+    let source = "OPENQASM (2 + 3);";
+
+    check_qasm_to_qsharp(
+        source,
+        &expect![[r#"
+            Qasm.Parser.Literal
+
+              x invalid version literal
+               ,-[Test.qasm:1:10]
+             1 | OPENQASM (2 + 3);
+               :          ^
+               `----
+        "#]],
+    );
+}


### PR DESCRIPTION
The `OPENQASM` statement parser would accept arbitrary expressions as valid versions. This PR changes that behavior to push an error in the non-valid cases.