### PR TITLE
Default to OpenQASM semantics on compile

### DIFF
--- a/source/pip/src/interop.rs
+++ b/source/pip/src/interop.rs
@@ -333,7 +333,7 @@ pub(crate) fn compile_qasm_program_to_qir(
     let res = qsc::openqasm::semantic::parse_sources(&sources);
 
     let program_ty = ProgramType::File;
-    let output_semantics = get_output_semantics(&kwargs, || OutputSemantics::Qiskit)?;
+    let output_semantics = get_output_semantics(&kwargs, || OutputSemantics::OpenQasm)?;
     let (package, source_map, signature) =
         compile_qasm_enriching_errors(res, &operation_name, program_ty, output_semantics, false)?;
 
@@ -432,7 +432,7 @@ pub(crate) fn compile_qasm_to_qsharp(
     let res = qsc::openqasm::semantic::parse_sources(&sources);
 
     let program_ty = get_program_type(&kwargs, || ProgramType::File)?;
-    let output_semantics = get_output_semantics(&kwargs, || OutputSemantics::Qiskit)?;
+    let output_semantics = get_output_semantics(&kwargs, || OutputSemantics::OpenQasm)?;
     let (package, _, _) =
         compile_qasm_enriching_errors(res, &operation_name, program_ty, output_semantics, true)?;
 

--- a/source/pip/tests/test_cpu_simulator.py
+++ b/source/pip/tests/test_cpu_simulator.py
@@ -326,7 +326,7 @@ def test_cpu_cy_noise_distribution():
     count_target_one = 0
     for shot in output:
         shot_results = cast(Sequence[Result], shot)
-        if shot_results[0] == Result.One:
+        if shot_results[-1] == Result.One:
             count_target_one += 1
 
     actual_p1 = count_target_one / n_shots


### PR DESCRIPTION
This updates the code for `openqasm.compile` to default to OpenQASM output semantics instead of Qiskit during compile. This allows for individual bits as output, as well as maintaining the array ordering for registers rather than reversing them.