### PR TITLE
Fix `qsharp` package readme

### DIFF
--- a/source/pip/pyproject.toml
+++ b/source/pip/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "qsharp"
 version = "0.0.0"
+readme = "README.md"
 requires-python = ">= 3.10"
 classifiers = [
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The explicit readme inclusion was missing from the pyproject.toml for the qsharp package. This used to get picked up by our previous build automatically, but now that line is required for the readme to show up.