### PR TITLE
Use `CCNOT` instead of `AND` for multi-controlled operations

### DIFF
--- a/library/std/src/Std/InternalHelpers.qs
+++ b/library/std/src/Std/InternalHelpers.qs
@@ -109,13 +109,13 @@ internal operation EntangleForJointMeasure(basis : Pauli, aux : Qubit, qubit : Q
 internal operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : Int) : Unit is Adj {
     // First collect the controls into the first part of the auxiliary list.
     for i in 0..2..(Length(ctls) - 2) {
-        AND(ctls[i], ctls[i + 1], aux[i / 2]);
+        CCNOT(ctls[i], ctls[i + 1], aux[i / 2]);
     }
     // Then collect the auxiliary qubits in the first part of the list forward into the last
     // qubit of the auxiliary list. The adjustment is used to allow the caller to reduce or increase
     // the number of times this is run based on the eventual number of control qubits needed.
     for i in 0..((Length(ctls) / 2) - 2 - adjustment) {
-        AND(aux[i * 2], aux[(i * 2) + 1], aux[i + Length(ctls) / 2]);
+        CCNOT(aux[i * 2], aux[(i * 2) + 1], aux[i + Length(ctls) / 2]);
     }
 }
 
@@ -123,7 +123,7 @@ internal operation CollectControls(ctls : Qubit[], aux : Qubit[], adjustment : I
 /// last control and the second to last auxiliary will be collected into the last auxiliary.
 internal operation AdjustForSingleControl(ctls : Qubit[], aux : Qubit[]) : Unit is Adj {
     if Length(ctls) % 2 != 0 {
-        AND(ctls[Length(ctls) - 1], aux[Length(ctls) - 3], aux[Length(ctls) - 2]);
+        CCNOT(ctls[Length(ctls) - 1], aux[Length(ctls) - 3], aux[Length(ctls) - 2]);
     }
 }
 

--- a/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
+++ b/source/compiler/qsc_qasm/src/tests/statement/pragma/profile.rs
@@ -36,41 +36,20 @@ fn profile_pragma_compiles_with_adaptive_ri() -> miette::Result<(), Vec<Report>>
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
-          %var_5 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 0 to %Result*))
-          br i1 %var_5, label %block_1, label %block_2
-        block_1:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          br label %block_2
-        block_2:
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-          %var_8 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 1 to %Result*))
-          br i1 %var_8, label %block_3, label %block_4
-        block_3:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          br label %block_4
-        block_4:
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
-          %var_10 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 2 to %Result*))
-          br i1 %var_10, label %block_5, label %block_6
-        block_5:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          br label %block_6
-        block_6:
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
           call void @__quantum__rt__array_record_output(i64 5, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @empty_tag, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 7 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 6 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 5 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
           ret i64 0
         }
 
@@ -78,21 +57,13 @@ fn profile_pragma_compiles_with_adaptive_ri() -> miette::Result<(), Vec<Report>>
 
         declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
 
-        declare void @__quantum__qis__h__body(%Qubit*)
-
-        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
-
-        declare i1 @__quantum__rt__read_result(%Result*)
-
-        declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
-
         declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
         declare void @__quantum__rt__array_record_output(i64, i8*)
 
         declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="8" }
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="5" }
         attributes #1 = { "irreversible" }
 
         ; module flags
@@ -140,41 +111,20 @@ fn profile_pragma_compiles_with_adaptive_rif() -> miette::Result<(), Vec<Report>
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
-          %var_5 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 0 to %Result*))
-          br i1 %var_5, label %block_1, label %block_2
-        block_1:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          br label %block_2
-        block_2:
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-          %var_8 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 1 to %Result*))
-          br i1 %var_8, label %block_3, label %block_4
-        block_3:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          br label %block_4
-        block_4:
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
-          %var_10 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 2 to %Result*))
-          br i1 %var_10, label %block_5, label %block_6
-        block_5:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          br label %block_6
-        block_6:
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
           call void @__quantum__rt__array_record_output(i64 5, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @empty_tag, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 7 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 6 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 5 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
           ret i64 0
         }
 
@@ -182,21 +132,13 @@ fn profile_pragma_compiles_with_adaptive_rif() -> miette::Result<(), Vec<Report>
 
         declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
 
-        declare void @__quantum__qis__h__body(%Qubit*)
-
-        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
-
-        declare i1 @__quantum__rt__read_result(%Result*)
-
-        declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
-
         declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
         declare void @__quantum__rt__array_record_output(i64, i8*)
 
         declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="8" }
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="5" }
         attributes #1 = { "irreversible" }
 
         ; module flags
@@ -242,73 +184,13 @@ fn profile_pragma_compiles_with_base() -> miette::Result<(), Vec<Report>> {
         define i64 @ENTRYPOINT__main() #0 {
         block_0:
           call void @__quantum__rt__initialize(i8* null)
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 0 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 2 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 2 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__t__body(%Qubit* inttoptr (i64 0 to %Qubit*))
-          call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__cx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 0 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
           call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
           call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
           call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
@@ -324,14 +206,6 @@ fn profile_pragma_compiles_with_base() -> miette::Result<(), Vec<Report>> {
         }
 
         declare void @__quantum__rt__initialize(i8*)
-
-        declare void @__quantum__qis__h__body(%Qubit*)
-
-        declare void @__quantum__qis__cx__body(%Qubit*, %Qubit*)
-
-        declare void @__quantum__qis__t__body(%Qubit*)
-
-        declare void @__quantum__qis__t__adj(%Qubit*)
 
         declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
 
@@ -427,41 +301,20 @@ fn profile_pragma_first_wins() -> miette::Result<(), Vec<Report>> {
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
           call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*), %Qubit* inttoptr (i64 5 to %Qubit*))
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 8 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 8 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
-          %var_5 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 0 to %Result*))
-          br i1 %var_5, label %block_1, label %block_2
-        block_1:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
-          br label %block_2
-        block_2:
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 7 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 7 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-          %var_8 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 1 to %Result*))
-          br i1 %var_8, label %block_3, label %block_4
-        block_3:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
-          br label %block_4
-        block_4:
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 6 to %Qubit*))
-          call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
-          %var_10 = call i1 @__quantum__rt__read_result(%Result* inttoptr (i64 2 to %Result*))
-          br i1 %var_10, label %block_5, label %block_6
-        block_5:
-          call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*))
-          br label %block_6
-        block_6:
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 5 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 6 to %Result*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 7 to %Result*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 6 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*), %Qubit* inttoptr (i64 8 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*), %Qubit* inttoptr (i64 7 to %Qubit*))
+          call void @__quantum__qis__ccx__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 6 to %Qubit*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 4 to %Qubit*), %Result* inttoptr (i64 4 to %Result*))
           call void @__quantum__rt__array_record_output(i64 5, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @empty_tag, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 7 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 6 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 5 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
-          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 4 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i64 0, i64 0))
+          call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @4, i64 0, i64 0))
           ret i64 0
         }
 
@@ -469,21 +322,13 @@ fn profile_pragma_first_wins() -> miette::Result<(), Vec<Report>> {
 
         declare void @__quantum__qis__ccx__body(%Qubit*, %Qubit*, %Qubit*)
 
-        declare void @__quantum__qis__h__body(%Qubit*)
-
-        declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
-
-        declare i1 @__quantum__rt__read_result(%Result*)
-
-        declare void @__quantum__qis__cz__body(%Qubit*, %Qubit*)
-
         declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
         declare void @__quantum__rt__array_record_output(i64, i8*)
 
         declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="8" }
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="9" "required_num_results"="5" }
         attributes #1 = { "irreversible" }
 
         ; module flags

--- a/source/compiler/qsc_rca/src/tests/callables.rs
+++ b/source/compiler/qsc_rca/src/tests/callables.rs
@@ -268,19 +268,19 @@ fn check_rca_for_unrestricted_h() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -366,25 +366,25 @@ fn check_rca_for_unrestricted_r1() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -482,25 +482,25 @@ fn check_rca_for_unrestricted_rx() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -604,31 +604,31 @@ fn check_rca_for_unrestricted_rxx() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                         [2]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                         [2]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -738,25 +738,25 @@ fn check_rca_for_unrestricted_ry() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -860,31 +860,31 @@ fn check_rca_for_unrestricted_ryy() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                         [2]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                         [2]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -994,25 +994,25 @@ fn check_rca_for_unrestricted_rz() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -1116,31 +1116,31 @@ fn check_rca_for_unrestricted_rzz() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                         [2]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
                             value_kind: Element(Static)
                         [1]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                         [2]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -1244,19 +1244,19 @@ fn check_rca_for_unrestricted_s() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -1336,19 +1336,19 @@ fn check_rca_for_unrestricted_t() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -1428,19 +1428,19 @@ fn check_rca_for_unrestricted_x() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -1520,19 +1520,19 @@ fn check_rca_for_unrestricted_y() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );
@@ -1612,19 +1612,19 @@ fn check_rca_for_unrestricted_z() {
                             value_kind: Element(Static)
                 ctl: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)
                 ctl-adj: ApplicationsGeneratorSet:
                     inherent: Quantum: QuantumProperties:
-                        runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                        runtime_features: RuntimeFeatureFlags(0x0)
                         value_kind: Element(Static)
                     dynamic_param_applications:
                         [0]: [Parameter Type Element] Quantum: QuantumProperties:
-                            runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
+                            runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
                             value_kind: Element(Static)"#
         ],
     );

--- a/source/compiler/qsc_rca/src/tests/lambdas.rs
+++ b/source/compiler/qsc_rca/src/tests/lambdas.rs
@@ -212,7 +212,7 @@ fn check_rca_for_operation_lambda_two_parameters_with_controls() {
         &expect![[r#"
             ApplicationsGeneratorSet:
                 inherent: Quantum: QuantumProperties:
-                    runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
+                    runtime_features: RuntimeFeatureFlags(0x0)
                     value_kind: Element(Static)
                 dynamic_param_applications: <empty>"#]],
     );

--- a/source/resource_estimator/src/counts/tests.rs
+++ b/source/resource_estimator/src/counts/tests.rs
@@ -307,9 +307,9 @@ fn memory_annotations_work() {
                 t_count: 4,
                 rotation_count: 8,
                 rotation_depth: 5,
-                ccz_count: 16,
+                ccz_count: 24,
                 ccix_count: 0,
-                measurement_count: 8,
+                measurement_count: 0,
                 num_compute_qubits: Some(
                     10,
                 ),


### PR DESCRIPTION
This avoids the measurement-based uncomputation in the intrinsic `AND` operation in favor of just using `CCNOT` when decomposing multiple controls on `Std.Intrinsic` gates. This leaves optimization of resulting QIR ccx to the program author or the backend that receives the QIR. This makes the behavior of most code more predictable and straightforward, and avoids special (often expensive) adaptive behavior being triggered automatically/enexpectedly by use of multi-controlled gates.
Other libraries still use the existing `AND` with it's alternate approach, such as the arithmetic libraries, which keeps the behavior and resource estimates of those more advanced programs largely the same.