### PR TITLE
Update cell timeout in notebook integration tests

### DIFF
--- a/source/vscode/test/suites/language-service/notebook.test.ts
+++ b/source/vscode/test/suites/language-service/notebook.test.ts
@@ -41,7 +41,7 @@ suite("Q# Notebook Tests", function suite() {
           .getCells()
           .find((cell) => cell.document.languageId === "qsharp"),
       vscode.workspace.onDidChangeNotebookDocument,
-      50,
+      2000,
       "timed out waiting for a Q# code cell",
     );
   });
@@ -75,7 +75,7 @@ suite("Q# Notebook Tests", function suite() {
         );
       },
       vscode.workspace.onDidChangeNotebookDocument,
-      50,
+      2000,
       "timed out waiting for a Python code cell",
     );
   });


### PR DESCRIPTION
This extends the timeout to hopefully make these parts of the integration tests more reliable. We've been seeing intermittent timeouts when waiting for VS code to report the creation of a new cell in a notebook, but used a timeout of 50 ms that was probably too aggressive for the (sometimes slow) CI. Fixes #3134