### PR TITLE
fix error in settings reference for vscode-insiders

### DIFF
--- a/source/vscode/src/webview/webview.tsx
+++ b/source/vscode/src/webview/webview.tsx
@@ -201,11 +201,11 @@ function App({ state }: { state: State }) {
           {state.suppressSettings ? null : (
             <p style="margin-top: 8px; font-size: 0.8em">
               Note: If a{" "}
-              <a href="command:workbench.action.openSettings?%22Q%23.simulation.pauliNoise%22">
+              <a href="command:workbench.action.openSettings?%5B%22Q%23.simulation.pauliNoise%22%5D">
                 noise model
               </a>{" "}
               or any{" "}
-              <a href="command:workbench.action.openSettings?%22Q%23.simulation.qubitLoss%22">
+              <a href="command:workbench.action.openSettings?%5B%22Q%23.simulation.qubitLoss%22%5D">
                 qubit loss
               </a>{" "}
               has been configured, this may impact results


### PR DESCRIPTION
Fix for [issue #2981](https://github.com/microsoft/qdk/issues/2981)

The bug only happened in vscode-insiders because the settings URI should be written accordingly to the platform, as:
`vscode-insiders://settings/Q%23.simulation.pauliNoise`

My solution uses command URIs (as per the [documentation](https://code.visualstudio.com/api/extension-guides/command#command-uris)), which are platform agnostic and avoid adding unnecessary complexity to the code. 

In the end, we're executing the same command, and the user will be having the same experience, but it works both in vscode as in vscode-insiders.