### PR TITLE
Fix wording on error message

### DIFF
--- a/source/qdk_package/src/qdk/widgets.py
+++ b/source/qdk_package/src/qdk/widgets.py
@@ -3,7 +3,7 @@
 
 """Re-export shim for the optional widgets package as qdk.widgets.
 
-If widgets is not installed (with the qdk[widgets] extra), importing this
+If widgets is not installed (with the qdk[jupyter] extra), importing this
 module raises an ImportError describing how to enable it.
 """
 
@@ -11,5 +11,5 @@ try:
     from qsharp_widgets import *  # pyright: ignore[reportWildcardImportFromLibrary]
 except Exception as ex:
     raise ImportError(
-        "qdk.widgets requires the widgets extra. Install with 'pip install qdk[widgets]'."
+        "qdk.widgets requires the jupyter extra. Install with 'pip install qdk[jupyter]'."
     ) from ex


### PR DESCRIPTION
Found that a description and error message in the qdk python was referencing an out-of-date name for the jupyter extra. This PR fixes that.