### PR TITLE
Circuit diagrams: fix URI encoding in source links

### DIFF
--- a/source/npm/qsharp/ux/circuit.tsx
+++ b/source/npm/qsharp/ux/circuit.tsx
@@ -361,7 +361,7 @@ function renderLocations(locations: SourceLocation[]) {
   });
   const title = titles.length > 1 ? `${titles[0]}, ...` : titles[0];
 
-  const argsStr = encodeURIComponent(JSON.stringify([qdkLocations]));
+  const argsStr = encodeURI(encodeURIComponent(JSON.stringify([qdkLocations])));
   const href = `command:qsharp-vscode.gotoLocations?${argsStr}`;
   return {
     title,


### PR DESCRIPTION
If the file path contains a "#" characters, the URI gets incorrectly escaped and source links from circuit diagrams don't resolve.

The problem is visible on the Q# playground at https://insiders.vscode.dev/+quantum.qsharp-lang-vscode-dev/playground/  where the folder name is "Samples (Q#)".