### PR TITLE
OpenQASM language service: add rename/definition/references, semantic passes, and VS Code wiring

### DIFF
--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -1457,12 +1457,10 @@ impl QasmCompiler {
         // when closing over a constant value we will have a const value
         // associated with the symbol, but due to scoping rule differences
         // we have to "copy" the value into the usage.
-        if let Some(value) = symbol.get_const_value() {
-            self.compile_literal_expr(&value, span)
-        } else {
-            // todo: err?
-            build_path_ident_expr(&symbol.name, span, span)
-        }
+        let Some(value) = symbol.get_const_value() else {
+            unreachable!("captured ident exprs should always have a const value");
+        };
+        self.compile_literal_expr(&value, span)
     }
 
     fn compile_ident_expr(&mut self, symbol_id: SymbolId, span: Span) -> qsast::Expr {

--- a/source/compiler/qsc_qasm/src/compiler.rs
+++ b/source/compiler/qsc_qasm/src/compiler.rs
@@ -606,6 +606,7 @@ impl QasmCompiler {
                 span: stmt.rhs.span,
                 ty: Type::BitArray(width, false),
                 expr: stmt.lhs.clone(),
+                kind: semast::CastKind::Implicit,
             })),
             const_value: None,
             ty: Type::BitArray(width, false),

--- a/source/compiler/qsc_qasm/src/semantic.rs
+++ b/source/compiler/qsc_qasm/src/semantic.rs
@@ -18,8 +18,10 @@ pub mod error;
 mod lowerer;
 pub use error::Error;
 pub use error::SemanticErrorKind;
+pub mod passes;
 pub mod symbols;
 pub mod types;
+pub mod visit;
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/source/compiler/qsc_qasm/src/semantic.rs
+++ b/source/compiler/qsc_qasm/src/semantic.rs
@@ -12,7 +12,7 @@ use qsc_frontend::error::WithSource;
 
 use std::sync::Arc;
 
-pub(crate) mod ast;
+pub mod ast;
 pub(crate) mod const_eval;
 pub mod error;
 mod lowerer;

--- a/source/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/source/compiler/qsc_qasm/src/semantic/ast.rs
@@ -1082,6 +1082,7 @@ pub enum ExprKind {
     /// An expression with invalid syntax that can't be parsed.
     #[default]
     Err,
+    CapturedIdent(SymbolId),
     Ident(SymbolId),
     UnaryOp(UnaryOpExpr),
     BinaryOp(BinaryOpExpr),
@@ -1099,6 +1100,7 @@ impl Display for ExprKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             ExprKind::Err => write!(f, "Err"),
+            ExprKind::CapturedIdent(id) => write!(f, "CapturedSymbolId({id})"),
             ExprKind::Ident(id) => write!(f, "SymbolId({id})"),
             ExprKind::UnaryOp(expr) => write!(f, "{expr}"),
             ExprKind::BinaryOp(expr) => write!(f, "{expr}"),

--- a/source/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/source/compiler/qsc_qasm/src/semantic/ast.rs
@@ -1246,18 +1246,35 @@ impl Display for BuiltinFunctionCall {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CastKind {
+    Explicit,
+    Implicit,
+}
+
+impl Display for CastKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            CastKind::Explicit => write!(f, "Explicit"),
+            CastKind::Implicit => write!(f, "Implicit"),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Cast {
     pub span: Span,
     pub ty: crate::semantic::types::Type,
     pub expr: Expr,
+    pub kind: CastKind,
 }
 
 impl Display for Cast {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln_header(f, "Cast", self.span)?;
         writeln_field(f, "ty", &self.ty)?;
-        write_field(f, "expr", &self.expr)
+        writeln_field(f, "expr", &self.expr)?;
+        write_field(f, "kind", &self.kind)
     }
 }
 

--- a/source/compiler/qsc_qasm/src/semantic/ast.rs
+++ b/source/compiler/qsc_qasm/src/semantic/ast.rs
@@ -497,6 +497,7 @@ impl Display for Expr {
 }
 
 impl Expr {
+    #[must_use]
     pub fn new(span: Span, kind: ExprKind, ty: super::types::Type) -> Self {
         Self {
             span,
@@ -506,6 +507,7 @@ impl Expr {
         }
     }
 
+    #[must_use]
     pub fn int(val: i64, span: Span) -> Self {
         let val = LiteralKind::Int(val);
         Expr {
@@ -516,6 +518,7 @@ impl Expr {
         }
     }
 
+    #[must_use]
     pub fn uint(val: i64, span: Span) -> Self {
         let val = LiteralKind::Int(val);
         Expr {
@@ -526,6 +529,7 @@ impl Expr {
         }
     }
 
+    #[must_use]
     pub fn float(val: f64, span: Span) -> Self {
         let val = LiteralKind::Float(val);
         Expr {
@@ -536,6 +540,7 @@ impl Expr {
         }
     }
 
+    #[must_use]
     pub fn builtin_funcall(
         name: &str,
         span: Span,
@@ -564,6 +569,7 @@ impl Expr {
         }
     }
 
+    #[must_use]
     pub fn bin_op(op: BinOp, lhs: Self, rhs: Self) -> Self {
         let ty = lhs.ty.clone();
         let span = Span {
@@ -1171,6 +1177,7 @@ pub struct BinaryOpExpr {
 }
 
 impl BinaryOpExpr {
+    #[must_use]
     pub fn span(&self) -> Span {
         Span {
             lo: self.lhs.span.lo,
@@ -1439,6 +1446,7 @@ pub enum Index {
 }
 
 impl Index {
+    #[must_use]
     pub fn span(&self) -> Span {
         match self {
             Index::Expr(expr) => expr.span,

--- a/source/compiler/qsc_qasm/src/semantic/const_eval.rs
+++ b/source/compiler/qsc_qasm/src/semantic/const_eval.rs
@@ -99,7 +99,9 @@ impl Expr {
         }
 
         match &*self.kind {
-            ExprKind::Ident(symbol_id) => symbol_id.const_eval(ctx),
+            ExprKind::CapturedIdent(symbol_id) | ExprKind::Ident(symbol_id) => {
+                symbol_id.const_eval(ctx)
+            }
             ExprKind::UnaryOp(unary_op_expr) => unary_op_expr.const_eval(ctx),
             ExprKind::BinaryOp(binary_op_expr) => binary_op_expr.const_eval(ctx),
             ExprKind::Lit(literal_kind) => Some(literal_kind.clone()),

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -925,8 +925,8 @@ impl Lowerer {
             && is_symbol_declaration_outside_gate_or_function_scope;
 
         let kind = if need_to_capture_symbol && symbol.ty.is_const() {
-            if let Some(val) = symbol.get_const_value() {
-                semantic::ExprKind::Lit(val)
+            if symbol.get_const_value().is_some() {
+                semantic::ExprKind::CapturedIdent(symbol_id)
             } else {
                 // If the const evaluation fails, we return Err but don't push
                 // any additional error. The error was already pushed in the
@@ -3991,16 +3991,10 @@ impl Lowerer {
             // const_eval will push any needed errors
             let lowered_expr = lowered_expr.with_const_value(self);
 
-            let lit = lowered_expr.get_const_value()?;
+            // fail the lowering if we couldn't evaluate the const value
+            let _ = lowered_expr.get_const_value()?;
 
-            Some(
-                semantic::Expr::new(
-                    lowered_expr.span,
-                    semantic::ExprKind::Lit(lit.clone()),
-                    Type::Int(None, true),
-                )
-                .with_const_value(self),
-            )
+            Some(lowered_expr)
         };
 
         let start = range.start.as_ref().map(&mut lower_and_const_eval);

--- a/source/compiler/qsc_qasm/src/semantic/passes.rs
+++ b/source/compiler/qsc_qasm/src/semantic/passes.rs
@@ -1,0 +1,372 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(test)]
+mod tests;
+
+use qsc_data_structures::span::Span;
+
+use crate::semantic::{
+    ast::{
+        AliasDeclStmt, ClassicalDeclarationStmt, DefStmt, Expr, ExprKind, ExternDecl, ForStmt,
+        FunctionCall, GateCall, InputDeclaration, OutputDeclaration, Program,
+        QuantumGateDefinition, QubitArrayDeclaration, QubitDeclaration,
+    },
+    symbols::{self, SymbolId},
+    visit::{
+        Visitor, walk_alias_decl_stmt, walk_classical_decl_stmt, walk_def_stmt, walk_expr,
+        walk_extern_decl, walk_for_stmt, walk_function_call_expr, walk_gate_call_stmt,
+        walk_input_declaration, walk_output_declaration, walk_quantum_gate_definition,
+        walk_qubit_array_decl, walk_qubit_decl,
+    },
+};
+
+pub struct ReferenceFinder<'a> {
+    references: Vec<Span>,
+    id: SymbolId,
+    symbol_table: &'a symbols::SymbolTable,
+}
+
+impl<'a> ReferenceFinder<'a> {
+    fn new(id: SymbolId, symbol_table: &'a symbols::SymbolTable) -> Self {
+        Self {
+            references: Vec::new(),
+            id,
+            symbol_table,
+        }
+    }
+
+    /// Visits the block and accumulates the references of all relevant
+    /// statements that have a reference.
+    /// Returns the total references of all statements in the block.
+    #[must_use]
+    pub fn get_references(
+        scope: &Program,
+        id: SymbolId,
+        symbol_table: &symbols::SymbolTable,
+    ) -> Vec<Span> {
+        let mut accumulator = ReferenceFinder::new(id, symbol_table);
+        accumulator.visit_program(scope);
+        accumulator.references
+    }
+}
+
+impl Visitor for ReferenceFinder<'_> {
+    fn visit_alias_decl_stmt(&mut self, stmt: &AliasDeclStmt) {
+        if self.id == stmt.symbol_id {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+            // we just saw that the decl id is this target id,
+            // so we can skip visiting the rest of the declaration
+            return;
+        }
+        walk_alias_decl_stmt(self, stmt);
+    }
+
+    fn visit_classical_decl_stmt(&mut self, stmt: &ClassicalDeclarationStmt) {
+        if self.id == stmt.symbol_id {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+            // we just saw that the decl id is this target id,
+            // so we can skip visiting the rest of the declaration
+            return;
+        }
+        walk_classical_decl_stmt(self, stmt);
+    }
+
+    fn visit_def_stmt(&mut self, stmt: &DefStmt) {
+        if self.id == stmt.symbol_id {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+        }
+        stmt.params.iter().for_each(|id| {
+            if self.id == *id {
+                let symbol = &self.symbol_table[self.id];
+                self.references.push(symbol.span);
+            }
+        });
+        // function calls can be recursive, so we need to visit the body looking for references
+        // to the target id.
+        walk_def_stmt(self, stmt);
+    }
+
+    fn visit_extern_decl(&mut self, stmt: &ExternDecl) {
+        if self.id == stmt.symbol_id {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+            // we just saw that the decl id is this target id,
+            // so we can skip visiting the rest of the declaration
+            return;
+        }
+        walk_extern_decl(self, stmt);
+    }
+
+    fn visit_for_stmt(&mut self, stmt: &ForStmt) {
+        if self.id == stmt.loop_variable {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+        }
+        walk_for_stmt(self, stmt);
+    }
+
+    fn visit_gate_call_stmt(&mut self, stmt: &GateCall) {
+        if self.id == stmt.symbol_id {
+            self.references.push(stmt.gate_name_span);
+            // we just saw that the decl id is this target id,
+            // so we can skip visiting the rest of the declaration
+            // as gate calls cannot take gate calls as parameters,
+            return;
+        }
+        walk_gate_call_stmt(self, stmt);
+    }
+
+    fn visit_input_declaration(&mut self, stmt: &InputDeclaration) {
+        if self.id == stmt.symbol_id {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+            // we just saw that the decl id is this target id,
+            // so we can skip visiting the rest of the declaration.
+            return;
+        }
+        walk_input_declaration(self, stmt);
+    }
+
+    fn visit_output_declaration(&mut self, stmt: &OutputDeclaration) {
+        if self.id == stmt.symbol_id {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+            // we just saw that the decl id is this target id,
+            // so we can skip visiting the rest of the declaration.
+            return;
+        }
+        walk_output_declaration(self, stmt);
+    }
+
+    fn visit_quantum_gate_definition(&mut self, stmt: &QuantumGateDefinition) {
+        if self.id == stmt.symbol_id {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+            // gates can't be recursive, and we just saw that the id is this gate's id,
+            // so we can skip visiting the body.
+            // This is an optimization to avoid unnecessary recursion.
+            return;
+        }
+        // for params and qubits, we are looking at the original definition,
+        // so we use the symbol table to find the symbol and its span.
+        stmt.params.iter().for_each(|id| {
+            if self.id == *id {
+                let symbol = &self.symbol_table[self.id];
+                self.references.push(symbol.span);
+            }
+        });
+        stmt.qubits.iter().for_each(|id| {
+            if self.id == *id {
+                let symbol = &self.symbol_table[self.id];
+                self.references.push(symbol.span);
+            }
+        });
+        walk_quantum_gate_definition(self, stmt);
+    }
+
+    fn visit_qubit_decl(&mut self, stmt: &QubitDeclaration) {
+        if self.id == stmt.symbol_id {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+        }
+        walk_qubit_decl(self, stmt);
+    }
+
+    fn visit_qubit_array_decl(&mut self, stmt: &QubitArrayDeclaration) {
+        if self.id == stmt.symbol_id {
+            let symbol = &self.symbol_table[self.id];
+            self.references.push(symbol.span);
+        }
+        walk_qubit_array_decl(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        if let ExprKind::Ident(id) = expr.kind.as_ref() {
+            if self.id == *id {
+                self.references.push(expr.span);
+            }
+        }
+        walk_expr(self, expr);
+    }
+
+    fn visit_function_call_expr(&mut self, expr: &FunctionCall) {
+        if self.id == expr.symbol_id {
+            self.references.push(expr.fn_name_span);
+        }
+        walk_function_call_expr(self, expr);
+    }
+}
+
+pub struct SymbolFinder<'a> {
+    symbol_id: Option<SymbolId>,
+    offset: u32,
+    symbol_table: &'a symbols::SymbolTable,
+}
+
+impl<'a> SymbolFinder<'a> {
+    fn new(offset: u32, symbol_table: &'a symbols::SymbolTable) -> Self {
+        Self {
+            symbol_id: None,
+            offset,
+            symbol_table,
+        }
+    }
+
+    #[must_use]
+    pub fn get_symbol_at_offset(
+        scope: &Program,
+        offset: u32,
+        symbol_table: &symbols::SymbolTable,
+    ) -> Option<SymbolId> {
+        let mut accumulator = SymbolFinder::new(offset, symbol_table);
+        accumulator.visit_program(scope);
+        accumulator.symbol_id
+    }
+}
+
+impl Visitor for SymbolFinder<'_> {
+    fn visit_alias_decl_stmt(&mut self, stmt: &AliasDeclStmt) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+        walk_alias_decl_stmt(self, stmt);
+    }
+
+    fn visit_classical_decl_stmt(&mut self, stmt: &ClassicalDeclarationStmt) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+        walk_classical_decl_stmt(self, stmt);
+    }
+
+    fn visit_def_stmt(&mut self, stmt: &DefStmt) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+        stmt.params.iter().for_each(|id| {
+            let symbol = &self.symbol_table[*id];
+            if symbol.span.touches(self.offset) {
+                self.symbol_id = Some(*id);
+            }
+        });
+        // function calls can be recursive, so we need to visit the body looking for references
+        // to the target id.
+        walk_def_stmt(self, stmt);
+    }
+
+    fn visit_extern_decl(&mut self, stmt: &ExternDecl) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+        walk_extern_decl(self, stmt);
+    }
+
+    fn visit_for_stmt(&mut self, stmt: &ForStmt) {
+        let symbol = &self.symbol_table[stmt.loop_variable];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.loop_variable);
+            return;
+        }
+        walk_for_stmt(self, stmt);
+    }
+
+    fn visit_gate_call_stmt(&mut self, stmt: &GateCall) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+        walk_gate_call_stmt(self, stmt);
+    }
+
+    fn visit_input_declaration(&mut self, stmt: &InputDeclaration) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+        walk_input_declaration(self, stmt);
+    }
+
+    fn visit_output_declaration(&mut self, stmt: &OutputDeclaration) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+        walk_output_declaration(self, stmt);
+    }
+
+    fn visit_quantum_gate_definition(&mut self, stmt: &QuantumGateDefinition) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+        // for params and qubits, we are looking at the original definition,
+        // so we use the symbol table to find the symbol and its span.
+        stmt.params.iter().for_each(|id| {
+            let symbol = &self.symbol_table[*id];
+            if symbol.span.touches(self.offset) {
+                self.symbol_id = Some(*id);
+            }
+        });
+        stmt.qubits.iter().for_each(|id| {
+            let symbol = &self.symbol_table[*id];
+            if symbol.span.touches(self.offset) {
+                self.symbol_id = Some(*id);
+            }
+        });
+        walk_quantum_gate_definition(self, stmt);
+    }
+
+    fn visit_qubit_decl(&mut self, stmt: &QubitDeclaration) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+
+        walk_qubit_decl(self, stmt);
+    }
+
+    fn visit_qubit_array_decl(&mut self, stmt: &QubitArrayDeclaration) {
+        let symbol = &self.symbol_table[stmt.symbol_id];
+        if symbol.span.touches(self.offset) {
+            self.symbol_id = Some(stmt.symbol_id);
+            return;
+        }
+
+        walk_qubit_array_decl(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        if let ExprKind::Ident(id) = expr.kind.as_ref() {
+            if expr.span.touches(self.offset) {
+                self.symbol_id = Some(*id);
+                return;
+            }
+        }
+        walk_expr(self, expr);
+    }
+
+    fn visit_function_call_expr(&mut self, expr: &FunctionCall) {
+        if expr.fn_name_span.contains(self.offset) {
+            self.symbol_id = Some(expr.symbol_id);
+            return;
+        }
+        walk_function_call_expr(self, expr);
+    }
+}

--- a/source/compiler/qsc_qasm/src/semantic/passes.rs
+++ b/source/compiler/qsc_qasm/src/semantic/passes.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#[cfg(test)]
-mod tests;
-
 use qsc_data_structures::span::Span;
 
 use crate::semantic::{

--- a/source/compiler/qsc_qasm/src/semantic/passes.rs
+++ b/source/compiler/qsc_qasm/src/semantic/passes.rs
@@ -231,7 +231,7 @@ impl<'a> SymbolFinder<'a> {
 impl Visitor for SymbolFinder<'_> {
     fn visit_alias_decl_stmt(&mut self, stmt: &AliasDeclStmt) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -240,7 +240,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_classical_decl_stmt(&mut self, stmt: &ClassicalDeclarationStmt) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -249,13 +249,13 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_def_stmt(&mut self, stmt: &DefStmt) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
         stmt.params.iter().for_each(|id| {
             let symbol = &self.symbol_table[*id];
-            if symbol.span.touches(self.offset) {
+            if symbol.span.contains(self.offset) {
                 self.symbol_id = Some(*id);
             }
         });
@@ -266,7 +266,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_extern_decl(&mut self, stmt: &ExternDecl) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -275,7 +275,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_for_stmt(&mut self, stmt: &ForStmt) {
         let symbol = &self.symbol_table[stmt.loop_variable];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.loop_variable);
             return;
         }
@@ -283,8 +283,7 @@ impl Visitor for SymbolFinder<'_> {
     }
 
     fn visit_gate_call_stmt(&mut self, stmt: &GateCall) {
-        let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if stmt.gate_name_span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -293,7 +292,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_input_declaration(&mut self, stmt: &InputDeclaration) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -302,7 +301,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_output_declaration(&mut self, stmt: &OutputDeclaration) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -311,7 +310,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_quantum_gate_definition(&mut self, stmt: &QuantumGateDefinition) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -319,13 +318,13 @@ impl Visitor for SymbolFinder<'_> {
         // so we use the symbol table to find the symbol and its span.
         stmt.params.iter().for_each(|id| {
             let symbol = &self.symbol_table[*id];
-            if symbol.span.touches(self.offset) {
+            if symbol.span.contains(self.offset) {
                 self.symbol_id = Some(*id);
             }
         });
         stmt.qubits.iter().for_each(|id| {
             let symbol = &self.symbol_table[*id];
-            if symbol.span.touches(self.offset) {
+            if symbol.span.contains(self.offset) {
                 self.symbol_id = Some(*id);
             }
         });
@@ -334,7 +333,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_qubit_decl(&mut self, stmt: &QubitDeclaration) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -344,7 +343,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_qubit_array_decl(&mut self, stmt: &QubitArrayDeclaration) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.touches(self.offset) {
+        if symbol.span.contains(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -354,7 +353,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_expr(&mut self, expr: &Expr) {
         if let ExprKind::Ident(id) = expr.kind.as_ref() {
-            if expr.span.touches(self.offset) {
+            if expr.span.contains(self.offset) {
                 self.symbol_id = Some(*id);
                 return;
             }

--- a/source/compiler/qsc_qasm/src/semantic/passes.rs
+++ b/source/compiler/qsc_qasm/src/semantic/passes.rs
@@ -231,7 +231,7 @@ impl<'a> SymbolFinder<'a> {
 impl Visitor for SymbolFinder<'_> {
     fn visit_alias_decl_stmt(&mut self, stmt: &AliasDeclStmt) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -240,7 +240,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_classical_decl_stmt(&mut self, stmt: &ClassicalDeclarationStmt) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -249,13 +249,13 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_def_stmt(&mut self, stmt: &DefStmt) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
         stmt.params.iter().for_each(|id| {
             let symbol = &self.symbol_table[*id];
-            if symbol.span.contains(self.offset) {
+            if symbol.span.touches(self.offset) {
                 self.symbol_id = Some(*id);
             }
         });
@@ -266,7 +266,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_extern_decl(&mut self, stmt: &ExternDecl) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -275,7 +275,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_for_stmt(&mut self, stmt: &ForStmt) {
         let symbol = &self.symbol_table[stmt.loop_variable];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.loop_variable);
             return;
         }
@@ -283,7 +283,7 @@ impl Visitor for SymbolFinder<'_> {
     }
 
     fn visit_gate_call_stmt(&mut self, stmt: &GateCall) {
-        if stmt.gate_name_span.contains(self.offset) {
+        if stmt.gate_name_span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -292,7 +292,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_input_declaration(&mut self, stmt: &InputDeclaration) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -301,7 +301,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_output_declaration(&mut self, stmt: &OutputDeclaration) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -310,7 +310,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_quantum_gate_definition(&mut self, stmt: &QuantumGateDefinition) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -318,13 +318,13 @@ impl Visitor for SymbolFinder<'_> {
         // so we use the symbol table to find the symbol and its span.
         stmt.params.iter().for_each(|id| {
             let symbol = &self.symbol_table[*id];
-            if symbol.span.contains(self.offset) {
+            if symbol.span.touches(self.offset) {
                 self.symbol_id = Some(*id);
             }
         });
         stmt.qubits.iter().for_each(|id| {
             let symbol = &self.symbol_table[*id];
-            if symbol.span.contains(self.offset) {
+            if symbol.span.touches(self.offset) {
                 self.symbol_id = Some(*id);
             }
         });
@@ -333,7 +333,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_qubit_decl(&mut self, stmt: &QubitDeclaration) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -343,7 +343,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_qubit_array_decl(&mut self, stmt: &QubitArrayDeclaration) {
         let symbol = &self.symbol_table[stmt.symbol_id];
-        if symbol.span.contains(self.offset) {
+        if symbol.span.touches(self.offset) {
             self.symbol_id = Some(stmt.symbol_id);
             return;
         }
@@ -353,7 +353,7 @@ impl Visitor for SymbolFinder<'_> {
 
     fn visit_expr(&mut self, expr: &Expr) {
         if let ExprKind::Ident(id) = expr.kind.as_ref() {
-            if expr.span.contains(self.offset) {
+            if expr.span.touches(self.offset) {
                 self.symbol_id = Some(*id);
                 return;
             }
@@ -362,7 +362,7 @@ impl Visitor for SymbolFinder<'_> {
     }
 
     fn visit_function_call_expr(&mut self, expr: &FunctionCall) {
-        if expr.fn_name_span.contains(self.offset) {
+        if expr.fn_name_span.touches(self.offset) {
             self.symbol_id = Some(expr.symbol_id);
             return;
         }

--- a/source/compiler/qsc_qasm/src/semantic/passes/tests.rs
+++ b/source/compiler/qsc_qasm/src/semantic/passes/tests.rs
@@ -1,2 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.

--- a/source/compiler/qsc_qasm/src/semantic/passes/tests.rs
+++ b/source/compiler/qsc_qasm/src/semantic/passes/tests.rs
@@ -1,0 +1,2 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.

--- a/source/compiler/qsc_qasm/src/semantic/tests.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests.rs
@@ -221,11 +221,12 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                                         kind: SymbolId(41)
                                     rhs: Expr [225-226]:
                                         ty: bool
-                                        kind: Cast [0-0]:
+                                        kind: Cast [225-226]:
                                             ty: bool
                                             expr: Expr [225-226]:
                                                 ty: bit
                                                 kind: SymbolId(40)
+                                            kind: Implicit
                     Stmt [140-154]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [140-154]:
@@ -248,11 +249,12 @@ fn semantic_errors_map_to_their_corresponding_file_specific_spans() {
                                         kind: SymbolId(42)
                                     rhs: Expr [173-178]:
                                         ty: float
-                                        kind: Cast [0-0]:
+                                        kind: Cast [173-178]:
                                             ty: float
                                             expr: Expr [173-178]:
                                                 ty: const bool
                                                 kind: Lit: Bool(false)
+                                            kind: Implicit
                     Stmt [74-84]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [74-84]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/assignment.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/assignment.rs
@@ -32,52 +32,58 @@ fn too_many_indices_in_indexed_assignment() {
                                             kind: Lit:     array:
                                                     Expr [45-48]:
                                                         ty: float[32]
-                                                        kind: Cast [0-0]:
+                                                        kind: Cast [45-48]:
                                                             ty: float[32]
                                                             expr: Expr [45-48]:
                                                                 ty: const float
                                                                 kind: Lit: Float(1.1)
+                                                            kind: Implicit
                                                     Expr [50-53]:
                                                         ty: float[32]
-                                                        kind: Cast [0-0]:
+                                                        kind: Cast [50-53]:
                                                             ty: float[32]
                                                             expr: Expr [50-53]:
                                                                 ty: const float
                                                                 kind: Lit: Float(1.2)
+                                                            kind: Implicit
                                         Expr [56-66]:
                                             ty: array[float[32], 2]
                                             kind: Lit:     array:
                                                     Expr [57-60]:
                                                         ty: float[32]
-                                                        kind: Cast [0-0]:
+                                                        kind: Cast [57-60]:
                                                             ty: float[32]
                                                             expr: Expr [57-60]:
                                                                 ty: const float
                                                                 kind: Lit: Float(2.1)
+                                                            kind: Implicit
                                                     Expr [62-65]:
                                                         ty: float[32]
-                                                        kind: Cast [0-0]:
+                                                        kind: Cast [62-65]:
                                                             ty: float[32]
                                                             expr: Expr [62-65]:
                                                                 ty: const float
                                                                 kind: Lit: Float(2.2)
+                                                            kind: Implicit
                                         Expr [68-78]:
                                             ty: array[float[32], 2]
                                             kind: Lit:     array:
                                                     Expr [69-72]:
                                                         ty: float[32]
-                                                        kind: Cast [0-0]:
+                                                        kind: Cast [69-72]:
                                                             ty: float[32]
                                                             expr: Expr [69-72]:
                                                                 ty: const float
                                                                 kind: Lit: Float(3.1)
+                                                            kind: Implicit
                                                     Expr [74-77]:
                                                         ty: float[32]
-                                                        kind: Cast [0-0]:
+                                                        kind: Cast [74-77]:
                                                             ty: float[32]
                                                             expr: Expr [74-77]:
                                                                 ty: const float
                                                                 kind: Lit: Float(3.2)
+                                                            kind: Implicit
                     Stmt [89-113]:
                         annotations: <empty>
                         kind: AssignStmt [89-113]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/angle.rs
@@ -367,7 +367,7 @@ fn const_lit_decl_signed_float_lit_cast_neg() {
                 init_expr: Expr [17-19]:
                     ty: const angle
                     const_value: Angle(5.5663706143591725)
-                    kind: Cast [0-0]:
+                    kind: Cast [17-19]:
                         ty: const angle
                         expr: Expr [17-19]:
                             ty: const float
@@ -376,6 +376,7 @@ fn const_lit_decl_signed_float_lit_cast_neg() {
                                 expr: Expr [17-19]:
                                     ty: const float
                                     kind: Lit: Float(7.0)
+                        kind: Implicit
             [8] Symbol [12-13]:
                 name: x
                 type: const angle

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/complex.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/complex.rs
@@ -332,7 +332,7 @@ fn implicit_bitness_simple_double_neg_real() {
                         op: Add
                         lhs: Expr [20-23]:
                             ty: const complex[float]
-                            kind: Cast [0-0]:
+                            kind: Cast [20-23]:
                                 ty: const complex[float]
                                 expr: Expr [20-23]:
                                     ty: const float
@@ -341,6 +341,7 @@ fn implicit_bitness_simple_double_neg_real() {
                                         expr: Expr [20-23]:
                                             ty: const float
                                             kind: Lit: Float(1.1)
+                                kind: Implicit
                         rhs: Expr [26-31]:
                             ty: const complex[float]
                             kind: Lit: Complex(0.0, 2.2)
@@ -367,7 +368,7 @@ fn const_implicit_bitness_simple_double_neg_real() {
                         op: Add
                         lhs: Expr [26-29]:
                             ty: const complex[float]
-                            kind: Cast [0-0]:
+                            kind: Cast [26-29]:
                                 ty: const complex[float]
                                 expr: Expr [26-29]:
                                     ty: const float
@@ -376,6 +377,7 @@ fn const_implicit_bitness_simple_double_neg_real() {
                                         expr: Expr [26-29]:
                                             ty: const float
                                             kind: Lit: Float(1.1)
+                                kind: Implicit
                         rhs: Expr [32-37]:
                             ty: const complex[float]
                             kind: Lit: Complex(0.0, 2.2)

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/float.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/float.rs
@@ -391,7 +391,7 @@ fn const_lit_decl_signed_int_lit_cast_neg() {
                 init_expr: Expr [17-18]:
                     ty: const float
                     const_value: Float(-7.0)
-                    kind: Cast [0-0]:
+                    kind: Cast [17-18]:
                         ty: const float
                         expr: Expr [17-18]:
                             ty: const int
@@ -400,6 +400,7 @@ fn const_lit_decl_signed_int_lit_cast_neg() {
                                 expr: Expr [17-18]:
                                     ty: const int
                                     kind: Lit: Int(7)
+                        kind: Implicit
             [8] Symbol [12-13]:
                 name: x
                 type: const float
@@ -471,7 +472,7 @@ fn init_float_with_int_value_equal_min_safely_representable_values() {
                 ty_span: [0-5]
                 init_expr: Expr [11-27]:
                     ty: float
-                    kind: Cast [0-0]:
+                    kind: Cast [11-27]:
                         ty: float
                         expr: Expr [11-27]:
                             ty: const int
@@ -480,6 +481,7 @@ fn init_float_with_int_value_equal_min_safely_representable_values() {
                                 expr: Expr [11-27]:
                                     ty: const int
                                     kind: Lit: Int(9007199254740992)
+                        kind: Implicit
             [8] Symbol [6-7]:
                 name: a
                 type: float

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/int.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/int.rs
@@ -374,7 +374,7 @@ fn implicit_bitness_int_negative_float_decl_is_runtime_conversion() {
                 ty_span: [0-3]
                 init_expr: Expr [9-12]:
                     ty: int
-                    kind: Cast [0-0]:
+                    kind: Cast [9-12]:
                         ty: int
                         expr: Expr [9-12]:
                             ty: const float
@@ -383,6 +383,7 @@ fn implicit_bitness_int_negative_float_decl_is_runtime_conversion() {
                                 expr: Expr [9-12]:
                                     ty: const float
                                     kind: Lit: Float(42.0)
+                        kind: Implicit
             [8] Symbol [4-5]:
                 name: x
                 type: int

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/uint.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/uint.rs
@@ -328,7 +328,7 @@ fn assigning_uint_to_negative_lit() {
                 init_expr: Expr [20-22]:
                     ty: const uint[10]
                     const_value: Int(-42)
-                    kind: Cast [0-0]:
+                    kind: Cast [20-22]:
                         ty: const uint[10]
                         expr: Expr [20-22]:
                             ty: const int
@@ -337,6 +337,7 @@ fn assigning_uint_to_negative_lit() {
                                 expr: Expr [20-22]:
                                     ty: const int
                                     kind: Lit: Int(42)
+                        kind: Implicit
             [8] Symbol [15-16]:
                 name: x
                 type: const uint[10]
@@ -356,7 +357,7 @@ fn implicit_bitness_uint_const_negative_decl() {
                 init_expr: Expr [16-18]:
                     ty: const uint
                     const_value: Int(-42)
-                    kind: Cast [0-0]:
+                    kind: Cast [16-18]:
                         ty: const uint
                         expr: Expr [16-18]:
                             ty: const int
@@ -365,6 +366,7 @@ fn implicit_bitness_uint_const_negative_decl() {
                                 expr: Expr [16-18]:
                                     ty: const int
                                     kind: Lit: Int(42)
+                        kind: Implicit
             [8] Symbol [11-12]:
                 name: x
                 type: const uint
@@ -384,7 +386,7 @@ fn explicit_bitness_uint_const_negative_decl() {
                 init_expr: Expr [20-22]:
                     ty: const uint[32]
                     const_value: Int(-42)
-                    kind: Cast [0-0]:
+                    kind: Cast [20-22]:
                         ty: const uint[32]
                         expr: Expr [20-22]:
                             ty: const int
@@ -393,6 +395,7 @@ fn explicit_bitness_uint_const_negative_decl() {
                                 expr: Expr [20-22]:
                                     ty: const int
                                     kind: Lit: Int(42)
+                        kind: Implicit
             [8] Symbol [15-16]:
                 name: x
                 type: const uint[32]

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/arithmetic_conversions.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/arithmetic_conversions.rs
@@ -111,11 +111,12 @@ fn int_idents_with_different_width_can_be_multiplied() {
                         op: Mul
                         lhs: Expr [55-56]:
                             ty: int[64]
-                            kind: Cast [0-0]:
+                            kind: Cast [55-56]:
                                 ty: int[64]
                                 expr: Expr [55-56]:
                                     ty: int[32]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [59-60]:
                             ty: int[64]
                             kind: SymbolId(9)
@@ -155,11 +156,12 @@ fn multiplying_int_idents_with_different_width_result_in_higher_width_result() {
                         op: Mul
                         lhs: Expr [67-68]:
                             ty: int[64]
-                            kind: Cast [0-0]:
+                            kind: Cast [67-68]:
                                 ty: int[64]
                                 expr: Expr [67-68]:
                                     ty: int[32]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [71-72]:
                             ty: int[64]
                             kind: SymbolId(9)
@@ -195,7 +197,7 @@ fn multiplying_int_idents_with_different_width_result_in_no_width_result() {
                 ty_span: [55-58]
                 init_expr: Expr [63-68]:
                     ty: int
-                    kind: Cast [0-0]:
+                    kind: Cast [63-68]:
                         ty: int
                         expr: Expr [63-68]:
                             ty: int[64]
@@ -203,14 +205,16 @@ fn multiplying_int_idents_with_different_width_result_in_no_width_result() {
                                 op: Mul
                                 lhs: Expr [63-64]:
                                     ty: int[64]
-                                    kind: Cast [0-0]:
+                                    kind: Cast [63-64]:
                                         ty: int[64]
                                         expr: Expr [63-64]:
                                             ty: int[32]
                                             kind: SymbolId(8)
+                                        kind: Implicit
                                 rhs: Expr [67-68]:
                                     ty: int[64]
                                     kind: SymbolId(9)
+                        kind: Implicit
         "#]],
     );
 }
@@ -243,7 +247,7 @@ fn multiplying_int_idents_with_width_greater_than_64_result_in_bigint_result() {
                 ty_span: [55-62]
                 init_expr: Expr [67-72]:
                     ty: int[67]
-                    kind: Cast [0-0]:
+                    kind: Cast [67-72]:
                         ty: int[67]
                         expr: Expr [67-72]:
                             ty: int[64]
@@ -251,14 +255,16 @@ fn multiplying_int_idents_with_width_greater_than_64_result_in_bigint_result() {
                                 op: Mul
                                 lhs: Expr [67-68]:
                                     ty: int[64]
-                                    kind: Cast [0-0]:
+                                    kind: Cast [67-68]:
                                         ty: int[64]
                                         expr: Expr [67-68]:
                                             ty: int[32]
                                             kind: SymbolId(8)
+                                        kind: Implicit
                                 rhs: Expr [71-72]:
                                     ty: int[64]
                                     kind: SymbolId(9)
+                        kind: Implicit
         "#]],
     );
 }
@@ -298,11 +304,12 @@ fn left_shift_casts_rhs_to_uint() {
                             kind: SymbolId(8)
                         rhs: Expr [60-61]:
                             ty: uint
-                            kind: Cast [0-0]:
+                            kind: Cast [60-61]:
                                 ty: uint
                                 expr: Expr [60-61]:
                                     ty: int
                                     kind: SymbolId(9)
+                                kind: Implicit
         "#]],
     );
 }
@@ -361,7 +368,7 @@ fn bin_op_with_const_lhs_and_non_const_rhs_sized() {
                 ty_span: [32-39]
                 init_expr: Expr [44-49]:
                     ty: int[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [44-49]:
                         ty: int[32]
                         expr: Expr [44-49]:
                             ty: int
@@ -372,11 +379,13 @@ fn bin_op_with_const_lhs_and_non_const_rhs_sized() {
                                     kind: Lit: Int(2)
                                 rhs: Expr [48-49]:
                                     ty: int
-                                    kind: Cast [0-0]:
+                                    kind: Cast [48-49]:
                                         ty: int
                                         expr: Expr [48-49]:
                                             ty: int[32]
                                             kind: SymbolId(8)
+                                        kind: Implicit
+                        kind: Implicit
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison.rs
@@ -50,18 +50,20 @@ fn bitarray_var_comparisons_can_be_translated() {
                         op: Gt
                         lhs: Expr [66-67]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [66-67]:
                                 ty: int
                                 expr: Expr [66-67]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [70-71]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [70-71]:
                                 ty: int
                                 expr: Expr [70-71]:
                                     ty: bit[1]
                                     kind: SymbolId(9)
+                                kind: Implicit
             ClassicalDeclarationStmt [81-97]:
                 symbol_id: 11
                 ty_span: [81-85]
@@ -71,18 +73,20 @@ fn bitarray_var_comparisons_can_be_translated() {
                         op: Gte
                         lhs: Expr [90-91]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [90-91]:
                                 ty: int
                                 expr: Expr [90-91]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [95-96]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [95-96]:
                                 ty: int
                                 expr: Expr [95-96]:
                                     ty: bit[1]
                                     kind: SymbolId(9)
+                                kind: Implicit
             ClassicalDeclarationStmt [106-121]:
                 symbol_id: 12
                 ty_span: [106-110]
@@ -92,18 +96,20 @@ fn bitarray_var_comparisons_can_be_translated() {
                         op: Lt
                         lhs: Expr [115-116]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [115-116]:
                                 ty: int
                                 expr: Expr [115-116]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [119-120]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [119-120]:
                                 ty: int
                                 expr: Expr [119-120]:
                                     ty: bit[1]
                                     kind: SymbolId(9)
+                                kind: Implicit
             ClassicalDeclarationStmt [130-146]:
                 symbol_id: 13
                 ty_span: [130-134]
@@ -113,18 +119,20 @@ fn bitarray_var_comparisons_can_be_translated() {
                         op: Lte
                         lhs: Expr [139-140]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [139-140]:
                                 ty: int
                                 expr: Expr [139-140]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [144-145]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [144-145]:
                                 ty: int
                                 expr: Expr [144-145]:
                                     ty: bit[1]
                                     kind: SymbolId(9)
+                                kind: Implicit
             ClassicalDeclarationStmt [155-171]:
                 symbol_id: 14
                 ty_span: [155-159]
@@ -134,18 +142,20 @@ fn bitarray_var_comparisons_can_be_translated() {
                         op: Eq
                         lhs: Expr [164-165]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [164-165]:
                                 ty: int
                                 expr: Expr [164-165]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [169-170]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [169-170]:
                                 ty: int
                                 expr: Expr [169-170]:
                                     ty: bit[1]
                                     kind: SymbolId(9)
+                                kind: Implicit
             ClassicalDeclarationStmt [180-196]:
                 symbol_id: 15
                 ty_span: [180-184]
@@ -155,18 +165,20 @@ fn bitarray_var_comparisons_can_be_translated() {
                         op: Neq
                         lhs: Expr [189-190]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [189-190]:
                                 ty: int
                                 expr: Expr [189-190]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [194-195]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [194-195]:
                                 ty: int
                                 expr: Expr [194-195]:
                                     ty: bit[1]
                                     kind: SymbolId(9)
+                                kind: Implicit
         "#]],
     );
 }
@@ -211,11 +223,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                         op: Gt
                         lhs: Expr [63-64]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [63-64]:
                                 ty: int
                                 expr: Expr [63-64]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [67-68]:
                             ty: int
                             kind: SymbolId(9)
@@ -228,11 +241,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                         op: Gte
                         lhs: Expr [87-88]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [87-88]:
                                 ty: int
                                 expr: Expr [87-88]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [92-93]:
                             ty: int
                             kind: SymbolId(9)
@@ -245,11 +259,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                         op: Lt
                         lhs: Expr [112-113]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [112-113]:
                                 ty: int
                                 expr: Expr [112-113]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [116-117]:
                             ty: int
                             kind: SymbolId(9)
@@ -262,11 +277,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                         op: Lte
                         lhs: Expr [136-137]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [136-137]:
                                 ty: int
                                 expr: Expr [136-137]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [141-142]:
                             ty: int
                             kind: SymbolId(9)
@@ -279,11 +295,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                         op: Eq
                         lhs: Expr [161-162]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [161-162]:
                                 ty: int
                                 expr: Expr [161-162]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [166-167]:
                             ty: int
                             kind: SymbolId(9)
@@ -296,11 +313,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                         op: Neq
                         lhs: Expr [186-187]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [186-187]:
                                 ty: int
                                 expr: Expr [186-187]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [191-192]:
                             ty: int
                             kind: SymbolId(9)
@@ -316,11 +334,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                             kind: SymbolId(9)
                         rhs: Expr [215-216]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [215-216]:
                                 ty: int
                                 expr: Expr [215-216]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
             ClassicalDeclarationStmt [226-242]:
                 symbol_id: 17
                 ty_span: [226-230]
@@ -333,11 +352,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                             kind: SymbolId(9)
                         rhs: Expr [240-241]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [240-241]:
                                 ty: int
                                 expr: Expr [240-241]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
             ClassicalDeclarationStmt [251-266]:
                 symbol_id: 18
                 ty_span: [251-255]
@@ -350,11 +370,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                             kind: SymbolId(9)
                         rhs: Expr [264-265]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [264-265]:
                                 ty: int
                                 expr: Expr [264-265]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
             ClassicalDeclarationStmt [275-291]:
                 symbol_id: 19
                 ty_span: [275-279]
@@ -367,11 +388,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                             kind: SymbolId(9)
                         rhs: Expr [289-290]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [289-290]:
                                 ty: int
                                 expr: Expr [289-290]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
             ClassicalDeclarationStmt [300-316]:
                 symbol_id: 20
                 ty_span: [300-304]
@@ -384,11 +406,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                             kind: SymbolId(9)
                         rhs: Expr [314-315]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [314-315]:
                                 ty: int
                                 expr: Expr [314-315]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
             ClassicalDeclarationStmt [325-341]:
                 symbol_id: 21
                 ty_span: [325-329]
@@ -401,11 +424,12 @@ fn bitarray_var_comparison_to_int_can_be_translated() {
                             kind: SymbolId(9)
                         rhs: Expr [339-340]:
                             ty: int
-                            kind: Cast [0-0]:
+                            kind: Cast [339-340]:
                                 ty: int
                                 expr: Expr [339-340]:
                                     ty: bit[1]
                                     kind: SymbolId(8)
+                                kind: Implicit
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/bit_to_bit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/comparison/bit_to_bit.rs
@@ -47,18 +47,20 @@ fn logical_and() {
                         op: AndL
                         lhs: Expr [56-57]:
                             ty: bool
-                            kind: Cast [0-0]:
+                            kind: Cast [56-57]:
                                 ty: bool
                                 expr: Expr [56-57]:
                                     ty: bit
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [61-62]:
                             ty: bool
-                            kind: Cast [0-0]:
+                            kind: Cast [61-62]:
                                 ty: bool
                                 expr: Expr [61-62]:
                                     ty: bit
                                     kind: SymbolId(9)
+                                kind: Implicit
             [10] Symbol [52-53]:
                 name: a
                 type: bool
@@ -110,18 +112,20 @@ fn logical_or() {
                         op: OrL
                         lhs: Expr [56-57]:
                             ty: bool
-                            kind: Cast [0-0]:
+                            kind: Cast [56-57]:
                                 ty: bool
                                 expr: Expr [56-57]:
                                     ty: bit
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [61-62]:
                             ty: bool
-                            kind: Cast [0-0]:
+                            kind: Cast [61-62]:
                                 ty: bool
                                 expr: Expr [61-62]:
                                     ty: bit
                                     kind: SymbolId(9)
+                                kind: Implicit
             [10] Symbol [52-53]:
                 name: a
                 type: bool
@@ -177,22 +181,24 @@ fn unop_not_logical_and_unop_not() {
                                 op: NotL
                                 expr: Expr [57-58]:
                                     ty: bool
-                                    kind: Cast [0-0]:
+                                    kind: Cast [57-58]:
                                         ty: bool
                                         expr: Expr [57-58]:
                                             ty: bit
                                             kind: SymbolId(8)
+                                        kind: Implicit
                         rhs: Expr [63-64]:
                             ty: bool
                             kind: UnaryOpExpr [63-64]:
                                 op: NotL
                                 expr: Expr [63-64]:
                                     ty: bool
-                                    kind: Cast [0-0]:
+                                    kind: Cast [63-64]:
                                         ty: bool
                                         expr: Expr [63-64]:
                                             ty: bit
                                             kind: SymbolId(9)
+                                        kind: Implicit
             [10] Symbol [52-53]:
                 name: a
                 type: bool
@@ -248,22 +254,24 @@ fn unop_not_logical_or_unop_not() {
                                 op: NotL
                                 expr: Expr [57-58]:
                                     ty: bool
-                                    kind: Cast [0-0]:
+                                    kind: Cast [57-58]:
                                         ty: bool
                                         expr: Expr [57-58]:
                                             ty: bit
                                             kind: SymbolId(8)
+                                        kind: Implicit
                         rhs: Expr [63-64]:
                             ty: bool
                             kind: UnaryOpExpr [63-64]:
                                 op: NotL
                                 expr: Expr [63-64]:
                                     ty: bool
-                                    kind: Cast [0-0]:
+                                    kind: Cast [63-64]:
                                         ty: bool
                                         expr: Expr [63-64]:
                                             ty: bit
                                             kind: SymbolId(9)
+                                        kind: Implicit
             [10] Symbol [52-53]:
                 name: a
                 type: bool
@@ -319,18 +327,20 @@ fn unop_not_logical_and() {
                                 op: NotL
                                 expr: Expr [57-58]:
                                     ty: bool
-                                    kind: Cast [0-0]:
+                                    kind: Cast [57-58]:
                                         ty: bool
                                         expr: Expr [57-58]:
                                             ty: bit
                                             kind: SymbolId(8)
+                                        kind: Implicit
                         rhs: Expr [62-63]:
                             ty: bool
-                            kind: Cast [0-0]:
+                            kind: Cast [62-63]:
                                 ty: bool
                                 expr: Expr [62-63]:
                                     ty: bit
                                     kind: SymbolId(9)
+                                kind: Implicit
             [10] Symbol [52-53]:
                 name: a
                 type: bool
@@ -386,18 +396,20 @@ fn unop_not_logical_or() {
                                 op: NotL
                                 expr: Expr [57-58]:
                                     ty: bool
-                                    kind: Cast [0-0]:
+                                    kind: Cast [57-58]:
                                         ty: bool
                                         expr: Expr [57-58]:
                                             ty: bit
                                             kind: SymbolId(8)
+                                        kind: Implicit
                         rhs: Expr [62-63]:
                             ty: bool
-                            kind: Cast [0-0]:
+                            kind: Cast [62-63]:
                                 ty: bool
                                 expr: Expr [62-63]:
                                     ty: bit
                                     kind: SymbolId(9)
+                                kind: Implicit
             [10] Symbol [52-53]:
                 name: a
                 type: bool
@@ -449,22 +461,24 @@ fn logical_and_unop_not() {
                         op: AndL
                         lhs: Expr [56-57]:
                             ty: bool
-                            kind: Cast [0-0]:
+                            kind: Cast [56-57]:
                                 ty: bool
                                 expr: Expr [56-57]:
                                     ty: bit
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [62-63]:
                             ty: bool
                             kind: UnaryOpExpr [62-63]:
                                 op: NotL
                                 expr: Expr [62-63]:
                                     ty: bool
-                                    kind: Cast [0-0]:
+                                    kind: Cast [62-63]:
                                         ty: bool
                                         expr: Expr [62-63]:
                                             ty: bit
                                             kind: SymbolId(9)
+                                        kind: Implicit
             [10] Symbol [52-53]:
                 name: a
                 type: bool
@@ -516,22 +530,24 @@ fn logical_or_unop_not() {
                         op: OrL
                         lhs: Expr [56-57]:
                             ty: bool
-                            kind: Cast [0-0]:
+                            kind: Cast [56-57]:
                                 ty: bool
                                 expr: Expr [56-57]:
                                     ty: bit
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [62-63]:
                             ty: bool
                             kind: UnaryOpExpr [62-63]:
                                 op: NotL
                                 expr: Expr [62-63]:
                                     ty: bool
-                                    kind: Cast [0-0]:
+                                    kind: Cast [62-63]:
                                         ty: bool
                                         expr: Expr [62-63]:
                                             ty: bit
                                             kind: SymbolId(9)
+                                        kind: Implicit
             [10] Symbol [52-53]:
                 name: a
                 type: bool

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/ident.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/binary/ident.rs
@@ -153,11 +153,12 @@ fn const_int_idents_widthless_lhs_can_be_multiplied_by_explicit_width_int() {
                         op: Mul
                         lhs: Expr [63-64]:
                             ty: const int
-                            kind: Cast [0-0]:
+                            kind: Cast [63-64]:
                                 ty: const int
                                 expr: Expr [63-64]:
                                     ty: const int[32]
                                     kind: SymbolId(8)
+                                kind: Implicit
                         rhs: Expr [67-68]:
                             ty: const int
                             kind: SymbolId(9)

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/cos.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/cos.rs
@@ -40,30 +40,31 @@ fn cos_angle() {
     check_stmt_kinds(
         source,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-28]:
-            symbol_id: 8
-            ty_span: [15-20]
-            init_expr: Expr [25-27]:
-                ty: const angle
-                const_value: Angle(3.141592653589793)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-28]:
+                symbol_id: 8
+                ty_span: [15-20]
+                init_expr: Expr [25-27]:
                     ty: const angle
-                    expr: Expr [25-27]:
-                        ty: const float
-                        kind: SymbolId(2)
-        ExprStmt [37-44]:
-            expr: Expr [37-43]:
-                ty: const float
-                const_value: Float(-1.0)
-                kind: BuiltinFunctionCall [37-43]:
-                    fn_name_span: [37-40]
-                    name: cos
-                    function_ty: def (const angle) -> const float
-                    args:
-                        Expr [41-42]:
-                            ty: const angle
-                            const_value: Angle(3.141592653589793)
-                            kind: SymbolId(8)
-    "#]],
+                    const_value: Angle(3.141592653589793)
+                    kind: Cast [25-27]:
+                        ty: const angle
+                        expr: Expr [25-27]:
+                            ty: const float
+                            kind: SymbolId(2)
+                        kind: Implicit
+            ExprStmt [37-44]:
+                expr: Expr [37-43]:
+                    ty: const float
+                    const_value: Float(-1.0)
+                    kind: BuiltinFunctionCall [37-43]:
+                        fn_name_span: [37-40]
+                        name: cos
+                        function_ty: def (const angle) -> const float
+                        args:
+                            Expr [41-42]:
+                                ty: const angle
+                                const_value: Angle(3.141592653589793)
+                                kind: SymbolId(8)
+        "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sin.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/sin.rs
@@ -40,30 +40,31 @@ fn sin_angle() {
     check_stmt_kinds(
         source,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-28]:
-            symbol_id: 8
-            ty_span: [15-20]
-            init_expr: Expr [25-27]:
-                ty: const angle
-                const_value: Angle(3.141592653589793)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-28]:
+                symbol_id: 8
+                ty_span: [15-20]
+                init_expr: Expr [25-27]:
                     ty: const angle
-                    expr: Expr [25-27]:
-                        ty: const float
-                        kind: SymbolId(2)
-        ExprStmt [37-44]:
-            expr: Expr [37-43]:
-                ty: const float
-                const_value: Float(1.2246467991473532e-16)
-                kind: BuiltinFunctionCall [37-43]:
-                    fn_name_span: [37-40]
-                    name: sin
-                    function_ty: def (const angle) -> const float
-                    args:
-                        Expr [41-42]:
-                            ty: const angle
-                            const_value: Angle(3.141592653589793)
-                            kind: SymbolId(8)
-    "#]],
+                    const_value: Angle(3.141592653589793)
+                    kind: Cast [25-27]:
+                        ty: const angle
+                        expr: Expr [25-27]:
+                            ty: const float
+                            kind: SymbolId(2)
+                        kind: Implicit
+            ExprStmt [37-44]:
+                expr: Expr [37-43]:
+                    ty: const float
+                    const_value: Float(1.2246467991473532e-16)
+                    kind: BuiltinFunctionCall [37-43]:
+                        fn_name_span: [37-40]
+                        name: sin
+                        function_ty: def (const angle) -> const float
+                        args:
+                            Expr [41-42]:
+                                ty: const angle
+                                const_value: Angle(3.141592653589793)
+                                kind: SymbolId(8)
+        "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/tan.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/builtin_functions/tan.rs
@@ -47,37 +47,38 @@ fn tan_angle() {
     check_stmt_kinds(
         source,
         &expect![[r#"
-        ClassicalDeclarationStmt [9-33]:
-            symbol_id: 8
-            ty_span: [15-20]
-            init_expr: Expr [25-32]:
-                ty: const angle
-                const_value: Angle(0.7853981633974483)
-                kind: Cast [0-0]:
+            ClassicalDeclarationStmt [9-33]:
+                symbol_id: 8
+                ty_span: [15-20]
+                init_expr: Expr [25-32]:
                     ty: const angle
-                    expr: Expr [25-32]:
-                        ty: const float
-                        kind: BinaryOpExpr:
-                            op: Div
-                            lhs: Expr [25-27]:
-                                ty: const float
-                                kind: SymbolId(2)
-                            rhs: Expr [30-32]:
-                                ty: const float
-                                kind: Lit: Float(4.0)
-        ExprStmt [42-49]:
-            expr: Expr [42-48]:
-                ty: const float
-                const_value: Float(0.9999999999999999)
-                kind: BuiltinFunctionCall [42-48]:
-                    fn_name_span: [42-45]
-                    name: tan
-                    function_ty: def (const angle) -> const float
-                    args:
-                        Expr [46-47]:
-                            ty: const angle
-                            const_value: Angle(0.7853981633974483)
-                            kind: SymbolId(8)
-    "#]],
+                    const_value: Angle(0.7853981633974483)
+                    kind: Cast [25-32]:
+                        ty: const angle
+                        expr: Expr [25-32]:
+                            ty: const float
+                            kind: BinaryOpExpr:
+                                op: Div
+                                lhs: Expr [25-27]:
+                                    ty: const float
+                                    kind: SymbolId(2)
+                                rhs: Expr [30-32]:
+                                    ty: const float
+                                    kind: Lit: Float(4.0)
+                        kind: Implicit
+            ExprStmt [42-49]:
+                expr: Expr [42-48]:
+                    ty: const float
+                    const_value: Float(0.9999999999999999)
+                    kind: BuiltinFunctionCall [42-48]:
+                        fn_name_span: [42-45]
+                        name: tan
+                        function_ty: def (const angle) -> const float
+                        args:
+                            Expr [46-47]:
+                                ty: const angle
+                                const_value: Angle(0.7853981633974483)
+                                kind: SymbolId(8)
+        "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_angle.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_angle.rs
@@ -41,6 +41,7 @@ fn angle_to_bool() {
                         expr: Expr [31-32]:
                             ty: angle
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -68,6 +69,7 @@ fn sized_angle_to_bool() {
                         expr: Expr [35-36]:
                             ty: angle[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -958,6 +960,7 @@ fn angle_to_sized_angle() {
                         expr: Expr [36-37]:
                             ty: angle
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -985,6 +988,7 @@ fn sized_angle_to_angle() {
                         expr: Expr [36-37]:
                             ty: angle[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1035,6 +1039,7 @@ fn sized_angle_to_sized_angle_truncating() {
                         expr: Expr [40-41]:
                             ty: angle[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1062,6 +1067,7 @@ fn sized_angle_to_sized_angle_expanding() {
                         expr: Expr [40-41]:
                             ty: angle[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1343,6 +1349,7 @@ fn angle_to_bit() {
                         expr: Expr [30-31]:
                             ty: angle
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1411,6 +1418,7 @@ fn sized_angle_to_bit() {
                         expr: Expr [34-35]:
                             ty: angle[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1438,6 +1446,7 @@ fn sized_angle_to_bitarray() {
                         expr: Expr [38-39]:
                             ty: angle[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bit.rs
@@ -41,6 +41,7 @@ fn bit_to_bool() {
                         expr: Expr [29-30]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -68,6 +69,7 @@ fn bitarray_to_bool() {
                         expr: Expr [33-34]:
                             ty: bit[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -185,6 +187,7 @@ fn bit_to_int() {
                         expr: Expr [28-29]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -212,6 +215,7 @@ fn bit_to_sized_int() {
                         expr: Expr [32-33]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -281,6 +285,7 @@ fn bitarray_to_sized_int() {
                         expr: Expr [36-37]:
                             ty: bit[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -394,6 +399,7 @@ fn bit_to_uint() {
                         expr: Expr [29-30]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -421,6 +427,7 @@ fn bit_to_sized_uint() {
                         expr: Expr [33-34]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -490,6 +497,7 @@ fn bitarray_to_sized_uint() {
                         expr: Expr [37-38]:
                             ty: bit[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -603,6 +611,7 @@ fn bit_to_float() {
                         expr: Expr [30-31]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -630,6 +639,7 @@ fn bit_to_sized_float() {
                         expr: Expr [34-35]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -948,6 +958,7 @@ fn bitarray_to_sized_angle() {
                         expr: Expr [38-39]:
                             ty: bit[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1334,6 +1345,7 @@ fn bit_to_bitarray() {
                         expr: Expr [32-33]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1361,6 +1373,7 @@ fn bitarray_to_bit() {
                         expr: Expr [32-33]:
                             ty: bit[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bool.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_bool.rs
@@ -113,6 +113,7 @@ fn bool_to_int() {
                         expr: Expr [29-30]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -140,6 +141,7 @@ fn bool_to_sized_int() {
                         expr: Expr [33-34]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -171,6 +173,7 @@ fn bool_to_uint() {
                         expr: Expr [30-31]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -198,6 +201,7 @@ fn bool_to_sized_uint() {
                         expr: Expr [34-35]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -229,6 +233,7 @@ fn bool_to_float() {
                         expr: Expr [31-32]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -256,6 +261,7 @@ fn bool_to_sized_float() {
                         expr: Expr [35-36]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -459,6 +465,7 @@ fn bool_to_bit() {
                         expr: Expr [29-30]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -486,6 +493,7 @@ fn bool_to_bitarray() {
                         expr: Expr [33-34]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_complex.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_complex.rs
@@ -1236,6 +1236,7 @@ fn complex_to_sized_complex() {
                         expr: Expr [47-48]:
                             ty: complex[float]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1263,6 +1264,7 @@ fn sized_complex_to_complex() {
                         expr: Expr [47-48]:
                             ty: complex[float[32]]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1336,6 +1338,7 @@ fn sized_complex_to_sized_complex_expanding() {
                         expr: Expr [58-59]:
                             ty: complex[float[32]]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_float.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_float.rs
@@ -41,6 +41,7 @@ fn float_to_bool() {
                         expr: Expr [31-32]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -68,6 +69,7 @@ fn sized_float_to_bool() {
                         expr: Expr [35-36]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -185,6 +187,7 @@ fn float_to_int() {
                         expr: Expr [30-31]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -212,6 +215,7 @@ fn float_to_sized_int() {
                         expr: Expr [34-35]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -239,6 +243,7 @@ fn sized_float_to_int() {
                         expr: Expr [34-35]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -266,6 +271,7 @@ fn sized_float_to_sized_int() {
                         expr: Expr [38-39]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -293,6 +299,7 @@ fn sized_float_to_sized_int_truncating() {
                         expr: Expr [38-39]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -320,6 +327,7 @@ fn sized_float_to_sized_int_expanding() {
                         expr: Expr [38-39]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -351,6 +359,7 @@ fn float_to_uint() {
                         expr: Expr [31-32]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -378,6 +387,7 @@ fn float_to_sized_uint() {
                         expr: Expr [35-36]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -405,6 +415,7 @@ fn sized_float_to_uint() {
                         expr: Expr [35-36]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -432,6 +443,7 @@ fn sized_float_to_sized_uint() {
                         expr: Expr [39-40]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -459,6 +471,7 @@ fn sized_float_to_sized_uint_truncating() {
                         expr: Expr [39-40]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -486,6 +499,7 @@ fn sized_float_to_sized_uint_expanding() {
                         expr: Expr [39-40]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -540,6 +554,7 @@ fn float_to_sized_float() {
                         expr: Expr [36-37]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -567,6 +582,7 @@ fn sized_float_to_float() {
                         expr: Expr [36-37]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -617,6 +633,7 @@ fn sized_float_to_sized_float_truncating() {
                         expr: Expr [40-41]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -644,6 +661,7 @@ fn sized_float_to_sized_float_expanding() {
                         expr: Expr [40-41]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -675,6 +693,7 @@ fn float_to_angle() {
                         expr: Expr [32-33]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -702,6 +721,7 @@ fn float_to_sized_angle() {
                         expr: Expr [36-37]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -729,6 +749,7 @@ fn sized_float_to_angle() {
                         expr: Expr [36-37]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -756,6 +777,7 @@ fn sized_float_to_sized_angle() {
                         expr: Expr [40-41]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -783,6 +805,7 @@ fn sized_float_to_sized_angle_truncating() {
                         expr: Expr [40-41]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -810,6 +833,7 @@ fn sized_float_to_sized_angle_expanding() {
                         expr: Expr [40-41]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -841,6 +865,7 @@ fn float_to_complex() {
                         expr: Expr [34-35]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -868,6 +893,7 @@ fn float_to_sized_complex() {
                         expr: Expr [45-46]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -895,6 +921,7 @@ fn sized_float_to_complex() {
                         expr: Expr [38-39]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -922,6 +949,7 @@ fn sized_float_to_sized_complex() {
                         expr: Expr [49-50]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -949,6 +977,7 @@ fn sized_float_to_sized_complex_truncating() {
                         expr: Expr [49-50]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -976,6 +1005,7 @@ fn sized_float_to_sized_complex_expanding() {
                         expr: Expr [49-50]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1007,6 +1037,7 @@ fn float_to_bit() {
                         expr: Expr [30-31]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1075,6 +1106,7 @@ fn sized_float_to_bit() {
                         expr: Expr [34-35]:
                             ty: float[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_int.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_int.rs
@@ -41,6 +41,7 @@ fn int_to_bool() {
                         expr: Expr [29-30]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -68,6 +69,7 @@ fn sized_int_to_bool() {
                         expr: Expr [33-34]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -208,6 +210,7 @@ fn int_to_sized_int() {
                         expr: Expr [32-33]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -235,6 +238,7 @@ fn sized_int_to_int() {
                         expr: Expr [32-33]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -285,6 +289,7 @@ fn sized_int_to_sized_int_truncating() {
                         expr: Expr [36-37]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -312,6 +317,7 @@ fn sized_int_to_sized_int_expanding() {
                         expr: Expr [36-37]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -343,6 +349,7 @@ fn int_to_uint() {
                         expr: Expr [29-30]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -370,6 +377,7 @@ fn int_to_sized_uint() {
                         expr: Expr [33-34]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -397,6 +405,7 @@ fn sized_int_to_uint() {
                         expr: Expr [33-34]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -424,6 +433,7 @@ fn sized_int_to_sized_uint() {
                         expr: Expr [37-38]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -451,6 +461,7 @@ fn sized_int_to_sized_uint_truncating() {
                         expr: Expr [37-38]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -478,6 +489,7 @@ fn sized_int_to_sized_uint_expanding() {
                         expr: Expr [37-38]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -509,6 +521,7 @@ fn int_to_float() {
                         expr: Expr [30-31]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -536,6 +549,7 @@ fn int_to_sized_float() {
                         expr: Expr [34-35]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -563,6 +577,7 @@ fn sized_int_to_float() {
                         expr: Expr [34-35]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -590,6 +605,7 @@ fn sized_int_to_sized_float() {
                         expr: Expr [38-39]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -617,6 +633,7 @@ fn sized_int_to_sized_float_truncating() {
                         expr: Expr [38-39]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -644,6 +661,7 @@ fn sized_int_to_sized_float_expanding() {
                         expr: Expr [38-39]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -925,6 +943,7 @@ fn int_to_complex() {
                         expr: Expr [32-33]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -952,6 +971,7 @@ fn int_to_sized_complex() {
                         expr: Expr [43-44]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -979,6 +999,7 @@ fn sized_int_to_complex() {
                         expr: Expr [36-37]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1006,6 +1027,7 @@ fn sized_int_to_sized_complex() {
                         expr: Expr [47-48]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1033,6 +1055,7 @@ fn sized_int_to_sized_complex_truncating() {
                         expr: Expr [47-48]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1060,6 +1083,7 @@ fn sized_int_to_sized_complex_expanding() {
                         expr: Expr [47-48]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1091,6 +1115,7 @@ fn int_to_bit() {
                         expr: Expr [28-29]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1159,6 +1184,7 @@ fn sized_int_to_bit() {
                         expr: Expr [32-33]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1186,6 +1212,7 @@ fn sized_int_to_bitarray() {
                         expr: Expr [36-37]:
                             ty: int[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_uint.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/explicit_cast_from_uint.rs
@@ -41,6 +41,7 @@ fn uint_to_bool() {
                         expr: Expr [30-31]:
                             ty: uint
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -68,6 +69,7 @@ fn sized_uint_to_bool() {
                         expr: Expr [34-35]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -185,6 +187,7 @@ fn uint_to_int() {
                         expr: Expr [29-30]:
                             ty: uint
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -212,6 +215,7 @@ fn uint_to_sized_int() {
                         expr: Expr [33-34]:
                             ty: uint
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -239,6 +243,7 @@ fn sized_uint_to_int() {
                         expr: Expr [33-34]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -266,6 +271,7 @@ fn sized_uint_to_sized_int() {
                         expr: Expr [37-38]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -293,6 +299,7 @@ fn sized_uint_to_sized_int_truncating() {
                         expr: Expr [37-38]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -320,6 +327,7 @@ fn sized_uint_to_sized_int_expanding() {
                         expr: Expr [37-38]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -374,6 +382,7 @@ fn uint_to_sized_uint() {
                         expr: Expr [34-35]:
                             ty: uint
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -401,6 +410,7 @@ fn sized_uint_to_uint() {
                         expr: Expr [34-35]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -451,6 +461,7 @@ fn sized_uint_to_sized_uint_truncating() {
                         expr: Expr [38-39]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -478,6 +489,7 @@ fn sized_uint_to_sized_uint_expanding() {
                         expr: Expr [38-39]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -509,6 +521,7 @@ fn uint_to_float() {
                         expr: Expr [31-32]:
                             ty: uint
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -536,6 +549,7 @@ fn uint_to_sized_float() {
                         expr: Expr [35-36]:
                             ty: uint
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -563,6 +577,7 @@ fn sized_uint_to_float() {
                         expr: Expr [35-36]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -590,6 +605,7 @@ fn sized_uint_to_sized_float() {
                         expr: Expr [39-40]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -617,6 +633,7 @@ fn sized_uint_to_sized_float_truncating() {
                         expr: Expr [39-40]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -644,6 +661,7 @@ fn sized_uint_to_sized_float_expanding() {
                         expr: Expr [39-40]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -925,6 +943,7 @@ fn uint_to_complex() {
                         expr: Expr [33-34]:
                             ty: uint
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -952,6 +971,7 @@ fn uint_to_sized_complex() {
                         expr: Expr [44-45]:
                             ty: uint
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -979,6 +999,7 @@ fn sized_uint_to_complex() {
                         expr: Expr [37-38]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1006,6 +1027,7 @@ fn sized_uint_to_sized_complex() {
                         expr: Expr [48-49]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1033,6 +1055,7 @@ fn sized_uint_to_sized_complex_truncating() {
                         expr: Expr [48-49]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1060,6 +1083,7 @@ fn sized_uint_to_sized_complex_expanding() {
                         expr: Expr [48-49]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1091,6 +1115,7 @@ fn uint_to_bit() {
                         expr: Expr [29-30]:
                             ty: uint
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1159,6 +1184,7 @@ fn sized_uint_to_bit() {
                         expr: Expr [33-34]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }
@@ -1186,6 +1212,7 @@ fn sized_uint_to_bitarray() {
                         expr: Expr [37-38]:
                             ty: uint[32]
                             kind: SymbolId(8)
+                        kind: Explicit
         "#]],
     );
 }

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_angle.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_angle.rs
@@ -31,11 +31,12 @@ fn to_bit_implicitly() {
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
                     ty: bit
-                    kind: Cast [0-0]:
+                    kind: Cast [40-41]:
                         ty: bit
                         expr: Expr [40-41]:
                             ty: angle
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [36-37]:
                 name: y
                 type: bit
@@ -71,11 +72,12 @@ fn explicit_width_to_bit_implicitly_fails() {
                 ty_span: [36-39]
                 init_expr: Expr [44-45]:
                     ty: bit
-                    kind: Cast [0-0]:
+                    kind: Cast [44-45]:
                         ty: bit
                         expr: Expr [44-45]:
                             ty: angle[64]
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [40-41]:
                 name: y
                 type: bit
@@ -110,11 +112,12 @@ fn to_bool_implicitly() {
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
                     ty: bool
-                    kind: Cast [0-0]:
+                    kind: Cast [41-42]:
                         ty: bool
                         expr: Expr [41-42]:
                             ty: angle
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [37-38]:
                 name: y
                 type: bool
@@ -277,7 +280,7 @@ fn negative_lit_to_implicit_uint_implicitly_fails() {
                             ty_span: [9-14]
                             init_expr: Expr [20-23]:
                                 ty: angle
-                                kind: Cast [0-0]:
+                                kind: Cast [20-23]:
                                     ty: angle
                                     expr: Expr [20-23]:
                                         ty: const float
@@ -286,6 +289,7 @@ fn negative_lit_to_implicit_uint_implicitly_fails() {
                                             expr: Expr [20-23]:
                                                 ty: const float
                                                 kind: Lit: Float(42.0)
+                                    kind: Implicit
                     Stmt [33-44]:
                         annotations: <empty>
                         kind: ClassicalDeclarationStmt [33-44]:
@@ -634,11 +638,12 @@ fn to_explicit_angle_implicitly() {
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
                     ty: angle[4]
-                    kind: Cast [0-0]:
+                    kind: Cast [45-46]:
                         ty: angle[4]
                         expr: Expr [45-46]:
                             ty: angle
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [41-42]:
                 name: y
                 type: angle[4]
@@ -686,7 +691,7 @@ fn width_promotion() {
                 ty_span: [63-66]
                 init_expr: Expr [71-76]:
                     ty: bit
-                    kind: Cast [0-0]:
+                    kind: Cast [71-76]:
                         ty: bit
                         expr: Expr [71-76]:
                             ty: uint[48]
@@ -694,14 +699,16 @@ fn width_promotion() {
                                 op: Div
                                 lhs: Expr [71-72]:
                                     ty: angle[48]
-                                    kind: Cast [0-0]:
+                                    kind: Cast [71-72]:
                                         ty: angle[48]
                                         expr: Expr [71-72]:
                                             ty: angle[32]
                                             kind: SymbolId(8)
+                                        kind: Implicit
                                 rhs: Expr [75-76]:
                                     ty: angle[48]
                                     kind: SymbolId(9)
+                        kind: Implicit
             [10] Symbol [67-68]:
                 name: z
                 type: bit

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bit.rs
@@ -119,11 +119,12 @@ fn to_bool_implicitly() {
                 ty_span: [30-34]
                 init_expr: Expr [39-40]:
                     ty: bool
-                    kind: Cast [0-0]:
+                    kind: Cast [39-40]:
                         ty: bool
                         expr: Expr [39-40]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [35-36]:
                 name: y
                 type: bool
@@ -159,11 +160,12 @@ fn to_implicit_int_implicitly() {
                 ty_span: [28-31]
                 init_expr: Expr [36-37]:
                     ty: int
-                    kind: Cast [0-0]:
+                    kind: Cast [36-37]:
                         ty: int
                         expr: Expr [36-37]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [32-33]:
                 name: y
                 type: int
@@ -199,11 +201,12 @@ fn to_explicit_int_implicitly() {
                 ty_span: [28-35]
                 init_expr: Expr [40-41]:
                     ty: int[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [40-41]:
                         ty: int[32]
                         expr: Expr [40-41]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [36-37]:
                 name: y
                 type: int[32]
@@ -239,11 +242,12 @@ fn to_implicit_uint_implicitly() {
                 ty_span: [28-32]
                 init_expr: Expr [37-38]:
                     ty: uint
-                    kind: Cast [0-0]:
+                    kind: Cast [37-38]:
                         ty: uint
                         expr: Expr [37-38]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [33-34]:
                 name: y
                 type: uint
@@ -279,11 +283,12 @@ fn to_explicit_uint_implicitly() {
                 ty_span: [28-36]
                 init_expr: Expr [41-42]:
                     ty: uint[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [41-42]:
                         ty: uint[32]
                         expr: Expr [41-42]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [37-38]:
                 name: y
                 type: uint[32]
@@ -319,11 +324,12 @@ fn to_explicit_bigint_implicitly() {
                 ty_span: [28-35]
                 init_expr: Expr [40-41]:
                     ty: int[65]
-                    kind: Cast [0-0]:
+                    kind: Cast [40-41]:
                         ty: int[65]
                         expr: Expr [40-41]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [36-37]:
                 name: y
                 type: int[65]
@@ -359,11 +365,12 @@ fn to_implicit_float_implicitly() {
                 ty_span: [28-33]
                 init_expr: Expr [38-39]:
                     ty: float
-                    kind: Cast [0-0]:
+                    kind: Cast [38-39]:
                         ty: float
                         expr: Expr [38-39]:
                             ty: bit
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [34-35]:
                 name: y
                 type: float

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bitarray.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bitarray.rs
@@ -31,11 +31,12 @@ fn to_int_decl_implicitly() {
                 ty_span: [29-32]
                 init_expr: Expr [37-40]:
                     ty: int
-                    kind: Cast [0-0]:
+                    kind: Cast [37-40]:
                         ty: int
                         expr: Expr [37-40]:
                             ty: bit[5]
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [33-34]:
                 name: b
                 type: int
@@ -74,11 +75,12 @@ fn to_int_assignment_implicitly() {
                     kind: SymbolId(9)
                 rhs: Expr [48-51]:
                     ty: int
-                    kind: Cast [0-0]:
+                    kind: Cast [48-51]:
                         ty: int
                         expr: Expr [48-51]:
                             ty: bit[5]
                             kind: SymbolId(8)
+                        kind: Implicit
         "#]],
     );
 }
@@ -112,11 +114,12 @@ fn to_int_with_equal_width_in_assignment_implicitly() {
                     kind: SymbolId(9)
                 rhs: Expr [51-54]:
                     ty: int[5]
-                    kind: Cast [0-0]:
+                    kind: Cast [51-54]:
                         ty: int[5]
                         expr: Expr [51-54]:
                             ty: bit[5]
                             kind: SymbolId(8)
+                        kind: Implicit
         "#]],
     );
 }
@@ -147,11 +150,12 @@ fn to_int_with_equal_width_in_decl_implicitly() {
                 ty_span: [29-35]
                 init_expr: Expr [40-43]:
                     ty: int[5]
-                    kind: Cast [0-0]:
+                    kind: Cast [40-43]:
                         ty: int[5]
                         expr: Expr [40-43]:
                             ty: bit[5]
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [36-37]:
                 name: a
                 type: int[5]

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bool.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_bool.rs
@@ -31,11 +31,12 @@ fn to_bit_implicitly() {
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
                     ty: bit
-                    kind: Cast [0-0]:
+                    kind: Cast [40-41]:
                         ty: bit
                         expr: Expr [40-41]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [36-37]:
                 name: y
                 type: bit
@@ -71,11 +72,12 @@ fn to_implicit_int_implicitly() {
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
                     ty: int
-                    kind: Cast [0-0]:
+                    kind: Cast [40-41]:
                         ty: int
                         expr: Expr [40-41]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [36-37]:
                 name: y
                 type: int
@@ -111,11 +113,12 @@ fn to_explicit_int_implicitly() {
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
                     ty: int[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [44-45]:
                         ty: int[32]
                         expr: Expr [44-45]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [40-41]:
                 name: y
                 type: int[32]
@@ -151,11 +154,12 @@ fn to_implicit_uint_implicitly() {
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
                     ty: uint
-                    kind: Cast [0-0]:
+                    kind: Cast [41-42]:
                         ty: uint
                         expr: Expr [41-42]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [37-38]:
                 name: y
                 type: uint
@@ -191,11 +195,12 @@ fn to_explicit_uint_implicitly() {
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
                     ty: uint[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [45-46]:
                         ty: uint[32]
                         expr: Expr [45-46]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [41-42]:
                 name: y
                 type: uint[32]
@@ -231,11 +236,12 @@ fn to_explicit_bigint_implicitly() {
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
                     ty: int[65]
-                    kind: Cast [0-0]:
+                    kind: Cast [44-45]:
                         ty: int[65]
                         expr: Expr [44-45]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [40-41]:
                 name: y
                 type: int[65]
@@ -271,11 +277,12 @@ fn to_implicit_float_implicitly() {
                 ty_span: [32-37]
                 init_expr: Expr [42-43]:
                     ty: float
-                    kind: Cast [0-0]:
+                    kind: Cast [42-43]:
                         ty: float
                         expr: Expr [42-43]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [38-39]:
                 name: y
                 type: float
@@ -311,11 +318,12 @@ fn to_explicit_float_implicitly() {
                 ty_span: [32-41]
                 init_expr: Expr [46-47]:
                     ty: float[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [46-47]:
                         ty: float[32]
                         expr: Expr [46-47]:
                             ty: bool
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [42-43]:
                 name: y
                 type: float[32]

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_float.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_float.rs
@@ -31,11 +31,12 @@ fn to_bit_implicitly() {
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
                     ty: bit
-                    kind: Cast [0-0]:
+                    kind: Cast [40-41]:
                         ty: bit
                         expr: Expr [40-41]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [36-37]:
                 name: y
                 type: bit
@@ -71,11 +72,12 @@ fn explicit_width_to_bit_implicitly() {
                 ty_span: [36-39]
                 init_expr: Expr [44-45]:
                     ty: bit
-                    kind: Cast [0-0]:
+                    kind: Cast [44-45]:
                         ty: bit
                         expr: Expr [44-45]:
                             ty: float[64]
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [40-41]:
                 name: y
                 type: bit
@@ -110,11 +112,12 @@ fn to_bool_implicitly() {
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
                     ty: bool
-                    kind: Cast [0-0]:
+                    kind: Cast [41-42]:
                         ty: bool
                         expr: Expr [41-42]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [37-38]:
                 name: y
                 type: bool
@@ -150,11 +153,12 @@ fn to_implicit_int_implicitly() {
                 ty_span: [32-35]
                 init_expr: Expr [40-41]:
                     ty: int
-                    kind: Cast [0-0]:
+                    kind: Cast [40-41]:
                         ty: int
                         expr: Expr [40-41]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [36-37]:
                 name: y
                 type: int
@@ -190,11 +194,12 @@ fn to_explicit_int_implicitly() {
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
                     ty: int[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [44-45]:
                         ty: int[32]
                         expr: Expr [44-45]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [40-41]:
                 name: y
                 type: int[32]
@@ -230,11 +235,12 @@ fn to_implicit_uint_implicitly() {
                 ty_span: [32-36]
                 init_expr: Expr [41-42]:
                     ty: uint
-                    kind: Cast [0-0]:
+                    kind: Cast [41-42]:
                         ty: uint
                         expr: Expr [41-42]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [37-38]:
                 name: y
                 type: uint
@@ -274,11 +280,12 @@ fn negative_lit_to_implicit_uint_implicitly() {
                 ty_span: [33-37]
                 init_expr: Expr [42-43]:
                     ty: uint
-                    kind: Cast [0-0]:
+                    kind: Cast [42-43]:
                         ty: uint
                         expr: Expr [42-43]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [38-39]:
                 name: y
                 type: uint
@@ -314,11 +321,12 @@ fn to_explicit_uint_implicitly() {
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
                     ty: uint[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [45-46]:
                         ty: uint[32]
                         expr: Expr [45-46]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [41-42]:
                 name: y
                 type: uint[32]
@@ -354,11 +362,12 @@ fn to_explicit_bigint_implicitly() {
                 ty_span: [32-39]
                 init_expr: Expr [44-45]:
                     ty: int[65]
-                    kind: Cast [0-0]:
+                    kind: Cast [44-45]:
                         ty: int[65]
                         expr: Expr [44-45]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [40-41]:
                 name: y
                 type: int[65]
@@ -430,11 +439,12 @@ fn to_explicit_float_implicitly() {
                 ty_span: [32-41]
                 init_expr: Expr [46-47]:
                     ty: float[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [46-47]:
                         ty: float[32]
                         expr: Expr [46-47]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [42-43]:
                 name: y
                 type: float[32]
@@ -470,11 +480,12 @@ fn to_implicit_complex_implicitly() {
                 ty_span: [32-46]
                 init_expr: Expr [51-52]:
                     ty: complex[float]
-                    kind: Cast [0-0]:
+                    kind: Cast [51-52]:
                         ty: complex[float]
                         expr: Expr [51-52]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [47-48]:
                 name: y
                 type: complex[float]
@@ -510,11 +521,12 @@ fn to_explicit_complex_implicitly() {
                 ty_span: [32-50]
                 init_expr: Expr [55-56]:
                     ty: complex[float[32]]
-                    kind: Cast [0-0]:
+                    kind: Cast [55-56]:
                         ty: complex[float[32]]
                         expr: Expr [55-56]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [51-52]:
                 name: y
                 type: complex[float[32]]
@@ -550,11 +562,12 @@ fn to_angle_implicitly() {
                 ty_span: [32-37]
                 init_expr: Expr [42-43]:
                     ty: angle
-                    kind: Cast [0-0]:
+                    kind: Cast [42-43]:
                         ty: angle
                         expr: Expr [42-43]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [38-39]:
                 name: y
                 type: angle
@@ -590,11 +603,12 @@ fn to_explicit_angle_implicitly() {
                 ty_span: [32-40]
                 init_expr: Expr [45-46]:
                     ty: angle[4]
-                    kind: Cast [0-0]:
+                    kind: Cast [45-46]:
                         ty: angle[4]
                         expr: Expr [45-46]:
                             ty: float
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [41-42]:
                 name: y
                 type: angle[4]

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_int.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/implicit_cast_from_int.rs
@@ -31,11 +31,12 @@ fn to_bit_implicitly() {
                 ty_span: [29-32]
                 init_expr: Expr [37-38]:
                     ty: bit
-                    kind: Cast [0-0]:
+                    kind: Cast [37-38]:
                         ty: bit
                         expr: Expr [37-38]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [33-34]:
                 name: y
                 type: bit
@@ -71,11 +72,12 @@ fn to_bool_implicitly() {
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: bool
-                    kind: Cast [0-0]:
+                    kind: Cast [38-39]:
                         ty: bool
                         expr: Expr [38-39]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [34-35]:
                 name: y
                 type: bool
@@ -147,11 +149,12 @@ fn to_explicit_int_implicitly() {
                 ty_span: [29-36]
                 init_expr: Expr [41-42]:
                     ty: int[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [41-42]:
                         ty: int[32]
                         expr: Expr [41-42]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [37-38]:
                 name: y
                 type: int[32]
@@ -187,11 +190,12 @@ fn to_implicit_uint_implicitly() {
                 ty_span: [29-33]
                 init_expr: Expr [38-39]:
                     ty: uint
-                    kind: Cast [0-0]:
+                    kind: Cast [38-39]:
                         ty: uint
                         expr: Expr [38-39]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [34-35]:
                 name: y
                 type: uint
@@ -227,11 +231,12 @@ fn to_explicit_uint_implicitly() {
                 ty_span: [29-37]
                 init_expr: Expr [42-43]:
                     ty: uint[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [42-43]:
                         ty: uint[32]
                         expr: Expr [42-43]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [38-39]:
                 name: y
                 type: uint[32]
@@ -267,11 +272,12 @@ fn to_explicit_bigint_implicitly() {
                 ty_span: [29-36]
                 init_expr: Expr [41-42]:
                     ty: int[65]
-                    kind: Cast [0-0]:
+                    kind: Cast [41-42]:
                         ty: int[65]
                         expr: Expr [41-42]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [37-38]:
                 name: y
                 type: int[65]
@@ -307,11 +313,12 @@ fn to_implicit_float_implicitly() {
                 ty_span: [29-34]
                 init_expr: Expr [39-40]:
                     ty: float
-                    kind: Cast [0-0]:
+                    kind: Cast [39-40]:
                         ty: float
                         expr: Expr [39-40]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [35-36]:
                 name: y
                 type: float
@@ -347,11 +354,12 @@ fn to_explicit_float_implicitly() {
                 ty_span: [29-38]
                 init_expr: Expr [43-44]:
                     ty: float[32]
-                    kind: Cast [0-0]:
+                    kind: Cast [43-44]:
                         ty: float[32]
                         expr: Expr [43-44]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [39-40]:
                 name: y
                 type: float[32]
@@ -387,11 +395,12 @@ fn to_implicit_complex_implicitly() {
                 ty_span: [29-43]
                 init_expr: Expr [48-49]:
                     ty: complex[float]
-                    kind: Cast [0-0]:
+                    kind: Cast [48-49]:
                         ty: complex[float]
                         expr: Expr [48-49]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [44-45]:
                 name: y
                 type: complex[float]
@@ -427,11 +436,12 @@ fn to_explicit_complex_implicitly() {
                 ty_span: [29-47]
                 init_expr: Expr [52-53]:
                     ty: complex[float[32]]
-                    kind: Cast [0-0]:
+                    kind: Cast [52-53]:
                         ty: complex[float[32]]
                         expr: Expr [52-53]:
                             ty: int
                             kind: SymbolId(8)
+                        kind: Implicit
             [9] Symbol [48-49]:
                 name: y
                 type: complex[float[32]]

--- a/source/compiler/qsc_qasm/src/semantic/tests/expression/indexing.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/expression/indexing.rs
@@ -69,7 +69,11 @@ fn array_slice_with_negative_start_has_correct_size() {
                             start: Expr [35-36]:
                                 ty: const int
                                 const_value: Int(-7)
-                                kind: Lit: Int(-7)
+                                kind: UnaryOpExpr [35-36]:
+                                    op: Neg
+                                    expr: Expr [35-36]:
+                                        ty: const int
+                                        kind: Lit: Int(7)
                             step: <none>
                             end: Expr [37-38]:
                                 ty: const int
@@ -111,7 +115,11 @@ fn array_slice_with_negative_end_has_correct_size() {
                             end: Expr [37-38]:
                                 ty: const int
                                 const_value: Int(-2)
-                                kind: Lit: Int(-2)
+                                kind: UnaryOpExpr [37-38]:
+                                    op: Neg
+                                    expr: Expr [37-38]:
+                                        ty: const int
+                                        kind: Lit: Int(2)
         "#]],
     );
 }
@@ -227,7 +235,11 @@ fn array_slice_with_negative_step_has_correct_size() {
                             step: Expr [37-38]:
                                 ty: const int
                                 const_value: Int(-3)
-                                kind: Lit: Int(-3)
+                                kind: UnaryOpExpr [37-38]:
+                                    op: Neg
+                                    expr: Expr [37-38]:
+                                        ty: const int
+                                        kind: Lit: Int(3)
                             end: Expr [39-40]:
                                 ty: const int
                                 const_value: Int(0)

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/box_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/box_stmt.rs
@@ -218,11 +218,12 @@ fn box_can_contain_gphase() {
                             args:
                                 Expr [40-42]:
                                     ty: angle
-                                    kind: Cast [0-0]:
+                                    kind: Cast [40-42]:
                                         ty: angle
                                         expr: Expr [40-42]:
                                             ty: const float
                                             kind: SymbolId(2)
+                                        kind: Implicit
                             qubits: <empty>
                             duration: <none>
                             classical_arity: 1

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/if_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/if_stmt.rs
@@ -162,11 +162,12 @@ fn condition_cast() {
             IfStmt [0-12]:
                 condition: Expr [4-5]:
                     ty: const bool
-                    kind: Cast [0-0]:
+                    kind: Cast [4-5]:
                         ty: const bool
                         expr: Expr [4-5]:
                             ty: const int
                             kind: Lit: Int(1)
+                        kind: Implicit
                 if_body: Stmt [7-12]:
                     annotations: <empty>
                     kind: Block [7-12]:

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/switch_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/switch_stmt.rs
@@ -110,21 +110,23 @@ fn target_cast() {
             SwitchStmt [0-31]:
                 target: Expr [8-12]:
                     ty: const int
-                    kind: Cast [0-0]:
+                    kind: Cast [8-12]:
                         ty: const int
                         expr: Expr [8-12]:
                             ty: const bool
                             kind: Lit: Bool(true)
+                        kind: Implicit
                 cases:
                     SwitchCase [16-29]:
                         labels:
                             Expr [21-26]:
                                 ty: const int
-                                kind: Cast [0-0]:
+                                kind: Cast [21-26]:
                                     ty: const int
                                     expr: Expr [21-26]:
                                         ty: const bool
                                         kind: Lit: Bool(false)
+                                    kind: Implicit
                         block: Block [27-29]: <empty>
                 default_case: <none>
         "#]],

--- a/source/compiler/qsc_qasm/src/semantic/tests/statements/while_stmt.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/statements/while_stmt.rs
@@ -78,11 +78,12 @@ fn condition_cast() {
             WhileLoop [0-15]:
                 condition: Expr [7-8]:
                     ty: const bool
-                    kind: Cast [0-0]:
+                    kind: Cast [7-8]:
                         ty: const bool
                         expr: Expr [7-8]:
                             ty: const int
                             kind: Lit: Int(1)
+                        kind: Implicit
                 body: Stmt [10-15]:
                     annotations: <empty>
                     kind: Block [10-15]:

--- a/source/compiler/qsc_qasm/src/semantic/types.rs
+++ b/source/compiler/qsc_qasm/src/semantic/types.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use qsc_data_structures::span::Span;
 
-use super::ast::{BinOp, Expr, ExprKind, Index, LiteralKind, Range};
+use super::ast::{BinOp, Expr, Index, LiteralKind, Range};
 use crate::parser::ast as syntax;
 use crate::semantic::{Lowerer, SemanticErrorKind};
 use core::fmt;
@@ -619,8 +619,12 @@ pub(crate) fn compute_slice_components(
     // guaranteed to be of literals of type `int` by this point.
     let unwrap_lit_or_default = |expr: Option<&Expr>, default: i64| {
         if let Some(expr) = expr {
-            if let ExprKind::Lit(LiteralKind::Int(val)) = &*expr.kind {
-                *val
+            // slices must be const int exprs. If we failed to const eval the range,
+            // the lowering of the range would have failed. Since we are here,
+            // we know lowering succeeded and the const value is available.
+            // If this is ever false, we have a compiler bug.
+            if let Some(LiteralKind::Int(val)) = expr.get_const_value() {
+                val
             } else {
                 unreachable!("range components are guaranteed to be int literals")
             }

--- a/source/compiler/qsc_qasm/src/semantic/visit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/visit.rs
@@ -1,0 +1,713 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This is setting the foundation for passes and visitors in the QASM semantic analysis phase.
+#![allow(dead_code)]
+
+use qsc_data_structures::span::Span;
+
+use crate::{
+    parser::ast::{Ident, Path, PathKind},
+    semantic::{
+        ast::{
+            AliasDeclStmt, Annotation, Array, AssignStmt, BarrierStmt, BinOp, BinaryOpExpr, Block,
+            BoxStmt, BreakStmt, BuiltinFunctionCall, CalibrationGrammarStmt, CalibrationStmt, Cast,
+            ClassicalDeclarationStmt, ContinueStmt, DefCalStmt, DefStmt, DelayStmt, EndStmt,
+            EnumerableSet, Expr, ExprKind, ExprStmt, ExternDecl, ForStmt, FunctionCall, GateCall,
+            GateModifierKind, GateOperand, GateOperandKind, HardwareQubit, IfStmt, IncludeStmt,
+            Index, IndexedClassicalTypeAssignStmt, IndexedExpr, InputDeclaration, LiteralKind,
+            MeasureArrowStmt, MeasureExpr, OutputDeclaration, Pragma, Program,
+            QuantumGateDefinition, QuantumGateModifier, QubitArrayDeclaration, QubitDeclaration,
+            Range, ResetStmt, ReturnStmt, Set, SizeofCallExpr, Stmt, StmtKind, SwitchCase,
+            SwitchStmt, TimeUnit, UnaryOp, UnaryOpExpr, Version, WhileLoop,
+        },
+        symbols::SymbolId,
+        types::Type,
+    },
+};
+
+pub trait Visitor: Sized {
+    fn visit_program(&mut self, program: &Program) {
+        walk_program(self, program);
+    }
+
+    fn visit_version(&mut self, version: &Version) {
+        walk_version(self, version);
+    }
+
+    fn visit_pragma(&mut self, pragma: &Pragma) {
+        walk_pragma(self, pragma);
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        walk_stmt(self, stmt);
+    }
+
+    fn visit_annotation(&mut self, annotation: &Annotation) {
+        walk_annotation(self, annotation);
+    }
+
+    fn visit_alias_decl_stmt(&mut self, stmt: &AliasDeclStmt) {
+        walk_alias_decl_stmt(self, stmt);
+    }
+
+    fn visit_assign_stmt(&mut self, stmt: &AssignStmt) {
+        walk_assign_stmt(self, stmt);
+    }
+
+    fn visit_barrier_stmt(&mut self, stmt: &BarrierStmt) {
+        walk_barrier_stmt(self, stmt);
+    }
+
+    fn visit_box_stmt(&mut self, stmt: &BoxStmt) {
+        walk_box_stmt(self, stmt);
+    }
+
+    fn visit_block(&mut self, block: &Block) {
+        walk_block(self, block);
+    }
+
+    fn visit_break_stmt(&mut self, stmt: &BreakStmt) {
+        walk_break_stmt(self, stmt);
+    }
+
+    fn visit_calibration_stmt(&mut self, stmt: &CalibrationStmt) {
+        walk_calibration_stmt(self, stmt);
+    }
+
+    fn visit_calibration_grammar_stmt(&mut self, stmt: &CalibrationGrammarStmt) {
+        walk_calibration_grammar_stmt(self, stmt);
+    }
+
+    fn visit_classical_decl_stmt(&mut self, stmt: &ClassicalDeclarationStmt) {
+        walk_classical_decl_stmt(self, stmt);
+    }
+
+    fn visit_continue_stmt(&mut self, stmt: &ContinueStmt) {
+        walk_continue_stmt(self, stmt);
+    }
+
+    fn visit_def_stmt(&mut self, stmt: &DefStmt) {
+        walk_def_stmt(self, stmt);
+    }
+
+    fn visit_def_cal_stmt(&mut self, stmt: &DefCalStmt) {
+        walk_def_cal_stmt(self, stmt);
+    }
+
+    fn visit_delay_stmt(&mut self, stmt: &DelayStmt) {
+        walk_delay_stmt(self, stmt);
+    }
+
+    fn visit_end_stmt(&mut self, stmt: &EndStmt) {
+        walk_end_stmt(self, stmt);
+    }
+
+    fn visit_expr_stmt(&mut self, stmt: &ExprStmt) {
+        walk_expr_stmt(self, stmt);
+    }
+
+    fn visit_extern_decl(&mut self, stmt: &ExternDecl) {
+        walk_extern_decl(self, stmt);
+    }
+
+    fn visit_for_stmt(&mut self, stmt: &ForStmt) {
+        walk_for_stmt(self, stmt);
+    }
+
+    fn visit_gate_call_stmt(&mut self, stmt: &GateCall) {
+        walk_gate_call_stmt(self, stmt);
+    }
+
+    fn visit_if_stmt(&mut self, stmt: &IfStmt) {
+        walk_if_stmt(self, stmt);
+    }
+
+    fn visit_include_stmt(&mut self, stmt: &IncludeStmt) {
+        walk_include_stmt(self, stmt);
+    }
+
+    fn visit_indexed_classical_type_assign_stmt(&mut self, stmt: &IndexedClassicalTypeAssignStmt) {
+        walk_indexed_classical_type_assign_stmt(self, stmt);
+    }
+
+    fn visit_input_declaration(&mut self, stmt: &InputDeclaration) {
+        walk_input_declaration(self, stmt);
+    }
+
+    fn visit_output_declaration(&mut self, stmt: &OutputDeclaration) {
+        walk_output_declaration(self, stmt);
+    }
+
+    fn visit_measure_arrow_stmt(&mut self, stmt: &MeasureArrowStmt) {
+        walk_measure_arrow_stmt(self, stmt);
+    }
+
+    fn visit_quantum_gate_definition(&mut self, stmt: &QuantumGateDefinition) {
+        walk_quantum_gate_definition(self, stmt);
+    }
+
+    fn visit_qubit_decl(&mut self, stmt: &QubitDeclaration) {
+        walk_qubit_decl(self, stmt);
+    }
+
+    fn visit_qubit_array_decl(&mut self, stmt: &QubitArrayDeclaration) {
+        walk_qubit_array_decl(self, stmt);
+    }
+
+    fn visit_reset_stmt(&mut self, stmt: &ResetStmt) {
+        walk_reset_stmt(self, stmt);
+    }
+
+    fn visit_return_stmt(&mut self, stmt: &ReturnStmt) {
+        walk_return_stmt(self, stmt);
+    }
+
+    fn visit_switch_stmt(&mut self, stmt: &SwitchStmt) {
+        walk_switch_stmt(self, stmt);
+    }
+
+    fn visit_while_loop(&mut self, stmt: &WhileLoop) {
+        walk_while_loop(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        walk_expr(self, expr);
+    }
+
+    fn visit_unary_op_expr(&mut self, expr: &UnaryOpExpr) {
+        walk_unary_op_expr(self, expr);
+    }
+
+    fn visit_binary_op_expr(&mut self, expr: &BinaryOpExpr) {
+        walk_binary_op_expr(self, expr);
+    }
+
+    fn visit_function_call_expr(&mut self, expr: &FunctionCall) {
+        walk_function_call_expr(self, expr);
+    }
+
+    fn visit_builtin_function_call_expr(&mut self, expr: &BuiltinFunctionCall) {
+        walk_builtin_function_call_expr(self, expr);
+    }
+
+    fn visit_cast_expr(&mut self, expr: &Cast) {
+        walk_cast_expr(self, expr);
+    }
+
+    fn visit_indexed_expr(&mut self, expr: &IndexedExpr) {
+        walk_indexed_expr(self, expr);
+    }
+
+    fn visit_measure_expr(&mut self, expr: &MeasureExpr) {
+        walk_measure_expr(self, expr);
+    }
+
+    fn visit_sizeof_call_expr(&mut self, expr: &SizeofCallExpr) {
+        walk_sizeof_call_expr(self, expr);
+    }
+
+    // fn visit_durationof_call_expr(&mut self, expr: &DurationofCallExpr) {
+    //     walk_durationof_call_expr(self, expr);
+    // }
+
+    fn visit_set(&mut self, set: &Set) {
+        walk_set(self, set);
+    }
+
+    fn visit_range(&mut self, range: &Range) {
+        walk_range(self, range);
+    }
+
+    fn visit_quantum_gate_modifier(&mut self, modifier: &QuantumGateModifier) {
+        walk_quantum_gate_modifier(self, modifier);
+    }
+
+    fn visit_gate_operand(&mut self, operand: &GateOperand) {
+        walk_gate_operand(self, operand);
+    }
+
+    fn visit_hardware_qubit(&mut self, qubit: &HardwareQubit) {
+        walk_hardware_qubit(self, qubit);
+    }
+
+    fn visit_enumerable_set(&mut self, set: &EnumerableSet) {
+        walk_enumerable_set(self, set);
+    }
+
+    fn visit_switch_case(&mut self, case: &SwitchCase) {
+        walk_switch_case(self, case);
+    }
+
+    fn visit_index(&mut self, index: &Index) {
+        walk_index(self, index);
+    }
+
+    fn visit_literal(&mut self, literal: &LiteralKind) {
+        walk_literal(self, literal);
+    }
+
+    fn visit_array(&mut self, array: &Array) {
+        walk_array(self, array);
+    }
+
+    fn visit_path(&mut self, path: &Path) {
+        walk_path(self, path);
+    }
+
+    fn visit_path_kind(&mut self, path: &PathKind) {
+        walk_path_kind(self, path);
+    }
+
+    fn visit_ident(&mut self, _: &Ident) {}
+
+    fn visit_idents(&mut self, idents: &[Ident]) {
+        walk_idents(self, idents);
+    }
+
+    // Terminal nodes that typically don't need further traversal
+    fn visit_span(&mut self, _: Span) {}
+    fn visit_symbol_id(&mut self, _: SymbolId) {}
+    fn visit_bin_op(&mut self, _: BinOp) {}
+    fn visit_unary_op(&mut self, _: UnaryOp) {}
+    fn visit_time_unit(&mut self, _: TimeUnit) {}
+    fn visit_ty(&mut self, _: &Type) {}
+}
+
+pub fn walk_program(vis: &mut impl Visitor, program: &Program) {
+    program.version.iter().for_each(|v| vis.visit_version(v));
+    program.pragmas.iter().for_each(|p| vis.visit_pragma(p));
+    program.statements.iter().for_each(|s| vis.visit_stmt(s));
+}
+
+pub fn walk_version(vis: &mut impl Visitor, version: &Version) {
+    vis.visit_span(version.span);
+}
+
+pub fn walk_pragma(vis: &mut impl Visitor, pragma: &Pragma) {
+    vis.visit_span(pragma.span);
+    pragma
+        .identifier
+        .iter()
+        .for_each(|id| vis.visit_path_kind(id));
+    pragma
+        .value_span
+        .iter()
+        .for_each(|span| vis.visit_span(*span));
+}
+
+pub fn walk_stmt(vis: &mut impl Visitor, stmt: &Stmt) {
+    vis.visit_span(stmt.span);
+    stmt.annotations
+        .iter()
+        .for_each(|a| vis.visit_annotation(a));
+    match stmt.kind.as_ref() {
+        StmtKind::Alias(stmt) => vis.visit_alias_decl_stmt(stmt),
+        StmtKind::Assign(stmt) => vis.visit_assign_stmt(stmt),
+        StmtKind::Barrier(stmt) => vis.visit_barrier_stmt(stmt),
+        StmtKind::Box(stmt) => vis.visit_box_stmt(stmt),
+        StmtKind::Block(block) => vis.visit_block(block),
+        StmtKind::Break(stmt) => vis.visit_break_stmt(stmt),
+        StmtKind::Calibration(stmt) => vis.visit_calibration_stmt(stmt),
+        StmtKind::CalibrationGrammar(stmt) => vis.visit_calibration_grammar_stmt(stmt),
+        StmtKind::ClassicalDecl(stmt) => vis.visit_classical_decl_stmt(stmt),
+        StmtKind::Continue(stmt) => vis.visit_continue_stmt(stmt),
+        StmtKind::Def(stmt) => vis.visit_def_stmt(stmt),
+        StmtKind::DefCal(stmt) => vis.visit_def_cal_stmt(stmt),
+        StmtKind::Delay(stmt) => vis.visit_delay_stmt(stmt),
+        StmtKind::End(stmt) => vis.visit_end_stmt(stmt),
+        StmtKind::ExprStmt(stmt) => vis.visit_expr_stmt(stmt),
+        StmtKind::ExternDecl(stmt) => vis.visit_extern_decl(stmt),
+        StmtKind::For(stmt) => vis.visit_for_stmt(stmt),
+        StmtKind::GateCall(stmt) => vis.visit_gate_call_stmt(stmt),
+        StmtKind::If(stmt) => vis.visit_if_stmt(stmt),
+        StmtKind::Include(stmt) => vis.visit_include_stmt(stmt),
+        StmtKind::IndexedClassicalTypeAssign(stmt) => {
+            vis.visit_indexed_classical_type_assign_stmt(stmt);
+        }
+        StmtKind::InputDeclaration(stmt) => vis.visit_input_declaration(stmt),
+        StmtKind::OutputDeclaration(stmt) => vis.visit_output_declaration(stmt),
+        StmtKind::MeasureArrow(stmt) => vis.visit_measure_arrow_stmt(stmt),
+        StmtKind::Pragma(pragma) => vis.visit_pragma(pragma),
+        StmtKind::QuantumGateDefinition(stmt) => vis.visit_quantum_gate_definition(stmt),
+        StmtKind::QubitDecl(stmt) => vis.visit_qubit_decl(stmt),
+        StmtKind::QubitArrayDecl(stmt) => vis.visit_qubit_array_decl(stmt),
+        StmtKind::Reset(stmt) => vis.visit_reset_stmt(stmt),
+        StmtKind::Return(stmt) => vis.visit_return_stmt(stmt),
+        StmtKind::Switch(stmt) => vis.visit_switch_stmt(stmt),
+        StmtKind::WhileLoop(stmt) => vis.visit_while_loop(stmt),
+        StmtKind::Err => {}
+    }
+}
+
+pub fn walk_annotation(vis: &mut impl Visitor, annotation: &Annotation) {
+    vis.visit_span(annotation.span);
+    vis.visit_path_kind(&annotation.identifier);
+    annotation
+        .value_span
+        .iter()
+        .for_each(|span| vis.visit_span(*span));
+}
+
+pub fn walk_alias_decl_stmt(vis: &mut impl Visitor, stmt: &AliasDeclStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_symbol_id(stmt.symbol_id);
+    stmt.exprs.iter().for_each(|e| vis.visit_expr(e));
+}
+
+pub fn walk_assign_stmt(vis: &mut impl Visitor, stmt: &AssignStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_expr(&stmt.lhs);
+    vis.visit_expr(&stmt.rhs);
+}
+
+pub fn walk_barrier_stmt(vis: &mut impl Visitor, stmt: &BarrierStmt) {
+    vis.visit_span(stmt.span);
+    stmt.qubits.iter().for_each(|q| vis.visit_gate_operand(q));
+}
+
+pub fn walk_box_stmt(vis: &mut impl Visitor, stmt: &BoxStmt) {
+    vis.visit_span(stmt.span);
+    stmt.duration.iter().for_each(|d| vis.visit_expr(d));
+    stmt.body.iter().for_each(|s| vis.visit_stmt(s));
+}
+
+pub fn walk_block(vis: &mut impl Visitor, block: &Block) {
+    vis.visit_span(block.span);
+    block.stmts.iter().for_each(|s| vis.visit_stmt(s));
+}
+
+pub fn walk_break_stmt(vis: &mut impl Visitor, stmt: &BreakStmt) {
+    vis.visit_span(stmt.span);
+}
+
+pub fn walk_calibration_stmt(vis: &mut impl Visitor, stmt: &CalibrationStmt) {
+    vis.visit_span(stmt.span);
+}
+
+pub fn walk_calibration_grammar_stmt(vis: &mut impl Visitor, stmt: &CalibrationGrammarStmt) {
+    vis.visit_span(stmt.span);
+}
+
+pub fn walk_classical_decl_stmt(vis: &mut impl Visitor, stmt: &ClassicalDeclarationStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_span(stmt.ty_span);
+    vis.visit_symbol_id(stmt.symbol_id);
+    vis.visit_expr(&stmt.init_expr);
+}
+
+pub fn walk_continue_stmt(vis: &mut impl Visitor, stmt: &ContinueStmt) {
+    vis.visit_span(stmt.span);
+}
+
+pub fn walk_def_stmt(vis: &mut impl Visitor, stmt: &DefStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_symbol_id(stmt.symbol_id);
+    stmt.params.iter().for_each(|p| vis.visit_symbol_id(*p));
+    vis.visit_block(&stmt.body);
+    vis.visit_span(stmt.return_type_span);
+}
+
+pub fn walk_def_cal_stmt(vis: &mut impl Visitor, stmt: &DefCalStmt) {
+    vis.visit_span(stmt.span);
+}
+
+pub fn walk_delay_stmt(vis: &mut impl Visitor, stmt: &DelayStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_expr(&stmt.duration);
+    stmt.qubits.iter().for_each(|q| vis.visit_gate_operand(q));
+}
+
+pub fn walk_end_stmt(vis: &mut impl Visitor, stmt: &EndStmt) {
+    vis.visit_span(stmt.span);
+}
+
+pub fn walk_expr_stmt(vis: &mut impl Visitor, stmt: &ExprStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_expr(&stmt.expr);
+}
+
+pub fn walk_extern_decl(vis: &mut impl Visitor, stmt: &ExternDecl) {
+    vis.visit_span(stmt.span);
+    vis.visit_symbol_id(stmt.symbol_id);
+}
+
+pub fn walk_for_stmt(vis: &mut impl Visitor, stmt: &ForStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_symbol_id(stmt.loop_variable);
+    vis.visit_enumerable_set(&stmt.set_declaration);
+    vis.visit_stmt(&stmt.body);
+}
+
+pub fn walk_gate_call_stmt(vis: &mut impl Visitor, stmt: &GateCall) {
+    vis.visit_span(stmt.span);
+    stmt.modifiers
+        .iter()
+        .for_each(|m| vis.visit_quantum_gate_modifier(m));
+    vis.visit_symbol_id(stmt.symbol_id);
+    vis.visit_span(stmt.gate_name_span);
+    stmt.args.iter().for_each(|a| vis.visit_expr(a));
+    stmt.qubits.iter().for_each(|q| vis.visit_gate_operand(q));
+    stmt.duration.iter().for_each(|d| vis.visit_expr(d));
+}
+
+pub fn walk_if_stmt(vis: &mut impl Visitor, stmt: &IfStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_expr(&stmt.condition);
+    vis.visit_stmt(&stmt.if_body);
+    stmt.else_body.iter().for_each(|s| vis.visit_stmt(s));
+}
+
+pub fn walk_include_stmt(vis: &mut impl Visitor, stmt: &IncludeStmt) {
+    vis.visit_span(stmt.span);
+}
+
+pub fn walk_indexed_classical_type_assign_stmt(
+    vis: &mut impl Visitor,
+    stmt: &IndexedClassicalTypeAssignStmt,
+) {
+    vis.visit_span(stmt.span);
+    vis.visit_expr(&stmt.lhs);
+    stmt.indices.iter().for_each(|i| vis.visit_index(i));
+    vis.visit_expr(&stmt.rhs);
+}
+
+pub fn walk_input_declaration(vis: &mut impl Visitor, stmt: &InputDeclaration) {
+    vis.visit_span(stmt.span);
+    vis.visit_symbol_id(stmt.symbol_id);
+}
+
+pub fn walk_output_declaration(vis: &mut impl Visitor, stmt: &OutputDeclaration) {
+    vis.visit_span(stmt.span);
+    vis.visit_span(stmt.ty_span);
+    vis.visit_symbol_id(stmt.symbol_id);
+    vis.visit_expr(&stmt.init_expr);
+}
+
+pub fn walk_measure_arrow_stmt(vis: &mut impl Visitor, stmt: &MeasureArrowStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_measure_expr(&stmt.measurement);
+    stmt.target.iter().for_each(|t| vis.visit_expr(t));
+}
+
+pub fn walk_quantum_gate_definition(vis: &mut impl Visitor, stmt: &QuantumGateDefinition) {
+    vis.visit_span(stmt.span);
+    vis.visit_span(stmt.name_span);
+    vis.visit_symbol_id(stmt.symbol_id);
+    stmt.params.iter().for_each(|p| vis.visit_symbol_id(*p));
+    stmt.qubits.iter().for_each(|q| vis.visit_symbol_id(*q));
+    vis.visit_block(&stmt.body);
+}
+
+pub fn walk_qubit_decl(vis: &mut impl Visitor, stmt: &QubitDeclaration) {
+    vis.visit_span(stmt.span);
+    vis.visit_symbol_id(stmt.symbol_id);
+}
+
+pub fn walk_qubit_array_decl(vis: &mut impl Visitor, stmt: &QubitArrayDeclaration) {
+    vis.visit_span(stmt.span);
+    vis.visit_symbol_id(stmt.symbol_id);
+    vis.visit_expr(&stmt.size);
+    vis.visit_span(stmt.size_span);
+}
+
+pub fn walk_reset_stmt(vis: &mut impl Visitor, stmt: &ResetStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_span(stmt.reset_token_span);
+    vis.visit_gate_operand(&stmt.operand);
+}
+
+pub fn walk_return_stmt(vis: &mut impl Visitor, stmt: &ReturnStmt) {
+    vis.visit_span(stmt.span);
+    stmt.expr.iter().for_each(|e| vis.visit_expr(e));
+}
+
+pub fn walk_switch_stmt(vis: &mut impl Visitor, stmt: &SwitchStmt) {
+    vis.visit_span(stmt.span);
+    vis.visit_expr(&stmt.target);
+    stmt.cases.iter().for_each(|c| vis.visit_switch_case(c));
+    stmt.default.iter().for_each(|d| vis.visit_block(d));
+}
+
+pub fn walk_while_loop(vis: &mut impl Visitor, stmt: &WhileLoop) {
+    vis.visit_span(stmt.span);
+    vis.visit_expr(&stmt.condition);
+    vis.visit_stmt(&stmt.body);
+}
+
+pub fn walk_expr(vis: &mut impl Visitor, expr: &Expr) {
+    vis.visit_span(expr.span);
+    expr.const_value.iter().for_each(|v| vis.visit_literal(v));
+    vis.visit_ty(&expr.ty);
+    match expr.kind.as_ref() {
+        ExprKind::CapturedIdent(id) => vis.visit_symbol_id(*id),
+        ExprKind::Ident(id) => vis.visit_symbol_id(*id),
+        ExprKind::UnaryOp(expr) => vis.visit_unary_op_expr(expr),
+        ExprKind::BinaryOp(expr) => vis.visit_binary_op_expr(expr),
+        ExprKind::Lit(lit) => vis.visit_literal(lit),
+        ExprKind::FunctionCall(call) => vis.visit_function_call_expr(call),
+        ExprKind::BuiltinFunctionCall(call) => vis.visit_builtin_function_call_expr(call),
+        ExprKind::Cast(cast) => vis.visit_cast_expr(cast),
+        ExprKind::IndexedExpr(expr) => vis.visit_indexed_expr(expr),
+        ExprKind::Paren(expr) => vis.visit_expr(expr),
+        ExprKind::Measure(expr) => vis.visit_measure_expr(expr),
+        ExprKind::SizeofCall(call) => vis.visit_sizeof_call_expr(call),
+        // ExprKind::DurationofCall(call) => vis.visit_durationof_call_expr(call), // Other PR: Handle durationof calls
+        ExprKind::Err => {}
+    }
+}
+
+pub fn walk_unary_op_expr(vis: &mut impl Visitor, expr: &UnaryOpExpr) {
+    vis.visit_span(expr.span);
+    vis.visit_unary_op(expr.op);
+    vis.visit_expr(&expr.expr);
+}
+
+pub fn walk_binary_op_expr(vis: &mut impl Visitor, expr: &BinaryOpExpr) {
+    vis.visit_bin_op(expr.op);
+    vis.visit_expr(&expr.lhs);
+    vis.visit_expr(&expr.rhs);
+}
+
+pub fn walk_function_call_expr(vis: &mut impl Visitor, expr: &FunctionCall) {
+    vis.visit_span(expr.span);
+    vis.visit_span(expr.fn_name_span);
+    vis.visit_symbol_id(expr.symbol_id);
+    expr.args.iter().for_each(|a| vis.visit_expr(a));
+}
+
+pub fn walk_builtin_function_call_expr(vis: &mut impl Visitor, expr: &BuiltinFunctionCall) {
+    vis.visit_span(expr.span);
+    vis.visit_span(expr.fn_name_span);
+    vis.visit_ty(&expr.function_ty);
+    expr.args.iter().for_each(|a| vis.visit_expr(a));
+}
+
+pub fn walk_cast_expr(vis: &mut impl Visitor, expr: &Cast) {
+    vis.visit_span(expr.span);
+    vis.visit_ty(&expr.ty);
+    vis.visit_expr(&expr.expr);
+}
+
+pub fn walk_indexed_expr(vis: &mut impl Visitor, expr: &IndexedExpr) {
+    vis.visit_span(expr.span);
+    vis.visit_expr(&expr.collection);
+    vis.visit_index(&expr.index);
+}
+
+pub fn walk_measure_expr(vis: &mut impl Visitor, expr: &MeasureExpr) {
+    vis.visit_span(expr.span);
+    vis.visit_span(expr.measure_token_span);
+    vis.visit_gate_operand(&expr.operand);
+}
+
+pub fn walk_sizeof_call_expr(vis: &mut impl Visitor, expr: &SizeofCallExpr) {
+    vis.visit_span(expr.span);
+    vis.visit_span(expr.fn_name_span);
+    vis.visit_expr(&expr.array);
+    vis.visit_expr(&expr.dim);
+}
+
+// pub fn walk_durationof_call_expr(vis: &mut impl Visitor, expr: &DurationofCallExpr) {
+//     vis.visit_span(expr.span);
+//     vis.visit_span(expr.fn_name_span);
+//     vis.visit_block(&expr.scope);
+// }
+
+pub fn walk_set(vis: &mut impl Visitor, set: &Set) {
+    vis.visit_span(set.span);
+    set.values.iter().for_each(|v| vis.visit_expr(v));
+}
+
+pub fn walk_range(vis: &mut impl Visitor, range: &Range) {
+    vis.visit_span(range.span);
+    range.start.iter().for_each(|s| vis.visit_expr(s));
+    range.end.iter().for_each(|e| vis.visit_expr(e));
+    range.step.iter().for_each(|s| vis.visit_expr(s));
+}
+
+pub fn walk_quantum_gate_modifier(vis: &mut impl Visitor, modifier: &QuantumGateModifier) {
+    vis.visit_span(modifier.span);
+    vis.visit_span(modifier.modifier_keyword_span);
+    match &modifier.kind {
+        GateModifierKind::Inv => {}
+        GateModifierKind::Pow(expr)
+        | GateModifierKind::Ctrl(expr)
+        | GateModifierKind::NegCtrl(expr) => vis.visit_expr(expr),
+    }
+}
+
+pub fn walk_gate_operand(vis: &mut impl Visitor, operand: &GateOperand) {
+    vis.visit_span(operand.span);
+    match &operand.kind {
+        GateOperandKind::Expr(expr) => vis.visit_expr(expr),
+        GateOperandKind::HardwareQubit(qubit) => vis.visit_hardware_qubit(qubit),
+        GateOperandKind::Err => {}
+    }
+}
+
+pub fn walk_hardware_qubit(vis: &mut impl Visitor, qubit: &HardwareQubit) {
+    vis.visit_span(qubit.span);
+}
+
+pub fn walk_enumerable_set(vis: &mut impl Visitor, set: &EnumerableSet) {
+    match set {
+        EnumerableSet::Set(set) => vis.visit_set(set),
+        EnumerableSet::Range(range) => vis.visit_range(range),
+        EnumerableSet::Expr(expr) => vis.visit_expr(expr),
+    }
+}
+
+pub fn walk_switch_case(vis: &mut impl Visitor, case: &SwitchCase) {
+    vis.visit_span(case.span);
+    case.labels.iter().for_each(|l| vis.visit_expr(l));
+    vis.visit_block(&case.block);
+}
+
+pub fn walk_index(vis: &mut impl Visitor, index: &Index) {
+    match index {
+        Index::Expr(expr) => vis.visit_expr(expr),
+        Index::Range(range) => vis.visit_range(range),
+    }
+}
+
+pub fn walk_literal(vis: &mut impl Visitor, literal: &LiteralKind) {
+    match literal {
+        LiteralKind::Array(array) => vis.visit_array(array),
+        // Other literal kinds are terminal and don't need traversal
+        LiteralKind::Angle(_)
+        | LiteralKind::Bitstring(_, _)
+        | LiteralKind::Bool(_)
+        | LiteralKind::Duration(..)
+        | LiteralKind::Float(_)
+        | LiteralKind::Complex(_)
+        | LiteralKind::Int(_)
+        | LiteralKind::BigInt(_)
+        | LiteralKind::Bit(_) => {}
+    }
+}
+
+pub fn walk_array(vis: &mut impl Visitor, array: &Array) {
+    array.data.iter().for_each(|e| vis.visit_expr(e));
+}
+
+pub fn walk_path(vis: &mut impl Visitor, path: &Path) {
+    if let Some(ref parts) = path.segments {
+        vis.visit_idents(parts);
+    }
+    vis.visit_ident(&path.name);
+}
+
+pub fn walk_path_kind(vis: &mut impl Visitor, path: &PathKind) {
+    match path {
+        PathKind::Ok(path) => vis.visit_path(path),
+        PathKind::Err(Some(incomplete_path)) => {
+            vis.visit_idents(&incomplete_path.segments);
+        }
+        PathKind::Err(None) => {}
+    }
+}
+
+pub fn walk_idents(vis: &mut impl Visitor, idents: &[Ident]) {
+    idents.iter().for_each(|i| vis.visit_ident(i));
+}

--- a/source/compiler/qsc_qasm/src/semantic/visit.rs
+++ b/source/compiler/qsc_qasm/src/semantic/visit.rs
@@ -540,8 +540,7 @@ pub fn walk_expr(vis: &mut impl Visitor, expr: &Expr) {
     expr.const_value.iter().for_each(|v| vis.visit_literal(v));
     vis.visit_ty(&expr.ty);
     match expr.kind.as_ref() {
-        ExprKind::CapturedIdent(id) => vis.visit_symbol_id(*id),
-        ExprKind::Ident(id) => vis.visit_symbol_id(*id),
+        ExprKind::CapturedIdent(id) | ExprKind::Ident(id) => vis.visit_symbol_id(*id),
         ExprKind::UnaryOp(expr) => vis.visit_unary_op_expr(expr),
         ExprKind::BinaryOp(expr) => vis.visit_binary_op_expr(expr),
         ExprKind::Lit(lit) => vis.visit_literal(lit),

--- a/source/compiler/qsc_qasm/src/tests/statement/for_loop.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/for_loop.rs
@@ -140,6 +140,29 @@ fn for_loops_can_iterate_bit_register() -> miette::Result<(), Vec<Report>> {
 }
 
 #[test]
+fn for_loops_can_iterate_const_bit_register() -> miette::Result<(), Vec<Report>> {
+    let source = r#"
+        int sum = 0;
+        bit[5] reg = "10101";
+        for bit b in reg {
+            sum += b;
+        }
+    "#;
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        mutable sum = 0;
+        mutable reg = [One, Zero, One, Zero, One];
+        for b : Result in reg {
+            set sum = sum + Std.OpenQASM.Convert.ResultAsInt(b);
+        }
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
 fn loop_variables_should_be_scoped_to_for_loop() {
     let source = r#"
         int sum = 0;

--- a/source/compiler/qsc_qasm/src/tests/statement/gate_call.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/gate_call.rs
@@ -123,23 +123,14 @@ fn custom_gates_can_be_called_bypassing_stdgates() -> miette::Result<(), Vec<Rep
             U(Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793 / 2., 53), new Std.OpenQASM.Angle.Angle {
                 Value = 0,
                 Size = 53
-            }, new Std.OpenQASM.Angle.Angle {
-                Value = 4503599627370496,
-                Size = 53
-            }, a);
+            }, Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793, 53), a);
             gphase(Std.OpenQASM.Angle.DoubleAsAngle(-3.141592653589793 / 4., 53));
         }
         operation x(a : Qubit) : Unit is Adj + Ctl {
-            U(new Std.OpenQASM.Angle.Angle {
-                Value = 4503599627370496,
-                Size = 53
-            }, new Std.OpenQASM.Angle.Angle {
+            U(Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793, 53), new Std.OpenQASM.Angle.Angle {
                 Value = 0,
                 Size = 53
-            }, new Std.OpenQASM.Angle.Angle {
-                Value = 4503599627370496,
-                Size = 53
-            }, a);
+            }, Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793, 53), a);
             gphase(Std.OpenQASM.Angle.DoubleAsAngle(-3.141592653589793 / 2., 53));
         }
         operation cx(a : Qubit, b : Qubit) : Unit is Adj + Ctl {
@@ -1028,22 +1019,13 @@ fn qasm2_custom_gates_can_be_called_bypassing_stdgates() -> miette::Result<(), V
             u2(new Std.OpenQASM.Angle.Angle {
                 Value = 0,
                 Size = 53
-            }, new Std.OpenQASM.Angle.Angle {
-                Value = 4503599627370496,
-                Size = 53
-            }, a);
+            }, Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793, 53), a);
         }
         operation x(a : Qubit) : Unit is Adj + Ctl {
-            u3(new Std.OpenQASM.Angle.Angle {
-                Value = 4503599627370496,
-                Size = 53
-            }, new Std.OpenQASM.Angle.Angle {
+            u3(Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793, 53), new Std.OpenQASM.Angle.Angle {
                 Value = 0,
                 Size = 53
-            }, new Std.OpenQASM.Angle.Angle {
-                Value = 4503599627370496,
-                Size = 53
-            }, a);
+            }, Std.OpenQASM.Angle.DoubleAsAngle(3.141592653589793, 53), a);
         }
         operation rz(phi : Std.OpenQASM.Angle.Angle, a : Qubit) : Unit is Adj + Ctl {
             u1(phi, a);

--- a/source/language_service/src/completion.rs
+++ b/source/language_service/src/completion.rs
@@ -12,7 +12,7 @@ mod tests;
 mod text_edits;
 
 use crate::{
-    compilation::{Compilation, CompilationKind},
+    compilation::{Compilation, CompilationKind, source_position_to_package_offset},
     protocol::{CompletionItem, CompletionItemKind, CompletionList, TextEdit},
 };
 use ast_context::AstContext;
@@ -36,17 +36,18 @@ pub(crate) fn get_completions(
     position: Position,
     position_encoding: Encoding,
 ) -> CompletionList {
+    let unit = &compilation.user_unit();
     let package_offset =
-        compilation.source_position_to_package_offset(source_name, position, position_encoding);
-    let source = compilation
-        .user_unit()
+        source_position_to_package_offset(&unit.sources, source_name, position, position_encoding);
+
+    let source = unit
         .sources
         .find_by_offset(package_offset)
         .expect("source should exist");
     let source_offset: u32 = package_offset - source.offset;
 
     // The parser uses the relative source name to figure out the implicit namespace.
-    let source_name_relative = compilation.user_unit().sources.relative_name(&source.name);
+    let source_name_relative = unit.sources.relative_name(&source.name);
 
     if log_enabled!(Trace) {
         let last_char = if source_offset > 0 {

--- a/source/language_service/src/completion/tests/openqasm.rs
+++ b/source/language_service/src/completion/tests/openqasm.rs
@@ -1,55 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::sync::Arc;
-
-use crate::{Compilation, completion::tests::check, test_utils::get_sources_and_markers};
+use crate::{completion::tests::check, test_utils::openqasm::compile_with_markers};
 use expect_test::{Expect, expect};
 use indoc::indoc;
-use qsc::{
-    PackageType,
-    line_column::{Position, Range},
-    location::Location,
-};
-
-fn compile_project_with_markers_cursor_optional(
-    sources_with_markers: &[(&str, &str)],
-) -> (Compilation, Option<(String, Position)>, Vec<Location>) {
-    let (sources, cursor_location, target_spans) = get_sources_and_markers(sources_with_markers);
-
-    (
-        Compilation::new_qasm(
-            PackageType::Lib,
-            sources,
-            vec![],
-            &Arc::from("test project"),
-        ),
-        cursor_location,
-        target_spans,
-    )
-}
-
-pub(crate) fn compile_project_with_markers(
-    sources_with_markers: &[(&str, &str)],
-) -> (Compilation, String, Position, Vec<Location>) {
-    let (compilation, cursor_location, target_spans) =
-        compile_project_with_markers_cursor_optional(sources_with_markers);
-
-    let (cursor_uri, cursor_offset) =
-        cursor_location.expect("input string should have a cursor marker");
-
-    (compilation, cursor_uri, cursor_offset, target_spans)
-}
-
-pub fn compile_with_markers(source_with_markers: &str) -> (Compilation, Position, Vec<Range>) {
-    let (compilation, _, cursor_offset, target_spans) =
-        compile_project_with_markers(&[("<source>", source_with_markers)]);
-    (
-        compilation,
-        cursor_offset,
-        target_spans.iter().map(|l| l.range).collect(),
-    )
-}
 
 fn check_single_file(source_with_cursor: &str, completions_to_check: &[&str], expect: &Expect) {
     let (compilation, cursor_position, _) = compile_with_markers(source_with_cursor);

--- a/source/language_service/src/definition.rs
+++ b/source/language_service/src/definition.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::compilation::{Compilation, CompilationKind};
+use crate::compilation::{Compilation, CompilationKind, source_position_to_package_offset};
 use crate::name_locator::{Handler, Locator, LocatorContext};
 use crate::qsc_utils::into_location;
 use qsc::ast::visit::Visitor;
@@ -22,9 +22,10 @@ pub(crate) fn get_definition(
     if let CompilationKind::OpenQASM { sources, .. } = &compilation.kind {
         return crate::openqasm::get_definition(sources, source_name, position, position_encoding);
     }
+    let unit = &compilation.user_unit();
     let offset =
-        compilation.source_position_to_package_offset(source_name, position, position_encoding);
-    let user_ast_package = &compilation.user_unit().ast.package;
+        source_position_to_package_offset(&unit.sources, source_name, position, position_encoding);
+    let user_ast_package = &unit.ast.package;
 
     let mut definition_finder = DefinitionFinder {
         position_encoding,

--- a/source/language_service/src/definition.rs
+++ b/source/language_service/src/definition.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::compilation::Compilation;
+use crate::compilation::{Compilation, CompilationKind};
 use crate::name_locator::{Handler, Locator, LocatorContext};
 use crate::qsc_utils::into_location;
 use qsc::ast::visit::Visitor;
@@ -19,6 +19,9 @@ pub(crate) fn get_definition(
     position: Position,
     position_encoding: Encoding,
 ) -> Option<Location> {
+    if let CompilationKind::OpenQASM { sources, .. } = &compilation.kind {
+        return crate::openqasm::get_definition(sources, source_name, position, position_encoding);
+    }
     let offset =
         compilation.source_position_to_package_offset(source_name, position, position_encoding);
     let user_ast_package = &compilation.user_unit().ast.package;

--- a/source/language_service/src/hover.rs
+++ b/source/language_service/src/hover.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::compilation::Compilation;
+use crate::compilation::{Compilation, source_position_to_package_offset};
 use crate::name_locator::{Handler, Locator, LocatorContext};
 use crate::protocol::Hover;
 use crate::qsc_utils::into_range;
@@ -23,9 +23,10 @@ pub(crate) fn get_hover(
     position: Position,
     position_encoding: Encoding,
 ) -> Option<Hover> {
+    let unit = &compilation.user_unit();
     let offset =
-        compilation.source_position_to_package_offset(source_name, position, position_encoding);
-    let user_ast_package = &compilation.user_unit().ast.package;
+        source_position_to_package_offset(&unit.sources, source_name, position, position_encoding);
+    let user_ast_package = &unit.ast.package;
 
     let mut hover_visitor = HoverGenerator {
         position_encoding,

--- a/source/language_service/src/lib.rs
+++ b/source/language_service/src/lib.rs
@@ -9,6 +9,7 @@ pub mod definition;
 pub mod format;
 pub mod hover;
 mod name_locator;
+mod openqasm;
 pub mod protocol;
 mod qsc_utils;
 pub mod references;

--- a/source/language_service/src/openqasm.rs
+++ b/source/language_service/src/openqasm.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+mod definition;
+mod references;
+mod rename;
+use std::sync::Arc;
+
+pub use definition::get_definition;
+use log::trace;
+use qsc::SourceMap;
+use qsc::line_column::Encoding;
+use qsc::line_column::Position;
+use qsc::qasm::semantic::passes::SymbolFinder;
+pub use references::get_references;
+pub use rename::get_rename;
+pub use rename::prepare_rename;
+
+/// Tries to find a symbol in the given source at the specified position.
+/// returns the semantic parse result and the symbol ID if found.
+fn find_symbol_in_sources(
+    sources: &[(Arc<str>, Arc<str>)],
+    source_name: &str,
+    position: Position,
+    position_encoding: Encoding,
+) -> (
+    qsc::qasm::semantic::QasmSemanticParseResult,
+    Option<qsc::qasm::semantic::symbols::SymbolId>,
+) {
+    let res = qsc::qasm::semantic::parse_sources(sources);
+    let offset = source_position_to_package_offset(
+        &res.source_map,
+        source_name,
+        position,
+        position_encoding,
+    );
+    let id = SymbolFinder::get_symbol_at_offset(&res.program, offset, &res.symbols);
+    (res, id)
+}
+
+/// Maps a source position from the user package
+/// to a package (`SourceMap`) offset.
+fn source_position_to_package_offset(
+    sources: &SourceMap,
+    source_name: &str,
+    source_position: Position,
+    position_encoding: Encoding,
+) -> u32 {
+    let source = sources
+        .find_by_name(source_name)
+        .expect("source should exist in the user source map");
+
+    let mut offset =
+        source_position.to_utf8_byte_offset(position_encoding, source.contents.as_ref());
+
+    let len = u32::try_from(source.contents.len()).expect("source length should fit into u32");
+    if offset > len {
+        // This can happen if the document contents are out of sync with the client's view.
+        // we don't want to accidentally return an offset into the next file -
+        // remap to the end of the current file.
+        trace!(
+            "offset {offset} out of bounds for {}, using end offset instead",
+            source.name
+        );
+        offset = len;
+    }
+
+    source.offset + offset
+}

--- a/source/language_service/src/openqasm/references.rs
+++ b/source/language_service/src/openqasm/references.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::sync::Arc;
+
+use qsc::line_column::{Encoding, Position, Range};
+use qsc::location::Location;
+use qsc::qasm::semantic::passes::ReferenceFinder;
+
+pub fn get_references(
+    sources: &[(Arc<str>, Arc<str>)],
+    source_name: &str,
+    position: Position,
+    position_encoding: Encoding,
+) -> Vec<Location> {
+    let (res, id) =
+        super::find_symbol_in_sources(sources, source_name, position, position_encoding);
+
+    let Some(id) = id else {
+        return vec![];
+    };
+
+    let reference_spans = ReferenceFinder::get_references(&res.program, id, &res.symbols);
+    reference_spans
+        .into_iter()
+        .map(|span| {
+            let source = res
+                .source_map
+                .find_by_offset(span.lo)
+                .expect("source should exist for offset");
+            Location {
+                source: source.name.clone(),
+                range: Range::from_span(
+                    position_encoding,
+                    &source.contents,
+                    &(span - source.offset),
+                ),
+            }
+        })
+        .collect::<Vec<_>>()
+}

--- a/source/language_service/src/openqasm/references.rs
+++ b/source/language_service/src/openqasm/references.rs
@@ -3,9 +3,10 @@
 
 use std::sync::Arc;
 
-use qsc::line_column::{Encoding, Position, Range};
+use qsc::line_column::{Encoding, Position};
 use qsc::location::Location;
-use qsc::qasm::semantic::passes::ReferenceFinder;
+
+use crate::openqasm::get_reference_locations;
 
 pub fn get_references(
     sources: &[(Arc<str>, Arc<str>)],
@@ -20,22 +21,11 @@ pub fn get_references(
         return vec![];
     };
 
-    let reference_spans = ReferenceFinder::get_references(&res.program, id, &res.symbols);
-    reference_spans
-        .into_iter()
-        .map(|span| {
-            let source = res
-                .source_map
-                .find_by_offset(span.lo)
-                .expect("source should exist for offset");
-            Location {
-                source: source.name.clone(),
-                range: Range::from_span(
-                    position_encoding,
-                    &source.contents,
-                    &(span - source.offset),
-                ),
-            }
-        })
-        .collect::<Vec<_>>()
+    get_reference_locations(
+        position_encoding,
+        &res.program,
+        &res.source_map,
+        &res.symbols,
+        id,
+    )
 }

--- a/source/language_service/src/openqasm/rename.rs
+++ b/source/language_service/src/openqasm/rename.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::sync::Arc;
+
+use crate::qsc_utils::into_range;
+use log::trace;
+
+use qsc::line_column::{Encoding, Position, Range};
+use qsc::location::Location;
+use qsc::qasm::semantic::passes::ReferenceFinder;
+
+pub fn prepare_rename(
+    sources: &[(Arc<str>, Arc<str>)],
+    source_name: &str,
+    position: Position,
+    position_encoding: Encoding,
+) -> Option<(Range, String)> {
+    let (res, id) =
+        super::find_symbol_in_sources(sources, source_name, position, position_encoding);
+    let id = id?;
+    let symbol = &res.symbols[id];
+    let range = into_range(position_encoding, symbol.span, &res.source_map);
+    let name = symbol.name.to_string();
+    trace!("prepare_rename: found symbol {name} at {range:?}");
+    Some((range, name))
+}
+
+pub fn get_rename(
+    sources: &[(Arc<str>, Arc<str>)],
+    source_name: &str,
+    position: Position,
+    position_encoding: Encoding,
+) -> Vec<Location> {
+    let (res, id) =
+        super::find_symbol_in_sources(sources, source_name, position, position_encoding);
+
+    let Some(id) = id else {
+        return vec![];
+    };
+    let reference_spans = ReferenceFinder::get_references(&res.program, id, &res.symbols);
+    reference_spans
+        .into_iter()
+        .map(|span| {
+            let source = res
+                .source_map
+                .find_by_offset(span.lo)
+                .expect("source should exist for offset");
+            Location {
+                source: source.name.clone(),
+                range: Range::from_span(
+                    position_encoding,
+                    &source.contents,
+                    &(span - source.offset),
+                ),
+            }
+        })
+        .collect::<Vec<_>>()
+}

--- a/source/language_service/src/references.rs
+++ b/source/language_service/src/references.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use std::rc::Rc;
 
-use crate::compilation::Compilation;
+use crate::compilation::{Compilation, CompilationKind};
 use crate::name_locator::{Handler, Locator, LocatorContext};
 use crate::qsc_utils::into_location;
 use qsc::ast::PathKind;
@@ -25,6 +25,9 @@ pub(crate) fn get_references(
     position_encoding: Encoding,
     include_declaration: bool,
 ) -> Vec<Location> {
+    if let CompilationKind::OpenQASM { sources, .. } = &compilation.kind {
+        return crate::openqasm::get_references(sources, source_name, position, position_encoding);
+    }
     let offset =
         compilation.source_position_to_package_offset(source_name, position, position_encoding);
     let user_ast_package = &compilation.user_unit().ast.package;

--- a/source/language_service/src/references.rs
+++ b/source/language_service/src/references.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use std::rc::Rc;
 
-use crate::compilation::{Compilation, CompilationKind};
+use crate::compilation::{Compilation, CompilationKind, source_position_to_package_offset};
 use crate::name_locator::{Handler, Locator, LocatorContext};
 use crate::qsc_utils::into_location;
 use qsc::ast::PathKind;
@@ -28,9 +28,10 @@ pub(crate) fn get_references(
     if let CompilationKind::OpenQASM { sources, .. } = &compilation.kind {
         return crate::openqasm::get_references(sources, source_name, position, position_encoding);
     }
+    let unit = &compilation.user_unit();
     let offset =
-        compilation.source_position_to_package_offset(source_name, position, position_encoding);
-    let user_ast_package = &compilation.user_unit().ast.package;
+        source_position_to_package_offset(&unit.sources, source_name, position, position_encoding);
+    let user_ast_package = &unit.ast.package;
 
     let mut name_handler = NameHandler {
         reference_finder: ReferenceFinder::new(position_encoding, compilation, include_declaration),

--- a/source/language_service/src/rename.rs
+++ b/source/language_service/src/rename.rs
@@ -7,7 +7,7 @@ mod tests;
 #[cfg(test)]
 mod openqasm_tests;
 
-use crate::compilation::{Compilation, CompilationKind};
+use crate::compilation::{Compilation, CompilationKind, source_position_to_package_offset};
 use crate::name_locator::{Handler, Locator, LocatorContext};
 use crate::qsc_utils::into_range;
 use crate::references::ReferenceFinder;
@@ -26,9 +26,10 @@ pub(crate) fn prepare_rename(
     if let CompilationKind::OpenQASM { sources, .. } = &compilation.kind {
         return crate::openqasm::prepare_rename(sources, source_name, position, position_encoding);
     }
+    let unit = &compilation.user_unit();
     let offset =
-        compilation.source_position_to_package_offset(source_name, position, position_encoding);
-    let user_ast_package = &compilation.user_unit().ast.package;
+        source_position_to_package_offset(&unit.sources, source_name, position, position_encoding);
+    let user_ast_package = &unit.ast.package;
 
     let mut prepare_rename = Rename::new(position_encoding, compilation, true);
     let mut locator = Locator::new(&mut prepare_rename, offset, compilation);
@@ -50,9 +51,10 @@ pub(crate) fn get_rename(
     if let CompilationKind::OpenQASM { sources, .. } = &compilation.kind {
         return crate::openqasm::get_rename(sources, source_name, position, position_encoding);
     }
+    let unit = &compilation.user_unit();
     let offset =
-        compilation.source_position_to_package_offset(source_name, position, position_encoding);
-    let user_ast_package = &compilation.user_unit().ast.package;
+        source_position_to_package_offset(&unit.sources, source_name, position, position_encoding);
+    let user_ast_package = &unit.ast.package;
 
     let mut rename = Rename::new(position_encoding, compilation, false);
     let mut locator = Locator::new(&mut rename, offset, compilation);

--- a/source/language_service/src/rename.rs
+++ b/source/language_service/src/rename.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::compilation::Compilation;
+use crate::compilation::{Compilation, CompilationKind};
 use crate::name_locator::{Handler, Locator, LocatorContext};
 use crate::qsc_utils::into_range;
 use crate::references::ReferenceFinder;
@@ -20,6 +20,9 @@ pub(crate) fn prepare_rename(
     position: Position,
     position_encoding: Encoding,
 ) -> Option<(Range, String)> {
+    if let CompilationKind::OpenQASM { sources, .. } = &compilation.kind {
+        return crate::openqasm::prepare_rename(sources, source_name, position, position_encoding);
+    }
     let offset =
         compilation.source_position_to_package_offset(source_name, position, position_encoding);
     let user_ast_package = &compilation.user_unit().ast.package;
@@ -41,6 +44,9 @@ pub(crate) fn get_rename(
     position: Position,
     position_encoding: Encoding,
 ) -> Vec<Location> {
+    if let CompilationKind::OpenQASM { sources, .. } = &compilation.kind {
+        return crate::openqasm::get_rename(sources, source_name, position, position_encoding);
+    }
     let offset =
         compilation.source_position_to_package_offset(source_name, position, position_encoding);
     let user_ast_package = &compilation.user_unit().ast.package;

--- a/source/language_service/src/rename.rs
+++ b/source/language_service/src/rename.rs
@@ -4,6 +4,9 @@
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod openqasm_tests;
+
 use crate::compilation::{Compilation, CompilationKind};
 use crate::name_locator::{Handler, Locator, LocatorContext};
 use crate::qsc_utils::into_range;

--- a/source/language_service/src/rename/openqasm_tests.rs
+++ b/source/language_service/src/rename/openqasm_tests.rs
@@ -1,0 +1,389 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::{get_rename, prepare_rename};
+use crate::Encoding;
+use crate::test_utils::openqasm::compile_with_markers;
+
+/// Asserts that the rename locations given at the cursor position matches the expected rename locations.
+/// The cursor position is indicated by a `↘` marker in the source text.
+/// The expected rename location ranges are indicated by `◉` markers in the source text.
+fn check(source_with_markers: &str) {
+    let (compilation, cursor_position, target_spans) = compile_with_markers(source_with_markers);
+    let actual = get_rename(&compilation, "<source>", cursor_position, Encoding::Utf8)
+        .into_iter()
+        .map(|l| l.range)
+        .collect::<Vec<_>>();
+    for target in &target_spans {
+        assert!(actual.contains(target));
+    }
+    assert!(target_spans.len() == actual.len());
+}
+
+/// Asserts that the prepare rename given at the cursor position returns None.
+/// The cursor position is indicated by a `↘` marker in the source text.
+fn assert_no_rename(source_with_markers: &str) {
+    let (compilation, cursor_position, _) = compile_with_markers(source_with_markers);
+    let actual = prepare_rename(&compilation, "<source>", cursor_position, Encoding::Utf8);
+    assert!(actual.is_none());
+}
+
+#[test]
+fn callable_def() {
+    check(
+        r#"
+        def ◉Fo↘o◉(int x, int y, int z) {
+            ◉Foo◉(x, y, z);
+        }
+
+        def Bar(int x, int y, int z) {
+            ◉Foo◉(x, y, z);
+        }
+    "#,
+    );
+}
+
+#[test]
+fn callable_ref() {
+    check(
+        r#"
+        def ◉Foo◉(int x, int y, int z) {
+            ◉Foo◉(x, y, z);
+        }
+
+        def Bar(int x, int y, int z) {
+            ◉Fo↘o◉(x, y, z);
+        }
+    "#,
+    );
+}
+
+#[test]
+fn gate_def() {
+    check(
+        r#"
+        gate ◉Fo↘o◉(x, y, z) q { }
+
+        gate Bar(x, y, z) q {
+            ◉Foo◉(x, y, z) q;
+        }
+    "#,
+    );
+}
+
+#[test]
+fn gate_ref() {
+    check(
+        r#"
+        gate ◉Foo◉(x, y, z) q { }
+
+        gate Bar(x, y, z) q {
+            ◉Fo↘o◉(x, y, z) q;
+        }
+    "#,
+    );
+}
+
+#[test]
+fn parameter_def() {
+    check(
+        r#"
+        def Foo(int ◉↘x◉, int y, int z) {
+            int temp = ◉x◉;
+            Foo(◉x◉, y, z);
+        }
+    "#,
+    );
+}
+
+#[test]
+fn parameter_ref() {
+    check(
+        r#"
+        def Foo(int ◉x◉, int y, int z) {
+            int temp = ◉x◉;
+            Foo(◉↘x◉, y, z);
+        }
+    "#,
+    );
+}
+
+#[test]
+fn local_def_in_def() {
+    check(
+        r#"
+        int temp = x;
+        def Foo(int x, int y, int z) {
+            int ◉t↘emp◉ = x;
+            Foo(◉temp◉, y, ◉temp◉);
+        }
+        Foo(temp, y, temp);
+    "#,
+    );
+}
+
+#[test]
+fn local_ref_in_def() {
+    check(
+        r#"
+        int temp = x;
+        def Foo(int x, int y, int z) {
+            int ◉temp◉ = x;
+            Foo(◉t↘emp◉, y, ◉temp◉);
+        }
+        Foo(temp, y, temp);
+    "#,
+    );
+}
+
+#[test]
+fn local_def() {
+    check(
+        r#"
+        def Foo(int x, int y, int z) {
+            int temp = x;
+            Foo(temp, y, temp);
+        }
+        int ◉t↘emp◉ = x;
+        Foo(◉temp◉, y, ◉temp◉);
+    "#,
+    );
+}
+
+#[test]
+fn local_ref() {
+    check(
+        r#"
+        def Foo(int x, int y, int z) {
+            int temp = x;
+            Foo(temp, y, temp);
+        }
+        int ◉temp◉ = x;
+        Foo(◉t↘emp◉, y, ◉temp◉);
+    "#,
+    );
+}
+
+#[test]
+fn input_def() {
+    check(
+        r#"
+        def Foo(int x, int y, int z) {
+            int temp = x;
+            Foo(temp, y, temp);
+        }
+        input int ◉t↘emp◉;
+        Foo(◉temp◉, y, ◉temp◉);
+    "#,
+    );
+}
+
+#[test]
+fn input_ref() {
+    check(
+        r#"
+        def Foo(int x, int y, int z) {
+            int temp = x;
+            Foo(temp, y, temp);
+        }
+        input int ◉temp◉;
+        Foo(◉t↘emp◉, y, ◉temp◉);
+    "#,
+    );
+}
+
+#[test]
+fn output_def() {
+    check(
+        r#"
+        def Foo(int x, int y, int z) {
+            int temp = x;
+            Foo(temp, y, temp);
+        }
+        output int ◉t↘emp◉;
+        Foo(◉temp◉, y, ◉temp◉);
+    "#,
+    );
+}
+
+#[test]
+fn output_ref() {
+    check(
+        r#"
+        def Foo(int x, int y, int z) {
+            int temp = x;
+            Foo(temp, y, temp);
+        }
+        output int ◉temp◉;
+        Foo(◉t↘emp◉, y, ◉temp◉);
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_openqasm_header() {
+    assert_no_rename(
+        r#"
+    OP↘ENQASM 3.0;
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_keyword() {
+    assert_no_rename(
+        r#"
+    inc↘lude "stdgates.inc";
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_type() {
+    assert_no_rename(
+        r#"
+    in↘t x;
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_string_literal() {
+    assert_no_rename(
+        r#"
+    include "He↘llo World!";
+    "#,
+    );
+}
+
+#[test]
+fn rename_for_loop_iter_def() {
+    check(
+        r#"
+    def Foo(int x, int y, int z) {}
+    for int ◉i↘ndex◉ in [0:10] {
+        int temp = ◉index◉;
+        Foo(◉index◉, 0, 7 * ◉index◉ + 3);
+    }
+    "#,
+    );
+}
+
+#[test]
+fn rename_for_loop_iter_ref() {
+    check(
+        r#"
+    def Foo(int x, int y, int z) {}
+    for int ◉index◉ in [0:10] {
+        int temp = ◉↘index◉;
+        Foo(◉index◉, 0, 7 * ◉index◉ + 3);
+    }
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_comment() {
+    assert_no_rename(
+        r#"
+    OPENQASM 3.0;
+    // He↘llo World!
+    include "stdgates.inc";
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_std_item() {
+    assert_no_rename(
+        r#"
+    OPENQASM 3.0;
+    include "stdgates.inc";
+
+    // Built-in operation identifier shouldn't be renameable
+    qubit[1] q;
+    ↘x q[0];
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_intrinsic_3_item() {
+    assert_no_rename(
+        r#"
+    OPENQASM 3.0;
+    // Built-in operation identifier shouldn't be renameable
+    qubit q;
+    ↘U(0.0, 0.0, 0.0) q;
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_intrinsic_2_item() {
+    assert_no_rename(
+        r#"
+    OPENQASM 2.0;
+    // Built-in operation identifier shouldn't be renameable
+    qubit q;
+    ↘U(0.0, 0.0, 0.0) q;
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_intrinsic_const() {
+    assert_no_rename(
+        r#"
+    float i = ↘pi * 7. / 8.;
+    "#,
+    );
+}
+
+#[test]
+fn no_rename_non_id_character() {
+    assert_no_rename(
+        r#"
+    // Non-identifier character '='
+    int x ↘= 0;
+    "#,
+    );
+}
+
+#[test]
+fn ty_param_def() {
+    check(
+        r#"
+    // Use a parameter identifier to model rename
+    def Foo(int ◉↘t◉) -> int { return ◉t◉; }
+    "#,
+    );
+}
+
+#[test]
+fn ty_param_ref() {
+    check(
+        r#"
+    def Foo(int ◉t◉) -> int { return ◉↘t◉; }
+    "#,
+    );
+}
+
+#[test]
+#[ignore = "not yet implemented"]
+fn sized_ty_param_ref() {
+    check(
+        r#"
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    const int ◉size◉ = 5;
+    def Foo(int[◉↘size◉] t) -> int { return t; }
+    const int[◉size◉] u = 10;
+    float[◉size◉] v = 3.14;
+    complex[float[◉size◉]] w = 1.0 + 2.0i;
+    uint[◉size◉] x = 0;
+    array[int[◉size◉]] y = [1, 2, 3, 4, 5];
+    array[complex[float[◉size◉ - 3]]] z = [1.0 + 2.0i, 3.0 + 4.0i];
+    "#,
+    );
+}

--- a/source/language_service/src/rename/openqasm_tests.rs
+++ b/source/language_service/src/rename/openqasm_tests.rs
@@ -165,6 +165,34 @@ fn local_ref() {
 }
 
 #[test]
+fn local_ref_cursor_touches_start() {
+    check(
+        r#"
+        def Foo(int x, int y, int z) {
+            int temp = x;
+            Foo(temp, y, temp);
+        }
+        int ◉temp◉ = x;
+        Foo(◉↘temp◉, y, ◉temp◉);
+    "#,
+    );
+}
+
+#[test]
+fn local_ref_cursor_touches_end() {
+    check(
+        r#"
+        def Foo(int x, int y, int z) {
+            int temp = x;
+            Foo(temp, y, temp);
+        }
+        int ◉temp◉ = x;
+        Foo(◉temp↘◉, y, ◉temp◉);
+    "#,
+    );
+}
+
+#[test]
 fn input_def() {
     check(
         r#"

--- a/source/language_service/src/signature_help.rs
+++ b/source/language_service/src/signature_help.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use crate::{
     Encoding,
-    compilation::Compilation,
+    compilation::{Compilation, source_position_to_package_offset},
     protocol::{ParameterInformation, SignatureHelp, SignatureInformation},
 };
 use qsc::{
@@ -28,8 +28,12 @@ pub(crate) fn get_signature_help(
     position: Position,
     position_encoding: Encoding,
 ) -> Option<SignatureHelp> {
-    let offset =
-        compilation.source_position_to_package_offset(source_name, position, position_encoding);
+    let offset = source_position_to_package_offset(
+        &compilation.user_unit().sources,
+        source_name,
+        position,
+        position_encoding,
+    );
     let user_ast_package = &compilation.user_unit().ast.package;
 
     let mut finder = SignatureHelpFinder {

--- a/source/language_service/src/test_utils.rs
+++ b/source/language_service/src/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+pub(super) mod openqasm;
+
 use std::sync::Arc;
 
 use crate::compilation::{Compilation, CompilationKind};
@@ -396,55 +398,4 @@ fn target_offsets_to_spans(target_offsets: &[u32]) -> Vec<Span> {
         });
     }
     spans
-}
-
-pub(crate) mod openqasm {
-    use super::get_sources_and_markers;
-    use crate::Compilation;
-    use qsc::{
-        PackageType,
-        line_column::{Position, Range},
-        location::Location,
-    };
-    use std::sync::Arc;
-
-    fn compile_project_with_markers_cursor_optional(
-        sources_with_markers: &[(&str, &str)],
-    ) -> (Compilation, Option<(String, Position)>, Vec<Location>) {
-        let (sources, cursor_location, target_spans) =
-            get_sources_and_markers(sources_with_markers);
-
-        (
-            Compilation::new_qasm(
-                PackageType::Lib,
-                sources,
-                vec![],
-                &Arc::from("test project"),
-            ),
-            cursor_location,
-            target_spans,
-        )
-    }
-
-    pub(crate) fn compile_project_with_markers(
-        sources_with_markers: &[(&str, &str)],
-    ) -> (Compilation, String, Position, Vec<Location>) {
-        let (compilation, cursor_location, target_spans) =
-            compile_project_with_markers_cursor_optional(sources_with_markers);
-
-        let (cursor_uri, cursor_offset) =
-            cursor_location.expect("input string should have a cursor marker");
-
-        (compilation, cursor_uri, cursor_offset, target_spans)
-    }
-
-    pub fn compile_with_markers(source_with_markers: &str) -> (Compilation, Position, Vec<Range>) {
-        let (compilation, _, cursor_offset, target_spans) =
-            compile_project_with_markers(&[("<source>", source_with_markers)]);
-        (
-            compilation,
-            cursor_offset,
-            target_spans.iter().map(|l| l.range).collect(),
-        )
-    }
 }

--- a/source/language_service/src/test_utils.rs
+++ b/source/language_service/src/test_utils.rs
@@ -397,3 +397,54 @@ fn target_offsets_to_spans(target_offsets: &[u32]) -> Vec<Span> {
     }
     spans
 }
+
+pub(crate) mod openqasm {
+    use super::get_sources_and_markers;
+    use crate::Compilation;
+    use qsc::{
+        PackageType,
+        line_column::{Position, Range},
+        location::Location,
+    };
+    use std::sync::Arc;
+
+    fn compile_project_with_markers_cursor_optional(
+        sources_with_markers: &[(&str, &str)],
+    ) -> (Compilation, Option<(String, Position)>, Vec<Location>) {
+        let (sources, cursor_location, target_spans) =
+            get_sources_and_markers(sources_with_markers);
+
+        (
+            Compilation::new_qasm(
+                PackageType::Lib,
+                sources,
+                vec![],
+                &Arc::from("test project"),
+            ),
+            cursor_location,
+            target_spans,
+        )
+    }
+
+    pub(crate) fn compile_project_with_markers(
+        sources_with_markers: &[(&str, &str)],
+    ) -> (Compilation, String, Position, Vec<Location>) {
+        let (compilation, cursor_location, target_spans) =
+            compile_project_with_markers_cursor_optional(sources_with_markers);
+
+        let (cursor_uri, cursor_offset) =
+            cursor_location.expect("input string should have a cursor marker");
+
+        (compilation, cursor_uri, cursor_offset, target_spans)
+    }
+
+    pub fn compile_with_markers(source_with_markers: &str) -> (Compilation, Position, Vec<Range>) {
+        let (compilation, _, cursor_offset, target_spans) =
+            compile_project_with_markers(&[("<source>", source_with_markers)]);
+        (
+            compilation,
+            cursor_offset,
+            target_spans.iter().map(|l| l.range).collect(),
+        )
+    }
+}

--- a/source/language_service/src/test_utils/openqasm.rs
+++ b/source/language_service/src/test_utils/openqasm.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::get_sources_and_markers;
+use crate::Compilation;
+use qsc::{
+    PackageType,
+    line_column::{Position, Range},
+    location::Location,
+};
+use std::sync::Arc;
+
+fn compile_project_with_markers_cursor_optional(
+    sources_with_markers: &[(&str, &str)],
+) -> (Compilation, Option<(String, Position)>, Vec<Location>) {
+    let (sources, cursor_location, target_spans) = get_sources_and_markers(sources_with_markers);
+
+    (
+        Compilation::new_qasm(
+            PackageType::Lib,
+            sources,
+            vec![],
+            &Arc::from("test project"),
+        ),
+        cursor_location,
+        target_spans,
+    )
+}
+
+pub(crate) fn compile_project_with_markers(
+    sources_with_markers: &[(&str, &str)],
+) -> (Compilation, String, Position, Vec<Location>) {
+    let (compilation, cursor_location, target_spans) =
+        compile_project_with_markers_cursor_optional(sources_with_markers);
+
+    let (cursor_uri, cursor_offset) =
+        cursor_location.expect("input string should have a cursor marker");
+
+    (compilation, cursor_uri, cursor_offset, target_spans)
+}
+
+pub fn compile_with_markers(source_with_markers: &str) -> (Compilation, Position, Vec<Range>) {
+    let (compilation, _, cursor_offset, target_spans) =
+        compile_project_with_markers(&[("<source>", source_with_markers)]);
+    (
+        compilation,
+        cursor_offset,
+        target_spans.iter().map(|l| l.range).collect(),
+    )
+}

--- a/source/vscode/src/language-service/activate.ts
+++ b/source/vscode/src/language-service/activate.ts
@@ -119,10 +119,24 @@ export async function activateLanguageService(
     ),
   );
 
+  subscriptions.push(
+    vscode.languages.registerDefinitionProvider(
+      openqasmLanguageId,
+      createDefinitionProvider(languageService),
+    ),
+  );
+
   // find references
   subscriptions.push(
     vscode.languages.registerReferenceProvider(
       qsharpLanguageId,
+      createReferenceProvider(languageService),
+    ),
+  );
+
+  subscriptions.push(
+    vscode.languages.registerReferenceProvider(
+      openqasmLanguageId,
       createReferenceProvider(languageService),
     ),
   );
@@ -141,6 +155,13 @@ export async function activateLanguageService(
   subscriptions.push(
     vscode.languages.registerRenameProvider(
       qsharpLanguageId,
+      createRenameProvider(languageService),
+    ),
+  );
+
+  subscriptions.push(
+    vscode.languages.registerRenameProvider(
+      openqasmLanguageId,
       createRenameProvider(languageService),
     ),
   );

--- a/source/vscode/src/language-service/activate.ts
+++ b/source/vscode/src/language-service/activate.ts
@@ -114,14 +114,7 @@ export async function activateLanguageService(
   // go to def
   subscriptions.push(
     vscode.languages.registerDefinitionProvider(
-      qsharpLanguageId,
-      createDefinitionProvider(languageService),
-    ),
-  );
-
-  subscriptions.push(
-    vscode.languages.registerDefinitionProvider(
-      openqasmLanguageId,
+      [qsharpLanguageId, openqasmLanguageId],
       createDefinitionProvider(languageService),
     ),
   );
@@ -129,14 +122,7 @@ export async function activateLanguageService(
   // find references
   subscriptions.push(
     vscode.languages.registerReferenceProvider(
-      qsharpLanguageId,
-      createReferenceProvider(languageService),
-    ),
-  );
-
-  subscriptions.push(
-    vscode.languages.registerReferenceProvider(
-      openqasmLanguageId,
+      [qsharpLanguageId, openqasmLanguageId],
       createReferenceProvider(languageService),
     ),
   );
@@ -154,14 +140,7 @@ export async function activateLanguageService(
   // rename symbol
   subscriptions.push(
     vscode.languages.registerRenameProvider(
-      qsharpLanguageId,
-      createRenameProvider(languageService),
-    ),
-  );
-
-  subscriptions.push(
-    vscode.languages.registerRenameProvider(
-      openqasmLanguageId,
+      [qsharpLanguageId, openqasmLanguageId],
       createRenameProvider(languageService),
     ),
   );
@@ -169,7 +148,7 @@ export async function activateLanguageService(
   // code lens
   subscriptions.push(
     vscode.languages.registerCodeLensProvider(
-      qsharpLanguageId,
+      [qsharpLanguageId, openqasmLanguageId],
       createQdkCodeLensProvider(languageService),
     ),
   );
@@ -178,14 +157,6 @@ export async function activateLanguageService(
     vscode.languages.registerCodeActionsProvider(
       qsharpLanguageId,
       createCodeActionsProvider(languageService),
-    ),
-  );
-
-  // code lens for openqasm
-  subscriptions.push(
-    vscode.languages.registerCodeLensProvider(
-      openqasmLanguageId,
-      createQdkCodeLensProvider(languageService),
     ),
   );
 


### PR DESCRIPTION
## Summary of changes

- Language service (OpenQASM)
  - Added OpenQASM support for prepare-rename, rename, go-to-definition, and find-references.
  - Added tests for OpenQASM rename. Other functionalities are transitively tested as they all use the same code underneath
- OpenQASM semantic layer (compiler)
  - Implemented semantic passes and visitors to support symbol lookup and reference finding (SymbolFinder, ReferenceFinder).
  - Fixed and standardized source span tracking (notably for casts) locations.
  - Introduced new semantic AST field indicating whether casts were implicit or explicit
- VS Code extension
  - Registered providers for OpenQASM: completion, definition, references, and rename.
- In VS Code, OpenQASM files now support:
  - Rename symbol (F2) for user-defined identifiers, gates, functions, etc; built-ins are not renameable.
  - Go to Definition (F12) and Find All References (Shift+F12).

### Notes

- Expressions in type designators are not support with the LS features. We need a follow up PR to add the support as it will be a significant set of changes to support this. There is an ignored test for this scenario for the follow up PR.
- The semantic span fixes (e.g., casts) were required to make rename/definition locations correct, but it turned out that we couldn't reuse the Q# AST based LS features, so they are now correct, but aren't used for LS features.