### PR TITLE
Add URI handler for one-click workspace connection from external sources

### DIFF
--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -20,6 +20,7 @@
   "browser": "./out/extension.js",
   "virtualWorkspaces": true,
   "activationEvents": [
+    "onUri",
     "onNotebook:jupyter-notebook",
     "onDebug",
     "onDebugResolve:qsharp",

--- a/source/vscode/src/azure/commands.ts
+++ b/source/vscode/src/azure/commands.ts
@@ -38,6 +38,7 @@ import {
   getAzurePortalWorkspaceLink,
   getJobFiles,
   getPythonCodeForWorkspace,
+  parseConnectionString,
   queryWorkspaces,
   submitJob,
   uploadBlob,
@@ -479,6 +480,19 @@ export async function initAzureWorkspaces(context: vscode.ExtensionContext) {
       },
     ),
   );
+
+  return {
+    /**
+     * Adds a workspace connection programmatically (e.g. from a URI handler).
+     * The workspace is persisted and its refresh cycle is started.
+     */
+    async addWorkspace(workspace: WorkspaceConnection) {
+      workspaceTreeProvider.updateWorkspace(workspace);
+      await saveWorkspaceList();
+      startRefreshCycle(workspaceTreeProvider, workspace);
+    },
+    parseConnectionString,
+  };
 }
 
 type Buckets = {

--- a/source/vscode/src/azure/commands.ts
+++ b/source/vscode/src/azure/commands.ts
@@ -38,10 +38,12 @@ import {
   getAzurePortalWorkspaceLink,
   getJobFiles,
   getPythonCodeForWorkspace,
+  parseConnectionString,
   queryWorkspaces,
   submitJob,
   uploadBlob,
 } from "./workspaceActions";
+import { UriRouteHandler } from "../uriHandler.js";
 
 const workspacesSecret = `${qsharpExtensionId}.workspaces`;
 let extensionUri: vscode.Uri;
@@ -480,17 +482,44 @@ export async function initAzureWorkspaces(context: vscode.ExtensionContext) {
     ),
   );
 
-  return {
-    /**
-     * Adds a workspace connection programmatically (e.g. from a URI handler).
-     * The workspace is persisted and its refresh cycle is started.
-     */
-    async addWorkspace(workspace: WorkspaceConnection) {
+  /**
+   * URI route handler for the "/connectWorkspace" path.
+   *
+   * Expects a `connectionString` query parameter in the connection string format:
+   *   SubscriptionId=<guid>;ResourceGroupName=<name>;WorkspaceName=<name>;ApiKey=<secret>;QuantumEndpoint=<https://...>
+   *
+   * Shows a confirmation modal before saving the workspace.
+   */
+  const connectWorkspaceUriHandler: UriRouteHandler = async (params) => {
+    const connStr = params.get("connectionString");
+    if (!connStr) {
+      vscode.window.showErrorMessage(
+        "No connection string provided in the workspace URI.",
+      );
+      return;
+    }
+
+    const workspace = parseConnectionString(connStr);
+    if (!workspace) {
+      vscode.window.showErrorMessage(
+        "The workspace URI contained an invalid connection string.",
+      );
+      return;
+    }
+
+    const confirmed = await vscode.window.showInformationMessage(
+      `Add quantum workspace "${workspace.name}" to your connections?`,
+      { modal: true },
+      "Add Workspace",
+    );
+    if (confirmed === "Add Workspace") {
       workspaceTreeProvider.updateWorkspace(workspace);
       await saveWorkspaceList();
       startRefreshCycle(workspaceTreeProvider, workspace);
-    },
+    }
   };
+
+  return { connectWorkspaceUriHandler };
 }
 
 type Buckets = {

--- a/source/vscode/src/azure/commands.ts
+++ b/source/vscode/src/azure/commands.ts
@@ -38,7 +38,6 @@ import {
   getAzurePortalWorkspaceLink,
   getJobFiles,
   getPythonCodeForWorkspace,
-  parseConnectionString,
   queryWorkspaces,
   submitJob,
   uploadBlob,
@@ -491,7 +490,6 @@ export async function initAzureWorkspaces(context: vscode.ExtensionContext) {
       await saveWorkspaceList();
       startRefreshCycle(workspaceTreeProvider, workspace);
     },
-    parseConnectionString,
   };
 }
 

--- a/source/vscode/src/azure/workspaceActions.ts
+++ b/source/vscode/src/azure/workspaceActions.ts
@@ -124,6 +124,50 @@ workspace = Workspace(
   return pythonCode;
 }
 
+/**
+ * Parses a connection string into a WorkspaceConnection, or returns undefined
+ * if any required fields are missing. Does not validate the connection against
+ * the service — call getTokenForWorkspace / azureRequest to validate.
+ *
+ * Expected format:
+ *   SubscriptionId=<guid>;ResourceGroupName=<name>;WorkspaceName=<name>;ApiKey=<secret>;QuantumEndpoint=<serviceUri>
+ */
+export function parseConnectionString(
+  connStr: string,
+): WorkspaceConnection | undefined {
+  const partsMap = new Map<string, string>();
+  connStr.split(";").forEach((part) => {
+    const eq = part.indexOf("=");
+    if (eq === -1) return;
+    partsMap.set(part.substring(0, eq).toLowerCase(), part.substring(eq + 1));
+  });
+
+  if (
+    !partsMap.has("subscriptionid") ||
+    !partsMap.has("resourcegroupname") ||
+    !partsMap.has("workspacename") ||
+    !partsMap.has("apikey") ||
+    !partsMap.has("quantumendpoint")
+  ) {
+    return undefined;
+  }
+
+  const workspaceId =
+    `/subscriptions/${partsMap.get("subscriptionid")}` +
+    `/resourceGroups/${partsMap.get("resourcegroupname")}` +
+    `/providers/Microsoft.Quantum/Workspaces/${partsMap.get("workspacename")}`;
+
+  return {
+    id: workspaceId,
+    name: partsMap.get("workspacename")!,
+    endpointUri: partsMap.get("quantumendpoint")!,
+    tenantId: "", // Blank means not authenticated via a token
+    apiKey: partsMap.get("apikey"),
+    providers: [], // Providers and jobs will be populated by a following 'queryWorkspace' call
+    jobs: [],
+  };
+}
+
 async function getWorkspaceWithConnectionString(
   endEventProperties: EndEventProperties,
 ): Promise<WorkspaceConnection | undefined> {
@@ -139,20 +183,8 @@ async function getWorkspaceWithConnectionString(
       return;
     }
 
-    const partsMap = new Map<string, string>();
-    connStr.split(";").forEach((part) => {
-      const eq = part.indexOf("=");
-      if (eq === -1) return;
-      partsMap.set(part.substring(0, eq).toLowerCase(), part.substring(eq + 1));
-    });
-
-    if (
-      !partsMap.has("subscriptionid") ||
-      !partsMap.has("resourcegroupname") ||
-      !partsMap.has("workspacename") ||
-      !partsMap.has("apikey") ||
-      !partsMap.has("quantumendpoint")
-    ) {
+    const workspace = parseConnectionString(connStr);
+    if (!workspace) {
       const action = await vscode.window.showErrorMessage(
         "Invalid connection string. Please follow the placeholder format.",
         { modal: true },
@@ -166,23 +198,6 @@ async function getWorkspaceWithConnectionString(
         return;
       }
     }
-
-    const workspaceId =
-      `/subscriptions/${partsMap.get("subscriptionid")}` +
-      `/resourceGroups/${partsMap.get("resourcegroupname")}` +
-      `/providers/Microsoft.Quantum/Workspaces/${partsMap.get(
-        "workspacename",
-      )}`;
-
-    const workspace: WorkspaceConnection = {
-      id: workspaceId,
-      name: partsMap.get("workspacename")!,
-      endpointUri: partsMap.get("quantumendpoint")!,
-      tenantId: "", // Blank means not authenticated via a token
-      apiKey: partsMap.get("apikey"),
-      providers: [], // Providers and jobs will be populated by a following 'queryWorkspace' call
-      jobs: [],
-    };
 
     // Validate the connection string info before returning as valid for further use.
     try {

--- a/source/vscode/src/extension.ts
+++ b/source/vscode/src/extension.ts
@@ -10,6 +10,7 @@ import {
 } from "qsharp-lang";
 import * as vscode from "vscode";
 import { initAzureWorkspaces } from "./azure/commands.js";
+import { parseConnectionString } from "./azure/workspaceActions.js";
 import { CircuitEditorProvider } from "./circuitEditor.js";
 import { initProjectCreator } from "./createProject.js";
 import { activateDebugger } from "./debugger/activate.js";
@@ -95,7 +96,7 @@ export async function activate(
             return;
           }
 
-          const workspace = azureApi.parseConnectionString(connStr);
+          const workspace = parseConnectionString(connStr);
           if (!workspace) {
             vscode.window.showErrorMessage(
               "The workspace URI contained an invalid connection string.",

--- a/source/vscode/src/extension.ts
+++ b/source/vscode/src/extension.ts
@@ -79,7 +79,42 @@ export async function activate(
   context.subscriptions.push(CircuitEditorProvider.register(context));
   context.subscriptions.push(...registerChangelogCommand(context));
 
-  await initAzureWorkspaces(context);
+  /// Handle incoming workspace connection URIs from the Azure portal. The URI will be in the format:
+  /// `vscode://quantum.qsharp-lang-vscode/connectWorkspace?connectionString=SubscriptionId=<guid>;ResourceGroupName=<name>;WorkspaceName=<name>;ApiKey=<secret>;QuantumEndpoint=<https://...>`
+  const azureApi = await initAzureWorkspaces(context);
+  context.subscriptions.push(
+    vscode.window.registerUriHandler({
+      async handleUri(uri: vscode.Uri) {
+        if (uri.path === "/connectWorkspace") {
+          const params = new URLSearchParams(uri.query);
+          const connStr = params.get("connectionString");
+          if (!connStr) {
+            vscode.window.showErrorMessage(
+              "No connection string provided in the workspace URI.",
+            );
+            return;
+          }
+
+          const workspace = azureApi.parseConnectionString(connStr);
+          if (!workspace) {
+            vscode.window.showErrorMessage(
+              "The workspace URI contained an invalid connection string.",
+            );
+            return;
+          }
+
+          const confirmed = await vscode.window.showInformationMessage(
+            `Add quantum workspace "${workspace.name}" to your connections?`,
+            { modal: true },
+            "Add Workspace",
+          );
+          if (confirmed === "Add Workspace") {
+            await azureApi.addWorkspace(workspace);
+          }
+        }
+      },
+    }),
+  );
   initCodegen(context);
   await activateDebugger(context);
   registerCreateNotebookCommand(context);

--- a/source/vscode/src/extension.ts
+++ b/source/vscode/src/extension.ts
@@ -10,7 +10,6 @@ import {
 } from "qsharp-lang";
 import * as vscode from "vscode";
 import { initAzureWorkspaces } from "./azure/commands.js";
-import { parseConnectionString } from "./azure/workspaceActions.js";
 import { CircuitEditorProvider } from "./circuitEditor.js";
 import { initProjectCreator } from "./createProject.js";
 import { activateDebugger } from "./debugger/activate.js";
@@ -32,6 +31,7 @@ import { getGithubSourceContent, setGithubEndpoint } from "./projectSystem.js";
 import { initCodegen } from "./qirGeneration.js";
 import { initTelemetry } from "./telemetry.js";
 import { registerWebViewCommands } from "./webviewPanel.js";
+import { registerUriHandler } from "./uriHandler.js";
 import {
   maybeShowChangelogPrompt,
   registerChangelogCommand,
@@ -80,41 +80,13 @@ export async function activate(
   context.subscriptions.push(CircuitEditorProvider.register(context));
   context.subscriptions.push(...registerChangelogCommand(context));
 
-  /// Handle incoming workspace connection URIs from the Azure portal. The URI will be in the format:
+  /// Handle incoming workspace connection URIs. The URI will be in the format:
   /// `vscode://quantum.qsharp-lang-vscode/connectWorkspace?connectionString=SubscriptionId=<guid>;ResourceGroupName=<name>;WorkspaceName=<name>;ApiKey=<secret>;QuantumEndpoint=<https://...>`
   const azureApi = await initAzureWorkspaces(context);
   context.subscriptions.push(
-    vscode.window.registerUriHandler({
-      async handleUri(uri: vscode.Uri) {
-        if (uri.path === "/connectWorkspace") {
-          const params = new URLSearchParams(uri.query);
-          const connStr = params.get("connectionString");
-          if (!connStr) {
-            vscode.window.showErrorMessage(
-              "No connection string provided in the workspace URI.",
-            );
-            return;
-          }
-
-          const workspace = parseConnectionString(connStr);
-          if (!workspace) {
-            vscode.window.showErrorMessage(
-              "The workspace URI contained an invalid connection string.",
-            );
-            return;
-          }
-
-          const confirmed = await vscode.window.showInformationMessage(
-            `Add quantum workspace "${workspace.name}" to your connections?`,
-            { modal: true },
-            "Add Workspace",
-          );
-          if (confirmed === "Add Workspace") {
-            await azureApi.addWorkspace(workspace);
-          }
-        }
-      },
-    }),
+    registerUriHandler(
+      new Map([["/connectWorkspace", azureApi.connectWorkspaceUriHandler]]),
+    ),
   );
   initCodegen(context);
   await activateDebugger(context);

--- a/source/vscode/src/uriHandler.ts
+++ b/source/vscode/src/uriHandler.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { log } from "qsharp-lang";
+import * as vscode from "vscode";
+
+/**
+ * A handler for a specific URI path routed through the extension's URI handler.
+ *
+ * Receives the parsed query parameters from the incoming URI. The path itself
+ * is used for routing and does not need to be re-examined by the handler.
+ */
+export type UriRouteHandler = (params: URLSearchParams) => Promise<void>;
+
+/**
+ * A map from URI path (e.g. "/connectWorkspace") to its handler function.
+ */
+export type UriRoutes = Map<string, UriRouteHandler>;
+
+/**
+ * Registers the extension's URI handler with VS Code, dispatching incoming
+ * URIs to the appropriate route handler based on the URI path.
+ *
+ * Requires `"onUri"` in the extension's `activationEvents` in package.json.
+ *
+ * @example
+ * // In extension.ts activate():
+ * const routes: UriRoutes = new Map([
+ *   ["/connectWorkspace", handleConnectWorkspace],
+ * ]);
+ * context.subscriptions.push(registerUriHandler(routes));
+ */
+export function registerUriHandler(routes: UriRoutes): vscode.Disposable {
+  return vscode.window.registerUriHandler({
+    async handleUri(uri: vscode.Uri) {
+      const handler = routes.get(uri.path);
+      if (handler) {
+        const params = new URLSearchParams(uri.query);
+        await handler(params);
+      } else {
+        log.warn(`No URI route registered for path: ${uri.path}`);
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Adds a `vscode://` URI handler to the QDK extension that allows external websites or tools to open VS Code and automatically prompt the user to add a quantum workspace connection.

When VS Code navigates to a URI of the form:
```
vscode://quantum.qsharp-lang-vscode/connectWorkspace?connectionString=<encoded>
```
the extension presents a confirmation modal and, if accepted, saves the workspace connection identically to the existing manual "Add Workspace" flow.

## Changes

- **`package.json`**: Added `onUri` to `activationEvents` so the extension activates when a URI is handled even if it wasn't already running.
- **`workspaceActions.ts`**: Extracted connection string parsing out of `getWorkspaceWithConnectionString` into a new exported `parseConnectionString()` function. The existing manual flow delegates to it with no behavior change.
- **`commands.ts`**: `initAzureWorkspaces` now returns an `addWorkspace` helper that programmatically saves a workspace and starts its refresh cycle, reusing the existing private `saveWorkspaceList` and `startRefreshCycle` logic.
- **`extension.ts`**: Registers the URI handler. Validates the connection string and shows a user confirmation prompt before adding the workspace. User-facing messages are intentionally provider-agnostic.

## Testing

Use the following URL pattern in a browser to exercise the handler locally:
```
vscode://quantum.qsharp-lang-vscode-dev/connectWorkspace?connectionString=SubscriptionId=...;ResourceGroupName=...;WorkspaceName=...;ApiKey=...;QuantumEndpoint=...
```

Tested Scenarios:
- [x] Confirmation modal appears with the correct workspace name
- [x] Accepting adds the workspace to the Quantum Workspaces panel
- [x] Dismissing the modal does not add the workspace
- [x] A missing or malformed `connectionString` parameter shows an appropriate error message