### PR TITLE
Fix CSS for upcoming dark modern

### DIFF
--- a/source/npm/qsharp/ux/qsharp-circuit.css
+++ b/source/npm/qsharp/ux/qsharp-circuit.css
@@ -69,12 +69,12 @@
 
   /* Background for gates */
   .gate-unitary {
-    fill: var(--vscode-button-secondaryBackground, #333333);
+    fill: var(--vscode-input-background, #333333);
   }
 
   /* Text for gates */
   .gate text {
-    fill: var(--vscode-button-secondaryForeground, #ffffff);
+    fill: var(--vscode-input-foreground, #ffffff);
   }
 
   a.qs-circuit-source-link .qs-qubit-label {


### PR DESCRIPTION
Fixed #2877 

With this change is now appears as below. Other themes look fine also

<img width="607" height="329" alt="image" src="https://github.com/user-attachments/assets/5a8172d7-4201-4bc2-9b0d-2554ee6b7920" />
