### PR TITLE
Enable verifying notebooks using qdk in integration tests

### DIFF
--- a/build.py
+++ b/build.py
@@ -675,7 +675,7 @@ if build_jupyterlab:
     subprocess.run(pip_build_args, check=True, text=True, cwd=jupyterlab_src)
     step_end()
 
-if build_pip and build_widgets and args.integration_tests:
+if build_pip and build_widgets and build_qdk and args.integration_tests:
     step_start("Running notebook samples integration tests")
     # Find all notebooks in the samples directory. Skip some of the samples since these won't run.
     notebook_files = [
@@ -689,15 +689,12 @@ if build_pip and build_widgets and args.integration_tests:
             or f.startswith("circuits.")
             or f.startswith("iterative_phase_estimation.")
             or f.startswith("repeat_until_success.")
-            or f.startswith("python-deps.")
             or f.startswith("cirq_submission_to_azure.")
             or f.startswith("neutral_atom_simulator.")
             or f.startswith("qir_circuit_submission_to_azure.")
             or f.startswith("qiskit_submission_to_azure")
             or f.startswith("pennylane_submission_to_azure.")
             or f.startswith("benzene.")
-            or f.startswith("parallel_teleport.")
-            or f.startswith("carbon.")
         )
     ]
     (python_bin, pip_env) = use_python_env(samples_src)
@@ -710,8 +707,10 @@ if build_pip and build_widgets and args.integration_tests:
         "install",
         "--force-reinstall",
         "--no-index",
+        "--no-deps",
         "--find-links=" + wheels_dir,
-        f"qsharp",
+        "qdk",
+        "qsharp",
     ]
     subprocess.run(pip_install_args, check=True, text=True, cwd=pip_src, env=pip_env)
 
@@ -737,6 +736,7 @@ if build_pip and build_widgets and args.integration_tests:
         "nbconvert",
         "pandas",
         "qutip",
+        "pyqir",
     ]
     subprocess.run(pip_install_args, check=True, text=True, cwd=root_dir, env=pip_env)
 


### PR DESCRIPTION
This updates the build script to make notebook testing dependent on building the qdk wheel and installs it alsong with dependencies during integration testing to allow validation of notebooks that use the qdk package.

This will allow follow up that updates the older sample notebooks to use the `from qdk import ...` pattern.