### PR TITLE
Temporary plotting for estimation results

### DIFF
--- a/source/pip/qsharp/qre/_estimation.py
+++ b/source/pip/qsharp/qre/_estimation.py
@@ -348,6 +348,128 @@ class EstimationTable(list["EstimationTableEntry"]):
             ]
         )
 
+    # Mapping from runtime unit name to its value in nanoseconds.
+    _TIME_UNITS: dict[str, float] = {
+        "ns": 1,
+        "µs": 1e3,
+        "us": 1e3,
+        "ms": 1e6,
+        "s": 1e9,
+        "min": 60e9,
+        "hours": 3600e9,
+        "days": 86_400e9,
+        "weeks": 604_800e9,
+        "months": 31 * 86_400e9,
+        "years": 365 * 86_400e9,
+        "decades": 10 * 365 * 86_400e9,
+        "centuries": 100 * 365 * 86_400e9,
+    }
+
+    # Ordered subset of _TIME_UNITS used for default x-axis tick labels.
+    _TICK_UNITS: list[tuple[str, float]] = [
+        ("1 ns", _TIME_UNITS["ns"]),
+        ("1 µs", _TIME_UNITS["µs"]),
+        ("1 ms", _TIME_UNITS["ms"]),
+        ("1 s", _TIME_UNITS["s"]),
+        ("1 min", _TIME_UNITS["min"]),
+        ("1 hour", _TIME_UNITS["hours"]),
+        ("1 day", _TIME_UNITS["days"]),
+        ("1 week", _TIME_UNITS["weeks"]),
+        ("1 month", _TIME_UNITS["months"]),
+        ("1 year", _TIME_UNITS["years"]),
+        ("1 decade", _TIME_UNITS["decades"]),
+        ("1 century", _TIME_UNITS["centuries"]),
+    ]
+
+    def plot(
+        self,
+        *,
+        runtime_unit: Optional[str] = None,
+        figsize: tuple[float, float] = (15, 8),
+        scatter_args: dict[str, Any] = {"marker": "x"},
+    ):
+        """Returns a plot of the estimates displaying qubits vs runtime.
+
+        Creates a log-log scatter plot where the x-axis shows the total
+        runtime and the y-axis shows the total number of physical qubits.
+
+        When *runtime_unit* is ``None`` (the default), the x-axis uses
+        human-readable time-unit tick labels spanning nanoseconds to
+        centuries.  When a unit string is given (e.g. ``"hours"``), all
+        runtimes are scaled to that unit and the x-axis label includes the
+        unit while the ticks are plain numbers.
+
+        Supported *runtime_unit* values: ``"ns"``, ``"µs"`` (or ``"us"``),
+        ``"ms"``, ``"s"``, ``"min"``, ``"hours"``, ``"days"``, ``"weeks"``,
+        ``"months"``, ``"years"``.
+
+        Args:
+            runtime_unit: Optional time unit to scale the x-axis to.
+            scatter_args: Additional keyword arguments to pass to
+                ``matplotlib.axes.Axes.scatter`` when plotting the points.
+
+        Returns:
+            matplotlib.figure.Figure: The figure containing the plot.
+
+        Raises:
+            ImportError: If matplotlib is not installed.
+            ValueError: If the table is empty or *runtime_unit* is not
+                recognised.
+        """
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            raise ImportError(
+                "Missing optional 'matplotlib' dependency. To install run: "
+                "pip install matplotlib"
+            )
+
+        if len(self) == 0:
+            raise ValueError("Cannot plot an empty EstimationTable.")
+
+        if runtime_unit is not None and runtime_unit not in self._TIME_UNITS:
+            raise ValueError(
+                f"Unknown runtime_unit {runtime_unit!r}. "
+                f"Supported units: {', '.join(self._TIME_UNITS)}"
+            )
+
+        ys = [entry.qubits for entry in self]
+
+        fig, ax = plt.subplots(figsize=figsize)
+
+        ax.set_ylabel("Physical qubits")
+
+        if runtime_unit is not None:
+            scale = self._TIME_UNITS[runtime_unit]
+            xs = [entry.runtime / scale for entry in self]
+            ax.set_xlabel(f"Runtime ({runtime_unit})")
+            ax.set_xscale("log")
+            ax.set_yscale("log")
+            ax.scatter(x=xs, y=ys, **scatter_args)
+        else:
+            xs = [entry.runtime for entry in self]
+            ax.set_xlabel("Runtime")
+            ax.set_xscale("log")
+            ax.set_yscale("log")
+            ax.scatter(x=xs, y=ys, **scatter_args)
+
+            time_labels, time_units = zip(*self._TICK_UNITS)
+
+            cutoff = (
+                next(
+                    (i for i, x in enumerate(time_units) if x > max(xs)),
+                    len(time_units) - 1,
+                )
+                + 1
+            )
+
+            ax.set_xticks(time_units[:cutoff])
+            ax.set_xticklabels(time_labels[:cutoff], rotation=90)
+
+        plt.close(fig)
+
+        return fig
+
 
 @dataclass(frozen=True, slots=True)
 class EstimationTableColumn:

--- a/source/pip/tests/test_qre.py
+++ b/source/pip/tests/test_qre.py
@@ -4,7 +4,7 @@
 from dataclasses import KW_ONLY, dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import cast, Generator
+from typing import cast, Generator, Sized
 import os
 import pytest
 
@@ -1293,6 +1293,76 @@ def test_estimation_table_computed_column():
     frame = table.as_frame()
     assert frame["qubit_error_product"][0] == pytest.approx(1.0)
     assert frame["qubit_error_product"][1] == pytest.approx(4.0)
+
+
+def test_estimation_table_plot_returns_figure():
+    """Test that plot() returns a matplotlib Figure with correct axes."""
+    from matplotlib.figure import Figure
+
+    table = EstimationTable()
+    table.append(_make_entry(100, 5_000_000_000, 0.01))
+    table.append(_make_entry(200, 10_000_000_000, 0.02))
+    table.append(_make_entry(50, 50_000_000_000, 0.005))
+
+    fig = table.plot()
+
+    assert isinstance(fig, Figure)
+    ax = fig.axes[0]
+    assert ax.get_ylabel() == "Physical qubits"
+    assert ax.get_xlabel() == "Runtime"
+    assert ax.get_xscale() == "log"
+    assert ax.get_yscale() == "log"
+
+    # Verify data points
+    offsets = ax.collections[0].get_offsets()
+    assert len(cast(Sized, offsets)) == 3
+
+
+def test_estimation_table_plot_empty_raises():
+    """Test that plot() raises ValueError on an empty table."""
+    table = EstimationTable()
+    with pytest.raises(ValueError, match="Cannot plot an empty EstimationTable"):
+        table.plot()
+
+
+def test_estimation_table_plot_single_entry():
+    """Test that plot() works with a single entry."""
+    from matplotlib.figure import Figure
+
+    table = EstimationTable()
+    table.append(_make_entry(100, 1_000_000, 0.01))
+
+    fig = table.plot()
+    assert isinstance(fig, Figure)
+
+    offsets = fig.axes[0].collections[0].get_offsets()
+    assert len(cast(Sized, offsets)) == 1
+
+
+def test_estimation_table_plot_with_runtime_unit():
+    """Test that plot(runtime_unit=...) scales x values and labels the axis."""
+    table = EstimationTable()
+    # 1 hour = 3600e9 ns, 2 hours = 7200e9 ns
+    table.append(_make_entry(100, int(3600e9), 0.01))
+    table.append(_make_entry(200, int(7200e9), 0.02))
+
+    fig = table.plot(runtime_unit="hours")
+
+    ax = fig.axes[0]
+    assert ax.get_xlabel() == "Runtime (hours)"
+
+    # Verify the x data is scaled: should be 1.0 and 2.0 hours
+    offsets = cast(list, ax.collections[0].get_offsets())
+    assert offsets[0][0] == pytest.approx(1.0)
+    assert offsets[1][0] == pytest.approx(2.0)
+
+
+def test_estimation_table_plot_invalid_runtime_unit():
+    """Test that plot() raises ValueError for an unknown runtime_unit."""
+    table = EstimationTable()
+    table.append(_make_entry(100, 1000, 0.01))
+    with pytest.raises(ValueError, match="Unknown runtime_unit"):
+        table.plot(runtime_unit="fortnights")
 
 
 def _ll_files():


### PR DESCRIPTION
Adding a plotting function for estimation results. We may change this later to use Q# widgets like other parts in the repo. But adding this functionality now to support samples of higher priority.