### PR TITLE
Update the pip install commands in notebook samples for qdk

### DIFF
--- a/samples/python_interop/cirq_submission_to_azure.ipynb
+++ b/samples/python_interop/cirq_submission_to_azure.ipynb
@@ -31,7 +31,8 @@
    "metadata": {},
    "source": [
     "## Prerequisites\n",
-    "Ensure the `qdk` package (with Azure + Cirq extras) and `cirq` are installed. If not, install dependencies below."
+    "\n",
+    "Ensure the `qdk` package (with Azure extra) and `cirq` are installed. If not, install dependencies below."
    ]
   },
   {
@@ -41,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install qdk[azure,cirq]"
+    "%pip install \"qdk[azure]\" cirq"
    ]
   },
   {

--- a/samples/python_interop/pennylane_submission_to_azure.ipynb
+++ b/samples/python_interop/pennylane_submission_to_azure.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "## 1. Prerequisites\n",
     "\n",
-    "This notebook assumes the `qdk`, Azure Quantum integration, and PennyLane packages are installed. You can these with:"
+    "This notebook assumes the `qdk`, Azure Quantum integration, and PennyLane packages are installed. You can install these with:"
    ]
   },
   {
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install qdk[azure] pennylane"
+    "%pip install \"qdk[azure]\" pennylane"
    ]
   },
   {

--- a/samples/python_interop/submit_qiskit_circuit_to_azure.ipynb
+++ b/samples/python_interop/submit_qiskit_circuit_to_azure.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install qdk[azure,qiskit]"
+    "%pip install \"qdk[azure,qiskit]\""
    ]
   },
   {


### PR DESCRIPTION
Fixes bug where cirq was incorrectly listed as an extra in qdk in cirq sample notebook.
Puts quotes around qdk extras syntax in pip install commands in sample notebooks.