### PR TITLE
Unresolved names in call expression avoid ambiguous type error

### DIFF
--- a/source/compiler/qsc/src/interpret/tests.rs
+++ b/source/compiler/qsc/src/interpret/tests.rs
@@ -93,8 +93,6 @@ mod given_interpreter {
                     &expect![[r#"
                         name error: `Message` not found
                            [line_0] [Message]
-                        type error: insufficient type information to infer type
-                           [line_0] [Message("_")]
                     "#]],
                 );
             }
@@ -591,8 +589,6 @@ mod given_interpreter {
                       ambiguous name [line_3] [DumpMachine]
                       found in this namespace [line_1] [Other]
                       and also in this namespace [line_2] [Std.Diagnostics]
-                    type error: insufficient type information to infer type
-                       [line_3] [DumpMachine()]
                 "#]],
             );
         }
@@ -1296,8 +1292,6 @@ mod given_interpreter {
                 &expect![[r#"
                     name error: `Bar` not found
                        [line_1] [Bar]
-                    type error: insufficient type information to infer type
-                       [line_1] [Bar()]
                 "#]],
             );
         }
@@ -1383,8 +1377,6 @@ mod given_interpreter {
                 &expect![[r#"
                     name error: `Bar` not found
                        [line_2] [Bar]
-                    type error: insufficient type information to infer type
-                       [line_2] [Bar()]
                 "#]],
             );
         }
@@ -2351,8 +2343,6 @@ mod given_interpreter {
                 &expect![[r#"
                     name error: `Foo` not found
                        [line_0] [Foo]
-                    type error: insufficient type information to infer type
-                       [line_0] [Foo()]
                 "#]],
             );
         }

--- a/source/compiler/qsc_frontend/src/compile/tests.rs
+++ b/source/compiler/qsc_frontend/src/compile/tests.rs
@@ -217,13 +217,7 @@ fn two_files_error() {
         .map(|error| source_span(&unit.sources, error))
         .collect();
 
-    assert_eq!(
-        vec![
-            ("test2", Span { lo: 50, hi: 51 }),
-            ("test2", Span { lo: 50, hi: 53 }),
-        ],
-        errors
-    );
+    assert_eq!(vec![("test2", Span { lo: 50, hi: 51 }),], errors);
 }
 
 #[test]
@@ -570,8 +564,8 @@ fn package_dependency_internal_error() {
                     output: Int
                     functors: empty set
                     body: SpecDecl 3 [25-76]: Impl:
-                        Block 4 [46-76] [Type Int]:
-                            Stmt 5 [56-70]: Expr: Expr 6 [56-70] [Type Int]: Call:
+                        Block 4 [46-76] [Type ?]:
+                            Stmt 5 [56-70]: Expr: Expr 6 [56-70] [Type ?]: Call:
                                 Expr 7 [56-68] [Type ?]: Var: Err
                                 Expr 8 [68-70] [Type Unit]: Unit
                     adj: <none>

--- a/source/compiler/qsc_frontend/src/compile/tests/multiple_packages.rs
+++ b/source/compiler/qsc_frontend/src/compile/tests/multiple_packages.rs
@@ -193,18 +193,6 @@ fn namespace_named_main_doesnt_create_main_namespace() {
                         ),
                     ),
                 ),
-                Error(
-                    Type(
-                        Error(
-                            AmbiguousTy(
-                                Span {
-                                    lo: 205,
-                                    hi: 218,
-                                },
-                            ),
-                        ),
-                    ),
-                ),
             ]"#]),
     );
 }
@@ -310,18 +298,6 @@ fn multiple_packages_disallow_unexported_imports() {
                                 lo: 78,
                                 hi: 87,
                             },
-                        ),
-                    ),
-                ),
-                Error(
-                    Type(
-                        Error(
-                            AmbiguousTy(
-                                Span {
-                                    lo: 78,
-                                    hi: 89,
-                                },
-                            ),
                         ),
                     ),
                 ),

--- a/source/compiler/qsc_frontend/src/incremental/tests.rs
+++ b/source/compiler/qsc_frontend/src/incremental/tests.rs
@@ -343,9 +343,6 @@ fn errors_across_multiple_lines() {
             Some(
                 "line_3",
             ),
-            Some(
-                "line_4",
-            ),
         ]
     "#]]
     .assert_debug_eq(&labels);

--- a/source/compiler/qsc_frontend/src/lower/tests.rs
+++ b/source/compiler/qsc_frontend/src/lower/tests.rs
@@ -1977,8 +1977,8 @@ fn partial_app_unknown_callable() {
                         body: SpecDecl 3 [18-70]: Impl:
                             Block 4 [38-70] [Type Unit]:
                                 Stmt 5 [40-68]: Local (Immutable):
-                                    Pat 6 [44-45] [Type ?3]: Bind: Ident 7 [44-45] "f"
-                                    Expr 8 [48-67] [Type ?3]: Call:
+                                    Pat 6 [44-45] [Type ?0]: Bind: Ident 7 [44-45] "f"
+                                    Expr 8 [48-67] [Type ?]: Call:
                                         Expr 9 [48-55] [Type ?]: Var: Err
                                         Expr 10 [55-67] [Type (Bool, ?1, ?2)]: Tuple:
                                             Expr 11 [56-60] [Type Bool]: Lit: Bool(true)

--- a/source/compiler/qsc_frontend/src/typeck/rules.rs
+++ b/source/compiler/qsc_frontend/src/typeck/rules.rs
@@ -285,7 +285,15 @@ impl<'a> Context<'a> {
                         },
                     }
                 };
-                let output_ty = self.inferrer.fresh_ty(TySource::not_divergent(expr.span));
+                let output_ty = if callee.ty == Ty::Err {
+                    // If the callee is already an error, don't create a new inference type.
+                    // Using an error type here prevents cascading errors, as other rules
+                    // may not be able to constrain the type further and we leave behind an
+                    // ambiguous type variable.
+                    Ty::Err
+                } else {
+                    self.inferrer.fresh_ty(TySource::not_divergent(expr.span))
+                };
                 self.inferrer.class(
                     expr.span,
                     Class::Call {

--- a/source/compiler/qsc_frontend/src/typeck/tests.rs
+++ b/source/compiler/qsc_frontend/src/typeck/tests.rs
@@ -3355,10 +3355,10 @@ fn unknown_name_has_any_class() {
     check(
         "",
         "{ foo(); foo + 1 }",
-        &expect![[r#"
+        &expect![[r##"
             #1 0-18 "{ foo(); foo + 1 }" : ?
             #2 0-18 "{ foo(); foo + 1 }" : ?
-            #4 2-7 "foo()" : ?0
+            #4 2-7 "foo()" : ?
             #5 2-5 "foo" : ?
             #8 5-7 "()" : Unit
             #10 9-16 "foo + 1" : ?
@@ -3366,8 +3366,7 @@ fn unknown_name_has_any_class() {
             #14 15-16 "1" : Int
             Error(Resolve(NotFound("foo", Span { lo: 2, hi: 5 })))
             Error(Resolve(NotFound("foo", Span { lo: 9, hi: 12 })))
-            Error(Type(Error(AmbiguousTy(Span { lo: 2, hi: 7 }))))
-        "#]],
+        "##]],
     );
 }
 

--- a/source/language_service/src/state/tests.rs
+++ b/source/language_service/src/state/tests.rs
@@ -686,8 +686,6 @@ async fn notebook_document_errors() {
               uri: "cell2" version: Some(1) errors: [
                 name error
                   [cell2] [Foo]
-                type error
-                  [cell2] [Foo()]
               ],
             ]"#]],
     );
@@ -753,8 +751,6 @@ async fn notebook_update_remove_cell_clears_errors() {
               uri: "cell2" version: Some(1) errors: [
                 name error
                   [cell2] [Foo]
-                type error
-                  [cell2] [Foo()]
               ],
             ]"#]],
     );
@@ -801,8 +797,6 @@ async fn close_notebook_clears_errors() {
               uri: "cell2" version: Some(1) errors: [
                 name error
                   [cell2] [Foo]
-                type error
-                  [cell2] [Foo()]
               ],
             ]"#]],
     );
@@ -908,8 +902,6 @@ async fn update_notebook_reports_errors_from_dependencies() {
                   [cell1] [Foo]
                 name error
                   [cell1] [Bar]
-                type error
-                  [cell1] [Bar()]
               ],
 
               uri: "project/src/file.qs" version: None errors: [

--- a/source/npm/qsharp/test/basics.js
+++ b/source/npm/qsharp/test/basics.js
@@ -802,12 +802,7 @@ test("language service in notebook", async () => {
   assert.deepStrictEqual(
     [
       {
-        messages: [
-          "name error: `Foo` not found",
-          "type error: insufficient type information to infer type\n" +
-            "\n" +
-            "help: provide a type annotation",
-        ],
+        messages: ["name error: `Foo` not found"],
       },
       {
         messages: [],


### PR DESCRIPTION
This avoids extra error noise when a callee in a call expression results in a `Ty::Err` due to unresolved name. These errors always came together, often with the less helpful one (ambiguous type) obscuring the more helpful one (name not found). This tweak to type inference avoids the ambiguous type error by always treating the output type as error in the call constraint when the callee is a type error.

Note that the only production code change is in source/compiler/qsc_frontend/src/typeck/rules.rs. The rest of the changes are test updates since now fewer errors are returned.