### PR TITLE
Ket Labels on Results from Azure

### DIFF
--- a/source/npm/qsharp/ux/histogram.tsx
+++ b/source/npm/qsharp/ux/histogram.tsx
@@ -67,14 +67,14 @@ function getDefaultMenuSelection(
   return selection;
 }
 
-const reKetResult = /^\[(?:(Zero|One|Loss|0|1|-), *)*(Zero|One|Loss|0|1|-)\]$/;
+const reKetResult =
+  /^\[(?:(Zero|One|Loss|0|1|2|-), *)*(Zero|One|Loss|0|1|2|-)\]$/;
 function resultToKet(result: string): string {
   if (typeof result !== "string") return "ERROR";
 
   if (reKetResult.test(result)) {
-    // The result is a simple array of Zero, One, and Loss
-    // The below will return an array of "Zero" or "One" in the order found
-    const matches = result.match(/(One|Zero|Loss|0|1|-)/g);
+    // The result fits our expected pattern, so we can convert it to a ket. If not, just return the raw result.
+    const matches = result.match(/(One|Zero|Loss|0|1|2|-)/g);
     let ket = "|";
     matches?.forEach(
       (digit) =>


### PR DESCRIPTION
Job results from some hardware targets used a different representation for results than our simulators. This PR makes the ket-label-building logic on histograms more general to account for integer result representations.