### PR TITLE
Minor playground fix

### DIFF
--- a/source/npm/qsharp/src/workers/adapters/browser.ts
+++ b/source/npm/qsharp/src/workers/adapters/browser.ts
@@ -7,7 +7,9 @@ export class BrowserWorkerHost implements IWorkerHost {
   private worker: Worker;
 
   constructor(url: string | URL) {
-    // Make sure the URL is absolute so that importScripts works inside the blob
+    // Resolve to an absolute URL because importScripts inside a blob worker
+    // cannot resolve relative URLs (there is no base URL to resolve against).
+    // Note: import.meta.url is replaced with document.URL by the bundler.
     const scriptUrl =
       typeof url === "string" ? new URL(url, import.meta.url).href : url.href;
     const bootstrap = `

--- a/source/npm/qsharp/src/workers/adapters/browser.ts
+++ b/source/npm/qsharp/src/workers/adapters/browser.ts
@@ -7,7 +7,9 @@ export class BrowserWorkerHost implements IWorkerHost {
   private worker: Worker;
 
   constructor(url: string | URL) {
-    const scriptUrl = typeof url === "string" ? url : url.href;
+    // Make sure the URL is absolute so that importScripts works inside the blob
+    const scriptUrl =
+      typeof url === "string" ? new URL(url, import.meta.url).href : url.href;
     const bootstrap = `
       self.WorkerSelf = {
         postMessage(msg) { self.postMessage(msg); },


### PR DESCRIPTION
The worker code was breaking because the worker bootstrap was receiving a relative URL. Now I make sure that it's a absolute URL by transforming the string into a URL first.