### PR TITLE
Add build step markers for integration tests dependencies

### DIFF
--- a/build.py
+++ b/build.py
@@ -93,8 +93,26 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+
+def step_start(description):
+    global start_time
+    prefix = "::group::" if os.getenv("GITHUB_ACTIONS") == "true" else ""
+    print(f"{prefix}build.py: {description}")
+    start_time = time.time()
+
+
+def step_end():
+    global start_time
+    duration = time.time() - start_time
+    print(f"build.py: Finished in {duration:.3f}s.")
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        print(f"::endgroup::")
+
+
 if args.check_prereqs:
+    step_start("Checking prerequisites")
     check_prereqs()
+    step_end()
 
 # If no specific project given then build all
 build_all = (
@@ -155,21 +173,6 @@ QISKIT_VERSION_MATRIX = [
         "requirements": ["qiskit>=2.0.0,<3.0.0"],
     },
 ]
-
-
-def step_start(description):
-    global start_time
-    prefix = "::group::" if os.getenv("GITHUB_ACTIONS") == "true" else ""
-    print(f"{prefix}build.py: {description}")
-    start_time = time.time()
-
-
-def step_end():
-    global start_time
-    duration = time.time() - start_time
-    print(f"build.py: Finished in {duration:.3f}s.")
-    if os.getenv("GITHUB_ACTIONS") == "true":
-        print(f"::endgroup::")
 
 
 def install_build_package(cwd, interpreter):
@@ -453,8 +456,10 @@ if build_pip:
         step_end()
 
     if args.integration_tests:
+        step_start("Setting up for integration tests for the pip package")
         test_dir = os.path.join(pip_src, "tests-integration")
         install_python_test_requirements(test_dir, python_bin, check=False)
+        step_end()
 
         for version in QISKIT_VERSION_MATRIX:
             step_start(


### PR DESCRIPTION
This is a small quality-of-life change. There are two spots in our build script that don't have the `step_start` and `step_end` delimiters, causing longer build logs and portions that don't have the convenient collapsable sections. This adds them to the prereqs check and the Python integration tests dependencies installation, making the over all build log cleaner to read on GitHub Workflows.