### PR TITLE
Circuit diagrams: auto-expand all single nested operations

### DIFF
--- a/source/npm/qsharp/ux/circuit-vis/sqore.ts
+++ b/source/npm/qsharp/ux/circuit-vis/sqore.ts
@@ -122,21 +122,7 @@ export class Sqore {
     );
 
     // If only one top-level operation, expand automatically:
-    if (
-      _circuit.componentGrid.length == 1 &&
-      _circuit.componentGrid[0].components.length == 1 &&
-      _circuit.componentGrid[0].components[0].dataAttributes != null &&
-      Object.prototype.hasOwnProperty.call(
-        _circuit.componentGrid[0].components[0].dataAttributes,
-        "location",
-      ) &&
-      _circuit.componentGrid[0].components[0].dataAttributes["expanded"] !==
-        "false"
-    ) {
-      const location: string =
-        _circuit.componentGrid[0].components[0].dataAttributes["location"];
-      this.expandOperation(_circuit.componentGrid, location);
-    }
+    this.expandIfSingleOperation(_circuit.componentGrid);
 
     // Create visualization components
     const composedSqore: ComposedSqore = this.compose(_circuit);
@@ -165,6 +151,29 @@ export class Sqore {
       enableEvents(container, this, () => this.renderCircuit(container));
       if (this.options.editCallback != undefined) {
         this.options.editCallback(this.minimizeCircuits(this.circuitGroup));
+      }
+    }
+  }
+
+  private expandIfSingleOperation(grid: ComponentGrid) {
+    if (grid.length == 1 && grid[0].components.length == 1) {
+      const onlyComponent = grid[0].components[0];
+      if (
+        onlyComponent.dataAttributes != null &&
+        Object.prototype.hasOwnProperty.call(
+          onlyComponent.dataAttributes,
+          "location",
+        ) &&
+        onlyComponent.dataAttributes["expanded"] !== "false"
+      ) {
+        const location: string = onlyComponent.dataAttributes["location"];
+        this.expandOperation(grid, location);
+      }
+    }
+    // Recursively expand if the only child is also a single operation
+    for (const col of grid) {
+      for (const op of col.components) {
+        this.expandIfSingleOperation(op.children || []);
       }
     }
   }


### PR DESCRIPTION
When an expanded box contains only one child operation, we automatically expand that one as well. 

This prevents the case where we generate a circuit, and we're met with a single, uninteresting box. 

We do this recursively, so that when the user clicks an (+) to expand any of the inner operations, any of _its_ only-children will be auto-expanded as well.


BEFORE:

HiddenShiftNISQ.qs:

<img width="270" height="536" alt="image" src="https://github.com/user-attachments/assets/263fb91f-ff19-4d28-a06f-3224a65b54db" />


AFTER:

HiddenShiftNISQ.qs:

<img width="690" height="530" alt="image" src="https://github.com/user-attachments/assets/a5857e43-e038-488c-9064-2a3728d0e3c2" />
