### PR TITLE
Refactor RCA, part 2

### DIFF
--- a/source/compiler/qsc_partial_eval/src/evaluation_context.rs
+++ b/source/compiler/qsc_partial_eval/src/evaluation_context.rs
@@ -144,10 +144,10 @@ impl Scope {
                     Arg::Discard(value) => value,
                     Arg::Var(_, var) => &var.value,
                 };
-                ComputeKind::new_with_runtime_features(
-                    RuntimeFeatureFlags::empty(),
-                    map_eval_value_to_value_kind(value),
-                )
+                ComputeKind::Dynamic {
+                    runtime_features: RuntimeFeatureFlags::empty(),
+                    value_kind: map_eval_value_to_value_kind(value),
+                }
             })
             .collect();
 
@@ -159,10 +159,8 @@ impl Scope {
             env.bind_variable_in_top_frame(local_var_id, var);
         }
 
-        // Add the values to both the classical environment and the hybrid variables depending on whether the value is
-        // static or dynamic.
-        let arg_runtime_kind_tuple = args.into_iter().zip(args_compute_kind.iter());
-        for (arg, _) in arg_runtime_kind_tuple {
+        // Add the values to both environments.
+        for arg in args {
             let Arg::Var(local_var_id, var) = arg else {
                 continue;
             };
@@ -303,23 +301,23 @@ fn map_eval_value_to_value_kind(value: &Value) -> ValueKind {
         Value::Array(elements) => {
             for element in elements.iter() {
                 let element_runtime_kind = map_eval_value_to_value_kind(element);
-                if element_runtime_kind == ValueKind::Dynamic {
-                    return ValueKind::Dynamic;
+                if element_runtime_kind == ValueKind::Variable {
+                    return ValueKind::Variable;
                 }
             }
 
-            ValueKind::Static
+            ValueKind::Constant
         }
         Value::Tuple(elements, _) => {
             for element in elements.iter() {
                 let element_runtime_kind = map_eval_value_to_value_kind(element);
-                if element_runtime_kind == ValueKind::Dynamic {
-                    return ValueKind::Dynamic;
+                if element_runtime_kind == ValueKind::Variable {
+                    return ValueKind::Variable;
                 }
             }
-            ValueKind::Static
+            ValueKind::Constant
         }
-        Value::Result(Result::Id(_) | Result::Loss) | Value::Var(_) => ValueKind::Dynamic,
+        Value::Result(Result::Id(_) | Result::Loss) | Value::Var(_) => ValueKind::Variable,
         Value::BigInt(_)
         | Value::Bool(_)
         | Value::Closure(_)
@@ -330,6 +328,6 @@ fn map_eval_value_to_value_kind(value: &Value) -> ValueKind {
         | Value::Qubit(_)
         | Value::Range(_)
         | Value::Result(Result::Val(_))
-        | Value::String(_) => ValueKind::Static,
+        | Value::String(_) => ValueKind::Constant,
     }
 }

--- a/source/compiler/qsc_partial_eval/src/lib.rs
+++ b/source/compiler/qsc_partial_eval/src/lib.rs
@@ -41,7 +41,7 @@ use qsc_fir::{
 use qsc_lowerer::map_fir_package_to_hir;
 use qsc_rca::{
     ComputeKind, ComputePropertiesLookup, ItemComputeProperties, PackageStoreComputeProperties,
-    QuantumProperties, RuntimeFeatureFlags, ValueKind,
+    RuntimeFeatureFlags, ValueKind,
     errors::{
         Error as CapabilityError, generate_errors_from_runtime_features,
         get_missing_runtime_features,
@@ -1158,7 +1158,7 @@ impl<'a> PartialEvaluator<'a> {
         }
     }
 
-    fn eval_classical_expr(&mut self, expr_id: ExprId) -> Result<EvalControlFlow, Error> {
+    fn eval_static_expr(&mut self, expr_id: ExprId) -> Result<EvalControlFlow, Error> {
         let current_package_id = self.get_current_package_id();
         let store_expr_id = StoreExprId::from((current_package_id, expr_id));
         let expr = self.package_store.get_expr(store_expr_id);
@@ -1214,7 +1214,7 @@ impl<'a> PartialEvaluator<'a> {
         eval_result
     }
 
-    fn eval_hybrid_expr(&mut self, expr_id: ExprId) -> Result<EvalControlFlow, Error> {
+    fn eval_dynamic_expr(&mut self, expr_id: ExprId) -> Result<EvalControlFlow, Error> {
         let expr = self.get_expr(expr_id);
         let expr_package_span = self.get_expr_package_span(expr_id);
         match &expr.kind {
@@ -1592,10 +1592,10 @@ impl<'a> PartialEvaluator<'a> {
         // by the target.
         if self.is_unresolved_callee_expr(callee_expr_id) {
             let call_compute_kind = self.get_call_compute_kind(call_scope);
-            if let ComputeKind::Quantum(QuantumProperties {
+            if let ComputeKind::Dynamic {
                 runtime_features,
                 value_kind,
-            }) = call_compute_kind
+            } = call_compute_kind
             {
                 let missing_features = get_missing_runtime_features(
                     runtime_features,
@@ -1612,10 +1612,10 @@ impl<'a> PartialEvaluator<'a> {
                     return Err(Error::CapabilityError(error));
                 }
 
-                // If the call produces a dynamic value, we treat it as an error because we know that later
-                // analysis has not taken that dynamism into account and further partial evaluation may fail
+                // If the call produces a variable value, we treat it as an error because we know that later
+                // analysis has not taken that variable into account and further partial evaluation may fail
                 // when it encounters that value.
-                if value_kind == ValueKind::Dynamic {
+                if value_kind == ValueKind::Variable {
                     return Err(Error::UnexpectedDynamicValue(
                         self.get_expr_package_span(call_expr_id),
                     ));
@@ -2328,11 +2328,13 @@ impl<'a> PartialEvaluator<'a> {
         condition_expr_id: ExprId,
         body_block_id: BlockId,
     ) -> Result<EvalControlFlow, Error> {
-        // Verify assumptions: the condition expression must either classical (such that it can be fully evaluated) or
-        // quantum but statically known at runtime (such that it can be partially evaluated to a known value).
+        // Verify assumptions: the condition expression must either static (such that it can be fully evaluated) or
+        // dynamic but constant at runtime (such that it can be partially evaluated to a known value).
         assert!(
-            !self.get_expr_compute_kind(condition_expr_id).is_dynamic(),
-            "loop conditions must be purely classical"
+            !self
+                .get_expr_compute_kind(condition_expr_id)
+                .is_variable_value_kind(),
+            "loop conditions must be known at code generation time."
         );
 
         // Evaluate the block until the loop condition is false.
@@ -2866,9 +2868,9 @@ impl<'a> PartialEvaluator<'a> {
             .expect("program block does not exist")
     }
 
-    fn is_classical_expr(&self, expr_id: ExprId) -> bool {
+    fn is_static_expr(&self, expr_id: ExprId) -> bool {
         let compute_kind = self.get_expr_compute_kind(expr_id);
-        matches!(compute_kind, ComputeKind::Classical)
+        matches!(compute_kind, ComputeKind::Static)
     }
 
     fn allocate_qubit(&mut self) -> Value {
@@ -3111,11 +3113,13 @@ impl<'a> PartialEvaluator<'a> {
     }
 
     fn try_eval_expr(&mut self, expr_id: ExprId) -> Result<EvalControlFlow, Error> {
-        // An expression is evaluated differently depending on whether it is purely classical or hybrid.
-        if self.is_classical_expr(expr_id) {
-            self.eval_classical_expr(expr_id)
+        // An expression is evaluated differently depending on whether it is purely static or dynamic,
+        // since static expressions can be fully evaluated and do not need to generate any instructions,
+        // while dynamic expressions may need to generate instructions and map their value to a variable.
+        if self.is_static_expr(expr_id) {
+            self.eval_static_expr(expr_id)
         } else {
-            self.eval_hybrid_expr(expr_id)
+            self.eval_dynamic_expr(expr_id)
         }
     }
 

--- a/source/compiler/qsc_passes/src/capabilitiesck.rs
+++ b/source/compiler/qsc_passes/src/capabilitiesck.rs
@@ -230,14 +230,15 @@ impl<'a> Checker<'a> {
 
     fn check_expr(&mut self, expr_id: ExprId) {
         let compute_kind = self.compute_properties.get_expr(expr_id).inherent;
-        let ComputeKind::Quantum(quantum_properties) = compute_kind else {
+        let ComputeKind::Dynamic {
+            runtime_features, ..
+        } = compute_kind
+        else {
             return;
         };
 
-        let missing_features = get_missing_runtime_features(
-            quantum_properties.runtime_features,
-            self.target_capabilities,
-        );
+        let missing_features =
+            get_missing_runtime_features(runtime_features, self.target_capabilities);
         let expr = self.get_expr(expr_id);
         if !missing_features.is_empty() {
             self.missing_features_map
@@ -319,11 +320,12 @@ impl<'a> Checker<'a> {
                 .expect("ctl_adj specialization is none"),
         };
 
-        if let ComputeKind::Quantum(quantum_properties) = spec_compute_properties.inherent {
-            let missing_features = get_missing_runtime_features(
-                quantum_properties.runtime_features,
-                self.target_capabilities,
-            );
+        if let ComputeKind::Dynamic {
+            runtime_features, ..
+        } = spec_compute_properties.inherent
+        {
+            let missing_features =
+                get_missing_runtime_features(runtime_features, self.target_capabilities);
             let missing_spec_level_runtime_features =
                 get_spec_level_runtime_features(missing_features);
 
@@ -355,7 +357,10 @@ impl<'a> Checker<'a> {
 
     fn check_output_recording(&mut self, expr: &Expr) {
         let compute_kind = self.compute_properties.get_expr(expr.id).inherent;
-        let ComputeKind::Quantum(quantum_properties) = compute_kind else {
+        let ComputeKind::Dynamic {
+            runtime_features, ..
+        } = compute_kind
+        else {
             return;
         };
 
@@ -368,10 +373,9 @@ impl<'a> Checker<'a> {
         };
 
         // Calculate the missing features but only consider the output recording flags.
-        let missing_features = get_missing_runtime_features(
-            quantum_properties.runtime_features,
-            self.target_capabilities,
-        ) & RuntimeFeatureFlags::output_recording_flags();
+        let missing_features =
+            get_missing_runtime_features(runtime_features, self.target_capabilities)
+                & RuntimeFeatureFlags::output_recording_flags();
         if !missing_features.is_empty() {
             self.missing_features_map
                 .entry(output_reporting_span)

--- a/source/compiler/qsc_rca/src/applications.rs
+++ b/source/compiler/qsc_rca/src/applications.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
-    ApplicationGeneratorSet, ComputeKind, QuantumProperties, RuntimeFeatureFlags, ValueKind,
+    ApplicationGeneratorSet, ComputeKind, RuntimeFeatureFlags, ValueKind,
     common::{Local, LocalKind, LocalsLookup, initialize_locals_map},
     scaffolding::InternalPackageComputeProperties,
 };
@@ -47,7 +47,7 @@ impl GeneratorSetsBuilder {
         for input_param in input_params {
             let input_param_variants = match input_param.ty {
                 Ty::Array(_) => {
-                    // For parameters of type array, two dynamic variants exit. Each
+                    // For parameters of type array, two dynamic variants exist:
                     // - An array with dynamic content and static size.
                     // - An array with dynamic content and dynamic size.
                     let dynamic_content_static_size = ApplicationInstance::new(
@@ -56,10 +56,10 @@ impl GeneratorSetsBuilder {
                         return_type,
                         Some((
                             input_param.index,
-                            ComputeKind::new_with_runtime_features(
-                                RuntimeFeatureFlags::empty(),
-                                ValueKind::Dynamic,
-                            ),
+                            ComputeKind::Dynamic {
+                                runtime_features: RuntimeFeatureFlags::empty(),
+                                value_kind: ValueKind::Variable,
+                            },
                         )),
                     );
                     let dynamic_content_dynamic_size = ApplicationInstance::new(
@@ -68,10 +68,10 @@ impl GeneratorSetsBuilder {
                         return_type,
                         Some((
                             input_param.index,
-                            ComputeKind::new_with_runtime_features(
-                                RuntimeFeatureFlags::UseOfDynamicallySizedArray,
-                                ValueKind::Dynamic,
-                            ),
+                            ComputeKind::Dynamic {
+                                runtime_features: RuntimeFeatureFlags::UseOfDynamicallySizedArray,
+                                value_kind: ValueKind::Variable,
+                            },
                         )),
                     );
                     vec![dynamic_content_static_size, dynamic_content_dynamic_size]
@@ -84,10 +84,10 @@ impl GeneratorSetsBuilder {
                         return_type,
                         Some((
                             input_param.index,
-                            ComputeKind::new_with_runtime_features(
-                                RuntimeFeatureFlags::empty(),
-                                ValueKind::Dynamic,
-                            ),
+                            ComputeKind::Dynamic {
+                                runtime_features: RuntimeFeatureFlags::empty(),
+                                value_kind: ValueKind::Variable,
+                            },
                         )),
                     )]
                 }
@@ -450,12 +450,12 @@ impl ApplicationInstance {
         // Initialize the locals map with the specialization controls (if any).
         let mut locals_map = LocalsComputeKindMap::default();
         if let Some(controls) = controls {
-            // Controls compute properties are handled at the call expression, so just use quantum compute kind with
-            // no runtime features here.
-            let compute_kind = ComputeKind::Quantum(QuantumProperties {
+            // Controls compute properties are handled at the call expression, so just use dynamic compute kind with
+            // no runtime features and constant value kind here.
+            let compute_kind = ComputeKind::Dynamic {
                 runtime_features: RuntimeFeatureFlags::empty(),
-                value_kind: ValueKind::Static,
-            });
+                value_kind: ValueKind::Constant,
+            };
             locals_map.insert(
                 controls.var,
                 LocalComputeKind {
@@ -472,7 +472,7 @@ impl ApplicationInstance {
             };
 
             // If a dynamic application is provided, set the compute kind associated to the parameter accordingly.
-            let mut compute_kind = ComputeKind::Classical;
+            let mut compute_kind = ComputeKind::Static;
             if let Some((dynamic_param_index, dynamic_param_compute_kind)) = dynamic_param
                 && input_param_index == dynamic_param_index
             {
@@ -507,35 +507,36 @@ impl ApplicationInstance {
             let return_expr_compute_kind = self.get_expr_compute_kind(return_expr_id);
 
             // There are two scenarios in which a value kind is considered, and both of them only happen if the return
-            // expression is quantum.
-            if let ComputeKind::Quantum(return_quantum_properties) = return_expr_compute_kind {
-                let return_value_kind = if return_quantum_properties
-                    .runtime_features
+            // expression is dynamic.
+            if let ComputeKind::Dynamic {
+                runtime_features, ..
+            } = return_expr_compute_kind
+            {
+                let return_value_kind = if runtime_features
                     .contains(RuntimeFeatureFlags::ReturnWithinDynamicScope)
                 {
-                    // The return expression happens within a dynamic scope so the value kind is dynamic.
-                    ValueKind::new_dynamic_from_type(&self.return_type)
+                    // The return expression happens within a dynamic scope so the value kind is variable.
+                    ValueKind::new_variable_from_type(&self.return_type)
                 } else {
                     // What we actually want here is the value kind of the returned value expression.
                     let returned_value_expr_compute_kind =
                         self.get_expr_compute_kind(returned_value_expr_id);
-                    let ComputeKind::Quantum(returned_value_quantum_properties) =
-                        returned_value_expr_compute_kind
+                    let ComputeKind::Dynamic { value_kind, .. } = returned_value_expr_compute_kind
                     else {
-                        panic!("returned value expression is expected to be quantum");
+                        panic!("returned value expression is expected to be dynamic");
                     };
-                    returned_value_quantum_properties.value_kind
+                    *value_kind
                 };
                 value_kinds.push(return_value_kind);
             }
         }
 
-        // An application instance does not always have a value kind, only when there is at least one quantum return
+        // An application instance does not always have a value kind, only when there is at least one dynamic return
         // expression.
         let value_kind = if value_kinds.is_empty() {
             None
         } else {
-            let initial_value_kind = ValueKind::Static;
+            let initial_value_kind = ValueKind::Constant;
             let value_kind = value_kinds.iter().fold(
                 initial_value_kind,
                 |aggregated_value_kind, return_value_kind| {

--- a/source/compiler/qsc_rca/src/core.rs
+++ b/source/compiler/qsc_rca/src/core.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     ApplicationGeneratorSet, ArrayParamApplication, ComputeKind, ComputePropertiesLookup,
-    ParamApplication, QuantumProperties, RuntimeFeatureFlags, ValueKind,
+    ParamApplication, RuntimeFeatureFlags, ValueKind,
     applications::{ApplicationInstance, GeneratorSetsBuilder, LocalComputeKind},
     common::{
         AssignmentStmtCounter, Callee, FunctorAppExt, GlobalSpecId, Local, LocalKind,
@@ -62,8 +62,8 @@ impl<'a> Analyzer<'a> {
     fn analyze_expr_array(&mut self, exprs: &Vec<ExprId>) -> ComputeKind {
         // Visit each sub-expression in the array to determine their compute kind, and aggregate ONLY the runtime
         // features to the array's compute kind.
-        let default_value_kind = ValueKind::Static;
-        let mut compute_kind = ComputeKind::Classical;
+        let default_value_kind = ValueKind::Constant;
+        let mut compute_kind = ComputeKind::Static;
         let mut has_dynamic_content = false;
         for expr_id in exprs {
             self.visit_expr(*expr_id);
@@ -71,17 +71,17 @@ impl<'a> Analyzer<'a> {
             let expr_compute_kind = application_instance.get_expr_compute_kind(*expr_id);
             compute_kind =
                 compute_kind.aggregate_runtime_features(*expr_compute_kind, default_value_kind);
-            has_dynamic_content |= expr_compute_kind.is_dynamic();
+            has_dynamic_content |= expr_compute_kind.is_variable_value_kind();
         }
 
         if has_dynamic_content {
-            let ComputeKind::Quantum(quantum_properties) = &mut compute_kind else {
+            let ComputeKind::Dynamic { value_kind, .. } = &mut compute_kind else {
                 panic!(
                     "the compute kind of an array expression cannot have dynamic content and be classical"
                 );
             };
 
-            quantum_properties.value_kind = ValueKind::Dynamic;
+            *value_kind = ValueKind::Variable;
         }
 
         compute_kind
@@ -101,26 +101,30 @@ impl<'a> Analyzer<'a> {
         let application_instance = self.get_current_application_instance();
         let size_expr_compute_kind = *application_instance.get_expr_compute_kind(size_expr_id);
         let value_expr_compute_kind = *application_instance.get_expr_compute_kind(value_expr_id);
-        let default_value_kind = ValueKind::Static;
-        let mut compute_kind = ComputeKind::Classical;
+        let default_value_kind = ValueKind::Constant;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind =
             compute_kind.aggregate_runtime_features(size_expr_compute_kind, default_value_kind);
         compute_kind =
             compute_kind.aggregate_runtime_features(value_expr_compute_kind, default_value_kind);
 
-        if let ComputeKind::Quantum(quantum_properties) = &mut compute_kind {
-            // If the array is dynamic, it requires an additional runtime feature.
-            if size_expr_compute_kind.is_dynamic() {
-                quantum_properties.runtime_features |=
-                    RuntimeFeatureFlags::UseOfDynamicallySizedArray;
+        if let ComputeKind::Dynamic {
+            runtime_features,
+            value_kind,
+        } = &mut compute_kind
+        {
+            // If the array is not constant, it requires an additional runtime feature.
+            if size_expr_compute_kind.is_variable_value_kind() {
+                *runtime_features |= RuntimeFeatureFlags::UseOfDynamicallySizedArray;
             }
 
-            quantum_properties.value_kind =
-                if value_expr_compute_kind.is_dynamic() || size_expr_compute_kind.is_dynamic() {
-                    ValueKind::Dynamic
-                } else {
-                    ValueKind::Static
-                };
+            *value_kind = if value_expr_compute_kind.is_variable_value_kind()
+                || size_expr_compute_kind.is_variable_value_kind()
+            {
+                ValueKind::Variable
+            } else {
+                ValueKind::Constant
+            };
         }
 
         compute_kind
@@ -141,8 +145,8 @@ impl<'a> Analyzer<'a> {
 
         // We do not care about the value kind for this kind of expression because it is an assignment, but we still
         // need a default one.
-        let default_value_kind = ValueKind::Static;
-        let mut compute_kind = ComputeKind::Classical;
+        let default_value_kind = ValueKind::Constant;
+        let mut compute_kind = ComputeKind::Static;
 
         // The compute kind of an assign expression is determined by the runtime features of the updated compute kind
         // associated to the local variable.
@@ -168,32 +172,26 @@ impl<'a> Analyzer<'a> {
         let mut replacement_value_compute_kind =
             *application_instance.get_expr_compute_kind(replacement_value_expr_id);
 
-        let mut default_value_kind = ValueKind::Static;
-        // If we are within a dynamic scope, the compute kind of the assign index expression is dynamic and an additional
+        let mut default_value_kind = ValueKind::Constant;
+        // If we are within a dynamic scope, the compute kind of the assign index expression must be variable and an additional
         // runtime feature is used to mark the array itself as dynamically sized.
         if !application_instance.active_dynamic_scopes.is_empty() {
-            default_value_kind = ValueKind::Dynamic;
+            default_value_kind = ValueKind::Variable;
             replacement_value_compute_kind =
-                replacement_value_compute_kind.aggregate(ComputeKind::new_with_runtime_features(
-                    RuntimeFeatureFlags::UseOfDynamicallySizedArray,
-                    ValueKind::Static,
-                ));
+                replacement_value_compute_kind.aggregate(ComputeKind::Dynamic {
+                    runtime_features: RuntimeFeatureFlags::UseOfDynamicallySizedArray,
+                    value_kind: ValueKind::Constant,
+                });
         }
 
-        let mut updated_compute_kind = ComputeKind::Classical;
+        let mut updated_compute_kind = ComputeKind::Static;
         updated_compute_kind = updated_compute_kind
             .aggregate_runtime_features(replacement_value_compute_kind, default_value_kind);
 
-        // If the replacement value expression is dynamic, the runtime features and value kind of the update have to
+        // If the replacement value expression is variable, the runtime features and value kind of the update have to
         // take this into account.
-        if replacement_value_compute_kind.is_dynamic() {
-            let ComputeKind::Quantum(quantum_properties) = &mut updated_compute_kind else {
-                panic!(
-                    "the compute kind of the update must be quantum if the replacement value is dynamic"
-                );
-            };
-
-            quantum_properties.value_kind = ValueKind::Dynamic;
+        if replacement_value_compute_kind.is_variable_value_kind() {
+            updated_compute_kind.set_variable_value_kind();
         }
 
         // Update the compute kind of the local variable in the locals map.
@@ -210,21 +208,21 @@ impl<'a> Analyzer<'a> {
         // replacement expressions.
         // We do not care about the value kind for this kind of expression because it is an assignment, but we still
         // need a default one.
-        let default_value_kind = ValueKind::Static;
+        let default_value_kind = ValueKind::Constant;
         let index_compute_kind = *application_instance.get_expr_compute_kind(index_expr_id);
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind =
             compute_kind.aggregate_runtime_features(index_compute_kind, default_value_kind);
         compute_kind = compute_kind
             .aggregate_runtime_features(replacement_value_compute_kind, default_value_kind);
 
-        // Finally, if the index expression is dynamic, we aggregate an additional runtime feature.
-        if index_compute_kind.is_dynamic() {
+        // Finally, if the index expression is variable, we aggregate an additional runtime feature.
+        if index_compute_kind.is_variable_value_kind() {
             compute_kind = compute_kind.aggregate_runtime_features(
-                ComputeKind::new_with_runtime_features(
-                    RuntimeFeatureFlags::UseOfDynamicIndex,
-                    default_value_kind,
-                ),
+                ComputeKind::Dynamic {
+                    runtime_features: RuntimeFeatureFlags::UseOfDynamicIndex,
+                    value_kind: default_value_kind,
+                },
                 default_value_kind,
             );
         }
@@ -245,22 +243,22 @@ impl<'a> Analyzer<'a> {
         let application_instance = self.get_current_application_instance();
         let lhs_compute_kind = *application_instance.get_expr_compute_kind(lhs_expr_id);
         let rhs_compute_kind = *application_instance.get_expr_compute_kind(rhs_expr_id);
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind = compute_kind.aggregate(lhs_compute_kind);
         compute_kind = compute_kind.aggregate(rhs_compute_kind);
 
         // Additionally, since the new compute kind can be of a different type than its operands (e.g. 1 == 1),
         // aggregate additional runtime features depending on the binary operator expression's type (if it's dynamic).
-        if let Some(value_kind) = compute_kind.value_kind() {
-            let ComputeKind::Quantum(quantum_properties) = &mut compute_kind else {
-                panic!("expected quantum variant of compute kind");
-            };
-
-            quantum_properties.runtime_features |=
-                derive_runtime_features_for_value_kind_associated_to_type(value_kind, expr_type);
+        if let ComputeKind::Dynamic {
+            runtime_features,
+            value_kind,
+        } = &mut compute_kind
+        {
+            *runtime_features |=
+                derive_runtime_features_for_value_kind_associated_to_type(*value_kind, expr_type);
 
             let lhs_expr_ty = &self.get_expr(lhs_expr_id).ty;
-            if value_kind == ValueKind::Dynamic
+            if *value_kind == ValueKind::Variable
                 && matches!(lhs_expr_ty, Ty::Prim(Prim::String))
                 && expr_type == &Ty::Prim(Prim::Bool)
             {
@@ -270,7 +268,7 @@ impl<'a> Analyzer<'a> {
                 // track the need for string support in the runtime.
                 // Note that output of strings from the entry point is separate checked and does not rely on detecting
                 // this runtime feature.
-                quantum_properties.runtime_features |= RuntimeFeatureFlags::UseOfDynamicString;
+                *runtime_features |= RuntimeFeatureFlags::UseOfDynamicString;
             }
         }
 
@@ -286,20 +284,20 @@ impl<'a> Analyzer<'a> {
         let application_instance = self.get_current_application_instance();
         let lhs_compute_kind = *application_instance.get_expr_compute_kind(lhs_expr_id);
         let rhs_compute_kind = *application_instance.get_expr_compute_kind(rhs_expr_id);
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind = compute_kind.aggregate(lhs_compute_kind);
         compute_kind = compute_kind.aggregate(rhs_compute_kind);
 
-        // As a special case for exp, if the rhs is dynamic the expression gets an extra runtime feature.
+        // As a special case for exp, if the rhs is variable the expression gets an extra runtime feature.
         // This is because we don't emit a native exponential binary operator but unroll it into a sequence
         // of multiplications, which requires the rhs to be known at compile time.
-        if rhs_compute_kind.is_dynamic() {
+        if rhs_compute_kind.is_variable_value_kind() {
             compute_kind = compute_kind.aggregate_runtime_features(
-                ComputeKind::new_with_runtime_features(
-                    RuntimeFeatureFlags::UseOfDynamicExponent,
-                    ValueKind::Static,
-                ),
-                ValueKind::Static,
+                ComputeKind::Dynamic {
+                    runtime_features: RuntimeFeatureFlags::UseOfDynamicExponent,
+                    value_kind: ValueKind::Constant,
+                },
+                ValueKind::Constant,
             );
         }
 
@@ -328,14 +326,14 @@ impl<'a> Analyzer<'a> {
         // The compute kind of this expression depends on whether the callee expression is dynamic.
         let application_instance = self.get_current_application_instance();
         let callee_expr_compute_kind = *application_instance.get_expr_compute_kind(callee_expr_id);
-        let mut compute_kind = if callee_expr_compute_kind.is_dynamic() {
-            // The value kind of a call expression with an dynamic callee is dynamic but its specific variant depends
+        let mut compute_kind = if callee_expr_compute_kind.is_variable_value_kind() {
+            // The value kind of a call expression with an variable callee is variable but its specific variant depends
             // on the expression's type.
-            let value_kind = ValueKind::new_dynamic_from_type(expr_type);
-            ComputeKind::Quantum(QuantumProperties {
+            let value_kind = ValueKind::new_variable_from_type(expr_type);
+            ComputeKind::Dynamic {
                 runtime_features: RuntimeFeatureFlags::CallToDynamicCallee,
                 value_kind,
-            })
+            }
         } else {
             let call_compute_kind =
                 self.analyze_expr_call_with_static_callee(callee_expr_id, args_expr_id, expr_type);
@@ -352,40 +350,41 @@ impl<'a> Analyzer<'a> {
         if !application_instance.active_dynamic_scopes.is_empty() {
             // If the call expression type is either a result or a qubit, it uses dynamic allocation runtime features.
             if let Ty::Prim(Prim::Qubit) = expr_type {
-                // We consider this qubit dynamic so the value kind of this expression must be dynamic.
-                compute_kind = compute_kind.aggregate(ComputeKind::Quantum(QuantumProperties {
+                // We consider this qubit dynamic so the value kind of this expression must be dynamic and variable.
+                compute_kind = compute_kind.aggregate(ComputeKind::Dynamic {
                     runtime_features: RuntimeFeatureFlags::empty(),
-                    value_kind: ValueKind::Dynamic,
-                }));
+                    value_kind: ValueKind::Variable,
+                });
             }
 
             if let Ty::Prim(Prim::Result) = expr_type {
                 compute_kind = compute_kind.aggregate_runtime_features(
-                    ComputeKind::new_with_runtime_features(
-                        RuntimeFeatureFlags::MeasurementWithinDynamicScope,
-                        ValueKind::Static,
-                    ),
-                    ValueKind::Static,
+                    ComputeKind::Dynamic {
+                        runtime_features: RuntimeFeatureFlags::MeasurementWithinDynamicScope,
+                        value_kind: ValueKind::Constant,
+                    },
+                    ValueKind::Constant,
                 );
             }
         }
 
         // If the call expression is dynamic, aggregate the corresponding runtime features depending on its type.
-        if let Some(value_kind) = compute_kind.value_kind() {
-            let ComputeKind::Quantum(quantum_properties) = &mut compute_kind else {
-                panic!("expected quantum variant of Compute Kind");
-            };
-            quantum_properties.runtime_features |=
-                derive_runtime_features_for_value_kind_associated_to_type(value_kind, expr_type);
+        if let ComputeKind::Dynamic {
+            runtime_features,
+            value_kind,
+        } = &mut compute_kind
+        {
+            *runtime_features |=
+                derive_runtime_features_for_value_kind_associated_to_type(*value_kind, expr_type);
         }
 
         // Aggregate the runtime features of the callee and arguments expressions.
         let callee_expr_compute_kind = *application_instance.get_expr_compute_kind(callee_expr_id);
         let args_expr_compute_kind = *application_instance.get_expr_compute_kind(args_expr_id);
         compute_kind =
-            compute_kind.aggregate_runtime_features(callee_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(callee_expr_compute_kind, ValueKind::Constant);
         compute_kind =
-            compute_kind.aggregate_runtime_features(args_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(args_expr_compute_kind, ValueKind::Constant);
         compute_kind
     }
 
@@ -393,18 +392,17 @@ impl<'a> Analyzer<'a> {
         let application_instance = self.get_current_application_instance();
         let args_compute_kind = *application_instance.get_expr_compute_kind(args_expr_id);
         match args_compute_kind {
-            ComputeKind::Classical => ComputeKind::Classical,
-            ComputeKind::Quantum(quantum_properties) => {
-                if quantum_properties
-                    .runtime_features
-                    .contains(RuntimeFeatureFlags::UseOfDynamicallySizedArray)
-                {
-                    ComputeKind::new_with_runtime_features(
-                        quantum_properties.runtime_features,
-                        ValueKind::Dynamic,
-                    )
+            ComputeKind::Static => ComputeKind::Static,
+            ComputeKind::Dynamic {
+                runtime_features, ..
+            } => {
+                if runtime_features.contains(RuntimeFeatureFlags::UseOfDynamicallySizedArray) {
+                    ComputeKind::Dynamic {
+                        runtime_features,
+                        value_kind: ValueKind::Variable,
+                    }
                 } else {
-                    ComputeKind::Classical
+                    ComputeKind::Static
                 }
             }
         }
@@ -460,7 +458,7 @@ impl<'a> Analyzer<'a> {
                     self.get_current_application_instance()
                         .locals_map
                         .find_local_compute_kind(local_var_id)
-                        .map_or(ComputeKind::Classical, |v| v.compute_kind)
+                        .map_or(ComputeKind::Static, |v| v.compute_kind)
                 })
                 .chain(self.derive_arg_compute_kinds(&arg_exprs))
                 .collect()
@@ -471,36 +469,32 @@ impl<'a> Analyzer<'a> {
             application_generator_set.generate_application_compute_kind(&arg_compute_kinds);
 
         // Aggregate the runtime features of the qubit controls expressions.
-        let mut has_dynamic_controls = false;
-        let default_value_kind = ValueKind::Static;
+        let mut has_variable_controls = false;
+        let default_value_kind = ValueKind::Constant;
         for control_expr in args_controls {
             let control_expr_compute_kind =
                 *application_instance.get_expr_compute_kind(control_expr);
             compute_kind = compute_kind
                 .aggregate_runtime_features(control_expr_compute_kind, default_value_kind);
-            has_dynamic_controls |= control_expr_compute_kind.is_dynamic();
+            has_variable_controls |= control_expr_compute_kind.is_variable_value_kind();
         }
 
-        // If any of the control expressions is dynamic, set the compute kind of the call expression to the
-        // corresponding dynamic variant.
-        if has_dynamic_controls {
-            let value_kind = ValueKind::new_dynamic_from_type(&callable_decl.output);
+        // If any of the control expressions is variable, set the compute kind of the call expression to the
+        // corresponding variable variant.
+        if has_variable_controls {
+            let value_kind = ValueKind::new_variable_from_type(&callable_decl.output);
             compute_kind.aggregate_value_kind(value_kind);
         }
 
         // To distinguish between a cyclic operation and a call to a cyclic operation, replace the cyclic operation
         // runtime feature (if any) by a call to a cyclic operation.
-        if let ComputeKind::Quantum(quantum_properties) = &mut compute_kind
-            && quantum_properties
-                .runtime_features
-                .contains(RuntimeFeatureFlags::CyclicOperationSpec)
+        if let ComputeKind::Dynamic {
+            runtime_features, ..
+        } = &mut compute_kind
+            && runtime_features.contains(RuntimeFeatureFlags::CyclicOperationSpec)
         {
-            quantum_properties
-                .runtime_features
-                .remove(RuntimeFeatureFlags::CyclicOperationSpec);
-            quantum_properties
-                .runtime_features
-                .insert(RuntimeFeatureFlags::CallToCyclicOperation);
+            runtime_features.remove(RuntimeFeatureFlags::CyclicOperationSpec);
+            runtime_features.insert(RuntimeFeatureFlags::CallToCyclicOperation);
         }
 
         CallComputeKind::Regular(compute_kind)
@@ -528,10 +522,10 @@ impl<'a> Analyzer<'a> {
             // The value kind of a call expression with an unresolved callee is not known, so to avoid
             // spurious errors in later analysis where the value is used we assume static.
             // During partial-evaluation, the callable is known the actual return kind will be checked.
-            let compute_kind = ComputeKind::Quantum(QuantumProperties {
+            let compute_kind = ComputeKind::Dynamic {
                 runtime_features: RuntimeFeatureFlags::CallToUnresolvedCallee,
-                value_kind: ValueKind::Static,
-            });
+                value_kind: ValueKind::Constant,
+            };
             self.get_current_application_instance_mut()
                 .unresolved_callee_exprs
                 .push(callee_expr_id);
@@ -554,18 +548,18 @@ impl<'a> Analyzer<'a> {
             self.get_current_application_instance_mut()
                 .unresolved_callee_exprs
                 .push(callee_expr_id);
-            return CallComputeKind::Regular(ComputeKind::Quantum(QuantumProperties {
+            return CallComputeKind::Regular(ComputeKind::Dynamic {
                 runtime_features: RuntimeFeatureFlags::CallToUnresolvedCallee,
-                value_kind: ValueKind::Static,
-            }));
+                value_kind: ValueKind::Constant,
+            });
         }
 
-        // We could resolve the callee. Determine the compute kind of the call depending on the callee kind.
+        // We try to resolve the callee and determine the compute kind of the call depending on the callee kind.
         let Some(global_callee) = self.package_store.get_global(callee.item) else {
             // If the callee is not found, that is an indication that it is an item that was removed during
-            // incremental compilation but remains in the name resolution data structures. Assume it is classical
+            // incremental compilation but remains in the name resolution data structures. Assume it is static
             // so that it generates an "unbound name" error at runtime.
-            return CallComputeKind::Regular(ComputeKind::Classical);
+            return CallComputeKind::Regular(ComputeKind::Static);
         };
         match global_callee {
             Global::Callable(callable_decl) => self.analyze_expr_call_with_spec_callee(
@@ -586,14 +580,14 @@ impl<'a> Analyzer<'a> {
 
         // To determine the compute kind of an UDT call expression, aggregate the runtime features of the arguments
         // expression.
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind =
-            compute_kind.aggregate_runtime_features(args_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(args_expr_compute_kind, ValueKind::Constant);
 
         // If any argument to the UDT constructor is dynamic, then the UDT instance is also dynamic and uses an
         // additional runtime feature.
-        if args_expr_compute_kind.is_dynamic() {
-            compute_kind.aggregate_value_kind(ValueKind::Dynamic);
+        if args_expr_compute_kind.is_variable_value_kind() {
+            compute_kind.set_variable_value_kind();
         }
 
         compute_kind
@@ -607,9 +601,9 @@ impl<'a> Analyzer<'a> {
         // additional runtime feature if the message expression is dynamic.
         let application_instance = self.get_current_application_instance();
         let msg_expr_compute_kind = *application_instance.get_expr_compute_kind(msg_expr_id);
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind =
-            compute_kind.aggregate_runtime_features(msg_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(msg_expr_compute_kind, ValueKind::Constant);
 
         compute_kind
     }
@@ -622,13 +616,13 @@ impl<'a> Analyzer<'a> {
         // the value kind adapted to the expression's type.
         let application_instance = self.get_current_application_instance();
         let record_expr_compute_kind = *application_instance.get_expr_compute_kind(record_expr_id);
-        let runtime_kind = if record_expr_compute_kind.is_dynamic() {
-            ValueKind::new_dynamic_from_type(expr_type)
+        let runtime_kind = if record_expr_compute_kind.is_variable_value_kind() {
+            ValueKind::new_variable_from_type(expr_type)
         } else {
-            ValueKind::Static
+            ValueKind::Constant
         };
 
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind =
             compute_kind.aggregate_runtime_features(record_expr_compute_kind, runtime_kind);
         compute_kind
@@ -644,11 +638,11 @@ impl<'a> Analyzer<'a> {
         // Visit the condition expression to determine its compute kind.
         self.visit_expr(condition_expr_id);
 
-        // If the condition expression is dynamic, we push a new dynamic scope.
+        // If the condition expression is not constant, we push a new dynamic scope.
         let application_instance = self.get_current_application_instance_mut();
         let condition_expr_compute_kind =
             *application_instance.get_expr_compute_kind(condition_expr_id);
-        let within_dynamic_scope = condition_expr_compute_kind.is_dynamic();
+        let within_dynamic_scope = condition_expr_compute_kind.is_variable_value_kind();
         if within_dynamic_scope {
             application_instance
                 .active_dynamic_scopes
@@ -673,40 +667,43 @@ impl<'a> Analyzer<'a> {
 
         // Aggregate the runtime features of the sub-expressions.
         let application_instance = self.get_current_application_instance();
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         let condition_expr_compute_kind =
             *application_instance.get_expr_compute_kind(condition_expr_id);
-        compute_kind =
-            compute_kind.aggregate_runtime_features(condition_expr_compute_kind, ValueKind::Static);
+        compute_kind = compute_kind
+            .aggregate_runtime_features(condition_expr_compute_kind, ValueKind::Constant);
         let body_expr_compute_kind = *application_instance.get_expr_compute_kind(body_expr_id);
         compute_kind =
-            compute_kind.aggregate_runtime_features(body_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(body_expr_compute_kind, ValueKind::Constant);
         if let Some(otherwise_expr_id) = otherwise_expr_id {
             let otherwise_expr_compute_kind =
                 *application_instance.get_expr_compute_kind(otherwise_expr_id);
             compute_kind = compute_kind
-                .aggregate_runtime_features(otherwise_expr_compute_kind, ValueKind::Static);
+                .aggregate_runtime_features(otherwise_expr_compute_kind, ValueKind::Constant);
         }
 
-        // If any of the sub-expressions is dynamic, then the compute kind of an if-expression is dynamic and additional
+        // If any of the sub-expressions is variable, then the compute kind of an if-expression is variable and additional
         // runtime features are aggregated.
-        let is_any_sub_expr_dynamic = condition_expr_compute_kind.is_dynamic()
-            || body_expr_compute_kind.is_dynamic()
-            || otherwise_expr_id
-                .is_some_and(|e| application_instance.get_expr_compute_kind(e).is_dynamic());
-        if is_any_sub_expr_dynamic {
+        let is_any_sub_expr_variable = condition_expr_compute_kind.is_variable_value_kind()
+            || body_expr_compute_kind.is_variable_value_kind()
+            || otherwise_expr_id.is_some_and(|e| {
+                application_instance
+                    .get_expr_compute_kind(e)
+                    .is_variable_value_kind()
+            });
+        if is_any_sub_expr_variable {
             let dynamic_value_kind = if matches!(expr_type, Ty::Array(..)) {
-                // An array coming from a dynamic conditional should be treated as dynamic.
-                ValueKind::Dynamic
+                // An array coming from a variable conditional should be treated as variable.
+                ValueKind::Variable
             } else {
-                ValueKind::new_dynamic_from_type(expr_type)
+                ValueKind::new_variable_from_type(expr_type)
             };
             let mut dynamic_runtime_features =
                 derive_runtime_features_for_value_kind_associated_to_type(
                     dynamic_value_kind,
                     expr_type,
                 );
-            if condition_expr_compute_kind.is_dynamic() {
+            if condition_expr_compute_kind.is_variable_value_kind() {
                 if is_any_result(expr_type) {
                     dynamic_runtime_features |= RuntimeFeatureFlags::UseOfDynamicResult;
                 }
@@ -720,10 +717,10 @@ impl<'a> Analyzer<'a> {
                     _ => {}
                 }
             }
-            let dynamic_compute_kind = ComputeKind::Quantum(QuantumProperties {
+            let dynamic_compute_kind = ComputeKind::Dynamic {
                 runtime_features: dynamic_runtime_features,
                 value_kind: dynamic_value_kind,
-            });
+            };
             compute_kind = compute_kind.aggregate(dynamic_compute_kind);
         }
 
@@ -745,41 +742,42 @@ impl<'a> Analyzer<'a> {
         let application_instance = self.get_current_application_instance();
         let array_expr_compute_kind = *application_instance.get_expr_compute_kind(array_expr_id);
         let index_expr_compute_kind = *application_instance.get_expr_compute_kind(index_expr_id);
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind =
-            compute_kind.aggregate_runtime_features(array_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(array_expr_compute_kind, ValueKind::Constant);
         compute_kind =
-            compute_kind.aggregate_runtime_features(index_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(index_expr_compute_kind, ValueKind::Constant);
 
-        // If the index expression is dynamic, the value kind of the expression is also dynamic and an additional
-        // runtime feature is used.
-        if let ComputeKind::Quantum(index_quantum_properties) = &index_expr_compute_kind
-            && index_quantum_properties.value_kind == ValueKind::Dynamic
+        // If the index expression is variable, the value kind of the expression is at least dynamic (possibly variable)
+        // and an additional runtime feature is used.
+        if let ComputeKind::Dynamic { value_kind, .. } = &index_expr_compute_kind
+            && *value_kind == ValueKind::Variable
         {
             let dynamic_runtime_features = RuntimeFeatureFlags::UseOfDynamicIndex;
-            let dynamic_runtime_kind = ValueKind::new_dynamic_from_type(expr_type);
-            compute_kind = compute_kind.aggregate(ComputeKind::Quantum(QuantumProperties {
+            let dynamic_runtime_kind = ValueKind::new_variable_from_type(expr_type);
+            compute_kind = compute_kind.aggregate(ComputeKind::Dynamic {
                 runtime_features: dynamic_runtime_features,
                 value_kind: dynamic_runtime_kind,
-            }));
+            });
         }
 
         // The value kind of the access by index expression also depends on whether the content of the array expression
-        // is dynamic.
-        if let ComputeKind::Quantum(array_quantum_properties) = &array_expr_compute_kind
-            && array_quantum_properties.value_kind == ValueKind::Dynamic
+        // is variable.
+        if let ComputeKind::Dynamic { value_kind, .. } = &array_expr_compute_kind
+            && *value_kind == ValueKind::Variable
         {
-            let dynamic_value_kind = ValueKind::new_dynamic_from_type(expr_type);
+            let dynamic_value_kind = ValueKind::new_variable_from_type(expr_type);
             compute_kind.aggregate_value_kind(dynamic_value_kind);
         }
 
         // If the index expression is dynamic, aggregate the corresponding runtime features depending on its type.
-        if let Some(value_kind) = compute_kind.value_kind() {
-            let ComputeKind::Quantum(quantum_properties) = &mut compute_kind else {
-                panic!("expected quantum variant of Compute Kind");
-            };
-            quantum_properties.runtime_features |=
-                derive_runtime_features_for_value_kind_associated_to_type(value_kind, expr_type);
+        if let ComputeKind::Dynamic {
+            runtime_features,
+            value_kind,
+        } = &mut compute_kind
+        {
+            *runtime_features |=
+                derive_runtime_features_for_value_kind_associated_to_type(*value_kind, expr_type);
         }
 
         compute_kind
@@ -804,26 +802,26 @@ impl<'a> Analyzer<'a> {
 
         // The compute kind of a range expression is the aggregation of its start, step and end expressions.
         let application_instance = self.get_current_application_instance();
-        let start_expr_compute_kind = start_expr_id.map_or(ComputeKind::Classical, |e| {
+        let start_expr_compute_kind = start_expr_id.map_or(ComputeKind::Static, |e| {
             *application_instance.get_expr_compute_kind(e)
         });
-        let step_expr_compute_kind = step_expr_id.map_or(ComputeKind::Classical, |e| {
+        let step_expr_compute_kind = step_expr_id.map_or(ComputeKind::Static, |e| {
             *application_instance.get_expr_compute_kind(e)
         });
-        let end_expr_compute_kind = end_expr_id.map_or(ComputeKind::Classical, |e| {
+        let end_expr_compute_kind = end_expr_id.map_or(ComputeKind::Static, |e| {
             *application_instance.get_expr_compute_kind(e)
         });
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind = compute_kind.aggregate(start_expr_compute_kind);
         compute_kind = compute_kind.aggregate(step_expr_compute_kind);
         compute_kind = compute_kind.aggregate(end_expr_compute_kind);
 
-        // Additionally, if the compute kind of the range is dynamic, mark it with the appropriate runtime feature.
-        if compute_kind.is_dynamic() {
-            compute_kind = compute_kind.aggregate(ComputeKind::new_with_runtime_features(
-                RuntimeFeatureFlags::UseOfDynamicRange,
-                ValueKind::Static,
-            ));
+        // Additionally, if the compute kind of the range is variable, mark it with the appropriate runtime feature.
+        if compute_kind.is_variable_value_kind() {
+            compute_kind = compute_kind.aggregate(ComputeKind::Dynamic {
+                runtime_features: RuntimeFeatureFlags::UseOfDynamicRange,
+                value_kind: ValueKind::Constant,
+            });
         }
         compute_kind
     }
@@ -835,18 +833,18 @@ impl<'a> Analyzer<'a> {
         // The compute kind of the return expression depends on whether the expression happens within a dynamic scope.
         let application_instance = self.get_current_application_instance();
         let mut compute_kind = if application_instance.active_dynamic_scopes.is_empty() {
-            ComputeKind::Classical
+            ComputeKind::Static
         } else {
-            ComputeKind::Quantum(QuantumProperties {
+            ComputeKind::Dynamic {
                 runtime_features: RuntimeFeatureFlags::ReturnWithinDynamicScope,
-                value_kind: ValueKind::Static,
-            })
+                value_kind: ValueKind::Constant,
+            }
         };
 
         // Now just aggregate the runtime features of the value expression.
         let value_expr_compute_kind = *application_instance.get_expr_compute_kind(value_expr_id);
         compute_kind =
-            compute_kind.aggregate_runtime_features(value_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(value_expr_compute_kind, ValueKind::Constant);
         compute_kind
     }
 
@@ -856,16 +854,16 @@ impl<'a> Analyzer<'a> {
         fields: &[FieldAssign],
         expr_type: &Ty,
     ) -> ComputeKind {
-        let mut compute_kind = ComputeKind::Classical;
-        let mut has_dynamic_sub_exprs = false;
+        let mut compute_kind = ComputeKind::Static;
+        let mut has_variable_sub_exprs = false;
         if let Some(copy_expr_id) = copy {
             // Visit the copy expression to determine its compute kind.
             self.visit_expr(copy_expr_id);
             let application_instance = self.get_current_application_instance();
             let expr_compute_kind = *application_instance.get_expr_compute_kind(copy_expr_id);
             compute_kind =
-                compute_kind.aggregate_runtime_features(expr_compute_kind, ValueKind::Static);
-            has_dynamic_sub_exprs |= expr_compute_kind.is_dynamic();
+                compute_kind.aggregate_runtime_features(expr_compute_kind, ValueKind::Constant);
+            has_variable_sub_exprs |= expr_compute_kind.is_variable_value_kind();
         }
 
         // Visit the fields to determine their compute kind.
@@ -874,22 +872,23 @@ impl<'a> Analyzer<'a> {
             let application_instance = self.get_current_application_instance();
             let expr_compute_kind = *application_instance.get_expr_compute_kind(expr_id);
             compute_kind =
-                compute_kind.aggregate_runtime_features(expr_compute_kind, ValueKind::Static);
-            has_dynamic_sub_exprs |= expr_compute_kind.is_dynamic();
+                compute_kind.aggregate_runtime_features(expr_compute_kind, ValueKind::Constant);
+            has_variable_sub_exprs |= expr_compute_kind.is_variable_value_kind();
         }
 
-        // If any of the sub-expressions are dynamic, then the struct expression is dynamic as well.
-        if has_dynamic_sub_exprs {
-            compute_kind.aggregate_value_kind(ValueKind::Dynamic);
+        // If any of the sub-expressions are variable, then the struct expression is variable as well.
+        if has_variable_sub_exprs {
+            compute_kind.set_variable_value_kind();
         }
 
         // If the constructor is dynamic, aggregate the corresponding runtime features depending on its type.
-        if let ComputeKind::Quantum(quantum_properties) = &mut compute_kind {
-            quantum_properties.runtime_features |=
-                derive_runtime_features_for_value_kind_associated_to_type(
-                    quantum_properties.value_kind,
-                    expr_type,
-                );
+        if let ComputeKind::Dynamic {
+            runtime_features,
+            value_kind,
+        } = &mut compute_kind
+        {
+            *runtime_features |=
+                derive_runtime_features_for_value_kind_associated_to_type(*value_kind, expr_type);
         }
 
         compute_kind
@@ -897,9 +896,9 @@ impl<'a> Analyzer<'a> {
 
     fn analyze_expr_string(&mut self, components: &Vec<StringComponent>) -> ComputeKind {
         // Visit the string components to determine their compute kind, aggregate its runtime features and track whether
-        // any of them is dynamic to construct the compute kind of the string expression itself.
-        let mut has_dynamic_components = false;
-        let mut compute_kind = ComputeKind::Classical;
+        // any of them is variable to construct the compute kind of the string expression itself.
+        let mut has_variable_components = false;
+        let mut compute_kind = ComputeKind::Static;
         for component in components {
             match component {
                 StringComponent::Expr(expr_id) => {
@@ -908,8 +907,8 @@ impl<'a> Analyzer<'a> {
                     let component_compute_kind =
                         *application_instance.get_expr_compute_kind(*expr_id);
                     compute_kind = compute_kind
-                        .aggregate_runtime_features(component_compute_kind, ValueKind::Static);
-                    has_dynamic_components |= component_compute_kind.is_dynamic();
+                        .aggregate_runtime_features(component_compute_kind, ValueKind::Constant);
+                    has_variable_components |= component_compute_kind.is_variable_value_kind();
                 }
                 StringComponent::Lit(_) => {
                     // Nothing to aggregate.
@@ -917,12 +916,9 @@ impl<'a> Analyzer<'a> {
             }
         }
 
-        // If any of the string components is dynamic, then the string expression is dynamic as well.
-        if has_dynamic_components {
-            let ComputeKind::Quantum(quantum_properties) = &mut compute_kind else {
-                panic!("Quantum variant was expected for the compute kind of string expression ");
-            };
-            quantum_properties.value_kind = ValueKind::Dynamic;
+        // If any of the string components is variable, then the string expression is variable as well.
+        if has_variable_components {
+            compute_kind.set_variable_value_kind();
         }
 
         compute_kind
@@ -930,21 +926,21 @@ impl<'a> Analyzer<'a> {
 
     fn analyze_expr_tuple(&mut self, exprs: &Vec<ExprId>) -> ComputeKind {
         // Visit the sub-expressions to determine their compute kind, aggregate its runtime features and track whether
-        // any of them is dynamic to construct the compute kind of the tuple expression itself.
-        let mut compute_kind = ComputeKind::Classical;
-        let mut has_dynamic_sub_exprs = false;
+        // any of them is variable to construct the compute kind of the tuple expression itself.
+        let mut compute_kind = ComputeKind::Static;
+        let mut has_variable_sub_exprs = false;
         for expr_id in exprs {
             self.visit_expr(*expr_id);
             let application_instance = self.get_current_application_instance();
             let expr_compute_kind = *application_instance.get_expr_compute_kind(*expr_id);
             compute_kind =
-                compute_kind.aggregate_runtime_features(expr_compute_kind, ValueKind::Static);
-            has_dynamic_sub_exprs |= expr_compute_kind.is_dynamic();
+                compute_kind.aggregate_runtime_features(expr_compute_kind, ValueKind::Constant);
+            has_variable_sub_exprs |= expr_compute_kind.is_variable_value_kind();
         }
 
-        // If any of the sub-expressions is dynamic, then the tuple expression is dynamic as well.
-        if has_dynamic_sub_exprs {
-            compute_kind.aggregate_value_kind(ValueKind::Dynamic);
+        // If any of the sub-expressions is variable, then the tuple expression is variable as well.
+        if has_variable_sub_exprs {
+            compute_kind.set_variable_value_kind();
         }
 
         compute_kind
@@ -974,15 +970,17 @@ impl<'a> Analyzer<'a> {
         let record_expr_compute_kind = *application_instance.get_expr_compute_kind(record_expr_id);
         let replace_expr_compute_kind =
             *application_instance.get_expr_compute_kind(replace_expr_id);
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind =
-            compute_kind.aggregate_runtime_features(record_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(record_expr_compute_kind, ValueKind::Constant);
         compute_kind =
-            compute_kind.aggregate_runtime_features(replace_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(replace_expr_compute_kind, ValueKind::Constant);
 
-        // If either the record or the replace expressions are dynamic, the update field expression is dynamic as well.
-        if record_expr_compute_kind.is_dynamic() || replace_expr_compute_kind.is_dynamic() {
-            compute_kind.aggregate_value_kind(ValueKind::Dynamic);
+        // If either the record or the replace expressions are variable, the update field expression is variable as well.
+        if record_expr_compute_kind.is_variable_value_kind()
+            || replace_expr_compute_kind.is_variable_value_kind()
+        {
+            compute_kind.set_variable_value_kind();
         }
 
         compute_kind
@@ -1006,33 +1004,34 @@ impl<'a> Analyzer<'a> {
         let index_expr_compute_kind = *application_instance.get_expr_compute_kind(index_expr_id);
         let replacement_value_expr_compute_kind =
             *application_instance.get_expr_compute_kind(replacement_value_expr_id);
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
         compute_kind =
-            compute_kind.aggregate_runtime_features(array_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(array_expr_compute_kind, ValueKind::Constant);
         compute_kind =
-            compute_kind.aggregate_runtime_features(index_expr_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(index_expr_compute_kind, ValueKind::Constant);
         compute_kind = compute_kind
-            .aggregate_runtime_features(replacement_value_expr_compute_kind, ValueKind::Static);
-        // If the index expression is dynamic, an additional runtime feature is used.
-        if index_expr_compute_kind.is_dynamic() {
-            let additional_compute_kind = ComputeKind::Quantum(QuantumProperties {
+            .aggregate_runtime_features(replacement_value_expr_compute_kind, ValueKind::Constant);
+        // If the index expression is variable, an additional runtime feature is used.
+        if index_expr_compute_kind.is_variable_value_kind() {
+            let additional_compute_kind = ComputeKind::Dynamic {
                 runtime_features: RuntimeFeatureFlags::UseOfDynamicIndex,
-                value_kind: ValueKind::Static,
-            });
-            compute_kind =
-                compute_kind.aggregate_runtime_features(additional_compute_kind, ValueKind::Static);
+                value_kind: ValueKind::Constant,
+            };
+            compute_kind = compute_kind
+                .aggregate_runtime_features(additional_compute_kind, ValueKind::Constant);
         }
 
         // The value kind of the update index expression is based on the value kind of the array expression.
-        if let ComputeKind::Quantum(array_quantum_properties) = array_expr_compute_kind {
-            compute_kind.aggregate_value_kind(array_quantum_properties.value_kind);
+        if let ComputeKind::Dynamic { value_kind, .. } = array_expr_compute_kind {
+            compute_kind.aggregate_value_kind(value_kind);
         }
 
-        // If either the index or the replacement value expressions are dynamic, then the content of the resulting array
-        // expression is also dynamic.
-        if index_expr_compute_kind.is_dynamic() || replacement_value_expr_compute_kind.is_dynamic()
+        // If either the index or the replacement value expressions are variable, then the content of the resulting array
+        // expression is also variable.
+        if index_expr_compute_kind.is_variable_value_kind()
+            || replacement_value_expr_compute_kind.is_variable_value_kind()
         {
-            compute_kind.aggregate_value_kind(ValueKind::Dynamic);
+            compute_kind.set_variable_value_kind();
         }
 
         compute_kind
@@ -1040,15 +1039,15 @@ impl<'a> Analyzer<'a> {
 
     fn analyze_expr_var(&self, res: &Res) -> ComputeKind {
         match res {
-            // Global items do not have quantum properties by themselves so we can consider them classical.
-            Res::Item(_) => ComputeKind::Classical,
+            // Global items do not have dynamic properties by themselves so we can consider them classical.
+            Res::Item(_) => ComputeKind::Static,
             // Gather the current compute kind of the local.
             Res::Local(local_var_id) => {
                 let application_instance = self.get_current_application_instance();
                 application_instance
                     .locals_map
                     .find_local_compute_kind(*local_var_id)
-                    .map_or(ComputeKind::Classical, |v| v.compute_kind)
+                    .map_or(ComputeKind::Static, |v| v.compute_kind)
             }
             Res::Err => panic!("unexpected error resolution"),
         }
@@ -1076,7 +1075,7 @@ impl<'a> Analyzer<'a> {
             let application_instance = self.get_current_application_instance_mut();
             condition_expr_compute_kind =
                 *application_instance.get_expr_compute_kind(condition_expr_id);
-            let within_dynamic_scope = condition_expr_compute_kind.is_dynamic();
+            let within_dynamic_scope = condition_expr_compute_kind.is_variable_value_kind();
             if within_dynamic_scope {
                 application_instance
                     .active_dynamic_scopes
@@ -1097,18 +1096,21 @@ impl<'a> Analyzer<'a> {
         // Return the aggregated runtime features of the condition expression and the block.
         let application_instance = self.get_current_application_instance();
         let block_compute_kind = *application_instance.get_block_compute_kind(block_id);
-        let mut compute_kind = ComputeKind::Classical;
+        let mut compute_kind = ComputeKind::Static;
+        compute_kind = compute_kind
+            .aggregate_runtime_features(condition_expr_compute_kind, ValueKind::Constant);
         compute_kind =
-            compute_kind.aggregate_runtime_features(condition_expr_compute_kind, ValueKind::Static);
-        compute_kind =
-            compute_kind.aggregate_runtime_features(block_compute_kind, ValueKind::Static);
+            compute_kind.aggregate_runtime_features(block_compute_kind, ValueKind::Constant);
 
-        // If the condition is dynamic, we require an additional runtime feature.
-        if condition_expr_compute_kind.is_dynamic() {
-            let ComputeKind::Quantum(quantum_properties) = &mut compute_kind else {
-                panic!("if the loop condition is quantum, the loop expression must be quantum too");
+        // If the condition is variable, we require an additional runtime feature.
+        if condition_expr_compute_kind.is_variable_value_kind() {
+            let ComputeKind::Dynamic {
+                runtime_features, ..
+            } = &mut compute_kind
+            else {
+                panic!("if the loop condition is variable, the loop expression must be dynamic");
             };
-            quantum_properties.runtime_features |= RuntimeFeatureFlags::LoopWithDynamicCondition;
+            *runtime_features |= RuntimeFeatureFlags::LoopWithDynamicCondition;
         }
 
         compute_kind
@@ -1177,13 +1179,16 @@ impl<'a> Analyzer<'a> {
                 let mut entry_compute_kind = *self
                     .get_current_application_instance()
                     .get_expr_compute_kind(entry_expr_id);
-                if let ComputeKind::Quantum(quantum_properties) = &mut entry_compute_kind {
-                    quantum_properties.runtime_features |= ty_flags;
+                if let ComputeKind::Dynamic {
+                    runtime_features, ..
+                } = &mut entry_compute_kind
+                {
+                    *runtime_features |= ty_flags;
                 } else {
-                    entry_compute_kind = ComputeKind::Quantum(QuantumProperties {
+                    entry_compute_kind = ComputeKind::Dynamic {
                         runtime_features: ty_flags,
-                        value_kind: ValueKind::Static,
-                    });
+                        value_kind: ValueKind::Constant,
+                    };
                 }
                 self.get_current_application_instance_mut()
                     .insert_expr_compute_kind(entry_expr_id, entry_compute_kind);
@@ -1521,7 +1526,7 @@ impl<'a> Analyzer<'a> {
                     .get_or_init_local_compute_kind(
                         *local_var_id,
                         LocalKind::Mutable,
-                        ComputeKind::Classical,
+                        ComputeKind::Static,
                     );
                 let mut updated_compute_kind = local_var_compute_kind.compute_kind;
 
@@ -1535,10 +1540,10 @@ impl<'a> Analyzer<'a> {
                 updated_compute_kind = updated_compute_kind.aggregate(value_expr_compute_kind);
 
                 // If a local is updated within a dynamic scope, the updated value of the local variable should be
-                // dynamic and additional runtime features may apply.
+                // dynamic and variable with additional runtime features that may apply.
                 if !application_instance.active_dynamic_scopes.is_empty() {
                     let local_type = &assignee_expr.ty;
-                    let mut dynamic_value_kind = ValueKind::new_dynamic_from_type(local_type);
+                    let mut dynamic_value_kind = ValueKind::new_variable_from_type(local_type);
                     let mut dynamic_runtime_features =
                         derive_runtime_features_for_value_kind_associated_to_type(
                             dynamic_value_kind,
@@ -1549,26 +1554,24 @@ impl<'a> Analyzer<'a> {
                         &mut dynamic_runtime_features,
                         &mut dynamic_value_kind,
                     );
-                    let dynamic_compute_kind = ComputeKind::new_with_runtime_features(
-                        dynamic_runtime_features,
-                        dynamic_value_kind,
-                    );
+                    let dynamic_compute_kind = ComputeKind::Dynamic {
+                        runtime_features: dynamic_runtime_features,
+                        value_kind: dynamic_value_kind,
+                    };
                     updated_compute_kind = updated_compute_kind.aggregate(dynamic_compute_kind);
                 }
 
                 // If the updated compute kind is dynamic, include additional properties depending on the type of the
                 // local variable.
-                if let Some(value_kind) = updated_compute_kind.value_kind() {
-                    let ComputeKind::Quantum(updated_quantum_properties) =
-                        &mut updated_compute_kind
-                    else {
-                        panic!("expected Quantum variant of Compute Kind");
-                    };
-                    updated_quantum_properties.runtime_features |=
-                        derive_runtime_features_for_value_kind_associated_to_type(
-                            value_kind,
-                            &assignee_expr.ty,
-                        );
+                if let ComputeKind::Dynamic {
+                    runtime_features,
+                    value_kind,
+                } = &mut updated_compute_kind
+                {
+                    *runtime_features |= derive_runtime_features_for_value_kind_associated_to_type(
+                        *value_kind,
+                        &assignee_expr.ty,
+                    );
                 }
 
                 let application_instance = self.get_current_application_instance_mut();
@@ -1582,7 +1585,7 @@ impl<'a> Analyzer<'a> {
                     assert!(assignee_exprs.len() == value_exprs.len());
 
                     // To determine the update compute kind, we aggregate the runtime features of each element.
-                    let mut updated_compute_kind = ComputeKind::Classical;
+                    let mut updated_compute_kind = ComputeKind::Static;
                     for (element_assignee_expr_id, element_value_expr_id) in
                         assignee_exprs.iter().zip(value_exprs.iter())
                     {
@@ -1592,19 +1595,19 @@ impl<'a> Analyzer<'a> {
                         );
                         updated_compute_kind = updated_compute_kind.aggregate_runtime_features(
                             element_update_compute_kind,
-                            ValueKind::Static,
+                            ValueKind::Constant,
                         );
                     }
                     updated_compute_kind
                 } else {
                     // To determine the update compute kind, we aggregate the runtime features of each update.
-                    let mut updated_compute_kind = ComputeKind::Classical;
+                    let mut updated_compute_kind = ComputeKind::Static;
                     for element_assignee_expr_id in assignee_exprs {
                         let element_update_compute_kind = self
                             .update_locals_compute_kind(*element_assignee_expr_id, value_expr_id);
                         updated_compute_kind = updated_compute_kind.aggregate_runtime_features(
                             element_update_compute_kind,
-                            ValueKind::Static,
+                            ValueKind::Constant,
                         );
                     }
                     updated_compute_kind
@@ -1681,13 +1684,13 @@ fn update_features_for_type(
             // For arrays updated in a dynamic context, we also need to include the runtime feature
             // of dynamic arrays and change the value kind.
             *dynamic_runtime_features |= RuntimeFeatureFlags::UseOfDynamicallySizedArray;
-            *dynamic_value_kind = ValueKind::Dynamic;
+            *dynamic_value_kind = ValueKind::Variable;
         }
         Ty::Tuple(tup) if !tup.is_empty() => {
             // For tuples updated in a dynamic context, we also need to include the runtime feature
             // of dynamic tuples and change the value kind.
             *dynamic_runtime_features |= RuntimeFeatureFlags::UseOfDynamicTuple;
-            *dynamic_value_kind = ValueKind::Dynamic;
+            *dynamic_value_kind = ValueKind::Variable;
         }
         Ty::Prim(Prim::Result) => {
             // For result types updated in a dynamic context, we need to include the runtime
@@ -1724,7 +1727,7 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
         let block = self.get_block(block_id);
 
         // Visit each statement in the block and aggregate its compute kind.
-        let mut block_compute_kind = ComputeKind::Classical;
+        let mut block_compute_kind = ComputeKind::Static;
         for stmt_id in &block.stmts {
             // Visiting a statement performs its analysis for the current application instance.
             self.visit_stmt(*stmt_id);
@@ -1732,8 +1735,8 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
             // Now, we can query the statement's compute kind and aggregate it to the block's compute kind.
             let application_instance = self.get_current_application_instance();
             let stmt_compute_kind = *application_instance.get_stmt_compute_kind(*stmt_id);
-            block_compute_kind =
-                block_compute_kind.aggregate_runtime_features(stmt_compute_kind, ValueKind::Static);
+            block_compute_kind = block_compute_kind
+                .aggregate_runtime_features(stmt_compute_kind, ValueKind::Constant);
         }
 
         // Update the block's value kind if its non-unit, based on the value kind of its last statement's expression.
@@ -1747,9 +1750,8 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
                 let application_instance = self.get_current_application_instance();
                 let last_expr_compute_kind =
                     application_instance.get_expr_compute_kind(last_expr_id);
-                if let ComputeKind::Quantum(last_expr_quantum_properties) = last_expr_compute_kind {
-                    block_compute_kind
-                        .aggregate_value_kind(last_expr_quantum_properties.value_kind);
+                if let ComputeKind::Dynamic { value_kind, .. } = last_expr_compute_kind {
+                    block_compute_kind.aggregate_value_kind(*value_kind);
                 }
             }
         }
@@ -1840,14 +1842,14 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
             ExprKind::Call(callee_expr_id, args_expr_id) => {
                 self.analyze_expr_call(*callee_expr_id, *args_expr_id, &expr.ty)
             }
-            ExprKind::Closure(..) => ComputeKind::Classical,
+            ExprKind::Closure(..) => ComputeKind::Static,
             ExprKind::Fail(msg_expr_id) => self.analyze_expr_fail(*msg_expr_id),
             ExprKind::Field(record_expr_id, _) => {
                 self.analyze_expr_field(*record_expr_id, &expr.ty)
             }
             ExprKind::Hole | ExprKind::Lit(_) => {
-                // Hole and literal expressions are purely classical.
-                ComputeKind::Classical
+                // Hole and literal expressions are always static.
+                ComputeKind::Static
             }
             ExprKind::If(condition_expr_id, body_expr_id, otherwise_expr_id) => {
                 let expr = self.get_expr(expr_id);
@@ -1974,8 +1976,8 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
                 // runtime features since the value kind is meaningless for semicolon statements.
                 let application_instance = self.get_current_application_instance();
                 let expr_compute_kind = *application_instance.get_expr_compute_kind(*expr_id);
-                ComputeKind::Classical
-                    .aggregate_runtime_features(expr_compute_kind, ValueKind::Static)
+                ComputeKind::Static
+                    .aggregate_runtime_features(expr_compute_kind, ValueKind::Constant)
             }
             StmtKind::Local(mutability, pat_id, value_expr_id) => {
                 // Visit the expression to determine its compute kind.
@@ -1988,12 +1990,12 @@ impl<'a> Visitor<'a> for Analyzer<'a> {
                 // runtime features since the value kind is meaningless for local (binding) statements.
                 let application_instance = self.get_current_application_instance();
                 let expr_compute_kind = *application_instance.get_expr_compute_kind(*value_expr_id);
-                ComputeKind::Classical
-                    .aggregate_runtime_features(expr_compute_kind, ValueKind::Static)
+                ComputeKind::Static
+                    .aggregate_runtime_features(expr_compute_kind, ValueKind::Constant)
             }
             StmtKind::Item(_) => {
-                // An item statement does not have any inherent quantum properties, so we just treat it as classical compute.
-                ComputeKind::Classical
+                // An item statement does not have any inherent dynamic properties, so we just treat it as static.
+                ComputeKind::Static
             }
         };
 
@@ -2176,14 +2178,14 @@ fn derive_intrinsic_function_application_generator_set(
         // When a parameter is bound to a dynamic value, its type contributes to the runtime features used by the
         // function application.
         let runtime_features = derive_runtime_features_for_value_kind_associated_to_type(
-            ValueKind::new_dynamic_from_type(&param.ty),
+            ValueKind::new_variable_from_type(&param.ty),
             &param.ty,
         );
-        let value_kind = ValueKind::new_dynamic_from_type(&callable_context.output_type);
-        let param_compute_kind = ComputeKind::Quantum(QuantumProperties {
+        let value_kind = ValueKind::new_variable_from_type(&callable_context.output_type);
+        let param_compute_kind = ComputeKind::Dynamic {
             runtime_features,
             value_kind,
-        });
+        };
 
         // Create a parameter application depending on the parameter type.
         let param_application = match &param.ty {
@@ -2196,8 +2198,8 @@ fn derive_intrinsic_function_application_generator_set(
     }
 
     ApplicationGeneratorSet {
-        // Functions are inherently classical.
-        inherent: ComputeKind::Classical,
+        // Functions are inherently static.
+        inherent: ComputeKind::Static,
         dynamic_param_applications,
     }
 }
@@ -2207,14 +2209,14 @@ fn array_param_application_from_runtime_features(
     value_kind: ValueKind,
 ) -> ParamApplication {
     ParamApplication::Array(ArrayParamApplication {
-        static_size: ComputeKind::Quantum(QuantumProperties {
+        static_size: ComputeKind::Dynamic {
             runtime_features,
             value_kind,
-        }),
-        dynamic_size: ComputeKind::Quantum(QuantumProperties {
+        },
+        dynamic_size: ComputeKind::Dynamic {
             runtime_features: runtime_features | RuntimeFeatureFlags::UseOfDynamicallySizedArray,
             value_kind,
-        }),
+        },
     })
 }
 
@@ -2227,9 +2229,9 @@ fn derive_instrinsic_operation_application_generator_set(
     let runtime_kind = if callable_context.output_type == Ty::UNIT
         || callable_context.output_type == Ty::Prim(Prim::Qubit)
     {
-        ValueKind::Static
+        ValueKind::Constant
     } else {
-        ValueKind::new_dynamic_from_type(&callable_context.output_type)
+        ValueKind::new_variable_from_type(&callable_context.output_type)
     };
 
     let mut inherent_runtime_features = RuntimeFeatureFlags::empty();
@@ -2240,11 +2242,11 @@ fn derive_instrinsic_operation_application_generator_set(
         inherent_runtime_features |= RuntimeFeatureFlags::CallToCustomReset;
     }
 
-    // The compute kind of intrinsic operations is always quantum.
-    let inherent_compute_kind = ComputeKind::Quantum(QuantumProperties {
+    // The compute kind of intrinsic operations is always dynamic.
+    let inherent_compute_kind = ComputeKind::Dynamic {
         runtime_features: inherent_runtime_features,
         value_kind: runtime_kind,
-    });
+    };
 
     // Determine the compute kind of all dynamic parameter applications.
     let mut dynamic_param_applications =
@@ -2255,14 +2257,14 @@ fn derive_instrinsic_operation_application_generator_set(
         // When a parameter is bound to a dynamic value, its type contributes to the runtime features used by the
         // operation application.
         let runtime_features = derive_runtime_features_for_value_kind_associated_to_type(
-            ValueKind::new_dynamic_from_type(&param.ty),
+            ValueKind::new_variable_from_type(&param.ty),
             &param.ty,
         );
-        let value_kind = ValueKind::new_dynamic_from_type(&callable_context.output_type);
-        let param_compute_kind = ComputeKind::Quantum(QuantumProperties {
+        let value_kind = ValueKind::new_variable_from_type(&callable_context.output_type);
+        let param_compute_kind = ComputeKind::Dynamic {
             runtime_features,
             value_kind,
-        });
+        };
 
         // Create a parameter application depending on the parameter type.
         let param_application = match &param.ty {
@@ -2332,8 +2334,8 @@ fn derive_runtime_features_for_value_kind_associated_to_type(
     ) -> RuntimeFeatureFlags {
         let mut runtime_features = RuntimeFeatureFlags::empty();
 
-        if value_kind == ValueKind::Dynamic {
-            let content_value_kind = ValueKind::new_dynamic_from_type(content_type);
+        if value_kind == ValueKind::Variable {
+            let content_value_kind = ValueKind::new_variable_from_type(content_type);
             runtime_features |= derive_runtime_features_for_value_kind_associated_to_type(
                 content_value_kind,
                 content_type,
@@ -2347,7 +2349,7 @@ fn derive_runtime_features_for_value_kind_associated_to_type(
         value_kind: ValueKind,
         arrow: &Arrow,
     ) -> RuntimeFeatureFlags {
-        if value_kind == ValueKind::Static {
+        if value_kind == ValueKind::Constant {
             return RuntimeFeatureFlags::empty();
         }
 
@@ -2361,7 +2363,7 @@ fn derive_runtime_features_for_value_kind_associated_to_type(
         value_kind: ValueKind,
         prim: Prim,
     ) -> RuntimeFeatureFlags {
-        if value_kind == ValueKind::Static {
+        if value_kind == ValueKind::Constant {
             return RuntimeFeatureFlags::empty();
         }
 
@@ -2385,13 +2387,13 @@ fn derive_runtime_features_for_value_kind_associated_to_type(
         value_kind: ValueKind,
         element_types: &Vec<Ty>,
     ) -> RuntimeFeatureFlags {
-        if value_kind == ValueKind::Static {
+        if value_kind == ValueKind::Constant {
             return RuntimeFeatureFlags::empty();
         }
 
         let mut runtime_features = RuntimeFeatureFlags::empty();
         for element_type in element_types {
-            let element_value_kind = ValueKind::new_dynamic_from_type(element_type);
+            let element_value_kind = ValueKind::new_variable_from_type(element_type);
             runtime_features |= derive_runtime_features_for_value_kind_associated_to_type(
                 element_value_kind,
                 element_type,
@@ -2404,8 +2406,8 @@ fn derive_runtime_features_for_value_kind_associated_to_type(
         value_kind: ValueKind,
     ) -> RuntimeFeatureFlags {
         match value_kind {
-            ValueKind::Dynamic => RuntimeFeatureFlags::UseOfDynamicUdt,
-            ValueKind::Static => RuntimeFeatureFlags::empty(),
+            ValueKind::Variable => RuntimeFeatureFlags::UseOfDynamicUdt,
+            ValueKind::Constant => RuntimeFeatureFlags::empty(),
         }
     }
 

--- a/source/compiler/qsc_rca/src/cyclic_callables.rs
+++ b/source/compiler/qsc_rca/src/cyclic_callables.rs
@@ -142,15 +142,15 @@ impl<'a> Analyzer<'a> {
         let mut dynamic_param_applications =
             Vec::<ParamApplication>::with_capacity(input_params.len());
         for param in input_params {
-            // If any parameter is dynamic, we assume the output of a function with cycles is also dynamic.
-            let value_kind = ValueKind::new_dynamic_from_type(output_type);
+            // If any parameter is dynamic, we assume the output of a function with cycles requires a variable value kind.
+            let value_kind = ValueKind::new_variable_from_type(output_type);
 
             // Since using cyclic functions with dynamic parameters requires advanced runtime capabilities, we use the
             // corresponding runtime feature.
-            let param_compute_kind = ComputeKind::new_with_runtime_features(
-                RuntimeFeatureFlags::CallToCyclicFunctionWithDynamicArg,
+            let param_compute_kind = ComputeKind::Dynamic {
+                runtime_features: RuntimeFeatureFlags::CallToCyclicFunctionWithDynamicArg,
                 value_kind,
-            );
+            };
 
             // Create a parameter application depending on the parameter type.
             let param_application = match &param.ty {
@@ -164,8 +164,8 @@ impl<'a> Analyzer<'a> {
         }
 
         ApplicationGeneratorSet {
-            // Functions are inherently classically pure.
-            inherent: ComputeKind::Classical,
+            // Functions are inherently classically pure, so when passed static parameters their output is static.
+            inherent: ComputeKind::Static,
             dynamic_param_applications,
         }
     }
@@ -276,11 +276,11 @@ fn create_operation_specialization_application_generator_set(
 ) -> ApplicationGeneratorSet {
     // Since operations can allocate and measure qubits freely, we assume its compute kind is quantum and that their
     // value kind is dynamic.
-    let value_kind = ValueKind::new_dynamic_from_type(output_type);
-    let inherent_compute_kind = ComputeKind::new_with_runtime_features(
-        RuntimeFeatureFlags::CyclicOperationSpec,
+    let value_kind = ValueKind::new_variable_from_type(output_type);
+    let inherent_compute_kind = ComputeKind::Dynamic {
+        runtime_features: RuntimeFeatureFlags::CyclicOperationSpec,
         value_kind,
-    );
+    };
 
     // The compute kind of a cyclic operation for all dynamic parameter applications is the same as its inherent
     // compute kind.

--- a/source/compiler/qsc_rca/src/lib.rs
+++ b/source/compiler/qsc_rca/src/lib.rs
@@ -319,7 +319,7 @@ pub struct ApplicationGeneratorSet {
 impl Default for ApplicationGeneratorSet {
     fn default() -> Self {
         Self {
-            inherent: ComputeKind::Classical,
+            inherent: ComputeKind::Static,
             dynamic_param_applications: Vec::new(),
         }
     }
@@ -360,26 +360,29 @@ impl ApplicationGeneratorSet {
         {
             match param_application {
                 ParamApplication::Element(param_compute_kind) => {
-                    if arg_compute_kind.is_dynamic() {
+                    if arg_compute_kind.is_variable_value_kind() {
                         compute_kind = compute_kind.aggregate(*param_compute_kind);
                     }
                 }
                 ParamApplication::Array(array_param_application) => {
-                    if let ComputeKind::Quantum(quantum_properties) = arg_compute_kind {
-                        match quantum_properties.value_kind {
-                            ValueKind::Dynamic
-                                if quantum_properties
-                                    .runtime_features
+                    if let ComputeKind::Dynamic {
+                        runtime_features,
+                        value_kind,
+                    } = arg_compute_kind
+                    {
+                        match value_kind {
+                            ValueKind::Variable
+                                if runtime_features
                                     .contains(RuntimeFeatureFlags::UseOfDynamicallySizedArray) =>
                             {
                                 compute_kind =
                                     compute_kind.aggregate(array_param_application.dynamic_size);
                             }
-                            ValueKind::Dynamic => {
+                            ValueKind::Variable => {
                                 compute_kind =
                                     compute_kind.aggregate(array_param_application.static_size);
                             }
-                            ValueKind::Static => {
+                            ValueKind::Constant => {
                                 // No aggregation needed for static arrays.
                             }
                         }
@@ -426,61 +429,72 @@ impl Display for ArrayParamApplication {
     }
 }
 
+/// The two computation kinds for a program element: static or dynamic. These correspond to the
+/// concepts in Partial Evaluation, where "static" refers to computations that can be performed
+/// at code generation time and "dynamic" refers to computations that must occur during runtime
+/// and are emitted into the generated code.
 #[derive(Clone, Copy, Debug)]
 pub enum ComputeKind {
-    Classical,
-    Quantum(QuantumProperties),
+    // An element that will be fully computed during code generation and does not affect the required capabilities of
+    // the runtime environment for emitted code.
+    Static,
+    // An element that will be emitted into the generated code and may require additional capabilities in the runtime
+    // environment.
+    Dynamic {
+        /// The runtime features used by the program element.
+        runtime_features: RuntimeFeatureFlags,
+        /// The kind of value produced by the program element.
+        value_kind: ValueKind,
+    },
 }
 
 impl Display for ComputeKind {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self {
-            ComputeKind::Quantum(quantum_properties) => write!(f, "Quantum: {quantum_properties}")?,
-            ComputeKind::Classical => write!(f, "Classical")?,
+            ComputeKind::Dynamic {
+                runtime_features,
+                value_kind,
+            } => {
+                let mut indent = set_indentation(indented(f), 0);
+                write!(indent, "Dynamic:",)?;
+                indent = set_indentation(indent, 1);
+                write!(indent, "\nruntime_features: {runtime_features:?}")?;
+                write!(indent, "\nvalue_kind: {value_kind}")?;
+            }
+            ComputeKind::Static => write!(f, "Static")?,
         }
         Ok(())
     }
 }
 
 impl ComputeKind {
-    #[must_use]
-    pub fn new_with_runtime_features(
-        runtime_features: RuntimeFeatureFlags,
-        value_kind: ValueKind,
-    ) -> Self {
-        Self::Quantum(QuantumProperties {
+    pub(crate) fn aggregate(self, value: Self) -> Self {
+        let ComputeKind::Dynamic {
             runtime_features,
             value_kind,
-        })
-    }
-
-    pub(crate) fn aggregate(self, value: Self) -> Self {
-        let ComputeKind::Quantum(value_quantum_properties) = value else {
-            // A classical compute kind has nothing to aggregate so just return self with no changes.
+        } = value
+        else {
+            // A static compute kind has nothing to aggregate so just return self with no changes.
             return self;
         };
 
-        // Determine the aggregated runtime features.
-        let runtime_features = match self {
-            Self::Classical => value_quantum_properties.runtime_features,
-            Self::Quantum(ref self_quantum_properties) => {
-                self_quantum_properties.runtime_features | value_quantum_properties.runtime_features
-            }
-        };
-
-        // Determine the aggregated value kind.
-        let value_kind = match self {
-            Self::Classical => value_quantum_properties.value_kind,
-            Self::Quantum(self_quantum_properties) => self_quantum_properties
-                .value_kind
-                .aggregate(value_quantum_properties.value_kind),
+        // Determine the aggregated runtime features and value kind.
+        let (runtime_features, value_kind) = match self {
+            Self::Static => (runtime_features, value_kind),
+            Self::Dynamic {
+                runtime_features: self_runtime_features,
+                value_kind: self_value_kind,
+            } => (
+                self_runtime_features | runtime_features,
+                self_value_kind.aggregate(value_kind),
+            ),
         };
 
         // Return the aggregated compute kind.
-        ComputeKind::Quantum(QuantumProperties {
+        ComputeKind::Dynamic {
             runtime_features,
             value_kind,
-        })
+        }
     }
 
     pub(crate) fn aggregate_runtime_features(
@@ -488,93 +502,77 @@ impl ComputeKind {
         value: ComputeKind,
         default_value_kind: ValueKind,
     ) -> Self {
-        let Self::Quantum(value_quantum_properties) = value else {
-            // A classical compute kind has nothing to aggregate so just return the self with no changes.
+        let Self::Dynamic {
+            runtime_features, ..
+        } = value
+        else {
+            // A static compute kind has nothing to aggregate so just return the self with no changes.
             return self;
         };
 
-        // Determine the aggregated runtime features.
-        let runtime_features = match self {
-            Self::Classical => value_quantum_properties.runtime_features,
-            Self::Quantum(ref self_quantum_properties) => {
-                self_quantum_properties.runtime_features | value_quantum_properties.runtime_features
-            }
-        };
-
-        // Use the value kind equivalent from self.
-        let value_kind = match self {
-            // If self was classical, the aggregated value kind is all static.
-            Self::Classical => default_value_kind,
-            Self::Quantum(self_quantum_properties) => self_quantum_properties.value_kind,
+        // Determine the aggregated runtime features, use the value kind equivalent from self or the default.
+        let (runtime_features, value_kind) = match self {
+            Self::Static => (runtime_features, default_value_kind),
+            Self::Dynamic {
+                runtime_features: self_runtime_features,
+                value_kind: self_value_kind,
+            } => (self_runtime_features | runtime_features, self_value_kind),
         };
 
         // Return the aggregated compute kind.
-        ComputeKind::Quantum(QuantumProperties {
+        ComputeKind::Dynamic {
             runtime_features,
             value_kind,
-        })
+        }
     }
 
     pub(crate) fn aggregate_value_kind(&mut self, value: ValueKind) {
-        let Self::Quantum(quantum_properties) = self else {
-            panic!("a value kind can only be aggregated to a compute kind of the quantum variant");
+        let Self::Dynamic { value_kind, .. } = self else {
+            panic!("a value kind can only be aggregated to a compute kind of the dynamic variant");
         };
 
-        quantum_properties.value_kind = quantum_properties.value_kind.aggregate(value);
+        *value_kind = value_kind.aggregate(value);
+    }
+
+    pub(crate) fn set_variable_value_kind(&mut self) {
+        let Self::Dynamic { value_kind, .. } = self else {
+            panic!(
+                "a value kind can only be set to variable for a compute kind of the dynamic variant"
+            );
+        };
+
+        *value_kind = ValueKind::Variable;
     }
 
     #[must_use]
-    pub fn is_dynamic(self) -> bool {
-        match self {
-            Self::Classical => false,
-            Self::Quantum(quantum_properties) => {
-                quantum_properties.value_kind == ValueKind::Dynamic
+    pub fn is_variable_value_kind(self) -> bool {
+        matches!(
+            self,
+            Self::Dynamic {
+                value_kind: ValueKind::Variable,
+                ..
             }
-        }
-    }
-
-    pub(crate) fn value_kind(self) -> Option<ValueKind> {
-        match self {
-            Self::Classical => None,
-            Self::Quantum(quantum_properties) => Some(quantum_properties.value_kind),
-        }
+        )
     }
 }
 
-/// The quantum properties of a program element.
-#[derive(Clone, Copy, Debug)]
-pub struct QuantumProperties {
-    /// The runtime features used by the program element.
-    pub runtime_features: RuntimeFeatureFlags,
-    /// The kind of value produced by the program element.
-    pub value_kind: ValueKind,
-}
-
-impl Display for QuantumProperties {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let mut indent = set_indentation(indented(f), 0);
-        write!(indent, "QuantumProperties:",)?;
-        indent = set_indentation(indent, 1);
-        write!(indent, "\nruntime_features: {:?}", self.runtime_features)?;
-        write!(indent, "\nvalue_kind: {}", self.value_kind)?;
-        Ok(())
-    }
-}
-
+/// The kind of value corresponding to a program element, indicating whether it is constant over the course of runtime or can vary.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ValueKind {
-    Static,
-    Dynamic,
+    // A value that is constant during execution.
+    Constant,
+    // A value that can vary during execution, which may require additional capabilities and support in the runtime environment.
+    Variable,
 }
 
 impl Display for ValueKind {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self {
-            ValueKind::Static => {
-                write!(f, "Static")?;
+            ValueKind::Constant => {
+                write!(f, "Constant")?;
             }
-            ValueKind::Dynamic => {
-                write!(f, "Dynamic")?;
+            ValueKind::Variable => {
+                write!(f, "Variable")?;
             }
         }
         Ok(())
@@ -584,17 +582,17 @@ impl Display for ValueKind {
 impl ValueKind {
     pub(crate) fn aggregate(self, value: ValueKind) -> Self {
         match value {
-            Self::Static => self,
-            Self::Dynamic => Self::Dynamic,
+            Self::Constant => self,
+            Self::Variable => Self::Variable,
         }
     }
 
-    pub(crate) fn new_dynamic_from_type(ty: &Ty) -> Self {
+    pub(crate) fn new_variable_from_type(ty: &Ty) -> Self {
         if *ty == Ty::UNIT {
-            // The associated value kind for a unit type is always static.
-            Self::Static
+            // The associated value kind for a unit type is always constant.
+            Self::Constant
         } else {
-            Self::Dynamic
+            Self::Variable
         }
     }
 }

--- a/source/compiler/qsc_rca/src/overrider.rs
+++ b/source/compiler/qsc_rca/src/overrider.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     ApplicationGeneratorSet, ArrayParamApplication, ComputeKind, PackageId, ParamApplication,
-    QuantumProperties, RuntimeFeatureFlags, ValueKind, common::LocalSpecId,
+    RuntimeFeatureFlags, ValueKind, common::LocalSpecId,
     scaffolding::InternalPackageStoreComputeProperties,
 };
 use qsc_fir::{
@@ -35,19 +35,23 @@ impl<'a> Overrider<'a> {
         package_store: &'a PackageStore,
         package_store_compute_properties: InternalPackageStoreComputeProperties,
     ) -> Self {
+        // We only override one callable as it is a special exception: `Std.Core.Length`.
+        // When given a static array or a dynamic array with static size, `Std.Core.Length` returns a static int.
+        // However, when given a dynamically sized array, it returns a dynamic int with the `UseOfDynamicallySizedArray` runtime feature.
+        // This captures the fact that the length of a dynamically sized array is not known at compile time.
         let callable_overrides_tuples: [(String, Vec<SpecOverride>); 1] = [(
             "Std.Core.Length".into(),
             vec![SpecOverride {
                 functor_set_value: FunctorSetValue::Empty,
                 application_generator_set: ApplicationGeneratorSet {
-                    inherent: ComputeKind::Classical,
+                    inherent: ComputeKind::Static,
                     dynamic_param_applications: vec![ParamApplication::Array(
                         ArrayParamApplication {
-                            static_size: ComputeKind::Classical,
-                            dynamic_size: ComputeKind::Quantum(QuantumProperties {
+                            static_size: ComputeKind::Static,
+                            dynamic_size: ComputeKind::Dynamic {
                                 runtime_features: RuntimeFeatureFlags::UseOfDynamicallySizedArray,
-                                value_kind: ValueKind::Dynamic,
-                            }),
+                                value_kind: ValueKind::Variable,
+                            },
                         },
                     )],
                 },

--- a/source/compiler/qsc_rca/src/tests/arrays.rs
+++ b/source/compiler/qsc_rca/src/tests/arrays.rs
@@ -13,7 +13,7 @@ fn check_rca_for_array_with_classical_elements() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -32,9 +32,9 @@ fn check_rca_for_array_with_dynamic_results() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -53,9 +53,9 @@ fn check_rca_for_array_with_dynamic_bools() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -69,7 +69,7 @@ fn check_rca_for_array_repeat_with_classical_value_and_classical_size() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -87,9 +87,9 @@ fn check_rca_for_array_repeat_with_dynamic_result_value_and_classical_size() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -108,9 +108,9 @@ fn check_rca_for_array_repeat_with_dynamic_bool_value_and_classical_size() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -129,9 +129,9 @@ fn check_rca_for_array_repeat_with_classical_value_and_dynamic_size() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -153,9 +153,9 @@ fn check_rca_for_array_repeat_with_dynamic_double_value_and_dynamic_size() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -177,9 +177,9 @@ fn check_rca_for_mutable_array_statically_appended() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -201,9 +201,9 @@ fn check_rca_for_mutable_array_dynamically_appended() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -225,7 +225,7 @@ fn check_rca_for_mutable_array_assignment_in_static_context() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -247,9 +247,9 @@ fn check_rca_for_mutable_array_assignment_in_dynamic_context() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -268,9 +268,9 @@ fn check_rca_for_immutable_array_bound_to_dynamic_array() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -292,7 +292,7 @@ fn check_rca_for_mutable_array_assign_index_in_classical_context() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -314,9 +314,9 @@ fn check_rca_for_mutable_array_assign_index_in_dynamic_context() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -339,9 +339,9 @@ fn check_rca_for_mutable_array_assign_index_dynamic_content_in_dynamic_context()
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -364,9 +364,9 @@ fn check_rca_for_mutable_array_assign_index_dynamic_nested_array_content_in_dyna
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -385,7 +385,7 @@ fn check_rca_for_access_using_classical_index() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -405,9 +405,9 @@ fn check_rca_for_access_using_dynamic_index() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble | UseOfDynamicIndex)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -428,9 +428,9 @@ fn check_rca_for_array_with_dynamic_size_bound_through_tuple() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -454,9 +454,9 @@ fn check_rca_for_array_with_dynamic_size_bound_through_tuple_from_callable() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -476,7 +476,7 @@ fn check_rca_for_array_with_static_size_bound_through_tuple() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -499,7 +499,7 @@ fn check_rca_for_array_with_static_size_bound_through_tuple_from_callable() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -520,9 +520,9 @@ fn check_rca_for_array_with_static_size_bound_through_dynamic_tuple() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -540,7 +540,7 @@ fn check_rca_for_index_range_on_array_with_classical_contents() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -559,9 +559,9 @@ fn check_rca_for_index_range_on_array_with_dynamic_contents() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -580,9 +580,9 @@ fn check_rca_for_indirect_length_on_array_with_dynamic_contents() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -602,9 +602,9 @@ fn check_rca_for_indirect_length_on_array_with_dynamic_length() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/assigns.rs
+++ b/source/compiler/qsc_rca/src/tests/assigns.rs
@@ -18,7 +18,7 @@ fn check_rca_for_classical_int_assign_to_local() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -38,9 +38,9 @@ fn check_rca_for_dynamic_result_assign_to_local() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -61,9 +61,9 @@ fn check_rca_for_dynamic_bool_assign_to_local() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -86,9 +86,9 @@ fn check_rca_for_dynamic_int_assign_to_local() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -112,9 +112,9 @@ fn check_rca_for_dynamic_double_assign_to_local() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -137,7 +137,7 @@ fn chec_rca_for_assign_call_result_to_tuple_of_vars() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -161,7 +161,7 @@ fn chec_rca_for_assign_var_binded_to_call_result_to_tuple_of_vars() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -182,7 +182,7 @@ fn chec_rca_for_assign_tuple_var_to_tuple_of_vars() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -205,7 +205,7 @@ fn check_rca_for_assign_classical_call_result_to_tuple_of_vars() {
         compilation_context.get_compute_properties(),
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
     compilation_context.update(
@@ -217,7 +217,7 @@ fn check_rca_for_assign_classical_call_result_to_tuple_of_vars() {
         compilation_context.get_compute_properties(),
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -242,9 +242,9 @@ fn check_rca_for_assign_dynamic_call_result_to_tuple_of_vars() {
         compilation_context.get_compute_properties(),
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
     compilation_context.update(
@@ -256,9 +256,9 @@ fn check_rca_for_assign_dynamic_call_result_to_tuple_of_vars() {
         compilation_context.get_compute_properties(),
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -281,9 +281,9 @@ fn check_rca_for_assign_dynamic_static_mix_call_result_to_tuple_of_vars() {
         compilation_context.get_compute_properties(),
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
     compilation_context.update(
@@ -295,9 +295,9 @@ fn check_rca_for_assign_dynamic_static_mix_call_result_to_tuple_of_vars() {
         compilation_context.get_compute_properties(),
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -320,7 +320,7 @@ fn check_rca_for_mutable_classical_integer_assigned_updated_with_classical_integ
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -343,9 +343,9 @@ fn check_rca_for_mutable_classical_integer_assigned_updated_with_dynamic_integer
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -368,9 +368,9 @@ fn check_rca_for_mutable_dynamic_integer_assigned_updated_with_classical_integer
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -393,9 +393,9 @@ fn check_rca_for_mutable_dynamic_integer_assigned_updated_with_dynamic_integer()
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -419,9 +419,9 @@ fn check_rca_for_mutable_dynamic_result_assigned_updated_in_dynamic_context() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicResult)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -441,9 +441,9 @@ fn check_rca_for_immutable_dynamic_result_bound_to_dynamic_result() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicResult)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -468,9 +468,9 @@ fn check_rca_for_immutable_dynamic_result_bound_to_result_from_classical_conditi
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -497,9 +497,9 @@ fn check_rca_for_immutable_dynamic_result_bound_to_call_with_dynamic_args() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicResult)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -522,7 +522,7 @@ fn check_rca_for_mutable_tuple_assigned_updated_in_static_context() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -545,9 +545,9 @@ fn check_rca_for_mutable_tuple_assigned_updated_in_dynamic_context() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | UseOfDynamicTuple)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -567,9 +567,9 @@ fn check_rca_for_immutable_tuple_bound_to_dynamic_tuple() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicTuple)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -593,7 +593,7 @@ fn check_rca_for_immutable_tuple_bound_to_tuple_from_classical_conditional() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/bindings.rs
+++ b/source/compiler/qsc_rca/src/tests/bindings.rs
@@ -19,7 +19,7 @@ fn check_rca_for_immutable_classical_result_binding() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -38,9 +38,9 @@ fn check_rca_for_immutable_dynamic_result_binding() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -58,7 +58,7 @@ fn check_rca_for_mutable_classical_bool_binding() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -78,9 +78,9 @@ fn check_rca_for_mutable_dynamic_bool_binding() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -98,7 +98,7 @@ fn check_rca_for_immutable_classical_int_binding() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -120,9 +120,9 @@ fn check_rca_for_immutable_dynamic_int_binding() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -140,7 +140,7 @@ fn check_rca_for_mutable_classical_double_binding() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -163,9 +163,9 @@ fn check_rca_for_mutable_dynamic_double_binding() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/binops.rs
+++ b/source/compiler/qsc_rca/src/tests/binops.rs
@@ -13,7 +13,7 @@ fn check_rca_for_bin_op_with_classical_lhs_and_classical_rhs() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -31,9 +31,9 @@ fn check_rca_for_bin_op_with_dynamic_lhs_and_classical_rhs() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -51,9 +51,9 @@ fn check_rca_for_bin_op_with_classical_lhs_and_dynamic_rhs() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -72,9 +72,9 @@ fn check_rca_for_bin_op_with_dynamic_lhs_and_dynamic_rhs() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -92,7 +92,7 @@ fn check_rca_for_nested_bin_ops_with_classic_operands() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -111,9 +111,9 @@ fn check_rca_for_nested_bin_ops_with_a_dynamic_operand() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -127,7 +127,7 @@ fn check_rca_for_exp_op_with_classical_lhs_and_classical_rhs() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -147,9 +147,9 @@ fn check_rca_for_exp_op_with_dynamic_lhs_and_classical_rhs() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -169,9 +169,9 @@ fn check_rca_for_exp_op_with_classical_lhs_and_dynamic_rhs() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicExponent)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -193,9 +193,9 @@ fn check_rca_for_exp_op_with_dynamic_lhs_and_dynamic_rhs() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicExponent)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/callables.rs
+++ b/source/compiler/qsc_rca/src/tests/callables.rs
@@ -17,14 +17,14 @@ fn check_rca_for_function_in_core_package() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(0x0)
-                            value_kind: Dynamic
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicallySizedArray | LoopWithDynamicCondition)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -46,7 +46,7 @@ fn check_rca_for_closure_function_with_classical_captured_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -68,7 +68,7 @@ fn check_rca_for_closure_function_with_dynamic_captured_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -89,7 +89,7 @@ fn check_rca_for_closure_operation_with_classical_captured_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -111,7 +111,7 @@ fn check_rca_for_closure_operation_with_dynamic_captured_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -136,9 +136,9 @@ fn check_rca_for_operation_with_one_classical_return_and_one_dynamic_return() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -163,7 +163,7 @@ fn check_rca_for_callable_block_with_unreachable_binding() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -193,9 +193,9 @@ fn check_rca_for_callable_block_with_dynamic_unreachable_binding() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | ReturnWithinDynamicScope)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -224,9 +224,9 @@ fn check_rca_for_test_callable() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -244,37 +244,37 @@ fn check_rca_for_unrestricted_h() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -288,37 +288,37 @@ fn check_rca_for_base_h() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -332,49 +332,49 @@ fn check_rca_for_unrestricted_r1() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -388,49 +388,49 @@ fn check_rca_for_base_r1() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -444,49 +444,49 @@ fn check_rca_for_unrestricted_rx() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -500,49 +500,49 @@ fn check_rca_for_base_rx() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -556,61 +556,61 @@ fn check_rca_for_unrestricted_rxx() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -624,61 +624,61 @@ fn check_rca_for_base_rxx() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -692,49 +692,49 @@ fn check_rca_for_unrestricted_ry() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -748,49 +748,49 @@ fn check_rca_for_base_ry() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -804,61 +804,61 @@ fn check_rca_for_unrestricted_ryy() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -872,61 +872,61 @@ fn check_rca_for_base_ryy() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -940,49 +940,49 @@ fn check_rca_for_unrestricted_rz() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -996,49 +996,49 @@ fn check_rca_for_base_rz() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1052,61 +1052,61 @@ fn check_rca_for_unrestricted_rzz() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1120,61 +1120,61 @@ fn check_rca_for_base_rzz() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1188,37 +1188,37 @@ fn check_rca_for_unrestricted_s() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1232,37 +1232,37 @@ fn check_rca_for_base_s() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1276,37 +1276,37 @@ fn check_rca_for_unrestricted_t() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1320,37 +1320,37 @@ fn check_rca_for_base_t() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1364,37 +1364,37 @@ fn check_rca_for_unrestricted_x() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1408,37 +1408,37 @@ fn check_rca_for_base_x() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1452,37 +1452,37 @@ fn check_rca_for_unrestricted_y() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1496,37 +1496,37 @@ fn check_rca_for_base_y() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1540,37 +1540,37 @@ fn check_rca_for_unrestricted_z() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }
 
@@ -1584,36 +1584,36 @@ fn check_rca_for_base_z() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static"#]],
+                            value_kind: Constant"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/calls.rs
+++ b/source/compiler/qsc_rca/src/tests/calls.rs
@@ -23,7 +23,7 @@ fn check_rca_for_call_to_cyclic_function_with_classical_argument() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -48,9 +48,9 @@ fn check_rca_for_call_to_cyclic_function_with_dynamic_argument() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | CallToCyclicFunctionWithDynamicArg)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -74,9 +74,9 @@ fn check_rca_for_call_to_cyclic_operation_with_classical_argument() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | CallToCyclicOperation)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -101,9 +101,9 @@ fn check_rca_for_call_to_cyclic_operation_with_dynamic_argument() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | CallToCyclicOperation)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -123,7 +123,7 @@ fn check_rca_for_call_to_static_closure_function() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -145,9 +145,9 @@ fn check_rca_for_call_to_dynamic_closure_function() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | LoopWithDynamicCondition)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -169,9 +169,9 @@ fn check_rca_for_call_to_static_closure_operation() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -193,9 +193,9 @@ fn check_rca_for_call_to_dynamic_closure_operation() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -219,9 +219,9 @@ fn check_rca_for_call_to_operation_with_one_classical_return_and_one_dynamic_ret
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | ReturnWithinDynamicScope)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -247,9 +247,9 @@ fn check_rca_for_call_to_operation_with_codegen_intrinsic_override_treated_as_in
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -276,9 +276,9 @@ fn check_rca_for_call_to_operation_with_codegen_intrinsic_override_treated_as_in
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -297,7 +297,7 @@ fn check_rca_for_call_to_function_that_receives_tuple_with_a_non_tuple_classical
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -319,9 +319,9 @@ fn check_rca_for_call_to_function_that_receives_tuple_with_a_non_tuple_dynamic_a
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -342,9 +342,9 @@ fn check_rca_for_call_to_function_passed_single_tuple_variable_for_multiple_args
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -365,9 +365,9 @@ fn check_rca_for_call_to_lambda_passed_single_tuple_variable_for_multiple_args()
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/cycles.rs
+++ b/source/compiler/qsc_rca/src/tests/cycles.rs
@@ -21,11 +21,11 @@ fn check_rca_for_one_function_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -52,11 +52,11 @@ fn check_rca_for_two_functions_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -69,11 +69,11 @@ fn check_rca_for_two_functions_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -102,11 +102,11 @@ fn check_rca_for_three_functions_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -118,11 +118,11 @@ fn check_rca_for_three_functions_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -134,11 +134,11 @@ fn check_rca_for_three_functions_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -162,11 +162,11 @@ fn check_rca_for_indirect_function_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -192,11 +192,11 @@ fn check_rca_for_indirect_chain_function_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -220,11 +220,11 @@ fn check_rca_for_indirect_tuple_function_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -248,11 +248,11 @@ fn check_rca_for_function_cycle_within_binding() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -277,11 +277,11 @@ fn check_rca_for_function_cycle_within_assignment() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -304,11 +304,11 @@ fn check_rca_for_function_cycle_within_return() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -332,11 +332,11 @@ fn check_rca_for_function_cycle_within_tuple() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -385,18 +385,18 @@ fn check_rca_for_function_cycle_within_call_input() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                         [1]: [Parameter Type Array] ArrayParamApplication:
-                            static_size: Quantum: QuantumProperties:
+                            static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                                value_kind: Dynamic
-                            dynamic_size: Quantum: QuantumProperties:
+                                value_kind: Variable
+                            dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                                value_kind: Dynamic
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -423,11 +423,11 @@ fn check_rca_for_function_cycle_within_if_block() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -454,11 +454,11 @@ fn check_rca_for_function_cycle_within_if_condition() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -484,11 +484,11 @@ fn check_rca_for_function_cycle_within_for_block() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -514,11 +514,11 @@ fn check_rca_for_function_cycle_within_while_block() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -543,11 +543,11 @@ fn check_rca_for_function_cycle_within_while_condition() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -570,17 +570,17 @@ fn check_rca_for_multi_param_recursive_bool_function() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -603,21 +603,21 @@ fn check_rca_for_multi_param_recursive_unit_function() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Static
+                            value_kind: Constant
                         [1]: [Parameter Type Array] ArrayParamApplication:
-                            static_size: Quantum: QuantumProperties:
+                            static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                                value_kind: Static
-                            dynamic_size: Quantum: QuantumProperties:
+                                value_kind: Constant
+                            dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                                value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                                value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToCyclicFunctionWithDynamicArg)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -640,13 +640,13 @@ fn check_rca_for_result_recursive_operation() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -669,22 +669,22 @@ fn check_rca_for_multi_param_result_recursive_operation() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Dynamic
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Dynamic
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Dynamic
-                        [3]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [3]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -707,13 +707,13 @@ fn check_rca_for_operation_body_recursion() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -741,21 +741,21 @@ fn check_rca_for_operation_body_adj_recursion() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl: <none>
                 ctl-adj: <none>"#]],
     );
@@ -782,22 +782,22 @@ fn check_rca_for_operation_body_ctl_recursion() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: <none>"#]],
     );
 }
@@ -823,22 +823,22 @@ fn check_rca_for_operation_multi_controlled_functor_recursion() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 ctl-adj: <none>"#]],
     );
 }
@@ -859,13 +859,13 @@ fn check_rca_for_operation_body_recursion_non_unit_return() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CyclicOperationSpec)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -891,13 +891,13 @@ fn check_rca_for_operation_body_recursion_preserves_inherent_capabilities() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit | CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -929,13 +929,13 @@ fn check_rca_for_two_operation_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -948,13 +948,13 @@ fn check_rca_for_two_operation_cycle() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(CallToUnresolvedCallee)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],

--- a/source/compiler/qsc_rca/src/tests/ifs.rs
+++ b/source/compiler/qsc_rca/src/tests/ifs.rs
@@ -25,7 +25,7 @@ fn check_rca_for_if_stmt_with_classic_condition_and_classic_if_true_block() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -53,9 +53,9 @@ fn check_rca_for_if_stmt_with_dynamic_condition_and_classic_if_true_block() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -80,7 +80,7 @@ fn check_rca_for_if_else_expr_with_classic_condition_and_classic_branch_blocks()
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -103,9 +103,9 @@ fn check_rca_for_if_else_expr_with_dynamic_condition_and_classic_branch_blocks()
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/intrinsics.rs
+++ b/source/compiler/qsc_rca/src/tests/intrinsics.rs
@@ -14,9 +14,9 @@ fn check_rca_for_quantum_rt_qubit_allocate() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -34,13 +34,13 @@ fn check_rca_for_quantum_rt_qubit_release() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -57,13 +57,13 @@ fn check_rca_for_quantum_qis_m_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -80,13 +80,13 @@ fn check_rca_for_length() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
                         [0]: [Parameter Type Array] ArrayParamApplication:
-                            static_size: Classical
-                            dynamic_size: Quantum: QuantumProperties:
+                            static_size: Static
+                            dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicallySizedArray)
-                                value_kind: Dynamic
+                                value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -103,13 +103,13 @@ fn check_rca_for_quantum_qis_mresetz_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -126,11 +126,11 @@ fn check_rca_for_int_as_double() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -147,11 +147,11 @@ fn check_rca_for_int_as_big_int() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -168,7 +168,7 @@ fn check_rca_for_dump_machine() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -186,13 +186,13 @@ fn check_rca_for_check_zero() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -209,11 +209,11 @@ fn check_rca_for_message() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(0x0)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -230,11 +230,11 @@ fn check_rca_for_arc_cos() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -251,11 +251,11 @@ fn check_rca_for_arc_sin() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -272,11 +272,11 @@ fn check_rca_for_arc_tan() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -293,14 +293,14 @@ fn check_rca_for_arc_tan_2() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -317,11 +317,11 @@ fn check_rca_for_cos() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -338,11 +338,11 @@ fn check_rca_for_cosh() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -359,11 +359,11 @@ fn check_rca_for_sin() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -380,11 +380,11 @@ fn check_rca_for_sinh() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -401,11 +401,11 @@ fn check_rca_for_tan() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -422,11 +422,11 @@ fn check_rca_for_tanh() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -443,11 +443,11 @@ fn check_rca_for_sqrt() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -464,11 +464,11 @@ fn check_rca_for_log() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -485,11 +485,11 @@ fn check_rca_for_truncate() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -506,19 +506,19 @@ fn check_rca_for_quantum_qis_ccx_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -535,16 +535,16 @@ fn check_rca_for_quantum_qis_cx_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -561,16 +561,16 @@ fn check_rca_for_quantum_qis_cy_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -587,16 +587,16 @@ fn check_rca_for_quantum_qis_cz_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -613,16 +613,16 @@ fn check_rca_for_quantum_qis_rx_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -639,19 +639,19 @@ fn check_rca_for_quantum_qis_rxx_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -668,16 +668,16 @@ fn check_rca_for_quantum_qis_ry_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -694,19 +694,19 @@ fn check_rca_for_quantum_qis_ryy_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -723,16 +723,16 @@ fn check_rca_for_quantum_qis_rz_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -749,19 +749,19 @@ fn check_rca_for_quantum_qis_rzz_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [2]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [2]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -778,13 +778,13 @@ fn check_rca_for_quantum_qis_h_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -801,13 +801,13 @@ fn check_rca_for_quantum_qis_s_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -824,13 +824,13 @@ fn check_rca_for_quantum_qis_s_adj() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -847,13 +847,13 @@ fn check_rca_for_quantum_qis_sx_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -870,13 +870,13 @@ fn check_rca_for_quantum_qis_t_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -893,13 +893,13 @@ fn check_rca_for_quantum_qis_t_adj() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -916,13 +916,13 @@ fn check_rca_for_quantum_qis_x_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -939,13 +939,13 @@ fn check_rca_for_quantum_qis_y_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -962,13 +962,13 @@ fn check_rca_for_quantum_qis_z_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -985,16 +985,16 @@ fn check_rca_for_quantum_qis_swap_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1011,13 +1011,13 @@ fn check_rca_for_quantum_qis_reset_body() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1034,16 +1034,16 @@ fn check_rca_for_draw_random_int() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Dynamic
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1060,16 +1060,16 @@ fn check_rca_for_draw_random_double() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1086,13 +1086,13 @@ fn check_rca_for_draw_random_bool() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Dynamic
+                        value_kind: Variable
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1109,14 +1109,14 @@ fn check_rca_for_begin_estimate_caching() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(0x0)
-                            value_kind: Dynamic
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                            value_kind: Variable
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Dynamic
+                            value_kind: Variable
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1133,7 +1133,7 @@ fn check_rca_for_end_estimate_caching() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Classical
+                    inherent: Static
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -1151,27 +1151,27 @@ fn check_rca_for_account_for_estimates_internal() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
                         [0]: [Parameter Type Array] ArrayParamApplication:
-                            static_size: Quantum: QuantumProperties:
+                            static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                                value_kind: Static
-                            dynamic_size: Quantum: QuantumProperties:
+                                value_kind: Constant
+                            dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicInt | UseOfDynamicallySizedArray)
-                                value_kind: Static
-                        [1]: [Parameter Type Element] Quantum: QuantumProperties:
+                                value_kind: Constant
+                        [1]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Static
+                            value_kind: Constant
                         [2]: [Parameter Type Array] ArrayParamApplication:
-                            static_size: Quantum: QuantumProperties:
+                            static_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit)
-                                value_kind: Static
-                            dynamic_size: Quantum: QuantumProperties:
+                                value_kind: Constant
+                            dynamic_size: Dynamic:
                                 runtime_features: RuntimeFeatureFlags(UseOfDynamicQubit | UseOfDynamicallySizedArray)
-                                value_kind: Static
+                                value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1188,13 +1188,13 @@ fn check_rca_for_begin_repeat_estimates_internal() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications:
-                        [0]: [Parameter Type Element] Quantum: QuantumProperties:
+                        [0]: [Parameter Type Element] Dynamic:
                             runtime_features: RuntimeFeatureFlags(UseOfDynamicInt)
-                            value_kind: Static
+                            value_kind: Constant
                 adj: <none>
                 ctl: <none>
                 ctl-adj: <none>"#]],
@@ -1211,9 +1211,9 @@ fn check_rca_for_end_repeat_estimates_internal() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(0x0)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>

--- a/source/compiler/qsc_rca/src/tests/lambdas.rs
+++ b/source/compiler/qsc_rca/src/tests/lambdas.rs
@@ -17,7 +17,7 @@ fn check_rca_for_classical_lambda_one_parameter() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -35,7 +35,7 @@ fn check_rca_for_classical_lambda_two_parameters() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -54,7 +54,7 @@ fn check_rca_for_classical_lambda_one_parameter_one_capture() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -74,7 +74,7 @@ fn check_rca_for_classical_lambda_one_parameter_two_captures() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -93,7 +93,7 @@ fn check_rca_for_classical_lambda_two_parameters_one_capture() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -113,7 +113,7 @@ fn check_rca_for_classical_lambda_two_parameters_two_captures() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -139,9 +139,9 @@ fn check_rca_for_dynamic_lambda_two_classical_parameters_one_dynamic_capture() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicDouble)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -168,9 +168,9 @@ fn check_rca_for_dynamic_lambda_two_dynamic_parameters_one_classical_capture() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -189,9 +189,9 @@ fn check_rca_for_operation_lambda_two_parameters() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -211,9 +211,9 @@ fn check_rca_for_operation_lambda_two_parameters_with_controls() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -232,7 +232,7 @@ fn check_rca_for_function_lambda_using_array_slicing_with_explicit_return() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -251,7 +251,7 @@ fn check_rca_for_function_lambda_using_array_slicing_with_implicit_return() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/loops.rs
+++ b/source/compiler/qsc_rca/src/tests/loops.rs
@@ -18,7 +18,7 @@ fn check_rca_for_classical_for_loop() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -39,9 +39,9 @@ fn check_rca_for_dynamic_for_loop() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | LoopWithDynamicCondition)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -61,7 +61,7 @@ fn check_rca_for_classical_repeat_until_loop() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -83,9 +83,9 @@ fn check_rca_for_dynamic_repeat_until_loop_with_initial_dynamic_condition() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | LoopWithDynamicCondition)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -110,9 +110,9 @@ fn check_rca_for_dynamic_repeat_until_loop_with_initial_classical_condition_and_
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -133,9 +133,9 @@ fn check_rca_for_dynamic_repeat_until_loop_with_measurement_in_condition() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -161,9 +161,9 @@ fn check_rca_for_dynamic_repeat_until_loop_with_initial_classical_condition_and_
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -182,7 +182,7 @@ fn check_rca_for_classical_while_loop() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -203,9 +203,9 @@ fn check_rca_for_dynamic_while_loop_with_initial_dynamic_condition() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | LoopWithDynamicCondition)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -229,9 +229,9 @@ fn check_rca_for_dynamic_while_loop_with_initial_classical_condition_and_measure
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -251,9 +251,9 @@ fn check_rca_for_dynamic_while_loop_with_measurement_in_condition() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -280,9 +280,9 @@ fn check_rca_for_dynamic_while_loop_with_initial_classical_condition_and_dynamic
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -308,9 +308,9 @@ fn check_rca_for_dynamic_while_loop_with_assignments_in_both_the_condition_and_t
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | MeasurementWithinDynamicScope | LoopWithDynamicCondition | UseOfDynamicResult)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/measurements.rs
+++ b/source/compiler/qsc_rca/src/tests/measurements.rs
@@ -17,9 +17,9 @@ fn check_rca_for_static_single_qubit_measurement() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -41,9 +41,9 @@ fn check_rca_for_dynamic_single_measurement() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(MeasurementWithinDynamicScope | UseOfDynamicResult)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -62,9 +62,9 @@ fn check_rca_for_static_single_measurement_and_reset() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -87,9 +87,9 @@ fn check_rca_for_dynamic_single_measurement_and_reset() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(MeasurementWithinDynamicScope | UseOfDynamicResult)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -108,9 +108,9 @@ fn check_rca_for_static_multi_qubit_measurement() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/overrides.rs
+++ b/source/compiler/qsc_rca/src/tests/overrides.rs
@@ -13,7 +13,7 @@ fn check_rca_for_length_of_statically_sized_array_with_static_content() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -31,7 +31,7 @@ fn check_rca_for_length_of_statically_sized_array_with_dynamic_content() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -51,9 +51,9 @@ fn check_rca_for_length_of_dynamically_sized_array_with_static_content() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -74,9 +74,9 @@ fn check_rca_for_length_of_dynamically_sized_array_with_dynamic_content() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicallySizedArray)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/qubits.rs
+++ b/source/compiler/qsc_rca/src/tests/qubits.rs
@@ -19,9 +19,9 @@ fn check_rca_for_static_single_qubit_allcation() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -49,9 +49,9 @@ fn check_rca_for_dynamic_single_qubit_allcation() {
         &expect![[r#"
             Callable: CallableComputeProperties:
                 body: ApplicationsGeneratorSet:
-                    inherent: Quantum: QuantumProperties:
+                    inherent: Dynamic:
                         runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicQubit)
-                        value_kind: Static
+                        value_kind: Constant
                     dynamic_param_applications: <empty>
                 adj: <none>
                 ctl: <none>
@@ -72,9 +72,9 @@ fn check_rca_for_static_multi_qubit_allcation() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -94,9 +94,9 @@ fn check_rca_for_dynamic_multi_qubit_allcation() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange | UseOfDynamicQubit | UseOfDynamicallySizedArray | LoopWithDynamicCondition)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/strings.rs
+++ b/source/compiler/qsc_rca/src/tests/strings.rs
@@ -13,7 +13,7 @@ fn check_rca_for_classical_string() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -31,9 +31,9 @@ fn check_rca_for_dynamic_string() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -47,7 +47,7 @@ fn check_rca_for_classical_interpolated_string() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -65,9 +65,9 @@ fn check_rca_for_dynamic_interpolated_string() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -81,7 +81,7 @@ fn check_rca_for_classical_nested_interpolated_string() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -99,9 +99,9 @@ fn check_rca_for_dynamic_nested_interpolated_string() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -115,7 +115,7 @@ fn check_rca_for_classical_concatenated_string() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -134,9 +134,9 @@ fn check_rca_for_dynamic_concatenated_string() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -150,7 +150,7 @@ fn check_rca_for_classical_string_comparison() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -168,9 +168,9 @@ fn check_rca_for_dynamic_string_comparison() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicString)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/structs.rs
+++ b/source/compiler/qsc_rca/src/tests/structs.rs
@@ -17,7 +17,7 @@ fn check_rca_for_struct_constructor_with_classical_values() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -37,9 +37,9 @@ fn check_rca_for_struct_constructor_with_a_dynamic_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -58,7 +58,7 @@ fn check_rca_for_struct_copy_constructor_with_classical_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -79,9 +79,9 @@ fn check_rca_for_struct_copy_constructor_with_dynamic_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -102,9 +102,9 @@ fn check_rca_for_struct_dynamic_constructor_overwritten_with_classic_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/types.rs
+++ b/source/compiler/qsc_rca/src/tests/types.rs
@@ -13,7 +13,7 @@ fn check_rca_for_classical_result() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -31,9 +31,9 @@ fn check_rca_for_dynamic_result() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -47,7 +47,7 @@ fn check_rca_for_classical_bool() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -66,9 +66,9 @@ fn check_rca_for_dynamic_bool() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -82,7 +82,7 @@ fn check_rca_for_classical_int() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -103,9 +103,9 @@ fn check_rca_for_dynamic_int() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -119,7 +119,7 @@ fn check_rca_for_classical_pauli() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -137,9 +137,9 @@ fn check_rca_for_dynamic_pauli() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicPauli)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -153,7 +153,7 @@ fn check_rca_for_classical_range() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -172,9 +172,9 @@ fn check_rca_for_dynamic_range() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicRange)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -188,7 +188,7 @@ fn check_rca_for_classical_double() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -210,9 +210,9 @@ fn check_rca_for_dynamic_double() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicInt | UseOfDynamicDouble)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -226,7 +226,7 @@ fn check_rca_for_classical_big_int() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -244,9 +244,9 @@ fn check_rca_for_dynamic_big_int() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicBigInt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/udts.rs
+++ b/source/compiler/qsc_rca/src/tests/udts.rs
@@ -17,7 +17,7 @@ fn check_rca_for_udt_constructor_with_classical_values() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -37,9 +37,9 @@ fn check_rca_for_udt_constructor_with_a_dynamic_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -59,7 +59,7 @@ fn check_rca_for_udt_field_update_with_classical_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -81,9 +81,9 @@ fn check_rca_for_udt_field_update_with_dynamic_value() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(UseOfDynamicBool | UseOfDynamicDouble | UseOfDynamicUdt)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }

--- a/source/compiler/qsc_rca/src/tests/vars.rs
+++ b/source/compiler/qsc_rca/src/tests/vars.rs
@@ -13,7 +13,7 @@ fn check_rca_for_callable_var() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -31,7 +31,7 @@ fn check_rca_for_udt_var() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -49,7 +49,7 @@ fn check_rca_for_static_int_var() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Classical
+                inherent: Static
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -67,9 +67,9 @@ fn check_rca_for_static_qubit_var() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Static
+                    value_kind: Constant
                 dynamic_param_applications: <empty>"#]],
     );
 }
@@ -88,9 +88,9 @@ fn check_rca_for_dynamic_result_var() {
         package_store_compute_properties,
         &expect![[r#"
             ApplicationsGeneratorSet:
-                inherent: Quantum: QuantumProperties:
+                inherent: Dynamic:
                     runtime_features: RuntimeFeatureFlags(0x0)
-                    value_kind: Dynamic
+                    value_kind: Variable
                 dynamic_param_applications: <empty>"#]],
     );
 }


### PR DESCRIPTION
This second part of the RCA refactor mostly focuses on some renames and further simplification of types. Specifically:
- `ComputeKind` variants renamed from `Classical` and `Quantum` to `Static` and `Dynamic`, respectively, to correspond to how the term-of-art in Partial Evaluation where all the static parts are computed away such that the remaining "residual" program is only the dynamic parts.
- `ValueKind` variants renamed from `Static` and `Dynamic` which are now taken to instead use `Constant` and `Variable`, respectively, which matches how they are emitted into the residual program aka RIR.
Other related pattern clean ups and helper removals to simplify manipulation of these types were made throughout.