### PR TITLE
UsePythonVersion will use a GH token when downloading the installer

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -115,6 +115,7 @@ extends:
               - task: UsePythonVersion@0
                 inputs:
                   versionSpec: "3.11"
+                  githubToken: "$(GH_PACKAGE_READ_TOKEN)"
 
               - task: UseNode@1
                 inputs:
@@ -162,6 +163,7 @@ extends:
               - task: UsePythonVersion@0
                 inputs:
                   versionSpec: "3.11"
+                  githubToken: "$(GH_PACKAGE_READ_TOKEN)"
 
               - task: UseNode@1
                 inputs:
@@ -223,6 +225,7 @@ extends:
               - task: UsePythonVersion@0
                 inputs:
                   versionSpec: "3.11"
+                  githubToken: "$(GH_PACKAGE_READ_TOKEN)"
 
               - task: UseNode@1
                 inputs:
@@ -296,6 +299,7 @@ extends:
                   - task: UsePythonVersion@0
                     inputs:
                       versionSpec: "3.11"
+                      githubToken: "$(GH_PACKAGE_READ_TOKEN)"
                       ${{ if eq(target.arch, 'aarch64') }}:
                         architecture: "arm64"
                     condition: not(and(eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64')))


### PR DESCRIPTION
Created a token that has permissions to read packages which will be used when fetching the Python installers