### PR TITLE
Improve interface and output for Submit Job Copilot tool

### DIFF
--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -699,29 +699,34 @@
         ],
         "toolReferenceName": "azureQuantumSubmitToTarget",
         "displayName": "Submit to Azure Quantum Target",
-        "modelDescription": "Submit the current program to Azure Quantum with the provided information. Call this when you need to submit or run a program with Azure Quantum, for example when a customer asks 'Can you submit this program to Azure?'",
+        "modelDescription": "Submits a Q# program to Azure Quantum. The path to a .qs file must be specified in the `filePath` parameter. The program will first be compiled to Quantum Intermediate Representation (QIR), and then submitted to run on the specified target.",
         "canBeReferencedInPrompt": true,
         "icon": "./resources/file-icon-light.svg",
         "inputSchema": {
           "type": "object",
           "properties": {
-            "job_name": {
+            "filePath": {
               "type": "string",
-              "description": "The string to name the created job."
+              "description": "The absolute path to the .qs file. If this file is part of a project, the whole project will be compiled as the program. A .qs file belongs to a project if it resides anywhere under a src/ directory whose parent directory also contains a qsharp.json manifest."
             },
-            "target_id": {
+            "jobName": {
               "type": "string",
-              "description": "The ID or name of the target to submit the job to."
+              "description": "A name for the job."
             },
-            "number_of_shots": {
+            "targetId": {
+              "type": "string",
+              "description": "The ID of the target to submit the job to, as returned by the azure-quantum-get-providers tool."
+            },
+            "shots": {
               "type": "number",
               "description": "The number of shots to use for the job."
             }
           },
           "required": [
-            "job_name",
-            "target_id",
-            "number_of_shots"
+            "filePath",
+            "jobName",
+            "targetId",
+            "shots"
           ],
           "additionalProperties": false
         }

--- a/source/vscode/src/gh-copilot/qsharpTools.ts
+++ b/source/vscode/src/gh-copilot/qsharpTools.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { VSDiagnostic } from "qsharp-lang";
+import { TargetProfile, VSDiagnostic } from "qsharp-lang";
 import vscode from "vscode";
 import { CircuitOrError, showCircuitCommand } from "../circuit";
 import { loadCompilerWorker, toVsCodeDiagnostic } from "../common";
@@ -11,6 +11,7 @@ import { FullProgramConfig, getProgramForDocument } from "../programConfig";
 import {
   determineDocumentType,
   EventType,
+  QsharpDocumentType,
   sendTelemetryEvent,
   UserTaskInvocationType,
 } from "../telemetry";
@@ -24,8 +25,8 @@ import { CopilotToolError, HistogramData } from "./types";
  * familiar with how we expand the project or how we determine target profile,
  * this output will give Copilot context to understand what just happened.
  */
-type ProjectInfo = {
-  project: {
+export type ProjectInfo = {
+  qsharpProject: {
     name: string;
     targetProfile: string;
   };
@@ -57,7 +58,7 @@ export class QSharpTools {
     const shots = input.shots ?? 1;
 
     const program = await this.getProgram(input.filePath);
-    const programConfig = program.program.programConfig;
+    const programConfig = program.config;
 
     const output: string[] = [];
     let finalHistogram: HistogramData | undefined;
@@ -122,15 +123,10 @@ export class QSharpTools {
       );
     }
 
-    const project = {
-      name: programConfig.projectName,
-      targetProfile: programConfig.profile,
-    };
-
     if (shots === 1) {
       // Return the output and results directly
       return {
-        project,
+        ...program.additionalContextForModel,
         output: output.join("\n"),
         result:
           sampleFailures.length > 0
@@ -140,7 +136,7 @@ export class QSharpTools {
     } else {
       // No output, return the histogram
       return {
-        project,
+        ...program.additionalContextForModel,
         sampleFailures,
         histogram: finalHistogram!,
         message: `Results are displayed in the Histogram panel.`,
@@ -158,7 +154,7 @@ export class QSharpTools {
       }
   > {
     const program = await this.getProgram(input.filePath);
-    const programConfig = program.program.programConfig;
+    const programConfig = program.config;
 
     const circuitOrError = await showCircuitCommand(
       this.extensionUri,
@@ -169,10 +165,7 @@ export class QSharpTools {
     );
 
     const result = {
-      project: {
-        name: programConfig.projectName,
-        targetProfile: programConfig.profile,
-      },
+      ...program.additionalContextForModel,
       ...circuitOrError,
     };
 
@@ -202,12 +195,7 @@ export class QSharpTools {
     }
   > {
     const program = await this.getProgram(input.filePath);
-    const programConfig = program.program.programConfig;
-
-    const project = {
-      name: programConfig.projectName,
-      targetProfile: programConfig.profile,
-    };
+    const programConfig = program.config;
 
     try {
       const qubitTypes = input.qubitTypes ?? ["qubit_gate_ns_e3"];
@@ -222,7 +210,7 @@ export class QSharpTools {
       );
 
       return {
-        project,
+        ...program.additionalContextForModel,
         estimates,
         message: "Results are displayed in the resource estimator panel.",
       };
@@ -234,19 +222,35 @@ export class QSharpTools {
     }
   }
 
-  private async getProgram(filePath: string) {
+  async getProgram(
+    filePath: string,
+    options: { targetProfileFallback?: TargetProfile } = {},
+  ): Promise<{
+    config: FullProgramConfig;
+    telemetryDocumentType: QsharpDocumentType;
+    additionalContextForModel: ProjectInfo;
+  }> {
     const docUri = vscode.Uri.file(filePath);
 
     const doc = await vscode.workspace.openTextDocument(docUri);
     const telemetryDocumentType = determineDocumentType(doc);
 
-    const program = await getProgramForDocument(doc);
+    const program = await getProgramForDocument(doc, options);
     if (!program.success) {
       throw new CopilotToolError(
         `Cannot get program for the file ${filePath}\n\n${program.diagnostics ? JSON.stringify(program.diagnostics) : program.errorMsg}`,
       );
     }
-    return { program, telemetryDocumentType };
+    return {
+      config: program.programConfig,
+      telemetryDocumentType,
+      additionalContextForModel: {
+        qsharpProject: {
+          name: program.programConfig.projectName,
+          targetProfile: program.programConfig.profile,
+        },
+      },
+    };
   }
 
   private async runQsharp(

--- a/source/vscode/src/gh-copilot/tools.ts
+++ b/source/vscode/src/gh-copilot/tools.ts
@@ -48,18 +48,21 @@ const toolDefinitions: {
   {
     name: "azure-quantum-submit-to-target",
     tool: async (input: {
-      job_name: string;
-      target_id: string;
-      number_of_shots: number;
-    }) => (await azqTools.submitToTarget(workspaceState, input)).result,
+      filePath: string;
+      jobName: string;
+      targetId: string;
+      shots: number;
+    }) =>
+      (await azqTools.submitToTarget(workspaceState, qsharpTools!, input))
+        .result,
     confirm: (input: {
-      job_name: string;
-      target_id: string;
-      number_of_shots: number;
+      jobName: string;
+      targetId: string;
+      shots: number;
     }): vscode.PreparedToolInvocation => ({
       confirmationMessages: {
         title: "Submit Azure Quantum job",
-        message: `Submit job "${input.job_name}" to ${input.target_id} for ${input.number_of_shots} shots?`,
+        message: `Submit job "${input.jobName}" to ${input.targetId} for ${input.shots} shots?`,
       },
     }),
   },

--- a/source/vscode/src/qirGeneration.ts
+++ b/source/vscode/src/qirGeneration.ts
@@ -14,14 +14,11 @@ import {
   FullProgramConfig,
   getActiveProgram,
   getActiveQdkDocumentUri,
-  getVisibleProgram,
-  getVisibleQdkDocumentUri,
 } from "./programConfig";
 import { openManifestFile } from "./projectSystem";
 import {
   EventType,
   getActiveDocumentType,
-  getVisibleDocumentType,
   QsharpDocumentType,
   sendTelemetryEvent,
 } from "./telemetry";
@@ -36,26 +33,6 @@ export class QirGenerationError extends Error {
     super(message);
     this.name = "QirGenerationError";
   }
-}
-
-export async function getQirForVisibleSource(
-  preferredTargetProfile: TargetProfile,
-): Promise<string> {
-  const program = await getVisibleProgram({
-    targetProfileFallback: preferredTargetProfile,
-  });
-
-  if (!program.success) {
-    throw new QirGenerationError(program.errorMsg);
-  }
-
-  const docUri = getVisibleQdkDocumentUri();
-  return getQirForProgram(
-    program.programConfig,
-    preferredTargetProfile,
-    getVisibleDocumentType(),
-    docUri,
-  );
 }
 
 export async function getQirForActiveWindow(
@@ -101,7 +78,7 @@ function checkCompatibility(
   );
 }
 
-async function getQirForProgram(
+export async function getQirForProgram(
   config: FullProgramConfig,
   preferredTargetProfile: TargetProfile,
   telemetryDocumentType: QsharpDocumentType,


### PR DESCRIPTION
Updates to the `azureQuantumSubmitToTarget` tool to submit Azure Quantum jobs.

- Instead of using the Q# from the "currently visible window" , the tool now takes an explicit file path. The visible window thing was just the wrong way to do it. Copilot knows which file path it's working with, while it has no idea what the currently visible window actually is (especially in projects involving multiple files, or if user is clicking around in the UI). The less hidden state tools use, the better.
- This tool now returns richer project context in the result, including properties we infer such as project name and TargetProfile. This additional context helps Copilot make sense of whatever is going on.
- Updated the tool description and parameter names to be clearer and match our conventions.
- Also, `azureQuantumGetProviders` tool now also attaches a `preferredProfile` to each target, making it easier for Copilot to select a target based on needs.

Here is an example of how this additional context helps Copilot correct its own mistakes. The starting point was our unedited Bernstein Vazirani sample.

<img width="831" height="785" alt="image" src="https://github.com/user-attachments/assets/05b16369-0b7e-4ae3-8fb1-02c31411761d" />
