### PR TITLE
Updated controlled ApproximatelyMultiplexZ, added test

### DIFF
--- a/library/src/tests/resources/src/state_preparation.qs
+++ b/library/src/tests/resources/src/state_preparation.qs
@@ -124,4 +124,14 @@ namespace Test {
         }
     }
 
+    operation TestControlledPreparation() : Unit {
+        use qs = Qubit[2];
+        let coeffs = [0.5, 0.5, 0.5, 0.5];
+        use c = Qubit();
+        H(c);
+        Controlled Std.StatePreparation.PreparePureStateD([c], (coeffs, qs));
+        Std.Diagnostics.DumpMachine();
+        ResetAll(qs + [c]);
+    }
+
 }

--- a/library/src/tests/state_preparation.rs
+++ b/library/src/tests/state_preparation.rs
@@ -307,3 +307,22 @@ fn check_uniform_superposition_invalid_state_count() {
 
     expect!["program failed: Number of basis states must be positive."].assert_eq(&out);
 }
+
+#[test]
+fn check_controlled_state_preparation() {
+    let out = test_expression_with_lib(
+        "Test.TestControlledPreparation()",
+        STATE_PREPARATION_TEST_LIB,
+        &Value::Tuple(vec![].into(), None),
+    );
+
+    expect![[r#"
+        STATE:
+        |000⟩: 0.7071+0.0000𝑖
+        |001⟩: 0.3536+0.0000𝑖
+        |011⟩: 0.3536+0.0000𝑖
+        |101⟩: 0.3536+0.0000𝑖
+        |111⟩: 0.3536+0.0000𝑖
+    "#]]
+    .assert_eq(&out);
+}

--- a/library/std/src/Std/StatePreparation.qs
+++ b/library/std/src/Std/StatePreparation.qs
@@ -13,6 +13,7 @@ import
     Std.Arithmetic.ApplyIfGreaterLE,
     Std.Arithmetic.ApplyIfGreaterL,
     Std.Arithmetic.ReflectAboutInteger,
+    Std.ArithmeticUtils.ApplyAsSinglyControlled,
     Std.Convert.IntAsBigInt,
     Std.Math.*,
     Std.Arrays.*;
@@ -351,7 +352,8 @@ operation ApproximatelyMultiplexZ(
         ApproximatelyMultiplexZ(tolerance, coefficients0, control, target);
         if AnyOutsideToleranceD(tolerance, coefficients1) {
             within {
-                Controlled X(controlRegister, target);
+                // Reduce circuit complexity by using aux qubits.
+                Controlled ApplyAsSinglyControlled(controlRegister, (X, target));
             } apply {
                 ApproximatelyMultiplexZ(tolerance, coefficients1, control, target);
             }


### PR DESCRIPTION
This PR implements the old suggestion by @msoeken and resolves the last remaining item in the issue https://github.com/microsoft/qdk/issues/1104.

The suggestion was "Instead of performing Controlled X apply an AND chain. I think you added such an operation for the PhaseUp..."

Also introduces a test for controlled version of preparation.

Closes #1104