### PR TITLE
Explicitly use `bash` shell on Windows

### DIFF
--- a/.github/workflows/multiplat.yml
+++ b/.github/workflows/multiplat.yml
@@ -55,6 +55,7 @@ jobs:
       - name: File issue on failure
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-issue
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
This fixes an issue where the multiplat CI would fail to file issues on Windows due to the default shell being pwsh. Explicitly using `shell: bash` should make the heredoc (`<<'PY'`) syntax work there as well as the others.