### PR TITLE
Exercise description for "Prepare Arbitrary State" incorrectly constrains α as non-negative

### DIFF
--- a/katas/content/single_qubit_gates/prepare_arbitrary_state/index.md
+++ b/katas/content/single_qubit_gates/prepare_arbitrary_state/index.md
@@ -1,6 +1,6 @@
 **Inputs:**
 
-1. A non-negative real number $\alpha$.
+1. A real number $\alpha$.
 2. A non-negative real number $\beta = \sqrt{1 - \alpha^2}$.
 3. A real number $\theta$.
 4. A qubit in state $\ket{0}$.


### PR DESCRIPTION
In the Single-Qubit Gates kata, the "Prepare Arbitrary State" exercise description states:

> 1. A **non-negative** real number α.
> 2. A **non-negative** real number β = √(1 − α²).

However, the verification test generates test cases with negative α values (e.g., `alpha = Cos(2) ≈ -0.416`), and the reference solution uses `ArcTan2(beta, alpha)` which handles negative α correctly.

### Why the "non-negative" constraint is wrong

The pedagogical goal of this exercise is to teach students to use `ArcTan2(beta, alpha)` rather than the simpler `ArcSin(beta)`. If α were truly non-negative, a student could ignore the `alpha` parameter entirely and write:

```qsharp
Ry(2.0 * ArcSin(beta), q);
R1(theta, q);
```

This would trivially pass, defeating the purpose of the exercise. The exercise hint even explicitly mentions `ArcTan2`, confirming the intended solution requires both inputs.