### PR TITLE
Update RIR reindex pass to avoid using extra qubits due to initial resets

### DIFF
--- a/source/compiler/qsc/src/codegen/tests.rs
+++ b/source/compiler/qsc/src/codegen/tests.rs
@@ -512,8 +512,8 @@ mod base_profile {
               call void @__quantum__rt__initialize(i8* null)
               call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
               call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
-              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
-              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
               call void @__quantum__rt__tuple_record_output(i64 2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @empty_tag, i64 0, i64 0))
               call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
               call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
@@ -530,7 +530,7 @@ mod base_profile {
 
             declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="4" "required_num_results"="2" }
+            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="3" "required_num_results"="2" }
             attributes #1 = { "irreversible" }
 
             ; module flags
@@ -583,7 +583,7 @@ mod adaptive_profile {
               call void @__quantum__qis__rz__body(double 2.0, %Qubit* inttoptr (i64 0 to %Qubit*))
               call void @__quantum__qis__rz__body(double 0.0, %Qubit* inttoptr (i64 0 to %Qubit*))
               call void @__quantum__qis__rz__body(double 1.0, %Qubit* inttoptr (i64 0 to %Qubit*))
-              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+              call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
               call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))
               ret i64 0
             }
@@ -592,9 +592,9 @@ mod adaptive_profile {
 
             declare void @__quantum__qis__rz__body(double, %Qubit*)
 
-            declare void @__quantum__rt__result_record_output(%Result*, i8*)
+            declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
 
-            declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
+            declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
             attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="1" "required_num_results"="1" }
             attributes #1 = { "irreversible" }
@@ -609,57 +609,6 @@ mod adaptive_profile {
             !3 = !{i32 1, !"dynamic_result_management", i1 false}
         "#]]
         .assert_eq(&qir);
-    }
-
-    #[test]
-    fn qubit_reuse_triggers_reindexing() {
-        let source = "namespace Test {
-            @EntryPoint()
-            operation Main() : (Result, Result) {
-                use q = Qubit();
-                (MResetZ(q), MResetZ(q))
-            }
-        }";
-        let qir = compile_source_to_qir(source, *CAPABILITIES);
-        expect![[r#"
-            %Result = type opaque
-            %Qubit = type opaque
-
-            @empty_tag = internal constant [1 x i8] c"\00"
-            @0 = internal constant [6 x i8] c"0_t0r\00"
-            @1 = internal constant [6 x i8] c"1_t1r\00"
-
-            define i64 @ENTRYPOINT__main() #0 {
-            block_0:
-              call void @__quantum__rt__initialize(i8* null)
-              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
-              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-              call void @__quantum__rt__tuple_record_output(i64 2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @empty_tag, i64 0, i64 0))
-              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
-              call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
-              ret i64 0
-            }
-
-            declare void @__quantum__rt__initialize(i8*)
-
-            declare void @__quantum__rt__tuple_record_output(i64, i8*)
-
-            declare void @__quantum__rt__result_record_output(%Result*, i8*)
-
-            declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
-
-            attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
-            attributes #1 = { "irreversible" }
-
-            ; module flags
-
-            !llvm.module.flags = !{!0, !1, !2, !3}
-
-            !0 = !{i32 1, !"qir_major_version", i32 1}
-            !1 = !{i32 7, !"qir_minor_version", i32 0}
-            !2 = !{i32 1, !"dynamic_qubit_management", i1 false}
-            !3 = !{i32 1, !"dynamic_result_management", i1 false}
-        "#]].assert_eq(&qir);
     }
 
     #[test]
@@ -802,9 +751,9 @@ mod adaptive_profile {
             block_0:
               call void @__quantum__rt__initialize(i8* null)
               call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 0 to %Qubit*))
-              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+              call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
               call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-              call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+              call void @__quantum__qis__mresetz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
               call void @__quantum__rt__array_record_output(i64 2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @empty_tag, i64 0, i64 0))
               call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
               call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i64 0, i64 0))
@@ -815,11 +764,11 @@ mod adaptive_profile {
 
             declare void @__quantum__qis__x__body(%Qubit*)
 
+            declare void @__quantum__qis__mresetz__body(%Qubit*, %Result*) #1
+
             declare void @__quantum__rt__array_record_output(i64, i8*)
 
             declare void @__quantum__rt__result_record_output(%Result*, i8*)
-
-            declare void @__quantum__qis__m__body(%Qubit*, %Result*) #1
 
             attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="2" "required_num_results"="2" }
             attributes #1 = { "irreversible" }
@@ -844,9 +793,7 @@ mod adaptive_ri_profile {
     use super::compile_source_to_qir;
     static CAPABILITIES: std::sync::LazyLock<TargetCapabilityFlags> =
         std::sync::LazyLock::new(|| {
-            TargetCapabilityFlags::Adaptive
-                | TargetCapabilityFlags::QubitReset
-                | TargetCapabilityFlags::IntegerComputations
+            TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::IntegerComputations
         });
 
     #[test]
@@ -1339,7 +1286,6 @@ mod adaptive_rif_profile {
     static CAPABILITIES: std::sync::LazyLock<TargetCapabilityFlags> =
         std::sync::LazyLock::new(|| {
             TargetCapabilityFlags::Adaptive
-                | TargetCapabilityFlags::QubitReset
                 | TargetCapabilityFlags::IntegerComputations
                 | TargetCapabilityFlags::FloatingPointComputations
         });

--- a/source/compiler/qsc/src/interpret/tests.rs
+++ b/source/compiler/qsc/src/interpret/tests.rs
@@ -1030,9 +1030,7 @@ mod given_interpreter {
         #[test]
         fn adaptive_qirgen() {
             let mut interpreter = get_interpreter_with_capabilities(
-                TargetCapabilityFlags::Adaptive
-                    | TargetCapabilityFlags::QubitReset
-                    | TargetCapabilityFlags::IntegerComputations,
+                TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::IntegerComputations,
             );
             let (result, output) = line(
                 &mut interpreter,
@@ -1100,9 +1098,8 @@ mod given_interpreter {
 
         #[test]
         fn adaptive_qirgen_nested_output_types() {
-            let mut interpreter = get_interpreter_with_capabilities(
-                TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::QubitReset,
-            );
+            let mut interpreter =
+                get_interpreter_with_capabilities(TargetCapabilityFlags::Adaptive);
             let (result, output) = line(
                 &mut interpreter,
                 indoc! {r#"
@@ -1453,9 +1450,8 @@ mod given_interpreter {
 
         #[test]
         fn adaptive_qirgen_custom_intrinsic_returning_bool() {
-            let mut interpreter = get_interpreter_with_capabilities(
-                TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::QubitReset,
-            );
+            let mut interpreter =
+                get_interpreter_with_capabilities(TargetCapabilityFlags::Adaptive);
             let res = interpreter
                 .qirgen("{ operation check_result(r : Result) : Bool { body intrinsic; }; operation Foo() : Bool { use q = Qubit(); let r = MResetZ(q); check_result(r) } Foo() }")
                 .expect("expected success");
@@ -1758,9 +1754,7 @@ mod given_interpreter {
             let result = Interpreter::new(
                 sources,
                 PackageType::Exe,
-                TargetCapabilityFlags::Adaptive
-                    | TargetCapabilityFlags::IntegerComputations
-                    | TargetCapabilityFlags::QubitReset,
+                TargetCapabilityFlags::Adaptive | TargetCapabilityFlags::IntegerComputations,
                 LanguageFeatures::default(),
                 store,
                 &[(std_id, None)],

--- a/source/compiler/qsc_data_structures/src/target.rs
+++ b/source/compiler/qsc_data_structures/src/target.rs
@@ -11,7 +11,6 @@ bitflags! {
         const FloatingPointComputations = 0b0000_0100;
         const BackwardsBranching = 0b0000_1000;
         const HigherLevelConstructs = 0b0001_0000;
-        const QubitReset = 0b0010_0000;
     }
 }
 
@@ -26,7 +25,6 @@ impl std::str::FromStr for TargetCapabilityFlags {
             "FloatingPointComputations" => Ok(TargetCapabilityFlags::FloatingPointComputations),
             "BackwardsBranching" => Ok(TargetCapabilityFlags::BackwardsBranching),
             "HigherLevelConstructs" => Ok(TargetCapabilityFlags::HigherLevelConstructs),
-            "QubitReset" => Ok(TargetCapabilityFlags::QubitReset),
             "Unrestricted" => Ok(TargetCapabilityFlags::all()),
             _ => Err(()),
         }
@@ -66,12 +64,9 @@ impl From<Profile> for TargetCapabilityFlags {
         match value {
             Profile::Unrestricted => Self::all(),
             Profile::Base => Self::empty(),
-            Profile::AdaptiveRI => Self::Adaptive | Self::QubitReset | Self::IntegerComputations,
+            Profile::AdaptiveRI => Self::Adaptive | Self::IntegerComputations,
             Profile::AdaptiveRIF => {
-                Self::Adaptive
-                    | Self::QubitReset
-                    | Self::IntegerComputations
-                    | Self::FloatingPointComputations
+                Self::Adaptive | Self::IntegerComputations | Self::FloatingPointComputations
             }
         }
     }

--- a/source/compiler/qsc_openqasm_compiler/src/tests/statement/reset.rs
+++ b/source/compiler/qsc_openqasm_compiler/src/tests/statement/reset.rs
@@ -76,8 +76,8 @@ fn reset_with_base_profile_is_rewritten_without_resets() -> miette::Result<(), V
         define i64 @ENTRYPOINT__main() #0 {
         block_0:
           call void @__quantum__rt__initialize(i8* null)
-          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
-          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
+          call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 0 to %Qubit*))
+          call void @__quantum__qis__m__body(%Qubit* inttoptr (i64 0 to %Qubit*), %Result* inttoptr (i64 0 to %Result*))
           call void @__quantum__rt__array_record_output(i64 1, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @empty_tag, i64 0, i64 0))
           call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 0 to %Result*), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i64 0, i64 0))
           ret i64 0
@@ -93,7 +93,7 @@ fn reset_with_base_profile_is_rewritten_without_resets() -> miette::Result<(), V
 
         declare void @__quantum__rt__result_record_output(%Result*, i8*)
 
-        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="2" "required_num_results"="1" }
+        attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="base_profile" "required_num_qubits"="1" "required_num_results"="1" }
         attributes #1 = { "irreversible" }
 
         ; module flags

--- a/source/compiler/qsc_partial_eval/src/tests/arrays.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/arrays.rs
@@ -1102,7 +1102,7 @@ fn result_array_index_range_returns_length_as_end() {
                     Call id(3), args( Integer(1), Tag(0, 3), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 2
             num_results: 2
             tags:

--- a/source/compiler/qsc_partial_eval/src/tests/loops.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/loops.rs
@@ -553,7 +553,7 @@ fn result_array_index_range_in_for_loop() {
                     Variable(2, Integer) = Store Variable(8, Integer)
                     Jump(3)
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 2
             num_results: 2
             tags:

--- a/source/compiler/qsc_partial_eval/src/tests/output_recording.rs
+++ b/source/compiler/qsc_partial_eval/src/tests/output_recording.rs
@@ -88,7 +88,7 @@ fn output_recording_for_tuple_of_different_types() {
                     Call id(6), args( Variable(1, Boolean), Tag(1, 5), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 1
             num_results: 1
             tags:
@@ -186,7 +186,7 @@ fn output_recording_for_nested_tuples() {
                     Call id(6), args( Variable(3, Boolean), Tag(3, 7), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 1
             num_results: 1
             tags:
@@ -294,7 +294,7 @@ fn output_recording_for_tuple_of_arrays() {
                     Call id(7), args( Variable(3, Boolean), Tag(2, 7), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 1
             num_results: 1
             tags:
@@ -401,7 +401,7 @@ fn output_recording_for_array_of_tuples() {
                     Call id(7), args( Variable(3, Boolean), Tag(3, 7), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 1
             num_results: 1
             tags:
@@ -457,7 +457,7 @@ fn output_recording_for_literal_bool() {
                     Call id(2), args( Bool(true), Tag(0, 3), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -510,7 +510,7 @@ fn output_recording_for_literal_double() {
                     Call id(2), args( Double(42.1), Tag(0, 3), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -563,7 +563,7 @@ fn output_recording_for_literal_int() {
                     Call id(2), args( Integer(42), Tag(0, 3), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -645,7 +645,7 @@ fn output_recording_for_mix_of_literal_and_variable() {
                     Call id(5), args( Bool(true), Tag(1, 5), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 1
             num_results: 1
             tags:

--- a/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck/tests_adaptive.rs
@@ -25,14 +25,6 @@ fn check_profile(source: &str, expect: &Expect) {
     check(source, expect, TargetCapabilityFlags::Adaptive);
 }
 
-fn check_profile_extended(source: &str, capabilities: TargetCapabilityFlags, expect: &Expect) {
-    check(
-        source,
-        expect,
-        TargetCapabilityFlags::Adaptive | capabilities,
-    );
-}
-
 fn check_profile_for_exe(source: &str, expect: &Expect) {
     check_for_exe(source, expect, TargetCapabilityFlags::Adaptive);
 }
@@ -477,9 +469,8 @@ fn custom_measurement_with_simulatable_intrinsic_yields_no_errors() {
 
 #[test]
 fn custom_reset_yields_no_errors() {
-    check_profile_extended(
+    check_profile(
         CUSTOM_RESET,
-        TargetCapabilityFlags::QubitReset,
         &expect![[r#"
             []
         "#]],
@@ -488,9 +479,8 @@ fn custom_reset_yields_no_errors() {
 
 #[test]
 fn custom_reset_with_simulatable_intrinsic_yields_no_errors() {
-    check_profile_extended(
+    check_profile(
         CUSTOM_RESET_WITH_SIMULATABLE_INTRINSIC_ATTR,
-        TargetCapabilityFlags::QubitReset,
         &expect![[r#"
             []
         "#]],

--- a/source/compiler/qsc_rca/src/lib.rs
+++ b/source/compiler/qsc_rca/src/lib.rs
@@ -921,7 +921,6 @@ impl RuntimeFeatureFlags {
         }
         if self.contains(RuntimeFeatureFlags::CallToCustomReset) {
             capabilities |= TargetCapabilityFlags::Adaptive;
-            capabilities |= TargetCapabilityFlags::QubitReset;
         }
         capabilities
     }

--- a/source/compiler/qsc_rir/src/passes.rs
+++ b/source/compiler/qsc_rir/src/passes.rs
@@ -46,18 +46,8 @@ pub fn check_and_transform(program: &mut Program) {
     check_unreachable_code(program);
     check_types(program);
 
-    // Run the RIR passes that are necessary for targets with no mid-program measurement.
-    // This requires that qubits are not reused after measurement or reset, so qubit ids must be reindexed.
-    // This also requires that the program has no loops and block ids form a topological ordering on a
-    // directed acyclic graph.
-    if !program
-        .config
-        .capabilities
-        .contains(TargetCapabilityFlags::QubitReset)
-    {
-        reindex_qubits(program);
-    }
     if program.config.capabilities == TargetCapabilityFlags::empty() {
+        reindex_qubits(program);
         defer_measurements(program);
     }
 }

--- a/source/compiler/qsc_rir/src/passes/reindex_qubits.rs
+++ b/source/compiler/qsc_rir/src/passes/reindex_qubits.rs
@@ -4,29 +4,21 @@
 #[cfg(test)]
 mod tests;
 
-use std::{collections::hash_map::Entry, ops::Sub};
+use std::ops::Sub;
 
-use qsc_data_structures::index_map::IndexMap;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     builder,
-    rir::{Block, BlockId, CallableId, CallableType, Instruction, Literal, Operand, Program},
-    utils::build_predecessors_map,
+    rir::{Block, CallableId, CallableType, Instruction, Literal, Operand, Program},
 };
-
-#[derive(Clone)]
-struct BlockQubitMap {
-    map: FxHashMap<u32, u32>,
-    next_qubit_id: u32,
-}
 
 /// Reindexes qubits after they have been measured or reset. This ensures there is no qubit reuse in
 /// the program. As part of the pass, reset callables are removed and mresetz calls are replaced with
 /// mz calls.
 /// Note that this pass has several assumptions:
 /// 1. Only one callable has a body, which is the entry point callable.
-/// 2. The entry point callable is a directed acyclic graph where block ids have topological ordering.
+/// 2. The entry point callable is a single block.
 /// 3. No dynamic qubits are used.
 ///
 /// The pass will panic if the input program violates any of these assumptions.
@@ -55,72 +47,12 @@ pub fn reindex_qubits(program: &mut Program) {
         highest_used_id: program.num_qubits.max(1).sub(1),
     };
 
-    let pred_map = build_predecessors_map(program);
-
-    let mut block_maps = IndexMap::new();
-    block_maps.insert(
-        BlockId(0),
-        BlockQubitMap {
-            map: FxHashMap::default(),
-            next_qubit_id: program.num_qubits,
-        },
-    );
-
-    let mut all_blocks = program.blocks.drain().collect::<Vec<_>>();
-    let (entry_block, rest_blocks) = all_blocks
-        .split_first_mut()
-        .expect("program should have at least one block");
-
-    // Reindex qubits in the entry block.
-    pass.reindex_qubits_in_block(
-        program,
-        &mut entry_block.1,
-        block_maps
-            .get_mut(entry_block.0)
-            .expect("entry block with id 0 should be in block_maps"),
-    );
-
-    for (block_id, block) in rest_blocks {
-        // Use the predecessors to build the block's initial, inherited qubit map.
-        let pred_ids = pred_map
-            .get(*block_id)
-            .expect("block should have predecessors");
-
-        // Start from an empty map with the program's initial qubit ids.
-        let mut new_block_map = BlockQubitMap {
-            map: FxHashMap::default(),
-            next_qubit_id: program.num_qubits,
-        };
-
-        for pred_id in pred_ids {
-            let pred_qubit_map = block_maps
-                .get(*pred_id)
-                .expect("predecessor should be in block_maps");
-
-            // Across each predecessor, ensure that any mapped ids are same, otherwise
-            // panic because we can't know which id to use.
-            for (qubit_id, new_qubit_id) in &pred_qubit_map.map {
-                match new_block_map.map.entry(*qubit_id) {
-                    Entry::Occupied(entry) if *entry.get() == *new_qubit_id => {}
-                    Entry::Occupied(_) => {
-                        panic!("Qubit id {qubit_id} has multiple mappings across predecessors");
-                    }
-                    Entry::Vacant(entry) => {
-                        entry.insert(*new_qubit_id);
-                    }
-                }
-            }
-            new_block_map.next_qubit_id = new_block_map
-                .next_qubit_id
-                .max(pred_qubit_map.next_qubit_id);
-        }
-
-        pass.reindex_qubits_in_block(program, block, &mut new_block_map);
-
-        block_maps.insert(*block_id, new_block_map);
-    }
-
-    program.blocks = all_blocks.into_iter().collect();
+    // Perform the reindexing on the single entry block.
+    let Some((block_id, mut block)) = program.blocks.drain().next() else {
+        panic!("program should have at least one block");
+    };
+    pass.reindex_qubits_in_block(program, &mut block);
+    program.blocks.insert(block_id, block);
     program.num_qubits = pass.highest_used_id + 1;
 
     // All reset function calls should be removed, so remove them from the callables.
@@ -147,12 +79,10 @@ struct ReindexQubitPass {
 }
 
 impl ReindexQubitPass {
-    fn reindex_qubits_in_block(
-        &mut self,
-        program: &Program,
-        block: &mut Block,
-        qubit_map: &mut BlockQubitMap,
-    ) {
+    fn reindex_qubits_in_block(&mut self, program: &Program, block: &mut Block) {
+        let mut map = FxHashMap::default();
+        let mut used_qubits: FxHashSet<u32> = FxHashSet::default();
+        let mut next_qubit_id = self.highest_used_id + 1;
         let instrs = std::mem::take(&mut block.0);
         for i in 0..instrs.len() {
             // Assume qubits only appear in void call instructions.
@@ -163,9 +93,11 @@ impl ReindexQubitPass {
                 {
                     // Generate any new qubit ids and skip adding the instruction.
                     for arg in args {
-                        if let Operand::Literal(Literal::Qubit(qubit_id)) = arg {
-                            qubit_map.map.insert(*qubit_id, qubit_map.next_qubit_id);
-                            qubit_map.next_qubit_id += 1;
+                        if let Operand::Literal(Literal::Qubit(qubit_id)) = arg
+                            && used_qubits.contains(qubit_id)
+                        {
+                            map.insert(*qubit_id, next_qubit_id);
+                            next_qubit_id += 1;
                         }
                     }
                 }
@@ -178,7 +110,7 @@ impl ReindexQubitPass {
                         .map(|arg| match arg {
                             Operand::Literal(Literal::Qubit(qubit_id)) => {
                                 ids_used.push(*qubit_id);
-                                match qubit_map.map.get(qubit_id) {
+                                match map.get(qubit_id) {
                                     Some(mapped_id) => {
                                         // If the qubit has already been mapped, use the mapped id.
                                         self.highest_used_id = self.highest_used_id.max(*mapped_id);
@@ -190,6 +122,8 @@ impl ReindexQubitPass {
                             _ => *arg,
                         })
                         .collect::<Vec<_>>();
+
+                    used_qubits.extend(ids_used.iter());
 
                     if *call_id == self.m_id {
                         if qubit_used_in_instrs(
@@ -204,14 +138,10 @@ impl ReindexQubitPass {
                             self.used_cx = true;
                             block.0.push(Instruction::Call(
                                 self.cx_id,
-                                vec![
-                                    new_args[0],
-                                    Operand::Literal(Literal::Qubit(qubit_map.next_qubit_id)),
-                                ],
+                                vec![new_args[0], Operand::Literal(Literal::Qubit(next_qubit_id))],
                                 None,
                             ));
-                            self.highest_used_id =
-                                self.highest_used_id.max(qubit_map.next_qubit_id);
+                            self.highest_used_id = self.highest_used_id.max(next_qubit_id);
                         } else {
                             // The call was to mz and the qubit is not reused later in the block, so
                             // there is no need to remap it at all as this is the last operation. Skip
@@ -235,8 +165,8 @@ impl ReindexQubitPass {
                         // Generate any new qubit ids after a measurement.
                         for arg in args {
                             if let Operand::Literal(Literal::Qubit(qubit_id)) = arg {
-                                qubit_map.map.insert(*qubit_id, qubit_map.next_qubit_id);
-                                qubit_map.next_qubit_id += 1;
+                                map.insert(*qubit_id, next_qubit_id);
+                                next_qubit_id += 1;
                             }
                         }
                     }

--- a/source/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
+++ b/source/compiler/qsc_rir/src/passes/ssa_transform/tests.rs
@@ -143,7 +143,7 @@ fn ssa_transform_removes_store_in_single_block_program() {
                     Variable(2, Boolean) = LogicalNot Variable(0, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -301,7 +301,7 @@ fn ssa_transform_removes_multiple_stores_in_single_block_program() {
                     Variable(4, Boolean) = LogicalNot Variable(3, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -474,7 +474,7 @@ fn ssa_transform_store_dominating_usage_propagates_to_successor_blocks() {
                     Variable(4, Boolean) = LogicalNot Variable(0, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -618,7 +618,7 @@ fn ssa_transform_store_dominating_usage_propagates_to_successor_blocks_without_i
                     Variable(4, Boolean) = LogicalNot Variable(0, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -814,7 +814,7 @@ fn ssa_transform_inserts_phi_for_store_not_dominating_usage() {
                     Variable(4, Boolean) = LogicalNot Variable(5, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -983,7 +983,7 @@ fn ssa_transform_inserts_phi_for_store_not_dominating_usage_in_one_branch() {
                     Variable(4, Boolean) = LogicalNot Variable(5, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -1246,7 +1246,7 @@ fn ssa_transform_inserts_phi_for_node_with_many_predecessors() {
                     Variable(5, Boolean) = LogicalNot Variable(6, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -1465,7 +1465,7 @@ fn ssa_transform_inserts_phi_for_multiple_stored_values() {
                     Variable(6, Boolean) = LogicalNot Variable(8, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -1798,7 +1798,7 @@ fn ssa_transform_inserts_phi_nodes_in_successive_blocks_for_chained_branches() {
                     Variable(8, Boolean) = LogicalNot Variable(10, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -2089,7 +2089,7 @@ fn ssa_transform_inerts_phi_nodes_for_early_return_graph_pattern() {
                     Variable(4, Boolean) = LogicalNot Variable(9, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -2259,7 +2259,7 @@ fn ssa_transform_propagates_updates_from_multiple_predecessors_to_later_single_s
                 Block 4: Block:
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -2381,7 +2381,7 @@ fn ssa_transform_maps_store_instrs_that_use_values_from_other_store_instrs() {
                     Variable(3, Boolean) = LogicalNot Variable(0, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -2539,7 +2539,7 @@ fn ssa_transform_maps_store_with_variable_from_store_in_conditional_to_phi_node(
                     Variable(3, Boolean) = LogicalNot Variable(4, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -2696,7 +2696,7 @@ fn ssa_transform_allows_point_in_time_copy_of_dynamic_variable() {
                     Variable(5, Boolean) = LogicalNot Variable(3, Boolean)
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:
@@ -2917,7 +2917,7 @@ fn ssa_transform_propagates_phi_var_to_successor_blocks_across_sequential_branch
                     Call id(2), args( Variable(4, Boolean), )
                     Return
             config: Config:
-                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs | QubitReset)
+                capabilities: TargetCapabilityFlags(Adaptive | IntegerComputations | FloatingPointComputations | BackwardsBranching | HigherLevelConstructs)
             num_qubits: 0
             num_results: 0
             tags:


### PR DESCRIPTION
This change avoids an issue with programs compiled for Base Profile that use initial resets on qubits and causes reindex to increase the total qubit count unnecessarily. Instead of treating these like the other resets during the program, a reset on a qubit that has not been used in any other operation is not reindexed and the reset is simply dropped.

This additionally fixes #2575 by removing the `QubitReset` capability which no longer applies since qubit reset is a default part of the `Adaptive` capability.