### PR TITLE
Fixed broken doc link in Kata

### DIFF
--- a/katas/content/distinguishing_unitaries/rz_ry/index.md
+++ b/katas/content/distinguishing_unitaries/rz_ry/index.md
@@ -2,7 +2,7 @@
 
 1. An angle $\theta \in [0.01 \pi; 0.99 \pi]$.
 2. An operation that implements a single-qubit unitary transformation:
-either the [$R_z(\theta)$ gate](https://learn.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.intrinsic/rz) or the [$R_y(\theta)$ gate](https://learn.microsoft.com/qsharp/api/qsharp/microsoft.quantum.intrinsic/ry). 
+either the [$R_z(\theta)$ gate](https://learn.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.intrinsic/rz) or the [$R_y(\theta)$ gate](https://learn.microsoft.com/qsharp/api/qsharp-lang/microsoft.quantum.intrinsic/ry). 
 
 > As a reminder,
 > 


### PR DESCRIPTION
This fixes the only remaining api/qsharp/ documentation link in Katas and moves it to api/qsharp-lang.
A broader sweep is needed to move everything from microsoft.quantum.* to std.*.