### PR TITLE
Update azure-quantum Python dependency

### DIFF
--- a/source/qdk_package/pyproject.toml
+++ b/source/qdk_package/pyproject.toml
@@ -14,12 +14,12 @@ dependencies = ["qsharp==0.0.0", "pyqir<0.12"]
 
 [project.optional-dependencies]
 jupyter = ["qsharp-widgets==0.0.0", "qsharp-jupyterlab==0.0.0"]
-azure = ["azure-quantum>=3.5.0"]
+azure = ["azure-quantum>=3.7.0"]
 qiskit = ["qiskit>=1.2.2,<3.0.0"]
 cirq = ["cirq-core>=1.3.0,<=1.4.1", "cirq-ionq>=1.3.0,<=1.4.1"]
 all = [
   "qsharp-widgets==0.0.0",
-  "azure-quantum>=3.5.0",
+  "azure-quantum>=3.7.0",
   "qiskit>=1.2.2,<3.0.0",
   "cirq-core>=1.3.0,<=1.4.1",
   "cirq-ionq>=1.3.0,<=1.4.1",


### PR DESCRIPTION
This will ensure users who update the qdk package with the `[azure]` optional dependency also get that package updated.

Resolves #2971