### PR TITLE
Provide lhs_span to binop errors when necessary

### DIFF
--- a/source/compiler/qsc_eval/src/lib.rs
+++ b/source/compiler/qsc_eval/src/lib.rs
@@ -977,6 +977,7 @@ impl State {
             ExprKind::ArrayRepeat(..) => self.eval_arr_repeat(expr.span)?,
             ExprKind::Assign(lhs, _) => self.eval_assign(env, globals, *lhs)?,
             ExprKind::AssignOp(op, lhs, rhs) => {
+                let lhs_span = globals.get_expr((self.package, *lhs).into()).span;
                 let rhs_span = globals.get_expr((self.package, *rhs).into()).span;
                 let (is_array, is_unique) =
                     is_updatable_in_place(env, globals.get_expr((self.package, *lhs).into()));
@@ -990,7 +991,7 @@ impl State {
                     self.push_val();
                     self.set_val_register(rhs_val);
                 }
-                self.eval_binop(*op, rhs_span)?;
+                self.eval_binop(*op, lhs_span, rhs_span)?;
                 self.eval_assign(env, globals, *lhs)?;
             }
             ExprKind::AssignField(record, field, _) => {
@@ -1010,9 +1011,10 @@ impl State {
                 self.eval_update_index(mid_span)?;
                 self.eval_assign(env, globals, *lhs)?;
             }
-            ExprKind::BinOp(op, _, rhs) => {
+            ExprKind::BinOp(op, lhs, rhs) => {
+                let lhs_span = globals.get_expr((self.package, *lhs).into()).span;
                 let rhs_span = globals.get_expr((self.package, *rhs).into()).span;
-                self.eval_binop(*op, rhs_span)?;
+                self.eval_binop(*op, lhs_span, rhs_span)?;
             }
             ExprKind::Block(..) => panic!("block expr should be handled by control flow"),
             ExprKind::Call(callee_expr, args_expr) => {
@@ -1156,23 +1158,23 @@ impl State {
         self.bind_value(env, globals, pat, val);
     }
 
-    fn eval_binop(&mut self, op: BinOp, span: Span) -> Result<(), Error> {
+    fn eval_binop(&mut self, op: BinOp, lhs_span: Span, rhs_span: Span) -> Result<(), Error> {
         match op {
             BinOp::Add => self.eval_binop_simple(eval_binop_add),
             BinOp::AndB => self.eval_binop_simple(eval_binop_andb),
-            BinOp::Div => self.eval_binop_with_error(span, eval_binop_div)?,
-            BinOp::Eq => self.eval_binop_with_error(span, eval_binop_eq)?,
-            BinOp::Exp => self.eval_binop_with_error(span, eval_binop_exp)?,
+            BinOp::Div => self.eval_binop_with_error(lhs_span, rhs_span, eval_binop_div)?,
+            BinOp::Eq => self.eval_binop_with_error(lhs_span, rhs_span, eval_binop_eq)?,
+            BinOp::Exp => self.eval_binop_with_error(lhs_span, rhs_span, eval_binop_exp)?,
             BinOp::Gt => self.eval_binop_simple(eval_binop_gt),
             BinOp::Gte => self.eval_binop_simple(eval_binop_gte),
             BinOp::Lt => self.eval_binop_simple(eval_binop_lt),
             BinOp::Lte => self.eval_binop_simple(eval_binop_lte),
-            BinOp::Mod => self.eval_binop_with_error(span, eval_binop_mod)?,
+            BinOp::Mod => self.eval_binop_with_error(lhs_span, rhs_span, eval_binop_mod)?,
             BinOp::Mul => self.eval_binop_simple(eval_binop_mul),
-            BinOp::Neq => self.eval_binop_with_error(span, eval_binop_neq)?,
+            BinOp::Neq => self.eval_binop_with_error(lhs_span, rhs_span, eval_binop_neq)?,
             BinOp::OrB => self.eval_binop_simple(eval_binop_orb),
-            BinOp::Shl => self.eval_binop_with_error(span, eval_binop_shl)?,
-            BinOp::Shr => self.eval_binop_with_error(span, eval_binop_shr)?,
+            BinOp::Shl => self.eval_binop_with_error(lhs_span, rhs_span, eval_binop_shl)?,
+            BinOp::Shr => self.eval_binop_with_error(lhs_span, rhs_span, eval_binop_shr)?,
             BinOp::Sub => self.eval_binop_simple(eval_binop_sub),
             BinOp::XorB => self.eval_binop_simple(eval_binop_xorb),
 
@@ -1190,13 +1192,15 @@ impl State {
 
     fn eval_binop_with_error(
         &mut self,
-        span: Span,
-        binop_func: impl FnOnce(Value, Value, PackageSpan) -> Result<Value, Error>,
+        lhs_span: Span,
+        rhs_span: Span,
+        binop_func: impl FnOnce(Value, Value, PackageSpan, PackageSpan) -> Result<Value, Error>,
     ) -> Result<(), Error> {
-        let span = self.to_global_span(span);
+        let lhs_span: PackageSpan = self.to_global_span(lhs_span);
+        let rhs_span: PackageSpan = self.to_global_span(rhs_span);
         let rhs_val = self.take_val_register();
         let lhs_val = self.pop_val();
-        self.set_val_register(binop_func(lhs_val, rhs_val, span)?);
+        self.set_val_register(binop_func(lhs_val, rhs_val, lhs_span, rhs_span)?);
         Ok(())
     }
 
@@ -1954,16 +1958,33 @@ fn lit_to_val(lit: &Lit) -> Value {
     }
 }
 
-fn eval_binop_eq(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Result<Value, Error> {
+fn eval_binop_eq(
+    lhs_val: Value,
+    rhs_val: Value,
+    lhs_span: PackageSpan,
+    rhs_span: PackageSpan,
+) -> Result<Value, Error> {
     match (lhs_val, rhs_val) {
-        (Value::Result(val::Result::Id(_)), _) | (_, Value::Result(val::Result::Id(_))) => {
+        (Value::Result(val::Result::Id(_)), _) => {
+            // Comparison of result ids is nonsensical, so we prevent it.
+            // This code path is reachable when using the circuit builder backend
+            // since we don't currently do runtime capability analysis
+            // to prevent executing programs that do result comparisons.
+            Err(Error::ResultComparisonUnsupported(lhs_span))
+        }
+        (Value::Result(val::Result::Loss), _) => {
+            // Loss is not comparable and should be checked ahead of time, so treat this as a runtime
+            // failure.
+            Err(Error::ResultLossComparisonUnsupported(lhs_span))
+        }
+        (_, Value::Result(val::Result::Id(_))) => {
             // Comparison of result ids is nonsensical, so we prevent it.
             // This code path is reachable when using the circuit builder backend
             // since we don't currently do runtime capability analysis
             // to prevent executing programs that do result comparisons.
             Err(Error::ResultComparisonUnsupported(rhs_span))
         }
-        (Value::Result(val::Result::Loss), _) | (_, Value::Result(val::Result::Loss)) => {
+        (_, Value::Result(val::Result::Loss)) => {
             // Loss is not comparable and should be checked ahead of time, so treat this as a runtime
             // failure.
             Err(Error::ResultLossComparisonUnsupported(rhs_span))
@@ -1972,20 +1993,38 @@ fn eval_binop_eq(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Resul
     }
 }
 
-fn eval_binop_neq(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Result<Value, Error> {
+fn eval_binop_neq(
+    lhs_val: Value,
+    rhs_val: Value,
+    lhs_span: PackageSpan,
+    rhs_span: PackageSpan,
+) -> Result<Value, Error> {
     match (lhs_val, rhs_val) {
-        (Value::Result(val::Result::Id(_)), _) | (_, Value::Result(val::Result::Id(_))) => {
+        (Value::Result(val::Result::Id(_)), _) => {
+            // Comparison of result ids is nonsensical, so we prevent it.
+            // This code path is reachable when using the circuit builder backend
+            // since we don't currently do runtime capability analysis
+            // to prevent executing programs that do result comparisons.
+            Err(Error::ResultComparisonUnsupported(lhs_span))
+        }
+        (Value::Result(val::Result::Loss), _) => {
+            // Loss is not comparable and should be checked ahead of time, so treat this as a runtime
+            // failure.
+            Err(Error::ResultLossComparisonUnsupported(lhs_span))
+        }
+        (_, Value::Result(val::Result::Id(_))) => {
             // Comparison of result ids is nonsensical, so we prevent it.
             // This code path is reachable when using the circuit builder backend
             // since we don't currently do runtime capability analysis
             // to prevent executing programs that do result comparisons.
             Err(Error::ResultComparisonUnsupported(rhs_span))
         }
-        (Value::Result(val::Result::Loss), _) | (_, Value::Result(val::Result::Loss)) => {
+        (_, Value::Result(val::Result::Loss)) => {
             // Loss is not comparable and should be checked ahead of time, so treat this as a runtime
             // failure.
             Err(Error::ResultLossComparisonUnsupported(rhs_span))
         }
+
         (lhs, rhs) => Ok(Value::Bool(lhs != rhs)),
     }
 }
@@ -2069,7 +2108,12 @@ fn eval_binop_andb(lhs_val: Value, rhs_val: Value) -> Value {
     }
 }
 
-fn eval_binop_div(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Result<Value, Error> {
+fn eval_binop_div(
+    lhs_val: Value,
+    rhs_val: Value,
+    _: PackageSpan,
+    rhs_span: PackageSpan,
+) -> Result<Value, Error> {
     match lhs_val {
         Value::BigInt(val) => {
             let rhs = rhs_val.unwrap_big_int();
@@ -2121,7 +2165,12 @@ fn eval_binop_div(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Resu
     }
 }
 
-fn eval_binop_exp(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Result<Value, Error> {
+fn eval_binop_exp(
+    lhs_val: Value,
+    rhs_val: Value,
+    _: PackageSpan,
+    rhs_span: PackageSpan,
+) -> Result<Value, Error> {
     match lhs_val {
         Value::BigInt(val) => {
             let rhs_val = rhs_val.unwrap_int();
@@ -2252,7 +2301,12 @@ fn eval_binop_lte(lhs_val: Value, rhs_val: Value) -> Value {
     }
 }
 
-fn eval_binop_mod(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Result<Value, Error> {
+fn eval_binop_mod(
+    lhs_val: Value,
+    rhs_val: Value,
+    _: PackageSpan,
+    rhs_span: PackageSpan,
+) -> Result<Value, Error> {
     match lhs_val {
         Value::BigInt(val) => {
             let rhs = rhs_val.unwrap_big_int();
@@ -2336,7 +2390,12 @@ fn eval_binop_orb(lhs_val: Value, rhs_val: Value) -> Value {
     }
 }
 
-fn eval_binop_shl(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Result<Value, Error> {
+fn eval_binop_shl(
+    lhs_val: Value,
+    rhs_val: Value,
+    _: PackageSpan,
+    rhs_span: PackageSpan,
+) -> Result<Value, Error> {
     Ok(match lhs_val {
         Value::BigInt(val) => {
             let rhs = rhs_val.unwrap_int();
@@ -2366,7 +2425,12 @@ fn eval_binop_shl(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Resu
     })
 }
 
-fn eval_binop_shr(lhs_val: Value, rhs_val: Value, rhs_span: PackageSpan) -> Result<Value, Error> {
+fn eval_binop_shr(
+    lhs_val: Value,
+    rhs_val: Value,
+    _: PackageSpan,
+    rhs_span: PackageSpan,
+) -> Result<Value, Error> {
     Ok(match lhs_val {
         Value::BigInt(val) => {
             let rhs = rhs_val.unwrap_int();

--- a/source/npm/qsharp/test/circuits-cases/conditionals.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/conditionals.qs.snapshot.html
@@ -10240,7 +10240,7 @@
       <pre>
 Error generating circuit: QdkDiagnostics: runtime error: cannot compare measurement results
 
-help: comparing measurement results is not supported when performing circuit synthesis or base profile QIR generation at conditionals.qs:28:15</pre
+help: comparing measurement results is not supported when performing circuit synthesis or base profile QIR generation at conditionals.qs:28:9</pre
       >
     </div>
     <div><h2>circuit-eval-expanded</h2></div>
@@ -10248,7 +10248,7 @@ help: comparing measurement results is not supported when performing circuit syn
       <pre>
 Error generating circuit: QdkDiagnostics: runtime error: cannot compare measurement results
 
-help: comparing measurement results is not supported when performing circuit synthesis or base profile QIR generation at conditionals.qs:28:15</pre
+help: comparing measurement results is not supported when performing circuit synthesis or base profile QIR generation at conditionals.qs:28:9</pre
       >
     </div>
   </body>

--- a/source/npm/qsharp/test/circuits-cases/if-else.qs.snapshot.html
+++ b/source/npm/qsharp/test/circuits-cases/if-else.qs.snapshot.html
@@ -775,7 +775,7 @@
       <pre>
 Error generating circuit: QdkDiagnostics: runtime error: cannot compare measurement results
 
-help: comparing measurement results is not supported when performing circuit synthesis or base profile QIR generation at if-else.qs:8:13</pre
+help: comparing measurement results is not supported when performing circuit synthesis or base profile QIR generation at if-else.qs:8:8</pre
       >
     </div>
     <div><h2>circuit-eval-expanded</h2></div>
@@ -783,7 +783,7 @@ help: comparing measurement results is not supported when performing circuit syn
       <pre>
 Error generating circuit: QdkDiagnostics: runtime error: cannot compare measurement results
 
-help: comparing measurement results is not supported when performing circuit synthesis or base profile QIR generation at if-else.qs:8:13</pre
+help: comparing measurement results is not supported when performing circuit synthesis or base profile QIR generation at if-else.qs:8:8</pre
       >
     </div>
   </body>


### PR DESCRIPTION
This PR resolves https://github.com/microsoft/qdk/issues/2581 by separating cases when errors are in the left-hand side and printing the appropriate span with the error message.

## Examples:

Error is in the left-hand side:
<img width="1012" height="203" alt="image" src="https://github.com/user-attachments/assets/514ab572-08a9-437d-b4c8-558aaadaa841" />

Error is in the right-hand side:
<img width="1012" height="203" alt="image" src="https://github.com/user-attachments/assets/fa48bef3-a966-4aca-b410-00c848c08d13" />

