### PR TITLE
Reject NaN, Infinity, and Neg-Infinity to ensure only finite floating-point literals are accepted as OpenQASM literals

### DIFF
--- a/source/compiler/qsc_qasm/src/parser/expr.rs
+++ b/source/compiler/qsc_qasm/src/parser/expr.rs
@@ -223,9 +223,13 @@ fn lit_token(lexeme: &str, token: Token) -> Result<Option<Lit>> {
             }
             Literal::Float => {
                 let lexeme = lexeme.replace('_', "");
-                let value = lexeme
+                let value: f64 = lexeme
                     .parse()
                     .map_err(|_| Error::new(ErrorKind::Lit("floating-point", token.span)))?;
+                // Reject NaN, Infinity, and Neg-Infinity to ensure only finite floating-point literals are accepted.
+                if !value.is_finite() {
+                    return Err(Error::new(ErrorKind::Lit("floating-point", token.span)));
+                }
                 Ok(Some(Lit {
                     kind: LiteralKind::Float(value),
                     span: token.span,

--- a/source/compiler/qsc_qasm/src/tests/fuzz.rs
+++ b/source/compiler/qsc_qasm/src/tests/fuzz.rs
@@ -165,3 +165,9 @@ fn fuzz_2620() {
     let source = "sqrt(888888888888888888);";
     compile_qasm_best_effort(source);
 }
+
+#[test]
+fn fuzz_2669() {
+    let source = "gphase(1E1000);";
+    compile_qasm_best_effort(source);
+}


### PR DESCRIPTION
Closes #2669