### PR TITLE
Fix quantum seed not being applied in invoke execution path

### DIFF
--- a/source/compiler/qsc/src/interpret.rs
+++ b/source/compiler/qsc/src/interpret.rs
@@ -1303,6 +1303,9 @@ impl Interpreter {
         args: Value,
         config: ExecGraphConfig,
     ) -> InterpretResult {
+        if self.quantum_seed.is_some() {
+            tracing_backend.set_seed(self.quantum_seed);
+        }
         qsc_eval::invoke(
             self.package,
             self.classical_seed,

--- a/source/compiler/qsc/src/interpret/tests.rs
+++ b/source/compiler/qsc/src/interpret/tests.rs
@@ -797,6 +797,97 @@ mod given_interpreter {
         }
 
         #[test]
+        fn invoke_with_noise_respects_quantum_seed() {
+            let mut interpreter = get_interpreter();
+            // Define a callable that measures qubits in superposition,
+            // producing non-deterministic results without a seed.
+            let (result, _) = line(
+                &mut interpreter,
+                indoc! {r#"
+                    operation MeasureRandom() : Result[] {
+                        use qs = Qubit[16];
+                        for q in qs { H(q); }
+                        MResetEachZ(qs)
+                    }
+                "#},
+            );
+            result.expect("callable definition should succeed");
+
+            let mut cursor = Cursor::new(Vec::<u8>::new());
+            let mut receiver = CursorReceiver::new(&mut cursor);
+            let callable = interpreter
+                .eval_fragments(&mut receiver, "MeasureRandom")
+                .expect("callable lookup should succeed");
+
+            // First run with seed
+            interpreter.set_quantum_seed(Some(42));
+            let result1 = interpreter
+                .invoke_with_noise(&mut receiver, callable.clone(), Value::unit(), None, None)
+                .expect("invoke should succeed");
+
+            // Second run with same seed
+            interpreter.set_quantum_seed(Some(42));
+            let result2 = interpreter
+                .invoke_with_noise(&mut receiver, callable.clone(), Value::unit(), None, None)
+                .expect("invoke should succeed");
+
+            assert_eq!(
+                result1, result2,
+                "invoke_with_noise should produce identical results with the same quantum seed"
+            );
+
+            // Third run with different seed should (almost certainly) differ
+            interpreter.set_quantum_seed(Some(12345));
+            let result3 = interpreter
+                .invoke_with_noise(&mut receiver, callable, Value::unit(), None, None)
+                .expect("invoke should succeed");
+
+            assert_ne!(
+                result1, result3,
+                "invoke_with_noise should produce different results with a different quantum seed"
+            );
+        }
+
+        #[test]
+        fn run_with_seed_produces_reproducible_results() {
+            let mut interpreter = get_interpreter();
+
+            // First run with seed
+            interpreter.set_quantum_seed(Some(42));
+            let (result1, _) = run(
+                &mut interpreter,
+                "{use qs = Qubit[16]; for q in qs { H(q); }; MResetEachZ(qs)}",
+            );
+            let result1 = result1.expect("run should succeed");
+
+            // Second run with same seed
+            interpreter.set_quantum_seed(Some(42));
+            let (result2, _) = run(
+                &mut interpreter,
+                "{use qs = Qubit[16]; for q in qs { H(q); }; MResetEachZ(qs)}",
+            );
+            let result2 = result2.expect("run should succeed");
+
+            assert_eq!(
+                result1, result2,
+                "run should produce identical results with the same quantum seed"
+            );
+
+            // Third run with different seed should produce different results
+            interpreter.set_quantum_seed(Some(12345));
+            let (result3, _) = run(
+                &mut interpreter,
+                "{use qs = Qubit[16]; for q in qs { H(q); }; MResetEachZ(qs)}",
+            );
+            let result3 = result3.expect("run should succeed");
+
+            assert_ne!(
+                result1, result3,
+                "run should produce different results with a different quantum seed"
+            );
+        }
+
+        #[test]
         fn callables_failing_profile_validation_are_not_registered() {
             let mut interpreter =
                 get_interpreter_with_capabilities(TargetCapabilityFlags::Adaptive);

--- a/source/compiler/qsc_eval/src/backend.rs
+++ b/source/compiler/qsc_eval/src/backend.rs
@@ -533,6 +533,17 @@ impl SparseSim {
     }
 
     #[must_use]
+    pub fn new_with_seed(seed: Option<u64>) -> Self {
+        Self {
+            sim: QuantumSim::new(seed.map(StdRng::seed_from_u64)),
+            noise: PauliNoise::default(),
+            loss: f64::zero(),
+            lost_qubits: BigUint::zero(),
+            rng: None,
+        }
+    }
+
+    #[must_use]
     pub fn new_with_noise(noise: &PauliNoise) -> Self {
         let mut sim = SparseSim::new();
         sim.set_noise(noise);

--- a/source/compiler/qsc_eval/src/backend/noise_tests.rs
+++ b/source/compiler/qsc_eval/src/backend/noise_tests.rs
@@ -227,3 +227,40 @@ fn measure_with_loss_returns_loss() {
         "Expected measurement with loss to return None"
     );
 }
+
+#[test]
+fn new_with_seed_produces_deterministic_measurements() {
+    // Two simulators constructed with the same seed should produce identical measurement sequences.
+    let mut sim1 = SparseSim::new_with_seed(Some(42));
+    let mut sim2 = SparseSim::new_with_seed(Some(42));
+    for _ in 0..64 {
+        let q1 = sim1.qubit_allocate();
+        sim1.h(q1);
+        let r1 = sim1.m(q1).unwrap_bool();
+        sim1.qubit_release(q1);
+
+        let q2 = sim2.qubit_allocate();
+        sim2.h(q2);
+        let r2 = sim2.m(q2).unwrap_bool();
+        sim2.qubit_release(q2);
+
+        assert_eq!(
+            r1, r2,
+            "Simulators with same seed should produce identical measurements"
+        );
+    }
+}
+
+#[test]
+fn new_with_seed_none_creates_valid_simulator() {
+    // Passing None should work the same as SparseSim::new().
+    let mut sim = SparseSim::new_with_seed(None);
+    let q = sim.qubit_allocate();
+    sim.h(q);
+    let res = sim.m(q);
+    assert!(
+        matches!(res, val::Result::Val(_)),
+        "Expected measurement to return a result"
+    );
+    sim.qubit_release(q);
+}


### PR DESCRIPTION
The `invoke_with_tracing_backend` method was missing the seed propagation that `run_with_sim` and `run_with_tracing_backend` already had. When `set_quantum_seed` was called followed by `invoke_with_noise`, `invoke_with_sim`, or circuit generation in simulate mode, the quantum seed was silently ignored. This produced non-deterministic measurement results even with a fixed seed.

Changes:

- Add `if self.quantum_seed.is_some() { tracing_backend.set_seed(self.quantum_seed); }` to `invoke_with_tracing_backend`, matching the existing pattern in the run path
- Add `SparseSim::new_with_seed(seed)` constructor that passes a seeded RNG directly to `QuantumSim::new()`, aligning with the constructor patterns used by all other simulators in the codebase (`StateVectorSimulator::new_with_seed`, `StabilizerSimulator::new`, etc.)
- Add regression tests for both the invoke and run paths, and unit tests for the new constructor