### PR TITLE
Use Rust parallelism for estimation with post processing

### DIFF
--- a/source/pip/qsharp/qre/_estimation.py
+++ b/source/pip/qsharp/qre/_estimation.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import cast, Optional, Callable, Any
 
@@ -78,33 +77,67 @@ def estimate(
 
     if post_process:
         # Enumerate traces with their parameters so we can post-process later
-        params_and_traces = list(trace_query.enumerate(app_ctx, track_parameters=True))
+        params_and_traces = cast(
+            list[tuple[Any, Trace]],
+            list(trace_query.enumerate(app_ctx, track_parameters=True)),
+        )
         isas = list(isa_query.enumerate(arch_ctx))
 
         num_traces = len(params_and_traces)
         num_isas = len(isas)
 
-        # Estimate all trace × ISA combinations using Python threads
-        collection = _EstimationCollection()
+        # Phase 1: Run all estimates in Rust (parallel, fast).
+        traces_only = [trace for _, trace in params_and_traces]
+        collection = _estimate_parallel(cast(list[Trace], traces_only), isas, max_error)
+        successful = collection.successful_estimates
+        summaries = collection.all_summaries  # (trace_idx, isa_idx, qubits, runtime)
 
-        def _estimate_one(params, trace, isa):
-            result = trace.estimate(isa, max_error)
+        # Phase 2: Learn per-trace runtime multiplier and qubit multiplier from
+        # one sample each: if post_process changes runtime or qubit count it
+        # will affect the Pareto optimality, but the changes depend only on the
+        # trace, not on the ISA.
+        trace_multipliers: dict[int, tuple[float, float]] = {}
+        trace_sample_isa: dict[int, int] = {}
+        for t_idx, i_idx, _q, r in summaries:
+            if t_idx not in trace_sample_isa:
+                trace_sample_isa[t_idx] = i_idx
+        for t_idx, i_idx in trace_sample_isa.items():
+            params, trace = params_and_traces[t_idx]
+            sample = trace.estimate(isas[i_idx], max_error)
+            if sample is not None:
+                pre_q = sample.qubits
+                pre_r = sample.runtime
+                pp = app_ctx.application.post_process(params, sample)
+                if pp is not None and pre_r > 0 and pre_q > 0:
+                    trace_multipliers[t_idx] = (pp.qubits / pre_q, pp.runtime / pre_r)
+
+        # Phase 3: Estimate post-pp values and filter to Pareto candidates.
+        estimated_pp: list[tuple[int, int, int, int]] = []  # (t, i, q, est_r)
+        for t_idx, i_idx, q, r in summaries:
+            mult_q, mult_r = trace_multipliers.get(t_idx, (0.0, 0.0))
+            est_q = int(q * mult_q) if mult_q > 0 else q
+            est_r = int(r * mult_r) if mult_r > 0 else r
+            estimated_pp.append((t_idx, i_idx, est_q, est_r))
+
+        # Build approximate post-pp Pareto frontier to identify candidates.
+        estimated_pp.sort(key=lambda x: (x[2], x[3]))  # sort by qubits, then runtime
+        approx_pareto: list[tuple[int, int, int, int]] = []
+        min_r = float("inf")
+        for item in estimated_pp:
+            if item[3] < min_r:
+                approx_pareto.append(item)
+                min_r = item[3]
+
+        # Phase 4: Re-estimate and post-process only the Pareto candidates.
+        pp_collection = _EstimationCollection()
+        for t_idx, i_idx, _q, _r in approx_pareto:
+            params, trace = params_and_traces[t_idx]
+            result = trace.estimate(isas[i_idx], max_error)
             if result is not None:
-                result = app_ctx.application.post_process(params, result)
-            return result
-
-        successful = 0
-        with ThreadPoolExecutor() as executor:
-            futures = [
-                executor.submit(_estimate_one, params, trace, isa)
-                for params, trace in cast(list[tuple[Any, Trace]], params_and_traces)
-                for isa in isas
-            ]
-            for future in futures:
-                result = future.result()
-                if result is not None:
-                    successful += 1
-                    collection.insert(result)
+                pp_result = app_ctx.application.post_process(params, result)
+                if pp_result is not None:
+                    pp_collection.insert(pp_result)
+        collection = pp_collection
     else:
         traces = list(trace_query.enumerate(app_ctx))
         isas = list(isa_query.enumerate(arch_ctx))

--- a/source/pip/qsharp/qre/_qre.pyi
+++ b/source/pip/qsharp/qre/_qre.pyi
@@ -945,6 +945,18 @@ class _EstimationCollection:
         """
         ...
 
+    @property
+    def all_summaries(self) -> list[tuple[int, int, int, int]]:
+        """
+        Returns lightweight summaries of ALL successful estimates as a list
+        of (trace_index, isa_index, qubits, runtime) tuples.
+
+        Returns:
+            list[tuple[int, int, int, int]]: List of (trace_index, isa_index,
+                qubits, runtime) for every successful estimation.
+        """
+        ...
+
 class FactoryResult:
     """
     Represents the result of a factory used in resource estimation.

--- a/source/pip/src/qre.rs
+++ b/source/pip/src/qre.rs
@@ -760,6 +760,17 @@ impl EstimationCollection {
         self.0.successful_estimates()
     }
 
+    /// Returns lightweight summaries of ALL successful estimates as a list
+    /// of (trace index, isa index, qubits, runtime) tuples.
+    #[getter]
+    pub fn all_summaries(&self) -> Vec<(usize, usize, u64, u64)> {
+        self.0
+            .all_summaries()
+            .iter()
+            .map(|s| (s.trace_index, s.isa_index, s.qubits, s.runtime))
+            .collect()
+    }
+
     #[allow(clippy::needless_pass_by_value)]
     pub fn __iter__(slf: PyRef<'_, Self>) -> PyResult<Py<EstimationCollectionIterator>> {
         let iter = EstimationCollectionIterator {

--- a/source/qre/src/lib.rs
+++ b/source/qre/src/lib.rs
@@ -15,7 +15,7 @@ pub use isa::{
     ConstraintBound, Encoding, ISA, ISARequirements, Instruction, InstructionConstraint, LockedISA,
     ProvenanceGraph, VariableArityFunction,
 };
-pub use result::{EstimationCollection, EstimationResult, FactoryResult};
+pub use result::{EstimationCollection, EstimationResult, FactoryResult, ResultSummary};
 mod trace;
 pub use trace::instruction_ids;
 pub use trace::instruction_ids::instruction_name;

--- a/source/qre/src/result.rs
+++ b/source/qre/src/result.rs
@@ -18,6 +18,7 @@ pub struct EstimationResult {
     factories: FxHashMap<u64, FactoryResult>,
     isa: ISA,
     isa_index: Option<usize>,
+    trace_index: Option<usize>,
     properties: FxHashMap<u64, Property>,
 }
 
@@ -99,6 +100,15 @@ impl EstimationResult {
         self.isa_index
     }
 
+    pub fn set_trace_index(&mut self, index: usize) {
+        self.trace_index = Some(index);
+    }
+
+    #[must_use]
+    pub fn trace_index(&self) -> Option<usize> {
+        self.trace_index
+    }
+
     pub fn set_property(&mut self, key: u64, value: Property) {
         self.properties.insert(key, value);
     }
@@ -155,9 +165,21 @@ impl ParetoItem2D for EstimationResult {
     }
 }
 
+/// Lightweight summary of a successful estimation, used to identify
+/// post-processing candidates without storing full results.
+#[derive(Clone, Copy)]
+pub struct ResultSummary {
+    pub trace_index: usize,
+    pub isa_index: usize,
+    pub qubits: u64,
+    pub runtime: u64,
+}
+
 #[derive(Default)]
 pub struct EstimationCollection {
     frontier: ParetoFrontier2D<EstimationResult>,
+    /// Lightweight summaries of ALL successful estimates (not just Pareto).
+    all_summaries: Vec<ResultSummary>,
     total_jobs: usize,
     successful_estimates: usize,
 }
@@ -184,6 +206,15 @@ impl EstimationCollection {
 
     pub fn set_successful_estimates(&mut self, successful_estimates: usize) {
         self.successful_estimates = successful_estimates;
+    }
+
+    pub fn push_summary(&mut self, summary: ResultSummary) {
+        self.all_summaries.push(summary);
+    }
+
+    #[must_use]
+    pub fn all_summaries(&self) -> &[ResultSummary] {
+        &self.all_summaries
     }
 }
 

--- a/source/qre/src/trace.rs
+++ b/source/qre/src/trace.rs
@@ -1,13 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    sync::atomic::AtomicUsize,
+};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     Error, EstimationCollection, EstimationResult, FactoryResult, ISA, Instruction, LockedISA,
+    ResultSummary,
     property_keys::{PHYSICAL_COMPUTE_QUBITS, PHYSICAL_FACTORY_QUBITS, PHYSICAL_MEMORY_QUBITS},
 };
 
@@ -665,7 +669,7 @@ pub fn estimate_parallel<'a>(
 
     // Shared atomic counter acts as a lock-free work queue.  Workers call
     // fetch_add to claim the next job index.
-    let next_job = std::sync::atomic::AtomicUsize::new(0);
+    let next_job = AtomicUsize::new(0);
 
     let mut collection = EstimationCollection::new();
     collection.set_total_jobs(total_jobs);
@@ -700,6 +704,8 @@ pub fn estimate_parallel<'a>(
                     if let Ok(mut estimation) = traces[trace_idx].estimate(isas[isa_idx], max_error)
                     {
                         estimation.set_isa_index(isa_idx);
+                        estimation.set_trace_index(trace_idx);
+
                         local_results.push(estimation);
                     }
                 }
@@ -714,6 +720,14 @@ pub fn estimate_parallel<'a>(
         // Collect results from all workers into the shared collection.
         let mut successful = 0;
         for local_results in rx {
+            for result in &local_results {
+                collection.push_summary(ResultSummary {
+                    trace_index: result.trace_index().unwrap_or(0),
+                    isa_index: result.isa_index().unwrap_or(0),
+                    qubits: result.qubits(),
+                    runtime: result.runtime(),
+                });
+            }
             successful += local_results.len();
             collection.extend(local_results.into_iter());
         }


### PR DESCRIPTION
When performing post processing we need to know the updated results after the post_process function on the application is called (in Python). As a result, so far a Python-based parallelism was used for estimation when post processing is in play. This is changed in this PR, by first computing all estimates in parallel (without filtering to Pareto optimal results) and then performing the filtering in Python. This reduces runtime by about 30% on some QRE tests. Further, it allows to use the same Rust-based estimation function which improves code sharing.