### PR TITLE
Avoid name collision in sample

### DIFF
--- a/samples/notebooks/sample.ipynb
+++ b/samples/notebooks/sample.ipynb
@@ -480,8 +480,8 @@
     "%%qsharp\n",
     "\n",
     "import Std.Diagnostics.DumpMachine;\n",
-    "namespace Bar {\n",
-    "    operation Baz() : Unit {\n",
+    "namespace MyNamespace {\n",
+    "    operation MyOperation() : Unit {\n",
     "        use qs = Qubit[2];\n",
     "        for q in qs {\n",
     "            H(q);\n",
@@ -499,9 +499,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qsharp.code.Bar import Baz\n",
+    "from qsharp.code.MyNamespace import MyOperation\n",
     "\n",
-    "Baz()"
+    "MyOperation()"
    ]
   },
   {
@@ -522,7 +522,7 @@
     "qsharp.init()\n",
     "\n",
     "try:\n",
-    "    Baz()\n",
+    "    MyOperation()\n",
     "except qsharp.QSharpError as e:\n",
     "    print(f\"QsharpError: {e}\")"
    ]


### PR DESCRIPTION
This avoids a name collision in the sample that can cause confusion (see #2771)