### PR TITLE
Fix `**kwargs` typehints

### DIFF
--- a/source/pip/qsharp/openqasm/_compile.py
+++ b/source/pip/qsharp/openqasm/_compile.py
@@ -21,8 +21,8 @@ from .. import telemetry_events
 
 def compile(
     source: Union[str, Callable],
-    *args,
-    **kwargs: Optional[Dict[str, Any]],
+    *args: Any,
+    **kwargs: Any,
 ) -> QirInputData:
     """
     Compiles the OpenQASM source code into a program that can be submitted to a

--- a/source/pip/qsharp/openqasm/_estimate.py
+++ b/source/pip/qsharp/openqasm/_estimate.py
@@ -22,8 +22,8 @@ from .. import telemetry_events
 def estimate(
     source: Union[str, Callable],
     params: Optional[Union[Dict[str, Any], List, EstimatorParams]] = None,
-    *args,
-    **kwargs: Optional[Dict[str, Any]],
+    *args: Any,
+    **kwargs: Any,
 ) -> EstimatorResult:
     """
     Estimates the resource requirements for executing OpenQASM source code.

--- a/source/pip/qsharp/openqasm/_import.py
+++ b/source/pip/qsharp/openqasm/_import.py
@@ -16,7 +16,7 @@ from .. import telemetry_events
 
 def import_openqasm(
     source: str,
-    **kwargs: Optional[Dict[str, Any]],
+    **kwargs: Any,
 ) -> Any:
     """
     Imports OpenQASM source code into the active Q# interpreter.

--- a/source/pip/qsharp/openqasm/_run.py
+++ b/source/pip/qsharp/openqasm/_run.py
@@ -38,7 +38,7 @@ def run(
     ] = None,
     qubit_loss: Optional[float] = None,
     as_bitstring: bool = False,
-    **kwargs: Optional[Dict[str, Any]],
+    **kwargs: Any,
 ) -> List[Any]:
     """
     Runs the given OpenQASM program for the given number of shots.


### PR DESCRIPTION
We have `**kwargs: Optional[Dict[str, Any]]` in a few places in our codebase. This is actually means "each kwarg is of type `Optional[Dict[str, Any]]`. The right thing to do is `**kwargs: Any`.

Once our minimum supported Python version is 3.11, we will be able to have more precise type hints for `**kwargs`.

https://typing.python.org/en/latest/spec/callables.html#unpack-kwargs

Before the change (with Pylance typeChecking set to "standard"):
<img width="800" height="144" alt="image" src="https://github.com/user-attachments/assets/9006e127-211f-4112-bedb-92a17f012063" />

After the change (with Pylance typeChecking set to "standard"):
<img width="1225" height="222" alt="image" src="https://github.com/user-attachments/assets/9a89f11f-7e98-4f52-a897-b39c645ead61" />
