### PR TITLE
Fix panic when running .qsc circuit file

### DIFF
--- a/source/wasm/src/debug_service.rs
+++ b/source/wasm/src/debug_service.rs
@@ -202,7 +202,11 @@ impl DebugService {
     }
 
     pub fn get_locals(&self, frame_id: usize) -> IVariableList {
-        let locals = self.debugger().get_locals(frame_id);
+        // VS-Code Debugger's frame_id is 0-indexed.
+        // However, our frame_id is 1-indexed, since we reserve
+        // the id 0 for the entry expr. So, we add 1 here to
+        // convert from VS-Code convention to our internal convention.
+        let locals = self.debugger().get_locals(frame_id + 1);
         let variables: Vec<_> = locals
             .into_iter()
             .map(|local| Variable {


### PR DESCRIPTION
The `Run` button in the left panel of the .qsc circuit files started panicking after #2572 fixed an off-by-one error.

The panic happened because:
1. The Run button generates a block entry expression instead of just a call to an `@EntryPoint` function.
2. When pushing scopes, we tag them with the current `frameId`.
3. However, since no functions have been called when running the entry expression, we haven't pushed any `frameId`s. So, we were trying to tag that block entry expression with a non-existing `frameId`, which caused the panic.

From the ideas we discussed to address this issue, the one that seemed more future proof was reserving the `frameId` `0` for the entry expression (even though there is no real Frame pushed by the entry expr, since it is not a function call). And the first actual Frame, e.g. the one from the `@EntryPoint` function, will have `frameId` `1`.
