### PR TITLE
Fix API leak in `qdk.qsharp`

### DIFF
--- a/source/pip/qsharp/__init__.py
+++ b/source/pip/qsharp/__init__.py
@@ -21,16 +21,14 @@ _warnings.warn(
     stacklevel=2,
 )
 
-# Re-export the full public API from qdk so that existing code keeps working.
-from qdk._types import (
+# Re-export the public API from qdk.qsharp so that existing code keeps working.
+from qdk.qsharp import (  # noqa: F401
     StateDump,
     ShotResult,
     PauliNoise,
     DepolarizingNoise,
     BitFlipNoise,
     PhaseFlipNoise,
-)
-from qdk._interpreter import (
     init,
     eval,
     run,
@@ -42,9 +40,6 @@ from qdk._interpreter import (
     set_classical_seed,
     dump_machine,
     dump_circuit,
-)
-
-from qdk._native import (
     Result,
     Pauli,
     QSharpError,

--- a/source/qdk_package/qdk/qsharp.py
+++ b/source/qdk_package/qdk/qsharp.py
@@ -1,21 +1,78 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Full re-export of the ``qsharp`` package as ``qdk.qsharp``.
+"""Q# interpreter public API.
 
-This module makes the entire ``qsharp`` public API available under the
-``qdk.qsharp`` namespace, so code that imports from ``qdk.qsharp`` behaves
-identically to importing from ``qsharp`` directly.
+This module is the public surface for Q# interpreter functionality
+within the ``qdk`` package.
+
 
 Key exports:
 
-- :func:`~qsharp.init`, :func:`~qsharp.eval`, :func:`~qsharp.run` — initialize and execute Q# code.
-- :class:`~qsharp.StateDump`, :class:`~qsharp.TargetProfile` — state inspection and compilation target.
-- :class:`~qsharp.PauliNoise`, :class:`~qsharp.DepolarizingNoise`, :class:`~qsharp.BitFlipNoise`, :class:`~qsharp.PhaseFlipNoise` — noise models.
-- :func:`~qdk.qsharp.dump_operation` — compute the unitary matrix of a Q# operation.
-
-For full API documentation see [qsharp](:mod:`qsharp`).
+- :func:`init`, :func:`eval`, :func:`run` — initialize and execute Q# code.
+- :class:`StateDump`, :class:`TargetProfile` — state inspection and compilation target.
+- :class:`PauliNoise`, :class:`DepolarizingNoise`, :class:`BitFlipNoise`, :class:`PhaseFlipNoise` — noise models.
+- :func:`dump_operation` — compute the unitary matrix of a Q# operation.
 """
 
-from ._types import *  # pyright: ignore[reportWildcardImportFromLibrary]
-from ._interpreter import *  # pyright: ignore[reportWildcardImportFromLibrary]
+from ._types import (
+    StateDump,
+    ShotResult,
+    PauliNoise,
+    DepolarizingNoise,
+    BitFlipNoise,
+    PhaseFlipNoise,
+)
+from ._interpreter import (
+    init,
+    eval,
+    run,
+    compile,
+    circuit,
+    estimate,
+    logical_counts,
+    set_quantum_seed,
+    set_classical_seed,
+    dump_machine,
+    dump_circuit,
+    dump_operation,
+)
+from ._native import (  # type: ignore
+    Result,
+    Pauli,
+    QSharpError,
+    TargetProfile,
+    estimate_custom,
+    CircuitGenerationMethod,
+)
+
+__all__ = [
+    # Core operations
+    "init",
+    "eval",
+    "run",
+    "compile",
+    "circuit",
+    "estimate",
+    "logical_counts",
+    # Seed / state
+    "set_quantum_seed",
+    "set_classical_seed",
+    "dump_machine",
+    "dump_circuit",
+    "dump_operation",
+    # Native types
+    "Result",
+    "Pauli",
+    "QSharpError",
+    "TargetProfile",
+    "estimate_custom",
+    "CircuitGenerationMethod",
+    # Python types
+    "StateDump",
+    "ShotResult",
+    "PauliNoise",
+    "DepolarizingNoise",
+    "BitFlipNoise",
+    "PhaseFlipNoise",
+]


### PR DESCRIPTION
Before the recent code migration, `qdk.qsharp` just wrapped around the qsharp package and imported everything in it's public API with a star import, while the qsharp's init was selective about what content it exported publicly from its private files.

When the migration happened, qdk.qsharp kept the star import, but now pointed to the private files that were migrated into it, and the qsharp package continued to define the public API as it imported from qdk. This left the public API from qdk.qsharp too exposed.

This PR fixes this by swapping who does the defining of the public API surface: `qdk.qsharp` selects the content from its private files to publicly export, and qsharp wraps from that public surface. The `qsharp` package is still verbose in what it grabs from the `qdk.qsharp` surface because `qdk.qsharp` also contains `dump_operation` which in the qsharp package is under utils.