### PR TITLE
retry on vscode test network failures

### DIFF
--- a/source/vscode/test/buildTests.mjs
+++ b/source/vscode/test/buildTests.mjs
@@ -14,6 +14,7 @@ const buildOptions = {
   entryPoints: [
     join(thisDir, "suites", "language-service", "index.ts"),
     join(thisDir, "suites", "debugger", "index.ts"),
+    join(thisDir, "suites", "empty", "index.ts"),
   ],
   outdir: join(thisDir, "out"),
   bundle: true,

--- a/source/vscode/test/runTests.mjs
+++ b/source/vscode/test/runTests.mjs
@@ -49,7 +49,7 @@ const thisDir = dirname(fileURLToPath(import.meta.url));
 const extensionDevelopmentPath = join(thisDir, "..");
 
 try {
-  const suites = ["language-service", "debugger"];
+  const suites = ["language-service", "debugger", "empty"];
   const toRun =
     selectedSuite && suites.includes(selectedSuite) ? [selectedSuite] : suites;
 

--- a/source/vscode/test/suites/empty/index.ts
+++ b/source/vscode/test/suites/empty/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This is a placeholder test suite to ensure that the test runner works
+// even when there are no real test suites to run.
+
+export async function run(): Promise<void> {}


### PR DESCRIPTION
Workaround for VS Code test runner issue tracked at https://github.com/microsoft/vscode-test-web/issues/175