### PR TITLE
add `DecomposeCcxPass` to `run_qir_cpu`

### DIFF
--- a/source/pip/qsharp/_simulation.py
+++ b/source/pip/qsharp/_simulation.py
@@ -514,6 +514,7 @@ def run_qir_cpu(
     seed: Optional[int] = None,
 ) -> List:
     (mod, shots, noise, seed) = preprocess_simulation_input(input, shots, noise, seed)
+    DecomposeCcxPass().run(mod)
     if noise is None:
         (gates, num_qubits, num_results) = AggregateGatesPass().run(mod)
     else:

--- a/source/pip/tests/test_cpu_simulator.py
+++ b/source/pip/tests/test_cpu_simulator.py
@@ -474,3 +474,31 @@ operation tiny_coeffs() : Result[] {{
         assert (
             abs(actual_count - expected_count) <= tolerance
         ), f"Count for {pattern} off by more than {tolerance_percent:.1f}% of shots. Actual={actual_count}, Expected={expected_count:.0f}, noise#{noise_number}, Program={program}."
+
+
+def test_ccx_gate_gets_decomposed():
+    qsharp.init(target_profile=TargetProfile.Base)
+    program = """
+    operation Main() : Result[] {
+        use qs = Qubit[3];
+        X(qs[0]);
+        X(qs[1]);
+        CCNOT(qs[0], qs[1], qs[2]);
+        MeasureEachZ(qs)
+    }
+    """
+    qsharp.eval(program)
+    input = qsharp.compile("Main()")
+
+    output = run_qir_cpu(str(input), shots=1000)
+    result = [result_array_to_string(cast(Sequence[Result], x)) for x in output]
+    histogram = Counter(result)
+    total = sum(histogram.values())
+    assert total > 0, "No measurement results recorded."
+    for bitstring in histogram:
+        assert bitstring.endswith("111"), f"Unexpected suffix in '{bitstring}'."
+    probability_111 = histogram.get("111", 0) / total
+    assert probability_111 == 1.0, (
+        f"Probability of 111 outside expected range. "
+        f"Actual={probability_111:.2%}, Shots={total}."
+    )

--- a/source/pip/tests/test_cpu_simulator.py
+++ b/source/pip/tests/test_cpu_simulator.py
@@ -489,16 +489,7 @@ def test_ccx_gate_gets_decomposed():
     """
     qsharp.eval(program)
     input = qsharp.compile("Main()")
-
     output = run_qir_cpu(str(input), shots=1000)
     result = [result_array_to_string(cast(Sequence[Result], x)) for x in output]
     histogram = Counter(result)
-    total = sum(histogram.values())
-    assert total > 0, "No measurement results recorded."
-    for bitstring in histogram:
-        assert bitstring.endswith("111"), f"Unexpected suffix in '{bitstring}'."
-    probability_111 = histogram.get("111", 0) / total
-    assert probability_111 == 1.0, (
-        f"Probability of 111 outside expected range. "
-        f"Actual={probability_111:.2%}, Shots={total}."
-    )
+    assert histogram.get("111", 0) == 1000


### PR DESCRIPTION
This PR adds the `DecomposeCcxPass` to the `run_qir_cpu` function, which will enable correct handling of CCX gates through the `run_qir(..., type="cpu")` codepath.