### PR TITLE
call stacks should get captured if group_by_scope=true

### DIFF
--- a/source/compiler/qsc_circuit/src/builder.rs
+++ b/source/compiler/qsc_circuit/src/builder.rs
@@ -134,7 +134,7 @@ impl Tracer for CircuitTracer {
     }
 
     fn is_stack_tracing_enabled(&self) -> bool {
-        self.config.source_locations
+        self.config.source_locations || self.config.group_by_scope
     }
 }
 


### PR DESCRIPTION
The `group_by_scope` setting wasn't working when passed in from Python because it by itself wasn't enough to switch on stack trace capturing.