### PR TITLE
Revert Histogram Colors for Dark High Contrast Theme CSS

### DIFF
--- a/source/npm/qsharp/ux/qsharp-ux.css
+++ b/source/npm/qsharp/ux/qsharp-ux.css
@@ -357,6 +357,14 @@ modern-normalize (see https://mattbrictson.com/blog/css-normalize-and-reset for 
   fill: var(--vscode-button-hoverBackground, var(--nav-hover-background));
 }
 
+[data-vscode-theme-kind="vscode-high-contrast"] .bar {
+  fill: #007acc;
+}
+
+[data-vscode-theme-kind="vscode-high-contrast"] .bar:hover {
+  fill: #005a9e;
+}
+
 .bar-selected {
   stroke: var(--bar-selected-outline);
   fill: var(--nav-current-background);


### PR DESCRIPTION
A recent change to the VS Code Dark High Contrast theme caused our histogram widget to be unreadable under that theme. The color for the histogram bars were the same black as the background. This fix addresses that by coloring the histogram bars as they were before the change to the theme, targeting CSS specific to the Dark High Contrast theme.

<img width="461" height="320" alt="image" src="https://github.com/user-attachments/assets/4e58957d-b6b2-4a70-af0a-5d152cd2e1e6" />
