### PR TITLE
Fix run command hanging on compile errors for OpenQASM and Q# programs

### DIFF
--- a/source/npm/qsharp/test/basics.js
+++ b/source/npm/qsharp/test/basics.js
@@ -872,6 +872,83 @@ async function testCompilerError(useWorker) {
 test("compiler error on run", () => testCompilerError(false));
 test("compiler error on run - worker", () => testCompilerError(true));
 
+test("OpenQASM compile error on run", async () => {
+  const compiler = await getCompiler();
+  const events = new QscEventTarget(true);
+  let promiseResult = undefined;
+  await compiler
+    .run(
+      {
+        sources: [
+          // Missing stdgates.inc, so CX is undefined
+          ["test.qasm", `OPENQASM 3.0;\nqubit[2] q;\nCX q[0], q[1];`],
+        ],
+        languageFeatures: [],
+        projectType: "openqasm",
+      },
+      "",
+      1,
+      events,
+    )
+    .then(() => {
+      promiseResult = "success";
+    })
+    .catch(() => {
+      promiseResult = "failure";
+    });
+
+  assert.equal(promiseResult, "failure");
+  const results = events.getResults();
+  assert.equal(results.length, 1);
+  assert.equal(results[0].success, false);
+});
+
+test("Q# dependency compile error on run", async () => {
+  const compiler = await getCompiler();
+  const events = new QscEventTarget(true);
+  let promiseResult = undefined;
+  await compiler
+    .run(
+      {
+        packageGraphSources: {
+          root: {
+            sources: [
+              [
+                "main.qs",
+                `import BrokenDep.Broken; operation Main() : Unit { Broken(); }`,
+              ],
+            ],
+            languageFeatures: [],
+            dependencies: { BrokenDep: "broken-dep-key" },
+          },
+          packages: {
+            "broken-dep-key": {
+              sources: [["lib.qs", "invalid code"]],
+              languageFeatures: [],
+              dependencies: {},
+              packageType: "lib",
+            },
+          },
+          hasManifest: true,
+        },
+      },
+      "",
+      1,
+      events,
+    )
+    .then(() => {
+      promiseResult = "success";
+    })
+    .catch(() => {
+      promiseResult = "failure";
+    });
+
+  assert.equal(promiseResult, "failure");
+  const results = events.getResults();
+  assert.equal(results.length, 1);
+  assert.equal(results[0].success, false);
+});
+
 test("debug service loading source without entry point attr fails - web worker", async () => {
   const debugService = getDebugServiceWorker(debugServiceWorkerPath);
   try {

--- a/source/wasm/src/debug_service.rs
+++ b/source/wasm/src/debug_service.rs
@@ -44,7 +44,7 @@ impl DebugService {
                     self.debugger = Some(debugger);
                     String::new()
                 }
-                Err(e) => e,
+                Err(e) => render_errors(e),
             }
         } else {
             match init_debugger(program, entry) {

--- a/source/wasm/src/lib.rs
+++ b/source/wasm/src/lib.rs
@@ -420,6 +420,35 @@ where
     }
 }
 
+fn run_interpreter<F>(
+    interpreter: &mut interpret::Interpreter,
+    out: &mut CallbackReceiver<F>,
+    shots: u32,
+    pauliNoise: &PauliNoise,
+    qubitLoss: f64,
+) where
+    F: FnMut(&str),
+{
+    for _ in 0..shots {
+        let result = {
+            let mut sim = SparseSim::new_with_noise(pauliNoise);
+            sim.set_loss(qubitLoss);
+            interpreter.eval_entry_with_sim(&mut sim, out)
+        };
+        let mut success = true;
+        let msg: serde_json::Value = match result {
+            Ok(value) => serde_json::Value::String(value.to_string()),
+            Err(errors) => {
+                success = false;
+                interpret_errors_to_run_result(&errors)
+            }
+        };
+
+        let msg_string = json!({"type": "Result", "success": success, "result": msg}).to_string();
+        (out.event_cb)(&msg_string);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_internal_with_features<F>(
     sources: SourceMap,
@@ -454,24 +483,7 @@ where
         }
     };
 
-    for _ in 0..shots {
-        let result = {
-            let mut sim = SparseSim::new_with_noise(pauliNoise);
-            sim.set_loss(qubitLoss);
-            interpreter.eval_entry_with_sim(&mut sim, &mut out)
-        };
-        let mut success = true;
-        let msg: serde_json::Value = match result {
-            Ok(value) => serde_json::Value::String(value.to_string()),
-            Err(errors) => {
-                success = false;
-                interpret_errors_to_run_result(&errors)
-            }
-        };
-
-        let msg_string = json!({"type": "Result", "success": success, "result": msg}).to_string();
-        (out.event_cb)(&msg_string);
-    }
+    run_interpreter(&mut interpreter, &mut out, shots, pauliNoise, qubitLoss);
     Ok(())
 }
 
@@ -492,8 +504,22 @@ pub fn run(
     )
 }
 
+/// Emits a failed `Result` event via the callback before returning the error,
+/// ensuring the caller always receives at least one `Result` event.
+fn emit_run_error(event_cb: &impl Fn(&str), errors: Vec<interpret::Error>) -> JsValue {
+    let diag = interpret_errors_to_run_result(&errors);
+    let msg = json!({"type": "Result", "success": false, "result": diag}).to_string();
+    event_cb(&msg);
+    JsError::from(
+        errors
+            .into_iter()
+            .next()
+            .expect("expected at least one error"),
+    )
+    .into()
+}
+
 #[wasm_bindgen]
-#[allow(clippy::too_many_lines)]
 pub fn runWithNoise(
     program: ProgramConfig,
     expr: &str,
@@ -541,67 +567,26 @@ pub fn runWithNoise(
 
     if is_openqasm_program(&program) {
         let (sources, capabilities) = into_openqasm_arg(program);
-        let mut out = CallbackReceiver { event_cb };
         let (entry_expr, mut interpreter) =
             match get_interpreter_from_openqasm(&sources, capabilities) {
                 Ok(result) => result,
-                Err(errors) => {
-                    // Emit a Result event with the compilation errors so that
-                    // the event target can resolve the promise, matching Q# behavior.
-                    let diag = interpret_errors_to_run_result(&errors);
-                    let msg = json!({"type": "Result", "success": false, "result": diag});
-                    (out.event_cb)(&msg.to_string());
-                    return Err(JsError::from(
-                        errors
-                            .into_iter()
-                            .next()
-                            .expect("expected at least one error"),
-                    )
-                    .into());
-                }
+                Err(errors) => return Err(emit_run_error(&event_cb, errors)),
             };
         if let Err(errors) = interpreter.set_entry_expr(&entry_expr) {
-            let diag = interpret_errors_to_run_result(&errors);
-            let msg = json!({"type": "Result", "success": false, "result": diag});
-            (out.event_cb)(&msg.to_string());
-            return Err(JsError::from(
-                errors
-                    .into_iter()
-                    .next()
-                    .expect("expected at least one error"),
-            )
-            .into());
+            return Err(emit_run_error(&event_cb, errors));
         }
-
-        for _ in 0..shots {
-            let result = {
-                let mut sim = SparseSim::new_with_noise(&noise);
-                sim.set_loss(qubitLoss);
-                interpreter.eval_entry_with_sim(&mut sim, &mut out)
-            };
-            let mut success = true;
-            let msg: serde_json::Value = match result {
-                Ok(value) => serde_json::Value::String(value.to_string()),
-                Err(errors) => {
-                    success = false;
-                    interpret_errors_to_run_result(&errors)
-                }
-            };
-
-            let msg_string =
-                json!({"type": "Result", "success": success, "result": msg}).to_string();
-            (out.event_cb)(&msg_string);
-        }
+        let mut out = CallbackReceiver { event_cb };
+        run_interpreter(&mut interpreter, &mut out, shots, &noise, qubitLoss);
         Ok(true)
     } else {
         let (source_map, capabilities, language_features, store, deps) =
-            into_qsc_args(program, Some(expr.into()), false).map_err(|mut e| {
-                // Wrap in `interpret::Error` and `JsError` to match the error type
-                // `run_internal_with_features` below
-                JsError::from(qsc::interpret::Error::from(
-                    e.pop().expect("expected at least one error"),
-                ))
-            })?;
+            match into_qsc_args(program, Some(expr.into()), false) {
+                Ok(args) => args,
+                Err(errors) => {
+                    let errors = errors.into_iter().map(Into::into).collect();
+                    return Err(emit_run_error(&event_cb, errors));
+                }
+            };
 
         match run_internal_with_features(
             source_map,

--- a/source/wasm/src/lib.rs
+++ b/source/wasm/src/lib.rs
@@ -91,7 +91,8 @@ pub(crate) fn get_qir_from_openqasm(
     sources: &[(Arc<str>, Arc<str>)],
     capabilities: TargetCapabilityFlags,
 ) -> Result<String, String> {
-    let (entry_expr, mut interpreter) = get_interpreter_from_openqasm(sources, capabilities)?;
+    let (entry_expr, mut interpreter) = get_interpreter_from_openqasm(sources, capabilities)
+        .map_err(interpret_errors_into_qsharp_errors_json)?;
     interpreter
         .qirgen(&entry_expr)
         .map_err(interpret_errors_into_qsharp_errors_json)
@@ -133,7 +134,8 @@ pub(crate) fn get_estimates_from_openqasm(
     capabilities: TargetCapabilityFlags,
     params: &str,
 ) -> Result<String, String> {
-    let (_, mut interpreter) = get_interpreter_from_openqasm(sources, capabilities)?;
+    let (_, mut interpreter) = get_interpreter_from_openqasm(sources, capabilities)
+        .map_err(interpret_errors_into_qsharp_errors_json)?;
     estimate_entry(&mut interpreter, params).map_err(|e| match &e[0] {
         re::Error::Interpreter(interpret::Error::Eval(e)) => e.to_string(),
         re::Error::Interpreter(_) => {
@@ -187,7 +189,8 @@ pub fn get_circuit(
 
     if is_openqasm_program(&program) {
         let (sources, capabilities) = into_openqasm_arg(program);
-        let (_, mut interpreter) = get_interpreter_from_openqasm(&sources, capabilities)?;
+        let (_, mut interpreter) = get_interpreter_from_openqasm(&sources, capabilities)
+            .map_err(interpret_errors_into_qsharp_errors_json)?;
 
         let circuit = interpreter
             .circuit(CircuitEntryPoint::EntryPoint, method, tracer_config)
@@ -490,6 +493,7 @@ pub fn run(
 }
 
 #[wasm_bindgen]
+#[allow(clippy::too_many_lines)]
 pub fn runWithNoise(
     program: ProgramConfig,
     expr: &str,
@@ -537,12 +541,38 @@ pub fn runWithNoise(
 
     if is_openqasm_program(&program) {
         let (sources, capabilities) = into_openqasm_arg(program);
-        let (entry_expr, mut interpreter) = get_interpreter_from_openqasm(&sources, capabilities)?;
-        if let Err(err) = interpreter.set_entry_expr(&entry_expr) {
-            return Err(interpret_errors_into_qsharp_errors_json(err).into());
+        let mut out = CallbackReceiver { event_cb };
+        let (entry_expr, mut interpreter) =
+            match get_interpreter_from_openqasm(&sources, capabilities) {
+                Ok(result) => result,
+                Err(errors) => {
+                    // Emit a Result event with the compilation errors so that
+                    // the event target can resolve the promise, matching Q# behavior.
+                    let diag = interpret_errors_to_run_result(&errors);
+                    let msg = json!({"type": "Result", "success": false, "result": diag});
+                    (out.event_cb)(&msg.to_string());
+                    return Err(JsError::from(
+                        errors
+                            .into_iter()
+                            .next()
+                            .expect("expected at least one error"),
+                    )
+                    .into());
+                }
+            };
+        if let Err(errors) = interpreter.set_entry_expr(&entry_expr) {
+            let diag = interpret_errors_to_run_result(&errors);
+            let msg = json!({"type": "Result", "success": false, "result": diag});
+            (out.event_cb)(&msg.to_string());
+            return Err(JsError::from(
+                errors
+                    .into_iter()
+                    .next()
+                    .expect("expected at least one error"),
+            )
+            .into());
         }
 
-        let mut out = CallbackReceiver { event_cb };
         for _ in 0..shots {
             let result = {
                 let mut sim = SparseSim::new_with_noise(&noise);
@@ -694,14 +724,14 @@ pub fn get_library_summaries() -> String {
 fn get_debugger_from_openqasm(
     sources: &[(Arc<str>, Arc<str>)],
     capabilities: TargetCapabilityFlags,
-) -> Result<(String, interpret::Interpreter), String> {
+) -> Result<(String, interpret::Interpreter), Vec<interpret::Error>> {
     get_configured_interpreter_from_openqasm(sources, capabilities, true)
 }
 
 fn get_interpreter_from_openqasm(
     sources: &[(Arc<str>, Arc<str>)],
     capabilities: TargetCapabilityFlags,
-) -> Result<(String, interpret::Interpreter), String> {
+) -> Result<(String, interpret::Interpreter), Vec<interpret::Error>> {
     get_configured_interpreter_from_openqasm(sources, capabilities, false)
 }
 
@@ -709,7 +739,7 @@ fn get_configured_interpreter_from_openqasm(
     sources: &[(Arc<str>, Arc<str>)],
     capabilities: TargetCapabilityFlags,
     dbg: bool,
-) -> Result<(String, interpret::Interpreter), String> {
+) -> Result<(String, interpret::Interpreter), Vec<interpret::Error>> {
     let (file, source) = sources
         .iter()
         .next()
@@ -725,12 +755,10 @@ fn get_configured_interpreter_from_openqasm(
         );
 
     if !errors.is_empty() {
-        return Err(interpret_errors_into_qsharp_errors_json(
-            errors
-                .iter()
-                .map(|e| qsc::interpret::Error::Compile(e.clone()))
-                .collect(),
-        ));
+        return Err(errors
+            .iter()
+            .map(|e| qsc::interpret::Error::Compile(e.clone()))
+            .collect());
     }
 
     let sig = sig.expect("msg: there should be a signature");
@@ -743,8 +771,7 @@ fn get_configured_interpreter_from_openqasm(
         capabilities,
         language_features,
         &dependencies,
-    )
-    .map_err(interpret_errors_into_qsharp_errors_json)?;
+    )?;
 
     Ok((entry_expr, interpreter))
 }


### PR DESCRIPTION
Running a program with compile errors via the Copilot tools (or VS Code) would hang indefinitely. The `run` WASM function emits `Result` events via a callback, and the JS caller waits for at least one to resolve its promise. When compilation failed, the error was returned without emitting an event, so the promise never resolved.

This affected two cases:
- OpenQASM programs with any compile error
- Q# programs with broken dependencies (errors from `into_qsc_args`)

**Repro — OpenQASM** (missing `include "stdgates.inc";`):
```qasm
OPENQASM 3.0;
qubit[2] q;
CX q[0], q[1];
bit[2] c;
c = measure q;
```

**Repro — Q#** (project references a dependency that doesn't compile):
```
samples/scratch/
├── qsharp.json              # {"dependencies": {"BrokenDep": {"path": "../scratch/broken_dep"}}}
├── src/Main.qs
└── broken_dep/
    ├── qsharp.json
    └── src/Lib.qs           # has type errors
```

**Changes:**
- `get_configured_interpreter_from_openqasm` now returns `Vec<interpret::Error>` instead of a pre-serialized JSON string, giving callers access to structured errors
- Callers that need the JSON string (`get_qir`, `get_estimates`, `get_circuit`) apply `map_err` themselves
- `runWithNoise` now emits a `Result` event before returning on compile errors, for both OpenQASM and Q# paths
- Extract `emit_run_error` helper to deduplicate the emit-then-return pattern across all error sites
- Extract `run_interpreter` to share the shot loop between the Q# and OpenQASM paths
- Fix `DebugService::load_program` to call `render_errors` on OpenQASM compile errors (was returning raw error type)