### PR TITLE
Adjust over-large address register in Unlookup

### DIFF
--- a/library/std/src/Std/TableLookup.qs
+++ b/library/std/src/Std/TableLookup.qs
@@ -251,7 +251,7 @@ operation Unlookup(
         let phaseData = Padded(-2^addressBitsNeeded, false, phaseData);
 
         // Apply phase lookup to correct phases in the address register
-        PhaseLookup(address, phaseData);
+        PhaseLookup(address[...addressBitsNeeded - 1], phaseData);
     }
 }
 


### PR DESCRIPTION
We check in PhaseLookup whether the number of data bit-strings matches the address length. However, the address register may be larger than necessary (which is not a problem), in which case we need to shrink it to the required size. The computation of the required size and its validation is already present in the `Unlookup` operation.