### PR TITLE
Fix a bug in trivial 1-to-1 distillation unit

### DIFF
--- a/source/resource_estimator/src/system/modeling/tfactory.rs
+++ b/source/resource_estimator/src/system/modeling/tfactory.rs
@@ -468,7 +468,7 @@ pub fn default_t_factory(logical_qubit: &LogicalPatch<Protocol>) -> TFactory {
     let unit = TFactoryDistillationUnit::by_template(&template, &tfactory_qubit);
 
     let length = 1;
-    let t_error_rate = logical_qubit.logical_error_rate();
+    let t_error_rate = logical_qubit.physical_qubit().t_gate_error_rate();
     let failure_probability_requirement = 0.0;
 
     let round = DistillationRound::new(&unit, failure_probability_requirement, 0);

--- a/source/resource_estimator/src/system/modeling/tfactory/tests.rs
+++ b/source/resource_estimator/src/system/modeling/tfactory/tests.rs
@@ -266,9 +266,9 @@ fn expression_by_formula2() {
 
 #[test]
 fn test_default_t_factory() {
-    let physical_qubit = PhysicalQubit::default();
+    let physical_qubit = Rc::new(PhysicalQubit::default());
     let ftp = surface_code_gate_based();
-    let logical_qubit = LogicalPatch::new(&ftp, 15, Rc::new(physical_qubit))
+    let logical_qubit = LogicalPatch::new(&ftp, 15, physical_qubit.clone())
         .expect("logical qubit construction should succeed");
     let tfactory = default_t_factory(&logical_qubit);
 
@@ -277,4 +277,7 @@ fn test_default_t_factory() {
     assert_eq!(tfactory.code_parameter_per_round(), vec![Some(&15)]);
     assert_eq!(tfactory.physical_qubits_per_round(), vec![450]);
     assert_eq!(tfactory.duration_per_round(), vec![6000]);
+    assert!(
+        (tfactory.output_error_rate() - physical_qubit.t_gate_error_rate()).abs() < f64::EPSILON
+    );
 }


### PR DESCRIPTION
The T-error-rate in a trivial pass-through distillation unit is the physical T gate error rate and not the logical error rate of the logical qubit.