### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/publish-playground.yml
+++ b/.github/workflows/publish-playground.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           submodules: "true"
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Setup rust toolchain
         uses: ./.github/actions/toolchains/rust
         with:
@@ -52,7 +52,7 @@ jobs:
       - name: Build and Test
         run: python ./build.py --no-check --no-test --wasm --npm --play
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./source/playground/public
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/configure-pages` | [`v3`](https://github.com/actions/configure-pages/releases/tag/v3) | [`v5`](https://github.com/actions/configure-pages/releases/tag/v5) | [Release](https://github.com/actions/configure-pages/releases/tag/v5) | publish-playground.yml |
| `actions/upload-pages-artifact` | [`v3`](https://github.com/actions/upload-pages-artifact/releases/tag/v3) | [`v4`](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | [Release](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | publish-playground.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
