### PR TITLE
Setting for Quantum OS Root Location

### DIFF
--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -197,6 +197,14 @@
             "hidden"
           ],
           "description": "Upload supplemental input data (circuit diagram) to the storage container when submitting jobs to Azure Quantum."
+        },
+        "Q#.azure.quantumOsRoot": {
+          "type": "string",
+          "default": "https://manage.quantum.microsoft.com",
+          "tags": [
+            "hidden"
+          ],
+          "description": "The root URL of the Quantum OS web portal, used when generating deep links to V2 workspaces and jobs."
         }
       }
     },

--- a/source/vscode/src/azure/workspaceActions.ts
+++ b/source/vscode/src/azure/workspaceActions.ts
@@ -20,13 +20,22 @@ import { getRandomGuid } from "../utils";
 import { EventType, sendTelemetryEvent, UserFlowStatus } from "../telemetry";
 import { getTenantIdAndToken, getTokenForWorkspace } from "./auth";
 
+function getQuantumOsRoot(): string {
+  return (
+    vscode.workspace
+      .getConfiguration("Q#")
+      .get<string>("azure.quantumOsRoot") ??
+    "https://manage.quantum.microsoft.com"
+  );
+}
+
 export function getQuantumOsJobLink(
   workspace: WorkspaceConnection,
   jobId: string,
 ) {
   // Quantum OS job page format:
-  // https://manage.quantum.microsoft.com/jobs/<job-id>
-  return `https://manage.quantum-test.microsoft.com/jobs/${jobId}`;
+  // <quantumOsRoot>/jobs/<job-id>
+  return `${getQuantumOsRoot()}/jobs/${jobId}`;
 }
 
 export function getWorkspacePortalLink(workspace: WorkspaceConnection) {
@@ -53,7 +62,7 @@ export function getWorkspacePortalLink(workspace: WorkspaceConnection) {
       (offeringId ? `&offeringId=${offeringId}` : "") +
       `&workspaceId=${workspace.id}`;
 
-    return `https://manage.quantum-test.microsoft.com/workspaces/${workspace.name}#${fragment}`;
+    return `${getQuantumOsRoot()}/workspaces/${workspace.name}#${fragment}`;
   }
 
   // Azure Portal link format:


### PR DESCRIPTION
Adds a hidden VS Code setting `Q#.azure.quantumOsRoot`. This allows users to overwrite the root URL for the Quantum OS website links created when linking to the website for workspace and job in V2 workspaces. The default value is the regular URL for the Quantum OS website.