### PR TITLE
Expose `CircuitGenerationMethod::Static` to Python

### DIFF
--- a/samples/notebooks/circuits.ipynb
+++ b/samples/notebooks/circuits.ipynb
@@ -161,7 +161,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Conditionals that compare `Result` values are not permitted during circuit synthesis. This is because they may introduce nondeterminism such that the circuit will look different depending on measurement outcome. Representing conditionals visually is not supported."
+    "By default, conditionals that compare `Result` values are not permitted during circuit synthesis. This is because the default method traces a single execution path through the program, and a conditional may produce a different circuit depending on measurement outcome."
    ]
   },
   {
@@ -215,11 +215,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Even though we can't synthesize the above program into a circuit, we still have the option of running it in the simulator, and displaying the resulting circuit.\n",
+    "There are two options for synthesizing circuits for programs that contain measurement-based conditionals.\n",
     "\n",
-    "This can be done by passing in `generation_method=GenerationMethod.Simulate` to the `circuit()` function.\n",
+    "### Option 1: Simulate\n",
     "\n",
-    "Note that the resulting circuit diagram shows only one of the two branches that could have been taken."
+    "By passing `generation_method=CircuitGenerationMethod.Simulate`, the program is run in the simulator and the resulting gates are recorded. Note that the resulting circuit diagram shows only one of the two branches that could have been taken."
    ]
   },
   {
@@ -231,6 +231,57 @@
     "from qsharp import CircuitGenerationMethod\n",
     "\n",
     "Circuit(qsharp.circuit(\"ResetIfOne()\", generation_method=CircuitGenerationMethod.Simulate))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Option 2: Static\n",
+    "\n",
+    "By passing `generation_method=CircuitGenerationMethod.Static`, the circuit is generated via static analysis of the program. This produces a circuit that shows _all_ conditional branches, rendered as classically controlled groups. This requires a target profile that supports mid-circuit measurement, such as `Adaptive_RIF`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qsharp.init(target_profile=qsharp.TargetProfile.Adaptive_RIF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "qsharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%qsharp\n",
+    "\n",
+    "operation ResetIfOne2() : Result {\n",
+    "    use q = Qubit();\n",
+    "    H(q);\n",
+    "    let r = M(q);\n",
+    "    if (r == One) {\n",
+    "        X(q);\n",
+    "    }\n",
+    "    Reset(q);\n",
+    "    return r\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Circuit(qsharp.circuit(\"ResetIfOne2()\", generation_method=CircuitGenerationMethod.Static))"
    ]
   }
  ],

--- a/source/compiler/qsc/src/interpret.rs
+++ b/source/compiler/qsc/src/interpret.rs
@@ -29,7 +29,9 @@ use qsc_circuit::{
     operations::{entry_expr_for_qubit_operation, qubit_param_info},
     rir_to_circuit::rir_to_circuit,
 };
-use qsc_codegen::qir::{fir_to_qir, fir_to_qir_from_callable, fir_to_rir};
+use qsc_codegen::qir::{
+    fir_to_qir, fir_to_qir_from_callable, fir_to_rir, fir_to_rir_from_callable,
+};
 use qsc_data_structures::{
     error::WithSource,
     functors::FunctorApp,
@@ -1053,18 +1055,9 @@ impl Interpreter {
             }
             CircuitGenerationMethod::Static => {
                 if let Some((callable, args)) = invoke_params {
-                    // Static circuit generation from a callable is not yet supported.
-                    // Fall back to classical eval.
-                    self.invoke_with_tracing_backend(
-                        &mut TracingBackend::<SparseSim>::no_backend(&mut tracer),
-                        &mut out,
-                        callable,
-                        args,
-                        eval_config,
-                    )?;
-                } else {
-                    return self.static_circuit(entry_expr.as_deref(), tracer_config);
+                    return self.static_circuit_from_callable(&callable, args, tracer_config);
                 }
+                return self.static_circuit(entry_expr.as_deref(), tracer_config);
             }
         }
         let circuit = tracer.finish(&(self.compiler.package_store(), &self.fir_store));
@@ -1083,6 +1076,55 @@ impl Interpreter {
         let program = self.compile_to_rir_with_debug_metadata(entry_expr)?;
         rir_to_circuit(
             &program,
+            tracer_config,
+            &[self.package, self.source_package],
+            &(self.compiler.package_store(), &self.fir_store),
+        )
+        .map_err(|e| vec![e.into()])
+    }
+
+    fn static_circuit_from_callable(
+        &mut self,
+        callable: &Value,
+        args: Value,
+        tracer_config: TracerConfig,
+    ) -> std::result::Result<Circuit, Vec<Error>> {
+        if self.capabilities == TargetCapabilityFlags::all() {
+            return Err(vec![Error::UnsupportedRuntimeCapabilities]);
+        }
+
+        let Value::Global(store_item_id, _) = callable else {
+            return Err(vec![Error::NotACallable]);
+        };
+
+        let (_original, transformed) = fir_to_rir_from_callable(
+            &self.fir_store,
+            self.capabilities,
+            None,
+            *store_item_id,
+            args,
+            PartialEvalConfig {
+                generate_debug_metadata: true,
+            },
+        )
+        .map_err(|e| {
+            let hir_package_id = match e.span() {
+                Some(span) => span.package,
+                None => map_fir_package_to_hir(self.package),
+            };
+            let source_package = self
+                .compiler
+                .package_store()
+                .get(hir_package_id)
+                .expect("package should exist in the package store");
+            vec![Error::PartialEvaluation(WithSource::from_map(
+                &source_package.sources,
+                e,
+            ))]
+        })?;
+
+        rir_to_circuit(
+            &transformed,
             tracer_config,
             &[self.package, self.source_package],
             &(self.compiler.package_store(), &self.fir_store),

--- a/source/compiler/qsc_circuit/src/circuit.rs
+++ b/source/compiler/qsc_circuit/src/circuit.rs
@@ -906,6 +906,21 @@ impl CircuitDisplay<'_> {
 
                     col_width = max(col_width, 1);
                 }
+            } else if op.is_controlled() {
+                // Rendering groups is disabled, but this is a controlled group - the meaning of the diagram would change if we showed just
+                // the group's contents without the control. So just render the group as a "black box" with the control,
+                // as if it's a standalone gate
+                add_operation_to_rows(
+                    op,
+                    rows,
+                    &target_rows,
+                    &control_rows,
+                    column,
+                    begin,
+                    end,
+                    None,
+                );
+                col_width = max(col_width, 1);
             } else {
                 // Don't render the group, render all the children directly
                 let offset = self.add_grid(column, op.children(), rows, insets, register_to_row);

--- a/source/compiler/qsc_codegen/src/qir.rs
+++ b/source/compiler/qsc_codegen/src/qir.rs
@@ -108,6 +108,33 @@ pub fn fir_to_qir_from_callable(
     Ok(ToQir::<String>::to_qir(&program, &program))
 }
 
+/// converts the given callable to RIR using the given arguments and language features.
+pub fn fir_to_rir_from_callable(
+    fir_store: &qsc_fir::fir::PackageStore,
+    capabilities: TargetCapabilityFlags,
+    compute_properties: Option<PackageStoreComputeProperties>,
+    callable: qsc_fir::fir::StoreItemId,
+    args: Value,
+    partial_eval_config: PartialEvalConfig,
+) -> Result<(Program, Program), qsc_partial_eval::Error> {
+    let compute_properties = compute_properties.unwrap_or_else(|| {
+        let analyzer = qsc_rca::Analyzer::init(fir_store);
+        analyzer.analyze_all()
+    });
+
+    let mut program = partially_evaluate_call(
+        fir_store,
+        &compute_properties,
+        callable,
+        args,
+        capabilities,
+        partial_eval_config,
+    )?;
+    let orig = program.clone();
+    check_and_transform(&mut program);
+    Ok((orig, program))
+}
+
 fn get_rir_from_compilation(
     fir_store: &qsc_fir::fir::PackageStore,
     compute_properties: Option<PackageStoreComputeProperties>,

--- a/source/pip/qsharp/_native.pyi
+++ b/source/pip/qsharp/_native.pyi
@@ -465,6 +465,13 @@ class CircuitGenerationMethod(Enum):
     Use simulation to generate the circuit.
     """
 
+    Static: CircuitGenerationMethod
+    """
+    Compile the program and transform to a circuit using partial evaluation.
+    Only works for AdaptiveRIF-compliant programs.
+    Requires a non-Unrestricted target profile (e.g. TargetProfile.Adaptive_RIF).
+    """
+
 class Circuit:
     def json(self) -> str: ...
     def __repr__(self) -> str: ...

--- a/source/pip/qsharp/_qsharp.py
+++ b/source/pip/qsharp/_qsharp.py
@@ -827,7 +827,9 @@ class QirInputData:
         return self._ll_str
 
 
-def compile(entry_expr: Union[str, Callable, GlobalCallable, Closure], *args) -> QirInputData:
+def compile(
+    entry_expr: Union[str, Callable, GlobalCallable, Closure], *args
+) -> QirInputData:
     """
     Compiles the Q# source code into a program that can be submitted to a target.
     Either an entry expression or a callable with arguments must be provided.
@@ -910,11 +912,9 @@ def circuit(
         )
     elif isinstance(entry_expr, (GlobalCallable, Closure)):
         args = python_args_to_interpreter_args(args)
-        res = get_interpreter().circuit(
-            config=config, callable=entry_expr, args=args
-        )
+        res = get_interpreter().circuit(config=config, callable=entry_expr, args=args)
     else:
-        assert isinstance(entry_expr, str)
+        assert entry_expr is None or isinstance(entry_expr, str)
         res = get_interpreter().circuit(config, entry_expr, operation=operation)
 
     durationMs = (monotonic() - start) * 1000
@@ -968,9 +968,7 @@ def estimate(
         )
     elif isinstance(entry_expr, (GlobalCallable, Closure)):
         args = python_args_to_interpreter_args(args)
-        res_str = get_interpreter().estimate(
-            param_str, callable=entry_expr, args=args
-        )
+        res_str = get_interpreter().estimate(param_str, callable=entry_expr, args=args)
     else:
         assert isinstance(entry_expr, str)
         res_str = get_interpreter().estimate(param_str, entry_expr=entry_expr)

--- a/source/pip/src/interop.rs
+++ b/source/pip/src/interop.rs
@@ -587,10 +587,19 @@ pub(crate) fn circuit_qasm_program(
 
     let package_type = PackageType::Exe;
     let language_features = LanguageFeatures::default();
+    let target_profile = if matches!(
+        config.generation_method,
+        Some(crate::interpreter::CircuitGenerationMethod::Static)
+    ) {
+        TargetProfile::Adaptive_RIF.into()
+    } else {
+        TargetProfile::Unrestricted.into()
+    };
+
     let mut interpreter = create_interpreter_from_ast(
         package,
         source_map,
-        TargetProfile::Unrestricted.into(),
+        target_profile,
         language_features,
         package_type,
     )

--- a/source/pip/src/interpreter.rs
+++ b/source/pip/src/interpreter.rs
@@ -1400,6 +1400,7 @@ impl CircuitConfig {
 pub(crate) enum CircuitGenerationMethod {
     ClassicalEval,
     Simulate,
+    Static,
 }
 
 impl From<CircuitGenerationMethod> for qsc::interpret::CircuitGenerationMethod {
@@ -1409,6 +1410,7 @@ impl From<CircuitGenerationMethod> for qsc::interpret::CircuitGenerationMethod {
                 qsc::interpret::CircuitGenerationMethod::ClassicalEval
             }
             CircuitGenerationMethod::Simulate => qsc::interpret::CircuitGenerationMethod::Simulate,
+            CircuitGenerationMethod::Static => qsc::interpret::CircuitGenerationMethod::Static,
         }
     }
 }

--- a/source/pip/tests/test_qasm.py
+++ b/source/pip/tests/test_qasm.py
@@ -9,6 +9,7 @@ from qsharp import (
     TargetProfile,
     set_quantum_seed,
     BitFlipNoise,
+    CircuitGenerationMethod,
     QSharpError,
     Result,
     eval as qsharp_eval,
@@ -198,7 +199,11 @@ def test_run_imported_with_noise_produces_noisy_results() -> None:
         """,
         name="Program0",
     )
-    result = qsharp_run("{ use (q1, q2) = (Qubit(), Qubit()); Program0(q1, q2) }", shots=1, noise=BitFlipNoise(0.1))
+    result = qsharp_run(
+        "{ use (q1, q2) = (Qubit(), Qubit()); Program0(q1, q2) }",
+        shots=1,
+        noise=BitFlipNoise(0.1),
+    )
     assert result[0] > 5
 
     result = import_openqasm(
@@ -214,7 +219,9 @@ def test_run_imported_with_noise_produces_noisy_results() -> None:
         """,
         name="Program1",
     )
-    result = qsharp_run("{ use q = Qubit(); Program1(q) }", shots=1, noise=BitFlipNoise(0.1))
+    result = qsharp_run(
+        "{ use q = Qubit(); Program1(q) }", shots=1, noise=BitFlipNoise(0.1)
+    )
     assert result[0] > 5
 
 
@@ -626,6 +633,29 @@ def test_circuit_from_program() -> None:
     )
 
 
+def test_circuit_from_program_static() -> None:
+    init()
+
+    c = circuit(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit q;
+        bit c;
+        h q;
+        c = measure q;
+        if (c) { x q; }
+        """,
+        generation_method=CircuitGenerationMethod.Static,
+    )
+    assert str(c) == dedent(
+        """\
+        q_0    ── H ──── M ──── if: c_0 = |1〉 ──
+                         ╘═══════════ ● ════════
+        """
+    )
+
+
 def test_circuit_from_callable() -> None:
     init()
     import_openqasm(
@@ -686,7 +716,9 @@ def test_circuit_from_callable_with_single_qubit_and_qubit_registers() -> None:
         program_type=ProgramType.Operation,
         name="Foo",
     )
-    c = qsharp_circuit("{ use (qs1, a, qs2) = (Qubit[2], Qubit(), Qubit[2]); Foo(qs1, a, qs2); }")
+    c = qsharp_circuit(
+        "{ use (qs1, a, qs2) = (Qubit[2], Qubit(), Qubit[2]); Foo(qs1, a, qs2); }"
+    )
     assert str(c) == dedent(
         """\
         q_0    ── X ──
@@ -731,6 +763,33 @@ def test_circuit_with_measure_from_callable() -> None:
         """\
         q_0    ── H ──── M ──
                          ╘═══
+        """
+    )
+
+
+def test_circuit_from_callable_static() -> None:
+    init(target_profile=TargetProfile.Adaptive_RIF)
+    import_openqasm(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit q;
+        bit c;
+        h q;
+        c = measure q;
+        if (c) { x q; }
+        """,
+        program_type=ProgramType.File,
+        name="Foo",
+    )
+    c = qsharp_circuit(
+        code.qasm_import.Foo,
+        generation_method=CircuitGenerationMethod.Static,
+    )
+    assert str(c) == dedent(
+        """\
+        q_0    ── H ──── M ──── if: c_0 = |1〉 ──
+                         ╘═══════════ ● ════════
         """
     )
 

--- a/source/pip/tests/test_qsharp.py
+++ b/source/pip/tests/test_qsharp.py
@@ -552,7 +552,9 @@ def test_run_with_result_from_qsharp_callable(capsys) -> None:
     assert stdout == "Hello, world!\nHello, world!\nHello, world!\n"
 
 
-def test_run_with_result_from_python_callable_while_global_qubits_allocated(capsys) -> None:
+def test_run_with_result_from_python_callable_while_global_qubits_allocated(
+    capsys,
+) -> None:
     qsharp.init()
     qsharp.eval("use q = Qubit();")
     qsharp.eval(
@@ -564,7 +566,9 @@ def test_run_with_result_from_python_callable_while_global_qubits_allocated(caps
     assert stdout == "Hello, world!\nHello, world!\nHello, world!\n"
 
 
-def test_run_with_result_from_qsharp_callable_while_global_qubits_allocated(capsys) -> None:
+def test_run_with_result_from_qsharp_callable_while_global_qubits_allocated(
+    capsys,
+) -> None:
     qsharp.init()
     qsharp.eval("use q = Qubit();")
     qsharp.eval(
@@ -983,6 +987,7 @@ def test_function_defined_before_namespace_keeps_both_accessible() -> None:
     assert qsharp.code.Four.Two() == 42
     from qsharp.code import Four
     from qsharp.code.Four import Two
+
     assert Four() == 4
     assert Two() == 42
 
@@ -995,6 +1000,7 @@ def test_namespace_defined_before_function_keeps_both_accessible() -> None:
     assert qsharp.code.Four.Two() == 42
     from qsharp.code import Four
     from qsharp.code.Four import Two
+
     assert Four() == 4
     assert Two() == 42
 
@@ -1079,6 +1085,55 @@ def test_circuit_with_generation_method() -> None:
         """\
         q_0    ── X ──── |0〉 ──
         q_1    ────────────────
+        """
+    )
+
+
+def test_circuit_with_static_generation_method() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Adaptive_RIF)
+    qsharp.eval(
+        """
+    operation Foo() : Result {
+        use q = Qubit();
+        H(q);
+        let r = M(q);
+        if r == One { X(q); }
+        Reset(q);
+        r
+    }
+    """
+    )
+    circuit = qsharp.circuit(
+        "Foo()", generation_method=qsharp.CircuitGenerationMethod.Static
+    )
+    assert str(circuit) == dedent(
+        """\
+        q_0    ── H ──── M ──── if: c_0 = |1〉 ──── |0〉 ──
+                         ╘═══════════ ● ═════════════════
+        """
+    )
+
+
+def test_circuit_from_qsharp_callable_static() -> None:
+    qsharp.init(target_profile=qsharp.TargetProfile.Adaptive_RIF)
+    qsharp.eval(
+        """
+    operation Foo() : Unit {
+        use q = Qubit();
+        H(q);
+        let r = M(q);
+        if r == One { X(q); }
+        Reset(q);
+    }
+    """
+    )
+    circuit = qsharp.circuit(
+        qsharp.code.Foo, generation_method=qsharp.CircuitGenerationMethod.Static
+    )
+    assert str(circuit) == dedent(
+        """\
+        q_0    ── H ──── M ──── if: c_0 = |1〉 ──── |0〉 ──
+                         ╘═══════════ ● ═════════════════
         """
     )
 


### PR DESCRIPTION
Previously, `CircuitGenerationMethod::Static` existed in the Rust compiler layer but was not exposed through the Python (`qsharp`) package. The only options available to Python users were `ClassicalEval` and `Simulate`. Calling `circuit()` with a callable and `Static` would silently fall back to `ClassicalEval`, which fails on programs with measurement-based branching.

This PR:

- Adds `Static` to the PyO3 `CircuitGenerationMethod` enum, type stubs, and `From` impl
- Adds `fir_to_rir_from_callable` in `qsc_codegen`, enabling static circuit generation from a callable (previously only `fir_to_rir` existed for entry expressions)
- Adds `static_circuit_from_callable` to `Interpreter`, wiring up the callable + `Static` path instead of falling back to `ClassicalEval`
- For OpenQASM programs, automatically uses `Adaptive_RIF` target profile when `Static` is requested (OpenQASM otherwise defaults to `Unrestricted`, which is incompatible with static circuit generation)
- Fixes `circuit(operation="Foo")` failing with an `AssertionError` when `entry_expr` is `None` (introduced by #2940)
- Updates circuits.ipynb notebook to demonstrate `Static` as an alternative to `Simulate` for programs with measurement-based conditionals

Usage:

```python
qsharp.init(target_profile=qsharp.TargetProfile.Adaptive_RIF)
qsharp.eval("""
operation Foo() : Result {
    use q = Qubit();
    H(q);
    let r = M(q);
    if r == One { X(q); }
    Reset(q);
    r
}
""")
# Shows all branches as classically controlled groups
qsharp.circuit("Foo()", generation_method=qsharp.CircuitGenerationMethod.Static)
```

```
q_0    ── H ──── M ──── if: c_0 = |1〉 ──── |0〉 ──
                 ╘═══════════ ● ═════════════════
```