### PR TITLE
Fix issue with shadowing in `qsharp.code`

### DIFF
--- a/source/pip/qsharp/_qsharp.py
+++ b/source/pip/qsharp/_qsharp.py
@@ -561,7 +561,8 @@ def _make_callable(callable: GlobalCallable, namespace: List[str], callable_name
         # Preserve any existing attributes on the attribute with the matching name,
         # since this could be a collision with an existing namespace/module.
         for key, val in module.__dict__.get(callable_name).__dict__.items():
-            _callable.__dict__[key] = val
+            if key != "__global_callable":
+                _callable.__dict__[key] = val
         module.__setattr__(callable_name, _callable)
 
 

--- a/source/pip/tests/test_qsharp.py
+++ b/source/pip/tests/test_qsharp.py
@@ -862,6 +862,14 @@ def test_namespace_defined_before_function_keeps_both_accessible() -> None:
     assert Two() == 42
 
 
+def test_callables_can_be_shadowed() -> None:
+    qsharp.init()
+    qsharp.eval("function Foo() : Int { 1 }")
+    assert qsharp.code.Foo() == 1
+    qsharp.eval("function Foo() : Int { 2 }")
+    assert qsharp.code.Foo() == 2
+
+
 def test_circuit_from_callable() -> None:
     qsharp.init()
     qsharp.eval(


### PR DESCRIPTION
If a callable shadowed a namespace or vice versa things worked as expected, but the fix in #2896 introduced a bug that caused callables to fail to shadow callables. This fixes the bug and adds a test case to confirm the behavior.