### PR TITLE
Set 10s test timeout for debugger test suite

### DIFF
--- a/source/vscode/test/suites/debugger/index.ts
+++ b/source/vscode/test/suites/debugger/index.ts
@@ -6,11 +6,11 @@ import { runMochaTests } from "../run";
 export function run(): Promise<void> {
   return runMochaTests(
     () => {
-    // We can't use any wildcards or dynamically discovered
-    // paths here since ESBuild needs these modules to be
-    // real paths on disk at bundling time.
-    require("./qsharp.test"); // eslint-disable-line @typescript-eslint/no-require-imports
-    require("./openqasm.test"); // eslint-disable-line @typescript-eslint/no-require-imports
+      // We can't use any wildcards or dynamically discovered
+      // paths here since ESBuild needs these modules to be
+      // real paths on disk at bundling time.
+      require("./qsharp.test"); // eslint-disable-line @typescript-eslint/no-require-imports
+      require("./openqasm.test"); // eslint-disable-line @typescript-eslint/no-require-imports
     },
     { timeout: 10_000 },
   );

--- a/source/vscode/test/suites/run.ts
+++ b/source/vscode/test/suites/run.ts
@@ -13,7 +13,7 @@ require("mocha/mocha"); // eslint-disable-line @typescript-eslint/no-require-imp
 
 export function runMochaTests(
   requireTestModules: () => void,
-  options?: Mocha.MochaOptions
+  options?: Mocha.MochaOptions,
 ): Promise<void> {
   return new Promise((c, e) => {
     mocha.setup({


### PR DESCRIPTION
This should take care of frequent timeouts in the debugger integration tests. 

`waitUntilPaused` relies on VS Code to orchestrate the Debug Adapter Protocol message sequence and update the UX after we send the `stopped` event. We rely on the UX to determine that the debugger is paused. This part is beyond our control, and tends to take half a second or so in my environment. The timing varies quite a bit especially on slow machines.

I did confirm via logging there's no bottleneck in our product code, which does trivial work taking <1ms or so.