### PR TITLE
Support numpy arrays in the Python interop layer

### DIFF
--- a/source/pip/qsharp/_qsharp.py
+++ b/source/pip/qsharp/_qsharp.py
@@ -27,6 +27,7 @@ from typing import (
     Union,
     List,
     Set,
+    Iterable,
 )
 from .estimator._estimator import EstimatorResult, EstimatorParams
 import json
@@ -54,15 +55,11 @@ def lower_python_obj(obj: object, visited: Optional[Set[object]] = None) -> Any:
     if isinstance(obj, tuple):
         return tuple(lower_python_obj(elt, visited) for elt in obj)
 
-    # Recursive case: Array
-    if isinstance(obj, list):
-        return [lower_python_obj(elt, visited) for elt in obj]
-
     # Recusive case: Dict
     if isinstance(obj, dict):
         return {name: lower_python_obj(val, visited) for name, val in obj.items()}
 
-    # Recursive case: Class
+    # Recursive case: Class with slots
     if hasattr(obj, "__slots__"):
         fields = {}
         for name in obj.__slots__:
@@ -72,12 +69,20 @@ def lower_python_obj(obj: object, visited: Optional[Set[object]] = None) -> Any:
             else:
                 val = getattr(obj, name)
                 fields[name] = lower_python_obj(val, visited)
-    elif hasattr(obj, "__dict__"):
+        return fields
+
+    # Recursive case: Class
+    if hasattr(obj, "__dict__"):
         fields = {
             name: lower_python_obj(val, visited) for name, val in obj.__dict__.items()
         }
-    else:
-        fields = {}
+        return fields
+
+    # Recursive case: Array
+    # By using `Iterable` instead of `list`, we can handle other kind of iterables
+    # numpy arrays and generators.
+    if isinstance(obj, Iterable):
+        return [lower_python_obj(elt, visited) for elt in obj]
 
     return fields
 

--- a/source/pip/qsharp/_qsharp.py
+++ b/source/pip/qsharp/_qsharp.py
@@ -84,7 +84,7 @@ def lower_python_obj(obj: object, visited: Optional[Set[object]] = None) -> Any:
     if isinstance(obj, Iterable):
         return [lower_python_obj(elt, visited) for elt in obj]
 
-    return fields
+    raise TypeError(f"unsupported type: {type(obj)}")
 
 
 def python_args_to_interpreter_args(args):

--- a/source/pip/qsharp/_qsharp.py
+++ b/source/pip/qsharp/_qsharp.py
@@ -80,7 +80,7 @@ def lower_python_obj(obj: object, visited: Optional[Set[object]] = None) -> Any:
 
     # Recursive case: Array
     # By using `Iterable` instead of `list`, we can handle other kind of iterables
-    # numpy arrays and generators.
+    # like numpy arrays and generators.
     if isinstance(obj, Iterable):
         return [lower_python_obj(elt, visited) for elt in obj]
 

--- a/source/pip/tests/test_qsharp.py
+++ b/source/pip/tests/test_qsharp.py
@@ -648,6 +648,8 @@ def test_callable_with_array_exposed_into_env_fails_incorrect_types() -> None:
     assert qsharp.code.Identity([4, 5, 6]) == [4, 5, 6]
     assert qsharp.code.Identity([]) == []
     assert qsharp.code.Identity((4, 5, 6)) == [4, 5, 6]
+    # This assert tests Iterables, numpy arrays fall under this category.
+    assert qsharp.code.Identity((elt for elt in range(4, 7))) == [4, 5, 6]
     with pytest.raises(TypeError):
         qsharp.code.Identity(4)
     with pytest.raises(TypeError):


### PR DESCRIPTION
This PR changes the if statement that detects python lists to detect iterables in general, allowing is to process, among other things, numpy arrays.