### PR TITLE
Plot multiple estimation tables in single plot

### DIFF
--- a/source/pip/qsharp/qre/__init__.py
+++ b/source/pip/qsharp/qre/__init__.py
@@ -8,6 +8,7 @@ from ._estimation import (
     EstimationTable,
     EstimationTableColumn,
     EstimationTableEntry,
+    plot_estimates,
 )
 from ._instruction import (
     LOGICAL,
@@ -49,6 +50,7 @@ __all__ = [
     "constraint",
     "estimate",
     "linear_function",
+    "plot_estimates",
     "Application",
     "Architecture",
     "Block",

--- a/source/pip/qsharp/qre/_estimation.py
+++ b/source/pip/qsharp/qre/_estimation.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import cast, Optional, Callable, Any
+from typing import cast, Optional, Callable, Any, Iterable
 
 import pandas as pd
 
@@ -204,6 +204,8 @@ def estimate(
     # Post-process the results and add them to a results table
     table = EstimationTable()
 
+    table.name = name
+
     if name is not None:
         table.insert_column(0, "name", lambda entry: name)
 
@@ -243,6 +245,7 @@ class EstimationTable(list["EstimationTableEntry"]):
         """Initialize an empty estimation table with default columns."""
         super().__init__()
 
+        self.name: Optional[str] = None
         self.stats = EstimationTableStats()
 
         self._columns: list[tuple[str, EstimationTableColumn]] = [
@@ -348,127 +351,16 @@ class EstimationTable(list["EstimationTableEntry"]):
             ]
         )
 
-    # Mapping from runtime unit name to its value in nanoseconds.
-    _TIME_UNITS: dict[str, float] = {
-        "ns": 1,
-        "µs": 1e3,
-        "us": 1e3,
-        "ms": 1e6,
-        "s": 1e9,
-        "min": 60e9,
-        "hours": 3600e9,
-        "days": 86_400e9,
-        "weeks": 604_800e9,
-        "months": 31 * 86_400e9,
-        "years": 365 * 86_400e9,
-        "decades": 10 * 365 * 86_400e9,
-        "centuries": 100 * 365 * 86_400e9,
-    }
+    def plot(self, **kwargs):
+        """Plot this table's results.
 
-    # Ordered subset of _TIME_UNITS used for default x-axis tick labels.
-    _TICK_UNITS: list[tuple[str, float]] = [
-        ("1 ns", _TIME_UNITS["ns"]),
-        ("1 µs", _TIME_UNITS["µs"]),
-        ("1 ms", _TIME_UNITS["ms"]),
-        ("1 s", _TIME_UNITS["s"]),
-        ("1 min", _TIME_UNITS["min"]),
-        ("1 hour", _TIME_UNITS["hours"]),
-        ("1 day", _TIME_UNITS["days"]),
-        ("1 week", _TIME_UNITS["weeks"]),
-        ("1 month", _TIME_UNITS["months"]),
-        ("1 year", _TIME_UNITS["years"]),
-        ("1 decade", _TIME_UNITS["decades"]),
-        ("1 century", _TIME_UNITS["centuries"]),
-    ]
-
-    def plot(
-        self,
-        *,
-        runtime_unit: Optional[str] = None,
-        figsize: tuple[float, float] = (15, 8),
-        scatter_args: dict[str, Any] = {"marker": "x"},
-    ):
-        """Returns a plot of the estimates displaying qubits vs runtime.
-
-        Creates a log-log scatter plot where the x-axis shows the total
-        runtime and the y-axis shows the total number of physical qubits.
-
-        When *runtime_unit* is ``None`` (the default), the x-axis uses
-        human-readable time-unit tick labels spanning nanoseconds to
-        centuries.  When a unit string is given (e.g. ``"hours"``), all
-        runtimes are scaled to that unit and the x-axis label includes the
-        unit while the ticks are plain numbers.
-
-        Supported *runtime_unit* values: ``"ns"``, ``"µs"`` (or ``"us"``),
-        ``"ms"``, ``"s"``, ``"min"``, ``"hours"``, ``"days"``, ``"weeks"``,
-        ``"months"``, ``"years"``.
-
-        Args:
-            runtime_unit: Optional time unit to scale the x-axis to.
-            scatter_args: Additional keyword arguments to pass to
-                ``matplotlib.axes.Axes.scatter`` when plotting the points.
+        Convenience wrapper around :func:`plot_estimates`.  All keyword
+        arguments are forwarded.
 
         Returns:
             matplotlib.figure.Figure: The figure containing the plot.
-
-        Raises:
-            ImportError: If matplotlib is not installed.
-            ValueError: If the table is empty or *runtime_unit* is not
-                recognised.
         """
-        try:
-            import matplotlib.pyplot as plt
-        except ImportError:
-            raise ImportError(
-                "Missing optional 'matplotlib' dependency. To install run: "
-                "pip install matplotlib"
-            )
-
-        if len(self) == 0:
-            raise ValueError("Cannot plot an empty EstimationTable.")
-
-        if runtime_unit is not None and runtime_unit not in self._TIME_UNITS:
-            raise ValueError(
-                f"Unknown runtime_unit {runtime_unit!r}. "
-                f"Supported units: {', '.join(self._TIME_UNITS)}"
-            )
-
-        ys = [entry.qubits for entry in self]
-
-        fig, ax = plt.subplots(figsize=figsize)
-
-        ax.set_ylabel("Physical qubits")
-
-        if runtime_unit is not None:
-            scale = self._TIME_UNITS[runtime_unit]
-            xs = [entry.runtime / scale for entry in self]
-            ax.set_xlabel(f"Runtime ({runtime_unit})")
-            ax.set_xscale("log")
-            ax.set_yscale("log")
-            ax.scatter(x=xs, y=ys, **scatter_args)
-        else:
-            xs = [entry.runtime for entry in self]
-            ax.set_xlabel("Runtime")
-            ax.set_xscale("log")
-            ax.set_yscale("log")
-            ax.scatter(x=xs, y=ys, **scatter_args)
-
-            time_labels, time_units = zip(*self._TICK_UNITS)
-
-            cutoff = (
-                next(
-                    (i for i, x in enumerate(time_units) if x > max(xs)),
-                    len(time_units) - 1,
-                )
-                + 1
-            )
-
-            ax.set_xticks(time_units[:cutoff])
-            ax.set_xticklabels(time_labels[:cutoff], rotation=90)
-
-        plt.close(fig)
-
-        return fig
+        return plot_estimates(self, **kwargs)
 
 
 @dataclass(frozen=True, slots=True)
@@ -522,3 +414,157 @@ class EstimationTableStats:
     total_jobs: int = 0
     successful_estimates: int = 0
     pareto_results: int = 0
+
+
+# Mapping from runtime unit name to its value in nanoseconds.
+_TIME_UNITS: dict[str, float] = {
+    "ns": 1,
+    "µs": 1e3,
+    "us": 1e3,
+    "ms": 1e6,
+    "s": 1e9,
+    "min": 60e9,
+    "hours": 3600e9,
+    "days": 86_400e9,
+    "weeks": 604_800e9,
+    "months": 31 * 86_400e9,
+    "years": 365 * 86_400e9,
+    "decades": 10 * 365 * 86_400e9,
+    "centuries": 100 * 365 * 86_400e9,
+}
+
+# Ordered subset of _TIME_UNITS used for default x-axis tick labels.
+_TICK_UNITS: list[tuple[str, float]] = [
+    ("1 ns", _TIME_UNITS["ns"]),
+    ("1 µs", _TIME_UNITS["µs"]),
+    ("1 ms", _TIME_UNITS["ms"]),
+    ("1 s", _TIME_UNITS["s"]),
+    ("1 min", _TIME_UNITS["min"]),
+    ("1 hour", _TIME_UNITS["hours"]),
+    ("1 day", _TIME_UNITS["days"]),
+    ("1 week", _TIME_UNITS["weeks"]),
+    ("1 month", _TIME_UNITS["months"]),
+    ("1 year", _TIME_UNITS["years"]),
+    ("1 decade", _TIME_UNITS["decades"]),
+    ("1 century", _TIME_UNITS["centuries"]),
+]
+
+
+def plot_estimates(
+    data: EstimationTable | Iterable[EstimationTable],
+    *,
+    runtime_unit: Optional[str] = None,
+    figsize: tuple[float, float] = (15, 8),
+    scatter_args: dict[str, Any] = {"marker": "x"},
+):
+    """Returns a plot of the estimates displaying qubits vs runtime.
+
+    Creates a log-log scatter plot where the x-axis shows the total runtime and
+    the y-axis shows the total number of physical qubits.
+
+    *data* may be a single `EstimationTable` or an iterable of tables.  When
+    multiple tables are provided, each is plotted as a separate series.  If a
+    table has a `EstimationTable.name` (set via the *name* parameter of
+    `estimate`), it is used as the legend label for that series.
+
+    When *runtime_unit* is ``None`` (the default), the x-axis uses
+    human-readable time-unit tick labels spanning nanoseconds to centuries.
+    When a unit string is given (e.g. ``"hours"``), all runtimes are scaled to
+    that unit and the x-axis label includes the unit while the ticks are plain
+    numbers.
+
+    Supported *runtime_unit* values: ``"ns"``, ``"µs"`` (or ``"us"``), ``"ms"``,
+    ``"s"``, ``"min"``, ``"hours"``, ``"days"``, ``"weeks"``, ``"months"``,
+    ``"years"``.
+
+    Args:
+        data: A single EstimationTable or an iterable of
+            EstimationTable objects to plot.
+        runtime_unit: Optional time unit to scale the x-axis to.
+        figsize: Figure dimensions in inches as ``(width, height)``.
+        scatter_args: Additional keyword arguments to pass to
+            ``matplotlib.axes.Axes.scatter`` when plotting the points.
+
+    Returns:
+        matplotlib.figure.Figure: The figure containing the plot.
+
+    Raises:
+        ImportError: If matplotlib is not installed.
+        ValueError: If all tables are empty or *runtime_unit* is not
+            recognised.
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise ImportError(
+            "Missing optional 'matplotlib' dependency. To install run: "
+            "pip install matplotlib"
+        )
+
+    # Normalize to a list of tables
+    if isinstance(data, EstimationTable):
+        tables = [data]
+    else:
+        tables = list(data)
+
+    if not tables or all(len(t) == 0 for t in tables):
+        raise ValueError("Cannot plot an empty EstimationTable.")
+
+    if runtime_unit is not None and runtime_unit not in _TIME_UNITS:
+        raise ValueError(
+            f"Unknown runtime_unit {runtime_unit!r}. "
+            f"Supported units: {', '.join(_TIME_UNITS)}"
+        )
+
+    fig, ax = plt.subplots(figsize=figsize)
+    ax.set_ylabel("Physical qubits")
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+
+    all_xs: list[float] = []
+    has_labels = False
+
+    for table in tables:
+        if len(table) == 0:
+            continue
+
+        ys = [entry.qubits for entry in table]
+
+        if runtime_unit is not None:
+            scale = _TIME_UNITS[runtime_unit]
+            xs = [entry.runtime / scale for entry in table]
+        else:
+            xs = [float(entry.runtime) for entry in table]
+
+        all_xs.extend(xs)
+
+        label = table.name
+        if label is not None:
+            has_labels = True
+
+        ax.scatter(x=xs, y=ys, label=label, **scatter_args)
+
+    if runtime_unit is not None:
+        ax.set_xlabel(f"Runtime ({runtime_unit})")
+    else:
+        ax.set_xlabel("Runtime")
+
+        time_labels, time_units = zip(*_TICK_UNITS)
+
+        cutoff = (
+            next(
+                (i for i, x in enumerate(time_units) if x > max(all_xs)),
+                len(time_units) - 1,
+            )
+            + 1
+        )
+
+        ax.set_xticks(time_units[:cutoff])
+        ax.set_xticklabels(time_labels[:cutoff], rotation=90)
+
+    if has_labels:
+        ax.legend()
+
+    plt.close(fig)
+
+    return fig


### PR DESCRIPTION
This is still an intermediate way to get plots into Jupyter notebooks and should be replaced by qdk widgets in a future PR.