### PR TITLE
Magnets: refactored Trotter step classes and added Sukuki and Yoshida recursion

### DIFF
--- a/source/pip/qsharp/magnets/trotter/__init__.py
+++ b/source/pip/qsharp/magnets/trotter/__init__.py
@@ -3,10 +3,22 @@
 
 """Trotter-Suzuki methods for time evolution."""
 
-from .trotter import TrotterStep, StrangStep, TrotterExpansion
+from .trotter import (
+    TrotterStep,
+    TrotterExpansion,
+    trotter_decomposition,
+    strang_splitting,
+    suzuki_recursion,
+    yoshida_recursion,
+    fourth_order_trotter_suzuki,
+)
 
 __all__ = [
     "TrotterStep",
-    "StrangStep",
     "TrotterExpansion",
+    "trotter_decomposition",
+    "strang_splitting",
+    "suzuki_recursion",
+    "yoshida_recursion",
+    "fourth_order_trotter_suzuki",
 ]

--- a/source/pip/qsharp/magnets/trotter/trotter.py
+++ b/source/pip/qsharp/magnets/trotter/trotter.py
@@ -9,38 +9,31 @@ from typing import Iterator
 
 class TrotterStep:
     """
-    Base class for Trotter decompositions. Essentially, this is a wrapper around
-    a list of (time, term_index) tuples, which specify which term to apply for
-    how long.
+    Base class for Trotter decompositions. Essentially, this is a wrapper around a
+    list of (time, term_index) tuples, which specify which term to apply for how long.
 
-    As a default, the base class implements the first-order Trotter-Suzuki formula
-    for approximating time evolution under a Hamiltonian represented as a sum of
-    terms H = ∑_k H_k by sequentially applying each term for the full time
-
-    e^{-i H t} ≈ ∏_k e^{-i H_k t}.
-
-    Example:
-
-    .. code-block:: python
-        >>> trotter = TrotterStep(num_terms=3, time=0.5)
-        >>> list(trotter.step())
-        [(0.5, 0), (0.5, 1), (0.5, 2)]
+    The TrotterStep class provides a common interface for different Trotter decompositions,
+    such as first-order Trotter and Strang splitting. It also serves as the base class for
+    higher-order Trotter steps that can be constructed via Suzuki or Yoshida recursion. Each
+    Trotter step is defined by the sequence of terms to apply and their corresponding time
+    durations, as well as the overall order of the decomposition and the time step for each term.
     """
 
-    def __init__(self, num_terms: int, time: float):
+    def __init__(self):
         """
-        Initialize the Trotter decomposition.
+        Creates an empty Trotter decomposition.
 
-        Args:
-            num_terms: Number of terms in the Hamiltonian
-            time: Total time for the evolution
         """
-        self.terms: list[tuple[float, int]] = [
-            (time, term_index) for term_index in range(num_terms)
-        ]
-        self._nterms = num_terms
-        self._time_step = time
-        self.order = 1
+        self.terms: list[tuple[float, int]] = []
+        self._nterms = 0
+        self._time_step = 0.0
+        self._order = 0
+        self._repr_string = "TrotterStep()"
+
+    @property
+    def order(self) -> int:
+        """Get the order of the Trotter decomposition."""
+        return self._order
 
     @property
     def nterms(self) -> int:
@@ -51,6 +44,34 @@ class TrotterStep:
     def time_step(self) -> float:
         """Get the time step for each term in the Trotter decomposition."""
         return self._time_step
+
+    def reduce(self) -> None:
+        """
+        Reduce the Trotter step in place by combining consecutive terms that are the same.
+
+        This can be useful for optimizing the Trotter sequence by merging adjacent
+        applications of the same term into a single application with a longer time step.
+
+        Example:
+        >>> trotter = TrotterStep()
+        >>> trotter.terms = [(0.5, 0), (0.5, 0), (0.5, 1)]
+        >>> trotter.reduce()
+        >>> list(trotter.step())
+        [(1.0, 0), (0.5, 1)]
+        """
+        if len(self.terms) > 1:
+            reduced_terms: list[tuple[float, int]] = []
+            current_time, current_term = self.terms[0]
+
+            for time, term in self.terms[1:]:
+                if term == current_term:
+                    current_time += time
+                else:
+                    reduced_terms.append((current_time, current_term))
+                    current_time, current_term = time, term
+
+            reduced_terms.append((current_time, current_term))
+            self.terms = reduced_terms
 
     def step(self) -> Iterator[tuple[float, int]]:
         """
@@ -64,18 +85,140 @@ class TrotterStep:
 
     def __str__(self) -> str:
         """String representation of the Trotter decomposition."""
-        return f"1st order Trotter expansion: time_step={self.time_step}, num_terms={self.nterms}"
+        return f"Trotter expansion of order {self._order}: time_step={self._time_step}, num_terms={self._nterms}"
 
     def __repr__(self) -> str:
         """String representation of the Trotter decomposition."""
-        return f"Trotter(time_step={self.time_step}, num_terms={self.nterms})"
+        return self._repr_string
 
 
-class StrangStep(TrotterStep):
+def suzuki_recursion(trotter: TrotterStep) -> TrotterStep:
     """
-    Strang splitting (second-order Trotter-Suzuki decomposition).
+    Apply one level of Suzuki recursion to double the order of a Trotter step.
+
+    Given a k-th order Trotter step S_k(t), this function constructs a (k+2)-nd order
+    step using the Suzuki fractal decomposition:
+
+        S_{k+2}(t) = S_{k}(p t) S_{k}(p t) S_{k}((1 - 4p) t) S_{k}(p t) S_{k}(p t)
+
+    where p = 1 / (4 - 4^{1/(2k+1)}).
+
+    The resulting step has improved accuracy: the error scales as O(t^{k+3}) instead
+    of O(t^{k+1}), at the cost of 5x more exponential applications per step.
+
+    Args:
+        trotter: A TrotterStep of order k to be promoted to order k+2.
+
+    Returns:
+        A new TrotterStep of order k+2 constructed via Suzuki recursion.
+
+    References:
+        M. Suzuki, Phys. Lett. A 146, 319 (1990).
+    """
+
+    suzuki = TrotterStep()
+    suzuki._nterms = trotter._nterms
+    suzuki._time_step = trotter._time_step
+    suzuki._order = trotter._order + 2
+    suzuki._repr_string = f"SuzukiRecursion(order={suzuki._order}, time_step={suzuki._time_step}, num_terms={suzuki._nterms})"
+
+    p = 1 / (4 - 4 ** (1 / (2 * trotter.order + 1)))
+
+    suzuki.terms = [(p * time, term_index) for time, term_index in trotter.step()]
+    suzuki.terms += [(p * time, term_index) for time, term_index in trotter.step()]
+    suzuki.terms += [
+        ((1 - 4 * p) * time, term_index) for time, term_index in trotter.step()
+    ]
+    suzuki.terms += [(p * time, term_index) for time, term_index in trotter.step()]
+    suzuki.terms += [(p * time, term_index) for time, term_index in trotter.step()]
+    suzuki.reduce()  # Combine consecutive terms that are the same
+
+    return suzuki
+
+
+def yoshida_recursion(trotter: TrotterStep) -> TrotterStep:
+    """
+    Apply one level of Yoshida recursion to increase the order of a Trotter step by 2.
+
+    Given a k-th order Trotter step S_k(t), this function constructs a (k+2)-nd order
+    step using Yoshida's symmetric triple-jump composition:
+
+        S_{k+2}(t) = S_{k}(w_1 t) S_{k}(w_0 t) S_{k}(w_1 t)
+
+    where:
+        w_1 = 1 / (2 - 2^{1/(2k+1)})
+        w_0 = -2^{1/(2k+1)} / (2 - 2^{1/(2k+1)}) = 1 - 2 w_1
+
+    The resulting step has improved accuracy: the error scales as O(t^{k+3}) instead
+    of O(t^{k+1}), at the cost of 3x more exponential applications per step.
+
+    Args:
+        trotter: A TrotterStep of order k to be promoted to order k+2.
+
+    Returns:
+        A new TrotterStep of order k+2 constructed via Yoshida recursion.
+
+    References:
+        H. Yoshida, Phys. Lett. A 150, 262 (1990).
+    """
+
+    yoshida = TrotterStep()
+    yoshida._nterms = trotter._nterms
+    yoshida._time_step = trotter._time_step
+    yoshida._order = trotter._order + 2
+    yoshida._repr_string = f"YoshidaRecursion(order={yoshida._order}, time_step={yoshida._time_step}, num_terms={yoshida._nterms})"
+
+    cube_root_2 = 2 ** (1 / (2 * trotter.order + 1))
+    w1 = 1 / (2 - cube_root_2)
+    w0 = 1 - 2 * w1  # equivalent to -cube_root_2 / (2 - cube_root_2)
+
+    yoshida.terms = [(w1 * time, term_index) for time, term_index in trotter.step()]
+    yoshida.terms += [(w0 * time, term_index) for time, term_index in trotter.step()]
+    yoshida.terms += [(w1 * time, term_index) for time, term_index in trotter.step()]
+    yoshida.reduce()  # Combine consecutive terms that are the same
+
+    return yoshida
+
+
+def trotter_decomposition(num_terms: int, time: float) -> TrotterStep:
+    """
+    Factory function for creating a first-order Trotter decomposition.
+
+    The first-order Trotter-Suzuki formula for approximating time evolution
+    under a Hamiltonian represented as a sum of terms
+
+    H = ∑_k H_k
+
+    is obtained by sequentially applying each term for the full time
+
+    e^{-i H t} ≈ ∏_k e^{-i H_k t}.
+
+    Example:
+
+    .. code-block:: python
+        >>> trotter = first_order_trotter(num_terms=3, time=0.5)
+        >>> list(trotter.step())
+        [(0.5, 0), (0.5, 1), (0.5, 2)]
+
+    References:
+        H. F. Trotter, Proc. Amer. Math. Soc. 10, 545 (1959).
+    """
+    trotter = TrotterStep()
+    trotter.terms = [(time, term_index) for term_index in range(num_terms)]
+    trotter._nterms = num_terms
+    trotter._time_step = time
+    trotter._order = 1
+    trotter._repr_string = f"FirstOrderTrotter(time_step={time}, num_terms={num_terms})"
+    return trotter
+
+
+def strang_splitting(num_terms: int, time: float) -> TrotterStep:
+    """
+    Factory function for creating a Strang splitting (second-order
+    Trotter-Suzuki decomposition).
 
     The second-order Trotter formula uses symmetric splitting:
+
     e^{-i H t} ≈ ∏_{k=1}^{n} e^{-i H_k t/2} ∏_{k=n}^{1} e^{-i H_k t/2}
 
     This provides second-order accuracy in the time step, compared to
@@ -84,68 +227,73 @@ class StrangStep(TrotterStep):
     Example:
 
     .. code-block:: python
-        >>> strang = StrangStep(num_terms=3, time=0.5)
+        >>> strang = strang_splitting(num_terms=3, time=0.5)
         >>> list(strang.step())
         [(0.25, 0), (0.25, 1), (0.5, 2), (0.25, 1), (0.25, 0)]
+
+    References:
+        G. Strang, SIAM J. Numer. Anal. 5, 506 (1968).
     """
+    strang = TrotterStep()
+    strang._nterms = num_terms
+    strang._time_step = time
+    strang._order = 2
+    strang._repr_string = f"StrangSplitting(time_step={time}, num_terms={num_terms})"
+    strang.terms = []
+    for term_index in range(num_terms - 1):
+        strang.terms.append((time / 2, term_index))
+    strang.terms.append((time, num_terms - 1))
+    for term_index in reversed(range(num_terms - 1)):
+        strang.terms.append((time / 2, term_index))
+    return strang
 
-    def __init__(self, num_terms: int, time: float):
-        """
-        Initialize the Strang splitting.
 
-        Args:
-            num_terms: Number of terms in the Hamiltonian
-            time: Total time for the evolution
-        """
-        self.terms: list[tuple[float, int]] = []
-        for term_index in range(num_terms - 1):
-            self.terms.append((time / 2, term_index))
-        self.terms.append((time, num_terms - 1))
-        for term_index in reversed(range(num_terms - 1)):
-            self.terms.append((time / 2, term_index))
+def fourth_order_trotter_suzuki(num_terms: int, time: float) -> TrotterStep:
+    """
+    Factory function for creating a fourth-order Trotter-Suzuki decomposition
+    using Suzuki recursion.
 
-        self._nterms = num_terms
-        self._time_step = time
-        self.order = 2
+    This is obtained by applying one level of Suzuki recursion to the second-order
+    Strang splitting. The resulting fourth-order decomposition has improved accuracy
+    compared to the second-order Strang splitting, at the cost of more exponential
+    applications per step.
 
-    def step(self) -> Iterator[tuple[float, int]]:
-        """
-        Iterate over the Strang splitting as a list of (time, term_index) tuples.
+    Example:
 
-        Returns:
-            Iterator of tuples where each tuple contains the time duration and the
-            index of the term to be applied. The sequence is symmetric for
-            second-order accuracy.
-        """
-        return iter(self.terms)
-
-    def __str__(self) -> str:
-        return f"2nd order Trotter expansion: time_step={self.time_step}, num_terms={self.nterms}"
-
-    def __repr__(self) -> str:
-        """String representation of the Strang splitting."""
-        return f"Strang(time_step={self.time_step}, num_terms={self.nterms})"
+    .. code-block:: python
+        >>> fourth_order = fourth_order_trotter_suzuki(num_terms=3, time=0.5)
+        >>> list(fourth_order.step())
+        [(0.1767766952966369, 0), (0.1767766952966369, 1), (0.1767766952966369, 2), (0.3535533905932738, 1), (0.3535533905932738, 0), (0.1767766952966369, 1), (0.1767766952966369, 2), (0.1767766952966369, 1), (0.1767766952966369, 0)]
+    """
+    return suzuki_recursion(strang_splitting(num_terms, time))
 
 
 class TrotterExpansion:
     """
-    Trotter expansion class for multiple Trotter steps. This class wraps around
-    a TrotterStep instance and specifies how many times to repeat this Trotter
-    step. The expansion can be used to represent the full time evolution
-    as a sequence of Trotter steps
+    Trotter expansion for repeated application of a Trotter step.
 
-        e^{-i H t} ≈ (∏_k e^{-i H_k t/n})^n.
+    This class wraps a TrotterStep instance and specifies how many times to repeat
+    the step. The expansion represents full time evolution as a sequence of
+    Trotter steps:
 
-    where n is the number of Trotter steps.
+        e^{-i H T} ≈ (S(T/n))^n
+
+    where S is the Trotter step formula, T is the total time, and n is the number
+    of steps.
 
     Example:
 
     .. code-block:: python
         >>> n = 4  # Number of Trotter steps
         >>> total_time = 1.0  # Total time
-        >>> trotter_expansion = TrotterExpansion(TrotterStep(2, total_time/n), n)
-        >>> trotter_expansion.get()
-        [([(0.25, 0), (0.25, 1)], 4)]
+        >>> step = trotter_decomposition(num_terms=2, time=total_time/n)
+        >>> expansion = TrotterExpansion(step, n)
+        >>> expansion.order
+        1
+        >>> expansion.total_time
+        1.0
+        >>> list(expansion.step())[:4]
+        [(0.25, 0), (0.25, 1), (0.25, 0), (0.25, 1)]
     """
 
     def __init__(self, trotter_step: TrotterStep, num_steps: int):
@@ -153,18 +301,62 @@ class TrotterExpansion:
         Initialize the Trotter expansion.
 
         Args:
-            trotter_step: An instance of TrotterStep representing a single Trotter step
-            num_steps: Number of Trotter steps
+            trotter_step: An instance of TrotterStep representing a single Trotter step.
+            num_steps: Number of times to repeat the Trotter step.
         """
         self._trotter_step = trotter_step
         self._num_steps = num_steps
 
-    def get(self) -> list[tuple[list[tuple[float, int]], int]]:
+    @property
+    def order(self) -> int:
+        """Get the order of the underlying Trotter step."""
+        return self._trotter_step.order
+
+    @property
+    def nterms(self) -> int:
+        """Get the number of Hamiltonian terms."""
+        return self._trotter_step.nterms
+
+    @property
+    def num_steps(self) -> int:
+        """Get the number of Trotter steps."""
+        return self._num_steps
+
+    @property
+    def total_time(self) -> float:
+        """Get the total evolution time (time_step * num_steps)."""
+        return self._trotter_step.time_step * self._num_steps
+
+    def step(self) -> Iterator[tuple[float, int]]:
         """
-        Get the Trotter expansion as a list of (terms, step_index) tuples.
+        Iterate over the full Trotter expansion.
+
+        Yields all (time, term_index) tuples for the complete expansion,
+        repeating the Trotter step sequence num_steps times.
 
         Returns:
-            List of tuples where each tuple contains the list of (time, term_index)
-            for that step and the number of times that step is executed.
+            Iterator of (time, term_index) tuples for the full evolution.
         """
-        return [(self._trotter_step.get(), self._num_steps)]
+        for _ in range(self._num_steps):
+            yield from self._trotter_step.step()
+
+    def get(self) -> list[tuple[list[tuple[float, int]], int]]:
+        """
+        Get the Trotter expansion as a compact representation.
+
+        Returns:
+            List containing a single tuple of (terms, num_steps) where terms
+            is the list of (time, term_index) for one step.
+        """
+        return [(list(self._trotter_step.step()), self._num_steps)]
+
+    def __str__(self) -> str:
+        """String representation of the Trotter expansion."""
+        return (
+            f"TrotterExpansion(order={self.order}, num_steps={self._num_steps}, "
+            f"total_time={self.total_time}, num_terms={self.nterms})"
+        )
+
+    def __repr__(self) -> str:
+        """Repr representation of the Trotter expansion."""
+        return f"TrotterExpansion({self._trotter_step!r}, num_steps={self._num_steps})"

--- a/source/pip/tests/magnets/test_trotter.py
+++ b/source/pip/tests/magnets/test_trotter.py
@@ -1,151 +1,188 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Unit tests for Trotter-Suzuki decomposition classes."""
+"""Unit tests for Trotter-Suzuki decomposition classes and factory functions."""
 
-from qsharp.magnets.trotter import TrotterStep, StrangStep, TrotterExpansion
-
-
-# TrotterStep tests
-
-
-def test_trotter_step_init_basic():
-    """Test basic TrotterStep initialization."""
-    trotter = TrotterStep(num_terms=3, time=0.5)
-    assert trotter._num_terms == 3
-    assert trotter._time_step == 0.5
+from qsharp.magnets.trotter import (
+    TrotterStep,
+    TrotterExpansion,
+    trotter_decomposition,
+    strang_splitting,
+    suzuki_recursion,
+    yoshida_recursion,
+    fourth_order_trotter_suzuki,
+)
 
 
-def test_trotter_step_get_single_term():
-    """Test TrotterStep with a single term."""
-    trotter = TrotterStep(num_terms=1, time=1.0)
-    result = trotter.get()
+# TrotterStep base class tests
+
+
+def test_trotter_step_empty_init():
+    """Test that TrotterStep initializes as empty."""
+    trotter = TrotterStep()
+    assert trotter.nterms == 0
+    assert trotter.time_step == 0.0
+    assert trotter.order == 0
+    assert list(trotter.step()) == []
+
+
+def test_trotter_step_reduce_combines_consecutive():
+    """Test that reduce combines consecutive same-term entries."""
+    trotter = TrotterStep()
+    trotter.terms = [(0.5, 0), (0.5, 0), (0.5, 1)]
+    trotter.reduce()
+    assert list(trotter.step()) == [(1.0, 0), (0.5, 1)]
+
+
+def test_trotter_step_reduce_no_change_when_different():
+    """Test that reduce does not change non-consecutive same terms."""
+    trotter = TrotterStep()
+    trotter.terms = [(0.5, 0), (0.5, 1), (0.5, 0)]
+    trotter.reduce()
+    assert list(trotter.step()) == [(0.5, 0), (0.5, 1), (0.5, 0)]
+
+
+def test_trotter_step_reduce_empty():
+    """Test that reduce handles empty terms."""
+    trotter = TrotterStep()
+    trotter.reduce()
+    assert list(trotter.step()) == []
+
+
+# trotter_decomposition factory tests
+
+
+def test_trotter_decomposition_basic():
+    """Test basic trotter_decomposition creation."""
+    trotter = trotter_decomposition(num_terms=3, time=0.5)
+    assert trotter.nterms == 3
+    assert trotter.time_step == 0.5
+    assert trotter.order == 1
+
+
+def test_trotter_decomposition_single_term():
+    """Test trotter_decomposition with a single term."""
+    trotter = trotter_decomposition(num_terms=1, time=1.0)
+    result = list(trotter.step())
     assert result == [(1.0, 0)]
 
 
-def test_trotter_step_get_multiple_terms():
-    """Test TrotterStep with multiple terms."""
-    trotter = TrotterStep(num_terms=3, time=0.5)
-    result = trotter.get()
+def test_trotter_decomposition_multiple_terms():
+    """Test trotter_decomposition with multiple terms."""
+    trotter = trotter_decomposition(num_terms=3, time=0.5)
+    result = list(trotter.step())
     assert result == [(0.5, 0), (0.5, 1), (0.5, 2)]
 
 
-def test_trotter_step_get_zero_time():
-    """Test TrotterStep with zero time."""
-    trotter = TrotterStep(num_terms=2, time=0.0)
-    result = trotter.get()
+def test_trotter_decomposition_zero_time():
+    """Test trotter_decomposition with zero time."""
+    trotter = trotter_decomposition(num_terms=2, time=0.0)
+    result = list(trotter.step())
     assert result == [(0.0, 0), (0.0, 1)]
 
 
-def test_trotter_step_get_returns_all_terms():
-    """Test that TrotterStep returns all term indices."""
+def test_trotter_decomposition_returns_all_terms():
+    """Test that trotter_decomposition returns all term indices."""
     num_terms = 5
-    trotter = TrotterStep(num_terms=num_terms, time=1.0)
-    result = trotter.get()
+    trotter = trotter_decomposition(num_terms=num_terms, time=1.0)
+    result = list(trotter.step())
     assert len(result) == num_terms
     term_indices = [idx for _, idx in result]
     assert term_indices == list(range(num_terms))
 
 
-def test_trotter_step_get_uniform_time():
-    """Test that all terms have the same time in TrotterStep."""
+def test_trotter_decomposition_uniform_time():
+    """Test that all terms have the same time in trotter_decomposition."""
     time = 0.25
-    trotter = TrotterStep(num_terms=4, time=time)
-    result = trotter.get()
+    trotter = trotter_decomposition(num_terms=4, time=time)
+    result = list(trotter.step())
     for t, _ in result:
         assert t == time
 
 
-def test_trotter_step_str():
-    """Test string representation of TrotterStep."""
-    trotter = TrotterStep(num_terms=3, time=0.5)
+def test_trotter_decomposition_str():
+    """Test string representation of trotter_decomposition result."""
+    trotter = trotter_decomposition(num_terms=3, time=0.5)
     result = str(trotter)
-    assert "Trotter" in result
-    assert "0.5" in result
-    assert "3" in result
+    assert "order" in result.lower() or "1" in result
 
 
-def test_trotter_step_repr():
-    """Test repr representation of TrotterStep."""
-    trotter = TrotterStep(num_terms=3, time=0.5)
-    assert repr(trotter) == str(trotter)
+def test_trotter_decomposition_repr():
+    """Test repr representation of trotter_decomposition result."""
+    trotter = trotter_decomposition(num_terms=3, time=0.5)
+    assert "FirstOrderTrotter" in repr(trotter)
 
 
-# StrangStep tests
+# strang_splitting factory tests
 
 
-def test_strang_step_init_basic():
-    """Test basic StrangStep initialization."""
-    strang = StrangStep(num_terms=3, time=0.5)
-    assert strang._num_terms == 3
-    assert strang._time_step == 0.5
+def test_strang_splitting_basic():
+    """Test basic strang_splitting creation."""
+    strang = strang_splitting(num_terms=3, time=0.5)
+    assert strang.nterms == 3
+    assert strang.time_step == 0.5
+    assert strang.order == 2
 
 
-def test_strang_step_inherits_trotter():
-    """Test that StrangStep inherits from TrotterStep."""
-    strang = StrangStep(num_terms=3, time=0.5)
-    assert isinstance(strang, TrotterStep)
-
-
-def test_strang_step_get_single_term():
-    """Test StrangStep with a single term."""
-    strang = StrangStep(num_terms=1, time=1.0)
-    result = strang.get()
+def test_strang_splitting_single_term():
+    """Test strang_splitting with a single term."""
+    strang = strang_splitting(num_terms=1, time=1.0)
+    result = list(strang.step())
     # Single term: just full time on term 0
     assert result == [(1.0, 0)]
 
 
-def test_strang_step_get_two_terms():
-    """Test StrangStep with two terms."""
-    strang = StrangStep(num_terms=2, time=1.0)
-    result = strang.get()
+def test_strang_splitting_two_terms():
+    """Test strang_splitting with two terms."""
+    strang = strang_splitting(num_terms=2, time=1.0)
+    result = list(strang.step())
     # Forward: half on term 0, full on term 1, backward: half on term 0
     assert result == [(0.5, 0), (1.0, 1), (0.5, 0)]
 
 
-def test_strang_step_get_three_terms():
-    """Test StrangStep with three terms (example from docstring)."""
-    strang = StrangStep(num_terms=3, time=0.5)
-    result = strang.get()
+def test_strang_splitting_three_terms():
+    """Test strang_splitting with three terms (example from docstring)."""
+    strang = strang_splitting(num_terms=3, time=0.5)
+    result = list(strang.step())
     expected = [(0.25, 0), (0.25, 1), (0.5, 2), (0.25, 1), (0.25, 0)]
     assert result == expected
 
 
-def test_strang_step_symmetric():
-    """Test that StrangStep produces symmetric sequence."""
-    strang = StrangStep(num_terms=4, time=1.0)
-    result = strang.get()
+def test_strang_splitting_symmetric():
+    """Test that strang_splitting produces symmetric sequence."""
+    strang = strang_splitting(num_terms=4, time=1.0)
+    result = list(strang.step())
     # Check symmetry: term indices should be palindromic
     term_indices = [idx for _, idx in result]
     assert term_indices == term_indices[::-1]
 
 
-def test_strang_step_time_sum():
-    """Test that total time in StrangStep equals expected value."""
+def test_strang_splitting_time_sum():
+    """Test that total time in strang_splitting equals expected value."""
     time = 1.0
     num_terms = 3
-    strang = StrangStep(num_terms=num_terms, time=time)
-    result = strang.get()
+    strang = strang_splitting(num_terms=num_terms, time=time)
+    result = list(strang.step())
     total_time = sum(t for t, _ in result)
     # Each term appears once with full time equivalent
     # (half + half for outer terms, full for middle)
     assert abs(total_time - time * num_terms) < 1e-10
 
 
-def test_strang_step_middle_term_full_time():
+def test_strang_splitting_middle_term_full_time():
     """Test that the middle term gets full time step."""
-    strang = StrangStep(num_terms=5, time=2.0)
-    result = strang.get()
+    strang = strang_splitting(num_terms=5, time=2.0)
+    result = list(strang.step())
     # Middle term (index 4, the last term) should have full time
     middle_entries = [(t, idx) for t, idx in result if idx == 4]
     assert len(middle_entries) == 1
     assert middle_entries[0][0] == 2.0
 
 
-def test_strang_step_outer_terms_half_time():
+def test_strang_splitting_outer_terms_half_time():
     """Test that outer terms get half time steps."""
-    strang = StrangStep(num_terms=4, time=2.0)
-    result = strang.get()
+    strang = strang_splitting(num_terms=4, time=2.0)
+    result = list(strang.step())
     # Term 0 should appear twice with half time each
     term_0_entries = [(t, idx) for t, idx in result if idx == 0]
     assert len(term_0_entries) == 2
@@ -153,13 +190,147 @@ def test_strang_step_outer_terms_half_time():
         assert t == 1.0
 
 
-def test_strang_step_str():
-    """Test string representation of StrangStep."""
-    strang = StrangStep(num_terms=3, time=0.5)
-    result = str(strang)
-    assert "Strang" in result
-    assert "0.5" in result
-    assert "3" in result
+def test_strang_splitting_repr():
+    """Test repr representation of strang_splitting result."""
+    strang = strang_splitting(num_terms=3, time=0.5)
+    assert "StrangSplitting" in repr(strang)
+
+
+# suzuki_recursion tests
+
+
+def test_suzuki_recursion_from_strang():
+    """Test Suzuki recursion applied to Strang splitting produces 4th order."""
+    strang = strang_splitting(num_terms=2, time=1.0)
+    suzuki = suzuki_recursion(strang)
+    assert suzuki.order == 4
+    assert suzuki.nterms == 2
+    assert suzuki.time_step == 1.0
+
+
+def test_suzuki_recursion_from_first_order():
+    """Test Suzuki recursion applied to first-order Trotter produces 3rd order."""
+    trotter = trotter_decomposition(num_terms=2, time=1.0)
+    suzuki = suzuki_recursion(trotter)
+    assert suzuki.order == 3
+    assert suzuki.nterms == 2
+
+
+def test_suzuki_recursion_preserves_nterms():
+    """Test that Suzuki recursion preserves number of terms."""
+    base = strang_splitting(num_terms=5, time=0.5)
+    suzuki = suzuki_recursion(base)
+    assert suzuki.nterms == base.nterms
+
+
+def test_suzuki_recursion_preserves_time_step():
+    """Test that Suzuki recursion preserves time step."""
+    base = strang_splitting(num_terms=3, time=0.75)
+    suzuki = suzuki_recursion(base)
+    assert suzuki.time_step == base.time_step
+
+
+def test_suzuki_recursion_repr():
+    """Test repr of Suzuki recursion result."""
+    base = strang_splitting(num_terms=2, time=1.0)
+    suzuki = suzuki_recursion(base)
+    assert "SuzukiRecursion" in repr(suzuki)
+
+
+def test_suzuki_recursion_time_weights_sum():
+    """Test that time weights in Suzuki recursion sum correctly."""
+    base = trotter_decomposition(num_terms=2, time=1.0)
+    suzuki = suzuki_recursion(base)
+    # The total scaled time should equal the original total time * nterms
+    # because we're scaling times, not adding them
+    result = list(suzuki.step())
+    total_time = sum(t for t, _ in result)
+    # For Suzuki: 5 copies scaled by p, p, (1-4p), p, p
+    # where weights sum to 4p + (1-4p) = 1, so total = base total
+    base_total = sum(t for t, _ in base.step())
+    assert abs(total_time - base_total) < 1e-10
+
+
+# yoshida_recursion tests
+
+
+def test_yoshida_recursion_from_strang():
+    """Test Yoshida recursion applied to Strang splitting produces 4th order."""
+    strang = strang_splitting(num_terms=2, time=1.0)
+    yoshida = yoshida_recursion(strang)
+    assert yoshida.order == 4
+    assert yoshida.nterms == 2
+    assert yoshida.time_step == 1.0
+
+
+def test_yoshida_recursion_from_first_order():
+    """Test Yoshida recursion applied to first-order Trotter produces 3rd order."""
+    trotter = trotter_decomposition(num_terms=2, time=1.0)
+    yoshida = yoshida_recursion(trotter)
+    assert yoshida.order == 3
+    assert yoshida.nterms == 2
+
+
+def test_yoshida_recursion_preserves_nterms():
+    """Test that Yoshida recursion preserves number of terms."""
+    base = strang_splitting(num_terms=5, time=0.5)
+    yoshida = yoshida_recursion(base)
+    assert yoshida.nterms == base.nterms
+
+
+def test_yoshida_recursion_preserves_time_step():
+    """Test that Yoshida recursion preserves time step."""
+    base = strang_splitting(num_terms=3, time=0.75)
+    yoshida = yoshida_recursion(base)
+    assert yoshida.time_step == base.time_step
+
+
+def test_yoshida_recursion_repr():
+    """Test repr of Yoshida recursion result."""
+    base = strang_splitting(num_terms=2, time=1.0)
+    yoshida = yoshida_recursion(base)
+    assert "YoshidaRecursion" in repr(yoshida)
+
+
+def test_yoshida_recursion_time_weights_sum():
+    """Test that time weights in Yoshida recursion sum correctly."""
+    base = trotter_decomposition(num_terms=2, time=1.0)
+    yoshida = yoshida_recursion(base)
+    # The total scaled time should equal the original total time * nterms
+    # because weights w1 + w0 + w1 = 2*w1 + w0 = 2*w1 + (1 - 2*w1) = 1
+    result = list(yoshida.step())
+    total_time = sum(t for t, _ in result)
+    base_total = sum(t for t, _ in base.step())
+    assert abs(total_time - base_total) < 1e-10
+
+
+def test_yoshida_fewer_terms_than_suzuki():
+    """Test that Yoshida produces fewer terms than Suzuki (3x vs 5x)."""
+    base = strang_splitting(num_terms=3, time=1.0)
+    suzuki = suzuki_recursion(base)
+    yoshida = yoshida_recursion(base)
+    # Yoshida uses 3 copies, Suzuki uses 5 copies
+    # After reduction, Yoshida should generally have fewer terms
+    assert len(list(yoshida.step())) <= len(list(suzuki.step()))
+
+
+# fourth_order_trotter_suzuki tests
+
+
+def test_fourth_order_trotter_suzuki_basic():
+    """Test fourth_order_trotter_suzuki factory function."""
+    fourth = fourth_order_trotter_suzuki(num_terms=2, time=1.0)
+    assert fourth.order == 4
+    assert fourth.nterms == 2
+    assert fourth.time_step == 1.0
+
+
+def test_fourth_order_trotter_suzuki_equals_suzuki_of_strang():
+    """Test that fourth_order_trotter_suzuki equals suzuki_recursion(strang_splitting)."""
+    fourth = fourth_order_trotter_suzuki(num_terms=3, time=0.5)
+    manual = suzuki_recursion(strang_splitting(num_terms=3, time=0.5))
+    assert list(fourth.step()) == list(manual.step())
+    assert fourth.order == manual.order
 
 
 # TrotterExpansion tests
@@ -167,7 +338,7 @@ def test_strang_step_str():
 
 def test_trotter_expansion_init_basic():
     """Test basic TrotterExpansion initialization."""
-    step = TrotterStep(num_terms=2, time=0.25)
+    step = trotter_decomposition(num_terms=2, time=0.25)
     expansion = TrotterExpansion(step, num_steps=4)
     assert expansion._trotter_step is step
     assert expansion._num_steps == 4
@@ -175,7 +346,7 @@ def test_trotter_expansion_init_basic():
 
 def test_trotter_expansion_get_single_step():
     """Test TrotterExpansion with a single step."""
-    step = TrotterStep(num_terms=2, time=1.0)
+    step = trotter_decomposition(num_terms=2, time=1.0)
     expansion = TrotterExpansion(step, num_steps=1)
     result = expansion.get()
     assert len(result) == 1
@@ -186,7 +357,7 @@ def test_trotter_expansion_get_single_step():
 
 def test_trotter_expansion_get_multiple_steps():
     """Test TrotterExpansion with multiple steps."""
-    step = TrotterStep(num_terms=2, time=0.25)
+    step = trotter_decomposition(num_terms=2, time=0.25)
     expansion = TrotterExpansion(step, num_steps=4)
     result = expansion.get()
     assert len(result) == 1
@@ -195,15 +366,15 @@ def test_trotter_expansion_get_multiple_steps():
     assert terms == [(0.25, 0), (0.25, 1)]
 
 
-def test_trotter_expansion_with_strang_step():
-    """Test TrotterExpansion using StrangStep."""
-    step = StrangStep(num_terms=2, time=0.5)
+def test_trotter_expansion_with_strang():
+    """Test TrotterExpansion using strang_splitting."""
+    step = strang_splitting(num_terms=2, time=0.5)
     expansion = TrotterExpansion(step, num_steps=2)
     result = expansion.get()
     assert len(result) == 1
     terms, count = result[0]
     assert count == 2
-    # StrangStep with 2 terms: [(0.25, 0), (0.5, 1), (0.25, 0)]
+    # strang_splitting with 2 terms: [(0.25, 0), (0.5, 1), (0.25, 0)]
     assert terms == [(0.25, 0), (0.5, 1), (0.25, 0)]
 
 
@@ -211,7 +382,7 @@ def test_trotter_expansion_total_time():
     """Test that total evolution time is correct."""
     total_time = 1.0
     num_steps = 4
-    step = TrotterStep(num_terms=3, time=total_time / num_steps)
+    step = trotter_decomposition(num_terms=3, time=total_time / num_steps)
     expansion = TrotterExpansion(step, num_steps=num_steps)
     result = expansion.get()
     terms, count = result[0]
@@ -224,18 +395,87 @@ def test_trotter_expansion_total_time():
 
 def test_trotter_expansion_preserves_step():
     """Test that expansion preserves the original step."""
-    step = TrotterStep(num_terms=3, time=0.5)
+    step = trotter_decomposition(num_terms=3, time=0.5)
     expansion = TrotterExpansion(step, num_steps=10)
     result = expansion.get()
     terms, _ = result[0]
-    assert terms == step.get()
+    assert terms == list(step.step())
 
 
-def test_trotter_expansion_docstring_example():
-    """Test the example from the TrotterExpansion docstring."""
-    n = 4  # Number of Trotter steps
-    total_time = 1.0  # Total time
-    trotter_expansion = TrotterExpansion(TrotterStep(2, total_time / n), n)
-    result = trotter_expansion.get()
-    expected = [([(0.25, 0), (0.25, 1)], 4)]
+def test_trotter_expansion_with_fourth_order():
+    """Test TrotterExpansion with fourth-order Trotter-Suzuki."""
+    step = fourth_order_trotter_suzuki(num_terms=2, time=0.25)
+    expansion = TrotterExpansion(step, num_steps=4)
+    result = expansion.get()
+    terms, count = result[0]
+    assert count == 4
+    assert step.order == 4
+
+
+def test_trotter_expansion_order_property():
+    """Test TrotterExpansion order property."""
+    step = strang_splitting(num_terms=3, time=0.5)
+    expansion = TrotterExpansion(step, num_steps=4)
+    assert expansion.order == 2
+
+
+def test_trotter_expansion_nterms_property():
+    """Test TrotterExpansion nterms property."""
+    step = trotter_decomposition(num_terms=5, time=0.5)
+    expansion = TrotterExpansion(step, num_steps=4)
+    assert expansion.nterms == 5
+
+
+def test_trotter_expansion_num_steps_property():
+    """Test TrotterExpansion num_steps property."""
+    step = trotter_decomposition(num_terms=2, time=0.25)
+    expansion = TrotterExpansion(step, num_steps=8)
+    assert expansion.num_steps == 8
+
+
+def test_trotter_expansion_total_time_property():
+    """Test TrotterExpansion total_time property."""
+    step = trotter_decomposition(num_terms=2, time=0.25)
+    expansion = TrotterExpansion(step, num_steps=4)
+    assert expansion.total_time == 1.0
+
+
+def test_trotter_expansion_step_iterator():
+    """Test TrotterExpansion step() iterator yields full expansion."""
+    step = trotter_decomposition(num_terms=2, time=0.5)
+    expansion = TrotterExpansion(step, num_steps=3)
+    result = list(expansion.step())
+    # Should yield 3 repetitions of [(0.5, 0), (0.5, 1)]
+    expected = [(0.5, 0), (0.5, 1), (0.5, 0), (0.5, 1), (0.5, 0), (0.5, 1)]
     assert result == expected
+
+
+def test_trotter_expansion_step_iterator_with_strang():
+    """Test TrotterExpansion step() with Strang splitting."""
+    step = strang_splitting(num_terms=2, time=1.0)
+    expansion = TrotterExpansion(step, num_steps=2)
+    result = list(expansion.step())
+    # Strang with 2 terms: [(0.5, 0), (1.0, 1), (0.5, 0)]
+    # Repeated twice
+    expected = [(0.5, 0), (1.0, 1), (0.5, 0), (0.5, 0), (1.0, 1), (0.5, 0)]
+    assert result == expected
+
+
+def test_trotter_expansion_str():
+    """Test TrotterExpansion string representation."""
+    step = strang_splitting(num_terms=3, time=0.25)
+    expansion = TrotterExpansion(step, num_steps=4)
+    result = str(expansion)
+    assert "order=2" in result
+    assert "num_steps=4" in result
+    assert "total_time=1.0" in result
+    assert "num_terms=3" in result
+
+
+def test_trotter_expansion_repr():
+    """Test TrotterExpansion repr representation."""
+    step = trotter_decomposition(num_terms=2, time=0.5)
+    expansion = TrotterExpansion(step, num_steps=4)
+    result = repr(expansion)
+    assert "TrotterExpansion" in result
+    assert "num_steps=4" in result


### PR DESCRIPTION
Changed some basic functionality:

- The TrotterStep class is now just a wrapper class with some information functions and an iterator
- Factory functions instantiate TrotterStep classes at desired orders (trotter_decomposition, strang_splitting)

Added recursion

- Both the Suzuki fractal recursion and Yoshide triple recursion are implemented (suzuki_recursion, yoshide_recursion)
- fourth_order_trotter_suzuki is a convenience function for strang_splitting composed with suzuki_recursion

Tests added.

This PR is independent from #2925.