### PR TITLE
Fix barrier instruction in adaptive qir simulations

### DIFF
--- a/source/pip/qsharp/_adaptive_pass.py
+++ b/source/pip/qsharp/_adaptive_pass.py
@@ -661,19 +661,10 @@ class AdaptiveProfilePass:
         callee = call.callee.name
 
         match callee:
-            case (
-                "__quantum__rt__initialize"
-                | "__quantum__rt__begin_parallel"
-                | "__quantum__rt__end_parallel"
-                | "__quantum__qis__barrier__body"
-            ):
-                pass  # No-op
             case "__quantum__qis__read_result__body" | "__quantum__rt__read_result":
                 dst = self._alloc_reg(call, REG_TYPE_BOOL)
                 result_reg = self._resolve_result_operand(call.args[0])
                 self._emit(OP_READ_RESULT, dst=dst, src0=result_reg)
-            case _ if callee.startswith("__quantum__qis__"):
-                self._emit_quantum_call(call)
             case "__quantum__rt__result_record_output":
                 result_reg = self._resolve_result_operand(call.args[0])
                 label_str = self._extract_label(call.args[1])
@@ -722,6 +713,13 @@ class AdaptiveProfilePass:
                 self._emit(
                     OP_RECORD_OUTPUT, src0=src, aux0=label_idx, aux1=4
                 )  # aux1=4 -> int
+            case (
+                "__quantum__rt__initialize"
+                | "__quantum__rt__begin_parallel"
+                | "__quantum__rt__end_parallel"
+                | "__quantum__qis__barrier__body"
+            ):
+                pass  # No-op
             case "__quantum__rt__read_loss":
                 # Allocate a bool register and emit OP_READ_LOSS so the runtime
                 # can ask the simulator whether the given result was produced
@@ -729,6 +727,8 @@ class AdaptiveProfilePass:
                 dst = self._alloc_reg(call, REG_TYPE_BOOL)
                 result_reg = self._resolve_result_operand(call.args[0])
                 self._emit(OP_READ_LOSS, dst=dst, src0=result_reg)
+            case _ if callee.startswith("__quantum__qis__"):
+                self._emit_quantum_call(call)
             case _ if callee in self._func_to_id:
                 self._emit_ir_function_call(call)
             case _ if "qdk_noise" in call.callee.attributes.func:

--- a/source/pip/qsharp/_adaptive_pass.py
+++ b/source/pip/qsharp/_adaptive_pass.py
@@ -661,6 +661,13 @@ class AdaptiveProfilePass:
         callee = call.callee.name
 
         match callee:
+            case (
+                "__quantum__rt__initialize"
+                | "__quantum__rt__begin_parallel"
+                | "__quantum__rt__end_parallel"
+                | "__quantum__qis__barrier__body"
+            ):
+                pass  # No-op
             case "__quantum__qis__read_result__body" | "__quantum__rt__read_result":
                 dst = self._alloc_reg(call, REG_TYPE_BOOL)
                 result_reg = self._resolve_result_operand(call.args[0])
@@ -715,13 +722,6 @@ class AdaptiveProfilePass:
                 self._emit(
                     OP_RECORD_OUTPUT, src0=src, aux0=label_idx, aux1=4
                 )  # aux1=4 -> int
-            case (
-                "__quantum__rt__initialize"
-                | "__quantum__rt__begin_parallel"
-                | "__quantum__rt__end_parallel"
-                | "__quantum__qis__barrier__body"
-            ):
-                pass  # No-op
             case "__quantum__rt__read_loss":
                 # Allocate a bool register and emit OP_READ_LOSS so the runtime
                 # can ask the simulator whether the given result was produced

--- a/source/pip/tests/test_adaptive_pass.py
+++ b/source/pip/tests/test_adaptive_pass.py
@@ -970,3 +970,40 @@ def test_arrays_capability_is_rejected():
     """Only Adaptive_RIFL is supported at the moment, no arrays."""
     with pytest.raises(ValueError, match="QIR arrays are not currently supported"):
         _run_pass(ADAPTIVE_RIFLA_QIR)
+
+
+BARRIER_QIR = r"""
+%Result = type opaque
+%Qubit = type opaque
+
+@0 = internal constant [4 x i8] c"0_t\00"
+
+define i64 @ENTRYPOINT__main() #0 {
+block_0:
+  call void @__quantum__rt__initialize(i8* null)
+  call void @__quantum__qis__barrier__body()
+  call void @__quantum__rt__tuple_record_output(i64 0, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))
+  ret i64 0
+}
+
+declare void @__quantum__rt__initialize(i8*)
+declare void @__quantum__qis__barrier__body()
+declare void @__quantum__rt__tuple_record_output(i64, i8*)
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="adaptive_profile" "required_num_qubits"="0" "required_num_results"="0" }
+attributes #1 = { "irreversible" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4, !5}
+
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+!4 = !{i32 5, !"int_computations", !{!"i64"}}
+!5 = !{i32 5, !"float_computations", !{!"double"}}
+
+"""
+
+
+def test_pass_on_qir_with_barrier_instruction_succeeds():
+    _run_pass(BARRIER_QIR)


### PR DESCRIPTION
The barrier instruction in the Adaptive QIR pass was not being handled correctly. This PR fixes it.