### PR TITLE
Short-circuiting expressions produce divergent types that propagate too far

### DIFF
--- a/source/compiler/qsc_frontend/src/typeck/tests/bounded_polymorphism.rs
+++ b/source/compiler/qsc_frontend/src/typeck/tests/bounded_polymorphism.rs
@@ -163,7 +163,7 @@ fn iter() {
             #11 67-74 "(a: 'T)" : Param<"'T": 0>
             #12 68-73 "a: 'T" : Param<"'T": 0>
             #19 82-180 "{\n                for item in a {\n                    return item;\n                }\n            }" : Bool
-            #21 100-166 "for item in a {\n                    return item;\n                }" : Bool
+            #21 100-166 "for item in a {\n                    return item;\n                }" : Unit
             #22 104-108 "item" : Bool
             #24 112-113 "a" : Param<"'T": 0>
             #27 114-166 "{\n                    return item;\n                }" : Unit
@@ -726,13 +726,13 @@ fn show_and_eq_should_fail() {
             #51 277-367 "{\n                let x = Foo(1, true);\n                let y = Foo(1, \"2\");\n            }" : Unit
             #53 299-300 "x" : String
             #55 303-315 "Foo(1, true)" : String
-            #56 303-306 "Foo" : ((Int, Int) -> String)
+            #56 303-306 "Foo" : ((Bool, Bool) -> String)
             #59 306-315 "(1, true)" : (Int, Bool)
             #60 307-308 "1" : Int
             #61 310-314 "true" : Bool
             #63 337-338 "y" : String
             #65 341-352 "Foo(1, \"2\")" : String
-            #66 341-344 "Foo" : ((Int, Int) -> String)
+            #66 341-344 "Foo" : ((String, String) -> String)
             #69 344-352 "(1, \"2\")" : (Int, String)
             #70 345-346 "1" : Int
             #71 348-351 "\"2\"" : String


### PR DESCRIPTION
This is a fairly significant adjustment to how divergent types propagate. Previously, every time a divergent type encountered another type in propagation during inference, the divergence would cause type erasure, losing all the information about the type calculated so far. This means tuples, like `(<Int>, <Divergent>, <Double>)` would just become `<Divergent>` which would allow it to unify with any type, even tuples of a different arity. The same is true for arrays, where `[<Int>, <Divergent>, <Double>]` would not produce an error even though the type inference saw an Int and a Double that can't be in the same array. For the fix, this continues to propagate the bool that indicates a type is divergent without erasing the type. In specific cases, like the boundaries of blocks in if-expressions or the block in a specialization, the inference performs intentional type erasure similar to before. This allows for short-circuit expressions to have the right effects while still having better validation of types we can detect.

Fixes #2697