### PR TITLE
Pointing to windows-2025 image on SDLSources stage

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -89,20 +89,6 @@ extends:
       - stage: build
         displayName: Build
         jobs:
-            # Add this diagnostic job to check .NET versions on windows-2025
-          - job: "Diagnostics_Windows_2025"
-            pool:
-              name: "Azure-Pipelines-DevTools-EO"
-              image: "windows-2025"
-              os: windows
-            timeoutInMinutes: 10
-            steps:
-              - powershell: |
-                  Write-Host "=== .NET SDK Versions ==="
-                  dotnet --list-sdks
-                  Write-Host "`n=== .NET Runtime Versions ==="
-                  dotnet --list-runtimes
-                displayName: List installed .NET versions
           - job: "Node"
             pool:
               name: "Azure-Pipelines-DevTools-EO"


### PR DESCRIPTION
Pointing to windows-2025 image on SDLSources stage to avoid EOL for Microsoft .Net Version 6.

- Created windows-2025 1ES image which is using 1ES PT - MMS Windows 2025 image.
- Added windows-2025 image to Azure-Pipelines-DevTools-EO 1ES Hosted Pool.
