### PR TITLE
Use platform-agnostic worker interface instead of web-worker dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6091,13 +6091,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/web-worker": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
-      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -6414,9 +6407,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.17.0"
-      },
-      "optionalDependencies": {
-        "web-worker": "^1.5.0"
       }
     },
     "source/playground": {
@@ -6427,7 +6417,6 @@
     "source/vscode": {
       "name": "qsharp-lang-vscode-dev",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "engines": {
         "vscode": "^1.100.0"

--- a/source/npm/qsharp/README.md
+++ b/source/npm/qsharp/README.md
@@ -11,11 +11,9 @@ to it when calling the `loadWasmModule` method so it may be located and loaded.
 
 ## Node and browser support
 
-This package is platform-agnostic, using a single entry point (`main.ts`) for both browser
-and Node.js environments. The wasm module and JavaScript glue code can be found in `./lib/web/`.
-Consumers must bundle the package for their target platform so that external
-dependencies (such as the `web-worker` package) are resolved correctly for the
-runtime environment.
+This package provides separate entry points for browser (`browser.ts`) and Node.js (`node.ts`)
+environments. Each entry point handles platform-specific setup before re-exporting the
+shared API from `main.ts`. The public API is the same regardless of the runtime.
 
 ## Design
 

--- a/source/npm/qsharp/package.json
+++ b/source/npm/qsharp/package.json
@@ -13,7 +13,7 @@
   },
   "exports": {
     ".": {
-      "browser": "./dist/main.js",
+      "browser": "./dist/browser.js",
       "node": "./dist/node.js",
       "default": "./dist/main.js"
     },

--- a/source/npm/qsharp/package.json
+++ b/source/npm/qsharp/package.json
@@ -44,8 +44,5 @@
     "docs",
     "lib",
     "ux"
-  ],
-  "optionalDependencies": {
-    "web-worker": "^1.5.0"
-  }
+  ]
 }

--- a/source/npm/qsharp/src/browser.ts
+++ b/source/npm/qsharp/src/browser.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { BrowserMainThreadAdapter } from "./workers/adapters/browser.js";
+
+globalThis.WorkerMain = BrowserMainThreadAdapter;
+export * from "./main.js";

--- a/source/npm/qsharp/src/browser.ts
+++ b/source/npm/qsharp/src/browser.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { BrowserMainThreadAdapter } from "./workers/adapters/browser.js";
+import { BrowserWorkerHost } from "./workers/adapters/browser.js";
 
-globalThis.WorkerMain = BrowserMainThreadAdapter;
+globalThis.WorkerHost = BrowserWorkerHost;
 export * from "./main.js";

--- a/source/npm/qsharp/src/compiler/worker.ts
+++ b/source/npm/qsharp/src/compiler/worker.ts
@@ -6,4 +6,3 @@ import { compilerProtocol } from "./compiler.js";
 
 // message handler exported for backwards compatibility
 export const messageHandler = createWorker(compilerProtocol);
-addEventListener("message", messageHandler);

--- a/source/npm/qsharp/src/debug-service/worker.ts
+++ b/source/npm/qsharp/src/debug-service/worker.ts
@@ -6,4 +6,3 @@ import { debugServiceProtocol } from "./debug-service.js";
 
 // message handler exported for backwards compatibility
 export const messageHandler = createWorker(debugServiceProtocol);
-addEventListener("message", messageHandler);

--- a/source/npm/qsharp/src/language-service/worker.ts
+++ b/source/npm/qsharp/src/language-service/worker.ts
@@ -6,4 +6,3 @@ import { languageServiceProtocol } from "./language-service.js";
 
 // message handler exported for backwards compatibility
 export const messageHandler = createWorker(languageServiceProtocol);
-addEventListener("message", messageHandler);

--- a/source/npm/qsharp/src/main.ts
+++ b/source/npm/qsharp/src/main.ts
@@ -30,13 +30,8 @@ import {
 } from "./language-service/language-service.js";
 import { log } from "./log.js";
 import { ProjectLoader } from "./project.js";
+import { MainThreadWorkerAdapter } from "./workers/adapters/types.js";
 import { createProxy } from "./workers/main.js";
-
-let workerType: "classic" | "module" = "classic";
-
-export function setWorkerType(type: "classic" | "module") {
-  workerType = type;
-}
 
 // Create once. A module is stateless and can be efficiently passed to WebWorkers.
 let wasmModule: WebAssembly.Module | null = null;
@@ -129,10 +124,10 @@ export async function getProjectLoader(
 // If the Worker was already created via other means and is ready to receive
 // messages, then the worker may be passed in and it will be initialized.
 export function getDebugServiceWorker(
-  worker: string | Worker,
+  worker: string | MainThreadWorkerAdapter,
 ): IDebugServiceWorker {
   if (!wasmModule) throw "Wasm module must be loaded first";
-  return createProxy(worker, wasmModule, debugServiceProtocol, workerType);
+  return createProxy(worker, wasmModule, debugServiceProtocol);
 }
 
 export async function getCompiler(): Promise<ICompiler> {
@@ -143,9 +138,11 @@ export async function getCompiler(): Promise<ICompiler> {
 // Create the compiler inside a WebWorker and proxy requests.
 // If the Worker was already created via other means and is ready to receive
 // messages, then the worker may be passed in and it will be initialized.
-export function getCompilerWorker(worker: string | Worker): ICompilerWorker {
+export function getCompilerWorker(
+  worker: string | MainThreadWorkerAdapter,
+): ICompilerWorker {
   if (!wasmModule) throw "Wasm module must be loaded first";
-  return createProxy(worker, wasmModule, compilerProtocol, workerType);
+  return createProxy(worker, wasmModule, compilerProtocol);
 }
 
 export async function getLanguageService(
@@ -159,10 +156,10 @@ export async function getLanguageService(
 // If the Worker was already created via other means and is ready to receive
 // messages, then the worker may be passed in and it will be initialized.
 export function getLanguageServiceWorker(
-  worker: string | Worker,
+  worker: string | MainThreadWorkerAdapter,
 ): ILanguageServiceWorker {
   if (!wasmModule) throw "Wasm module must be loaded first";
-  return createProxy(worker, wasmModule, languageServiceProtocol, workerType);
+  return createProxy(worker, wasmModule, languageServiceProtocol);
 }
 
 /// Extracts the target profile from a Q# source file's entry point.

--- a/source/npm/qsharp/src/main.ts
+++ b/source/npm/qsharp/src/main.ts
@@ -30,7 +30,7 @@ import {
 } from "./language-service/language-service.js";
 import { log } from "./log.js";
 import { ProjectLoader } from "./project.js";
-import { MainThreadWorkerAdapter } from "./workers/adapters/types.js";
+import { IWorkerHost } from "./workers/adapters/types.js";
 import { createProxy } from "./workers/main.js";
 
 // Create once. A module is stateless and can be efficiently passed to WebWorkers.
@@ -124,7 +124,7 @@ export async function getProjectLoader(
 // If the Worker was already created via other means and is ready to receive
 // messages, then the worker may be passed in and it will be initialized.
 export function getDebugServiceWorker(
-  worker: string | MainThreadWorkerAdapter,
+  worker: string | IWorkerHost,
 ): IDebugServiceWorker {
   if (!wasmModule) throw "Wasm module must be loaded first";
   return createProxy(worker, wasmModule, debugServiceProtocol);
@@ -139,7 +139,7 @@ export async function getCompiler(): Promise<ICompiler> {
 // If the Worker was already created via other means and is ready to receive
 // messages, then the worker may be passed in and it will be initialized.
 export function getCompilerWorker(
-  worker: string | MainThreadWorkerAdapter,
+  worker: string | IWorkerHost,
 ): ICompilerWorker {
   if (!wasmModule) throw "Wasm module must be loaded first";
   return createProxy(worker, wasmModule, compilerProtocol);
@@ -152,11 +152,11 @@ export async function getLanguageService(
   return new QSharpLanguageService(wasm, host);
 }
 
-// Create the compiler inside a WebWorker and proxy requests.
+// Create the language service inside a WebWorker and proxy requests.
 // If the Worker was already created via other means and is ready to receive
 // messages, then the worker may be passed in and it will be initialized.
 export function getLanguageServiceWorker(
-  worker: string | MainThreadWorkerAdapter,
+  worker: string | IWorkerHost,
 ): ILanguageServiceWorker {
   if (!wasmModule) throw "Wasm module must be loaded first";
   return createProxy(worker, wasmModule, languageServiceProtocol);

--- a/source/npm/qsharp/src/node.ts
+++ b/source/npm/qsharp/src/node.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { NodeMainThreadAdapter } from "./workers/adapters/node.js";
+import { NodeWorkerHost } from "./workers/adapters/node.js";
 
-globalThis.WorkerMain = NodeMainThreadAdapter;
+globalThis.WorkerHost = NodeWorkerHost;
 
 export * from "./main.js";

--- a/source/npm/qsharp/src/node.ts
+++ b/source/npm/qsharp/src/node.ts
@@ -1,14 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Node.js entrypoint. Polyfills the Worker global before loading the main module.
+import { NodeMainThreadAdapter } from "./workers/adapters/node.js";
 
-import worker from "web-worker";
-import { setWorkerType } from "./main.js";
-
-if (typeof globalThis.Worker === "undefined") {
-  globalThis.Worker = worker;
-}
-setWorkerType("module");
+globalThis.WorkerMain = NodeMainThreadAdapter;
 
 export * from "./main.js";

--- a/source/npm/qsharp/src/workers/adapters/browser.ts
+++ b/source/npm/qsharp/src/workers/adapters/browser.ts
@@ -1,0 +1,34 @@
+import type { MainThreadWorkerAdapter } from "./types.js";
+
+export class BrowserMainThreadAdapter implements MainThreadWorkerAdapter {
+  private worker: Worker;
+
+  constructor(url: string | URL) {
+    const scriptUrl = typeof url === "string" ? url : url.href;
+    const bootstrap = `
+      self.WorkerSelf = {
+        postMessage(msg) { self.postMessage(msg); },
+        onMessage(handler) { self.addEventListener("message", handler); }
+      };
+      importScripts("${scriptUrl}");
+    `;
+    const blob = new Blob([bootstrap], { type: "application/javascript" });
+    this.worker = new Worker(URL.createObjectURL(blob));
+  }
+
+  postMessage(msg: unknown): void {
+    this.worker.postMessage(msg);
+  }
+
+  onMessage(handler: (e: MessageEvent) => void): void {
+    this.worker.onmessage = handler;
+  }
+
+  onError(handler: (e: ErrorEvent) => void): void {
+    this.worker.onerror = handler;
+  }
+
+  terminate(): void {
+    this.worker.terminate();
+  }
+}

--- a/source/npm/qsharp/src/workers/adapters/browser.ts
+++ b/source/npm/qsharp/src/workers/adapters/browser.ts
@@ -1,6 +1,9 @@
-import type { MainThreadWorkerAdapter } from "./types.js";
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
-export class BrowserMainThreadAdapter implements MainThreadWorkerAdapter {
+import type { IWorkerHost } from "./types.js";
+
+export class BrowserWorkerHost implements IWorkerHost {
   private worker: Worker;
 
   constructor(url: string | URL) {
@@ -24,7 +27,7 @@ export class BrowserMainThreadAdapter implements MainThreadWorkerAdapter {
     this.worker.onmessage = handler;
   }
 
-  onError(handler: (e: ErrorEvent) => void): void {
+  onError(handler: (e: Event) => void): void {
     this.worker.onerror = handler;
   }
 

--- a/source/npm/qsharp/src/workers/adapters/node.ts
+++ b/source/npm/qsharp/src/workers/adapters/node.ts
@@ -1,7 +1,10 @@
-import { Worker } from "node:worker_threads";
-import type { MainThreadWorkerAdapter } from "./types.js";
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
-export class NodeMainThreadAdapter implements MainThreadWorkerAdapter {
+import { Worker } from "node:worker_threads";
+import type { IWorkerHost } from "./types.js";
+
+export class NodeWorkerHost implements IWorkerHost {
   private worker: Worker;
 
   constructor(url: string | URL) {
@@ -31,7 +34,7 @@ export class NodeMainThreadAdapter implements MainThreadWorkerAdapter {
     });
   }
 
-  onError(handler: (e: ErrorEvent) => void): void {
+  onError(handler: (e: Event) => void): void {
     this.worker.on("error", handler);
   }
 

--- a/source/npm/qsharp/src/workers/adapters/node.ts
+++ b/source/npm/qsharp/src/workers/adapters/node.ts
@@ -1,0 +1,41 @@
+import { Worker } from "node:worker_threads";
+import type { MainThreadWorkerAdapter } from "./types.js";
+
+export class NodeMainThreadAdapter implements MainThreadWorkerAdapter {
+  private worker: Worker;
+
+  constructor(url: string | URL) {
+    const workerUrl = typeof url === "string" ? new URL(url) : url;
+    const bootstrap = `
+      import { parentPort } from 'node:worker_threads';
+      globalThis.WorkerSelf = {
+        postMessage(msg) { parentPort.postMessage(msg); },
+        onMessage(handler) {
+          parentPort.on('message', (data) => handler({ data }));
+        }
+      };
+      await import("${workerUrl.href}");
+    `;
+    this.worker = new Worker(
+      new URL(`data:text/javascript,${encodeURIComponent(bootstrap)}`),
+    );
+  }
+
+  postMessage(msg: unknown): void {
+    this.worker.postMessage(msg);
+  }
+
+  onMessage(handler: (e: MessageEvent) => void): void {
+    this.worker.on("message", (data) => {
+      handler({ data } as MessageEvent);
+    });
+  }
+
+  onError(handler: (e: ErrorEvent) => void): void {
+    this.worker.on("error", handler);
+  }
+
+  terminate(): void {
+    this.worker.terminate();
+  }
+}

--- a/source/npm/qsharp/src/workers/adapters/types.ts
+++ b/source/npm/qsharp/src/workers/adapters/types.ts
@@ -1,0 +1,16 @@
+export interface MainThreadWorkerAdapter {
+  postMessage(msg: unknown): void;
+  onMessage(handler: (e: MessageEvent) => void): void;
+  onError(handler: (e: ErrorEvent) => void): void;
+  terminate(): void;
+}
+
+export interface WorkerThreadAdapter {
+  postMessage(msg: unknown): void;
+  onMessage(handler: (e: MessageEvent) => void): void;
+}
+
+declare global {
+  var WorkerMain: new (url: string | URL) => MainThreadWorkerAdapter;
+  var WorkerSelf: WorkerThreadAdapter;
+}

--- a/source/npm/qsharp/src/workers/adapters/types.ts
+++ b/source/npm/qsharp/src/workers/adapters/types.ts
@@ -1,16 +1,19 @@
-export interface MainThreadWorkerAdapter {
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface IWorkerHost {
   postMessage(msg: unknown): void;
   onMessage(handler: (e: MessageEvent) => void): void;
-  onError(handler: (e: ErrorEvent) => void): void;
+  onError(handler: (e: Event) => void): void;
   terminate(): void;
 }
 
-export interface WorkerThreadAdapter {
+export interface IWorkerSelf {
   postMessage(msg: unknown): void;
   onMessage(handler: (e: MessageEvent) => void): void;
 }
 
 declare global {
-  var WorkerMain: new (url: string | URL) => MainThreadWorkerAdapter;
-  var WorkerSelf: WorkerThreadAdapter;
+  var WorkerHost: new (url: string | URL) => IWorkerHost;
+  var WorkerSelf: IWorkerSelf;
 }

--- a/source/npm/qsharp/src/workers/main.ts
+++ b/source/npm/qsharp/src/workers/main.ts
@@ -5,6 +5,7 @@ import type { IQSharpError } from "../../lib/web/qsc_wasm.js";
 import type { CancellationToken } from "../cancellation.js";
 import { QdkDiagnostics } from "../diagnostics.js";
 import { log } from "../log.js";
+import type { MainThreadWorkerAdapter } from "./adapters/types.js";
 import type {
   CommonEventMessage,
   EventMessage,
@@ -26,7 +27,6 @@ import type {
  * @param workerArg The service web worker or the URL of the web worker script.
  * @param wasmModule The wasm module to initialize the service with
  * @param serviceProtocol An object that describes the service: its constructor, methods and events
- * @param workerType The type of worker to create: "classic" for browsers, "module" for Node.js
  * @returns A proxy object that implements the service interface.
  *   This interface can now be used as if calling into the real service,
  *   and the calls will be proxied to the web worker.
@@ -35,21 +35,15 @@ export function createProxy<
   TService extends ServiceMethods<TService>,
   TServiceEventMsg extends IServiceEventMessage,
 >(
-  workerArg: string | Worker,
+  workerArg: string | MainThreadWorkerAdapter,
   wasmModule: WebAssembly.Module,
   serviceProtocol: ServiceProtocol<TService, TServiceEventMsg>,
-  workerType: "classic" | "module",
 ): TService & IServiceProxy {
-  // Create or use the WebWorker
-  const useModuleWorker: WorkerOptions = { type: workerType };
-
   const worker =
-    typeof workerArg === "string"
-      ? new Worker(workerArg, useModuleWorker)
-      : workerArg;
+    typeof workerArg === "string" ? new WorkerMain(workerArg) : workerArg;
 
   // Log any errors from the worker
-  worker.addEventListener("error", (ev: Event) => {
+  worker.onError((ev: Event) => {
     log.error("Worker error:", ev);
   });
 
@@ -72,7 +66,7 @@ export function createProxy<
   );
 
   // Let proxy handle response and event messages from the worker
-  worker.addEventListener("message", (ev: MessageEvent) => {
+  worker.onMessage((ev: MessageEvent) => {
     proxy.onMsgFromWorker(ev.data);
   });
   return proxy;

--- a/source/npm/qsharp/src/workers/main.ts
+++ b/source/npm/qsharp/src/workers/main.ts
@@ -5,7 +5,7 @@ import type { IQSharpError } from "../../lib/web/qsc_wasm.js";
 import type { CancellationToken } from "../cancellation.js";
 import { QdkDiagnostics } from "../diagnostics.js";
 import { log } from "../log.js";
-import type { MainThreadWorkerAdapter } from "./adapters/types.js";
+import type { IWorkerHost } from "./adapters/types.js";
 import type {
   CommonEventMessage,
   EventMessage,
@@ -24,7 +24,7 @@ import type {
  * Creates and initializes a service in a web worker, and returns a proxy for the service
  * to be used from the main thread.
  *
- * @param workerArg The service web worker or the URL of the web worker script.
+ * @param workerArg An `IWorkerHost` instance, or a URL string to create one via the `WorkerHost` global.
  * @param wasmModule The wasm module to initialize the service with
  * @param serviceProtocol An object that describes the service: its constructor, methods and events
  * @returns A proxy object that implements the service interface.
@@ -35,12 +35,12 @@ export function createProxy<
   TService extends ServiceMethods<TService>,
   TServiceEventMsg extends IServiceEventMessage,
 >(
-  workerArg: string | MainThreadWorkerAdapter,
+  workerArg: string | IWorkerHost,
   wasmModule: WebAssembly.Module,
   serviceProtocol: ServiceProtocol<TService, TServiceEventMsg>,
 ): TService & IServiceProxy {
   const worker =
-    typeof workerArg === "string" ? new WorkerMain(workerArg) : workerArg;
+    typeof workerArg === "string" ? new WorkerHost(workerArg) : workerArg;
 
   // Log any errors from the worker
   worker.onError((ev: Event) => {

--- a/source/npm/qsharp/src/workers/worker.ts
+++ b/source/npm/qsharp/src/workers/worker.ts
@@ -19,11 +19,12 @@ import type {
 type Wasm = typeof wasm;
 
 /**
- * Creates an initializes a service, setting it up to receive requests.
- * This function to be is used in the worker.
+ * Creates and initializes a service, setting it up to receive requests.
+ * This function is used in the worker thread. It uses the `WorkerSelf` global,
+ * which is bootstrapped by the platform-specific adapter before this code runs.
  *
  * @param serviceProtocol An object that describes the service: its constructor, methods and events
- * @returns A message handler to be assigned to the `self.onmessage` handler in a web worker
+ * @returns The message handler registered on the worker thread.
  */
 export function createWorker<
   TService extends ServiceMethods<TService>,

--- a/source/npm/qsharp/src/workers/worker.ts
+++ b/source/npm/qsharp/src/workers/worker.ts
@@ -34,8 +34,7 @@ export function createWorker<
   let invokeService: ((req: RequestMessage<TService>) => Promise<void>) | null =
     null;
 
-  // This export should be assigned to 'self.onmessage' in a WebWorker
-  return function messageHandler(e: MessageEvent) {
+  const messageHandler = (e: MessageEvent) => {
     const data = e.data;
 
     if (!data.type || typeof data.type !== "string") {
@@ -49,7 +48,7 @@ export function createWorker<
           wasm.initSync({ module: data.wasmModule });
 
           invokeService = initService<TService, TServiceEventMsg>(
-            self.postMessage.bind(self),
+            WorkerSelf.postMessage.bind(WorkerSelf),
             serviceProtocol,
             wasm,
             data.qscLogLevel,
@@ -67,6 +66,9 @@ export function createWorker<
         }
     }
   };
+
+  WorkerSelf.onMessage(messageHandler);
+  return messageHandler;
 }
 
 /**

--- a/source/vscode/build.mjs
+++ b/source/vscode/build.mjs
@@ -59,7 +59,7 @@ const platformBuildOptions = {
     platform: "node",
     outdir: join(thisDir, "out", "node"),
     entryPoints: [join(thisDir, "src", "extension.ts")],
-    external: ["vscode", "web-worker"],
+    external: ["vscode"],
     banner: {
       js: 'const _importMetaUrl = require("url").pathToFileURL(__filename).href;',
     },

--- a/source/vscode/package.json
+++ b/source/vscode/package.json
@@ -1088,8 +1088,7 @@
     "tsc:check:view": "node ../../node_modules/typescript/bin/tsc -p ./src/webview/tsconfig.json",
     "tsc:check": "npm run tsc:check:main && npm run tsc:check:view",
     "tsc:watch": "node ../../node_modules/typescript/bin/tsc -p ./tsconfig.json --watch --preserveWatchOutput",
-    "tsc:watch:view": "node ../../node_modules/typescript/bin/tsc -p ./src/webview/tsconfig.json --watch --preserveWatchOutput",
-    "postinstall": "node -e \"require('fs').cpSync('../../node_modules/web-worker','node_modules/web-worker',{recursive:true})\""
+    "tsc:watch:view": "node ../../node_modules/typescript/bin/tsc -p ./src/webview/tsconfig.json --watch --preserveWatchOutput"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Replaces the `web-worker` npm polyfill with a platform-specific worker adapter layer. Each platform (browser, Node.js) now provides its own `IWorkerHost` and `IWorkerSelf` implementation, eliminating the third-party dependency while giving the shared code a single, clean interface for worker communication.

## What changed

- **Removed** the `web-worker` optional dependency and the `globalThis.Worker` polyfill in `node.ts`
- **Removed** `setWorkerType` / `workerType` — no longer needed since each adapter handles worker creation internally
- **Added** `src/workers/adapters/` with `IWorkerHost` (main→worker) and `IWorkerSelf` (worker→main) interfaces
- **Added** `BrowserWorkerHost` and `NodeWorkerHost` implementations
- **Added** `src/browser.ts` entry point (mirrors `node.ts`)
- **Updated** `package.json` exports to use `browser.ts` for browser builds
- Worker scripts no longer call `addEventListener("message", ...)` or `self.postMessage(...)` directly — they use the `WorkerSelf` global

## Architecture

### Before: polyfill the browser API into Node


```
  MAIN THREAD                              WORKER THREAD
  ───────────                              ─────────────

  ╔══════════════╗  ╔══════════════╗
  ║  browser.js  ║  ║   node.js    ║
  ║              ║  ║              ║
  ║ uses native  ║  ║ polyfills    ║
  ║ Worker API   ║  ║ via web-     ║
  ║              ║  ║ worker pkg   ║
  ╚══════╤═══════╝  ╚══════╤═══════╝
         │                 │
         └────────┬────────┘
                  │
                  ▼
  ┌───────────────────────┐    ┌───────────────────────┐
  │   Browser Worker API  │    │   Browser Worker API  │
  │                       │    │                       │
  │  · new Worker(url)    │    │  · self.postMessage() │
  │  · addEventListener() │    │  · addEventListener() │
  │  · postMessage()      │    │                       │
  └───────────┬───────────┘    └───────────┬───────────┘
              │                            │
              ▼                            ▼
      ┌───────────────┐           ┌───────────────┐
      │  Shared code  │◄─messages──│  Shared code  │
      │  (main.ts)    │──messages─►│  (worker.ts)  │
      └───────────────┘           └───────────────┘
```

- Node polyfilled the browser `Worker` global using `web-worker`
- All code used browser-native APIs (`addEventListener`, `self.postMessage`)
- `workerType` toggled between `"classic"` and `"module"`

### After: each platform provides its own adapter

```
  MAIN THREAD                              WORKER THREAD
  ───────────                              ─────────────

  ╔══════════════╗  ╔══════════════╗
  ║  browser.ts  ║  ║   node.ts    ║
  ╚══════╤═══════╝  ╚══════╤═══════╝
         │                 │
         ▼                 ▼
  ┌────────────┐    ┌────────────┐         ┌──────────────────┐
  │ Browser    │    │ Node       │ boot-   │ WorkerSelf       │
  │ WorkerHost │    │ WorkerHost │ straps  │                  │
  │            │    │            │────────►│ blob URL (browser)│
  │ wraps      │    │ wraps      │         │ data URL (node)  │
  │ Worker API │    │ worker_    │         │                  │
  │            │    │ threads    │         └────────┬─────────┘
  └─────┬──────┘    └─────┬──────┘                  │
        │                 │                         │
        └────────┬────────┘                         │
                 │                                  │
                 ▼                                  ▼
      ╔═════════════════════╗            ╔═════════════════════╗
      ║   IWorkerHost       ║            ║   IWorkerSelf       ║
      ║                     ║            ║                     ║
      ║  · postMessage()    ║            ║  · postMessage()    ║
      ║  · onMessage()      ║            ║  · onMessage()      ║
      ║  · terminate()      ║            ║                     ║
      ╚══════════╤══════════╝            ╚══════════╤══════════╝
                 │                                  │
                 ▼                                  ▼
         ┌───────────────┐              ┌───────────────┐
         │  Shared code  │◄──messages───│  Shared code  │
         │  (main.ts)    │───messages──►│  (worker.ts)  │
         └───────────────┘              └───────────────┘
```

- No polyfilling — each platform uses its native worker API behind the adapter
- Shared code only touches `IWorkerHost` and `IWorkerSelf` interfaces
- `WorkerSelf` is bootstrapped into the worker thread via blob URL (browser) or data URL (Node) before the worker script runs