### PR TITLE
disable zoom in editor mode

### DIFF
--- a/source/npm/qsharp/ux/circuit.tsx
+++ b/source/npm/qsharp/ux/circuit.tsx
@@ -88,9 +88,11 @@ function ZoomableCircuit(props: {
       qvizObj.current = qviz.draw(props.circuitGroup, container, {
         renderLocations: props.renderLocations,
         editor: props.editor,
-        onZoomChange: (zoom) => {
-          setZoomLevel(zoom);
-        },
+        onZoomChange: isEditable
+          ? undefined
+          : (zoom) => {
+              setZoomLevel(zoom);
+            },
       });
 
       // Disable "rendering" text


### PR DESCRIPTION
Regression in #2979 accidentally enabled zoom-to-fit behavior in editor mode.