### PR TITLE
Add QRE code owners for PR review assignment.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,9 @@
 /library @DmitryVasilevsky @swernli
 /source/npm @billti @DmitryVasilevsky @minestarks
 /source/pip @billti @idavis @minestarks
+/source/pip/qsharp/qre @msoeken @brad-lackey @jwhogabo
 /source/playground @billti @minestarks
+/source/qre @msoeken @brad-lackey @jwhogabo
 /source/resource_estimator @billti @ivanbasov @swernli
 /samples @DmitryVasilevsky @minestarks @swernli
 /source/vscode @billti @idavis @minestarks


### PR DESCRIPTION
I am adding the reviewers for the QRE PRs. This is also the first commit to the QRE feature branch.

However, I am not sure whether it suffices to have this pushed only into the feature branch.