### PR TITLE
Fix config key for upload supplemental data

### DIFF
--- a/source/vscode/src/config.ts
+++ b/source/vscode/src/config.ts
@@ -48,5 +48,5 @@ export function getShowDevDiagnostics(): boolean {
 export function getUploadSupplementalData(): boolean {
   return vscode.workspace
     .getConfiguration("Q#")
-    .get<boolean>("azure.uploadSupplementalData", false);
+    .get<boolean>("azure.experimental.uploadSupplementalData", false);
 }


### PR DESCRIPTION
Silly mistake - this setting name doesn't match what's declared in package.json at https://github.com/microsoft/qsharp/blob/47e1c8e20d1e1887ca82548da240ed25d2141130/source/vscode/package.json#L148