### PR TITLE
Fixes issue with dragging a control off the last qubit line

### DIFF
--- a/source/npm/qsharp/ux/circuit-vis/events.ts
+++ b/source/npm/qsharp/ux/circuit-vis/events.ts
@@ -170,11 +170,7 @@ class CircuitEvents {
           this.selectedOperation.controls != null &&
           this.selectedWire != null
         ) {
-          const controlIndex = this.selectedOperation.controls.findIndex(
-            (control) => control.qubit === this.selectedWire,
-          );
-          if (controlIndex !== -1)
-            this.selectedOperation.controls.splice(controlIndex, 1);
+          removeControl(this, this.selectedOperation, this.selectedWire);
         } else {
           // Otherwise, remove the selectedOperation
           removeOperation(this, selectedLocation);


### PR DESCRIPTION
Dragging the the last element of the last qubit off the grid should delete the element and remove the last qubit line, which is now empty. This PR fixes a bug where the qubit line is not removed if the element being dragged/removed is a control.