### PR TITLE
Use inline body for gh issue create

### DIFF
--- a/.github/workflows/multiplat.yml
+++ b/.github/workflows/multiplat.yml
@@ -60,17 +60,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          python - <<'PY'
-          import os, pathlib
-          body_text = """
-          ## Info
-          See the corresponding [**workflow run**](${{ env.WORKFLOW_RUN_URL }}) for failure details, update the issue with any relevant information, and assign to the appropriate team member(s).
-          """
-          pathlib.Path("/tmp/ci_issue.md").write_text(body_text)
-          PY
           url="$(gh issue create \
             --title "CI failure: ${{ matrix.platform }} (${{ github.run_id }})" \
-            --body-file /tmp/ci_issue.md \
+            --body "See the corresponding [**workflow run**](${{ env.WORKFLOW_RUN_URL }}) for failure details, update the issue with any relevant information, and assign to the appropriate team member(s)." \
             --label ci_failure \
             --assignee swernli,idavis,minestarks,billti)"
           number="$(gh issue view "$url" --json number --jq .number)"


### PR DESCRIPTION
A recent [build failure on Windows](https://github.com/microsoft/qdk/actions/runs/23170670543/job/67321571893) did not file an issue due to paths not working as expected. Rather than deal with multi-platform path quirks, this updates the issue filing to just use the inline body and a simple message so that issue filing is more robust/reliable.