### PR TITLE
Circuit diagrams: CSS fix to the appear/disappear behavior of expand buttons

### DIFF
--- a/source/npm/qsharp/ux/qsharp-circuit.css
+++ b/source/npm/qsharp/ux/qsharp-circuit.css
@@ -233,15 +233,22 @@
   .qviz .gate-collapse,
   .qviz .gate-expand {
     opacity: 0;
-    transition: opacity 1s;
+    transition: opacity 0.2s;
   }
 
   .qviz:hover .gate-collapse,
   .qviz:hover .gate-expand {
     visibility: visible;
     opacity: 0.2;
-    transition: visibility 1s;
-    transition: opacity 1s;
+    transition: visibility 0.2s;
+    transition: opacity 0.2s;
+  }
+
+  .qviz:hover .gate-collapse:hover,
+  .qviz:hover .gate-expand:hover {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.2s;
   }
 
   .gate-expand,
@@ -260,13 +267,6 @@
   .gate-expand path {
     stroke-width: 4px;
     stroke: black;
-  }
-
-  .gate:hover > .gate-collapse,
-  .gate:hover > .gate-expand {
-    visibility: visible;
-    opacity: 1;
-    transition: opacity 0.2s;
   }
 
   .dropzone-layer {


### PR DESCRIPTION
The (+)/(-) button transition felt a bit too sluggish. They also didn't always gray out when you move the cursor away from them.

**AFTER:**

https://github.com/user-attachments/assets/be501336-74c8-4ffa-bdff-ed63b31d7306

**BEFORE:**

https://github.com/user-attachments/assets/74433f8c-65ee-48d7-89a9-1b310de8c8c2

