### PR TITLE
Updated wording in 'complex numbers' kata

### DIFF
--- a/katas/content/complex_arithmetic/powers_of_i/index.md
+++ b/katas/content/complex_arithmetic/powers_of_i/index.md
@@ -1,3 +1,3 @@
-**Input:** An even integer $n$ (can be negative).
+**Input:** An even integer $n$. The integer can be zero, positive or negative, but it is guaranteed to be even.
 
 **Goal:** Return $i^n$, that is, the $n$-th power of $i$.


### PR DESCRIPTION
Emphasized that the input to `PowersOfI` is an even number.

Instead of '**Input:** An even integer $n$ (can be negative).' we say '**Input:** An even integer $n$. The integer can be zero, positive or negative, but it is guaranteed to be even.' We do very similar phrasing in other Katas, but for
quantum states (the state is guaranteed to be such and such). Requiring user to write a function that works for all integers is too early for this place in the kata because the complex number type isn't yet introduced.

Addressed katas feedback, thanks for reporting.