### PR TITLE
Remove error check on pagination

### DIFF
--- a/source/vscode/src/azure/workspaceActions.ts
+++ b/source/vscode/src/azure/workspaceActions.ts
@@ -412,10 +412,6 @@ export async function queryWorkspace(workspace: WorkspaceConnection) {
     log.trace(`Got jobs: ${JSON.stringify(jobs, null, 2)}`);
   }
 
-  if (jobs.nextLink) {
-    log.error("Jobs returned a nextLink. This is not supported yet.");
-  }
-
   if (jobs.value.length === 0) {
     sendTelemetryEvent(
       EventType.QueryWorkspaceEnd,


### PR DESCRIPTION
The service now does pagination on large jobs, so the `nextLink` may have a value.

Without this check it all still works as before, you'll just only see the most recent 100 jobs if you have more that 100.