### PR TITLE
Fix copilot histogram display

### DIFF
--- a/source/vscode/src/azure/commands.ts
+++ b/source/vscode/src/azure/commands.ts
@@ -485,7 +485,7 @@ type Buckets = {
   buckets: [string, number][];
   shotCount: number;
 };
-function getHistogramBucketsFromData(
+export function getHistogramBucketsFromData(
   file: string,
   shotCount?: number,
 ): Buckets | undefined {


### PR DESCRIPTION
The copilot histogram display didn't handle the v2 format yet. We already had the code to turn the JSON into buckets for the non-copilot flow, so just reusing that.