### PR TITLE
Creating an explicit namespace with the same name as a callable breaks Python interop

### DIFF
--- a/source/pip/qsharp/_qsharp.py
+++ b/source/pip/qsharp/_qsharp.py
@@ -519,6 +519,11 @@ def _make_callable(callable: GlobalCallable, namespace: List[str], callable_name
         # Use the existing entry, which should already be a module.
         if hasattr(module, name):
             module = module.__getattribute__(name)
+            if sys.modules.get(accumulated_namespace) is None:
+                # This is an existing entry that is not yet registered in sys.modules, so add it.
+                # This can happen if a callable with the same name as this namespace is already
+                # defined.
+                sys.modules[accumulated_namespace] = module
         else:
             # This namespace entry doesn't exist as a module yet, so create it, add it to the environment, and
             # add it to sys.modules so it supports import properly.
@@ -550,7 +555,14 @@ def _make_callable(callable: GlobalCallable, namespace: List[str], callable_name
     _callable.__global_callable = callable
 
     # Add the callable to the module.
-    module.__setattr__(callable_name, _callable)
+    if module.__dict__.get(callable_name) is None:
+        module.__setattr__(callable_name, _callable)
+    else:
+        # Preserve any existing attributes on the attribute with the matching name,
+        # since this could be a collision with an existing namespace/module.
+        for key, val in module.__dict__.get(callable_name).__dict__.items():
+            _callable.__dict__[key] = val
+        module.__setattr__(callable_name, _callable)
 
 
 def qsharp_value_to_python_value(obj):

--- a/source/pip/tests/test_qsharp.py
+++ b/source/pip/tests/test_qsharp.py
@@ -838,6 +838,30 @@ def test_lambdas_not_exposed_into_env() -> None:
     assert not hasattr(qsharp.code, "<lambda>")
 
 
+def test_function_defined_before_namespace_keeps_both_accessible() -> None:
+    qsharp.init()
+    qsharp.eval("function Four() : Int { 4 }")
+    qsharp.eval("namespace Four { function Two() : Int { 42 } }")
+    assert qsharp.code.Four() == 4
+    assert qsharp.code.Four.Two() == 42
+    from qsharp.code import Four
+    from qsharp.code.Four import Two
+    assert Four() == 4
+    assert Two() == 42
+
+
+def test_namespace_defined_before_function_keeps_both_accessible() -> None:
+    qsharp.init()
+    qsharp.eval("namespace Four { function Two() : Int { 42 } }")
+    qsharp.eval("function Four() : Int { 4 }")
+    assert qsharp.code.Four() == 4
+    assert qsharp.code.Four.Two() == 42
+    from qsharp.code import Four
+    from qsharp.code.Four import Two
+    assert Four() == 4
+    assert Two() == 42
+
+
 def test_circuit_from_callable() -> None:
     qsharp.init()
     qsharp.eval(


### PR DESCRIPTION
Fixes #2771