### PR TITLE
Increate Mocha Timeout Time for Notebook Test

### DIFF
--- a/source/vscode/test/suites/language-service/notebook.test.ts
+++ b/source/vscode/test/suites/language-service/notebook.test.ts
@@ -46,7 +46,9 @@ suite("Q# Notebook Tests", function suite() {
     );
   });
 
-  test("Cell language is set back to Python", async () => {
+  test("Cell language is set back to Python", async function () {
+    this.timeout(10000);
+
     const notebook = await vscode.workspace.openNotebookDocument(
       vscode.Uri.joinPath(workspaceFolderUri, "test.ipynb"),
     );


### PR DESCRIPTION
Mocha to wait a maximum of 10 seconds before timeout on this specific test.

This test has 4 async commands (open, show, focus, insert) plus the 2-second `waitForCondition` exceedes Mocha's default 2-second cap. Bumping the cap to 10 seconds gives the test room to complete without changing its behavior.