### PR TITLE
v2 workspace handling: fix generated Python; upload circuit diagram by default

### DIFF
--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -183,11 +183,11 @@
           "default": false,
           "description": "Suppress notifications about new QDK updates. If true, you will not be prompted about new features after updates."
         },
-        "Q#.azure.experimental.uploadSupplementalData": {
+        "Q#.azure.uploadSupplementalData": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "tags": [
-            "experimental"
+            "hidden"
           ],
           "description": "Upload supplemental input data (circuit diagram) to the storage container when submitting jobs to Azure Quantum."
         }

--- a/source/vscode/src/azure/commands.ts
+++ b/source/vscode/src/azure/commands.ts
@@ -672,17 +672,22 @@ async function uploadSupplementalData(
   token: string,
   associationId: string,
 ) {
-  const circuitDiagram = await getCircuitJson(program);
+  const endpointMatch = quantumUris.endpoint.match(QuantumUris.endpointRegExp);
+  const isV2Workspace = endpointMatch?.groups?.versionSuffix === "-v2";
 
-  await uploadBlob(
-    storageUris,
-    quantumUris,
-    token,
-    "circuitDiagram",
-    circuitDiagram,
-    "application/json",
-    associationId,
-  );
+  if (isV2Workspace) {
+    const circuitDiagram = await getCircuitJson(program);
+
+    await uploadBlob(
+      storageUris,
+      quantumUris,
+      token,
+      "circuitDiagram",
+      circuitDiagram,
+      "application/json",
+      associationId,
+    );
+  }
 }
 
 /**

--- a/source/vscode/src/azure/networkRequests.ts
+++ b/source/vscode/src/azure/networkRequests.ts
@@ -217,6 +217,14 @@ export class AzureUris {
 export class QuantumUris {
   readonly apiVersion = "2022-09-12-preview";
 
+  // Regular expression to extract the first part of the endpointUri
+  // - Captures only an exact "-v2" suffix (as versionSuffix) if present
+  // - Otherwise, keeps any other suffix as part of the location
+  // e.g. "https://westus.quantum.azure.com" -> location="westus", versionSuffix=undefined
+  // e.g. "https://eastus2-v2.quantum.azure.com" -> location="eastus2", versionSuffix="-v2"
+  public static readonly endpointRegExp =
+    /https:\/\/(?<location>[^.]+?)(?<versionSuffix>-v2)?\./;
+
   constructor(
     public endpoint: string, // e.g. "https://westus.quantum.azure.com"
     public id: string, // e.g. "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/quantumResourcegroup/providers/Microsoft.Quantum/Workspaces/quantumworkspace1"

--- a/source/vscode/src/azure/workspaceActions.ts
+++ b/source/vscode/src/azure/workspaceActions.ts
@@ -91,11 +91,8 @@ export function getPythonCodeForWorkspace(
   const idRegex =
     /\/subscriptions\/(?<subscriptionId>[^/]+)\/resourceGroups\/(?<resourceGroup>[^/]+)/;
 
-  // Regular expression to extract the first part of the endpointUri
-  const endpointRegex = /https:\/\/(?<location>[^.]+)\./;
-
   const idMatch = id.match(idRegex);
-  const endpointMatch = endpointUri.match(endpointRegex);
+  const endpointMatch = endpointUri.match(QuantumUris.endpointRegExp);
 
   const subscriptionId = idMatch?.groups?.subscriptionId;
   const resourceGroup = idMatch?.groups?.resourceGroup;

--- a/source/vscode/src/config.ts
+++ b/source/vscode/src/config.ts
@@ -48,5 +48,5 @@ export function getShowDevDiagnostics(): boolean {
 export function getUploadSupplementalData(): boolean {
   return vscode.workspace
     .getConfiguration("Q#")
-    .get<boolean>("azure.experimental.uploadSupplementalData", false);
+    .get<boolean>("azure.uploadSupplementalData", true);
 }


### PR DESCRIPTION
- The "generate Python code to connect to workspace" code should recognize the `-v2` suffix (currently the only expected suffix)
- We should upload the circuit diagram data by default to these workspaces.