### PR TITLE
remove dependency to `canvas` 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,6 @@
       },
       "engines": {
         "node": ">=22.14.0"
-      },
-      "optionalDependencies": {
-        "canvas": "^3.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2393,6 +2390,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2408,7 +2406,8 @@
         }
       ],
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -2454,8 +2453,10 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -2466,8 +2467,10 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2518,6 +2521,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2534,6 +2538,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -2602,9 +2607,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
       "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^7.0.0",
         "prebuild-install": "^7.1.3"
@@ -2702,8 +2709,10 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -2963,8 +2972,10 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -2998,8 +3009,10 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -3131,7 +3144,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3510,8 +3523,10 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
       "license": "(MIT OR WTFPL)",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3698,8 +3713,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3791,8 +3808,10 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/github-markdown-css": {
       "version": "5.5.1",
@@ -4110,6 +4129,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4125,7 +4145,8 @@
         }
       ],
       "license": "BSD-3-Clause",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -4176,14 +4197,16 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -4779,7 +4802,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4884,8 +4907,10 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4912,7 +4937,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "devOptional": true,
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4921,8 +4946,10 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/mocha": {
       "version": "10.8.2",
@@ -5081,8 +5108,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5104,8 +5133,10 @@
       "version": "3.78.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.78.0.tgz",
       "integrity": "sha512-E2wEyrgX/CqvicaQYU3Ze1PFGjc4QYPGsjUrlYkqAE0WjHEZwgOsGMPMzkMse4LjJbDmaEuDX3CM036j5K2DSQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -5117,7 +5148,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
       "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "^16 || ^18 || >= 20"
       }
@@ -5212,7 +5243,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5542,8 +5573,10 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -5569,8 +5602,10 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5579,8 +5614,10 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -5590,8 +5627,10 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5605,8 +5644,10 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -5618,8 +5659,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -5768,8 +5811,10 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -5784,8 +5829,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5978,7 +6025,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6018,7 +6065,7 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6146,27 +6193,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6183,6 +6210,30 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -6233,7 +6284,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -6242,7 +6293,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -6502,8 +6553,10 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -6673,7 +6726,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/validate.io-array": {
       "version": "1.0.6",
@@ -6835,7 +6888,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -6918,7 +6971,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,5 @@
     "url": "^0.11.3",
     "user-agent-data-types": "^0.4.2",
     "vscode-uri": "^3.0.8"
-  },
-  "optionalDependencies": {
-    "canvas": "^3.2.0"
   }
 }

--- a/source/npm/qsharp/test/circuits-cases/bell-pair.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/bell-pair.qs.snapshot.html
@@ -13,10 +13,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="378.0478515625"
+        width="379"
         height="200"
         style="max-width: fit-content"
-        viewBox="0 0 378 200"
+        viewBox="0 0 379 200"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -55,45 +55,33 @@
           </a>
         </g>
         <g class="wires">
-          <line
-            x1="40"
-            x2="378.0478515625"
-            y1="40"
-            y2="40"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="378.0478515625"
-            y1="120"
-            y2="120"
-            class="qubit-wire"
-          />
+          <line x1="40" x2="379" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="379" y1="120" y2="120" class="qubit-wire" />
           <g>
             <line
-              x1="249.0478515625"
-              x2="249.0478515625"
+              x1="250"
+              x2="250"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="247.0478515625"
-              x2="247.0478515625"
+              x1="248"
+              x2="248"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="249.0478515625"
-              x2="378.0478515625"
+              x1="250"
+              x2="379"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="247.0478515625"
-              x2="378.0478515625"
+              x1="248"
+              x2="379"
               y1="81"
               y2="81"
               class="register-classical"
@@ -101,29 +89,29 @@
           </g>
           <g>
             <line
-              x1="249.0478515625"
-              x2="249.0478515625"
+              x1="250"
+              x2="250"
               y1="120"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="247.0478515625"
-              x2="247.0478515625"
+              x1="248"
+              x2="248"
               y1="120"
               y2="161"
               class="register-classical"
             />
             <line
-              x1="249.0478515625"
-              x2="378.0478515625"
+              x1="250"
+              x2="379"
               y1="159"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="247.0478515625"
-              x2="378.0478515625"
+              x1="248"
+              x2="379"
               y1="161"
               y2="161"
               class="register-classical"
@@ -142,7 +130,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="288.0478515625"
+              width="289"
               height="180"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -162,17 +150,12 @@
                         class="gate-unitary"
                         x="90"
                         y="20"
-                        width="118.0478515625"
+                        width="119"
                         height="120"
                         data-wire-ys="[40,120]"
-                        data-width="118.0478515625"
+                        data-width="119"
                       />
-                      <text
-                        font-size="14"
-                        x="149.02392578125"
-                        y="80"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="149.5" y="80" class="qs-maintext">
                         <tspan class="qs-mathtext">PrepareBellPair</tspan>
                       </text>
                     </g>
@@ -194,7 +177,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="228.0478515625"
+                      x="229"
                       y="20"
                       width="40"
                       height="40"
@@ -203,12 +186,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 263.0478515625 42 A 15 12 0 0 0 233.0478515625 42"
+                      d="M 264 42 A 15 12 0 0 0 234 42"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="248.0478515625"
-                      x2="260.0478515625"
+                      x1="249"
+                      x2="261"
                       y1="48"
                       y2="28"
                       class="qs-line-measure"
@@ -228,7 +211,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="228.0478515625"
+                      x="229"
                       y="100"
                       width="40"
                       height="40"
@@ -237,12 +220,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 263.0478515625 122 A 15 12 0 0 0 233.0478515625 122"
+                      d="M 264 122 A 15 12 0 0 0 234 122"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="248.0478515625"
-                      x2="260.0478515625"
+                      x1="249"
+                      x2="261"
                       y1="128"
                       y2="108"
                       class="qs-line-measure"
@@ -263,7 +246,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="288.0478515625"
+                        x="289"
                         y="20"
                         width="40"
                         height="40"
@@ -272,7 +255,7 @@
                       />
                       <text
                         font-size="14"
-                        x="308.0478515625"
+                        x="309"
                         y="40"
                         class="qs-maintext ket-text"
                       >
@@ -294,7 +277,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="288.0478515625"
+                        x="289"
                         y="100"
                         width="40"
                         height="40"
@@ -303,7 +286,7 @@
                       />
                       <text
                         font-size="14"
-                        x="308.0478515625"
+                        x="309"
                         y="120"
                         class="qs-maintext ket-text"
                       >

--- a/source/npm/qsharp/test/circuits-cases/functors.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/functors.qs.snapshot.html
@@ -13,10 +13,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="370.9208984375"
+        width="366"
         height="120"
         style="max-width: fit-content"
-        viewBox="0 0 370 120"
+        viewBox="0 0 366 120"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -38,38 +38,32 @@
           </a>
         </g>
         <g class="wires">
-          <line
-            x1="40"
-            x2="370.9208984375"
-            y1="40"
-            y2="40"
-            class="qubit-wire"
-          />
+          <line x1="40" x2="366" y1="40" y2="40" class="qubit-wire" />
           <g>
             <line
-              x1="241.9208984375"
-              x2="241.9208984375"
+              x1="237"
+              x2="237"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="239.9208984375"
-              x2="239.9208984375"
+              x1="235"
+              x2="235"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="241.9208984375"
-              x2="370.9208984375"
+              x1="237"
+              x2="366"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="239.9208984375"
-              x2="370.9208984375"
+              x1="235"
+              x2="366"
               y1="81"
               y2="81"
               class="register-classical"
@@ -88,7 +82,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="280.9208984375"
+              width="276"
               height="100"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -108,17 +102,12 @@
                         class="gate-unitary"
                         x="90"
                         y="20"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
-                      <text
-                        font-size="14"
-                        x="112.06201171875"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="110.5" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
                       </text>
                     </g>
@@ -141,19 +130,14 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="154.1240234375"
+                        x="151"
                         y="20"
-                        width="46.796875"
+                        width="45"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="46.796875"
+                        data-width="45"
                       />
-                      <text
-                        font-size="14"
-                        x="177.5224609375"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="173.5" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
                         <tspan dx="2" dy="-3" style="font-size: 0.8em">†</tspan>
                       </text>
@@ -161,8 +145,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="156.1240234375" cy="22" r="10" />
-                  <path d="M156.1240234375,15 v14 M149.1240234375,22 h14" />
+                  <circle cx="153" cy="22" r="10" />
+                  <path d="M153,15 v14 M146,22 h14" />
                 </g>
               </g>
               <g
@@ -176,7 +160,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="220.9208984375"
+                      x="216"
                       y="20"
                       width="40"
                       height="40"
@@ -185,12 +169,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 255.9208984375 42 A 15 12 0 0 0 225.9208984375 42"
+                      d="M 251 42 A 15 12 0 0 0 221 42"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="240.9208984375"
-                      x2="252.9208984375"
+                      x1="236"
+                      x2="248"
                       y1="48"
                       y2="28"
                       class="qs-line-measure"
@@ -211,7 +195,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="280.9208984375"
+                        x="276"
                         y="20"
                         width="40"
                         height="40"
@@ -220,7 +204,7 @@
                       />
                       <text
                         font-size="14"
-                        x="300.9208984375"
+                        x="296"
                         y="40"
                         class="qs-maintext ket-text"
                       >

--- a/source/npm/qsharp/test/circuits-cases/intersecting-wires.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/intersecting-wires.qs.snapshot.html
@@ -13,10 +13,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="696.78515625"
+        width="682"
         height="700"
         style="max-width: fit-content"
-        viewBox="0 0 696 700"
+        viewBox="0 0 682 700"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -140,74 +140,38 @@
           </a>
         </g>
         <g class="wires">
-          <line x1="40" x2="696.78515625" y1="40" y2="40" class="qubit-wire" />
-          <line
-            x1="40"
-            x2="696.78515625"
-            y1="120"
-            y2="120"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="696.78515625"
-            y1="180"
-            y2="180"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="696.78515625"
-            y1="340"
-            y2="340"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="696.78515625"
-            y1="400"
-            y2="400"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="696.78515625"
-            y1="460"
-            y2="460"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="696.78515625"
-            y1="580"
-            y2="580"
-            class="qubit-wire"
-          />
+          <line x1="40" x2="682" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="682" y1="120" y2="120" class="qubit-wire" />
+          <line x1="40" x2="682" y1="180" y2="180" class="qubit-wire" />
+          <line x1="40" x2="682" y1="340" y2="340" class="qubit-wire" />
+          <line x1="40" x2="682" y1="400" y2="400" class="qubit-wire" />
+          <line x1="40" x2="682" y1="460" y2="460" class="qubit-wire" />
+          <line x1="40" x2="682" y1="580" y2="580" class="qubit-wire" />
           <g>
             <line
-              x1="113.06201171875"
-              x2="113.06201171875"
+              x1="111.5"
+              x2="111.5"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="111.06201171875"
-              x2="111.06201171875"
+              x1="109.5"
+              x2="109.5"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="113.06201171875"
-              x2="696.78515625"
+              x1="111.5"
+              x2="682"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="111.06201171875"
-              x2="696.78515625"
+              x1="109.5"
+              x2="682"
               y1="81"
               y2="81"
               class="register-classical"
@@ -215,29 +179,29 @@
           </g>
           <g>
             <line
-              x1="383.068359375"
-              x2="383.068359375"
+              x1="371"
+              x2="371"
               y1="180"
               y2="219"
               class="register-classical"
             />
             <line
-              x1="381.068359375"
-              x2="381.068359375"
+              x1="369"
+              x2="369"
               y1="180"
               y2="221"
               class="register-classical"
             />
             <line
-              x1="383.068359375"
-              x2="696.78515625"
+              x1="371"
+              x2="682"
               y1="219"
               y2="219"
               class="register-classical"
             />
             <line
-              x1="381.068359375"
-              x2="696.78515625"
+              x1="369"
+              x2="682"
               y1="221"
               y2="221"
               class="register-classical"
@@ -245,29 +209,29 @@
           </g>
           <g>
             <line
-              x1="443.068359375"
-              x2="443.068359375"
+              x1="431"
+              x2="431"
               y1="180"
               y2="259"
               class="register-classical"
             />
             <line
-              x1="441.068359375"
-              x2="441.068359375"
+              x1="429"
+              x2="429"
               y1="180"
               y2="261"
               class="register-classical"
             />
             <line
-              x1="443.068359375"
-              x2="696.78515625"
+              x1="431"
+              x2="682"
               y1="259"
               y2="259"
               class="register-classical"
             />
             <line
-              x1="441.068359375"
-              x2="696.78515625"
+              x1="429"
+              x2="682"
               y1="261"
               y2="261"
               class="register-classical"
@@ -275,15 +239,15 @@
           </g>
           <g>
             <line
-              x1="565.4267578125"
-              x2="696.78515625"
+              x1="552"
+              x2="682"
               y1="299"
               y2="299"
               class="register-classical"
             />
             <line
-              x1="563.4267578125"
-              x2="696.78515625"
+              x1="550"
+              x2="682"
               y1="301"
               y2="301"
               class="register-classical"
@@ -291,15 +255,15 @@
           </g>
           <g>
             <line
-              x1="181.0791015625"
-              x2="696.78515625"
+              x1="176.5"
+              x2="682"
               y1="499"
               y2="499"
               class="register-classical"
             />
             <line
-              x1="179.0791015625"
-              x2="696.78515625"
+              x1="174.5"
+              x2="682"
               y1="501"
               y2="501"
               class="register-classical"
@@ -307,15 +271,15 @@
           </g>
           <g>
             <line
-              x1="317.11328125"
-              x2="696.78515625"
+              x1="306.5"
+              x2="682"
               y1="539"
               y2="539"
               class="register-classical"
             />
             <line
-              x1="315.11328125"
-              x2="696.78515625"
+              x1="304.5"
+              x2="682"
               y1="541"
               y2="541"
               class="register-classical"
@@ -323,15 +287,15 @@
           </g>
           <g>
             <line
-              x1="181.0791015625"
-              x2="696.78515625"
+              x1="176.5"
+              x2="682"
               y1="619"
               y2="619"
               class="register-classical"
             />
             <line
-              x1="179.0791015625"
-              x2="696.78515625"
+              x1="174.5"
+              x2="682"
               y1="621"
               y2="621"
               class="register-classical"
@@ -339,15 +303,15 @@
           </g>
           <g>
             <line
-              x1="317.11328125"
-              x2="696.78515625"
+              x1="306.5"
+              x2="682"
               y1="659"
               y2="659"
               class="register-classical"
             />
             <line
-              x1="315.11328125"
-              x2="696.78515625"
+              x1="304.5"
+              x2="682"
               y1="661"
               y2="661"
               class="register-classical"
@@ -366,7 +330,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="606.78515625"
+              width="592"
               height="680"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -383,7 +347,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="92.06201171875"
+                      x="90.5"
                       y="20"
                       width="40"
                       height="40"
@@ -392,12 +356,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 127.06201171875 42 A 15 12 0 0 0 97.06201171875 42"
+                      d="M 125.5 42 A 15 12 0 0 0 95.5 42"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="112.06201171875"
-                      x2="124.06201171875"
+                      x1="110.5"
+                      x2="122.5"
                       y1="48"
                       y2="28"
                       class="qs-line-measure"
@@ -416,8 +380,8 @@
                   <title>intersecting-wires.qs:5:5 Foo([qs[2], qs[4]]);</title>
                   <g>
                     <line
-                      x1="112.06201171875"
-                      x2="112.06201171875"
+                      x1="110.5"
+                      x2="110.5"
                       y1="180"
                       y2="400"
                       stroke-dasharray="8, 8"
@@ -427,14 +391,14 @@
                         class="gate-unitary"
                         x="90"
                         y="160"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[180]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="112.06201171875"
+                        x="110.5"
                         y="180"
                         class="qs-maintext"
                       >
@@ -446,14 +410,14 @@
                         class="gate-unitary"
                         x="90"
                         y="380"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[400]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="112.06201171875"
+                        x="110.5"
                         y="400"
                         class="qs-maintext"
                       >
@@ -475,16 +439,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="91.1689453125"
+                        x="90"
                         y="440"
-                        width="41.7861328125"
+                        width="41"
                         height="40"
                         data-wire-ys="[460]"
-                        data-width="41.7861328125"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="112.06201171875"
+                        x="110.5"
                         y="460"
                         class="qs-maintext"
                       >
@@ -494,8 +458,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="93.1689453125" cy="442" r="10" />
-                  <path d="M93.1689453125,435 v14 M86.1689453125,442 h14" />
+                  <circle cx="92" cy="442" r="10" />
+                  <path d="M92,435 v14 M85,442 h14" />
                 </g>
               </g>
               <g
@@ -510,16 +474,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="91.1689453125"
+                        x="90"
                         y="560"
-                        width="41.7861328125"
+                        width="41"
                         height="40"
                         data-wire-ys="[580]"
-                        data-width="41.7861328125"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="112.06201171875"
+                        x="110.5"
                         y="580"
                         class="qs-maintext"
                       >
@@ -529,8 +493,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="93.1689453125" cy="562" r="10" />
-                  <path d="M93.1689453125,555 v14 M86.1689453125,562 h14" />
+                  <circle cx="92" cy="562" r="10" />
+                  <path d="M92,555 v14 M85,562 h14" />
                 </g>
               </g>
               <g
@@ -543,8 +507,8 @@
                   <title>intersecting-wires.qs:7:5 Foo(qs[0..1]);</title>
                   <g>
                     <line
-                      x1="180.0791015625"
-                      x2="180.0791015625"
+                      x1="175.5"
+                      x2="175.5"
                       y1="40"
                       y2="120"
                       stroke-dasharray="8, 8"
@@ -552,35 +516,30 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="158.01708984375"
+                        x="155"
                         y="20"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
-                      <text
-                        font-size="14"
-                        x="180.0791015625"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="175.5" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
                       </text>
                     </g>
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="158.01708984375"
+                        x="155"
                         y="100"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[120]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="180.0791015625"
+                        x="175.5"
                         y="120"
                         class="qs-maintext"
                       >
@@ -602,16 +561,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="158.01708984375"
+                        x="155"
                         y="320"
-                        width="44.1240234375"
+                        width="41"
                         height="100"
                         data-wire-ys="[340,400]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="180.0791015625"
+                        x="175.5"
                         y="370"
                         class="qs-maintext"
                       >
@@ -633,16 +592,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="154.1240234375"
+                        x="151"
                         y="440"
-                        width="51.91015625"
+                        width="49"
                         height="80"
                         data-wire-ys="[460,500]"
-                        data-width="51.91015625"
+                        data-width="49"
                       />
                       <text
                         font-size="14"
-                        x="180.0791015625"
+                        x="175.5"
                         y="480"
                         class="qs-maintext"
                       >
@@ -653,8 +612,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="156.1240234375" cy="442" r="10" />
-                  <path d="M156.1240234375,435 v14 M149.1240234375,442 h14" />
+                  <circle cx="153" cy="442" r="10" />
+                  <path d="M153,435 v14 M146,442 h14" />
                 </g>
               </g>
               <g
@@ -669,16 +628,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="154.1240234375"
+                        x="151"
                         y="560"
-                        width="51.91015625"
+                        width="49"
                         height="80"
                         data-wire-ys="[580,620]"
-                        data-width="51.91015625"
+                        data-width="49"
                       />
                       <text
                         font-size="14"
-                        x="180.0791015625"
+                        x="175.5"
                         y="600"
                         class="qs-maintext"
                       >
@@ -689,8 +648,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="156.1240234375" cy="562" r="10" />
-                  <path d="M156.1240234375,555 v14 M149.1240234375,562 h14" />
+                  <circle cx="153" cy="562" r="10" />
+                  <path d="M153,555 v14 M146,562 h14" />
                 </g>
               </g>
               <g
@@ -703,8 +662,8 @@
                   <title>intersecting-wires.qs:9:5 Foo([qs[2], qs[0]]);</title>
                   <g>
                     <line
-                      x1="248.09619140625"
-                      x2="248.09619140625"
+                      x1="240.5"
+                      x2="240.5"
                       y1="40"
                       y2="180"
                       stroke-dasharray="8, 8"
@@ -712,35 +671,30 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="226.0341796875"
+                        x="220"
                         y="20"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
-                      <text
-                        font-size="14"
-                        x="248.09619140625"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="240.5" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
                       </text>
                     </g>
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="226.0341796875"
+                        x="220"
                         y="160"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[180]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="248.09619140625"
+                        x="240.5"
                         y="180"
                         class="qs-maintext"
                       >
@@ -762,16 +716,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="227.203125"
+                        x="220"
                         y="440"
-                        width="41.7861328125"
+                        width="41"
                         height="40"
                         data-wire-ys="[460]"
-                        data-width="41.7861328125"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="248.09619140625"
+                        x="240.5"
                         y="460"
                         class="qs-maintext"
                       >
@@ -781,8 +735,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="229.203125" cy="442" r="10" />
-                  <path d="M229.203125,435 v14 M222.203125,442 h14" />
+                  <circle cx="222" cy="442" r="10" />
+                  <path d="M222,435 v14 M215,442 h14" />
                 </g>
               </g>
               <g
@@ -797,16 +751,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="227.203125"
+                        x="220"
                         y="560"
-                        width="41.7861328125"
+                        width="41"
                         height="40"
                         data-wire-ys="[580]"
-                        data-width="41.7861328125"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="248.09619140625"
+                        x="240.5"
                         y="580"
                         class="qs-maintext"
                       >
@@ -816,8 +770,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="229.203125" cy="562" r="10" />
-                  <path d="M229.203125,555 v14 M222.203125,562 h14" />
+                  <circle cx="222" cy="562" r="10" />
+                  <path d="M222,555 v14 M215,562 h14" />
                 </g>
               </g>
               <g
@@ -830,8 +784,8 @@
                   <title>intersecting-wires.qs:13:5 Foo(qs[0..2]);</title>
                   <g>
                     <line
-                      x1="316.11328125"
-                      x2="316.11328125"
+                      x1="305.5"
+                      x2="305.5"
                       y1="40"
                       y2="180"
                       stroke-dasharray="8, 8"
@@ -839,35 +793,30 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="294.05126953125"
+                        x="285"
                         y="20"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
-                      <text
-                        font-size="14"
-                        x="316.11328125"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="305.5" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
                       </text>
                     </g>
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="294.05126953125"
+                        x="285"
                         y="100"
-                        width="44.1240234375"
+                        width="41"
                         height="100"
                         data-wire-ys="[120,180]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="316.11328125"
+                        x="305.5"
                         y="150"
                         class="qs-maintext"
                       >
@@ -887,8 +836,8 @@
                   <title>intersecting-wires.qs:29:5 Foo2(q1);</title>
                   <g>
                     <line
-                      x1="316.11328125"
-                      x2="316.11328125"
+                      x1="305.5"
+                      x2="305.5"
                       y1="460"
                       y2="540"
                       stroke-dasharray="8, 8"
@@ -896,16 +845,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="290.158203125"
+                        x="281"
                         y="440"
-                        width="51.91015625"
+                        width="49"
                         height="40"
                         data-wire-ys="[460]"
-                        data-width="51.91015625"
+                        data-width="49"
                       />
                       <text
                         font-size="14"
-                        x="316.11328125"
+                        x="305.5"
                         y="460"
                         class="qs-maintext"
                       >
@@ -916,16 +865,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="290.158203125"
+                        x="281"
                         y="520"
-                        width="51.91015625"
+                        width="49"
                         height="40"
                         data-wire-ys="[540]"
-                        data-width="51.91015625"
+                        data-width="49"
                       />
                       <text
                         font-size="14"
-                        x="316.11328125"
+                        x="305.5"
                         y="540"
                         class="qs-maintext"
                       >
@@ -936,8 +885,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="292.158203125" cy="442" r="10" />
-                  <path d="M292.158203125,435 v14 M285.158203125,442 h14" />
+                  <circle cx="283" cy="442" r="10" />
+                  <path d="M283,435 v14 M276,442 h14" />
                 </g>
               </g>
               <g
@@ -950,8 +899,8 @@
                   <title>intersecting-wires.qs:32:5 Foo2(q2);</title>
                   <g>
                     <line
-                      x1="316.11328125"
-                      x2="316.11328125"
+                      x1="305.5"
+                      x2="305.5"
                       y1="580"
                       y2="660"
                       stroke-dasharray="8, 8"
@@ -959,16 +908,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="290.158203125"
+                        x="281"
                         y="560"
-                        width="51.91015625"
+                        width="49"
                         height="40"
                         data-wire-ys="[580]"
-                        data-width="51.91015625"
+                        data-width="49"
                       />
                       <text
                         font-size="14"
-                        x="316.11328125"
+                        x="305.5"
                         y="580"
                         class="qs-maintext"
                       >
@@ -979,16 +928,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="290.158203125"
+                        x="281"
                         y="640"
-                        width="51.91015625"
+                        width="49"
                         height="40"
                         data-wire-ys="[660]"
-                        data-width="51.91015625"
+                        data-width="49"
                       />
                       <text
                         font-size="14"
-                        x="316.11328125"
+                        x="305.5"
                         y="660"
                         class="qs-maintext"
                       >
@@ -999,8 +948,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="292.158203125" cy="562" r="10" />
-                  <path d="M292.158203125,555 v14 M285.158203125,562 h14" />
+                  <circle cx="283" cy="562" r="10" />
+                  <path d="M283,555 v14 M276,562 h14" />
                 </g>
               </g>
               <g
@@ -1014,7 +963,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="362.068359375"
+                      x="350"
                       y="160"
                       width="40"
                       height="40"
@@ -1023,12 +972,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 397.068359375 182 A 15 12 0 0 0 367.068359375 182"
+                      d="M 385 182 A 15 12 0 0 0 355 182"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="382.068359375"
-                      x2="394.068359375"
+                      x1="370"
+                      x2="382"
                       y1="188"
                       y2="168"
                       class="qs-line-measure"
@@ -1048,7 +997,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="422.068359375"
+                      x="410"
                       y="160"
                       width="40"
                       height="40"
@@ -1057,12 +1006,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 457.068359375 182 A 15 12 0 0 0 427.068359375 182"
+                      d="M 445 182 A 15 12 0 0 0 415 182"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="442.068359375"
-                      x2="454.068359375"
+                      x1="430"
+                      x2="442"
                       y1="188"
                       y2="168"
                       class="qs-line-measure"
@@ -1083,8 +1032,8 @@
                   </title>
                   <g>
                     <line
-                      x1="564.4267578125"
-                      x2="564.4267578125"
+                      x1="551"
+                      x2="551"
                       y1="40"
                       y2="400"
                       stroke-dasharray="8, 8"
@@ -1092,65 +1041,50 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="482.068359375"
+                        x="470"
                         y="20"
-                        width="164.716796875"
+                        width="162"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="164.716796875"
+                        data-width="162"
                       />
-                      <text
-                        font-size="14"
-                        x="564.4267578125"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="551" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">BoxWithMeasurements</tspan>
                       </text>
                     </g>
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="482.068359375"
+                        x="470"
                         y="100"
-                        width="164.716796875"
+                        width="162"
                         height="100"
                         data-wire-ys="[120,180]"
-                        data-width="164.716796875"
+                        data-width="162"
                       />
-                      <text
-                        font-size="14"
-                        x="564.4267578125"
-                        y="150"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="551" y="150" class="qs-maintext">
                         <tspan class="qs-mathtext">BoxWithMeasurements</tspan>
                       </text>
                     </g>
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="482.068359375"
+                        x="470"
                         y="280"
-                        width="164.716796875"
+                        width="162"
                         height="140"
                         data-wire-ys="[300,340,400]"
-                        data-width="164.716796875"
+                        data-width="162"
                       />
-                      <text
-                        font-size="14"
-                        x="564.4267578125"
-                        y="350"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="551" y="350" class="qs-maintext">
                         <tspan class="qs-mathtext">BoxWithMeasurements</tspan>
                       </text>
                     </g>
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="484.068359375" cy="22" r="10" />
-                  <path d="M484.068359375,15 v14 M477.068359375,22 h14" />
+                  <circle cx="472" cy="22" r="10" />
+                  <path d="M472,15 v14 M465,22 h14" />
                 </g>
               </g>
             </g>
@@ -1167,10 +1101,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="1294.1240234375"
+        width="1291"
         height="700"
         style="max-width: fit-content"
-        viewBox="0 0 1294 700"
+        viewBox="0 0 1291 700"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -1294,55 +1228,13 @@
           </a>
         </g>
         <g class="wires">
-          <line
-            x1="40"
-            x2="1294.1240234375"
-            y1="40"
-            y2="40"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="1294.1240234375"
-            y1="120"
-            y2="120"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="1294.1240234375"
-            y1="180"
-            y2="180"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="1294.1240234375"
-            y1="340"
-            y2="340"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="1294.1240234375"
-            y1="400"
-            y2="400"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="1294.1240234375"
-            y1="460"
-            y2="460"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="1294.1240234375"
-            y1="580"
-            y2="580"
-            class="qubit-wire"
-          />
+          <line x1="40" x2="1291" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="1291" y1="120" y2="120" class="qubit-wire" />
+          <line x1="40" x2="1291" y1="180" y2="180" class="qubit-wire" />
+          <line x1="40" x2="1291" y1="340" y2="340" class="qubit-wire" />
+          <line x1="40" x2="1291" y1="400" y2="400" class="qubit-wire" />
+          <line x1="40" x2="1291" y1="460" y2="460" class="qubit-wire" />
+          <line x1="40" x2="1291" y1="580" y2="580" class="qubit-wire" />
           <g>
             <line
               x1="156"
@@ -1360,14 +1252,14 @@
             />
             <line
               x1="156"
-              x2="1294.1240234375"
+              x2="1291"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
               x1="154"
-              x2="1294.1240234375"
+              x2="1291"
               y1="81"
               y2="81"
               class="register-classical"
@@ -1390,14 +1282,14 @@
             />
             <line
               x1="1011"
-              x2="1294.1240234375"
+              x2="1291"
               y1="219"
               y2="219"
               class="register-classical"
             />
             <line
               x1="1009"
-              x2="1294.1240234375"
+              x2="1291"
               y1="221"
               y2="221"
               class="register-classical"
@@ -1420,14 +1312,14 @@
             />
             <line
               x1="1071"
-              x2="1294.1240234375"
+              x2="1291"
               y1="259"
               y2="259"
               class="register-classical"
             />
             <line
               x1="1069"
-              x2="1294.1240234375"
+              x2="1291"
               y1="261"
               y2="261"
               class="register-classical"
@@ -1450,14 +1342,14 @@
             />
             <line
               x1="1141"
-              x2="1294.1240234375"
+              x2="1291"
               y1="299"
               y2="299"
               class="register-classical"
             />
             <line
               x1="1139"
-              x2="1294.1240234375"
+              x2="1291"
               y1="301"
               y2="301"
               class="register-classical"
@@ -1480,14 +1372,14 @@
             />
             <line
               x1="421"
-              x2="1294.1240234375"
+              x2="1291"
               y1="499"
               y2="499"
               class="register-classical"
             />
             <line
               x1="419"
-              x2="1294.1240234375"
+              x2="1291"
               y1="501"
               y2="501"
               class="register-classical"
@@ -1510,14 +1402,14 @@
             />
             <line
               x1="871"
-              x2="1294.1240234375"
+              x2="1291"
               y1="539"
               y2="539"
               class="register-classical"
             />
             <line
               x1="869"
-              x2="1294.1240234375"
+              x2="1291"
               y1="541"
               y2="541"
               class="register-classical"
@@ -1540,14 +1432,14 @@
             />
             <line
               x1="421"
-              x2="1294.1240234375"
+              x2="1291"
               y1="619"
               y2="619"
               class="register-classical"
             />
             <line
               x1="419"
-              x2="1294.1240234375"
+              x2="1291"
               y1="621"
               y2="621"
               class="register-classical"
@@ -1570,14 +1462,14 @@
             />
             <line
               x1="871"
-              x2="1294.1240234375"
+              x2="1291"
               y1="659"
               y2="659"
               class="register-classical"
             />
             <line
               x1="869"
-              x2="1294.1240234375"
+              x2="1291"
               y1="661"
               y2="661"
               class="register-classical"
@@ -1596,7 +1488,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="1204.1240234375"
+              width="1201"
               height="680"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -1655,12 +1547,12 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="132.93798828125"
+                        x="134.5"
                         y="160"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[180]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text font-size="14" x="155" y="180" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
@@ -1669,12 +1561,12 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="132.93798828125"
+                        x="134.5"
                         y="380"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[400]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text font-size="14" x="155" y="400" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
@@ -1840,12 +1732,12 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="357.93798828125"
+                        x="359.5"
                         y="20"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text font-size="14" x="380" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
@@ -1854,12 +1746,12 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="357.93798828125"
+                        x="359.5"
                         y="100"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[120]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text font-size="14" x="380" y="120" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
@@ -1880,12 +1772,12 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="357.93798828125"
+                        x="359.5"
                         y="320"
-                        width="44.1240234375"
+                        width="41"
                         height="100"
                         data-wire-ys="[340,400]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text font-size="14" x="380" y="370" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
@@ -2227,12 +2119,12 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="582.93798828125"
+                        x="584.5"
                         y="20"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text font-size="14" x="605" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
@@ -2241,12 +2133,12 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="582.93798828125"
+                        x="584.5"
                         y="160"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[180]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text font-size="14" x="605" y="180" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
@@ -2412,12 +2304,12 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="807.93798828125"
+                        x="809.5"
                         y="20"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text font-size="14" x="830" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
@@ -2426,12 +2318,12 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="807.93798828125"
+                        x="809.5"
                         y="100"
-                        width="44.1240234375"
+                        width="41"
                         height="100"
                         data-wire-ys="[120,180]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text font-size="14" x="830" y="150" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
@@ -2833,7 +2725,7 @@
                   class="gate-unitary"
                   x="1094"
                   y="12"
-                  width="150.1240234375"
+                  width="147"
                   height="416"
                   fill-opacity="0"
                   stroke-dasharray="8, 8"
@@ -2883,8 +2775,8 @@
                       <title>intersecting-wires.qs:47:5 Foo(qs);</title>
                       <g>
                         <line
-                          x1="1202.06201171875"
-                          x2="1202.06201171875"
+                          x1="1200.5"
+                          x2="1200.5"
                           y1="40"
                           y2="400"
                           stroke-dasharray="8, 8"
@@ -2894,14 +2786,14 @@
                             class="gate-unitary"
                             x="1180"
                             y="20"
-                            width="44.1240234375"
+                            width="41"
                             height="180"
                             data-wire-ys="[40,120,180]"
-                            data-width="44.1240234375"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="1202.06201171875"
+                            x="1200.5"
                             y="110"
                             class="qs-maintext"
                           >
@@ -2913,14 +2805,14 @@
                             class="gate-unitary"
                             x="1180"
                             y="320"
-                            width="44.1240234375"
+                            width="41"
                             height="100"
                             data-wire-ys="[340,400]"
-                            data-width="44.1240234375"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="1202.06201171875"
+                            x="1200.5"
                             y="370"
                             class="qs-maintext"
                           >

--- a/source/npm/qsharp/test/circuits-cases/intrinsics.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/intrinsics.qs.snapshot.html
@@ -13,10 +13,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="537.8544921875"
+        width="554"
         height="120"
         style="max-width: fit-content"
-        viewBox="0 0 537 120"
+        viewBox="0 0 554 120"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -38,38 +38,32 @@
           </a>
         </g>
         <g class="wires">
-          <line
-            x1="40"
-            x2="537.8544921875"
-            y1="40"
-            y2="40"
-            class="qubit-wire"
-          />
+          <line x1="40" x2="554" y1="40" y2="40" class="qubit-wire" />
           <g>
             <line
-              x1="408.8544921875"
-              x2="408.8544921875"
+              x1="425"
+              x2="425"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="406.8544921875"
-              x2="406.8544921875"
+              x1="423"
+              x2="423"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="408.8544921875"
-              x2="537.8544921875"
+              x1="425"
+              x2="554"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="406.8544921875"
-              x2="537.8544921875"
+              x1="423"
+              x2="554"
               y1="81"
               y2="81"
               class="register-classical"
@@ -88,7 +82,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="447.8544921875"
+              width="464"
               height="100"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -108,17 +102,12 @@
                         class="gate-unitary"
                         x="90"
                         y="20"
-                        width="116.46875"
+                        width="124"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="116.46875"
+                        data-width="124"
                       />
-                      <text
-                        font-size="14"
-                        x="148.234375"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="152" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">CustomIntrinsic</tspan>
                       </text>
                     </g>
@@ -137,27 +126,22 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="226.46875"
+                        x="234"
                         y="20"
-                        width="141.3857421875"
+                        width="150"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="141.3857421875"
+                        data-width="150"
                       />
-                      <text
-                        font-size="14"
-                        x="297.16162109375"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="309" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">SimulatableIntrinsic</tspan>
                       </text>
                     </g>
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="228.46875" cy="22" r="10" />
-                  <path d="M228.46875,15 v14 M221.46875,22 h14" />
+                  <circle cx="236" cy="22" r="10" />
+                  <path d="M236,15 v14 M229,22 h14" />
                 </g>
               </g>
               <g
@@ -171,7 +155,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="387.8544921875"
+                      x="404"
                       y="20"
                       width="40"
                       height="40"
@@ -180,12 +164,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 422.8544921875 42 A 15 12 0 0 0 392.8544921875 42"
+                      d="M 439 42 A 15 12 0 0 0 409 42"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="407.8544921875"
-                      x2="419.8544921875"
+                      x1="424"
+                      x2="436"
                       y1="48"
                       y2="28"
                       class="qs-line-measure"
@@ -206,7 +190,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="447.8544921875"
+                        x="464"
                         y="20"
                         width="40"
                         height="40"
@@ -215,7 +199,7 @@
                       />
                       <text
                         font-size="14"
-                        x="467.8544921875"
+                        x="484"
                         y="40"
                         class="qs-maintext ket-text"
                       >
@@ -239,10 +223,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="466.46875"
+        width="474"
         height="120"
         style="max-width: fit-content"
-        viewBox="0 0 466 120"
+        viewBox="0 0 474 120"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -264,32 +248,32 @@
           </a>
         </g>
         <g class="wires">
-          <line x1="40" x2="466.46875" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="474" y1="40" y2="40" class="qubit-wire" />
           <g>
             <line
-              x1="337.46875"
-              x2="337.46875"
+              x1="345"
+              x2="345"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="335.46875"
-              x2="335.46875"
+              x1="343"
+              x2="343"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="337.46875"
-              x2="466.46875"
+              x1="345"
+              x2="474"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="335.46875"
-              x2="466.46875"
+              x1="343"
+              x2="474"
               y1="81"
               y2="81"
               class="register-classical"
@@ -308,7 +292,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="376.46875"
+              width="384"
               height="100"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -328,17 +312,12 @@
                         class="gate-unitary"
                         x="90"
                         y="20"
-                        width="116.46875"
+                        width="124"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="116.46875"
+                        data-width="124"
                       />
-                      <text
-                        font-size="14"
-                        x="148.234375"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="152" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">CustomIntrinsic</tspan>
                       </text>
                     </g>
@@ -354,7 +333,7 @@
               >
                 <rect
                   class="gate-unitary"
-                  x="210.46875"
+                  x="218"
                   y="12"
                   width="86"
                   height="56"
@@ -374,7 +353,7 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="236.46875"
+                            x="244"
                             y="20"
                             width="40"
                             height="40"
@@ -383,7 +362,7 @@
                           />
                           <text
                             font-size="14"
-                            x="256.46875"
+                            x="264"
                             y="40"
                             class="qs-maintext"
                           >
@@ -395,8 +374,8 @@
                   </g>
                 </g>
                 <g class="gate-control gate-collapse">
-                  <circle cx="212.46875" cy="14" r="10" />
-                  <path d="M205.46875,14 h14" />
+                  <circle cx="220" cy="14" r="10" />
+                  <path d="M213,14 h14" />
                 </g>
               </g>
               <g
@@ -410,7 +389,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="316.46875"
+                      x="324"
                       y="20"
                       width="40"
                       height="40"
@@ -419,12 +398,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 351.46875 42 A 15 12 0 0 0 321.46875 42"
+                      d="M 359 42 A 15 12 0 0 0 329 42"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="336.46875"
-                      x2="348.46875"
+                      x1="344"
+                      x2="356"
                       y1="48"
                       y2="28"
                       class="qs-line-measure"
@@ -445,7 +424,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="376.46875"
+                        x="384"
                         y="20"
                         width="40"
                         height="40"
@@ -454,7 +433,7 @@
                       />
                       <text
                         font-size="14"
-                        x="396.46875"
+                        x="404"
                         y="40"
                         class="qs-maintext ket-text"
                       >

--- a/source/npm/qsharp/test/circuits-cases/lambda.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/lambda.qs.snapshot.html
@@ -13,10 +13,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="342.2685546875"
+        width="336"
         height="120"
         style="max-width: fit-content"
-        viewBox="0 0 342 120"
+        viewBox="0 0 336 120"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -38,38 +38,32 @@
           </a>
         </g>
         <g class="wires">
-          <line
-            x1="40"
-            x2="342.2685546875"
-            y1="40"
-            y2="40"
-            class="qubit-wire"
-          />
+          <line x1="40" x2="336" y1="40" y2="40" class="qubit-wire" />
           <g>
             <line
-              x1="213.2685546875"
-              x2="213.2685546875"
+              x1="207"
+              x2="207"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="211.2685546875"
-              x2="211.2685546875"
+              x1="205"
+              x2="205"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="213.2685546875"
-              x2="342.2685546875"
+              x1="207"
+              x2="336"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="211.2685546875"
-              x2="342.2685546875"
+              x1="205"
+              x2="336"
               y1="81"
               y2="81"
               class="register-classical"
@@ -88,7 +82,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="252.2685546875"
+              width="246"
               height="100"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -108,17 +102,12 @@
                         class="gate-unitary"
                         x="90"
                         y="20"
-                        width="82.2685546875"
+                        width="76"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="82.2685546875"
+                        data-width="76"
                       />
-                      <text
-                        font-size="14"
-                        x="131.13427734375"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="128" y="40" class="qs-maintext">
                         &lt;
                         <tspan class="qs-mathtext">lambda</tspan>
                         &gt;
@@ -142,7 +131,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="192.2685546875"
+                      x="186"
                       y="20"
                       width="40"
                       height="40"
@@ -151,12 +140,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 227.2685546875 42 A 15 12 0 0 0 197.2685546875 42"
+                      d="M 221 42 A 15 12 0 0 0 191 42"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="212.2685546875"
-                      x2="224.2685546875"
+                      x1="206"
+                      x2="218"
                       y1="48"
                       y2="28"
                       class="qs-line-measure"
@@ -177,7 +166,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="252.2685546875"
+                        x="246"
                         y="20"
                         width="40"
                         height="40"
@@ -186,7 +175,7 @@
                       />
                       <text
                         font-size="14"
-                        x="272.2685546875"
+                        x="266"
                         y="40"
                         class="qs-maintext ket-text"
                       >

--- a/source/npm/qsharp/test/circuits-cases/loops.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/loops.qs.snapshot.html
@@ -13,10 +13,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="457.861328125"
+        width="456"
         height="760"
         style="max-width: fit-content"
-        viewBox="0 0 457 760"
+        viewBox="0 0 456 760"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -174,88 +174,40 @@
           </a>
         </g>
         <g class="wires">
-          <line x1="40" x2="457.861328125" y1="40" y2="40" class="qubit-wire" />
-          <line
-            x1="40"
-            x2="457.861328125"
-            y1="120"
-            y2="120"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="457.861328125"
-            y1="200"
-            y2="200"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="457.861328125"
-            y1="280"
-            y2="280"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="457.861328125"
-            y1="360"
-            y2="360"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="457.861328125"
-            y1="440"
-            y2="440"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="457.861328125"
-            y1="520"
-            y2="520"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="457.861328125"
-            y1="600"
-            y2="600"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="457.861328125"
-            y1="680"
-            y2="680"
-            class="qubit-wire"
-          />
+          <line x1="40" x2="456" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="456" y1="120" y2="120" class="qubit-wire" />
+          <line x1="40" x2="456" y1="200" y2="200" class="qubit-wire" />
+          <line x1="40" x2="456" y1="280" y2="280" class="qubit-wire" />
+          <line x1="40" x2="456" y1="360" y2="360" class="qubit-wire" />
+          <line x1="40" x2="456" y1="440" y2="440" class="qubit-wire" />
+          <line x1="40" x2="456" y1="520" y2="520" class="qubit-wire" />
+          <line x1="40" x2="456" y1="600" y2="600" class="qubit-wire" />
+          <line x1="40" x2="456" y1="680" y2="680" class="qubit-wire" />
           <g>
             <line
-              x1="308.861328125"
-              x2="308.861328125"
+              x1="307"
+              x2="307"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="306.861328125"
+              x1="305"
+              x2="305"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="308.861328125"
-              x2="457.861328125"
+              x1="307"
+              x2="456"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="457.861328125"
+              x1="305"
+              x2="456"
               y1="81"
               y2="81"
               class="register-classical"
@@ -263,29 +215,29 @@
           </g>
           <g>
             <line
-              x1="308.861328125"
-              x2="308.861328125"
+              x1="307"
+              x2="307"
               y1="120"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="306.861328125"
+              x1="305"
+              x2="305"
               y1="120"
               y2="161"
               class="register-classical"
             />
             <line
-              x1="308.861328125"
-              x2="457.861328125"
+              x1="307"
+              x2="456"
               y1="159"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="457.861328125"
+              x1="305"
+              x2="456"
               y1="161"
               y2="161"
               class="register-classical"
@@ -293,29 +245,29 @@
           </g>
           <g>
             <line
-              x1="308.861328125"
-              x2="308.861328125"
+              x1="307"
+              x2="307"
               y1="200"
               y2="239"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="306.861328125"
+              x1="305"
+              x2="305"
               y1="200"
               y2="241"
               class="register-classical"
             />
             <line
-              x1="308.861328125"
-              x2="457.861328125"
+              x1="307"
+              x2="456"
               y1="239"
               y2="239"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="457.861328125"
+              x1="305"
+              x2="456"
               y1="241"
               y2="241"
               class="register-classical"
@@ -323,29 +275,29 @@
           </g>
           <g>
             <line
-              x1="308.861328125"
-              x2="308.861328125"
+              x1="307"
+              x2="307"
               y1="280"
               y2="319"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="306.861328125"
+              x1="305"
+              x2="305"
               y1="280"
               y2="321"
               class="register-classical"
             />
             <line
-              x1="308.861328125"
-              x2="457.861328125"
+              x1="307"
+              x2="456"
               y1="319"
               y2="319"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="457.861328125"
+              x1="305"
+              x2="456"
               y1="321"
               y2="321"
               class="register-classical"
@@ -353,29 +305,29 @@
           </g>
           <g>
             <line
-              x1="308.861328125"
-              x2="308.861328125"
+              x1="307"
+              x2="307"
               y1="360"
               y2="399"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="306.861328125"
+              x1="305"
+              x2="305"
               y1="360"
               y2="401"
               class="register-classical"
             />
             <line
-              x1="308.861328125"
-              x2="457.861328125"
+              x1="307"
+              x2="456"
               y1="399"
               y2="399"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="457.861328125"
+              x1="305"
+              x2="456"
               y1="401"
               y2="401"
               class="register-classical"
@@ -383,29 +335,29 @@
           </g>
           <g>
             <line
-              x1="308.861328125"
-              x2="308.861328125"
+              x1="307"
+              x2="307"
               y1="440"
               y2="479"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="306.861328125"
+              x1="305"
+              x2="305"
               y1="440"
               y2="481"
               class="register-classical"
             />
             <line
-              x1="308.861328125"
-              x2="457.861328125"
+              x1="307"
+              x2="456"
               y1="479"
               y2="479"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="457.861328125"
+              x1="305"
+              x2="456"
               y1="481"
               y2="481"
               class="register-classical"
@@ -413,29 +365,29 @@
           </g>
           <g>
             <line
-              x1="308.861328125"
-              x2="308.861328125"
+              x1="307"
+              x2="307"
               y1="520"
               y2="559"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="306.861328125"
+              x1="305"
+              x2="305"
               y1="520"
               y2="561"
               class="register-classical"
             />
             <line
-              x1="308.861328125"
-              x2="457.861328125"
+              x1="307"
+              x2="456"
               y1="559"
               y2="559"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="457.861328125"
+              x1="305"
+              x2="456"
               y1="561"
               y2="561"
               class="register-classical"
@@ -443,29 +395,29 @@
           </g>
           <g>
             <line
-              x1="308.861328125"
-              x2="308.861328125"
+              x1="307"
+              x2="307"
               y1="600"
               y2="639"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="306.861328125"
+              x1="305"
+              x2="305"
               y1="600"
               y2="641"
               class="register-classical"
             />
             <line
-              x1="308.861328125"
-              x2="457.861328125"
+              x1="307"
+              x2="456"
               y1="639"
               y2="639"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="457.861328125"
+              x1="305"
+              x2="456"
               y1="641"
               y2="641"
               class="register-classical"
@@ -473,29 +425,29 @@
           </g>
           <g>
             <line
-              x1="308.861328125"
-              x2="308.861328125"
+              x1="307"
+              x2="307"
               y1="680"
               y2="719"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="306.861328125"
+              x1="305"
+              x2="305"
               y1="680"
               y2="721"
               class="register-classical"
             />
             <line
-              x1="308.861328125"
-              x2="457.861328125"
+              x1="307"
+              x2="456"
               y1="719"
               y2="719"
               class="register-classical"
             />
             <line
-              x1="306.861328125"
-              x2="457.861328125"
+              x1="305"
+              x2="456"
               y1="721"
               y2="721"
               class="register-classical"
@@ -514,7 +466,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="367.861328125"
+              width="366"
               height="740"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -531,7 +483,7 @@
                   class="gate-unitary"
                   x="74"
                   y="12"
-                  width="333.861328125"
+                  width="332"
                   height="736"
                   fill-opacity="0"
                   stroke-dasharray="8, 8"
@@ -551,14 +503,14 @@
                             class="gate-unitary"
                             x="100"
                             y="20"
-                            width="167.861328125"
+                            width="166"
                             height="680"
                             data-wire-ys="[40,120,200,280,360,440,520,600,680]"
-                            data-width="167.861328125"
+                            data-width="166"
                           />
                           <text
                             font-size="14"
-                            x="183.9306640625"
+                            x="183"
                             y="360"
                             class="qs-maintext"
                           >
@@ -585,7 +537,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="287.861328125"
+                          x="286"
                           y="20"
                           width="40"
                           height="40"
@@ -594,12 +546,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 322.861328125 42 A 15 12 0 0 0 292.861328125 42"
+                          d="M 321 42 A 15 12 0 0 0 291 42"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="307.861328125"
-                          x2="319.861328125"
+                          x1="306"
+                          x2="318"
                           y1="48"
                           y2="28"
                           class="qs-line-measure"
@@ -619,7 +571,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="287.861328125"
+                          x="286"
                           y="100"
                           width="40"
                           height="40"
@@ -628,12 +580,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 322.861328125 122 A 15 12 0 0 0 292.861328125 122"
+                          d="M 321 122 A 15 12 0 0 0 291 122"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="307.861328125"
-                          x2="319.861328125"
+                          x1="306"
+                          x2="318"
                           y1="128"
                           y2="108"
                           class="qs-line-measure"
@@ -653,7 +605,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="287.861328125"
+                          x="286"
                           y="180"
                           width="40"
                           height="40"
@@ -662,12 +614,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 322.861328125 202 A 15 12 0 0 0 292.861328125 202"
+                          d="M 321 202 A 15 12 0 0 0 291 202"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="307.861328125"
-                          x2="319.861328125"
+                          x1="306"
+                          x2="318"
                           y1="208"
                           y2="188"
                           class="qs-line-measure"
@@ -687,7 +639,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="287.861328125"
+                          x="286"
                           y="260"
                           width="40"
                           height="40"
@@ -696,12 +648,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 322.861328125 282 A 15 12 0 0 0 292.861328125 282"
+                          d="M 321 282 A 15 12 0 0 0 291 282"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="307.861328125"
-                          x2="319.861328125"
+                          x1="306"
+                          x2="318"
                           y1="288"
                           y2="268"
                           class="qs-line-measure"
@@ -721,7 +673,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="287.861328125"
+                          x="286"
                           y="340"
                           width="40"
                           height="40"
@@ -730,12 +682,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 322.861328125 362 A 15 12 0 0 0 292.861328125 362"
+                          d="M 321 362 A 15 12 0 0 0 291 362"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="307.861328125"
-                          x2="319.861328125"
+                          x1="306"
+                          x2="318"
                           y1="368"
                           y2="348"
                           class="qs-line-measure"
@@ -755,7 +707,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="287.861328125"
+                          x="286"
                           y="420"
                           width="40"
                           height="40"
@@ -764,12 +716,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 322.861328125 442 A 15 12 0 0 0 292.861328125 442"
+                          d="M 321 442 A 15 12 0 0 0 291 442"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="307.861328125"
-                          x2="319.861328125"
+                          x1="306"
+                          x2="318"
                           y1="448"
                           y2="428"
                           class="qs-line-measure"
@@ -789,7 +741,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="287.861328125"
+                          x="286"
                           y="500"
                           width="40"
                           height="40"
@@ -798,12 +750,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 322.861328125 522 A 15 12 0 0 0 292.861328125 522"
+                          d="M 321 522 A 15 12 0 0 0 291 522"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="307.861328125"
-                          x2="319.861328125"
+                          x1="306"
+                          x2="318"
                           y1="528"
                           y2="508"
                           class="qs-line-measure"
@@ -823,7 +775,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="287.861328125"
+                          x="286"
                           y="580"
                           width="40"
                           height="40"
@@ -832,12 +784,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 322.861328125 602 A 15 12 0 0 0 292.861328125 602"
+                          d="M 321 602 A 15 12 0 0 0 291 602"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="307.861328125"
-                          x2="319.861328125"
+                          x1="306"
+                          x2="318"
                           y1="608"
                           y2="588"
                           class="qs-line-measure"
@@ -857,7 +809,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="287.861328125"
+                          x="286"
                           y="660"
                           width="40"
                           height="40"
@@ -866,12 +818,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 322.861328125 682 A 15 12 0 0 0 292.861328125 682"
+                          d="M 321 682 A 15 12 0 0 0 291 682"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="307.861328125"
-                          x2="319.861328125"
+                          x1="306"
+                          x2="318"
                           y1="688"
                           y2="668"
                           class="qs-line-measure"
@@ -892,7 +844,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="347.861328125"
+                            x="346"
                             y="20"
                             width="40"
                             height="40"
@@ -901,7 +853,7 @@
                           />
                           <text
                             font-size="14"
-                            x="367.861328125"
+                            x="366"
                             y="40"
                             class="qs-maintext ket-text"
                           >
@@ -923,7 +875,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="347.861328125"
+                            x="346"
                             y="100"
                             width="40"
                             height="40"
@@ -932,7 +884,7 @@
                           />
                           <text
                             font-size="14"
-                            x="367.861328125"
+                            x="366"
                             y="120"
                             class="qs-maintext ket-text"
                           >
@@ -954,7 +906,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="347.861328125"
+                            x="346"
                             y="180"
                             width="40"
                             height="40"
@@ -963,7 +915,7 @@
                           />
                           <text
                             font-size="14"
-                            x="367.861328125"
+                            x="366"
                             y="200"
                             class="qs-maintext ket-text"
                           >
@@ -985,7 +937,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="347.861328125"
+                            x="346"
                             y="260"
                             width="40"
                             height="40"
@@ -994,7 +946,7 @@
                           />
                           <text
                             font-size="14"
-                            x="367.861328125"
+                            x="366"
                             y="280"
                             class="qs-maintext ket-text"
                           >
@@ -1016,7 +968,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="347.861328125"
+                            x="346"
                             y="340"
                             width="40"
                             height="40"
@@ -1025,7 +977,7 @@
                           />
                           <text
                             font-size="14"
-                            x="367.861328125"
+                            x="366"
                             y="360"
                             class="qs-maintext ket-text"
                           >
@@ -1047,7 +999,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="347.861328125"
+                            x="346"
                             y="420"
                             width="40"
                             height="40"
@@ -1056,7 +1008,7 @@
                           />
                           <text
                             font-size="14"
-                            x="367.861328125"
+                            x="366"
                             y="440"
                             class="qs-maintext ket-text"
                           >
@@ -1078,7 +1030,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="347.861328125"
+                            x="346"
                             y="500"
                             width="40"
                             height="40"
@@ -1087,7 +1039,7 @@
                           />
                           <text
                             font-size="14"
-                            x="367.861328125"
+                            x="366"
                             y="520"
                             class="qs-maintext ket-text"
                           >
@@ -1109,7 +1061,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="347.861328125"
+                            x="346"
                             y="580"
                             width="40"
                             height="40"
@@ -1118,7 +1070,7 @@
                           />
                           <text
                             font-size="14"
-                            x="367.861328125"
+                            x="366"
                             y="600"
                             class="qs-maintext ket-text"
                           >
@@ -1140,7 +1092,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="347.861328125"
+                            x="346"
                             y="660"
                             width="40"
                             height="40"
@@ -1149,7 +1101,7 @@
                           />
                           <text
                             font-size="14"
-                            x="367.861328125"
+                            x="366"
                             y="680"
                             class="qs-maintext ket-text"
                           >
@@ -1179,7 +1131,7 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="2148.73828125"
+        width="2148"
         height="760"
         style="max-width: fit-content"
         viewBox="0 0 2148 760"
@@ -1340,88 +1292,40 @@
           </a>
         </g>
         <g class="wires">
-          <line x1="40" x2="2148.73828125" y1="40" y2="40" class="qubit-wire" />
-          <line
-            x1="40"
-            x2="2148.73828125"
-            y1="120"
-            y2="120"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="2148.73828125"
-            y1="200"
-            y2="200"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="2148.73828125"
-            y1="280"
-            y2="280"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="2148.73828125"
-            y1="360"
-            y2="360"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="2148.73828125"
-            y1="440"
-            y2="440"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="2148.73828125"
-            y1="520"
-            y2="520"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="2148.73828125"
-            y1="600"
-            y2="600"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="2148.73828125"
-            y1="680"
-            y2="680"
-            class="qubit-wire"
-          />
+          <line x1="40" x2="2148" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="2148" y1="120" y2="120" class="qubit-wire" />
+          <line x1="40" x2="2148" y1="200" y2="200" class="qubit-wire" />
+          <line x1="40" x2="2148" y1="280" y2="280" class="qubit-wire" />
+          <line x1="40" x2="2148" y1="360" y2="360" class="qubit-wire" />
+          <line x1="40" x2="2148" y1="440" y2="440" class="qubit-wire" />
+          <line x1="40" x2="2148" y1="520" y2="520" class="qubit-wire" />
+          <line x1="40" x2="2148" y1="600" y2="600" class="qubit-wire" />
+          <line x1="40" x2="2148" y1="680" y2="680" class="qubit-wire" />
           <g>
             <line
-              x1="1999.73828125"
-              x2="1999.73828125"
+              x1="1999"
+              x2="1999"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="1997.73828125"
+              x1="1997"
+              x2="1997"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="1999.73828125"
-              x2="2148.73828125"
+              x1="1999"
+              x2="2148"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="2148.73828125"
+              x1="1997"
+              x2="2148"
               y1="81"
               y2="81"
               class="register-classical"
@@ -1429,29 +1333,29 @@
           </g>
           <g>
             <line
-              x1="1999.73828125"
-              x2="1999.73828125"
+              x1="1999"
+              x2="1999"
               y1="120"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="1997.73828125"
+              x1="1997"
+              x2="1997"
               y1="120"
               y2="161"
               class="register-classical"
             />
             <line
-              x1="1999.73828125"
-              x2="2148.73828125"
+              x1="1999"
+              x2="2148"
               y1="159"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="2148.73828125"
+              x1="1997"
+              x2="2148"
               y1="161"
               y2="161"
               class="register-classical"
@@ -1459,29 +1363,29 @@
           </g>
           <g>
             <line
-              x1="1999.73828125"
-              x2="1999.73828125"
+              x1="1999"
+              x2="1999"
               y1="200"
               y2="239"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="1997.73828125"
+              x1="1997"
+              x2="1997"
               y1="200"
               y2="241"
               class="register-classical"
             />
             <line
-              x1="1999.73828125"
-              x2="2148.73828125"
+              x1="1999"
+              x2="2148"
               y1="239"
               y2="239"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="2148.73828125"
+              x1="1997"
+              x2="2148"
               y1="241"
               y2="241"
               class="register-classical"
@@ -1489,29 +1393,29 @@
           </g>
           <g>
             <line
-              x1="1999.73828125"
-              x2="1999.73828125"
+              x1="1999"
+              x2="1999"
               y1="280"
               y2="319"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="1997.73828125"
+              x1="1997"
+              x2="1997"
               y1="280"
               y2="321"
               class="register-classical"
             />
             <line
-              x1="1999.73828125"
-              x2="2148.73828125"
+              x1="1999"
+              x2="2148"
               y1="319"
               y2="319"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="2148.73828125"
+              x1="1997"
+              x2="2148"
               y1="321"
               y2="321"
               class="register-classical"
@@ -1519,29 +1423,29 @@
           </g>
           <g>
             <line
-              x1="1999.73828125"
-              x2="1999.73828125"
+              x1="1999"
+              x2="1999"
               y1="360"
               y2="399"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="1997.73828125"
+              x1="1997"
+              x2="1997"
               y1="360"
               y2="401"
               class="register-classical"
             />
             <line
-              x1="1999.73828125"
-              x2="2148.73828125"
+              x1="1999"
+              x2="2148"
               y1="399"
               y2="399"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="2148.73828125"
+              x1="1997"
+              x2="2148"
               y1="401"
               y2="401"
               class="register-classical"
@@ -1549,29 +1453,29 @@
           </g>
           <g>
             <line
-              x1="1999.73828125"
-              x2="1999.73828125"
+              x1="1999"
+              x2="1999"
               y1="440"
               y2="479"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="1997.73828125"
+              x1="1997"
+              x2="1997"
               y1="440"
               y2="481"
               class="register-classical"
             />
             <line
-              x1="1999.73828125"
-              x2="2148.73828125"
+              x1="1999"
+              x2="2148"
               y1="479"
               y2="479"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="2148.73828125"
+              x1="1997"
+              x2="2148"
               y1="481"
               y2="481"
               class="register-classical"
@@ -1579,29 +1483,29 @@
           </g>
           <g>
             <line
-              x1="1999.73828125"
-              x2="1999.73828125"
+              x1="1999"
+              x2="1999"
               y1="520"
               y2="559"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="1997.73828125"
+              x1="1997"
+              x2="1997"
               y1="520"
               y2="561"
               class="register-classical"
             />
             <line
-              x1="1999.73828125"
-              x2="2148.73828125"
+              x1="1999"
+              x2="2148"
               y1="559"
               y2="559"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="2148.73828125"
+              x1="1997"
+              x2="2148"
               y1="561"
               y2="561"
               class="register-classical"
@@ -1609,29 +1513,29 @@
           </g>
           <g>
             <line
-              x1="1999.73828125"
-              x2="1999.73828125"
+              x1="1999"
+              x2="1999"
               y1="600"
               y2="639"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="1997.73828125"
+              x1="1997"
+              x2="1997"
               y1="600"
               y2="641"
               class="register-classical"
             />
             <line
-              x1="1999.73828125"
-              x2="2148.73828125"
+              x1="1999"
+              x2="2148"
               y1="639"
               y2="639"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="2148.73828125"
+              x1="1997"
+              x2="2148"
               y1="641"
               y2="641"
               class="register-classical"
@@ -1639,29 +1543,29 @@
           </g>
           <g>
             <line
-              x1="1999.73828125"
-              x2="1999.73828125"
+              x1="1999"
+              x2="1999"
               y1="680"
               y2="719"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="1997.73828125"
+              x1="1997"
+              x2="1997"
               y1="680"
               y2="721"
               class="register-classical"
             />
             <line
-              x1="1999.73828125"
-              x2="2148.73828125"
+              x1="1999"
+              x2="2148"
               y1="719"
               y2="719"
               class="register-classical"
             />
             <line
-              x1="1997.73828125"
-              x2="2148.73828125"
+              x1="1997"
+              x2="2148"
               y1="721"
               y2="721"
               class="register-classical"
@@ -1680,7 +1584,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="2058.73828125"
+              width="2058"
               height="740"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -1697,7 +1601,7 @@
                   class="gate-unitary"
                   x="74"
                   y="12"
-                  width="2024.73828125"
+                  width="2024"
                   height="736"
                   fill-opacity="0"
                   stroke-dasharray="8, 8"
@@ -1714,7 +1618,7 @@
                       class="gate-unitary"
                       x="88"
                       y="14"
-                      width="1870.73828125"
+                      width="1870"
                       height="692"
                       fill-opacity="0"
                       stroke-dasharray="8, 8"
@@ -1731,7 +1635,7 @@
                           class="gate-unitary"
                           x="102"
                           y="16"
-                          width="252.10546875"
+                          width="252"
                           height="688"
                           fill-opacity="0"
                           stroke-dasharray="8, 8"
@@ -1753,14 +1657,14 @@
                                     class="gate-unitary"
                                     x="120"
                                     y="20"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[40]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="150.349609375"
+                                    x="151"
                                     y="33"
                                     class="qs-maintext"
                                   >
@@ -1768,7 +1672,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="150.349609375"
+                                    x="151"
                                     y="48"
                                     class="arg-button"
                                   >
@@ -1794,14 +1698,14 @@
                                     class="gate-unitary"
                                     x="120"
                                     y="100"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[120]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="150.349609375"
+                                    x="151"
                                     y="113"
                                     class="qs-maintext"
                                   >
@@ -1809,7 +1713,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="150.349609375"
+                                    x="151"
                                     y="128"
                                     class="arg-button"
                                   >
@@ -1835,14 +1739,14 @@
                                     class="gate-unitary"
                                     x="120"
                                     y="180"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[200]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="150.349609375"
+                                    x="151"
                                     y="193"
                                     class="qs-maintext"
                                   >
@@ -1850,7 +1754,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="150.349609375"
+                                    x="151"
                                     y="208"
                                     class="arg-button"
                                   >
@@ -1876,14 +1780,14 @@
                                     class="gate-unitary"
                                     x="120"
                                     y="260"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[280]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="150.349609375"
+                                    x="151"
                                     y="273"
                                     class="qs-maintext"
                                   >
@@ -1891,7 +1795,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="150.349609375"
+                                    x="151"
                                     y="288"
                                     class="arg-button"
                                   >
@@ -1917,14 +1821,14 @@
                                     class="gate-unitary"
                                     x="120"
                                     y="340"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[360]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="150.349609375"
+                                    x="151"
                                     y="353"
                                     class="qs-maintext"
                                   >
@@ -1932,7 +1836,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="150.349609375"
+                                    x="151"
                                     y="368"
                                     class="arg-button"
                                   >
@@ -1958,14 +1862,14 @@
                                     class="gate-unitary"
                                     x="120"
                                     y="420"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[440]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="150.349609375"
+                                    x="151"
                                     y="433"
                                     class="qs-maintext"
                                   >
@@ -1973,7 +1877,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="150.349609375"
+                                    x="151"
                                     y="448"
                                     class="arg-button"
                                   >
@@ -1999,14 +1903,14 @@
                                     class="gate-unitary"
                                     x="120"
                                     y="500"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[520]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="150.349609375"
+                                    x="151"
                                     y="513"
                                     class="qs-maintext"
                                   >
@@ -2014,7 +1918,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="150.349609375"
+                                    x="151"
                                     y="528"
                                     class="arg-button"
                                   >
@@ -2040,14 +1944,14 @@
                                     class="gate-unitary"
                                     x="120"
                                     y="580"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[600]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="150.349609375"
+                                    x="151"
                                     y="593"
                                     class="qs-maintext"
                                   >
@@ -2055,7 +1959,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="150.349609375"
+                                    x="151"
                                     y="608"
                                     class="arg-button"
                                   >
@@ -2081,14 +1985,14 @@
                                     class="gate-unitary"
                                     x="120"
                                     y="660"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[680]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="150.349609375"
+                                    x="151"
                                     y="673"
                                     class="qs-maintext"
                                   >
@@ -2096,7 +2000,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="150.349609375"
+                                    x="151"
                                     y="688"
                                     class="arg-button"
                                   >
@@ -2121,16 +2025,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="200.69921875"
+                                    x="202"
                                     y="20"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[40,120]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="229.05078125"
+                                    x="230"
                                     y="73"
                                     class="qs-maintext"
                                   >
@@ -2138,7 +2042,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="229.05078125"
+                                    x="230"
                                     y="88"
                                     class="arg-button"
                                   >
@@ -2163,16 +2067,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="200.69921875"
+                                    x="202"
                                     y="180"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[200,280]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="229.05078125"
+                                    x="230"
                                     y="233"
                                     class="qs-maintext"
                                   >
@@ -2180,7 +2084,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="229.05078125"
+                                    x="230"
                                     y="248"
                                     class="arg-button"
                                   >
@@ -2205,16 +2109,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="200.69921875"
+                                    x="202"
                                     y="340"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[360,440]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="229.05078125"
+                                    x="230"
                                     y="393"
                                     class="qs-maintext"
                                   >
@@ -2222,7 +2126,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="229.05078125"
+                                    x="230"
                                     y="408"
                                     class="arg-button"
                                   >
@@ -2247,16 +2151,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="200.69921875"
+                                    x="202"
                                     y="500"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[520,600]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="229.05078125"
+                                    x="230"
                                     y="553"
                                     class="qs-maintext"
                                   >
@@ -2264,7 +2168,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="229.05078125"
+                                    x="230"
                                     y="568"
                                     class="arg-button"
                                   >
@@ -2289,16 +2193,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="277.40234375"
+                                    x="278"
                                     y="100"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[120,200]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="305.75390625"
+                                    x="306"
                                     y="153"
                                     class="qs-maintext"
                                   >
@@ -2306,7 +2210,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="305.75390625"
+                                    x="306"
                                     y="168"
                                     class="arg-button"
                                   >
@@ -2331,16 +2235,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="277.40234375"
+                                    x="278"
                                     y="260"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[280,360]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="305.75390625"
+                                    x="306"
                                     y="313"
                                     class="qs-maintext"
                                   >
@@ -2348,7 +2252,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="305.75390625"
+                                    x="306"
                                     y="328"
                                     class="arg-button"
                                   >
@@ -2373,16 +2277,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="277.40234375"
+                                    x="278"
                                     y="420"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[440,520]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="305.75390625"
+                                    x="306"
                                     y="473"
                                     class="qs-maintext"
                                   >
@@ -2390,7 +2294,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="305.75390625"
+                                    x="306"
                                     y="488"
                                     class="arg-button"
                                   >
@@ -2415,16 +2319,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="277.40234375"
+                                    x="278"
                                     y="580"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[600,680]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="305.75390625"
+                                    x="306"
                                     y="633"
                                     class="qs-maintext"
                                   >
@@ -2432,7 +2336,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="305.75390625"
+                                    x="306"
                                     y="648"
                                     class="arg-button"
                                   >
@@ -2457,9 +2361,9 @@
                       >
                         <rect
                           class="gate-unitary"
-                          x="366.10546875"
+                          x="366"
                           y="16"
-                          width="252.10546875"
+                          width="252"
                           height="688"
                           fill-opacity="0"
                           stroke-dasharray="8, 8"
@@ -2479,16 +2383,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="384.10546875"
+                                    x="384"
                                     y="20"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[40]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="414.455078125"
+                                    x="415"
                                     y="33"
                                     class="qs-maintext"
                                   >
@@ -2496,7 +2400,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="414.455078125"
+                                    x="415"
                                     y="48"
                                     class="arg-button"
                                   >
@@ -2520,16 +2424,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="384.10546875"
+                                    x="384"
                                     y="100"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[120]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="414.455078125"
+                                    x="415"
                                     y="113"
                                     class="qs-maintext"
                                   >
@@ -2537,7 +2441,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="414.455078125"
+                                    x="415"
                                     y="128"
                                     class="arg-button"
                                   >
@@ -2561,16 +2465,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="384.10546875"
+                                    x="384"
                                     y="180"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[200]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="414.455078125"
+                                    x="415"
                                     y="193"
                                     class="qs-maintext"
                                   >
@@ -2578,7 +2482,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="414.455078125"
+                                    x="415"
                                     y="208"
                                     class="arg-button"
                                   >
@@ -2602,16 +2506,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="384.10546875"
+                                    x="384"
                                     y="260"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[280]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="414.455078125"
+                                    x="415"
                                     y="273"
                                     class="qs-maintext"
                                   >
@@ -2619,7 +2523,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="414.455078125"
+                                    x="415"
                                     y="288"
                                     class="arg-button"
                                   >
@@ -2643,16 +2547,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="384.10546875"
+                                    x="384"
                                     y="340"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[360]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="414.455078125"
+                                    x="415"
                                     y="353"
                                     class="qs-maintext"
                                   >
@@ -2660,7 +2564,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="414.455078125"
+                                    x="415"
                                     y="368"
                                     class="arg-button"
                                   >
@@ -2684,16 +2588,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="384.10546875"
+                                    x="384"
                                     y="420"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[440]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="414.455078125"
+                                    x="415"
                                     y="433"
                                     class="qs-maintext"
                                   >
@@ -2701,7 +2605,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="414.455078125"
+                                    x="415"
                                     y="448"
                                     class="arg-button"
                                   >
@@ -2725,16 +2629,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="384.10546875"
+                                    x="384"
                                     y="500"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[520]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="414.455078125"
+                                    x="415"
                                     y="513"
                                     class="qs-maintext"
                                   >
@@ -2742,7 +2646,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="414.455078125"
+                                    x="415"
                                     y="528"
                                     class="arg-button"
                                   >
@@ -2766,16 +2670,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="384.10546875"
+                                    x="384"
                                     y="580"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[600]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="414.455078125"
+                                    x="415"
                                     y="593"
                                     class="qs-maintext"
                                   >
@@ -2783,7 +2687,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="414.455078125"
+                                    x="415"
                                     y="608"
                                     class="arg-button"
                                   >
@@ -2807,16 +2711,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="384.10546875"
+                                    x="384"
                                     y="660"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[680]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="414.455078125"
+                                    x="415"
                                     y="673"
                                     class="qs-maintext"
                                   >
@@ -2824,7 +2728,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="414.455078125"
+                                    x="415"
                                     y="688"
                                     class="arg-button"
                                   >
@@ -2849,16 +2753,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="464.8046875"
+                                    x="466"
                                     y="20"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[40,120]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="493.15625"
+                                    x="494"
                                     y="73"
                                     class="qs-maintext"
                                   >
@@ -2866,7 +2770,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="493.15625"
+                                    x="494"
                                     y="88"
                                     class="arg-button"
                                   >
@@ -2891,16 +2795,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="464.8046875"
+                                    x="466"
                                     y="180"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[200,280]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="493.15625"
+                                    x="494"
                                     y="233"
                                     class="qs-maintext"
                                   >
@@ -2908,7 +2812,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="493.15625"
+                                    x="494"
                                     y="248"
                                     class="arg-button"
                                   >
@@ -2933,16 +2837,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="464.8046875"
+                                    x="466"
                                     y="340"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[360,440]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="493.15625"
+                                    x="494"
                                     y="393"
                                     class="qs-maintext"
                                   >
@@ -2950,7 +2854,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="493.15625"
+                                    x="494"
                                     y="408"
                                     class="arg-button"
                                   >
@@ -2975,16 +2879,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="464.8046875"
+                                    x="466"
                                     y="500"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[520,600]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="493.15625"
+                                    x="494"
                                     y="553"
                                     class="qs-maintext"
                                   >
@@ -2992,7 +2896,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="493.15625"
+                                    x="494"
                                     y="568"
                                     class="arg-button"
                                   >
@@ -3017,16 +2921,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="541.5078125"
+                                    x="542"
                                     y="100"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[120,200]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="569.859375"
+                                    x="570"
                                     y="153"
                                     class="qs-maintext"
                                   >
@@ -3034,7 +2938,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="569.859375"
+                                    x="570"
                                     y="168"
                                     class="arg-button"
                                   >
@@ -3059,16 +2963,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="541.5078125"
+                                    x="542"
                                     y="260"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[280,360]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="569.859375"
+                                    x="570"
                                     y="313"
                                     class="qs-maintext"
                                   >
@@ -3076,7 +2980,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="569.859375"
+                                    x="570"
                                     y="328"
                                     class="arg-button"
                                   >
@@ -3101,16 +3005,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="541.5078125"
+                                    x="542"
                                     y="420"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[440,520]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="569.859375"
+                                    x="570"
                                     y="473"
                                     class="qs-maintext"
                                   >
@@ -3118,7 +3022,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="569.859375"
+                                    x="570"
                                     y="488"
                                     class="arg-button"
                                   >
@@ -3143,16 +3047,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="541.5078125"
+                                    x="542"
                                     y="580"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[600,680]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="569.859375"
+                                    x="570"
                                     y="633"
                                     class="qs-maintext"
                                   >
@@ -3160,7 +3064,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="569.859375"
+                                    x="570"
                                     y="648"
                                     class="arg-button"
                                   >
@@ -3172,8 +3076,8 @@
                           </g>
                         </g>
                         <g class="gate-control gate-collapse">
-                          <circle cx="368.10546875" cy="18" r="10" />
-                          <path d="M361.10546875,18 h14" />
+                          <circle cx="368" cy="18" r="10" />
+                          <path d="M361,18 h14" />
                         </g>
                       </g>
                       <g
@@ -3185,9 +3089,9 @@
                       >
                         <rect
                           class="gate-unitary"
-                          x="630.2109375"
+                          x="630"
                           y="16"
-                          width="252.10546875"
+                          width="252"
                           height="688"
                           fill-opacity="0"
                           stroke-dasharray="8, 8"
@@ -3207,16 +3111,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="648.2109375"
+                                    x="648"
                                     y="20"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[40]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="678.560546875"
+                                    x="679"
                                     y="33"
                                     class="qs-maintext"
                                   >
@@ -3224,7 +3128,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="678.560546875"
+                                    x="679"
                                     y="48"
                                     class="arg-button"
                                   >
@@ -3248,16 +3152,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="648.2109375"
+                                    x="648"
                                     y="100"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[120]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="678.560546875"
+                                    x="679"
                                     y="113"
                                     class="qs-maintext"
                                   >
@@ -3265,7 +3169,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="678.560546875"
+                                    x="679"
                                     y="128"
                                     class="arg-button"
                                   >
@@ -3289,16 +3193,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="648.2109375"
+                                    x="648"
                                     y="180"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[200]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="678.560546875"
+                                    x="679"
                                     y="193"
                                     class="qs-maintext"
                                   >
@@ -3306,7 +3210,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="678.560546875"
+                                    x="679"
                                     y="208"
                                     class="arg-button"
                                   >
@@ -3330,16 +3234,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="648.2109375"
+                                    x="648"
                                     y="260"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[280]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="678.560546875"
+                                    x="679"
                                     y="273"
                                     class="qs-maintext"
                                   >
@@ -3347,7 +3251,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="678.560546875"
+                                    x="679"
                                     y="288"
                                     class="arg-button"
                                   >
@@ -3371,16 +3275,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="648.2109375"
+                                    x="648"
                                     y="340"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[360]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="678.560546875"
+                                    x="679"
                                     y="353"
                                     class="qs-maintext"
                                   >
@@ -3388,7 +3292,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="678.560546875"
+                                    x="679"
                                     y="368"
                                     class="arg-button"
                                   >
@@ -3412,16 +3316,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="648.2109375"
+                                    x="648"
                                     y="420"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[440]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="678.560546875"
+                                    x="679"
                                     y="433"
                                     class="qs-maintext"
                                   >
@@ -3429,7 +3333,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="678.560546875"
+                                    x="679"
                                     y="448"
                                     class="arg-button"
                                   >
@@ -3453,16 +3357,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="648.2109375"
+                                    x="648"
                                     y="500"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[520]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="678.560546875"
+                                    x="679"
                                     y="513"
                                     class="qs-maintext"
                                   >
@@ -3470,7 +3374,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="678.560546875"
+                                    x="679"
                                     y="528"
                                     class="arg-button"
                                   >
@@ -3494,16 +3398,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="648.2109375"
+                                    x="648"
                                     y="580"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[600]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="678.560546875"
+                                    x="679"
                                     y="593"
                                     class="qs-maintext"
                                   >
@@ -3511,7 +3415,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="678.560546875"
+                                    x="679"
                                     y="608"
                                     class="arg-button"
                                   >
@@ -3535,16 +3439,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="648.2109375"
+                                    x="648"
                                     y="660"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[680]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="678.560546875"
+                                    x="679"
                                     y="673"
                                     class="qs-maintext"
                                   >
@@ -3552,7 +3456,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="678.560546875"
+                                    x="679"
                                     y="688"
                                     class="arg-button"
                                   >
@@ -3577,16 +3481,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="728.91015625"
+                                    x="730"
                                     y="20"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[40,120]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="757.26171875"
+                                    x="758"
                                     y="73"
                                     class="qs-maintext"
                                   >
@@ -3594,7 +3498,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="757.26171875"
+                                    x="758"
                                     y="88"
                                     class="arg-button"
                                   >
@@ -3619,16 +3523,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="728.91015625"
+                                    x="730"
                                     y="180"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[200,280]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="757.26171875"
+                                    x="758"
                                     y="233"
                                     class="qs-maintext"
                                   >
@@ -3636,7 +3540,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="757.26171875"
+                                    x="758"
                                     y="248"
                                     class="arg-button"
                                   >
@@ -3661,16 +3565,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="728.91015625"
+                                    x="730"
                                     y="340"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[360,440]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="757.26171875"
+                                    x="758"
                                     y="393"
                                     class="qs-maintext"
                                   >
@@ -3678,7 +3582,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="757.26171875"
+                                    x="758"
                                     y="408"
                                     class="arg-button"
                                   >
@@ -3703,16 +3607,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="728.91015625"
+                                    x="730"
                                     y="500"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[520,600]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="757.26171875"
+                                    x="758"
                                     y="553"
                                     class="qs-maintext"
                                   >
@@ -3720,7 +3624,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="757.26171875"
+                                    x="758"
                                     y="568"
                                     class="arg-button"
                                   >
@@ -3745,16 +3649,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="805.61328125"
+                                    x="806"
                                     y="100"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[120,200]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="833.96484375"
+                                    x="834"
                                     y="153"
                                     class="qs-maintext"
                                   >
@@ -3762,7 +3666,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="833.96484375"
+                                    x="834"
                                     y="168"
                                     class="arg-button"
                                   >
@@ -3787,16 +3691,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="805.61328125"
+                                    x="806"
                                     y="260"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[280,360]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="833.96484375"
+                                    x="834"
                                     y="313"
                                     class="qs-maintext"
                                   >
@@ -3804,7 +3708,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="833.96484375"
+                                    x="834"
                                     y="328"
                                     class="arg-button"
                                   >
@@ -3829,16 +3733,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="805.61328125"
+                                    x="806"
                                     y="420"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[440,520]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="833.96484375"
+                                    x="834"
                                     y="473"
                                     class="qs-maintext"
                                   >
@@ -3846,7 +3750,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="833.96484375"
+                                    x="834"
                                     y="488"
                                     class="arg-button"
                                   >
@@ -3871,16 +3775,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="805.61328125"
+                                    x="806"
                                     y="580"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[600,680]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="833.96484375"
+                                    x="834"
                                     y="633"
                                     class="qs-maintext"
                                   >
@@ -3888,7 +3792,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="833.96484375"
+                                    x="834"
                                     y="648"
                                     class="arg-button"
                                   >
@@ -3900,8 +3804,8 @@
                           </g>
                         </g>
                         <g class="gate-control gate-collapse">
-                          <circle cx="632.2109375" cy="18" r="10" />
-                          <path d="M625.2109375,18 h14" />
+                          <circle cx="632" cy="18" r="10" />
+                          <path d="M625,18 h14" />
                         </g>
                       </g>
                       <g
@@ -3913,9 +3817,9 @@
                       >
                         <rect
                           class="gate-unitary"
-                          x="894.31640625"
+                          x="894"
                           y="16"
-                          width="252.10546875"
+                          width="252"
                           height="688"
                           fill-opacity="0"
                           stroke-dasharray="8, 8"
@@ -3935,16 +3839,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="912.31640625"
+                                    x="912"
                                     y="20"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[40]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="942.666015625"
+                                    x="943"
                                     y="33"
                                     class="qs-maintext"
                                   >
@@ -3952,7 +3856,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="942.666015625"
+                                    x="943"
                                     y="48"
                                     class="arg-button"
                                   >
@@ -3976,16 +3880,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="912.31640625"
+                                    x="912"
                                     y="100"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[120]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="942.666015625"
+                                    x="943"
                                     y="113"
                                     class="qs-maintext"
                                   >
@@ -3993,7 +3897,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="942.666015625"
+                                    x="943"
                                     y="128"
                                     class="arg-button"
                                   >
@@ -4017,16 +3921,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="912.31640625"
+                                    x="912"
                                     y="180"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[200]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="942.666015625"
+                                    x="943"
                                     y="193"
                                     class="qs-maintext"
                                   >
@@ -4034,7 +3938,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="942.666015625"
+                                    x="943"
                                     y="208"
                                     class="arg-button"
                                   >
@@ -4058,16 +3962,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="912.31640625"
+                                    x="912"
                                     y="260"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[280]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="942.666015625"
+                                    x="943"
                                     y="273"
                                     class="qs-maintext"
                                   >
@@ -4075,7 +3979,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="942.666015625"
+                                    x="943"
                                     y="288"
                                     class="arg-button"
                                   >
@@ -4099,16 +4003,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="912.31640625"
+                                    x="912"
                                     y="340"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[360]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="942.666015625"
+                                    x="943"
                                     y="353"
                                     class="qs-maintext"
                                   >
@@ -4116,7 +4020,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="942.666015625"
+                                    x="943"
                                     y="368"
                                     class="arg-button"
                                   >
@@ -4140,16 +4044,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="912.31640625"
+                                    x="912"
                                     y="420"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[440]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="942.666015625"
+                                    x="943"
                                     y="433"
                                     class="qs-maintext"
                                   >
@@ -4157,7 +4061,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="942.666015625"
+                                    x="943"
                                     y="448"
                                     class="arg-button"
                                   >
@@ -4181,16 +4085,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="912.31640625"
+                                    x="912"
                                     y="500"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[520]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="942.666015625"
+                                    x="943"
                                     y="513"
                                     class="qs-maintext"
                                   >
@@ -4198,7 +4102,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="942.666015625"
+                                    x="943"
                                     y="528"
                                     class="arg-button"
                                   >
@@ -4222,16 +4126,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="912.31640625"
+                                    x="912"
                                     y="580"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[600]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="942.666015625"
+                                    x="943"
                                     y="593"
                                     class="qs-maintext"
                                   >
@@ -4239,7 +4143,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="942.666015625"
+                                    x="943"
                                     y="608"
                                     class="arg-button"
                                   >
@@ -4263,16 +4167,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="912.31640625"
+                                    x="912"
                                     y="660"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[680]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="942.666015625"
+                                    x="943"
                                     y="673"
                                     class="qs-maintext"
                                   >
@@ -4280,7 +4184,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="942.666015625"
+                                    x="943"
                                     y="688"
                                     class="arg-button"
                                   >
@@ -4305,16 +4209,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="993.015625"
+                                    x="994"
                                     y="20"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[40,120]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1021.3671875"
+                                    x="1022"
                                     y="73"
                                     class="qs-maintext"
                                   >
@@ -4322,7 +4226,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1021.3671875"
+                                    x="1022"
                                     y="88"
                                     class="arg-button"
                                   >
@@ -4347,16 +4251,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="993.015625"
+                                    x="994"
                                     y="180"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[200,280]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1021.3671875"
+                                    x="1022"
                                     y="233"
                                     class="qs-maintext"
                                   >
@@ -4364,7 +4268,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1021.3671875"
+                                    x="1022"
                                     y="248"
                                     class="arg-button"
                                   >
@@ -4389,16 +4293,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="993.015625"
+                                    x="994"
                                     y="340"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[360,440]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1021.3671875"
+                                    x="1022"
                                     y="393"
                                     class="qs-maintext"
                                   >
@@ -4406,7 +4310,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1021.3671875"
+                                    x="1022"
                                     y="408"
                                     class="arg-button"
                                   >
@@ -4431,16 +4335,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="993.015625"
+                                    x="994"
                                     y="500"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[520,600]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1021.3671875"
+                                    x="1022"
                                     y="553"
                                     class="qs-maintext"
                                   >
@@ -4448,7 +4352,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1021.3671875"
+                                    x="1022"
                                     y="568"
                                     class="arg-button"
                                   >
@@ -4473,16 +4377,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1069.71875"
+                                    x="1070"
                                     y="100"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[120,200]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1098.0703125"
+                                    x="1098"
                                     y="153"
                                     class="qs-maintext"
                                   >
@@ -4490,7 +4394,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1098.0703125"
+                                    x="1098"
                                     y="168"
                                     class="arg-button"
                                   >
@@ -4515,16 +4419,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1069.71875"
+                                    x="1070"
                                     y="260"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[280,360]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1098.0703125"
+                                    x="1098"
                                     y="313"
                                     class="qs-maintext"
                                   >
@@ -4532,7 +4436,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1098.0703125"
+                                    x="1098"
                                     y="328"
                                     class="arg-button"
                                   >
@@ -4557,16 +4461,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1069.71875"
+                                    x="1070"
                                     y="420"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[440,520]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1098.0703125"
+                                    x="1098"
                                     y="473"
                                     class="qs-maintext"
                                   >
@@ -4574,7 +4478,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1098.0703125"
+                                    x="1098"
                                     y="488"
                                     class="arg-button"
                                   >
@@ -4599,16 +4503,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1069.71875"
+                                    x="1070"
                                     y="580"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[600,680]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1098.0703125"
+                                    x="1098"
                                     y="633"
                                     class="qs-maintext"
                                   >
@@ -4616,7 +4520,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1098.0703125"
+                                    x="1098"
                                     y="648"
                                     class="arg-button"
                                   >
@@ -4628,8 +4532,8 @@
                           </g>
                         </g>
                         <g class="gate-control gate-collapse">
-                          <circle cx="896.31640625" cy="18" r="10" />
-                          <path d="M889.31640625,18 h14" />
+                          <circle cx="896" cy="18" r="10" />
+                          <path d="M889,18 h14" />
                         </g>
                       </g>
                       <g
@@ -4641,9 +4545,9 @@
                       >
                         <rect
                           class="gate-unitary"
-                          x="1158.421875"
+                          x="1158"
                           y="16"
-                          width="252.10546875"
+                          width="252"
                           height="688"
                           fill-opacity="0"
                           stroke-dasharray="8, 8"
@@ -4663,16 +4567,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1176.421875"
+                                    x="1176"
                                     y="20"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[40]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="33"
                                     class="qs-maintext"
                                   >
@@ -4680,7 +4584,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="48"
                                     class="arg-button"
                                   >
@@ -4704,16 +4608,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1176.421875"
+                                    x="1176"
                                     y="100"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[120]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="113"
                                     class="qs-maintext"
                                   >
@@ -4721,7 +4625,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="128"
                                     class="arg-button"
                                   >
@@ -4745,16 +4649,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1176.421875"
+                                    x="1176"
                                     y="180"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[200]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="193"
                                     class="qs-maintext"
                                   >
@@ -4762,7 +4666,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="208"
                                     class="arg-button"
                                   >
@@ -4786,16 +4690,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1176.421875"
+                                    x="1176"
                                     y="260"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[280]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="273"
                                     class="qs-maintext"
                                   >
@@ -4803,7 +4707,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="288"
                                     class="arg-button"
                                   >
@@ -4827,16 +4731,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1176.421875"
+                                    x="1176"
                                     y="340"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[360]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="353"
                                     class="qs-maintext"
                                   >
@@ -4844,7 +4748,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="368"
                                     class="arg-button"
                                   >
@@ -4868,16 +4772,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1176.421875"
+                                    x="1176"
                                     y="420"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[440]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="433"
                                     class="qs-maintext"
                                   >
@@ -4885,7 +4789,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="448"
                                     class="arg-button"
                                   >
@@ -4909,16 +4813,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1176.421875"
+                                    x="1176"
                                     y="500"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[520]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="513"
                                     class="qs-maintext"
                                   >
@@ -4926,7 +4830,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="528"
                                     class="arg-button"
                                   >
@@ -4950,16 +4854,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1176.421875"
+                                    x="1176"
                                     y="580"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[600]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="593"
                                     class="qs-maintext"
                                   >
@@ -4967,7 +4871,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="608"
                                     class="arg-button"
                                   >
@@ -4991,16 +4895,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1176.421875"
+                                    x="1176"
                                     y="660"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[680]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="673"
                                     class="qs-maintext"
                                   >
@@ -5008,7 +4912,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1206.771484375"
+                                    x="1207"
                                     y="688"
                                     class="arg-button"
                                   >
@@ -5033,16 +4937,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1257.12109375"
+                                    x="1258"
                                     y="20"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[40,120]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1285.47265625"
+                                    x="1286"
                                     y="73"
                                     class="qs-maintext"
                                   >
@@ -5050,7 +4954,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1285.47265625"
+                                    x="1286"
                                     y="88"
                                     class="arg-button"
                                   >
@@ -5075,16 +4979,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1257.12109375"
+                                    x="1258"
                                     y="180"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[200,280]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1285.47265625"
+                                    x="1286"
                                     y="233"
                                     class="qs-maintext"
                                   >
@@ -5092,7 +4996,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1285.47265625"
+                                    x="1286"
                                     y="248"
                                     class="arg-button"
                                   >
@@ -5117,16 +5021,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1257.12109375"
+                                    x="1258"
                                     y="340"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[360,440]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1285.47265625"
+                                    x="1286"
                                     y="393"
                                     class="qs-maintext"
                                   >
@@ -5134,7 +5038,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1285.47265625"
+                                    x="1286"
                                     y="408"
                                     class="arg-button"
                                   >
@@ -5159,16 +5063,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1257.12109375"
+                                    x="1258"
                                     y="500"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[520,600]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1285.47265625"
+                                    x="1286"
                                     y="553"
                                     class="qs-maintext"
                                   >
@@ -5176,7 +5080,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1285.47265625"
+                                    x="1286"
                                     y="568"
                                     class="arg-button"
                                   >
@@ -5201,16 +5105,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1333.82421875"
+                                    x="1334"
                                     y="100"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[120,200]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1362.17578125"
+                                    x="1362"
                                     y="153"
                                     class="qs-maintext"
                                   >
@@ -5218,7 +5122,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1362.17578125"
+                                    x="1362"
                                     y="168"
                                     class="arg-button"
                                   >
@@ -5243,16 +5147,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1333.82421875"
+                                    x="1334"
                                     y="260"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[280,360]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1362.17578125"
+                                    x="1362"
                                     y="313"
                                     class="qs-maintext"
                                   >
@@ -5260,7 +5164,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1362.17578125"
+                                    x="1362"
                                     y="328"
                                     class="arg-button"
                                   >
@@ -5285,16 +5189,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1333.82421875"
+                                    x="1334"
                                     y="420"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[440,520]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1362.17578125"
+                                    x="1362"
                                     y="473"
                                     class="qs-maintext"
                                   >
@@ -5302,7 +5206,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1362.17578125"
+                                    x="1362"
                                     y="488"
                                     class="arg-button"
                                   >
@@ -5327,16 +5231,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1333.82421875"
+                                    x="1334"
                                     y="580"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[600,680]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1362.17578125"
+                                    x="1362"
                                     y="633"
                                     class="qs-maintext"
                                   >
@@ -5344,7 +5248,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1362.17578125"
+                                    x="1362"
                                     y="648"
                                     class="arg-button"
                                   >
@@ -5356,8 +5260,8 @@
                           </g>
                         </g>
                         <g class="gate-control gate-collapse">
-                          <circle cx="1160.421875" cy="18" r="10" />
-                          <path d="M1153.421875,18 h14" />
+                          <circle cx="1160" cy="18" r="10" />
+                          <path d="M1153,18 h14" />
                         </g>
                       </g>
                       <g
@@ -5369,9 +5273,9 @@
                       >
                         <rect
                           class="gate-unitary"
-                          x="1422.52734375"
+                          x="1422"
                           y="16"
-                          width="252.10546875"
+                          width="252"
                           height="688"
                           fill-opacity="0"
                           stroke-dasharray="8, 8"
@@ -5391,16 +5295,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1440.52734375"
+                                    x="1440"
                                     y="20"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[40]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="33"
                                     class="qs-maintext"
                                   >
@@ -5408,7 +5312,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="48"
                                     class="arg-button"
                                   >
@@ -5432,16 +5336,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1440.52734375"
+                                    x="1440"
                                     y="100"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[120]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="113"
                                     class="qs-maintext"
                                   >
@@ -5449,7 +5353,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="128"
                                     class="arg-button"
                                   >
@@ -5473,16 +5377,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1440.52734375"
+                                    x="1440"
                                     y="180"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[200]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="193"
                                     class="qs-maintext"
                                   >
@@ -5490,7 +5394,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="208"
                                     class="arg-button"
                                   >
@@ -5514,16 +5418,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1440.52734375"
+                                    x="1440"
                                     y="260"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[280]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="273"
                                     class="qs-maintext"
                                   >
@@ -5531,7 +5435,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="288"
                                     class="arg-button"
                                   >
@@ -5555,16 +5459,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1440.52734375"
+                                    x="1440"
                                     y="340"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[360]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="353"
                                     class="qs-maintext"
                                   >
@@ -5572,7 +5476,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="368"
                                     class="arg-button"
                                   >
@@ -5596,16 +5500,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1440.52734375"
+                                    x="1440"
                                     y="420"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[440]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="433"
                                     class="qs-maintext"
                                   >
@@ -5613,7 +5517,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="448"
                                     class="arg-button"
                                   >
@@ -5637,16 +5541,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1440.52734375"
+                                    x="1440"
                                     y="500"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[520]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="513"
                                     class="qs-maintext"
                                   >
@@ -5654,7 +5558,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="528"
                                     class="arg-button"
                                   >
@@ -5678,16 +5582,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1440.52734375"
+                                    x="1440"
                                     y="580"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[600]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="593"
                                     class="qs-maintext"
                                   >
@@ -5695,7 +5599,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="608"
                                     class="arg-button"
                                   >
@@ -5719,16 +5623,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1440.52734375"
+                                    x="1440"
                                     y="660"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[680]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="673"
                                     class="qs-maintext"
                                   >
@@ -5736,7 +5640,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1470.876953125"
+                                    x="1471"
                                     y="688"
                                     class="arg-button"
                                   >
@@ -5761,16 +5665,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1521.2265625"
+                                    x="1522"
                                     y="20"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[40,120]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1549.578125"
+                                    x="1550"
                                     y="73"
                                     class="qs-maintext"
                                   >
@@ -5778,7 +5682,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1549.578125"
+                                    x="1550"
                                     y="88"
                                     class="arg-button"
                                   >
@@ -5803,16 +5707,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1521.2265625"
+                                    x="1522"
                                     y="180"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[200,280]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1549.578125"
+                                    x="1550"
                                     y="233"
                                     class="qs-maintext"
                                   >
@@ -5820,7 +5724,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1549.578125"
+                                    x="1550"
                                     y="248"
                                     class="arg-button"
                                   >
@@ -5845,16 +5749,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1521.2265625"
+                                    x="1522"
                                     y="340"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[360,440]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1549.578125"
+                                    x="1550"
                                     y="393"
                                     class="qs-maintext"
                                   >
@@ -5862,7 +5766,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1549.578125"
+                                    x="1550"
                                     y="408"
                                     class="arg-button"
                                   >
@@ -5887,16 +5791,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1521.2265625"
+                                    x="1522"
                                     y="500"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[520,600]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1549.578125"
+                                    x="1550"
                                     y="553"
                                     class="qs-maintext"
                                   >
@@ -5904,7 +5808,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1549.578125"
+                                    x="1550"
                                     y="568"
                                     class="arg-button"
                                   >
@@ -5929,16 +5833,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1597.9296875"
+                                    x="1598"
                                     y="100"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[120,200]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1626.28125"
+                                    x="1626"
                                     y="153"
                                     class="qs-maintext"
                                   >
@@ -5946,7 +5850,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1626.28125"
+                                    x="1626"
                                     y="168"
                                     class="arg-button"
                                   >
@@ -5971,16 +5875,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1597.9296875"
+                                    x="1598"
                                     y="260"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[280,360]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1626.28125"
+                                    x="1626"
                                     y="313"
                                     class="qs-maintext"
                                   >
@@ -5988,7 +5892,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1626.28125"
+                                    x="1626"
                                     y="328"
                                     class="arg-button"
                                   >
@@ -6013,16 +5917,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1597.9296875"
+                                    x="1598"
                                     y="420"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[440,520]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1626.28125"
+                                    x="1626"
                                     y="473"
                                     class="qs-maintext"
                                   >
@@ -6030,7 +5934,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1626.28125"
+                                    x="1626"
                                     y="488"
                                     class="arg-button"
                                   >
@@ -6055,16 +5959,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1597.9296875"
+                                    x="1598"
                                     y="580"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[600,680]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1626.28125"
+                                    x="1626"
                                     y="633"
                                     class="qs-maintext"
                                   >
@@ -6072,7 +5976,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1626.28125"
+                                    x="1626"
                                     y="648"
                                     class="arg-button"
                                   >
@@ -6084,8 +5988,8 @@
                           </g>
                         </g>
                         <g class="gate-control gate-collapse">
-                          <circle cx="1424.52734375" cy="18" r="10" />
-                          <path d="M1417.52734375,18 h14" />
+                          <circle cx="1424" cy="18" r="10" />
+                          <path d="M1417,18 h14" />
                         </g>
                       </g>
                       <g
@@ -6097,9 +6001,9 @@
                       >
                         <rect
                           class="gate-unitary"
-                          x="1686.6328125"
+                          x="1686"
                           y="16"
-                          width="252.10546875"
+                          width="252"
                           height="688"
                           fill-opacity="0"
                           stroke-dasharray="8, 8"
@@ -6119,16 +6023,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1704.6328125"
+                                    x="1704"
                                     y="20"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[40]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="33"
                                     class="qs-maintext"
                                   >
@@ -6136,7 +6040,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="48"
                                     class="arg-button"
                                   >
@@ -6160,16 +6064,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1704.6328125"
+                                    x="1704"
                                     y="100"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[120]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="113"
                                     class="qs-maintext"
                                   >
@@ -6177,7 +6081,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="128"
                                     class="arg-button"
                                   >
@@ -6201,16 +6105,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1704.6328125"
+                                    x="1704"
                                     y="180"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[200]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="193"
                                     class="qs-maintext"
                                   >
@@ -6218,7 +6122,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="208"
                                     class="arg-button"
                                   >
@@ -6242,16 +6146,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1704.6328125"
+                                    x="1704"
                                     y="260"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[280]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="273"
                                     class="qs-maintext"
                                   >
@@ -6259,7 +6163,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="288"
                                     class="arg-button"
                                   >
@@ -6283,16 +6187,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1704.6328125"
+                                    x="1704"
                                     y="340"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[360]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="353"
                                     class="qs-maintext"
                                   >
@@ -6300,7 +6204,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="368"
                                     class="arg-button"
                                   >
@@ -6324,16 +6228,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1704.6328125"
+                                    x="1704"
                                     y="420"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[440]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="433"
                                     class="qs-maintext"
                                   >
@@ -6341,7 +6245,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="448"
                                     class="arg-button"
                                   >
@@ -6365,16 +6269,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1704.6328125"
+                                    x="1704"
                                     y="500"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[520]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="513"
                                     class="qs-maintext"
                                   >
@@ -6382,7 +6286,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="528"
                                     class="arg-button"
                                   >
@@ -6406,16 +6310,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1704.6328125"
+                                    x="1704"
                                     y="580"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[600]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="593"
                                     class="qs-maintext"
                                   >
@@ -6423,7 +6327,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="608"
                                     class="arg-button"
                                   >
@@ -6447,16 +6351,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1704.6328125"
+                                    x="1704"
                                     y="660"
-                                    width="60.69921875"
+                                    width="62"
                                     height="40"
                                     data-wire-ys="[680]"
-                                    data-width="60.69921875"
+                                    data-width="62"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="673"
                                     class="qs-maintext"
                                   >
@@ -6464,7 +6368,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1734.982421875"
+                                    x="1735"
                                     y="688"
                                     class="arg-button"
                                   >
@@ -6489,16 +6393,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1785.33203125"
+                                    x="1786"
                                     y="20"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[40,120]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1813.68359375"
+                                    x="1814"
                                     y="73"
                                     class="qs-maintext"
                                   >
@@ -6506,7 +6410,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1813.68359375"
+                                    x="1814"
                                     y="88"
                                     class="arg-button"
                                   >
@@ -6531,16 +6435,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1785.33203125"
+                                    x="1786"
                                     y="180"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[200,280]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1813.68359375"
+                                    x="1814"
                                     y="233"
                                     class="qs-maintext"
                                   >
@@ -6548,7 +6452,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1813.68359375"
+                                    x="1814"
                                     y="248"
                                     class="arg-button"
                                   >
@@ -6573,16 +6477,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1785.33203125"
+                                    x="1786"
                                     y="340"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[360,440]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1813.68359375"
+                                    x="1814"
                                     y="393"
                                     class="qs-maintext"
                                   >
@@ -6590,7 +6494,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1813.68359375"
+                                    x="1814"
                                     y="408"
                                     class="arg-button"
                                   >
@@ -6615,16 +6519,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1785.33203125"
+                                    x="1786"
                                     y="500"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[520,600]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1813.68359375"
+                                    x="1814"
                                     y="553"
                                     class="qs-maintext"
                                   >
@@ -6632,7 +6536,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1813.68359375"
+                                    x="1814"
                                     y="568"
                                     class="arg-button"
                                   >
@@ -6657,16 +6561,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1862.03515625"
+                                    x="1862"
                                     y="100"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[120,200]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1890.38671875"
+                                    x="1890"
                                     y="153"
                                     class="qs-maintext"
                                   >
@@ -6674,7 +6578,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1890.38671875"
+                                    x="1890"
                                     y="168"
                                     class="arg-button"
                                   >
@@ -6699,16 +6603,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1862.03515625"
+                                    x="1862"
                                     y="260"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[280,360]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1890.38671875"
+                                    x="1890"
                                     y="313"
                                     class="qs-maintext"
                                   >
@@ -6716,7 +6620,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1890.38671875"
+                                    x="1890"
                                     y="328"
                                     class="arg-button"
                                   >
@@ -6741,16 +6645,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1862.03515625"
+                                    x="1862"
                                     y="420"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[440,520]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1890.38671875"
+                                    x="1890"
                                     y="473"
                                     class="qs-maintext"
                                   >
@@ -6758,7 +6662,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1890.38671875"
+                                    x="1890"
                                     y="488"
                                     class="arg-button"
                                   >
@@ -6783,16 +6687,16 @@
                                 <g>
                                   <rect
                                     class="gate-unitary"
-                                    x="1862.03515625"
+                                    x="1862"
                                     y="580"
-                                    width="56.703125"
+                                    width="56"
                                     height="120"
                                     data-wire-ys="[600,680]"
-                                    data-width="56.703125"
+                                    data-width="56"
                                   />
                                   <text
                                     font-size="14"
-                                    x="1890.38671875"
+                                    x="1890"
                                     y="633"
                                     class="qs-maintext"
                                   >
@@ -6800,7 +6704,7 @@
                                   </text>
                                   <text
                                     font-size="12"
-                                    x="1890.38671875"
+                                    x="1890"
                                     y="648"
                                     class="arg-button"
                                   >
@@ -6812,8 +6716,8 @@
                           </g>
                         </g>
                         <g class="gate-control gate-collapse">
-                          <circle cx="1688.6328125" cy="18" r="10" />
-                          <path d="M1681.6328125,18 h14" />
+                          <circle cx="1688" cy="18" r="10" />
+                          <path d="M1681,18 h14" />
                         </g>
                       </g>
                     </g>
@@ -6833,7 +6737,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="1978.73828125"
+                          x="1978"
                           y="20"
                           width="40"
                           height="40"
@@ -6842,12 +6746,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 2013.73828125 42 A 15 12 0 0 0 1983.73828125 42"
+                          d="M 2013 42 A 15 12 0 0 0 1983 42"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="1998.73828125"
-                          x2="2010.73828125"
+                          x1="1998"
+                          x2="2010"
                           y1="48"
                           y2="28"
                           class="qs-line-measure"
@@ -6867,7 +6771,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="1978.73828125"
+                          x="1978"
                           y="100"
                           width="40"
                           height="40"
@@ -6876,12 +6780,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 2013.73828125 122 A 15 12 0 0 0 1983.73828125 122"
+                          d="M 2013 122 A 15 12 0 0 0 1983 122"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="1998.73828125"
-                          x2="2010.73828125"
+                          x1="1998"
+                          x2="2010"
                           y1="128"
                           y2="108"
                           class="qs-line-measure"
@@ -6901,7 +6805,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="1978.73828125"
+                          x="1978"
                           y="180"
                           width="40"
                           height="40"
@@ -6910,12 +6814,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 2013.73828125 202 A 15 12 0 0 0 1983.73828125 202"
+                          d="M 2013 202 A 15 12 0 0 0 1983 202"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="1998.73828125"
-                          x2="2010.73828125"
+                          x1="1998"
+                          x2="2010"
                           y1="208"
                           y2="188"
                           class="qs-line-measure"
@@ -6935,7 +6839,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="1978.73828125"
+                          x="1978"
                           y="260"
                           width="40"
                           height="40"
@@ -6944,12 +6848,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 2013.73828125 282 A 15 12 0 0 0 1983.73828125 282"
+                          d="M 2013 282 A 15 12 0 0 0 1983 282"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="1998.73828125"
-                          x2="2010.73828125"
+                          x1="1998"
+                          x2="2010"
                           y1="288"
                           y2="268"
                           class="qs-line-measure"
@@ -6969,7 +6873,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="1978.73828125"
+                          x="1978"
                           y="340"
                           width="40"
                           height="40"
@@ -6978,12 +6882,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 2013.73828125 362 A 15 12 0 0 0 1983.73828125 362"
+                          d="M 2013 362 A 15 12 0 0 0 1983 362"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="1998.73828125"
-                          x2="2010.73828125"
+                          x1="1998"
+                          x2="2010"
                           y1="368"
                           y2="348"
                           class="qs-line-measure"
@@ -7003,7 +6907,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="1978.73828125"
+                          x="1978"
                           y="420"
                           width="40"
                           height="40"
@@ -7012,12 +6916,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 2013.73828125 442 A 15 12 0 0 0 1983.73828125 442"
+                          d="M 2013 442 A 15 12 0 0 0 1983 442"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="1998.73828125"
-                          x2="2010.73828125"
+                          x1="1998"
+                          x2="2010"
                           y1="448"
                           y2="428"
                           class="qs-line-measure"
@@ -7037,7 +6941,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="1978.73828125"
+                          x="1978"
                           y="500"
                           width="40"
                           height="40"
@@ -7046,12 +6950,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 2013.73828125 522 A 15 12 0 0 0 1983.73828125 522"
+                          d="M 2013 522 A 15 12 0 0 0 1983 522"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="1998.73828125"
-                          x2="2010.73828125"
+                          x1="1998"
+                          x2="2010"
                           y1="528"
                           y2="508"
                           class="qs-line-measure"
@@ -7071,7 +6975,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="1978.73828125"
+                          x="1978"
                           y="580"
                           width="40"
                           height="40"
@@ -7080,12 +6984,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 2013.73828125 602 A 15 12 0 0 0 1983.73828125 602"
+                          d="M 2013 602 A 15 12 0 0 0 1983 602"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="1998.73828125"
-                          x2="2010.73828125"
+                          x1="1998"
+                          x2="2010"
                           y1="608"
                           y2="588"
                           class="qs-line-measure"
@@ -7105,7 +7009,7 @@
                       <g>
                         <rect
                           class="gate-measure"
-                          x="1978.73828125"
+                          x="1978"
                           y="660"
                           width="40"
                           height="40"
@@ -7114,12 +7018,12 @@
                         />
                         <path
                           class="arc-measure"
-                          d="M 2013.73828125 682 A 15 12 0 0 0 1983.73828125 682"
+                          d="M 2013 682 A 15 12 0 0 0 1983 682"
                           style="pointer-events: none"
                         />
                         <line
-                          x1="1998.73828125"
-                          x2="2010.73828125"
+                          x1="1998"
+                          x2="2010"
                           y1="688"
                           y2="668"
                           class="qs-line-measure"
@@ -7140,7 +7044,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="2038.73828125"
+                            x="2038"
                             y="20"
                             width="40"
                             height="40"
@@ -7149,7 +7053,7 @@
                           />
                           <text
                             font-size="14"
-                            x="2058.73828125"
+                            x="2058"
                             y="40"
                             class="qs-maintext ket-text"
                           >
@@ -7171,7 +7075,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="2038.73828125"
+                            x="2038"
                             y="100"
                             width="40"
                             height="40"
@@ -7180,7 +7084,7 @@
                           />
                           <text
                             font-size="14"
-                            x="2058.73828125"
+                            x="2058"
                             y="120"
                             class="qs-maintext ket-text"
                           >
@@ -7202,7 +7106,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="2038.73828125"
+                            x="2038"
                             y="180"
                             width="40"
                             height="40"
@@ -7211,7 +7115,7 @@
                           />
                           <text
                             font-size="14"
-                            x="2058.73828125"
+                            x="2058"
                             y="200"
                             class="qs-maintext ket-text"
                           >
@@ -7233,7 +7137,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="2038.73828125"
+                            x="2038"
                             y="260"
                             width="40"
                             height="40"
@@ -7242,7 +7146,7 @@
                           />
                           <text
                             font-size="14"
-                            x="2058.73828125"
+                            x="2058"
                             y="280"
                             class="qs-maintext ket-text"
                           >
@@ -7264,7 +7168,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="2038.73828125"
+                            x="2038"
                             y="340"
                             width="40"
                             height="40"
@@ -7273,7 +7177,7 @@
                           />
                           <text
                             font-size="14"
-                            x="2058.73828125"
+                            x="2058"
                             y="360"
                             class="qs-maintext ket-text"
                           >
@@ -7295,7 +7199,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="2038.73828125"
+                            x="2038"
                             y="420"
                             width="40"
                             height="40"
@@ -7304,7 +7208,7 @@
                           />
                           <text
                             font-size="14"
-                            x="2058.73828125"
+                            x="2058"
                             y="440"
                             class="qs-maintext ket-text"
                           >
@@ -7326,7 +7230,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="2038.73828125"
+                            x="2038"
                             y="500"
                             width="40"
                             height="40"
@@ -7335,7 +7239,7 @@
                           />
                           <text
                             font-size="14"
-                            x="2058.73828125"
+                            x="2058"
                             y="520"
                             class="qs-maintext ket-text"
                           >
@@ -7357,7 +7261,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="2038.73828125"
+                            x="2038"
                             y="580"
                             width="40"
                             height="40"
@@ -7366,7 +7270,7 @@
                           />
                           <text
                             font-size="14"
-                            x="2058.73828125"
+                            x="2058"
                             y="600"
                             class="qs-maintext ket-text"
                           >
@@ -7388,7 +7292,7 @@
                         <g>
                           <rect
                             class="gate-ket"
-                            x="2038.73828125"
+                            x="2038"
                             y="660"
                             width="40"
                             height="40"
@@ -7397,7 +7301,7 @@
                           />
                           <text
                             font-size="14"
-                            x="2058.73828125"
+                            x="2058"
                             y="680"
                             class="qs-maintext ket-text"
                           >

--- a/source/npm/qsharp/test/circuits-cases/nested-callables.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/nested-callables.qs.snapshot.html
@@ -13,10 +13,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="401.8203125"
+        width="394"
         height="280"
         style="max-width: fit-content"
-        viewBox="0 0 401 280"
+        viewBox="0 0 394 280"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -55,19 +55,19 @@
           </a>
         </g>
         <g class="wires">
-          <line x1="40" x2="401.8203125" y1="40" y2="40" class="qubit-wire" />
-          <line x1="40" x2="401.8203125" y1="160" y2="160" class="qubit-wire" />
+          <line x1="40" x2="394" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="394" y1="160" y2="160" class="qubit-wire" />
           <g>
             <line
-              x1="184.84814453125"
-              x2="401.8203125"
+              x1="182.5"
+              x2="394"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="182.84814453125"
-              x2="401.8203125"
+              x1="180.5"
+              x2="394"
               y1="81"
               y2="81"
               class="register-classical"
@@ -75,15 +75,15 @@
           </g>
           <g>
             <line
-              x1="310.75830078125"
-              x2="401.8203125"
+              x1="304.5"
+              x2="394"
               y1="119"
               y2="119"
               class="register-classical"
             />
             <line
-              x1="308.75830078125"
-              x2="401.8203125"
+              x1="302.5"
+              x2="394"
               y1="121"
               y2="121"
               class="register-classical"
@@ -91,15 +91,15 @@
           </g>
           <g>
             <line
-              x1="184.84814453125"
-              x2="401.8203125"
+              x1="182.5"
+              x2="394"
               y1="199"
               y2="199"
               class="register-classical"
             />
             <line
-              x1="182.84814453125"
-              x2="401.8203125"
+              x1="180.5"
+              x2="394"
               y1="201"
               y2="201"
               class="register-classical"
@@ -107,15 +107,15 @@
           </g>
           <g>
             <line
-              x1="310.75830078125"
-              x2="401.8203125"
+              x1="304.5"
+              x2="394"
               y1="239"
               y2="239"
               class="register-classical"
             />
             <line
-              x1="308.75830078125"
-              x2="401.8203125"
+              x1="302.5"
+              x2="394"
               y1="241"
               y2="241"
               class="register-classical"
@@ -134,7 +134,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="311.8203125"
+              width="304"
               height="260"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -151,7 +151,7 @@
                   class="gate-unitary"
                   x="74"
                   y="12"
-                  width="277.8203125"
+                  width="270"
                   height="256"
                   fill-opacity="0"
                   stroke-dasharray="8, 8"
@@ -171,14 +171,14 @@
                             class="gate-unitary"
                             x="100"
                             y="20"
-                            width="41.7861328125"
+                            width="41"
                             height="40"
                             data-wire-ys="[40]"
-                            data-width="41.7861328125"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="120.89306640625"
+                            x="120.5"
                             y="40"
                             class="qs-maintext"
                           >
@@ -206,14 +206,14 @@
                             class="gate-unitary"
                             x="100"
                             y="140"
-                            width="41.7861328125"
+                            width="41"
                             height="40"
                             data-wire-ys="[160]"
-                            data-width="41.7861328125"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="120.89306640625"
+                            x="120.5"
                             y="160"
                             class="qs-maintext"
                           >
@@ -239,16 +239,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="161.7861328125"
+                            x="161"
                             y="20"
-                            width="44.1240234375"
+                            width="41"
                             height="80"
                             data-wire-ys="[40,80]"
-                            data-width="44.1240234375"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="183.84814453125"
+                            x="181.5"
                             y="60"
                             class="qs-maintext"
                           >
@@ -258,8 +258,8 @@
                       </g>
                     </a>
                     <g class="gate-control gate-expand">
-                      <circle cx="163.7861328125" cy="22" r="10" />
-                      <path d="M163.7861328125,15 v14 M156.7861328125,22 h14" />
+                      <circle cx="163" cy="22" r="10" />
+                      <path d="M163,15 v14 M156,22 h14" />
                     </g>
                   </g>
                   <g
@@ -274,16 +274,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="161.7861328125"
+                            x="161"
                             y="140"
-                            width="44.1240234375"
+                            width="41"
                             height="80"
                             data-wire-ys="[160,200]"
-                            data-width="44.1240234375"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="183.84814453125"
+                            x="181.5"
                             y="180"
                             class="qs-maintext"
                           >
@@ -293,10 +293,8 @@
                       </g>
                     </a>
                     <g class="gate-control gate-expand">
-                      <circle cx="163.7861328125" cy="142" r="10" />
-                      <path
-                        d="M163.7861328125,135 v14 M156.7861328125,142 h14"
-                      />
+                      <circle cx="163" cy="142" r="10" />
+                      <path d="M163,135 v14 M156,142 h14" />
                     </g>
                   </g>
                   <g
@@ -311,16 +309,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="225.91015625"
+                            x="222"
                             y="20"
-                            width="41.7861328125"
+                            width="41"
                             height="40"
                             data-wire-ys="[40]"
-                            data-width="41.7861328125"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="246.80322265625"
+                            x="242.5"
                             y="40"
                             class="qs-maintext"
                           >
@@ -330,8 +328,8 @@
                       </g>
                     </a>
                     <g class="gate-control gate-expand">
-                      <circle cx="227.91015625" cy="22" r="10" />
-                      <path d="M227.91015625,15 v14 M220.91015625,22 h14" />
+                      <circle cx="224" cy="22" r="10" />
+                      <path d="M224,15 v14 M217,22 h14" />
                     </g>
                   </g>
                   <g
@@ -346,16 +344,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="225.91015625"
+                            x="222"
                             y="140"
-                            width="41.7861328125"
+                            width="41"
                             height="40"
                             data-wire-ys="[160]"
-                            data-width="41.7861328125"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="246.80322265625"
+                            x="242.5"
                             y="160"
                             class="qs-maintext"
                           >
@@ -365,8 +363,8 @@
                       </g>
                     </a>
                     <g class="gate-control gate-expand">
-                      <circle cx="227.91015625" cy="142" r="10" />
-                      <path d="M227.91015625,135 v14 M220.91015625,142 h14" />
+                      <circle cx="224" cy="142" r="10" />
+                      <path d="M224,135 v14 M217,142 h14" />
                     </g>
                   </g>
                   <g
@@ -379,8 +377,8 @@
                       <title>nested-callables.qs:12:5 Foo(q1);</title>
                       <g>
                         <line
-                          x1="309.75830078125"
-                          x2="309.75830078125"
+                          x1="303.5"
+                          x2="303.5"
                           y1="40"
                           y2="120"
                           stroke-dasharray="8, 8"
@@ -388,16 +386,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="287.6962890625"
+                            x="283"
                             y="20"
-                            width="44.1240234375"
+                            width="41"
                             height="40"
                             data-wire-ys="[40]"
-                            data-width="44.1240234375"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="309.75830078125"
+                            x="303.5"
                             y="40"
                             class="qs-maintext"
                           >
@@ -407,16 +405,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="287.6962890625"
+                            x="283"
                             y="100"
-                            width="44.1240234375"
+                            width="41"
                             height="40"
                             data-wire-ys="[120]"
-                            data-width="44.1240234375"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="309.75830078125"
+                            x="303.5"
                             y="120"
                             class="qs-maintext"
                           >
@@ -426,8 +424,8 @@
                       </g>
                     </a>
                     <g class="gate-control gate-expand">
-                      <circle cx="289.6962890625" cy="22" r="10" />
-                      <path d="M289.6962890625,15 v14 M282.6962890625,22 h14" />
+                      <circle cx="285" cy="22" r="10" />
+                      <path d="M285,15 v14 M278,22 h14" />
                     </g>
                   </g>
                   <g
@@ -440,8 +438,8 @@
                       <title>nested-callables.qs:15:5 Foo(q2);</title>
                       <g>
                         <line
-                          x1="309.75830078125"
-                          x2="309.75830078125"
+                          x1="303.5"
+                          x2="303.5"
                           y1="160"
                           y2="240"
                           stroke-dasharray="8, 8"
@@ -449,16 +447,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="287.6962890625"
+                            x="283"
                             y="140"
-                            width="44.1240234375"
+                            width="41"
                             height="40"
                             data-wire-ys="[160]"
-                            data-width="44.1240234375"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="309.75830078125"
+                            x="303.5"
                             y="160"
                             class="qs-maintext"
                           >
@@ -468,16 +466,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="287.6962890625"
+                            x="283"
                             y="220"
-                            width="44.1240234375"
+                            width="41"
                             height="40"
                             data-wire-ys="[240]"
-                            data-width="44.1240234375"
+                            data-width="41"
                           />
                           <text
                             font-size="14"
-                            x="309.75830078125"
+                            x="303.5"
                             y="240"
                             class="qs-maintext"
                           >
@@ -487,10 +485,8 @@
                       </g>
                     </a>
                     <g class="gate-control gate-expand">
-                      <circle cx="289.6962890625" cy="142" r="10" />
-                      <path
-                        d="M289.6962890625,135 v14 M282.6962890625,142 h14"
-                      />
+                      <circle cx="285" cy="142" r="10" />
+                      <path d="M285,135 v14 M278,142 h14" />
                     </g>
                   </g>
                 </g>

--- a/source/npm/qsharp/test/circuits-cases/ops-with-gap-ranges.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/ops-with-gap-ranges.qs.snapshot.html
@@ -13,10 +13,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="365.91015625"
+        width="362"
         height="840"
         style="max-width: fit-content"
-        viewBox="0 0 365 840"
+        viewBox="0 0 362 840"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -191,95 +191,41 @@
           </a>
         </g>
         <g class="wires">
-          <line x1="40" x2="365.91015625" y1="40" y2="40" class="qubit-wire" />
-          <line
-            x1="40"
-            x2="365.91015625"
-            y1="120"
-            y2="120"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="365.91015625"
-            y1="200"
-            y2="200"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="365.91015625"
-            y1="280"
-            y2="280"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="365.91015625"
-            y1="360"
-            y2="360"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="365.91015625"
-            y1="440"
-            y2="440"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="365.91015625"
-            y1="520"
-            y2="520"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="365.91015625"
-            y1="600"
-            y2="600"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="365.91015625"
-            y1="680"
-            y2="680"
-            class="qubit-wire"
-          />
-          <line
-            x1="40"
-            x2="365.91015625"
-            y1="760"
-            y2="760"
-            class="qubit-wire"
-          />
+          <line x1="40" x2="362" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="362" y1="120" y2="120" class="qubit-wire" />
+          <line x1="40" x2="362" y1="200" y2="200" class="qubit-wire" />
+          <line x1="40" x2="362" y1="280" y2="280" class="qubit-wire" />
+          <line x1="40" x2="362" y1="360" y2="360" class="qubit-wire" />
+          <line x1="40" x2="362" y1="440" y2="440" class="qubit-wire" />
+          <line x1="40" x2="362" y1="520" y2="520" class="qubit-wire" />
+          <line x1="40" x2="362" y1="600" y2="600" class="qubit-wire" />
+          <line x1="40" x2="362" y1="680" y2="680" class="qubit-wire" />
+          <line x1="40" x2="362" y1="760" y2="760" class="qubit-wire" />
           <g>
             <line
-              x1="176.01708984375"
-              x2="176.01708984375"
+              x1="172.5"
+              x2="172.5"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="174.01708984375"
-              x2="174.01708984375"
+              x1="170.5"
+              x2="170.5"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="176.01708984375"
-              x2="365.91015625"
+              x1="172.5"
+              x2="362"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="174.01708984375"
-              x2="365.91015625"
+              x1="170.5"
+              x2="362"
               y1="81"
               y2="81"
               class="register-classical"
@@ -287,29 +233,29 @@
           </g>
           <g>
             <line
-              x1="236.91015625"
-              x2="236.91015625"
+              x1="233"
+              x2="233"
               y1="120"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="234.91015625"
+              x1="231"
+              x2="231"
               y1="120"
               y2="161"
               class="register-classical"
             />
             <line
-              x1="236.91015625"
-              x2="365.91015625"
+              x1="233"
+              x2="362"
               y1="159"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="365.91015625"
+              x1="231"
+              x2="362"
               y1="161"
               y2="161"
               class="register-classical"
@@ -317,29 +263,29 @@
           </g>
           <g>
             <line
-              x1="236.91015625"
-              x2="236.91015625"
+              x1="233"
+              x2="233"
               y1="200"
               y2="239"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="234.91015625"
+              x1="231"
+              x2="231"
               y1="200"
               y2="241"
               class="register-classical"
             />
             <line
-              x1="236.91015625"
-              x2="365.91015625"
+              x1="233"
+              x2="362"
               y1="239"
               y2="239"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="365.91015625"
+              x1="231"
+              x2="362"
               y1="241"
               y2="241"
               class="register-classical"
@@ -347,29 +293,29 @@
           </g>
           <g>
             <line
-              x1="236.91015625"
-              x2="236.91015625"
+              x1="233"
+              x2="233"
               y1="280"
               y2="319"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="234.91015625"
+              x1="231"
+              x2="231"
               y1="280"
               y2="321"
               class="register-classical"
             />
             <line
-              x1="236.91015625"
-              x2="365.91015625"
+              x1="233"
+              x2="362"
               y1="319"
               y2="319"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="365.91015625"
+              x1="231"
+              x2="362"
               y1="321"
               y2="321"
               class="register-classical"
@@ -377,29 +323,29 @@
           </g>
           <g>
             <line
-              x1="236.91015625"
-              x2="236.91015625"
+              x1="233"
+              x2="233"
               y1="360"
               y2="399"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="234.91015625"
+              x1="231"
+              x2="231"
               y1="360"
               y2="401"
               class="register-classical"
             />
             <line
-              x1="236.91015625"
-              x2="365.91015625"
+              x1="233"
+              x2="362"
               y1="399"
               y2="399"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="365.91015625"
+              x1="231"
+              x2="362"
               y1="401"
               y2="401"
               class="register-classical"
@@ -407,29 +353,29 @@
           </g>
           <g>
             <line
-              x1="236.91015625"
-              x2="236.91015625"
+              x1="233"
+              x2="233"
               y1="440"
               y2="479"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="234.91015625"
+              x1="231"
+              x2="231"
               y1="440"
               y2="481"
               class="register-classical"
             />
             <line
-              x1="236.91015625"
-              x2="365.91015625"
+              x1="233"
+              x2="362"
               y1="479"
               y2="479"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="365.91015625"
+              x1="231"
+              x2="362"
               y1="481"
               y2="481"
               class="register-classical"
@@ -437,29 +383,29 @@
           </g>
           <g>
             <line
-              x1="236.91015625"
-              x2="236.91015625"
+              x1="233"
+              x2="233"
               y1="520"
               y2="559"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="234.91015625"
+              x1="231"
+              x2="231"
               y1="520"
               y2="561"
               class="register-classical"
             />
             <line
-              x1="236.91015625"
-              x2="365.91015625"
+              x1="233"
+              x2="362"
               y1="559"
               y2="559"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="365.91015625"
+              x1="231"
+              x2="362"
               y1="561"
               y2="561"
               class="register-classical"
@@ -467,29 +413,29 @@
           </g>
           <g>
             <line
-              x1="236.91015625"
-              x2="236.91015625"
+              x1="233"
+              x2="233"
               y1="600"
               y2="639"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="234.91015625"
+              x1="231"
+              x2="231"
               y1="600"
               y2="641"
               class="register-classical"
             />
             <line
-              x1="236.91015625"
-              x2="365.91015625"
+              x1="233"
+              x2="362"
               y1="639"
               y2="639"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="365.91015625"
+              x1="231"
+              x2="362"
               y1="641"
               y2="641"
               class="register-classical"
@@ -497,29 +443,29 @@
           </g>
           <g>
             <line
-              x1="236.91015625"
-              x2="236.91015625"
+              x1="233"
+              x2="233"
               y1="680"
               y2="719"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="234.91015625"
+              x1="231"
+              x2="231"
               y1="680"
               y2="721"
               class="register-classical"
             />
             <line
-              x1="236.91015625"
-              x2="365.91015625"
+              x1="233"
+              x2="362"
               y1="719"
               y2="719"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="365.91015625"
+              x1="231"
+              x2="362"
               y1="721"
               y2="721"
               class="register-classical"
@@ -527,29 +473,29 @@
           </g>
           <g>
             <line
-              x1="236.91015625"
-              x2="236.91015625"
+              x1="233"
+              x2="233"
               y1="760"
               y2="799"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="234.91015625"
+              x1="231"
+              x2="231"
               y1="760"
               y2="801"
               class="register-classical"
             />
             <line
-              x1="236.91015625"
-              x2="365.91015625"
+              x1="233"
+              x2="362"
               y1="799"
               y2="799"
               class="register-classical"
             />
             <line
-              x1="234.91015625"
-              x2="365.91015625"
+              x1="231"
+              x2="362"
               y1="801"
               y2="801"
               class="register-classical"
@@ -568,7 +514,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="275.91015625"
+              width="272"
               height="820"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -584,8 +530,8 @@
                   <title>ops-with-gap-ranges.qs:3:5 Foo(qs);</title>
                   <g>
                     <line
-                      x1="112.06201171875"
-                      x2="112.06201171875"
+                      x1="110.5"
+                      x2="110.5"
                       y1="40"
                       y2="520"
                       stroke-dasharray="8, 8"
@@ -595,17 +541,12 @@
                         class="gate-unitary"
                         x="90"
                         y="20"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
-                      <text
-                        font-size="14"
-                        x="112.06201171875"
-                        y="40"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="110.5" y="40" class="qs-maintext">
                         <tspan class="qs-mathtext">Foo</tspan>
                       </text>
                     </g>
@@ -614,14 +555,14 @@
                         class="gate-unitary"
                         x="90"
                         y="180"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[200]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="112.06201171875"
+                        x="110.5"
                         y="200"
                         class="qs-maintext"
                       >
@@ -633,14 +574,14 @@
                         class="gate-unitary"
                         x="90"
                         y="340"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[360]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="112.06201171875"
+                        x="110.5"
                         y="360"
                         class="qs-maintext"
                       >
@@ -652,14 +593,14 @@
                         class="gate-unitary"
                         x="90"
                         y="500"
-                        width="44.1240234375"
+                        width="41"
                         height="40"
                         data-wire-ys="[520]"
-                        data-width="44.1240234375"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="112.06201171875"
+                        x="110.5"
                         y="520"
                         class="qs-maintext"
                       >
@@ -684,7 +625,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="155.01708984375"
+                      x="151.5"
                       y="20"
                       width="40"
                       height="40"
@@ -693,12 +634,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 190.01708984375 42 A 15 12 0 0 0 160.01708984375 42"
+                      d="M 186.5 42 A 15 12 0 0 0 156.5 42"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="175.01708984375"
-                      x2="187.01708984375"
+                      x1="171.5"
+                      x2="183.5"
                       y1="48"
                       y2="28"
                       class="qs-line-measure"
@@ -717,8 +658,8 @@
                   <title>ops-with-gap-ranges.qs:4:5 Bar(qs);</title>
                   <g>
                     <line
-                      x1="175.01708984375"
-                      x2="175.01708984375"
+                      x1="171.5"
+                      x2="171.5"
                       y1="120"
                       y2="760"
                       stroke-dasharray="8, 8"
@@ -726,16 +667,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="154.1240234375"
+                        x="151"
                         y="100"
-                        width="41.7861328125"
+                        width="41"
                         height="40"
                         data-wire-ys="[120]"
-                        data-width="41.7861328125"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="175.01708984375"
+                        x="171.5"
                         y="120"
                         class="qs-maintext"
                       >
@@ -745,16 +686,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="154.1240234375"
+                        x="151"
                         y="260"
-                        width="41.7861328125"
+                        width="41"
                         height="40"
                         data-wire-ys="[280]"
-                        data-width="41.7861328125"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="175.01708984375"
+                        x="171.5"
                         y="280"
                         class="qs-maintext"
                       >
@@ -764,16 +705,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="154.1240234375"
+                        x="151"
                         y="420"
-                        width="41.7861328125"
+                        width="41"
                         height="40"
                         data-wire-ys="[440]"
-                        data-width="41.7861328125"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="175.01708984375"
+                        x="171.5"
                         y="440"
                         class="qs-maintext"
                       >
@@ -783,16 +724,16 @@
                     <g>
                       <rect
                         class="gate-unitary"
-                        x="154.1240234375"
+                        x="151"
                         y="740"
-                        width="41.7861328125"
+                        width="41"
                         height="40"
                         data-wire-ys="[760]"
-                        data-width="41.7861328125"
+                        data-width="41"
                       />
                       <text
                         font-size="14"
-                        x="175.01708984375"
+                        x="171.5"
                         y="760"
                         class="qs-maintext"
                       >
@@ -802,8 +743,8 @@
                   </g>
                 </a>
                 <g class="gate-control gate-expand">
-                  <circle cx="156.1240234375" cy="102" r="10" />
-                  <path d="M156.1240234375,95 v14 M149.1240234375,102 h14" />
+                  <circle cx="153" cy="102" r="10" />
+                  <path d="M153,95 v14 M146,102 h14" />
                 </g>
               </g>
               <g
@@ -818,7 +759,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="215.91015625"
+                        x="212"
                         y="20"
                         width="40"
                         height="40"
@@ -827,7 +768,7 @@
                       />
                       <text
                         font-size="14"
-                        x="235.91015625"
+                        x="232"
                         y="40"
                         class="qs-maintext ket-text"
                       >
@@ -848,7 +789,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="215.91015625"
+                      x="212"
                       y="100"
                       width="40"
                       height="40"
@@ -857,12 +798,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 250.91015625 122 A 15 12 0 0 0 220.91015625 122"
+                      d="M 247 122 A 15 12 0 0 0 217 122"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="235.91015625"
-                      x2="247.91015625"
+                      x1="232"
+                      x2="244"
                       y1="128"
                       y2="108"
                       class="qs-line-measure"
@@ -882,7 +823,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="215.91015625"
+                      x="212"
                       y="180"
                       width="40"
                       height="40"
@@ -891,12 +832,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 250.91015625 202 A 15 12 0 0 0 220.91015625 202"
+                      d="M 247 202 A 15 12 0 0 0 217 202"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="235.91015625"
-                      x2="247.91015625"
+                      x1="232"
+                      x2="244"
                       y1="208"
                       y2="188"
                       class="qs-line-measure"
@@ -916,7 +857,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="215.91015625"
+                      x="212"
                       y="260"
                       width="40"
                       height="40"
@@ -925,12 +866,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 250.91015625 282 A 15 12 0 0 0 220.91015625 282"
+                      d="M 247 282 A 15 12 0 0 0 217 282"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="235.91015625"
-                      x2="247.91015625"
+                      x1="232"
+                      x2="244"
                       y1="288"
                       y2="268"
                       class="qs-line-measure"
@@ -950,7 +891,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="215.91015625"
+                      x="212"
                       y="340"
                       width="40"
                       height="40"
@@ -959,12 +900,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 250.91015625 362 A 15 12 0 0 0 220.91015625 362"
+                      d="M 247 362 A 15 12 0 0 0 217 362"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="235.91015625"
-                      x2="247.91015625"
+                      x1="232"
+                      x2="244"
                       y1="368"
                       y2="348"
                       class="qs-line-measure"
@@ -984,7 +925,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="215.91015625"
+                      x="212"
                       y="420"
                       width="40"
                       height="40"
@@ -993,12 +934,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 250.91015625 442 A 15 12 0 0 0 220.91015625 442"
+                      d="M 247 442 A 15 12 0 0 0 217 442"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="235.91015625"
-                      x2="247.91015625"
+                      x1="232"
+                      x2="244"
                       y1="448"
                       y2="428"
                       class="qs-line-measure"
@@ -1018,7 +959,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="215.91015625"
+                      x="212"
                       y="500"
                       width="40"
                       height="40"
@@ -1027,12 +968,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 250.91015625 522 A 15 12 0 0 0 220.91015625 522"
+                      d="M 247 522 A 15 12 0 0 0 217 522"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="235.91015625"
-                      x2="247.91015625"
+                      x1="232"
+                      x2="244"
                       y1="528"
                       y2="508"
                       class="qs-line-measure"
@@ -1052,7 +993,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="215.91015625"
+                      x="212"
                       y="580"
                       width="40"
                       height="40"
@@ -1061,12 +1002,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 250.91015625 602 A 15 12 0 0 0 220.91015625 602"
+                      d="M 247 602 A 15 12 0 0 0 217 602"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="235.91015625"
-                      x2="247.91015625"
+                      x1="232"
+                      x2="244"
                       y1="608"
                       y2="588"
                       class="qs-line-measure"
@@ -1086,7 +1027,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="215.91015625"
+                      x="212"
                       y="660"
                       width="40"
                       height="40"
@@ -1095,12 +1036,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 250.91015625 682 A 15 12 0 0 0 220.91015625 682"
+                      d="M 247 682 A 15 12 0 0 0 217 682"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="235.91015625"
-                      x2="247.91015625"
+                      x1="232"
+                      x2="244"
                       y1="688"
                       y2="668"
                       class="qs-line-measure"
@@ -1120,7 +1061,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="215.91015625"
+                      x="212"
                       y="740"
                       width="40"
                       height="40"
@@ -1129,12 +1070,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 250.91015625 762 A 15 12 0 0 0 220.91015625 762"
+                      d="M 247 762 A 15 12 0 0 0 217 762"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="235.91015625"
-                      x2="247.91015625"
+                      x1="232"
+                      x2="244"
                       y1="768"
                       y2="748"
                       class="qs-line-measure"
@@ -1155,7 +1096,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="275.91015625"
+                        x="272"
                         y="100"
                         width="40"
                         height="40"
@@ -1164,7 +1105,7 @@
                       />
                       <text
                         font-size="14"
-                        x="295.91015625"
+                        x="292"
                         y="120"
                         class="qs-maintext ket-text"
                       >
@@ -1186,7 +1127,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="275.91015625"
+                        x="272"
                         y="180"
                         width="40"
                         height="40"
@@ -1195,7 +1136,7 @@
                       />
                       <text
                         font-size="14"
-                        x="295.91015625"
+                        x="292"
                         y="200"
                         class="qs-maintext ket-text"
                       >
@@ -1217,7 +1158,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="275.91015625"
+                        x="272"
                         y="260"
                         width="40"
                         height="40"
@@ -1226,7 +1167,7 @@
                       />
                       <text
                         font-size="14"
-                        x="295.91015625"
+                        x="292"
                         y="280"
                         class="qs-maintext ket-text"
                       >
@@ -1248,7 +1189,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="275.91015625"
+                        x="272"
                         y="340"
                         width="40"
                         height="40"
@@ -1257,7 +1198,7 @@
                       />
                       <text
                         font-size="14"
-                        x="295.91015625"
+                        x="292"
                         y="360"
                         class="qs-maintext ket-text"
                       >
@@ -1279,7 +1220,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="275.91015625"
+                        x="272"
                         y="420"
                         width="40"
                         height="40"
@@ -1288,7 +1229,7 @@
                       />
                       <text
                         font-size="14"
-                        x="295.91015625"
+                        x="292"
                         y="440"
                         class="qs-maintext ket-text"
                       >
@@ -1310,7 +1251,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="275.91015625"
+                        x="272"
                         y="500"
                         width="40"
                         height="40"
@@ -1319,7 +1260,7 @@
                       />
                       <text
                         font-size="14"
-                        x="295.91015625"
+                        x="292"
                         y="520"
                         class="qs-maintext ket-text"
                       >
@@ -1341,7 +1282,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="275.91015625"
+                        x="272"
                         y="580"
                         width="40"
                         height="40"
@@ -1350,7 +1291,7 @@
                       />
                       <text
                         font-size="14"
-                        x="295.91015625"
+                        x="292"
                         y="600"
                         class="qs-maintext ket-text"
                       >
@@ -1372,7 +1313,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="275.91015625"
+                        x="272"
                         y="660"
                         width="40"
                         height="40"
@@ -1381,7 +1322,7 @@
                       />
                       <text
                         font-size="14"
-                        x="295.91015625"
+                        x="292"
                         y="680"
                         class="qs-maintext ket-text"
                       >
@@ -1403,7 +1344,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="275.91015625"
+                        x="272"
                         y="740"
                         width="40"
                         height="40"
@@ -1412,7 +1353,7 @@
                       />
                       <text
                         font-size="14"
-                        x="295.91015625"
+                        x="292"
                         y="760"
                         class="qs-maintext ket-text"
                       >
@@ -1436,10 +1377,10 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="453.40625"
+        width="452"
         height="840"
         style="max-width: fit-content"
-        viewBox="0 0 453 840"
+        viewBox="0 0 452 840"
       >
         <g class="qubit-input-states">
           <a href="#" class="qs-circuit-source-link">
@@ -1614,41 +1555,41 @@
           </a>
         </g>
         <g class="wires">
-          <line x1="40" x2="453.40625" y1="40" y2="40" class="qubit-wire" />
-          <line x1="40" x2="453.40625" y1="120" y2="120" class="qubit-wire" />
-          <line x1="40" x2="453.40625" y1="200" y2="200" class="qubit-wire" />
-          <line x1="40" x2="453.40625" y1="280" y2="280" class="qubit-wire" />
-          <line x1="40" x2="453.40625" y1="360" y2="360" class="qubit-wire" />
-          <line x1="40" x2="453.40625" y1="440" y2="440" class="qubit-wire" />
-          <line x1="40" x2="453.40625" y1="520" y2="520" class="qubit-wire" />
-          <line x1="40" x2="453.40625" y1="600" y2="600" class="qubit-wire" />
-          <line x1="40" x2="453.40625" y1="680" y2="680" class="qubit-wire" />
-          <line x1="40" x2="453.40625" y1="760" y2="760" class="qubit-wire" />
+          <line x1="40" x2="452" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="452" y1="120" y2="120" class="qubit-wire" />
+          <line x1="40" x2="452" y1="200" y2="200" class="qubit-wire" />
+          <line x1="40" x2="452" y1="280" y2="280" class="qubit-wire" />
+          <line x1="40" x2="452" y1="360" y2="360" class="qubit-wire" />
+          <line x1="40" x2="452" y1="440" y2="440" class="qubit-wire" />
+          <line x1="40" x2="452" y1="520" y2="520" class="qubit-wire" />
+          <line x1="40" x2="452" y1="600" y2="600" class="qubit-wire" />
+          <line x1="40" x2="452" y1="680" y2="680" class="qubit-wire" />
+          <line x1="40" x2="452" y1="760" y2="760" class="qubit-wire" />
           <g>
             <line
-              x1="241.0546875"
-              x2="241.0546875"
+              x1="240"
+              x2="240"
               y1="40"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="239.0546875"
-              x2="239.0546875"
+              x1="238"
+              x2="238"
               y1="40"
               y2="81"
               class="register-classical"
             />
             <line
-              x1="241.0546875"
-              x2="453.40625"
+              x1="240"
+              x2="452"
               y1="79"
               y2="79"
               class="register-classical"
             />
             <line
-              x1="239.0546875"
-              x2="453.40625"
+              x1="238"
+              x2="452"
               y1="81"
               y2="81"
               class="register-classical"
@@ -1656,29 +1597,29 @@
           </g>
           <g>
             <line
-              x1="324.40625"
-              x2="324.40625"
+              x1="323"
+              x2="323"
               y1="120"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="322.40625"
+              x1="321"
+              x2="321"
               y1="120"
               y2="161"
               class="register-classical"
             />
             <line
-              x1="324.40625"
-              x2="453.40625"
+              x1="323"
+              x2="452"
               y1="159"
               y2="159"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="453.40625"
+              x1="321"
+              x2="452"
               y1="161"
               y2="161"
               class="register-classical"
@@ -1686,29 +1627,29 @@
           </g>
           <g>
             <line
-              x1="324.40625"
-              x2="324.40625"
+              x1="323"
+              x2="323"
               y1="200"
               y2="239"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="322.40625"
+              x1="321"
+              x2="321"
               y1="200"
               y2="241"
               class="register-classical"
             />
             <line
-              x1="324.40625"
-              x2="453.40625"
+              x1="323"
+              x2="452"
               y1="239"
               y2="239"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="453.40625"
+              x1="321"
+              x2="452"
               y1="241"
               y2="241"
               class="register-classical"
@@ -1716,29 +1657,29 @@
           </g>
           <g>
             <line
-              x1="324.40625"
-              x2="324.40625"
+              x1="323"
+              x2="323"
               y1="280"
               y2="319"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="322.40625"
+              x1="321"
+              x2="321"
               y1="280"
               y2="321"
               class="register-classical"
             />
             <line
-              x1="324.40625"
-              x2="453.40625"
+              x1="323"
+              x2="452"
               y1="319"
               y2="319"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="453.40625"
+              x1="321"
+              x2="452"
               y1="321"
               y2="321"
               class="register-classical"
@@ -1746,29 +1687,29 @@
           </g>
           <g>
             <line
-              x1="324.40625"
-              x2="324.40625"
+              x1="323"
+              x2="323"
               y1="360"
               y2="399"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="322.40625"
+              x1="321"
+              x2="321"
               y1="360"
               y2="401"
               class="register-classical"
             />
             <line
-              x1="324.40625"
-              x2="453.40625"
+              x1="323"
+              x2="452"
               y1="399"
               y2="399"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="453.40625"
+              x1="321"
+              x2="452"
               y1="401"
               y2="401"
               class="register-classical"
@@ -1776,29 +1717,29 @@
           </g>
           <g>
             <line
-              x1="324.40625"
-              x2="324.40625"
+              x1="323"
+              x2="323"
               y1="440"
               y2="479"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="322.40625"
+              x1="321"
+              x2="321"
               y1="440"
               y2="481"
               class="register-classical"
             />
             <line
-              x1="324.40625"
-              x2="453.40625"
+              x1="323"
+              x2="452"
               y1="479"
               y2="479"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="453.40625"
+              x1="321"
+              x2="452"
               y1="481"
               y2="481"
               class="register-classical"
@@ -1806,29 +1747,29 @@
           </g>
           <g>
             <line
-              x1="324.40625"
-              x2="324.40625"
+              x1="323"
+              x2="323"
               y1="520"
               y2="559"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="322.40625"
+              x1="321"
+              x2="321"
               y1="520"
               y2="561"
               class="register-classical"
             />
             <line
-              x1="324.40625"
-              x2="453.40625"
+              x1="323"
+              x2="452"
               y1="559"
               y2="559"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="453.40625"
+              x1="321"
+              x2="452"
               y1="561"
               y2="561"
               class="register-classical"
@@ -1836,29 +1777,29 @@
           </g>
           <g>
             <line
-              x1="324.40625"
-              x2="324.40625"
+              x1="323"
+              x2="323"
               y1="600"
               y2="639"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="322.40625"
+              x1="321"
+              x2="321"
               y1="600"
               y2="641"
               class="register-classical"
             />
             <line
-              x1="324.40625"
-              x2="453.40625"
+              x1="323"
+              x2="452"
               y1="639"
               y2="639"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="453.40625"
+              x1="321"
+              x2="452"
               y1="641"
               y2="641"
               class="register-classical"
@@ -1866,29 +1807,29 @@
           </g>
           <g>
             <line
-              x1="324.40625"
-              x2="324.40625"
+              x1="323"
+              x2="323"
               y1="680"
               y2="719"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="322.40625"
+              x1="321"
+              x2="321"
               y1="680"
               y2="721"
               class="register-classical"
             />
             <line
-              x1="324.40625"
-              x2="453.40625"
+              x1="323"
+              x2="452"
               y1="719"
               y2="719"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="453.40625"
+              x1="321"
+              x2="452"
               y1="721"
               y2="721"
               class="register-classical"
@@ -1896,29 +1837,29 @@
           </g>
           <g>
             <line
-              x1="324.40625"
-              x2="324.40625"
+              x1="323"
+              x2="323"
               y1="760"
               y2="799"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="322.40625"
+              x1="321"
+              x2="321"
               y1="760"
               y2="801"
               class="register-classical"
             />
             <line
-              x1="324.40625"
-              x2="453.40625"
+              x1="323"
+              x2="452"
               y1="799"
               y2="799"
               class="register-classical"
             />
             <line
-              x1="322.40625"
-              x2="453.40625"
+              x1="321"
+              x2="452"
               y1="801"
               y2="801"
               class="register-classical"
@@ -1937,7 +1878,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="363.40625"
+              width="362"
               height="820"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -1954,7 +1895,7 @@
                   class="gate-unitary"
                   x="74"
                   y="12"
-                  width="102.703125"
+                  width="102"
                   height="536"
                   fill-opacity="0"
                   stroke-dasharray="8, 8"
@@ -1972,8 +1913,8 @@
                       </title>
                       <g>
                         <line
-                          x1="128.3515625"
-                          x2="128.3515625"
+                          x1="128"
+                          x2="128"
                           y1="40"
                           y2="200"
                           stroke-dasharray="8, 8"
@@ -1983,14 +1924,14 @@
                             class="gate-unitary"
                             x="100"
                             y="20"
-                            width="56.703125"
+                            width="56"
                             height="40"
                             data-wire-ys="[40]"
-                            data-width="56.703125"
+                            data-width="56"
                           />
                           <text
                             font-size="14"
-                            x="128.3515625"
+                            x="128"
                             y="33"
                             class="qs-maintext"
                           >
@@ -1998,7 +1939,7 @@
                           </text>
                           <text
                             font-size="12"
-                            x="128.3515625"
+                            x="128"
                             y="48"
                             class="arg-button"
                           >
@@ -2010,14 +1951,14 @@
                             class="gate-unitary"
                             x="100"
                             y="180"
-                            width="56.703125"
+                            width="56"
                             height="40"
                             data-wire-ys="[200]"
-                            data-width="56.703125"
+                            data-width="56"
                           />
                           <text
                             font-size="14"
-                            x="128.3515625"
+                            x="128"
                             y="193"
                             class="qs-maintext"
                           >
@@ -2025,7 +1966,7 @@
                           </text>
                           <text
                             font-size="12"
-                            x="128.3515625"
+                            x="128"
                             y="208"
                             class="arg-button"
                           >
@@ -2047,8 +1988,8 @@
                       </title>
                       <g>
                         <line
-                          x1="128.3515625"
-                          x2="128.3515625"
+                          x1="128"
+                          x2="128"
                           y1="360"
                           y2="520"
                           stroke-dasharray="8, 8"
@@ -2058,14 +1999,14 @@
                             class="gate-unitary"
                             x="100"
                             y="340"
-                            width="56.703125"
+                            width="56"
                             height="40"
                             data-wire-ys="[360]"
-                            data-width="56.703125"
+                            data-width="56"
                           />
                           <text
                             font-size="14"
-                            x="128.3515625"
+                            x="128"
                             y="353"
                             class="qs-maintext"
                           >
@@ -2073,7 +2014,7 @@
                           </text>
                           <text
                             font-size="12"
-                            x="128.3515625"
+                            x="128"
                             y="368"
                             class="arg-button"
                           >
@@ -2085,14 +2026,14 @@
                             class="gate-unitary"
                             x="100"
                             y="500"
-                            width="56.703125"
+                            width="56"
                             height="40"
                             data-wire-ys="[520]"
-                            data-width="56.703125"
+                            data-width="56"
                           />
                           <text
                             font-size="14"
-                            x="128.3515625"
+                            x="128"
                             y="513"
                             class="qs-maintext"
                           >
@@ -2100,7 +2041,7 @@
                           </text>
                           <text
                             font-size="12"
-                            x="128.3515625"
+                            x="128"
                             y="528"
                             class="arg-button"
                           >
@@ -2127,7 +2068,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="220.0546875"
+                      x="219"
                       y="20"
                       width="40"
                       height="40"
@@ -2136,12 +2077,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 255.0546875 42 A 15 12 0 0 0 225.0546875 42"
+                      d="M 254 42 A 15 12 0 0 0 224 42"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="240.0546875"
-                      x2="252.0546875"
+                      x1="239"
+                      x2="251"
                       y1="48"
                       y2="28"
                       class="qs-line-measure"
@@ -2159,9 +2100,9 @@
               >
                 <rect
                   class="gate-unitary"
-                  x="180.703125"
+                  x="180"
                   y="92"
-                  width="102.703125"
+                  width="102"
                   height="696"
                   fill-opacity="0"
                   stroke-dasharray="8, 8"
@@ -2179,8 +2120,8 @@
                       </title>
                       <g>
                         <line
-                          x1="235.0546875"
-                          x2="235.0546875"
+                          x1="234"
+                          x2="234"
                           y1="120"
                           y2="280"
                           stroke-dasharray="8, 8"
@@ -2188,16 +2129,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="206.703125"
+                            x="206"
                             y="100"
-                            width="56.703125"
+                            width="56"
                             height="40"
                             data-wire-ys="[120]"
-                            data-width="56.703125"
+                            data-width="56"
                           />
                           <text
                             font-size="14"
-                            x="235.0546875"
+                            x="234"
                             y="113"
                             class="qs-maintext"
                           >
@@ -2205,7 +2146,7 @@
                           </text>
                           <text
                             font-size="12"
-                            x="235.0546875"
+                            x="234"
                             y="128"
                             class="arg-button"
                           >
@@ -2215,16 +2156,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="206.703125"
+                            x="206"
                             y="260"
-                            width="56.703125"
+                            width="56"
                             height="40"
                             data-wire-ys="[280]"
-                            data-width="56.703125"
+                            data-width="56"
                           />
                           <text
                             font-size="14"
-                            x="235.0546875"
+                            x="234"
                             y="273"
                             class="qs-maintext"
                           >
@@ -2232,7 +2173,7 @@
                           </text>
                           <text
                             font-size="12"
-                            x="235.0546875"
+                            x="234"
                             y="288"
                             class="arg-button"
                           >
@@ -2254,8 +2195,8 @@
                       </title>
                       <g>
                         <line
-                          x1="235.0546875"
-                          x2="235.0546875"
+                          x1="234"
+                          x2="234"
                           y1="440"
                           y2="760"
                           stroke-dasharray="8, 8"
@@ -2263,16 +2204,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="206.703125"
+                            x="206"
                             y="420"
-                            width="56.703125"
+                            width="56"
                             height="40"
                             data-wire-ys="[440]"
-                            data-width="56.703125"
+                            data-width="56"
                           />
                           <text
                             font-size="14"
-                            x="235.0546875"
+                            x="234"
                             y="433"
                             class="qs-maintext"
                           >
@@ -2280,7 +2221,7 @@
                           </text>
                           <text
                             font-size="12"
-                            x="235.0546875"
+                            x="234"
                             y="448"
                             class="arg-button"
                           >
@@ -2290,16 +2231,16 @@
                         <g>
                           <rect
                             class="gate-unitary"
-                            x="206.703125"
+                            x="206"
                             y="740"
-                            width="56.703125"
+                            width="56"
                             height="40"
                             data-wire-ys="[760]"
-                            data-width="56.703125"
+                            data-width="56"
                           />
                           <text
                             font-size="14"
-                            x="235.0546875"
+                            x="234"
                             y="753"
                             class="qs-maintext"
                           >
@@ -2307,7 +2248,7 @@
                           </text>
                           <text
                             font-size="12"
-                            x="235.0546875"
+                            x="234"
                             y="768"
                             class="arg-button"
                           >
@@ -2319,8 +2260,8 @@
                   </g>
                 </g>
                 <g class="gate-control gate-collapse">
-                  <circle cx="182.703125" cy="94" r="10" />
-                  <path d="M175.703125,94 h14" />
+                  <circle cx="182" cy="94" r="10" />
+                  <path d="M175,94 h14" />
                 </g>
               </g>
               <g
@@ -2335,7 +2276,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="303.40625"
+                        x="302"
                         y="20"
                         width="40"
                         height="40"
@@ -2344,7 +2285,7 @@
                       />
                       <text
                         font-size="14"
-                        x="323.40625"
+                        x="322"
                         y="40"
                         class="qs-maintext ket-text"
                       >
@@ -2365,7 +2306,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="303.40625"
+                      x="302"
                       y="100"
                       width="40"
                       height="40"
@@ -2374,12 +2315,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 338.40625 122 A 15 12 0 0 0 308.40625 122"
+                      d="M 337 122 A 15 12 0 0 0 307 122"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="323.40625"
-                      x2="335.40625"
+                      x1="322"
+                      x2="334"
                       y1="128"
                       y2="108"
                       class="qs-line-measure"
@@ -2399,7 +2340,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="303.40625"
+                      x="302"
                       y="180"
                       width="40"
                       height="40"
@@ -2408,12 +2349,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 338.40625 202 A 15 12 0 0 0 308.40625 202"
+                      d="M 337 202 A 15 12 0 0 0 307 202"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="323.40625"
-                      x2="335.40625"
+                      x1="322"
+                      x2="334"
                       y1="208"
                       y2="188"
                       class="qs-line-measure"
@@ -2433,7 +2374,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="303.40625"
+                      x="302"
                       y="260"
                       width="40"
                       height="40"
@@ -2442,12 +2383,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 338.40625 282 A 15 12 0 0 0 308.40625 282"
+                      d="M 337 282 A 15 12 0 0 0 307 282"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="323.40625"
-                      x2="335.40625"
+                      x1="322"
+                      x2="334"
                       y1="288"
                       y2="268"
                       class="qs-line-measure"
@@ -2467,7 +2408,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="303.40625"
+                      x="302"
                       y="340"
                       width="40"
                       height="40"
@@ -2476,12 +2417,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 338.40625 362 A 15 12 0 0 0 308.40625 362"
+                      d="M 337 362 A 15 12 0 0 0 307 362"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="323.40625"
-                      x2="335.40625"
+                      x1="322"
+                      x2="334"
                       y1="368"
                       y2="348"
                       class="qs-line-measure"
@@ -2501,7 +2442,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="303.40625"
+                      x="302"
                       y="420"
                       width="40"
                       height="40"
@@ -2510,12 +2451,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 338.40625 442 A 15 12 0 0 0 308.40625 442"
+                      d="M 337 442 A 15 12 0 0 0 307 442"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="323.40625"
-                      x2="335.40625"
+                      x1="322"
+                      x2="334"
                       y1="448"
                       y2="428"
                       class="qs-line-measure"
@@ -2535,7 +2476,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="303.40625"
+                      x="302"
                       y="500"
                       width="40"
                       height="40"
@@ -2544,12 +2485,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 338.40625 522 A 15 12 0 0 0 308.40625 522"
+                      d="M 337 522 A 15 12 0 0 0 307 522"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="323.40625"
-                      x2="335.40625"
+                      x1="322"
+                      x2="334"
                       y1="528"
                       y2="508"
                       class="qs-line-measure"
@@ -2569,7 +2510,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="303.40625"
+                      x="302"
                       y="580"
                       width="40"
                       height="40"
@@ -2578,12 +2519,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 338.40625 602 A 15 12 0 0 0 308.40625 602"
+                      d="M 337 602 A 15 12 0 0 0 307 602"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="323.40625"
-                      x2="335.40625"
+                      x1="322"
+                      x2="334"
                       y1="608"
                       y2="588"
                       class="qs-line-measure"
@@ -2603,7 +2544,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="303.40625"
+                      x="302"
                       y="660"
                       width="40"
                       height="40"
@@ -2612,12 +2553,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 338.40625 682 A 15 12 0 0 0 308.40625 682"
+                      d="M 337 682 A 15 12 0 0 0 307 682"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="323.40625"
-                      x2="335.40625"
+                      x1="322"
+                      x2="334"
                       y1="688"
                       y2="668"
                       class="qs-line-measure"
@@ -2637,7 +2578,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="303.40625"
+                      x="302"
                       y="740"
                       width="40"
                       height="40"
@@ -2646,12 +2587,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 338.40625 762 A 15 12 0 0 0 308.40625 762"
+                      d="M 337 762 A 15 12 0 0 0 307 762"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="323.40625"
-                      x2="335.40625"
+                      x1="322"
+                      x2="334"
                       y1="768"
                       y2="748"
                       class="qs-line-measure"
@@ -2672,7 +2613,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="363.40625"
+                        x="362"
                         y="100"
                         width="40"
                         height="40"
@@ -2681,7 +2622,7 @@
                       />
                       <text
                         font-size="14"
-                        x="383.40625"
+                        x="382"
                         y="120"
                         class="qs-maintext ket-text"
                       >
@@ -2703,7 +2644,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="363.40625"
+                        x="362"
                         y="180"
                         width="40"
                         height="40"
@@ -2712,7 +2653,7 @@
                       />
                       <text
                         font-size="14"
-                        x="383.40625"
+                        x="382"
                         y="200"
                         class="qs-maintext ket-text"
                       >
@@ -2734,7 +2675,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="363.40625"
+                        x="362"
                         y="260"
                         width="40"
                         height="40"
@@ -2743,7 +2684,7 @@
                       />
                       <text
                         font-size="14"
-                        x="383.40625"
+                        x="382"
                         y="280"
                         class="qs-maintext ket-text"
                       >
@@ -2765,7 +2706,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="363.40625"
+                        x="362"
                         y="340"
                         width="40"
                         height="40"
@@ -2774,7 +2715,7 @@
                       />
                       <text
                         font-size="14"
-                        x="383.40625"
+                        x="382"
                         y="360"
                         class="qs-maintext ket-text"
                       >
@@ -2796,7 +2737,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="363.40625"
+                        x="362"
                         y="420"
                         width="40"
                         height="40"
@@ -2805,7 +2746,7 @@
                       />
                       <text
                         font-size="14"
-                        x="383.40625"
+                        x="382"
                         y="440"
                         class="qs-maintext ket-text"
                       >
@@ -2827,7 +2768,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="363.40625"
+                        x="362"
                         y="500"
                         width="40"
                         height="40"
@@ -2836,7 +2777,7 @@
                       />
                       <text
                         font-size="14"
-                        x="383.40625"
+                        x="382"
                         y="520"
                         class="qs-maintext ket-text"
                       >
@@ -2858,7 +2799,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="363.40625"
+                        x="362"
                         y="580"
                         width="40"
                         height="40"
@@ -2867,7 +2808,7 @@
                       />
                       <text
                         font-size="14"
-                        x="383.40625"
+                        x="382"
                         y="600"
                         class="qs-maintext ket-text"
                       >
@@ -2889,7 +2830,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="363.40625"
+                        x="362"
                         y="660"
                         width="40"
                         height="40"
@@ -2898,7 +2839,7 @@
                       />
                       <text
                         font-size="14"
-                        x="383.40625"
+                        x="382"
                         y="680"
                         class="qs-maintext ket-text"
                       >
@@ -2920,7 +2861,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="363.40625"
+                        x="362"
                         y="740"
                         width="40"
                         height="40"
@@ -2929,7 +2870,7 @@
                       />
                       <text
                         font-size="14"
-                        x="383.40625"
+                        x="382"
                         y="760"
                         class="qs-maintext ket-text"
                       >

--- a/source/npm/qsharp/test/circuits-cases/two-qubit-gates.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/two-qubit-gates.qs.snapshot.html
@@ -13,7 +13,7 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="436.703125"
+        width="436"
         height="240"
         style="max-width: fit-content"
         viewBox="0 0 436 240"
@@ -81,34 +81,34 @@
           </a>
         </g>
         <g class="wires">
-          <line x1="40" x2="436.703125" y1="40" y2="40" class="qubit-wire" />
-          <line x1="40" x2="436.703125" y1="100" y2="100" class="qubit-wire" />
-          <line x1="40" x2="436.703125" y1="160" y2="160" class="qubit-wire" />
+          <line x1="40" x2="436" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="436" y1="100" y2="100" class="qubit-wire" />
+          <line x1="40" x2="436" y1="160" y2="160" class="qubit-wire" />
           <g>
             <line
-              x1="307.703125"
-              x2="307.703125"
+              x1="307"
+              x2="307"
               y1="160"
               y2="199"
               class="register-classical"
             />
             <line
-              x1="305.703125"
-              x2="305.703125"
+              x1="305"
+              x2="305"
               y1="160"
               y2="201"
               class="register-classical"
             />
             <line
-              x1="307.703125"
-              x2="436.703125"
+              x1="307"
+              x2="436"
               y1="199"
               y2="199"
               class="register-classical"
             />
             <line
-              x1="305.703125"
-              x2="436.703125"
+              x1="305"
+              x2="436"
               y1="201"
               y2="201"
               class="register-classical"
@@ -127,7 +127,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="346.703125"
+              width="346"
               height="220"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -169,8 +169,8 @@
                   <title>two-qubit-gates.qs:4:5 Rzz(1.2345, q1, q3);</title>
                   <g>
                     <line
-                      x1="178.3515625"
-                      x2="178.3515625"
+                      x1="178"
+                      x2="178"
                       y1="40"
                       y2="160"
                       stroke-dasharray="8, 8"
@@ -180,25 +180,15 @@
                         class="gate-unitary"
                         x="150"
                         y="20"
-                        width="56.703125"
+                        width="56"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="56.703125"
+                        data-width="56"
                       />
-                      <text
-                        font-size="14"
-                        x="178.3515625"
-                        y="33"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="178" y="33" class="qs-maintext">
                         <tspan class="qs-mathtext">Rzz</tspan>
                       </text>
-                      <text
-                        font-size="12"
-                        x="178.3515625"
-                        y="48"
-                        class="arg-button"
-                      >
+                      <text font-size="12" x="178" y="48" class="arg-button">
                         1.2345
                       </text>
                     </g>
@@ -207,25 +197,15 @@
                         class="gate-unitary"
                         x="150"
                         y="140"
-                        width="56.703125"
+                        width="56"
                         height="40"
                         data-wire-ys="[160]"
-                        data-width="56.703125"
+                        data-width="56"
                       />
-                      <text
-                        font-size="14"
-                        x="178.3515625"
-                        y="153"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="178" y="153" class="qs-maintext">
                         <tspan class="qs-mathtext">Rzz</tspan>
                       </text>
-                      <text
-                        font-size="12"
-                        x="178.3515625"
-                        y="168"
-                        class="arg-button"
-                      >
+                      <text font-size="12" x="178" y="168" class="arg-button">
                         1.2345
                       </text>
                     </g>
@@ -241,15 +221,15 @@
                 <a href="#" class="qs-circuit-source-link">
                   <title>two-qubit-gates.qs:5:5 CNOT(q2, q3);</title>
                   <line
-                    x1="246.703125"
-                    x2="246.703125"
+                    x1="246"
+                    x2="246"
                     y1="100"
                     y2="160"
                     class="control-line"
                     style="pointer-events: none"
                   />
                   <circle
-                    cx="246.703125"
+                    cx="246"
                     cy="100"
                     r="5"
                     class="control-dot"
@@ -257,9 +237,9 @@
                     data-width="10"
                   />
                   <g class="oplus" data-wire-ys="[160]" data-width="30">
-                    <circle cx="246.703125" cy="160" r="15" />
-                    <line x1="246.703125" x2="246.703125" y1="145" y2="175" />
-                    <line x1="231.703125" x2="261.703125" y1="160" y2="160" />
+                    <circle cx="246" cy="160" r="15" />
+                    <line x1="246" x2="246" y1="145" y2="175" />
+                    <line x1="231" x2="261" y1="160" y2="160" />
                   </g>
                 </a>
               </g>
@@ -274,22 +254,22 @@
                   <g>
                     <rect
                       class="gate-swap"
-                      x="286.703125"
+                      x="286"
                       y="20"
                       width="40"
                       height="100"
                     />
                     <g>
-                      <line x1="298.703125" x2="314.703125" y1="32" y2="48" />
-                      <line x1="298.703125" x2="314.703125" y1="48" y2="32" />
+                      <line x1="298" x2="314" y1="32" y2="48" />
+                      <line x1="298" x2="314" y1="48" y2="32" />
                     </g>
                     <g>
-                      <line x1="298.703125" x2="314.703125" y1="92" y2="108" />
-                      <line x1="298.703125" x2="314.703125" y1="108" y2="92" />
+                      <line x1="298" x2="314" y1="92" y2="108" />
+                      <line x1="298" x2="314" y1="108" y2="92" />
                     </g>
                     <line
-                      x1="306.703125"
-                      x2="306.703125"
+                      x1="306"
+                      x2="306"
                       y1="40"
                       y2="100"
                       style="pointer-events: none"
@@ -308,7 +288,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="286.703125"
+                      x="286"
                       y="140"
                       width="40"
                       height="40"
@@ -317,12 +297,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 321.703125 162 A 15 12 0 0 0 291.703125 162"
+                      d="M 321 162 A 15 12 0 0 0 291 162"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="306.703125"
-                      x2="318.703125"
+                      x1="306"
+                      x2="318"
                       y1="168"
                       y2="148"
                       class="qs-line-measure"
@@ -343,7 +323,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="346.703125"
+                        x="346"
                         y="140"
                         width="40"
                         height="40"
@@ -352,7 +332,7 @@
                       />
                       <text
                         font-size="14"
-                        x="366.703125"
+                        x="366"
                         y="160"
                         class="qs-maintext ket-text"
                       >
@@ -376,7 +356,7 @@
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="qviz"
-        width="436.703125"
+        width="436"
         height="240"
         style="max-width: fit-content"
         viewBox="0 0 436 240"
@@ -444,34 +424,34 @@
           </a>
         </g>
         <g class="wires">
-          <line x1="40" x2="436.703125" y1="40" y2="40" class="qubit-wire" />
-          <line x1="40" x2="436.703125" y1="100" y2="100" class="qubit-wire" />
-          <line x1="40" x2="436.703125" y1="160" y2="160" class="qubit-wire" />
+          <line x1="40" x2="436" y1="40" y2="40" class="qubit-wire" />
+          <line x1="40" x2="436" y1="100" y2="100" class="qubit-wire" />
+          <line x1="40" x2="436" y1="160" y2="160" class="qubit-wire" />
           <g>
             <line
-              x1="307.703125"
-              x2="307.703125"
+              x1="307"
+              x2="307"
               y1="160"
               y2="199"
               class="register-classical"
             />
             <line
-              x1="305.703125"
-              x2="305.703125"
+              x1="305"
+              x2="305"
               y1="160"
               y2="201"
               class="register-classical"
             />
             <line
-              x1="307.703125"
-              x2="436.703125"
+              x1="307"
+              x2="436"
               y1="199"
               y2="199"
               class="register-classical"
             />
             <line
-              x1="305.703125"
-              x2="436.703125"
+              x1="305"
+              x2="436"
               y1="201"
               y2="201"
               class="register-classical"
@@ -490,7 +470,7 @@
               class="gate-unitary"
               x="60"
               y="10"
-              width="346.703125"
+              width="346"
               height="220"
               fill-opacity="0"
               stroke-dasharray="8, 8"
@@ -532,8 +512,8 @@
                   <title>two-qubit-gates.qs:4:5 Rzz(1.2345, q1, q3);</title>
                   <g>
                     <line
-                      x1="178.3515625"
-                      x2="178.3515625"
+                      x1="178"
+                      x2="178"
                       y1="40"
                       y2="160"
                       stroke-dasharray="8, 8"
@@ -543,25 +523,15 @@
                         class="gate-unitary"
                         x="150"
                         y="20"
-                        width="56.703125"
+                        width="56"
                         height="40"
                         data-wire-ys="[40]"
-                        data-width="56.703125"
+                        data-width="56"
                       />
-                      <text
-                        font-size="14"
-                        x="178.3515625"
-                        y="33"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="178" y="33" class="qs-maintext">
                         <tspan class="qs-mathtext">Rzz</tspan>
                       </text>
-                      <text
-                        font-size="12"
-                        x="178.3515625"
-                        y="48"
-                        class="arg-button"
-                      >
+                      <text font-size="12" x="178" y="48" class="arg-button">
                         1.2345
                       </text>
                     </g>
@@ -570,25 +540,15 @@
                         class="gate-unitary"
                         x="150"
                         y="140"
-                        width="56.703125"
+                        width="56"
                         height="40"
                         data-wire-ys="[160]"
-                        data-width="56.703125"
+                        data-width="56"
                       />
-                      <text
-                        font-size="14"
-                        x="178.3515625"
-                        y="153"
-                        class="qs-maintext"
-                      >
+                      <text font-size="14" x="178" y="153" class="qs-maintext">
                         <tspan class="qs-mathtext">Rzz</tspan>
                       </text>
-                      <text
-                        font-size="12"
-                        x="178.3515625"
-                        y="168"
-                        class="arg-button"
-                      >
+                      <text font-size="12" x="178" y="168" class="arg-button">
                         1.2345
                       </text>
                     </g>
@@ -604,15 +564,15 @@
                 <a href="#" class="qs-circuit-source-link">
                   <title>two-qubit-gates.qs:5:5 CNOT(q2, q3);</title>
                   <line
-                    x1="246.703125"
-                    x2="246.703125"
+                    x1="246"
+                    x2="246"
                     y1="100"
                     y2="160"
                     class="control-line"
                     style="pointer-events: none"
                   />
                   <circle
-                    cx="246.703125"
+                    cx="246"
                     cy="100"
                     r="5"
                     class="control-dot"
@@ -620,9 +580,9 @@
                     data-width="10"
                   />
                   <g class="oplus" data-wire-ys="[160]" data-width="30">
-                    <circle cx="246.703125" cy="160" r="15" />
-                    <line x1="246.703125" x2="246.703125" y1="145" y2="175" />
-                    <line x1="231.703125" x2="261.703125" y1="160" y2="160" />
+                    <circle cx="246" cy="160" r="15" />
+                    <line x1="246" x2="246" y1="145" y2="175" />
+                    <line x1="231" x2="261" y1="160" y2="160" />
                   </g>
                 </a>
               </g>
@@ -637,22 +597,22 @@
                   <g>
                     <rect
                       class="gate-swap"
-                      x="286.703125"
+                      x="286"
                       y="20"
                       width="40"
                       height="100"
                     />
                     <g>
-                      <line x1="298.703125" x2="314.703125" y1="32" y2="48" />
-                      <line x1="298.703125" x2="314.703125" y1="48" y2="32" />
+                      <line x1="298" x2="314" y1="32" y2="48" />
+                      <line x1="298" x2="314" y1="48" y2="32" />
                     </g>
                     <g>
-                      <line x1="298.703125" x2="314.703125" y1="92" y2="108" />
-                      <line x1="298.703125" x2="314.703125" y1="108" y2="92" />
+                      <line x1="298" x2="314" y1="92" y2="108" />
+                      <line x1="298" x2="314" y1="108" y2="92" />
                     </g>
                     <line
-                      x1="306.703125"
-                      x2="306.703125"
+                      x1="306"
+                      x2="306"
                       y1="40"
                       y2="100"
                       style="pointer-events: none"
@@ -671,7 +631,7 @@
                   <g>
                     <rect
                       class="gate-measure"
-                      x="286.703125"
+                      x="286"
                       y="140"
                       width="40"
                       height="40"
@@ -680,12 +640,12 @@
                     />
                     <path
                       class="arc-measure"
-                      d="M 321.703125 162 A 15 12 0 0 0 291.703125 162"
+                      d="M 321 162 A 15 12 0 0 0 291 162"
                       style="pointer-events: none"
                     />
                     <line
-                      x1="306.703125"
-                      x2="318.703125"
+                      x1="306"
+                      x2="318"
                       y1="168"
                       y2="148"
                       class="qs-line-measure"
@@ -706,7 +666,7 @@
                     <g>
                       <rect
                         class="gate-ket"
-                        x="346.703125"
+                        x="346"
                         y="140"
                         width="40"
                         height="40"
@@ -715,7 +675,7 @@
                       />
                       <text
                         font-size="14"
-                        x="366.703125"
+                        x="366"
                         y="160"
                         class="qs-maintext ket-text"
                       >

--- a/source/npm/qsharp/test/circuits.js
+++ b/source/npm/qsharp/test/circuits.js
@@ -17,28 +17,6 @@ import prettier from "prettier";
 import { getCompiler } from "../dist/main.js";
 import { draw } from "../dist/ux/circuit-vis/index.js";
 
-// Attempt to load the optional native canvas dependency; skip tests if it is missing.
-/**
- * @type {((width: number, height: number) => { getContext(type: string, ...args: any[]): any }) | undefined}
- */
-let createCanvas;
-let canvasAvailable = true;
-const canvasSkipReason =
-  "Skipping circuit snapshot tests because optional dependency 'canvas' is not installed.";
-
-try {
-  ({ createCanvas } = await import("canvas"));
-} catch (error) {
-  canvasAvailable = false;
-  const errorMessage = error instanceof Error ? error.message : String(error);
-  console.warn(`[circuits] ${canvasSkipReason} (${errorMessage})`);
-}
-
-let testOptions = {};
-if (!canvasAvailable) {
-  testOptions = { skip: canvasSkipReason };
-}
-
 const documentTemplate = `<!doctype html><html>
   <head>
     <link rel="stylesheet" href="../../ux/qsharp-ux.css">
@@ -51,45 +29,24 @@ const documentTemplate = `<!doctype html><html>
 /** @type {JSDOM | null} */
 let jsdom = null;
 
-if (canvasAvailable) {
-  beforeEach(() => {
-    // Create a new test DOM
-    jsdom = new JSDOM(documentTemplate);
+beforeEach(() => {
+  // Create a new test DOM
+  jsdom = new JSDOM(documentTemplate);
 
-    // Set up canvas
-    // @ts-expect-error - the `canvas` typings and DOM typings don't match
-    jsdom.window.HTMLCanvasElement.prototype.getContext = function getContext(
-      /** @type {string} */
-      type,
-      /** @type {any[]} */
-      ...args
-    ) {
-      if (type === "2d") {
-        if (!createCanvas) {
-          throw new Error(canvasSkipReason);
-        }
-        // create a new canvas instance with the same dimensions
-        const nodeCanvas = createCanvas(this.width, this.height);
-        return nodeCanvas.getContext("2d", ...args);
-      }
-      return null;
-    };
+  // Override the globals used by product code
+  // @ts-expect-error - the `jsdom` typings and DOM typings don't match
+  globalThis.window = jsdom.window;
+  globalThis.document = jsdom.window.document;
+  globalThis.Node = jsdom.window.Node;
+  globalThis.HTMLElement = jsdom.window.HTMLElement;
+  globalThis.SVGElement = jsdom.window.SVGElement;
+  globalThis.XMLSerializer = jsdom.window.XMLSerializer;
+});
 
-    // Override the globals used by product code
-    // @ts-expect-error - the `jsdom` typings and DOM typings don't match
-    globalThis.window = jsdom.window;
-    globalThis.document = jsdom.window.document;
-    globalThis.Node = jsdom.window.Node;
-    globalThis.HTMLElement = jsdom.window.HTMLElement;
-    globalThis.SVGElement = jsdom.window.SVGElement;
-    globalThis.XMLSerializer = jsdom.window.XMLSerializer;
-  });
-
-  afterEach(() => {
-    jsdom?.window.close();
-    jsdom = null;
-  });
-}
+afterEach(() => {
+  jsdom?.window.close();
+  jsdom = null;
+});
 
 /**
  * Create and add a container div to the document body.
@@ -224,7 +181,7 @@ function renderLocation(location) {
   }
 }
 
-test("circuit snapshot tests - .qsc files", testOptions, async (t) => {
+test("circuit snapshot tests - .qsc files", async (t) => {
   const files = findFilesWithExtension(getCasesDirectory(), ".qsc");
   if (files.length === 0) {
     t.diagnostic("No .qsc files found under cases");
@@ -245,7 +202,7 @@ test("circuit snapshot tests - .qsc files", testOptions, async (t) => {
   }
 });
 
-test("circuit snapshot tests - .qs files", testOptions, async (t) => {
+test("circuit snapshot tests - .qs files", async (t) => {
   const files = findFilesWithExtension(getCasesDirectory(), ".qs");
   if (files.length === 0) {
     t.diagnostic("No .qs files found under cases");

--- a/source/npm/qsharp/ux/circuit-vis/utils.ts
+++ b/source/npm/qsharp/ux/circuit-vis/utils.ts
@@ -80,24 +80,66 @@ const getGateWidth = ({
 };
 
 /**
- * Get the width of a string with font-size `fontSize` and font-family Arial.
+ * Estimate string width in pixels based on character types and font size.
+ * This may not match the true rendered width, but should be close enough for
+ * calculating layout.
  *
- * @param text     Input string.
- * @param fontSize Font size of `text`.
+ * @param text - The text string to measure.
+ * @param fontSize - The font size in pixels (default is labelFontSize).
  *
- * @returns Pixel width of given string.
+ * @returns Estimated width of the string in pixels.
  */
 const _getStringWidth = (
   text: string,
   fontSize: number = labelFontSize,
 ): number => {
-  const canvas: HTMLCanvasElement = document.createElement("canvas");
-  const context: CanvasRenderingContext2D | null = canvas.getContext("2d");
-  if (context == null) throw new Error("Null canvas");
-
-  context.font = `${fontSize}px Arial`;
-  const metrics: TextMetrics = context.measureText(text);
-  return metrics.width;
+  let units = 0;
+  for (const ch of Array.from(text)) {
+    if (ch === " ") {
+      units += 0.33;
+      continue;
+    }
+    if ("il.:;,'`!|".includes(ch)) {
+      units += 0.28;
+      continue;
+    }
+    if ("mw".includes(ch)) {
+      units += 0.72;
+      continue;
+    }
+    if ("MW@#%&".includes(ch)) {
+      units += 0.78;
+      continue;
+    }
+    if (/[0-9]/.test(ch)) {
+      units += 0.55;
+      continue;
+    }
+    if (/[A-Z]/.test(ch)) {
+      units += 0.56;
+      continue;
+    }
+    if (/[a-z]/.test(ch)) {
+      units += 0.5;
+      continue;
+    }
+    if (/[θπ]/.test(ch)) {
+      units += 0.56;
+      continue;
+    }
+    if (/[ψ]/.test(ch)) {
+      units += 0.6;
+      continue;
+    }
+    if ("-+*/=^~_<>".includes(ch)) {
+      units += 0.5;
+      continue;
+    }
+    units += 0.56;
+  }
+  const kerningFudge = Math.max(0, text.length - 1) * 0.005;
+  // Round to a whole number to keep it easy to read
+  return Math.floor((units + kerningFudge) * fontSize);
 };
 
 /**


### PR DESCRIPTION
We were only using the `canvas` package for snapshot tests to mock out usage of the canvas element in the product code.

The product doesn't _need_ to use a Canvas element to estimate text width. Since we have a limited set of characters in gate names anyway, estimating with a small utility works just as well (and is probably more performant too since it doesn't do actual rendering)

The difference between the old method and the new method is a few pixels at most in all of the samples and snapshots I checked. There are no visually noticeable changes.