### PR TITLE
Add support for qubit alias decls

### DIFF
--- a/source/compiler/qsc_qasm/src/semantic/error.rs
+++ b/source/compiler/qsc_qasm/src/semantic/error.rs
@@ -187,6 +187,10 @@ pub enum SemanticErrorKind {
     #[error("{0} can only appear in {1} scopes")]
     #[diagnostic(code("Qasm.Lowerer.InvalidScope"))]
     InvalidScope(String, String, #[label] Span),
+    #[error("invalid type in alias expression: {0}")]
+    #[diagnostic(code("Qasm.Lowerer.InvalidTypeInAlias"))]
+    #[diagnostic(help("aliases can only be applied to quantum bits and registers"))]
+    InvalidTypeInAlias(String, #[label] Span),
     #[error("measure statements must have a name")]
     #[diagnostic(code("Qasm.Lowerer.MeasureExpressionsMustHaveName"))]
     MeasureExpressionsMustHaveName(#[label] Span),

--- a/source/compiler/qsc_qasm/src/semantic/lowerer.rs
+++ b/source/compiler/qsc_qasm/src/semantic/lowerer.rs
@@ -585,13 +585,13 @@ impl Lowerer {
     /// another name as long as the alias is in scope.
     /// The lhs type is always a register whose size is calculated based on the rhs expr.
     /// except where the rhs is a single (qu)bit.
-    /// ```
+    /// ```openqasm
     /// qubit[5] q;
     /// let myreg = q[1:4];
     /// ```
     /// Here `myreg[0]` refers to the qubit `q[1]` and so on. The type of `myreg` is
     /// `qubit[3]`. Aliases can also use array concatenation of registers.
-    /// ```
+    /// ```openqasm
     /// qubit[2] one;
     /// qubit[10] two;
     /// // Aliased register of twelve qubits

--- a/source/compiler/qsc_qasm/src/semantic/resources/openqasm_lowerer_errors_test.qasm
+++ b/source/compiler/qsc_qasm/src/semantic/resources/openqasm_lowerer_errors_test.qasm
@@ -35,9 +35,14 @@ int rxx = 3;
 undefined_symbol;
 
 // InconsistentTypesInAlias
-array[int, 2] alias_component_1 = {1, 2};
-array[angle, 2] alias_component_2 = {1.0, 2.0};
-let alias = alias_component_1 ++ alias_component_2;
+qubit[2] alias_component_1;
+bit[5] alias_component_2;
+let alias_1 = alias_component_1 ++ alias_component_2;
+
+// InvalidTypesInAlias
+bit[2] alias_component_3;
+int alias_component_4;
+let alias_2 = alias_component_3 ++ alias_component_4;
 
 // CannotUpdateConstVariable in simple assign
 const int const_variable = 1;

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+mod alias;
 mod angle;
 mod bit;
 mod bool;

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/alias.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/alias.rs
@@ -304,3 +304,65 @@ fn invalid_types_raise_error_for_each() {
             ]"#]],
     );
 }
+
+#[test]
+fn bit_alias_errors() {
+    check_last_stmt(
+        r#"
+        bit b;
+        // Aliased register of twelve qubits
+        let b_alias = b;
+        "#,
+        &expect![[r#"
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [9-15]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [9-15]:
+                            symbol_id: 8
+                            ty_span: [9-12]
+                            init_expr: Expr [9-15]:
+                                ty: const bit
+                                kind: Lit: Bit(0)
+                    Stmt [69-85]:
+                        annotations: <empty>
+                        kind: AliasDeclStmt [69-85]:
+                            symbol_id: 9
+                            exprs:
+                                Expr [83-84]:
+                                    ty: bit
+                                    kind: SymbolId(8)
+
+            [Qasm.Lowerer.InvalidTypeInAlias
+
+              x invalid type in alias expression: bit
+               ,-[test:4:23]
+             3 |         // Aliased register of twelve qubits
+             4 |         let b_alias = b;
+               :                       ^
+             5 |         
+               `----
+              help: aliases can only be applied to quantum bits and registers
+            ]"#]],
+    );
+}
+
+#[test]
+fn can_alias_qubit() {
+    check_last_stmt(
+        r#"
+        qubit q;
+        // Aliased register of twelve qubits
+        let q_alias = q;
+        "#,
+        &expect![[r#"
+            AliasDeclStmt [71-87]:
+                symbol_id: 9
+                exprs:
+                    Expr [85-86]:
+                        ty: qubit
+                        kind: SymbolId(8)"#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/alias.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/alias.rs
@@ -1,0 +1,306 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use expect_test::expect;
+
+use crate::semantic::tests::{check_last_stmt, check_stmt_kind, check_stmt_kinds};
+
+#[test]
+fn can_alias_qubit_registers() {
+    check_last_stmt(
+        r#"
+        qubit[2] one;
+        qubit[10] two;
+        // Aliased register of twelve qubits
+        let concatenated = one ++ two;
+        "#,
+        &expect![[r#"
+            AliasDeclStmt [99-129]:
+                symbol_id: 10
+                exprs:
+                    Expr [118-121]:
+                        ty: qubit[2]
+                        kind: SymbolId(8)
+                    Expr [125-128]:
+                        ty: qubit[10]
+                        kind: SymbolId(9)"#]],
+    );
+}
+
+#[test]
+fn first_qubit_from_aliased_qreg() {
+    check_last_stmt(
+        r#"
+        qubit[2] one;
+        qubit[10] two;
+        let concatenated = one ++ two;
+        // First qubit in aliased qubit array
+        let first = concatenated[0];
+        "#,
+        &expect![[r#"
+            AliasDeclStmt [139-167]:
+                symbol_id: 11
+                exprs:
+                    Expr [151-165]:
+                        ty: qubit
+                        kind: IndexedExpr [151-165]:
+                            collection: Expr [151-163]:
+                                ty: qubit[12]
+                                kind: SymbolId(10)
+                            index: Expr [164-165]:
+                                ty: const int
+                                kind: Lit: Int(0)"#]],
+    );
+}
+
+#[test]
+fn can_alias_bit_registers() {
+    check_last_stmt(
+        r#"
+        bit[2] one;
+        bit[10] two;
+        // Aliased register of twelve bits
+        let concatenated = one ++ two;
+        "#,
+        &expect![[r#"
+            AliasDeclStmt [93-123]:
+                symbol_id: 10
+                exprs:
+                    Expr [112-115]:
+                        ty: bit[2]
+                        kind: SymbolId(8)
+                    Expr [119-122]:
+                        ty: bit[10]
+                        kind: SymbolId(9)"#]],
+    );
+}
+
+#[test]
+fn first_bit_from_aliased_creg() {
+    check_last_stmt(
+        r#"
+        bit[2] one;
+        bit[10] two;
+        let concatenated = one ++ two;
+        // First bit in aliased bit array
+        bit first = concatenated[0];
+        "#,
+        &expect![[r#"
+            ClassicalDeclarationStmt [131-159]:
+                symbol_id: 11
+                ty_span: [131-134]
+                init_expr: Expr [143-157]:
+                    ty: bit
+                    kind: IndexedExpr [143-157]:
+                        collection: Expr [143-155]:
+                            ty: bit[12]
+                            kind: SymbolId(10)
+                        index: Expr [156-157]:
+                            ty: const int
+                            kind: Lit: Int(0)"#]],
+    );
+}
+
+#[test]
+fn inconsistent_types_raise_error() {
+    check_last_stmt(
+        r#"
+        // InconsistentTypesInAlias
+        qubit[2] alias_component_1;
+        bit[5] alias_component_2;
+        let alias_1 = alias_component_1 ++ alias_component_2;
+        "#,
+        &expect![[r#"
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [45-72]:
+                        annotations: <empty>
+                        kind: QubitArrayDeclaration [45-72]:
+                            symbol_id: 8
+                            size: Expr [51-52]:
+                                ty: const uint
+                                const_value: Int(2)
+                                kind: Lit: Int(2)
+                            size_span: [51-52]
+                    Stmt [81-106]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [81-106]:
+                            symbol_id: 9
+                            ty_span: [81-87]
+                            init_expr: Expr [81-106]:
+                                ty: const bit[5]
+                                kind: Lit: Bitstring("00000")
+                    Stmt [115-168]:
+                        annotations: <empty>
+                        kind: AliasDeclStmt [115-168]:
+                            symbol_id: 10
+                            exprs:
+                                Expr [129-146]:
+                                    ty: qubit[2]
+                                    kind: SymbolId(8)
+                                Expr [150-167]:
+                                    ty: bit[5]
+                                    kind: SymbolId(9)
+
+            [Qasm.Lowerer.InconsistentTypesInAlias
+
+              x inconsistent types in alias expression: qubit[2], bit[5]
+               ,-[test:5:23]
+             4 |         bit[5] alias_component_2;
+             5 |         let alias_1 = alias_component_1 ++ alias_component_2;
+               :                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             6 |         
+               `----
+            ]"#]],
+    );
+}
+
+#[test]
+fn invalid_types_raise_error() {
+    check_last_stmt(
+        r#"
+        // InvalidTypesInAlias
+        bit[2] alias_component_3;
+        int alias_component_4;
+        let alias_2 = alias_component_3 ++ alias_component_4;
+        "#,
+        &expect![[r#"
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [40-65]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [40-65]:
+                            symbol_id: 8
+                            ty_span: [40-46]
+                            init_expr: Expr [40-65]:
+                                ty: const bit[2]
+                                kind: Lit: Bitstring("00")
+                    Stmt [74-96]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [74-96]:
+                            symbol_id: 9
+                            ty_span: [74-77]
+                            init_expr: Expr [74-96]:
+                                ty: const int
+                                kind: Lit: Int(0)
+                    Stmt [105-158]:
+                        annotations: <empty>
+                        kind: AliasDeclStmt [105-158]:
+                            symbol_id: 10
+                            exprs:
+                                Expr [119-136]:
+                                    ty: bit[2]
+                                    kind: SymbolId(8)
+                                Expr [140-157]:
+                                    ty: int
+                                    kind: SymbolId(9)
+
+            [Qasm.Lowerer.InvalidTypeInAlias
+
+              x invalid type in alias expression: int
+               ,-[test:5:44]
+             4 |         int alias_component_4;
+             5 |         let alias_2 = alias_component_3 ++ alias_component_4;
+               :                                            ^^^^^^^^^^^^^^^^^
+             6 |         
+               `----
+              help: aliases can only be applied to quantum bits and registers
+            ]"#]],
+    );
+}
+
+#[test]
+fn invalid_types_raise_error_for_each() {
+    check_last_stmt(
+        r#"
+        array[int, 5] alias_component_0;
+        bit[2] alias_component_1;
+        int alias_component_2;
+        let alias = alias_component_0 ++ alias_component_1 ++ alias_component_2;
+        "#,
+        &expect![[r#"
+            Program:
+                version: <none>
+                pragmas: <empty>
+                statements:
+                    Stmt [9-41]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [9-41]:
+                            symbol_id: 8
+                            ty_span: [9-22]
+                            init_expr: Expr [9-41]:
+                                ty: array[int, 5]
+                                kind: Lit:     array:
+                                        Expr [9-41]:
+                                            ty: const int
+                                            kind: Lit: Int(0)
+                                        Expr [9-41]:
+                                            ty: const int
+                                            kind: Lit: Int(0)
+                                        Expr [9-41]:
+                                            ty: const int
+                                            kind: Lit: Int(0)
+                                        Expr [9-41]:
+                                            ty: const int
+                                            kind: Lit: Int(0)
+                                        Expr [9-41]:
+                                            ty: const int
+                                            kind: Lit: Int(0)
+                    Stmt [50-75]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [50-75]:
+                            symbol_id: 9
+                            ty_span: [50-56]
+                            init_expr: Expr [50-75]:
+                                ty: const bit[2]
+                                kind: Lit: Bitstring("00")
+                    Stmt [84-106]:
+                        annotations: <empty>
+                        kind: ClassicalDeclarationStmt [84-106]:
+                            symbol_id: 10
+                            ty_span: [84-87]
+                            init_expr: Expr [84-106]:
+                                ty: const int
+                                kind: Lit: Int(0)
+                    Stmt [115-187]:
+                        annotations: <empty>
+                        kind: AliasDeclStmt [115-187]:
+                            symbol_id: 11
+                            exprs:
+                                Expr [127-144]:
+                                    ty: array[int, 5]
+                                    kind: SymbolId(8)
+                                Expr [148-165]:
+                                    ty: bit[2]
+                                    kind: SymbolId(9)
+                                Expr [169-186]:
+                                    ty: int
+                                    kind: SymbolId(10)
+
+            [Qasm.Lowerer.InvalidTypeInAlias
+
+              x invalid type in alias expression: array[int, 5]
+               ,-[test:5:21]
+             4 |         int alias_component_2;
+             5 |         let alias = alias_component_0 ++ alias_component_1 ++ alias_component_2;
+               :                     ^^^^^^^^^^^^^^^^^
+             6 |         
+               `----
+              help: aliases can only be applied to quantum bits and registers
+            , Qasm.Lowerer.InvalidTypeInAlias
+
+              x invalid type in alias expression: int
+               ,-[test:5:63]
+             4 |         int alias_component_2;
+             5 |         let alias = alias_component_0 ++ alias_component_1 ++ alias_component_2;
+               :                                                               ^^^^^^^^^^^^^^^^^
+             6 |         
+               `----
+              help: aliases can only be applied to quantum bits and registers
+            ]"#]],
+    );
+}

--- a/source/compiler/qsc_qasm/src/semantic/tests/decls/alias.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/decls/alias.rs
@@ -3,7 +3,7 @@
 
 use expect_test::expect;
 
-use crate::semantic::tests::{check_last_stmt, check_stmt_kind, check_stmt_kinds};
+use crate::semantic::tests::check_last_stmt;
 
 #[test]
 fn can_alias_qubit_registers() {

--- a/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
@@ -83,622 +83,629 @@ fn check_lowerer_error_spans_are_correct() {
 
             Qasm.Lowerer.InconsistentTypesInAlias
 
-              x inconsistent types in alias expression: Expr [879-896]:
-              |     ty: array[int, 2]
-              |     kind: SymbolId(45), Expr [900-917]:
-              |     ty: array[angle, 2]
-              |     kind: SymbolId(46)
-                ,-[Test.qasm:40:1]
-             39 | array[angle, 2] alias_component_2 = {1.0, 2.0};
-             40 | let alias = alias_component_1 ++ alias_component_2;
-                : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              x inconsistent types in alias expression: qubit[2], bit[5]
+                ,-[Test.qasm:40:15]
+             39 | bit[5] alias_component_2;
+             40 | let alias_1 = alias_component_1 ++ alias_component_2;
+                :               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
              41 | 
                 `----
 
+            Qasm.Lowerer.InvalidTypesInAlias
+
+              x invalid types in alias expression: int
+                ,-[Test.qasm:45:36]
+             44 | int alias_component_4;
+             45 | let alias_2 = alias_component_3 ++ alias_component_4;
+                :                                    ^^^^^^^^^^^^^^^^^
+             46 | 
+                `----
+              help: aliases can only be applied to quantum bits and registers
+
             Qasm.Lowerer.CannotUpdateConstVariable
 
               x cannot update const variable const_variable
-                ,-[Test.qasm:44:1]
-             43 | const int const_variable = 1;
-             44 | const_variable = 2;
+                ,-[Test.qasm:49:1]
+             48 | const int const_variable = 1;
+             49 | const_variable = 2;
                 : ^^^^^^^^^^^^^^
-             45 | 
+             50 | 
                 `----
               help: mutable variables must be declared without the keyword `const`
 
             Qasm.Lowerer.CannotUpdateConstVariable
 
               x cannot update const variable const_bitarray
-                ,-[Test.qasm:48:1]
-             47 | const bit[2] const_bitarray = "11";
-             48 | const_bitarray[1] = 0;
+                ,-[Test.qasm:53:1]
+             52 | const bit[2] const_bitarray = "11";
+             53 | const_bitarray[1] = 0;
                 : ^^^^^^^^^^^^^^
-             49 | 
+             54 | 
                 `----
               help: mutable variables must be declared without the keyword `const`
 
             Qasm.Lowerer.CannotUpdateConstVariable
 
               x cannot update const variable const_variable
-                ,-[Test.qasm:51:1]
-             50 | // CannotUpdateConstVariable in simple assign_op
-             51 | const_variable += 2;
+                ,-[Test.qasm:56:1]
+             55 | // CannotUpdateConstVariable in simple assign_op
+             56 | const_variable += 2;
                 : ^^^^^^^^^^^^^^
-             52 | 
+             57 | 
                 `----
               help: mutable variables must be declared without the keyword `const`
 
             Qasm.Lowerer.CannotUpdateConstVariable
 
               x cannot update const variable const_bitarray
-                ,-[Test.qasm:54:1]
-             53 | // CannotUpdateConstVariable in indexed assign_op
-             54 | const_bitarray[1] += 7;
+                ,-[Test.qasm:59:1]
+             58 | // CannotUpdateConstVariable in indexed assign_op
+             59 | const_bitarray[1] += 7;
                 : ^^^^^^^^^^^^^^
-             55 | 
+             60 | 
                 `----
               help: mutable variables must be declared without the keyword `const`
 
             Qasm.Lowerer.ExprMustBeConst
 
-              x a captured variable must be a const expression
-                ,-[Test.qasm:59:13]
-             58 | def try_capture_non_const_global_variable() {
-             59 |     int a = non_const_global_variable;
+              x undefined symbol: non_const_global_variable
+                ,-[Test.qasm:64:13]
+             63 | def try_capture_non_const_global_variable() {
+             64 |     int a = non_const_global_variable;
                 :             ^^^^^^^^^^^^^^^^^^^^^^^^^
-             60 | }
+             65 | }
                 `----
 
             Qasm.Lowerer.ArrayDeclarationTypeError
 
               x expected an array of size 2 but found one of size 3
-                ,-[Test.qasm:63:51]
-             62 | // ArrayDeclarationTypeError
-             63 | array[int, 2] array_initialized_with_wrong_size = {1, 2, 3};
+                ,-[Test.qasm:68:51]
+             67 | // ArrayDeclarationTypeError
+             68 | array[int, 2] array_initialized_with_wrong_size = {1, 2, 3};
                 :                                                   ^^^^^^^^^
-             64 | 
+             69 | 
                 `----
 
             Qasm.Lowerer.ArrayDeclarationTypeError
 
               x expected an array of size 2 but found Int(2)
-                ,-[Test.qasm:66:54]
-             65 | // ArrayDeclarationTypeError
-             66 | array[int, 2] array_initialized_with_wrong_literal = 2;
+                ,-[Test.qasm:71:54]
+             70 | // ArrayDeclarationTypeError
+             71 | array[int, 2] array_initialized_with_wrong_literal = 2;
                 :                                                      ^
-             67 | 
+             72 | 
                 `----
 
             Qasm.Lowerer.CannotCastLiteral
 
               x cannot cast literal expression of type const int to type array[int, 2]
-                ,-[Test.qasm:66:1]
-             65 | // ArrayDeclarationTypeError
-             66 | array[int, 2] array_initialized_with_wrong_literal = 2;
+                ,-[Test.qasm:71:1]
+             70 | // ArrayDeclarationTypeError
+             71 | array[int, 2] array_initialized_with_wrong_literal = 2;
                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             67 | 
+             72 | 
                 `----
 
             Qasm.Lowerer.NotSupported
 
               x string literals are not supported
-                ,-[Test.qasm:69:1]
-             68 | // NotSupported string literals
-             69 | "string_literal";
+                ,-[Test.qasm:74:1]
+             73 | // NotSupported string literals
+             74 | "string_literal";
                 : ^^^^^^^^^^^^^^^^
-             70 | 
+             75 | 
                 `----
 
             Qasm.Lowerer.TypeDoesNotSupportedUnaryNegation
 
               x unary negation is not allowed for instances of bool
-                ,-[Test.qasm:74:2]
-             73 | bool binary_negation_not_supported = true;
-             74 | ~binary_negation_not_supported;
+                ,-[Test.qasm:79:2]
+             78 | bool binary_negation_not_supported = true;
+             79 | ~binary_negation_not_supported;
                 :  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             75 | 
+             80 | 
                 `----
 
             Qasm.Lowerer.NotSupported
 
               x arrays with more than 7 dimensions are not supported
-                ,-[Test.qasm:77:1]
-             76 | // NotSupported arrays with more than 7 dimensions
-             77 | array[int, 1, 2, 3, 1, 2, 3, 1, 2] array_with_more_than_7_dims;
+                ,-[Test.qasm:82:1]
+             81 | // NotSupported arrays with more than 7 dimensions
+             82 | array[int, 1, 2, 3, 1, 2, 3, 1, 2] array_with_more_than_7_dims;
                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             78 | 
+             83 | 
                 `----
 
             Qasm.Lowerer.NotSupported
 
               x stretch default values are not supported
-                ,-[Test.qasm:80:1]
-             79 | // NotSupported stretch default values
-             80 | stretch stretch_val;
+                ,-[Test.qasm:85:1]
+             84 | // NotSupported stretch default values
+             85 | stretch stretch_val;
                 : ^^^^^^^^^^^^^^^^^^^^
-             81 | 
+             86 | 
                 `----
 
             Qasm.Lowerer.ClassicalStmtInBox
 
               x invalid classical statement in box
-                ,-[Test.qasm:84:5]
-             83 |     // ClassicalStmtInBox
-             84 |     2;
+                ,-[Test.qasm:89:5]
+             88 |     // ClassicalStmtInBox
+             89 |     2;
                 :     ^^
-             85 | }
+             90 | }
                 `----
 
             Qasm.Lowerer.InvalidScope
 
               x break can only appear in loop scopes
-                ,-[Test.qasm:88:1]
-             87 | // InvalidScope break outside loop
-             88 | break;
+                ,-[Test.qasm:93:1]
+             92 | // InvalidScope break outside loop
+             93 | break;
                 : ^^^^^^
-             89 | 
+             94 | 
                 `----
 
             Qasm.Lowerer.InvalidScope
 
               x continue can only appear in loop scopes
-                ,-[Test.qasm:91:1]
-             90 | // InvalidScope continue outside loop
-             91 | continue;
+                ,-[Test.qasm:96:1]
+             95 | // InvalidScope continue outside loop
+             96 | continue;
                 : ^^^^^^^^^
-             92 | 
+             97 | 
                 `----
 
             Qasm.Lowerer.InvalidScope
 
               x return statements can only appear in subroutine scopes
-                ,-[Test.qasm:94:1]
-             93 | // InvalidScope return outside def
-             94 | return;
-                : ^^^^^^^
-             95 | 
-                `----
+                 ,-[Test.qasm:99:1]
+              98 | // InvalidScope return outside def
+              99 | return;
+                 : ^^^^^^^
+             100 | 
+                 `----
 
             Qasm.Lowerer.MissingTargetExpressionInReturnStmt
 
               x return statements on a non-void subroutine should have a target expression
-                ,-[Test.qasm:98:5]
-             97 | def missing_target_in_return() -> int {
-             98 |     return;
-                :     ^^^^^^^
-             99 | }
-                `----
+                 ,-[Test.qasm:103:5]
+             102 | def missing_target_in_return() -> int {
+             103 |     return;
+                 :     ^^^^^^^
+             104 | }
+                 `----
 
             Qasm.Lowerer.ReturningExpressionFromVoidSubroutine
 
               x cannot return an expression from a void subroutine
-                 ,-[Test.qasm:103:12]
-             102 | def returning_from_void_subroutine() {
-             103 |     return 2;
+                 ,-[Test.qasm:108:12]
+             107 | def returning_from_void_subroutine() {
+             108 |     return 2;
                  :            ^
-             104 | }
+             109 | }
                  `----
 
             Qasm.Lowerer.ExprMustBeConst
 
               x const decl init expr must be a const expression
-                 ,-[Test.qasm:114:23]
-             113 | int non_const_val = 2;
-             114 | const int const_val = non_const_val;
+                 ,-[Test.qasm:119:23]
+             118 | int non_const_val = 2;
+             119 | const int const_val = non_const_val;
                  :                       ^^^^^^^^^^^^^
-             115 | 
+             120 | 
                  `----
 
               x array declarations are only allowed in global scope
-                 ,-[Test.qasm:118:5]
-             117 | {
-             118 |     array[int, 1, 2] arr;
+                 ,-[Test.qasm:123:5]
+             122 | {
+             123 |     array[int, 1, 2] arr;
                  :     ^^^^^^^^^^^^^^^^^^^^^
-             119 | }
+             124 | }
                  `----
 
             Qasm.Lowerer.DefDeclarationInNonGlobalScope
 
               x def declarations must be done in global scope
-                 ,-[Test.qasm:123:5]
-             122 | {
-             123 |     def f() {}
+                 ,-[Test.qasm:128:5]
+             127 | {
+             128 |     def f() {}
                  :     ^^^^^^^^^^
-             124 | }
+             129 | }
                  `----
 
             Qasm.Lowerer.GateDeclarationInNonGlobalScope
 
               x gate declarations must be done in global scope
-                 ,-[Test.qasm:128:5]
-             127 | {
-             128 |     gate g q {}
+                 ,-[Test.qasm:133:5]
+             132 | {
+             133 |     gate g q {}
                  :     ^^^^^^^^^^^
-             129 | }
+             134 | }
                  `----
 
             Qasm.Lowerer.QubitDeclarationInNonGlobalScope
 
               x qubit declarations must be done in global scope
-                 ,-[Test.qasm:133:5]
-             132 | {
-             133 |     qubit non_global_qubit;
+                 ,-[Test.qasm:138:5]
+             137 | {
+             138 |     qubit non_global_qubit;
                  :     ^^^^^^^^^^^^^^^^^^^^^^^
-             134 | }
+             139 | }
                  `----
 
             Qasm.Lowerer.NonVoidDefShouldAlwaysReturn
 
               x non-void def should always return
-                 ,-[Test.qasm:137:37]
-             136 | // NonVoidDefShouldAlwaysReturn
-             137 | def non_void_def_should_return() -> int {
+                 ,-[Test.qasm:142:37]
+             141 | // NonVoidDefShouldAlwaysReturn
+             142 | def non_void_def_should_return() -> int {
                  :                                     ^^^
-             138 | 
+             143 | 
                  `----
 
             Qasm.Lowerer.DefDeclarationInNonGlobalScope
 
               x extern declarations must be done in global scope
-                 ,-[Test.qasm:147:5]
-             146 | {
-             147 |     extern f(int);
+                 ,-[Test.qasm:152:5]
+             151 | {
+             152 |     extern f(int);
                  :     ^^^^^^^^^^^^^^
-             148 | }
+             153 | }
                  `----
 
             Qasm.Lowerer.InvalidNumberOfClassicalArgs
 
               x gate expects 2 classical arguments, but 1 were provided
-                 ,-[Test.qasm:152:1]
-             151 | def invalid_arity_call(int a, int b) {}
-             152 | invalid_arity_call(2);
+                 ,-[Test.qasm:157:1]
+             156 | def invalid_arity_call(int a, int b) {}
+             157 | invalid_arity_call(2);
                  : ^^^^^^^^^^^^^^^^^^^^^
-             153 | 
+             158 | 
                  `----
 
             Qasm.Lowerer.GateCalledLikeFunc
 
               x gate called like function: gate(0, 1)
-                 ,-[Test.qasm:155:1]
-             154 | // CannotCallNonFunction
-             155 | x(2);
+                 ,-[Test.qasm:160:1]
+             159 | // CannotCallNonFunction
+             160 | x(2);
                  : ^^^^
-             156 | 
+             161 | 
                  `----
               help: ensure that qubit arguments are provided to the gate call
 
             Qasm.Lowerer.InvalidNumberOfClassicalArgs
 
               x gate expects 1 classical arguments, but 2 were provided
-                 ,-[Test.qasm:158:1]
-             157 | // InvalidNumberOfClassicalArgs in gate call
-             158 | rx(2.0, 3.0) q;
+                 ,-[Test.qasm:163:1]
+             162 | // InvalidNumberOfClassicalArgs in gate call
+             163 | rx(2.0, 3.0) q;
                  : ^^^^^^^^^^^^^^^
-             159 | 
+             164 | 
                  `----
 
             Qasm.Lowerer.InvalidNumberOfQubitArgs
 
               x gate expects 1 qubit arguments, but 2 were provided
-                 ,-[Test.qasm:161:1]
-             160 | // InvalidNumberOfQubitArgs
-             161 | rx(2.0) q, q;
+                 ,-[Test.qasm:166:1]
+             165 | // InvalidNumberOfQubitArgs
+             166 | rx(2.0) q, q;
                  : ^^^^^^^^^^^^^
-             162 | 
+             167 | 
                  `----
 
             Qasm.Lowerer.BroadcastCallQuantumArgsDisagreeInSize
 
               x first quantum register is of type qubit[1] but found an argument of type
               | qubit[2]
-                 ,-[Test.qasm:164:18]
-             163 | // BroadcastCallQuantumArgsDisagreeInSize
-             164 | ryy(2.0) qreg_1, qreg_2;
+                 ,-[Test.qasm:169:18]
+             168 | // BroadcastCallQuantumArgsDisagreeInSize
+             169 | ryy(2.0) qreg_1, qreg_2;
                  :                  ^^^^^^
-             165 | 
+             170 | 
                  `----
 
             Qasm.Lowerer.ExprMustFitInU32
 
               x ctrl modifier argument must fit in a u32
-                 ,-[Test.qasm:172:6]
-             171 | // ExprMustFitInU32
-             172 | ctrl(5000000000) @ x q;
+                 ,-[Test.qasm:177:6]
+             176 | // ExprMustFitInU32
+             177 | ctrl(5000000000) @ x q;
                  :      ^^^^^^^^^^
-             173 | 
+             178 | 
                  `----
 
             Qasm.Lowerer.CannotCastLiteral
 
               x cannot cast literal expression of type const float to type const uint
-                 ,-[Test.qasm:179:12]
-             178 | // ArraySizeMustBeNonNegativeConstExpr
-             179 | array[int, 2.0] non_int_array_size;
+                 ,-[Test.qasm:184:12]
+             183 | // ArraySizeMustBeNonNegativeConstExpr
+             184 | array[int, 2.0] non_int_array_size;
                  :            ^^^
-             180 | 
+             185 | 
                  `----
 
             Qasm.Lowerer.ExprMustBeNonNegativeInt
 
               x array size must be a non-negative integer
-                 ,-[Test.qasm:182:12]
-             181 | // ArraySizeMustBeNonNegativeConstExpr
-             182 | array[int, -2] negative_array_size;
+                 ,-[Test.qasm:187:12]
+             186 | // ArraySizeMustBeNonNegativeConstExpr
+             187 | array[int, -2] negative_array_size;
                  :            ^^
-             183 | 
+             188 | 
                  `----
 
             Qasm.Lowerer.DesignatorTooLarge
 
               x designator is too large
-                 ,-[Test.qasm:185:12]
-             184 | // DesignatorTooLarge
-             185 | array[int, 5000000000] arr_size_too_large;
+                 ,-[Test.qasm:190:12]
+             189 | // DesignatorTooLarge
+             190 | array[int, 5000000000] arr_size_too_large;
                  :            ^^^^^^^^^^
-             186 | 
+             191 | 
                  `----
 
             Qasm.Lowerer.CannotCastLiteral
 
               x cannot cast literal expression of type const float to type const uint
-                 ,-[Test.qasm:188:5]
-             187 | // TypeWidthMustBePositiveIntConstExpr
-             188 | int[2.0] non_int_width;
+                 ,-[Test.qasm:193:5]
+             192 | // TypeWidthMustBePositiveIntConstExpr
+             193 | int[2.0] non_int_width;
                  :     ^^^
-             189 | 
+             194 | 
                  `----
 
             Qasm.Lowerer.ExprMustBePositiveInt
 
               x type width must be a positive integer
-                 ,-[Test.qasm:191:5]
-             190 | // TypeWidthMustBePositiveIntConstExpr
-             191 | int[0] zero_width;
+                 ,-[Test.qasm:196:5]
+             195 | // TypeWidthMustBePositiveIntConstExpr
+             196 | int[0] zero_width;
                  :     ^
-             192 | int[-2] negative_width;
+             197 | int[-2] negative_width;
                  `----
 
             Qasm.Lowerer.ExprMustBePositiveInt
 
               x type width must be a positive integer
-                 ,-[Test.qasm:192:5]
-             191 | int[0] zero_width;
-             192 | int[-2] negative_width;
+                 ,-[Test.qasm:197:5]
+             196 | int[0] zero_width;
+             197 | int[-2] negative_width;
                  :     ^^
-             193 | 
+             198 | 
                  `----
 
             Qasm.Lowerer.DesignatorTooLarge
 
               x designator is too large
-                 ,-[Test.qasm:195:5]
-             194 | // DesignatorTooLarge
-             195 | int[5000000000] width_too_large;
+                 ,-[Test.qasm:200:5]
+             199 | // DesignatorTooLarge
+             200 | int[5000000000] width_too_large;
                  :     ^^^^^^^^^^
-             196 | 
+             201 | 
                  `----
 
             Qasm.Lowerer.TypeMaxWidthExceeded
 
               x float max width is 64 but 65 was provided
-                 ,-[Test.qasm:198:1]
-             197 | // TypeMaxWidthExceeded
-             198 | float[65] float_width_too_large;
+                 ,-[Test.qasm:203:1]
+             202 | // TypeMaxWidthExceeded
+             203 | float[65] float_width_too_large;
                  : ^^^^^^^^^
-             199 | angle[65] angle_width_too_large;
+             204 | angle[65] angle_width_too_large;
                  `----
 
             Qasm.Lowerer.TypeMaxWidthExceeded
 
               x angle max width is 64 but 65 was provided
-                 ,-[Test.qasm:199:1]
-             198 | float[65] float_width_too_large;
-             199 | angle[65] angle_width_too_large;
+                 ,-[Test.qasm:204:1]
+             203 | float[65] float_width_too_large;
+             204 | angle[65] angle_width_too_large;
                  : ^^^^^^^^^
-             200 | 
+             205 | 
                  `----
 
             Qasm.Lowerer.CannotCastLiteral
 
               x cannot cast literal expression of type const float to type int
-                 ,-[Test.qasm:202:1]
-             201 | // Invalid literal cast in cast_expr_with_target_type_or_default(...)
-             202 | int invalid_lit_cast = 2.0;
+                 ,-[Test.qasm:207:1]
+             206 | // Invalid literal cast in cast_expr_with_target_type_or_default(...)
+             207 | int invalid_lit_cast = 2.0;
                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-             203 | 
+             208 | 
                  `----
 
             Qasm.Lowerer.QuantumTypesInBinaryExpression
 
               x quantum typed values cannot be used in binary expressions
-                 ,-[Test.qasm:211:5]
-             210 | // QuantumTypesInBinaryExpression
-             211 | 1 + q;
+                 ,-[Test.qasm:216:5]
+             215 | // QuantumTypesInBinaryExpression
+             216 | 1 + q;
                  :     ^
-             212 | q + 1;
+             217 | q + 1;
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type qubit to type const float
-                 ,-[Test.qasm:211:5]
-             210 | // QuantumTypesInBinaryExpression
-             211 | 1 + q;
+                 ,-[Test.qasm:216:5]
+             215 | // QuantumTypesInBinaryExpression
+             216 | 1 + q;
                  :     ^
-             212 | q + 1;
+             217 | q + 1;
                  `----
 
             Qasm.Lowerer.QuantumTypesInBinaryExpression
 
               x quantum typed values cannot be used in binary expressions
-                 ,-[Test.qasm:212:1]
-             211 | 1 + q;
-             212 | q + 1;
+                 ,-[Test.qasm:217:1]
+             216 | 1 + q;
+             217 | q + 1;
                  : ^
-             213 | 
+             218 | 
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type qubit to type const float
-                 ,-[Test.qasm:212:1]
-             211 | 1 + q;
-             212 | q + 1;
+                 ,-[Test.qasm:217:1]
+             216 | 1 + q;
+             217 | q + 1;
                  : ^
-             213 | 
+             218 | 
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type angle to type float
-                 ,-[Test.qasm:216:1]
-             215 | angle uncastable_to_int = 2.0;
-             216 | uncastable_to_int + 3;
+                 ,-[Test.qasm:221:1]
+             220 | angle uncastable_to_int = 2.0;
+             221 | uncastable_to_int + 3;
                  : ^^^^^^^^^^^^^^^^^
-             217 | 3 + uncastable_to_int;
+             222 | 3 + uncastable_to_int;
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type angle to type const float
-                 ,-[Test.qasm:217:5]
-             216 | uncastable_to_int + 3;
-             217 | 3 + uncastable_to_int;
+                 ,-[Test.qasm:222:5]
+             221 | uncastable_to_int + 3;
+             222 | 3 + uncastable_to_int;
                  :     ^^^^^^^^^^^^^^^^^
-             218 | 
+             223 | 
                  `----
 
             Qasm.Lowerer.OperatorNotAllowedForComplexValues
 
               x the operator OrB is not allowed for complex values
-                 ,-[Test.qasm:220:1]
-             219 | // OperatorNotAllowedForComplexValues
-             220 | (2 + 1im) | 3im;
+                 ,-[Test.qasm:225:1]
+             224 | // OperatorNotAllowedForComplexValues
+             225 | (2 + 1im) | 3im;
                  : ^^^^^^^^^^^^^^^
-             221 | 
+             226 | 
                  `----
 
             Qasm.Lowerer.IndexSetOnlyAllowedInAliasStmt
 
               x index sets are only allowed in alias statements
-                 ,-[Test.qasm:223:8]
-             222 | // IndexSetOnlyAllowedInAliasStmt
-             223 | qreg_2[{0, 1}];
+                 ,-[Test.qasm:228:8]
+             227 | // IndexSetOnlyAllowedInAliasStmt
+             228 | qreg_2[{0, 1}];
                  :        ^^^^^^
-             224 | 
+             229 | 
                  `----
 
             Qasm.Lowerer.CannotCast
 
               x cannot cast expression of type const angle to type const int
-                 ,-[Test.qasm:227:13]
-             226 | array[int, 5] range_error;
-             227 | range_error[const_uncastable_to_int:2.2];
+                 ,-[Test.qasm:232:13]
+             231 | array[int, 5] range_error;
+             232 | range_error[const_uncastable_to_int:2.2];
                  :             ^^^^^^^^^^^^^^^^^^^^^^^
-             228 | 
+             233 | 
                  `----
 
             Qasm.Lowerer.ZeroStepInRange
 
               x range step cannot be zero
-                 ,-[Test.qasm:230:13]
-             229 | // ZeroStepInRange
-             230 | range_error[1:0:3];
+                 ,-[Test.qasm:235:13]
+             234 | // ZeroStepInRange
+             235 | range_error[1:0:3];
                  :             ^^^^^
-             231 | 
+             236 | 
                  `----
 
             Qasm.Lowerer.ZeroSizeArrayAccess
 
               x zero size array access is not allowed
-                 ,-[Test.qasm:234:1]
-             233 | array[int, 2, 0, 3] zero_size_array;
-             234 | zero_size_array[1];
+                 ,-[Test.qasm:239:1]
+             238 | array[int, 2, 0, 3] zero_size_array;
+             239 | zero_size_array[1];
                  : ^^^^^^^^^^^^^^^^^^
-             235 | 
+             240 | 
                  `----
               help: array size must be a positive integer const expression
 
             Qasm.Lowerer.CannotIndexType
 
               x cannot index variables of type bit
-                 ,-[Test.qasm:238:15]
-             237 | bit non_indexable;
-             238 | non_indexable[1];
+                 ,-[Test.qasm:243:15]
+             242 | bit non_indexable;
+             243 | non_indexable[1];
                  :               ^
-             239 | 
+             244 | 
                  `----
 
             Qasm.Lowerer.CannotIndexType
 
               x cannot index variables of type qubit
-                 ,-[Test.qasm:241:11]
-             240 | // TooManyIndices
-             241 | qreg_1[1, 2];
+                 ,-[Test.qasm:246:11]
+             245 | // TooManyIndices
+             246 | qreg_1[1, 2];
                  :           ^
-             242 | 
+             247 | 
                  `----
 
             Qasm.Lowerer.UndefinedSymbol
 
               x undefined symbol: missing_symbol
-                 ,-[Test.qasm:244:1]
-             243 | // Missing symbol in lower_indexed_ident_expr(...)
-             244 | missing_symbol[2];
+                 ,-[Test.qasm:249:1]
+             248 | // Missing symbol in lower_indexed_ident_expr(...)
+             249 | missing_symbol[2];
                  : ^^^^^^^^^^^^^^
-             245 | 
+             250 | 
                  `----
 
             Qasm.Lowerer.CannotIndexType
 
               x cannot index variables of type unknown
-                 ,-[Test.qasm:244:16]
-             243 | // Missing symbol in lower_indexed_ident_expr(...)
-             244 | missing_symbol[2];
+                 ,-[Test.qasm:249:16]
+             248 | // Missing symbol in lower_indexed_ident_expr(...)
+             249 | missing_symbol[2];
                  :                ^
-             245 | 
+             250 | 
                  `----
 
             Qasm.Lowerer.EmptyIndexOperator
 
               x index operator must contain at least one index
-                 ,-[Test.qasm:248:13]
-             247 | bit[4] empty_index;
-             248 | empty_index[];
+                 ,-[Test.qasm:253:13]
+             252 | bit[4] empty_index;
+             253 | empty_index[];
                  :             ^
-             249 | 
+             254 | 
                  `----
 
             Qasm.Lowerer.CannotCallNonFunction
 
               x cannot call an expression that is not a function
-                 ,-[Test.qasm:251:1]
-             250 | // CannotCallNonFunction
-             251 | empty_index();
+                 ,-[Test.qasm:256:1]
+             255 | // CannotCallNonFunction
+             256 | empty_index();
                  : ^^^^^^^^^^^^^
-             252 | 
+             257 | 
                  `----
 
             Qasm.Lowerer.FuncCalledLikeGate
 
               x function called like gate: def (qubit) -> void
-                 ,-[Test.qasm:254:5]
-             253 | // FuncCalledLikeGate
-             254 | def func_called_like_gate(qubit q) {}
+                 ,-[Test.qasm:259:5]
+             258 | // FuncCalledLikeGate
+             259 | def func_called_like_gate(qubit q) {}
                  :     ^^^^^^^^^^^^^^^^^^^^^
-             255 | func_called_like_gate q;
+             260 | func_called_like_gate q;
                  `----
               help: function parameters must be in parentheses
 
             Qasm.Lowerer.GateCallMissingParams
 
               x gate call missing parameters: gate(0, 1)
-                 ,-[Test.qasm:258:1]
-             257 | // GateCallMissingParams
-             258 | h;
+                 ,-[Test.qasm:263:1]
+             262 | // GateCallMissingParams
+             263 | h;
                  : ^
-             259 | 
+             264 | 
                  `----
               help: ensure that any classical and quantum arguments are provided to the
                     gate call
@@ -706,9 +713,9 @@ fn check_lowerer_error_spans_are_correct() {
             Qasm.Lowerer.FuncMissingParams
 
               x function call missing parameters: def (qubit) -> void
-                 ,-[Test.qasm:262:1]
-             261 | // FuncMissingParams
-             262 | func_called_like_gate;
+                 ,-[Test.qasm:267:1]
+             266 | // FuncMissingParams
+             267 | func_called_like_gate;
                  : ^^^^^^^^^^^^^^^^^^^^^
                  `----
               help: a function call must use parentheses, with any parameters inside

--- a/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
@@ -91,9 +91,9 @@ fn check_lowerer_error_spans_are_correct() {
              41 | 
                 `----
 
-            Qasm.Lowerer.InvalidTypesInAlias
+            Qasm.Lowerer.InvalidTypeInAlias
 
-              x invalid types in alias expression: int
+              x invalid type in alias expression: int
                 ,-[Test.qasm:45:36]
              44 | int alias_component_4;
              45 | let alias_2 = alias_component_3 ++ alias_component_4;

--- a/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
+++ b/source/compiler/qsc_qasm/src/semantic/tests/lowerer_errors.rs
@@ -148,7 +148,7 @@ fn check_lowerer_error_spans_are_correct() {
 
             Qasm.Lowerer.ExprMustBeConst
 
-              x undefined symbol: non_const_global_variable
+              x a captured variable must be a const expression
                 ,-[Test.qasm:64:13]
              63 | def try_capture_non_const_global_variable() {
              64 |     int a = non_const_global_variable;

--- a/source/compiler/qsc_qasm/src/tests/assignment/alias.rs
+++ b/source/compiler/qsc_qasm/src/tests/assignment/alias.rs
@@ -107,7 +107,7 @@ fn first_qubit_from_aliased_qreg() -> miette::Result<(), Vec<Report>> {
         let one = QIR.Runtime.AllocateQubitArray(2);
         let two = QIR.Runtime.AllocateQubitArray(10);
         let concatenated = one + two;
-        mutable first = concatenated[0];
+        let first = concatenated[0];
     "#]]
     .assert_eq(&qsharp);
     Ok(())
@@ -129,7 +129,7 @@ fn last_qubit_from_aliased_qreg() -> miette::Result<(), Vec<Report>> {
         let one = QIR.Runtime.AllocateQubitArray(2);
         let two = QIR.Runtime.AllocateQubitArray(10);
         let concatenated = one + two;
-        mutable last = concatenated[-1];
+        let last = concatenated[-1];
     "#]]
     .assert_eq(&qsharp);
     Ok(())

--- a/source/compiler/qsc_qasm/src/tests/assignment/alias.rs
+++ b/source/compiler/qsc_qasm/src/tests/assignment/alias.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::tests::{compile_fragments, fail_on_compilation_errors};
+use crate::tests::{compile_fragments, compile_qasm_to_qsharp, fail_on_compilation_errors};
+use expect_test::expect;
 use miette::Report;
 
 #[test]
@@ -67,5 +68,107 @@ fn quantum_old_style_decls() -> miette::Result<(), Vec<Report>> {
 
     let unit = compile_fragments(source)?;
     fail_on_compilation_errors(&unit);
+    Ok(())
+}
+
+#[test]
+fn can_alias_qubit_registers() -> miette::Result<(), Vec<Report>> {
+    let source = "
+        qubit[2] one;
+        qubit[10] two;
+        // Aliased register of twelve qubits
+        let concatenated = one ++ two;
+    ";
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let one = QIR.Runtime.AllocateQubitArray(2);
+        let two = QIR.Runtime.AllocateQubitArray(10);
+        let concatenated = one + two;
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn first_qubit_from_aliased_qreg() -> miette::Result<(), Vec<Report>> {
+    let source = "
+        qubit[2] one;
+        qubit[10] two;
+        let concatenated = one ++ two;
+        // First qubit in aliased qubit array
+        let first = concatenated[0];
+    ";
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let one = QIR.Runtime.AllocateQubitArray(2);
+        let two = QIR.Runtime.AllocateQubitArray(10);
+        let concatenated = one + two;
+        mutable first = concatenated[0];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn last_qubit_from_aliased_qreg() -> miette::Result<(), Vec<Report>> {
+    let source = "
+        qubit[2] one;
+        qubit[10] two;
+        let concatenated = one ++ two;
+        // Last qubit in aliased qubit array
+        let last = concatenated[-1];
+    ";
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let one = QIR.Runtime.AllocateQubitArray(2);
+        let two = QIR.Runtime.AllocateQubitArray(10);
+        let concatenated = one + two;
+        mutable last = concatenated[-1];
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+#[ignore = "index sets not yet implemented"]
+fn alias_idividual_qubits_from_qreg() -> miette::Result<(), Vec<Report>> {
+    let source = "
+        qubit[10] two;
+        // Qubits zero, three and five
+        let qubit_selection = two[{0, 3, 5}];
+    ";
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+
+    "#]]
+    .assert_eq(&qsharp);
+    Ok(())
+}
+
+#[test]
+fn alias_range_of_qubits_from_qreg() -> miette::Result<(), Vec<Report>> {
+    let source = "
+        qubit[2] one;
+        qubit[10] two;
+        let concatenated = one ++ two;
+        let every_second = concatenated[0:2:11];
+    ";
+
+    let qsharp = compile_qasm_to_qsharp(source)?;
+    expect![[r#"
+        import Std.OpenQASM.Intrinsic.*;
+        let one = QIR.Runtime.AllocateQubitArray(2);
+        let two = QIR.Runtime.AllocateQubitArray(10);
+        let concatenated = one + two;
+        let every_second = concatenated[0..2..11];
+    "#]]
+    .assert_eq(&qsharp);
     Ok(())
 }


### PR DESCRIPTION
This PR sets up the main uses of [alias statements](https://openqasm.com/language/types.html#aliasing) for qubit registers. 
- Lowers aliasing of qubit and bitarray registers
- Compilation (to Q# ast) fails when used with bitarray registers. This is a known limitation until we decide we want to dig into it. The naive implementation requires reference variables. We can do qubits as they are virtual ids
- Validates type information in lowering raising semantic errors if the aliases aren't type sound.
- There is a stub test case for when we support index sets as part of aliasing